### PR TITLE
Detect pull requests against upstream repositories

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -401,6 +401,18 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
     }
 
     if (args[0] === "pr" && args[1] === "view") {
+      const selector = args[2];
+      const queuedPullRequests =
+        typeof selector === "string"
+          ? (prListQueueByHeadSelector.get(selector)?.shift() ??
+            scenario.prListByHeadSelector?.[selector] ??
+            prListQueue.shift())
+          : undefined;
+      if (queuedPullRequests !== undefined) {
+        const parsed = JSON.parse(queuedPullRequests) as unknown;
+        const candidate = Array.isArray(parsed) ? parsed[0] : parsed;
+        return Effect.succeed(fakeGhOutput(candidate ? `${JSON.stringify(candidate)}\n` : ""));
+      }
       const pullRequest: FakePullRequest = scenario.pullRequest ?? {
         number: 101,
         title: "Pull request",
@@ -505,19 +517,28 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
       listOpenPullRequests: (input) => {
         const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
         const requestedLimit = input.limit ?? 1;
-        const args = [
-          "pr",
-          "list",
-          "--head",
-          qualifiedHead?.[2] ?? input.headSelector,
-          "--state",
-          "open",
-          "--limit",
-          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
-          ...(input.repository ? ["--repo", input.repository] : []),
-          "--json",
-          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
-        ];
+        const args = qualifiedHead
+          ? [
+              "pr",
+              "view",
+              input.headSelector,
+              ...(input.repository ? ["--repo", input.repository] : []),
+              "--json",
+              "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            ]
+          : [
+              "pr",
+              "list",
+              "--head",
+              input.headSelector,
+              "--state",
+              "open",
+              "--limit",
+              String(requestedLimit),
+              ...(input.repository ? ["--repo", input.repository] : []),
+              "--json",
+              "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            ];
         ghCalls.push(args.join(" "));
         if (scenario.failWith && ghCalls.length > (scenario.failAfterCalls ?? 0)) {
           return Effect.fail(scenario.failWith);
@@ -528,9 +549,9 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
           prListQueue.shift() ??
           "[]";
         // @effect-diagnostics-next-line preferSchemaOverJson:off
-        return Effect.sync(() => JSON.parse(stdout) as unknown[]).pipe(
+        return Effect.sync(() => JSON.parse(stdout) as unknown).pipe(
           Effect.map((raw) =>
-            raw
+            (Array.isArray(raw) ? raw : [raw])
               .map((entry) => normalizeFakePullRequestSummary(entry))
               .filter((entry): entry is GitHubCli.GitHubPullRequestSummary => entry !== null)
               .filter(
@@ -1035,6 +1056,62 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("uses the origin fork identity for a branch pushed without tracking", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const originDir = yield* createBareRemote();
+      const upstreamDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", originDir]);
+      yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["push", "upstream", "main"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "origin",
+        "git@github.com:octocat/codething-mvp.git",
+        originDir,
+      );
+      yield* runGit(repoDir, ["config", "remote.origin.pushurl", originDir]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "upstream",
+        "git@github.com:pingdotgg/codething-mvp.git",
+        upstreamDir,
+      );
+      yield* runGit(repoDir, ["checkout", "-b", "feature/pushed-no-tracking"]);
+      yield* runGit(repoDir, ["push", "origin", "feature/pushed-no-tracking"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListByHeadSelector: {
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "octocat:feature/pushed-no-tracking": JSON.stringify([
+              {
+                number: 215,
+                title: "Fork PR without tracking",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/215",
+                baseRefName: "main",
+                headRefName: "feature/pushed-no-tracking",
+                state: "OPEN",
+                isCrossRepository: true,
+                headRepository: { nameWithOwner: "octocat/codething-mvp" },
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
+          },
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.pr?.number).toBe(215);
+      expect(
+        ghCalls.some((call) => call.startsWith("pr view octocat:feature/pushed-no-tracking ")),
+      ).toBe(true);
+    }),
+  );
+
   it("backs off repeated PR lookup failures past the healthy refresh cadence", () => {
     expect(Duration.toMillis(GitManager.prLookupFailureTtl(1))).toBe(20_000);
     expect(Duration.toMillis(GitManager.prLookupFailureTtl(2))).toBe(40_000);
@@ -1149,7 +1226,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head statemachine --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr view jasonLaster:statemachine --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -1213,7 +1290,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head feature/upstream-pr --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr view contributor:feature/upstream-pr --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -2426,11 +2503,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
         expect(result.pr.status).toBe("opened_existing");
         expect(result.pr.number).toBe(142);
-        expect(
-          ghCalls.some((call) =>
-            call.includes("pr list --head statemachine --state open --limit 100"),
-          ),
-        ).toBe(true);
+        expect(ghCalls.some((call) => call.startsWith("pr view octocat:statemachine "))).toBe(true);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
       }),
     12_000,
@@ -2603,7 +2676,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
 
         const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
-          call.includes("pr list --head statemachine --state open --limit 100"),
+          call.startsWith("pr view octocat:statemachine "),
         );
         expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -2669,11 +2742,11 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.status).toBe("opened_existing");
         expect(result.pr.number).toBe(142);
 
-        const openLookupCalls = ghCalls.filter((call) => call.includes("--state open --limit 1"));
-        expect(openLookupCalls).toHaveLength(1);
-        expect(openLookupCalls[0]).toContain(
-          "pr list --head statemachine --state open --limit 100",
+        const openLookupCalls = ghCalls.filter((call) =>
+          call.startsWith("pr view octocat:statemachine "),
         );
+        expect(openLookupCalls).toHaveLength(1);
+        expect(openLookupCalls[0]).toContain("pr view octocat:statemachine");
       }),
     12_000,
   );
@@ -2870,13 +2943,13 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect("generates PR content against the remote base when the local base is stale", () =>
+  it.effect("generates PR content against a non-origin remote base when local base is stale", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");
       yield* initRepo(repoDir);
       const remoteDir = yield* createBareRemote();
-      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
-      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["remote", "add", "primary", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "primary", "main"]);
       yield* runGit(remoteDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
 
       const peerDir = yield* makeTempDir("t3code-git-peer-");
@@ -2888,18 +2961,18 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       yield* runGit(peerDir, ["commit", "-m", "Remote base commit"]);
       yield* runGit(peerDir, ["push", "origin", "main"]);
 
-      yield* runGit(repoDir, ["fetch", "origin"]);
+      yield* runGit(repoDir, ["fetch", "primary"]);
       yield* runGit(repoDir, [
         "checkout",
         "--no-track",
         "-b",
         "feature/remote-base",
-        "origin/main",
+        "primary/main",
       ]);
       NodeFS.writeFileSync(NodePath.join(repoDir, "feature.txt"), "feature\n");
       yield* runGit(repoDir, ["add", "feature.txt"]);
       yield* runGit(repoDir, ["commit", "-m", "Feature commit"]);
-      yield* runGit(repoDir, ["push", "-u", "origin", "feature/remote-base"]);
+      yield* runGit(repoDir, ["push", "-u", "primary", "feature/remote-base"]);
       yield* runGit(repoDir, ["config", "branch.feature/remote-base.gh-merge-base", "main"]);
 
       let generatedCommitSummary = "";

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -505,6 +505,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             "open",
             "--limit",
             String(input.limit ?? 1),
+            ...(input.repository ? ["--repo", input.repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
           ],
@@ -1122,6 +1123,70 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         });
         expect(ghCalls).toContain(
           "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+        );
+      }),
+    20_000,
+  );
+
+  it.effect(
+    "status detects fork PRs opened against the conventional upstream remote",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        const forkDir = yield* createBareRemote();
+        const upstreamDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", forkDir]);
+        yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/upstream-pr"]);
+        yield* runGit(repoDir, ["push", "-u", "origin", "feature/upstream-pr"]);
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "origin",
+          "git@github.com:contributor/t3code.git",
+          forkDir,
+        );
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "upstream",
+          "git@github.com:T3Tools/t3code.git",
+          upstreamDir,
+        );
+
+        const { manager, ghCalls } = yield* makeManager({
+          ghScenario: {
+            prListSequence: [
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([
+                {
+                  number: 1701,
+                  title: "Fix fork PR detection",
+                  url: "https://github.com/T3Tools/t3code/pull/1701",
+                  baseRefName: "main",
+                  headRefName: "feature/upstream-pr",
+                  state: "OPEN",
+                  updatedAt: "2026-07-11T12:00:00Z",
+                  isCrossRepository: true,
+                  headRepository: { nameWithOwner: "contributor/t3code" },
+                  headRepositoryOwner: { login: "contributor" },
+                },
+              ]),
+            ],
+          },
+        });
+
+        const status = yield* manager.status({ cwd: repoDir });
+
+        expect(status.pr).toEqual({
+          number: 1701,
+          title: "Fix fork PR detection",
+          url: "https://github.com/T3Tools/t3code/pull/1701",
+          baseRef: "main",
+          headRef: "feature/upstream-pr",
+          state: "open",
+        });
+        expect(ghCalls).toContain(
+          "pr list --head contributor:feature/upstream-pr --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -371,13 +371,22 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         headSelectorIndex >= 0 && headSelectorIndex < args.length - 1
           ? args[headSelectorIndex + 1]
           : undefined;
-      const mappedQueue =
+      const mappedHeadSelector =
         typeof headSelector === "string"
-          ? prListQueueByHeadSelector.get(headSelector)?.shift()
+          ? ([
+              ...prListQueueByHeadSelector.keys(),
+              ...Object.keys(scenario.prListByHeadSelector ?? {}),
+            ].find(
+              (candidate) => candidate === headSelector || candidate.endsWith(`:${headSelector}`),
+            ) ?? headSelector)
+          : undefined;
+      const mappedQueue =
+        typeof mappedHeadSelector === "string"
+          ? prListQueueByHeadSelector.get(mappedHeadSelector)?.shift()
           : undefined;
       const mappedStdout =
-        typeof headSelector === "string"
-          ? scenario.prListByHeadSelector?.[headSelector]
+        typeof mappedHeadSelector === "string"
+          ? scenario.prListByHeadSelector?.[mappedHeadSelector]
           : undefined;
       const stdout = (mappedQueue ?? mappedStdout ?? prListQueue.shift() ?? "[]") + "\n";
       return Effect.succeed(fakeGhOutput(stdout));
@@ -493,30 +502,48 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
   return {
     service: {
       execute,
-      listOpenPullRequests: (input) =>
-        execute({
-          cwd: input.cwd,
-          args: [
-            "pr",
-            "list",
-            "--head",
-            input.headSelector,
-            "--state",
-            "open",
-            "--limit",
-            String(input.limit ?? 1),
-            ...(input.repository ? ["--repo", input.repository] : []),
-            "--json",
-            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
-          ],
-        }).pipe(
-          Effect.map((result) => JSON.parse(result.stdout) as unknown[]),
+      listOpenPullRequests: (input) => {
+        const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
+        const requestedLimit = input.limit ?? 1;
+        const args = [
+          "pr",
+          "list",
+          "--head",
+          qualifiedHead?.[2] ?? input.headSelector,
+          "--state",
+          "open",
+          "--limit",
+          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+          ...(input.repository ? ["--repo", input.repository] : []),
+          "--json",
+          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+        ];
+        ghCalls.push(args.join(" "));
+        if (scenario.failWith && ghCalls.length > (scenario.failAfterCalls ?? 0)) {
+          return Effect.fail(scenario.failWith);
+        }
+        const stdout =
+          prListQueueByHeadSelector.get(input.headSelector)?.shift() ??
+          scenario.prListByHeadSelector?.[input.headSelector] ??
+          prListQueue.shift() ??
+          "[]";
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        return Effect.sync(() => JSON.parse(stdout) as unknown[]).pipe(
           Effect.map((raw) =>
             raw
               .map((entry) => normalizeFakePullRequestSummary(entry))
-              .filter((entry): entry is GitHubCli.GitHubPullRequestSummary => entry !== null),
+              .filter((entry): entry is GitHubCli.GitHubPullRequestSummary => entry !== null)
+              .filter(
+                (entry) =>
+                  !qualifiedHead ||
+                  (entry.headRefName === qualifiedHead[2] &&
+                    entry.headRepositoryOwnerLogin?.toLowerCase() ===
+                      qualifiedHead[1]?.toLowerCase()),
+              )
+              .slice(0, requestedLimit),
           ),
-        ),
+        );
+      },
       createPullRequest: (input) =>
         execute({
           cwd: input.cwd,
@@ -1122,7 +1149,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head statemachine --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -1186,7 +1213,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head contributor:feature/upstream-pr --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head feature/upstream-pr --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -2371,8 +2398,6 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           ghScenario: {
             prListSequence: [
               // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
               JSON.stringify([
                 {
                   number: 142,
@@ -2403,7 +2428,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
         expect(
           ghCalls.some((call) =>
-            call.includes("pr list --head octocat:statemachine --state open --limit 1"),
+            call.includes("pr list --head statemachine --state open --limit 100"),
           ),
         ).toBe(true);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -2578,7 +2603,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
 
         const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
-          call.includes("pr list --head octocat:statemachine --state open --limit 1"),
+          call.includes("pr list --head statemachine --state open --limit 100"),
         );
         expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -2647,7 +2672,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         const openLookupCalls = ghCalls.filter((call) => call.includes("--state open --limit 1"));
         expect(openLookupCalls).toHaveLength(1);
         expect(openLookupCalls[0]).toContain(
-          "pr list --head octocat:statemachine --state open --limit 1",
+          "pr list --head statemachine --state open --limit 100",
         );
       }),
     12_000,

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -3089,7 +3089,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       yield* configureVisibleRemoteUrlWithLocalRewrite(
         repoDir,
         "fork-seed",
-        "git@github.com:octocat/codething-mvp.git",
+        "https://github.com/octocat/codething-mvp.git/",
         forkDir,
       );
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -536,7 +536,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
           "--state",
           "open",
           "--limit",
-          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+          String(qualifiedHead ? 100 : requestedLimit),
           ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -412,6 +412,18 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
     }
 
     if (args[0] === "pr" && args[1] === "view") {
+      const selector = args[2];
+      const queuedPullRequests =
+        typeof selector === "string"
+          ? (prListQueueByHeadSelector.get(selector)?.shift() ??
+            scenario.prListByHeadSelector?.[selector] ??
+            prListQueue.shift())
+          : undefined;
+      if (queuedPullRequests !== undefined) {
+        const parsed = JSON.parse(queuedPullRequests) as unknown;
+        const candidate = Array.isArray(parsed) ? parsed[0] : parsed;
+        return Effect.succeed(fakeGhOutput(candidate ? `${JSON.stringify(candidate)}\n` : ""));
+      }
       const pullRequest: FakePullRequest = scenario.pullRequest ?? {
         number: 101,
         title: "Pull request",
@@ -539,9 +551,9 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
           prListQueue.shift() ??
           "[]";
         // @effect-diagnostics-next-line preferSchemaOverJson:off
-        return Effect.sync(() => JSON.parse(stdout) as unknown[]).pipe(
+        return Effect.sync(() => JSON.parse(stdout) as unknown).pipe(
           Effect.map((raw) =>
-            raw
+            (Array.isArray(raw) ? raw : [raw])
               .map((entry) => normalizeFakePullRequestSummary(entry))
               .filter((entry): entry is GitHubCli.GitHubPullRequestSummary => entry !== null)
               .filter(
@@ -1654,6 +1666,62 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("uses the origin fork identity for a branch pushed without tracking", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const originDir = yield* createBareRemote();
+      const upstreamDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", originDir]);
+      yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["push", "upstream", "main"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "origin",
+        "git@github.com:octocat/codething-mvp.git",
+        originDir,
+      );
+      yield* runGit(repoDir, ["config", "remote.origin.pushurl", originDir]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "upstream",
+        "git@github.com:pingdotgg/codething-mvp.git",
+        upstreamDir,
+      );
+      yield* runGit(repoDir, ["checkout", "-b", "feature/pushed-no-tracking"]);
+      yield* runGit(repoDir, ["push", "origin", "feature/pushed-no-tracking"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListByHeadSelector: {
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "octocat:feature/pushed-no-tracking": JSON.stringify([
+              {
+                number: 215,
+                title: "Fork PR without tracking",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/215",
+                baseRefName: "main",
+                headRefName: "feature/pushed-no-tracking",
+                state: "OPEN",
+                isCrossRepository: true,
+                headRepository: { nameWithOwner: "octocat/codething-mvp" },
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
+          },
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.pr?.number).toBe(215);
+      expect(
+        ghCalls.some((call) => call.startsWith("pr view octocat:feature/pushed-no-tracking ")),
+      ).toBe(true);
+    }),
+  );
+
   it("backs off repeated PR lookup failures past the healthy refresh cadence", () => {
     expect(Duration.toMillis(GitManager.prLookupFailureTtl(1))).toBe(20_000);
     expect(Duration.toMillis(GitManager.prLookupFailureTtl(2))).toBe(40_000);
@@ -2079,7 +2147,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head feature/upstream-pr --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr view contributor:feature/upstream-pr --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -3648,11 +3716,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
         expect(result.pr.status).toBe("opened_existing");
         expect(result.pr.number).toBe(142);
-        expect(
-          ghCalls.some((call) =>
-            call.includes("pr list --head statemachine --state open --limit 100"),
-          ),
-        ).toBe(true);
+        expect(ghCalls.some((call) => call.startsWith("pr view octocat:statemachine "))).toBe(true);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
       }),
     12_000,
@@ -3825,7 +3889,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
 
         const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
-          call.includes("pr list --head statemachine --state open --limit 100"),
+          call.startsWith("pr view octocat:statemachine "),
         );
         expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -3891,11 +3955,11 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.status).toBe("opened_existing");
         expect(result.pr.number).toBe(142);
 
-        const openLookupCalls = ghCalls.filter((call) => call.includes("--state open --limit 1"));
-        expect(openLookupCalls).toHaveLength(1);
-        expect(openLookupCalls[0]).toContain(
-          "pr list --head statemachine --state open --limit 100",
+        const openLookupCalls = ghCalls.filter((call) =>
+          call.startsWith("pr view octocat:statemachine "),
         );
+        expect(openLookupCalls).toHaveLength(1);
+        expect(openLookupCalls[0]).toContain("pr view octocat:statemachine");
       }),
     12_000,
   );
@@ -4092,13 +4156,13 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect("generates PR content against the remote base when the local base is stale", () =>
+  it.effect("generates PR content against a non-origin remote base when local base is stale", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");
       yield* initRepo(repoDir);
       const remoteDir = yield* createBareRemote();
-      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
-      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["remote", "add", "primary", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "primary", "main"]);
       yield* runGit(remoteDir, ["symbolic-ref", "HEAD", "refs/heads/main"]);
 
       const peerDir = yield* makeTempDir("t3code-git-peer-");
@@ -4110,18 +4174,18 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       yield* runGit(peerDir, ["commit", "-m", "Remote base commit"]);
       yield* runGit(peerDir, ["push", "origin", "main"]);
 
-      yield* runGit(repoDir, ["fetch", "origin"]);
+      yield* runGit(repoDir, ["fetch", "primary"]);
       yield* runGit(repoDir, [
         "checkout",
         "--no-track",
         "-b",
         "feature/remote-base",
-        "origin/main",
+        "primary/main",
       ]);
       NodeFS.writeFileSync(NodePath.join(repoDir, "feature.txt"), "feature\n");
       yield* runGit(repoDir, ["add", "feature.txt"]);
       yield* runGit(repoDir, ["commit", "-m", "Feature commit"]);
-      yield* runGit(repoDir, ["push", "-u", "origin", "feature/remote-base"]);
+      yield* runGit(repoDir, ["push", "-u", "primary", "feature/remote-base"]);
       yield* runGit(repoDir, ["config", "branch.feature/remote-base.gh-merge-base", "main"]);
 
       let generatedCommitSummary = "";

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -4425,6 +4425,63 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       }),
   );
 
+  it.effect("creates a same-repository PR against its non-default tracked base", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "origin", "main:release"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/same-repo-base"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "same-repo.txt"), "change\n");
+      yield* runGit(repoDir, ["add", "same-repo.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Same-repository feature"]);
+      yield* runGit(repoDir, ["push", "origin", "HEAD:feature/same-repo-base"]);
+      yield* runGit(repoDir, ["branch", "--set-upstream-to", "origin/release"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "origin",
+        "git@github.com:T3Tools/t3code.git",
+        remoteDir,
+      );
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequenceByHeadSelector: {
+            "feature/same-repo-base": [
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([]),
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([
+                {
+                  number: 1706,
+                  title: "Same-repository feature",
+                  url: "https://github.com/T3Tools/t3code/pull/1706",
+                  baseRefName: "release",
+                  headRefName: "feature/same-repo-base",
+                  state: "OPEN",
+                  isCrossRepository: false,
+                },
+              ]),
+            ],
+          },
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+      });
+
+      expect(result.pr.number).toBe(1706);
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr create --base release --head feature/same-repo-base"),
+        ),
+      ).toBe(true);
+    }),
+  );
+
   it.effect("creates an enterprise fork PR from the local branch against its tracked base", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -382,13 +382,22 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         headSelectorIndex >= 0 && headSelectorIndex < args.length - 1
           ? args[headSelectorIndex + 1]
           : undefined;
-      const mappedQueue =
+      const mappedHeadSelector =
         typeof headSelector === "string"
-          ? prListQueueByHeadSelector.get(headSelector)?.shift()
+          ? ([
+              ...prListQueueByHeadSelector.keys(),
+              ...Object.keys(scenario.prListByHeadSelector ?? {}),
+            ].find(
+              (candidate) => candidate === headSelector || candidate.endsWith(`:${headSelector}`),
+            ) ?? headSelector)
+          : undefined;
+      const mappedQueue =
+        typeof mappedHeadSelector === "string"
+          ? prListQueueByHeadSelector.get(mappedHeadSelector)?.shift()
           : undefined;
       const mappedStdout =
-        typeof headSelector === "string"
-          ? scenario.prListByHeadSelector?.[headSelector]
+        typeof mappedHeadSelector === "string"
+          ? scenario.prListByHeadSelector?.[mappedHeadSelector]
           : undefined;
       const stdout = (mappedQueue ?? mappedStdout ?? prListQueue.shift() ?? "[]") + "\n";
       return Effect.succeed(fakeGhOutput(stdout));
@@ -504,30 +513,48 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
   return {
     service: {
       execute,
-      listOpenPullRequests: (input) =>
-        execute({
-          cwd: input.cwd,
-          args: [
-            "pr",
-            "list",
-            "--head",
-            input.headSelector,
-            "--state",
-            "open",
-            "--limit",
-            String(input.limit ?? 1),
-            ...(input.repository ? ["--repo", input.repository] : []),
-            "--json",
-            "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
-          ],
-        }).pipe(
-          Effect.map((result) => JSON.parse(result.stdout) as unknown[]),
+      listOpenPullRequests: (input) => {
+        const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
+        const requestedLimit = input.limit ?? 1;
+        const args = [
+          "pr",
+          "list",
+          "--head",
+          qualifiedHead?.[2] ?? input.headSelector,
+          "--state",
+          "open",
+          "--limit",
+          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+          ...(input.repository ? ["--repo", input.repository] : []),
+          "--json",
+          "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
+        ];
+        ghCalls.push(args.join(" "));
+        if (scenario.failWith && ghCalls.length > (scenario.failAfterCalls ?? 0)) {
+          return Effect.fail(scenario.failWith);
+        }
+        const stdout =
+          prListQueueByHeadSelector.get(input.headSelector)?.shift() ??
+          scenario.prListByHeadSelector?.[input.headSelector] ??
+          prListQueue.shift() ??
+          "[]";
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        return Effect.sync(() => JSON.parse(stdout) as unknown[]).pipe(
           Effect.map((raw) =>
             raw
               .map((entry) => normalizeFakePullRequestSummary(entry))
-              .filter((entry): entry is GitHubCli.GitHubPullRequestSummary => entry !== null),
+              .filter((entry): entry is GitHubCli.GitHubPullRequestSummary => entry !== null)
+              .filter(
+                (entry) =>
+                  !qualifiedHead ||
+                  (entry.headRefName === qualifiedHead[2] &&
+                    entry.headRepositoryOwnerLogin?.toLowerCase() ===
+                      qualifiedHead[1]?.toLowerCase()),
+              )
+              .slice(0, requestedLimit),
           ),
-        ),
+        );
+      },
       createPullRequest: (input) =>
         execute({
           cwd: input.cwd,
@@ -1922,7 +1949,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           updatedAt: "2026-03-10T07:00:00.000Z",
         });
         expect(ghCalls).toContain(
-          "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head statemachine --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -2052,7 +2079,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head contributor:feature/upstream-pr --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head feature/upstream-pr --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -3593,8 +3620,6 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           ghScenario: {
             prListSequence: [
               // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
               JSON.stringify([
                 {
                   number: 142,
@@ -3625,7 +3650,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
         expect(
           ghCalls.some((call) =>
-            call.includes("pr list --head octocat:statemachine --state open --limit 1"),
+            call.includes("pr list --head statemachine --state open --limit 100"),
           ),
         ).toBe(true);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -3800,7 +3825,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
 
         const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
-          call.includes("pr list --head octocat:statemachine --state open --limit 1"),
+          call.includes("pr list --head statemachine --state open --limit 100"),
         );
         expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -3869,7 +3894,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         const openLookupCalls = ghCalls.filter((call) => call.includes("--state open --limit 1"));
         expect(openLookupCalls).toHaveLength(1);
         expect(openLookupCalls[0]).toContain(
-          "pr list --head octocat:statemachine --state open --limit 1",
+          "pr list --head statemachine --state open --limit 100",
         );
       }),
     12_000,

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2236,6 +2236,59 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
   );
 
   it.effect(
+    "does not treat repositories on different GitHub Enterprise hosts as forks",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        const originDir = yield* createBareRemote();
+        const upstreamDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", originDir]);
+        yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/host-isolation"]);
+        yield* runGit(repoDir, ["push", "-u", "origin", "feature/host-isolation"]);
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "origin",
+          "git@github.one.test:contributor/t3code.git",
+          originDir,
+        );
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "upstream",
+          "git@github.two.test:T3Tools/t3code.git",
+          upstreamDir,
+        );
+
+        const { manager, ghCalls } = yield* makeManager({
+          ghScenario: {
+            prListByHeadSelector: {
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              "feature/host-isolation": JSON.stringify([
+                {
+                  number: 1705,
+                  title: "Host-isolated PR",
+                  url: "https://github.one.test/contributor/t3code/pull/1705",
+                  baseRefName: "main",
+                  headRefName: "feature/host-isolation",
+                  state: "OPEN",
+                  updatedAt: "2026-08-02T12:00:00Z",
+                  isCrossRepository: false,
+                },
+              ]),
+            },
+          },
+        });
+
+        const status = yield* manager.status({ cwd: repoDir });
+
+        expect(status.pr?.number).toBe(1705);
+        expect(ghCalls.some((call) => call.includes("--head contributor:"))).toBe(false);
+      }),
+    20_000,
+  );
+
+  it.effect(
     "status ignores synthetic local branch aliases when the upstream remote name contains slashes",
     () =>
       Effect.gen(function* () {

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2163,6 +2163,79 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
   );
 
   it.effect(
+    "status uses the local branch when a fork checkout still tracks origin main",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        const forkDir = yield* createBareRemote();
+        const upstreamDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", forkDir]);
+        yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+        yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+        yield* runGit(repoDir, ["push", "upstream", "main"]);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/from-main"]);
+        yield* runGit(repoDir, ["push", "origin", "HEAD:feature/from-main"]);
+        yield* runGit(repoDir, ["branch", "--set-upstream-to", "origin/main"]);
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "origin",
+          "git@github.com:contributor/t3code.git",
+          forkDir,
+        );
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "upstream",
+          "git@github.com:T3Tools/t3code.git",
+          upstreamDir,
+        );
+
+        const { manager, ghCalls } = yield* makeManager({
+          ghScenario: {
+            prListByHeadSelector: {
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              "contributor:main": JSON.stringify([
+                {
+                  number: 1702,
+                  title: "Unrelated default-branch PR",
+                  url: "https://github.com/T3Tools/t3code/pull/1702",
+                  baseRefName: "feature/elsewhere",
+                  headRefName: "main",
+                  state: "OPEN",
+                  isCrossRepository: true,
+                  headRepository: { nameWithOwner: "contributor/t3code" },
+                  headRepositoryOwner: { login: "contributor" },
+                },
+              ]),
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              "contributor:feature/from-main": JSON.stringify([
+                {
+                  number: 1703,
+                  title: "Feature PR",
+                  url: "https://github.com/T3Tools/t3code/pull/1703",
+                  baseRefName: "main",
+                  headRefName: "feature/from-main",
+                  state: "OPEN",
+                  updatedAt: "2026-08-01T12:00:00Z",
+                  isCrossRepository: true,
+                  headRepository: { nameWithOwner: "contributor/t3code" },
+                  headRepositoryOwner: { login: "contributor" },
+                },
+              ]),
+            },
+          },
+        });
+
+        const status = yield* manager.status({ cwd: repoDir });
+
+        expect(status.pr?.number).toBe(1703);
+        expect(ghCalls.some((call) => call.includes("--head contributor:main "))).toBe(false);
+        expect(ghCalls.some((call) => call.includes("--head feature/from-main "))).toBe(true);
+      }),
+    20_000,
+  );
+
+  it.effect(
     "status ignores synthetic local branch aliases when the upstream remote name contains slashes",
     () =>
       Effect.gen(function* () {
@@ -4297,6 +4370,76 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           ),
         ).toBe(true);
       }),
+  );
+
+  it.effect("creates an enterprise fork PR from the local branch against its tracked base", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const forkDir = yield* createBareRemote();
+      const upstreamDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", forkDir]);
+      yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+      yield* runGit(repoDir, ["push", "origin", "main:release"]);
+      yield* runGit(repoDir, ["push", "upstream", "main:release"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/enterprise"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "enterprise.txt"), "change\n");
+      yield* runGit(repoDir, ["add", "enterprise.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Enterprise feature"]);
+      yield* runGit(repoDir, ["push", "origin", "HEAD:feature/enterprise"]);
+      yield* runGit(repoDir, ["branch", "--set-upstream-to", "origin/release"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "origin",
+        "git@github.enterprise.test:contributor/t3code.git",
+        forkDir,
+      );
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "upstream",
+        "git@github.enterprise.test:T3Tools/t3code.git",
+        upstreamDir,
+      );
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequenceByHeadSelector: {
+            "contributor:feature/enterprise": [
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([]),
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([
+                {
+                  number: 1704,
+                  title: "Enterprise feature",
+                  url: "https://github.enterprise.test/T3Tools/t3code/pull/1704",
+                  baseRefName: "release",
+                  headRefName: "feature/enterprise",
+                  state: "OPEN",
+                  isCrossRepository: true,
+                  headRepository: { nameWithOwner: "contributor/t3code" },
+                  headRepositoryOwner: { login: "contributor" },
+                },
+              ]),
+            ],
+          },
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+      });
+
+      expect(result.pr.status).toBe("created");
+      expect(result.pr.number).toBe(1704);
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr create --base release --head contributor:feature/enterprise"),
+        ),
+      ).toBe(true);
+      expect(ghCalls.some((call) => call.includes("--head contributor:release "))).toBe(false);
+    }),
   );
 
   it.effect("creates cross-repo PRs with the fork owner selector and default base branch", () =>

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -666,7 +666,6 @@ function preparePullRequestThread(
 
 function makeManager(input?: {
   ghScenario?: FakeGhScenario;
-  sourceControlProvider?: SourceControlProvider["Service"];
   textGeneration?: Partial<FakeGitTextGeneration>;
   serverSettings?: Parameters<typeof ServerSettings.layerTest>[0];
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -37,7 +37,7 @@ import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubSourceControlProvider from "../sourceControl/GitHubSourceControlProvider.ts";
 import * as GitLabSourceControlProvider from "../sourceControl/GitLabSourceControlProvider.ts";
-import type { SourceControlProvider } from "../sourceControl/SourceControlProvider.ts";
+import * as SourceControlProvider from "../sourceControl/SourceControlProvider.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectSetupScriptRunner from "../project/ProjectSetupScriptRunner.ts";
@@ -671,6 +671,7 @@ function makeManager(input?: {
   serverSettings?: Parameters<typeof ServerSettings.layerTest>[0];
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
   gitConfigReads?: string[];
+  sourceControlProvider?: SourceControlProvider.SourceControlProvider["Service"];
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
   const textGeneration = createTextGeneration(input?.textGeneration);
@@ -706,9 +707,11 @@ function makeManager(input?: {
       );
   const sourceControlRegistryLayer = Layer.effect(
     SourceControlProviderRegistry.SourceControlProviderRegistry,
-    (input?.sourceControlProvider === undefined
-      ? GitHubSourceControlProvider.make
-      : Effect.succeed(input.sourceControlProvider)
+    (input?.sourceControlProvider
+      ? Effect.succeed(input.sourceControlProvider)
+      : GitHubSourceControlProvider.make.pipe(
+          Effect.provide(Layer.succeed(GitHubCli.GitHubCli, gitHubCli)),
+        )
     ).pipe(
       Effect.map((provider) =>
         SourceControlProviderRegistry.SourceControlProviderRegistry.of({
@@ -718,7 +721,6 @@ function makeManager(input?: {
           discover: Effect.succeed([]),
         }),
       ),
-      Effect.provide(Layer.succeed(GitHubCli.GitHubCli, gitHubCli)),
     ),
   );
 
@@ -1372,7 +1374,9 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         updatedAt: "2026-04-05T15:00:00.000Z",
       });
       expect(
-        ghCalls.some((call) => call.startsWith("pr view contributor:feature/deleted-fork-branch ")),
+        ghCalls.some((call) =>
+          call.startsWith("pr list --head feature/deleted-fork-branch --state all --limit 100 "),
+        ),
       ).toBe(true);
     }),
   );
@@ -1717,7 +1721,9 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
       expect(status.pr?.number).toBe(215);
       expect(
-        ghCalls.some((call) => call.startsWith("pr view octocat:feature/pushed-no-tracking ")),
+        ghCalls.some((call) =>
+          call.startsWith("pr list --head feature/pushed-no-tracking --state all --limit 100 "),
+        ),
       ).toBe(true);
     }),
   );
@@ -2083,7 +2089,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           updatedAt: "2026-03-10T07:00:00.000Z",
         });
         expect(ghCalls).toContain(
-          "pr list --head contributor:main --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head main --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -2101,6 +2107,8 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
         yield* runGit(repoDir, ["checkout", "-b", "feature/upstream-pr"]);
         yield* runGit(repoDir, ["push", "-u", "origin", "feature/upstream-pr"]);
+        yield* runGit(repoDir, ["update-ref", "refs/remotes/upstream/feature/upstream-pr", "HEAD"]);
+        yield* runGit(repoDir, ["branch", "--set-upstream-to", "upstream/feature/upstream-pr"]);
         yield* configureVisibleRemoteUrlWithLocalRewrite(
           repoDir,
           "origin",
@@ -2148,7 +2156,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           updatedAt: "2026-07-11T12:00:00.000Z",
         });
         expect(ghCalls).toContain(
-          "pr view contributor:feature/upstream-pr --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head feature/upstream-pr --state all --limit 100 --json number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,
@@ -2471,9 +2479,11 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
         const status = yield* manager.status({ cwd: repoDir });
         expect(status.pr?.number).toBe(89);
-        expect(ghCalls.some((call) => call.includes("--head contributor:feature/fork-plain"))).toBe(
-          true,
-        );
+        expect(
+          ghCalls.some((call) =>
+            call.includes("--head feature/fork-plain --state all --limit 100"),
+          ),
+        ).toBe(true);
         expect(ghCalls.some((call) => call.includes("--head main"))).toBe(false);
       }),
   );
@@ -3717,7 +3727,9 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
         expect(result.pr.status).toBe("opened_existing");
         expect(result.pr.number).toBe(142);
-        expect(ghCalls.some((call) => call.startsWith("pr view octocat:statemachine "))).toBe(true);
+        expect(
+          ghCalls.some((call) => call.startsWith("pr list --head statemachine --state open ")),
+        ).toBe(true);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
       }),
     12_000,
@@ -3890,7 +3902,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
 
         const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
-          call.startsWith("pr view octocat:statemachine "),
+          call.startsWith("pr list --head statemachine --state open --limit 100 "),
         );
         expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
@@ -3957,10 +3969,10 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
 
         const openLookupCalls = ghCalls.filter((call) =>
-          call.startsWith("pr view octocat:statemachine "),
+          call.startsWith("pr list --head statemachine --state open --limit 100 "),
         );
         expect(openLookupCalls).toHaveLength(1);
-        expect(openLookupCalls[0]).toContain("pr view octocat:statemachine");
+        expect(openLookupCalls[0]).toContain("pr list --head statemachine");
       }),
     12_000,
   );
@@ -4355,6 +4367,76 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           call.includes("pr create --base statemachine --head octocat:statemachine"),
         ),
       ).toBe(false);
+    }),
+  );
+
+  it.effect("omits GitHub-shaped source repositories for non-GitHub PR creation", () =>
+    Effect.gen(function* () {
+      for (const scenario of [
+        { kind: "gitlab" as const, remoteUrl: "git@gitlab.com:group/project.git" },
+        { kind: "bitbucket" as const, remoteUrl: "git@bitbucket.org:workspace/project.git" },
+      ]) {
+        const repoDir = yield* makeTempDir(`t3code-git-manager-${scenario.kind}-`);
+        yield* initRepo(repoDir);
+        const remoteDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+        yield* runGit(repoDir, ["checkout", "-b", `feature/${scenario.kind}-source`]);
+        yield* runGit(repoDir, ["push", "-u", "origin", `feature/${scenario.kind}-source`]);
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "origin",
+          scenario.remoteUrl,
+          remoteDir,
+        );
+
+        let listCalls = 0;
+        let createInput:
+          | Parameters<
+              SourceControlProvider.SourceControlProvider["Service"]["createChangeRequest"]
+            >[0]
+          | null = null;
+        const sourceControlProvider = SourceControlProvider.SourceControlProvider.of({
+          kind: scenario.kind,
+          listChangeRequests: () => {
+            listCalls++;
+            return Effect.succeed(
+              listCalls === 1
+                ? []
+                : [
+                    {
+                      provider: scenario.kind,
+                      number: 42,
+                      title: "Provider PR",
+                      url: `https://example.test/pull/42`,
+                      baseRefName: "main",
+                      headRefName: `feature/${scenario.kind}-source`,
+                      state: "open" as const,
+                      updatedAt: Option.none(),
+                    },
+                  ],
+            );
+          },
+          getChangeRequest: () => Effect.die("unexpected getChangeRequest"),
+          createChangeRequest: (request) =>
+            Effect.sync(() => {
+              createInput = request;
+            }),
+          getRepositoryCloneUrls: () => Effect.die("unexpected getRepositoryCloneUrls"),
+          createRepository: () => Effect.die("unexpected createRepository"),
+          getDefaultBranch: () => Effect.succeed("main"),
+          checkoutChangeRequest: () => Effect.die("unexpected checkoutChangeRequest"),
+        });
+        const { manager } = yield* makeManager({ sourceControlProvider });
+
+        const result = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "create_pr",
+        });
+
+        expect(result.pr.status).toBe("created");
+        expect(createInput).not.toBeNull();
+        expect(createInput).not.toHaveProperty("source");
+      }
     }),
   );
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1372,7 +1372,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         updatedAt: "2026-04-05T15:00:00.000Z",
       });
       expect(
-        ghCalls.some((call) => call.includes("--head contributor:feature/deleted-fork-branch")),
+        ghCalls.some((call) => call.startsWith("pr view contributor:feature/deleted-fork-branch ")),
       ).toBe(true);
     }),
   );
@@ -2145,6 +2145,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           baseRef: "main",
           headRef: "feature/upstream-pr",
           state: "open",
+          updatedAt: "2026-07-11T12:00:00.000Z",
         });
         expect(ghCalls).toContain(
           "pr view contributor:feature/upstream-pr --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -4302,7 +4303,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       yield* configureVisibleRemoteUrlWithLocalRewrite(
         repoDir,
         "fork-seed",
-        "git@github.com:octocat/codething-mvp.git",
+        "https://github.com/octocat/codething-mvp.git/",
         forkDir,
       );
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -516,6 +516,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             "open",
             "--limit",
             String(input.limit ?? 1),
+            ...(input.repository ? ["--repo", input.repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
           ],
@@ -1988,6 +1989,70 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         });
         expect(ghCalls).toContain(
           "pr list --head contributor:main --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+        );
+      }),
+    20_000,
+  );
+
+  it.effect(
+    "status detects fork PRs opened against the conventional upstream remote",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        const forkDir = yield* createBareRemote();
+        const upstreamDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "origin", forkDir]);
+        yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/upstream-pr"]);
+        yield* runGit(repoDir, ["push", "-u", "origin", "feature/upstream-pr"]);
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "origin",
+          "git@github.com:contributor/t3code.git",
+          forkDir,
+        );
+        yield* configureVisibleRemoteUrlWithLocalRewrite(
+          repoDir,
+          "upstream",
+          "git@github.com:T3Tools/t3code.git",
+          upstreamDir,
+        );
+
+        const { manager, ghCalls } = yield* makeManager({
+          ghScenario: {
+            prListSequence: [
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([
+                {
+                  number: 1701,
+                  title: "Fix fork PR detection",
+                  url: "https://github.com/T3Tools/t3code/pull/1701",
+                  baseRefName: "main",
+                  headRefName: "feature/upstream-pr",
+                  state: "OPEN",
+                  updatedAt: "2026-07-11T12:00:00Z",
+                  isCrossRepository: true,
+                  headRepository: { nameWithOwner: "contributor/t3code" },
+                  headRepositoryOwner: { login: "contributor" },
+                },
+              ]),
+            ],
+          },
+        });
+
+        const status = yield* manager.status({ cwd: repoDir });
+
+        expect(status.pr).toEqual({
+          number: 1701,
+          title: "Fix fork PR detection",
+          url: "https://github.com/T3Tools/t3code/pull/1701",
+          baseRef: "main",
+          headRef: "feature/upstream-pr",
+          state: "open",
+        });
+        expect(ghCalls).toContain(
+          "pr list --head contributor:feature/upstream-pr --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         );
       }),
     20_000,

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1199,19 +1199,21 @@ export const make = Effect.gen(function* () {
       upstreamRepository.repositoryNameWithOwner,
     );
     const targetRepository = upstreamIsRelated ? upstreamRepository : originRepository;
-    const targetRemoteName = upstreamIsRelated ? "upstream" : "origin";
+    const targetRemoteName = upstreamIsRelated ? "upstream" : null;
+    const headRepository =
+      remoteRepository.repositoryNameWithOwner ??
+      (remoteName === null ? originRepository.repositoryNameWithOwner : null);
+    const headRepositoryOwnerLogin = parseRepositoryOwnerLogin(headRepository);
     const isCrossRepository =
-      remoteRepository.repositoryNameWithOwner !== null &&
-      targetRepository.repositoryNameWithOwner !== null
-        ? remoteRepository.repositoryNameWithOwner.toLowerCase() !==
-          targetRepository.repositoryNameWithOwner.toLowerCase()
+      headRepository !== null && targetRepository.repositoryNameWithOwner !== null
+        ? headRepository.toLowerCase() !== targetRepository.repositoryNameWithOwner.toLowerCase()
         : remoteName !== null &&
           remoteName !== "origin" &&
           remoteRepository.repositoryNameWithOwner !== null;
 
     const ownerHeadSelector =
-      remoteRepository.ownerLogin && headBranch.length > 0
-        ? `${remoteRepository.ownerLogin}:${headBranch}`
+      headRepositoryOwnerLogin && headBranch.length > 0
+        ? `${headRepositoryOwnerLogin}:${headBranch}`
         : null;
     const remoteAliasHeadSelector =
       remoteName && headBranch.length > 0 ? `${remoteName}:${headBranch}` : null;
@@ -1249,8 +1251,8 @@ export const make = Effect.gen(function* () {
       headRemoteUrlKey:
         remoteRepository.remoteUrlKey ??
         (remoteName === null ? originRepository.remoteUrlKey : null),
-      headRepositoryNameWithOwner: remoteRepository.repositoryNameWithOwner,
-      headRepositoryOwnerLogin: remoteRepository.ownerLogin,
+      headRepositoryNameWithOwner: headRepository,
+      headRepositoryOwnerLogin,
       isCrossRepository,
     } satisfies BranchHeadContext;
   });

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -238,6 +238,7 @@ function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): st
   try {
     const parsed = new URL(trimmed);
     const [owner, name, ...rest] = parsed.pathname
+      .replace(/\/+$/, "")
       .replace(/\.git$/i, "")
       .split("/")
       .filter((part) => part.length > 0);

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1150,19 +1150,22 @@ export const make = Effect.gen(function* () {
     const shouldProbeLocalBranchSelector =
       headBranchFromUpstream.length === 0 || headBranch === details.branch;
 
-    const [remoteRepository, originRepository] = yield* Effect.all(
+    const [remoteRepository, upstreamRepository, originRepository] = yield* Effect.all(
       [
         resolveRemoteRepositoryContext(cwd, remoteName),
+        resolveRemoteRepositoryContext(cwd, "upstream"),
         resolveRemoteRepositoryContext(cwd, "origin"),
       ],
       { concurrency: "unbounded" },
     );
 
+    const targetRepository =
+      upstreamRepository.repositoryNameWithOwner !== null ? upstreamRepository : originRepository;
     const isCrossRepository =
       remoteRepository.repositoryNameWithOwner !== null &&
-      originRepository.repositoryNameWithOwner !== null
+      targetRepository.repositoryNameWithOwner !== null
         ? remoteRepository.repositoryNameWithOwner.toLowerCase() !==
-          originRepository.repositoryNameWithOwner.toLowerCase()
+          targetRepository.repositoryNameWithOwner.toLowerCase()
         : remoteName !== null &&
           remoteName !== "origin" &&
           remoteRepository.repositoryNameWithOwner !== null;

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1721,6 +1721,17 @@ export const make = Effect.gen(function* () {
         cwd,
         baseRefName: baseBranch,
         headSelector: headContext.preferredHeadSelector,
+        ...(headContext.headRepositoryNameWithOwner
+          ? {
+              source: {
+                refName: headContext.headBranch,
+                ...(headContext.headRepositoryOwnerLogin
+                  ? { owner: headContext.headRepositoryOwnerLogin }
+                  : {}),
+                repository: headContext.headRepositoryNameWithOwner,
+              },
+            }
+          : {}),
         title: generated.title,
         bodyFile,
       })

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -176,6 +176,7 @@ interface BranchHeadContext {
   headSelectors: ReadonlyArray<string>;
   preferredHeadSelector: string;
   remoteName: string | null;
+  targetRemoteName: string | null;
   headRemoteUrlKey: string | null;
   headRepositoryNameWithOwner: string | null;
   headRepositoryOwnerLogin: string | null;
@@ -228,12 +229,43 @@ function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): st
     return null;
   }
 
-  const match =
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/|git:\/\/github\.com\/)([^/\s]+\/[^/\s]+?)(?:\.git)?\/?$/i.exec(
-      trimmed,
-    );
-  const repositoryNameWithOwner = match?.[1]?.trim() ?? "";
-  return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
+  const scpStyle = /^git@([^:/\s]+):([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(trimmed);
+  if (scpStyle?.[1] && scpStyle[2] && scpStyle[3]) {
+    return scpStyle[1].toLowerCase() === "github.com"
+      ? `${scpStyle[2]}/${scpStyle[3]}`
+      : `${scpStyle[1]}/${scpStyle[2]}/${scpStyle[3]}`;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    const [owner, name, ...rest] = parsed.pathname
+      .replace(/\.git$/i, "")
+      .split("/")
+      .filter((part) => part.length > 0);
+    if (!owner || !name || rest.length > 0) return null;
+    return parsed.hostname.toLowerCase() === "github.com"
+      ? `${owner}/${name}`
+      : `${parsed.hostname}/${owner}/${name}`;
+  } catch {
+    return null;
+  }
+}
+
+function repositoryCoordinatesMatchAsForks(left: string | null, right: string | null): boolean {
+  const parse = (value: string | null) => {
+    const parts = value?.split("/") ?? [];
+    if (parts.length === 2) return { host: "github.com", owner: parts[0], name: parts[1] };
+    if (parts.length === 3) return { host: parts[0], owner: parts[1], name: parts[2] };
+    return null;
+  };
+  const leftCoordinate = parse(left);
+  const rightCoordinate = parse(right);
+  return Boolean(
+    leftCoordinate &&
+    rightCoordinate &&
+    leftCoordinate.host?.toLowerCase() === rightCoordinate.host?.toLowerCase() &&
+    leftCoordinate.name?.toLowerCase() === rightCoordinate.name?.toLowerCase() &&
+    leftCoordinate.owner?.toLowerCase() !== rightCoordinate.owner?.toLowerCase(),
+  );
 }
 
 function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null {
@@ -241,7 +273,8 @@ function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null 
   if (trimmed.length === 0) {
     return null;
   }
-  const [ownerLogin] = trimmed.split("/");
+  const parts = trimmed.split("/");
+  const ownerLogin = parts.length === 3 ? parts[1] : parts[0];
   const normalizedOwnerLogin = ownerLogin?.trim() ?? "";
   return normalizedOwnerLogin.length > 0 ? normalizedOwnerLogin : null;
 }
@@ -1159,8 +1192,14 @@ export const make = Effect.gen(function* () {
       { concurrency: "unbounded" },
     );
 
-    const targetRepository =
-      upstreamRepository.repositoryNameWithOwner !== null ? upstreamRepository : originRepository;
+    const forkRepository =
+      remoteRepository.repositoryNameWithOwner ?? originRepository.repositoryNameWithOwner;
+    const upstreamIsRelated = repositoryCoordinatesMatchAsForks(
+      forkRepository,
+      upstreamRepository.repositoryNameWithOwner,
+    );
+    const targetRepository = upstreamIsRelated ? upstreamRepository : originRepository;
+    const targetRemoteName = upstreamIsRelated ? "upstream" : "origin";
     const isCrossRepository =
       remoteRepository.repositoryNameWithOwner !== null &&
       targetRepository.repositoryNameWithOwner !== null
@@ -1206,6 +1245,7 @@ export const make = Effect.gen(function* () {
       preferredHeadSelector:
         ownerHeadSelector && isCrossRepository ? ownerHeadSelector : headBranch,
       remoteName,
+      targetRemoteName,
       headRemoteUrlKey:
         remoteRepository.remoteUrlKey ??
         (remoteName === null ? originRepository.remoteUrlKey : null),
@@ -1447,10 +1487,11 @@ export const make = Effect.gen(function* () {
   const resolveBaseRangeRef = Effect.fn("resolveBaseRangeRef")(function* (
     cwd: string,
     baseBranch: string,
+    targetRemoteName: string | null,
   ) {
-    const remoteName = yield* gitCore
-      .resolvePrimaryRemoteName(cwd)
-      .pipe(Effect.orElseSucceed(() => null));
+    const remoteName =
+      targetRemoteName ??
+      (yield* gitCore.resolvePrimaryRemoteName(cwd).pipe(Effect.orElseSucceed(() => null)));
     if (!remoteName) return baseBranch;
 
     return yield* gitCore
@@ -1676,7 +1717,7 @@ export const make = Effect.gen(function* () {
       phase: "pr",
       label: `Generating ${terms.shortLabel} content...`,
     });
-    const baseRangeRef = yield* resolveBaseRangeRef(cwd, baseBranch);
+    const baseRangeRef = yield* resolveBaseRangeRef(cwd, baseBranch, headContext.targetRemoteName);
     const rangeContext = yield* gitCore.readRangeContext(cwd, baseRangeRef);
     const policy = yield* resolveStylePolicy(cwd, settings.style);
     const changeRequestTemplate =

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1540,26 +1540,25 @@ export const make = Effect.gen(function* () {
       headContext.headBranch === details.defaultBranch ||
       (details.defaultBranch === null &&
         (headContext.headBranch === "main" || headContext.headBranch === "master"));
-    if (
-      !headContext.trackingRefIsBase &&
-      (headContext.headBranch === details.branch ||
-        !upstreamHeadIsDefault ||
-        headContext.isCrossRepository)
-    ) {
+    if (headContext.headBranch === details.branch) {
       return { headContext, lookup: true };
     }
     const remoteName = yield* findRemoteTrackingRemote(cwd, details.branch, headContext.remoteName);
-    if (remoteName === null) {
-      return { headContext, lookup: false };
+    if (remoteName !== null) {
+      const ownNameContext = yield* resolveBranchHeadContext(cwd, {
+        branch: details.branch,
+        upstreamRef: null,
+        remoteName,
+      });
+      return {
+        headContext: { ...ownNameContext, trackingRefIsBase: true },
+        lookup: true,
+      };
     }
-    const ownNameContext = yield* resolveBranchHeadContext(cwd, {
-      branch: details.branch,
-      upstreamRef: null,
-      remoteName,
-    });
     return {
-      headContext: { ...ownNameContext, trackingRefIsBase: headContext.trackingRefIsBase },
-      lookup: true,
+      headContext,
+      lookup:
+        !headContext.trackingRefIsBase && (!upstreamHeadIsDefault || headContext.isCrossRepository),
     };
   });
 
@@ -1776,20 +1775,19 @@ export const make = Effect.gen(function* () {
     cwd: string,
     branch: string,
     upstreamRef: string | null,
-    headContext: Pick<BranchHeadContext, "headBranch" | "remoteName" | "trackingRefIsBase">,
+    headContext: Pick<
+      BranchHeadContext,
+      "headBranch" | "isCrossRepository" | "remoteName" | "trackingRefIsBase"
+    >,
   ) {
     const configured = yield* gitCore.readConfigValue(cwd, `branch.${branch}.gh-merge-base`);
     if (configured) return configured;
 
-    if (upstreamRef && headContext.trackingRefIsBase) {
+    if (upstreamRef && (headContext.trackingRefIsBase || !headContext.isCrossRepository)) {
       const upstreamBranch = extractBranchNameFromRemoteRef(upstreamRef, {
         remoteName: headContext.remoteName,
       });
-      if (
-        upstreamBranch.length > 0 &&
-        upstreamBranch !== branch &&
-        upstreamBranch !== headContext.headBranch
-      ) {
+      if (upstreamBranch.length > 0 && upstreamBranch !== branch) {
         return upstreamBranch;
       }
     }

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -286,6 +286,7 @@ function parseRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string |
   try {
     const parsed = new URL(trimmed);
     const [owner, name, ...rest] = parsed.pathname
+      .replace(/\/+$/, "")
       .replace(/\.git$/i, "")
       .split("/")
       .filter((part) => part.length > 0);

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -279,9 +279,7 @@ function parseRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string |
 
   const scpStyle = /^git@([^:/\s]+):([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(trimmed);
   if (scpStyle?.[1] && scpStyle[2] && scpStyle[3]) {
-    return scpStyle[1].toLowerCase() === "github.com"
-      ? `${scpStyle[2]}/${scpStyle[3]}`
-      : `${scpStyle[1]}/${scpStyle[2]}/${scpStyle[3]}`;
+    return scpStyle[1].toLowerCase() === "github.com" ? `${scpStyle[2]}/${scpStyle[3]}` : null;
   }
   try {
     const parsed = new URL(trimmed);
@@ -291,9 +289,7 @@ function parseRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string |
       .split("/")
       .filter((part) => part.length > 0);
     if (!owner || !name || rest.length > 0) return null;
-    return parsed.hostname.toLowerCase() === "github.com"
-      ? `${owner}/${name}`
-      : `${parsed.hostname}/${owner}/${name}`;
+    return parsed.hostname.toLowerCase() === "github.com" ? `${owner}/${name}` : null;
   } catch {
     return null;
   }
@@ -1320,13 +1316,18 @@ export const make = Effect.gen(function* () {
   });
 
   const resolvePrLookupRepositoryIdentity = Effect.fn("resolvePrLookupRepositoryIdentity")(
-    function* (cwd: string, branch: string, remoteNameOverride?: string) {
+    function* (
+      cwd: string,
+      branch: string,
+      remoteNameOverride?: string,
+      targetRemoteNameOverride?: string,
+    ) {
       const remoteName =
         remoteNameOverride ?? (yield* readConfigValueNullable(cwd, `branch.${branch}.remote`));
       const [headRemote, targetRemote] = yield* Effect.all(
         [
           resolveRemoteRepositoryContext(cwd, remoteName),
-          resolveRemoteRepositoryContext(cwd, "origin"),
+          resolveRemoteRepositoryContext(cwd, targetRemoteNameOverride ?? "origin"),
         ],
         { concurrency: "unbounded" },
       );
@@ -1362,8 +1363,19 @@ export const make = Effect.gen(function* () {
       { concurrency: "unbounded" },
     );
 
+    const remoteMatchesUpstream =
+      remoteName === "upstream" ||
+      (remoteRepository.remoteUrlKey !== null &&
+        remoteRepository.remoteUrlKey === upstreamRepository.remoteUrlKey);
+    const originIsUpstreamFork = repositoryCoordinatesMatchAsForks(
+      originRepository.repositoryNameWithOwner,
+      upstreamRepository.repositoryNameWithOwner,
+    );
+    const useOriginFork = remoteMatchesUpstream && originIsUpstreamFork;
+    const headRemoteName = useOriginFork ? "origin" : remoteName;
+    const headRemoteRepository = useOriginFork ? originRepository : remoteRepository;
     const forkRepository =
-      remoteRepository.repositoryNameWithOwner ?? originRepository.repositoryNameWithOwner;
+      headRemoteRepository.repositoryNameWithOwner ?? originRepository.repositoryNameWithOwner;
     const upstreamIsRelated = repositoryCoordinatesMatchAsForks(
       forkRepository,
       upstreamRepository.repositoryNameWithOwner,
@@ -1371,24 +1383,24 @@ export const make = Effect.gen(function* () {
     const targetRepository = upstreamIsRelated ? upstreamRepository : originRepository;
     const targetRemoteName = upstreamIsRelated ? "upstream" : null;
     const headRepository =
-      remoteRepository.repositoryNameWithOwner ??
+      headRemoteRepository.repositoryNameWithOwner ??
       (remoteName === null ? originRepository.repositoryNameWithOwner : null);
     const headRepositoryOwnerLogin = parseRepositoryOwnerLogin(headRepository);
     const isCrossRepository =
       headRepository !== null && targetRepository.repositoryNameWithOwner !== null
         ? headRepository.toLowerCase() !== targetRepository.repositoryNameWithOwner.toLowerCase()
-        : remoteName !== null &&
-          remoteName !== "origin" &&
-          remoteRepository.repositoryNameWithOwner !== null;
+        : headRemoteName !== null &&
+          headRemoteName !== "origin" &&
+          headRemoteRepository.repositoryNameWithOwner !== null;
 
     const ownerHeadSelector =
       headRepositoryOwnerLogin && headBranch.length > 0
         ? `${headRepositoryOwnerLogin}:${headBranch}`
         : null;
     const remoteAliasHeadSelector =
-      remoteName && headBranch.length > 0 ? `${remoteName}:${headBranch}` : null;
+      headRemoteName && headBranch.length > 0 ? `${headRemoteName}:${headBranch}` : null;
     const shouldProbeRemoteOwnedSelectors =
-      isCrossRepository || (remoteName !== null && remoteName !== "origin");
+      isCrossRepository || (headRemoteName !== null && headRemoteName !== "origin");
 
     const headSelectors: string[] = [];
     if (isCrossRepository && shouldProbeRemoteOwnedSelectors) {
@@ -1416,10 +1428,10 @@ export const make = Effect.gen(function* () {
       headSelectors,
       preferredHeadSelector:
         ownerHeadSelector && isCrossRepository ? ownerHeadSelector : headBranch,
-      remoteName,
+      remoteName: headRemoteName,
       targetRemoteName,
       headRemoteUrlKey:
-        remoteRepository.remoteUrlKey ??
+        headRemoteRepository.remoteUrlKey ??
         (remoteName === null ? originRepository.remoteUrlKey : null),
       targetRemoteUrlKey: targetRepository.remoteUrlKey,
       headRepositoryNameWithOwner: headRepository,
@@ -2046,7 +2058,7 @@ export const make = Effect.gen(function* () {
         cwd,
         baseRefName: baseBranch,
         headSelector: headContext.preferredHeadSelector,
-        ...(headContext.headRepositoryNameWithOwner
+        ...(provider.kind === "github" && headContext.headRepositoryNameWithOwner
           ? {
               source: {
                 refName: headContext.headBranch,
@@ -2203,6 +2215,7 @@ export const make = Effect.gen(function* () {
       cacheCwd,
       branch,
       identityRemoteName(cached.headContext),
+      cached.headContext.targetRemoteName ?? undefined,
     );
     const canVerifyIdentity = (headContext: BranchHeadContext, identity: typeof currentIdentity) =>
       !(
@@ -2226,6 +2239,7 @@ export const make = Effect.gen(function* () {
         cacheCwd,
         branch,
         identityRemoteName(cached.headContext),
+        cached.headContext.targetRemoteName ?? undefined,
       );
       if (
         !canVerifyIdentity(cached.headContext, refreshedIdentity) ||

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1368,19 +1368,21 @@ export const make = Effect.gen(function* () {
       upstreamRepository.repositoryNameWithOwner,
     );
     const targetRepository = upstreamIsRelated ? upstreamRepository : originRepository;
-    const targetRemoteName = upstreamIsRelated ? "upstream" : "origin";
+    const targetRemoteName = upstreamIsRelated ? "upstream" : null;
+    const headRepository =
+      remoteRepository.repositoryNameWithOwner ??
+      (remoteName === null ? originRepository.repositoryNameWithOwner : null);
+    const headRepositoryOwnerLogin = parseRepositoryOwnerLogin(headRepository);
     const isCrossRepository =
-      remoteRepository.repositoryNameWithOwner !== null &&
-      targetRepository.repositoryNameWithOwner !== null
-        ? remoteRepository.repositoryNameWithOwner.toLowerCase() !==
-          targetRepository.repositoryNameWithOwner.toLowerCase()
+      headRepository !== null && targetRepository.repositoryNameWithOwner !== null
+        ? headRepository.toLowerCase() !== targetRepository.repositoryNameWithOwner.toLowerCase()
         : remoteName !== null &&
           remoteName !== "origin" &&
           remoteRepository.repositoryNameWithOwner !== null;
 
     const ownerHeadSelector =
-      remoteRepository.ownerLogin && headBranch.length > 0
-        ? `${remoteRepository.ownerLogin}:${headBranch}`
+      headRepositoryOwnerLogin && headBranch.length > 0
+        ? `${headRepositoryOwnerLogin}:${headBranch}`
         : null;
     const remoteAliasHeadSelector =
       remoteName && headBranch.length > 0 ? `${remoteName}:${headBranch}` : null;
@@ -1418,9 +1420,9 @@ export const make = Effect.gen(function* () {
       headRemoteUrlKey:
         remoteRepository.remoteUrlKey ??
         (remoteName === null ? originRepository.remoteUrlKey : null),
-      targetRemoteUrlKey: originRepository.remoteUrlKey,
-      headRepositoryNameWithOwner: remoteRepository.repositoryNameWithOwner,
-      headRepositoryOwnerLogin: remoteRepository.ownerLogin,
+      targetRemoteUrlKey: targetRepository.remoteUrlKey,
+      headRepositoryNameWithOwner: headRepository,
+      headRepositoryOwnerLogin,
       isCrossRepository,
     } satisfies BranchHeadContext;
   });

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -277,19 +277,38 @@ function parseRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string |
   if (trimmed.length === 0) {
     return null;
   }
+
+  const match =
+    /^(?:[^@/\s]+@[^:/\s]+:|(?:ssh|https?|git):\/\/[^/]+\/)((?:[^/\s]+\/)+[^/\s]+?)(?:\.git)?\/?$/iu.exec(
+      trimmed,
+    );
+  const repositoryNameWithOwner = match?.[1]?.trim() ?? "";
+  return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
+}
+
+function parseGitHubRepositoryCoordinatesFromRemoteUrl(
+  url: string | null,
+): { readonly host: string; readonly nameWithOwner: string } | null {
+  const trimmed = url?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return null;
+  }
   if (detectSourceControlProviderFromGitRemoteUrl(trimmed)?.kind !== "github") return null;
 
   const [host, owner, name, ...rest] = normalizeGitRemoteUrl(trimmed).split("/");
   if (!host || !owner || !name || rest.length > 0) return null;
-  return `${owner}/${name}`;
+  return { host, nameWithOwner: `${owner}/${name}` };
 }
 
-function repositoryCoordinatesMatchAsForks(left: string | null, right: string | null): boolean {
-  const parse = (value: string | null) => {
-    const parts = value?.split("/") ?? [];
-    if (parts.length === 2) return { host: "github.com", owner: parts[0], name: parts[1] };
-    if (parts.length === 3) return { host: parts[0], owner: parts[1], name: parts[2] };
-    return null;
+function repositoryCoordinatesMatchAsForks(
+  left: { readonly host: string | null; readonly nameWithOwner: string | null },
+  right: { readonly host: string | null; readonly nameWithOwner: string | null },
+): boolean {
+  const parse = (value: typeof left) => {
+    const [owner, name, ...rest] = value.nameWithOwner?.split("/") ?? [];
+    return value.host && owner && name && rest.length === 0
+      ? { host: value.host, owner, name }
+      : null;
   };
   const leftCoordinate = parse(left);
   const rightCoordinate = parse(right);
@@ -307,8 +326,8 @@ function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null 
   if (trimmed.length === 0) {
     return null;
   }
-  const parts = trimmed.split("/");
-  const ownerLogin = parts.length === 3 ? parts[1] : parts[0];
+  // GitLab reports the top-level group as owner.
+  const [ownerLogin] = trimmed.split("/");
   const normalizedOwnerLogin = ownerLogin?.trim() ?? "";
   return normalizedOwnerLogin.length > 0 ? normalizedOwnerLogin : null;
 }
@@ -1291,15 +1310,18 @@ export const make = Effect.gen(function* () {
       return {
         remoteUrlKey: null,
         repositoryNameWithOwner: null,
+        repositoryHost: null,
         ownerLogin: null,
       };
     }
 
     const remoteUrl = yield* readConfigValueNullable(cwd, `remote.${remoteName}.url`);
+    const repositoryCoordinates = parseGitHubRepositoryCoordinatesFromRemoteUrl(remoteUrl);
     const repositoryNameWithOwner = parseRepositoryNameWithOwnerFromRemoteUrl(remoteUrl);
     return {
       remoteUrlKey: remoteUrl ? normalizeGitRemoteUrl(remoteUrl) : null,
       repositoryNameWithOwner,
+      repositoryHost: repositoryCoordinates?.host ?? null,
       ownerLogin: parseRepositoryOwnerLogin(repositoryNameWithOwner),
     };
   });
@@ -1357,8 +1379,14 @@ export const make = Effect.gen(function* () {
       (remoteRepository.remoteUrlKey !== null &&
         remoteRepository.remoteUrlKey === upstreamRepository.remoteUrlKey);
     const originIsUpstreamFork = repositoryCoordinatesMatchAsForks(
-      originRepository.repositoryNameWithOwner,
-      upstreamRepository.repositoryNameWithOwner,
+      {
+        host: originRepository.repositoryHost,
+        nameWithOwner: originRepository.repositoryNameWithOwner,
+      },
+      {
+        host: upstreamRepository.repositoryHost,
+        nameWithOwner: upstreamRepository.repositoryNameWithOwner,
+      },
     );
     const useOriginFork = remoteMatchesUpstream && originIsUpstreamFork;
     const trackingRefIsBase =
@@ -1371,8 +1399,14 @@ export const make = Effect.gen(function* () {
     const forkRepository =
       headRemoteRepository.repositoryNameWithOwner ?? originRepository.repositoryNameWithOwner;
     const upstreamIsRelated = repositoryCoordinatesMatchAsForks(
-      forkRepository,
-      upstreamRepository.repositoryNameWithOwner,
+      {
+        host: headRemoteRepository.repositoryHost ?? originRepository.repositoryHost,
+        nameWithOwner: forkRepository,
+      },
+      {
+        host: upstreamRepository.repositoryHost,
+        nameWithOwner: upstreamRepository.repositoryNameWithOwner,
+      },
     );
     const targetRepository = upstreamIsRelated ? upstreamRepository : originRepository;
     const targetRemoteName = upstreamIsRelated ? "upstream" : null;

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -212,6 +212,7 @@ interface BranchHeadContext {
   headRepositoryNameWithOwner: string | null;
   headRepositoryOwnerLogin: string | null;
   isCrossRepository: boolean;
+  trackingRefIsBase: boolean;
 }
 
 export function pullRequestRepositoryKey(value: string): string | null {
@@ -276,23 +277,11 @@ function parseRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string |
   if (trimmed.length === 0) {
     return null;
   }
+  if (detectSourceControlProviderFromGitRemoteUrl(trimmed)?.kind !== "github") return null;
 
-  const scpStyle = /^git@([^:/\s]+):([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(trimmed);
-  if (scpStyle?.[1] && scpStyle[2] && scpStyle[3]) {
-    return scpStyle[1].toLowerCase() === "github.com" ? `${scpStyle[2]}/${scpStyle[3]}` : null;
-  }
-  try {
-    const parsed = new URL(trimmed);
-    const [owner, name, ...rest] = parsed.pathname
-      .replace(/\/+$/, "")
-      .replace(/\.git$/i, "")
-      .split("/")
-      .filter((part) => part.length > 0);
-    if (!owner || !name || rest.length > 0) return null;
-    return parsed.hostname.toLowerCase() === "github.com" ? `${owner}/${name}` : null;
-  } catch {
-    return null;
-  }
+  const [host, owner, name, ...rest] = normalizeGitRemoteUrl(trimmed).split("/");
+  if (!host || !owner || !name || rest.length > 0) return null;
+  return `${owner}/${name}`;
 }
 
 function repositoryCoordinatesMatchAsForks(left: string | null, right: string | null): boolean {
@@ -1372,6 +1361,11 @@ export const make = Effect.gen(function* () {
       upstreamRepository.repositoryNameWithOwner,
     );
     const useOriginFork = remoteMatchesUpstream && originIsUpstreamFork;
+    const trackingRefIsBase =
+      headBranchFromUpstream.length > 0 &&
+      headBranch !== details.branch &&
+      originIsUpstreamFork &&
+      (remoteName === "origin" || remoteMatchesUpstream);
     const headRemoteName = useOriginFork ? "origin" : remoteName;
     const headRemoteRepository = useOriginFork ? originRepository : remoteRepository;
     const forkRepository =
@@ -1437,6 +1431,7 @@ export const make = Effect.gen(function* () {
       headRepositoryNameWithOwner: headRepository,
       headRepositoryOwnerLogin,
       isCrossRepository,
+      trackingRefIsBase,
     } satisfies BranchHeadContext;
   });
 
@@ -1512,9 +1507,10 @@ export const make = Effect.gen(function* () {
       (details.defaultBranch === null &&
         (headContext.headBranch === "main" || headContext.headBranch === "master"));
     if (
-      headContext.headBranch === details.branch ||
-      !upstreamHeadIsDefault ||
-      headContext.isCrossRepository
+      !headContext.trackingRefIsBase &&
+      (headContext.headBranch === details.branch ||
+        !upstreamHeadIsDefault ||
+        headContext.isCrossRepository)
     ) {
       return { headContext, lookup: true };
     }
@@ -1527,7 +1523,10 @@ export const make = Effect.gen(function* () {
       upstreamRef: null,
       remoteName,
     });
-    return { headContext: ownNameContext, lookup: true };
+    return {
+      headContext: { ...ownNameContext, trackingRefIsBase: headContext.trackingRefIsBase },
+      lookup: true,
+    };
   });
 
   /**
@@ -1743,16 +1742,20 @@ export const make = Effect.gen(function* () {
     cwd: string,
     branch: string,
     upstreamRef: string | null,
-    headContext: Pick<BranchHeadContext, "isCrossRepository" | "remoteName">,
+    headContext: Pick<BranchHeadContext, "headBranch" | "remoteName" | "trackingRefIsBase">,
   ) {
     const configured = yield* gitCore.readConfigValue(cwd, `branch.${branch}.gh-merge-base`);
     if (configured) return configured;
 
-    if (upstreamRef && !headContext.isCrossRepository) {
+    if (upstreamRef && headContext.trackingRefIsBase) {
       const upstreamBranch = extractBranchNameFromRemoteRef(upstreamRef, {
         remoteName: headContext.remoteName,
       });
-      if (upstreamBranch.length > 0 && upstreamBranch !== branch) {
+      if (
+        upstreamBranch.length > 0 &&
+        upstreamBranch !== branch &&
+        upstreamBranch !== headContext.headBranch
+      ) {
         return upstreamBranch;
       }
     }
@@ -1990,10 +1993,18 @@ export const make = Effect.gen(function* () {
       });
     }
 
-    const headContext = yield* resolveBranchHeadContext(cwd, {
+    const { headContext, lookup } = yield* resolveLookupHeadContext(cwd, {
       branch,
       upstreamRef: details.upstreamRef,
+      defaultBranch: null,
     });
+    if (!lookup) {
+      return yield* new GitManagerError({
+        operation: "runPrStep",
+        cwd,
+        detail: "Current branch has not been pushed. Push before creating a PR.",
+      });
+    }
 
     const existing = yield* findOpenPr(cwd, headContext);
     if (existing) {

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1320,19 +1320,22 @@ export const make = Effect.gen(function* () {
     const shouldProbeLocalBranchSelector =
       headBranchFromUpstream.length === 0 || headBranch === details.branch;
 
-    const [remoteRepository, originRepository] = yield* Effect.all(
+    const [remoteRepository, upstreamRepository, originRepository] = yield* Effect.all(
       [
         resolveRemoteRepositoryContext(cwd, remoteName),
+        resolveRemoteRepositoryContext(cwd, "upstream"),
         resolveRemoteRepositoryContext(cwd, "origin"),
       ],
       { concurrency: "unbounded" },
     );
 
+    const targetRepository =
+      upstreamRepository.repositoryNameWithOwner !== null ? upstreamRepository : originRepository;
     const isCrossRepository =
       remoteRepository.repositoryNameWithOwner !== null &&
-      originRepository.repositoryNameWithOwner !== null
+      targetRepository.repositoryNameWithOwner !== null
         ? remoteRepository.repositoryNameWithOwner.toLowerCase() !==
-          originRepository.repositoryNameWithOwner.toLowerCase()
+          targetRepository.repositoryNameWithOwner.toLowerCase()
         : remoteName !== null &&
           remoteName !== "origin" &&
           remoteRepository.repositoryNameWithOwner !== null;

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -2003,6 +2003,17 @@ export const make = Effect.gen(function* () {
         cwd,
         baseRefName: baseBranch,
         headSelector: headContext.preferredHeadSelector,
+        ...(headContext.headRepositoryNameWithOwner
+          ? {
+              source: {
+                refName: headContext.headBranch,
+                ...(headContext.headRepositoryOwnerLogin
+                  ? { owner: headContext.headRepositoryOwnerLogin }
+                  : {}),
+                repository: headContext.headRepositoryNameWithOwner,
+              },
+            }
+          : {}),
         title: generated.title,
         bodyFile,
       })

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -206,6 +206,7 @@ interface BranchHeadContext {
   headSelectors: ReadonlyArray<string>;
   preferredHeadSelector: string;
   remoteName: string | null;
+  targetRemoteName: string | null;
   headRemoteUrlKey: string | null;
   targetRemoteUrlKey: string | null;
   headRepositoryNameWithOwner: string | null;
@@ -276,12 +277,43 @@ function parseRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string |
     return null;
   }
 
-  const match =
-    /^(?:[^@/\s]+@[^:/\s]+:|(?:ssh|https?|git):\/\/[^/]+\/)((?:[^/\s]+\/)+[^/\s]+?)(?:\.git)?\/?$/iu.exec(
-      trimmed,
-    );
-  const repositoryNameWithOwner = match?.[1]?.trim() ?? "";
-  return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
+  const scpStyle = /^git@([^:/\s]+):([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(trimmed);
+  if (scpStyle?.[1] && scpStyle[2] && scpStyle[3]) {
+    return scpStyle[1].toLowerCase() === "github.com"
+      ? `${scpStyle[2]}/${scpStyle[3]}`
+      : `${scpStyle[1]}/${scpStyle[2]}/${scpStyle[3]}`;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    const [owner, name, ...rest] = parsed.pathname
+      .replace(/\.git$/i, "")
+      .split("/")
+      .filter((part) => part.length > 0);
+    if (!owner || !name || rest.length > 0) return null;
+    return parsed.hostname.toLowerCase() === "github.com"
+      ? `${owner}/${name}`
+      : `${parsed.hostname}/${owner}/${name}`;
+  } catch {
+    return null;
+  }
+}
+
+function repositoryCoordinatesMatchAsForks(left: string | null, right: string | null): boolean {
+  const parse = (value: string | null) => {
+    const parts = value?.split("/") ?? [];
+    if (parts.length === 2) return { host: "github.com", owner: parts[0], name: parts[1] };
+    if (parts.length === 3) return { host: parts[0], owner: parts[1], name: parts[2] };
+    return null;
+  };
+  const leftCoordinate = parse(left);
+  const rightCoordinate = parse(right);
+  return Boolean(
+    leftCoordinate &&
+    rightCoordinate &&
+    leftCoordinate.host?.toLowerCase() === rightCoordinate.host?.toLowerCase() &&
+    leftCoordinate.name?.toLowerCase() === rightCoordinate.name?.toLowerCase() &&
+    leftCoordinate.owner?.toLowerCase() !== rightCoordinate.owner?.toLowerCase(),
+  );
 }
 
 function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null {
@@ -289,8 +321,8 @@ function parseRepositoryOwnerLogin(nameWithOwner: string | null): string | null 
   if (trimmed.length === 0) {
     return null;
   }
-  // GitLab reports the top-level group as owner. The full path distinguishes subgroups.
-  const [ownerLogin] = trimmed.split("/");
+  const parts = trimmed.split("/");
+  const ownerLogin = parts.length === 3 ? parts[1] : parts[0];
   const normalizedOwnerLogin = ownerLogin?.trim() ?? "";
   return normalizedOwnerLogin.length > 0 ? normalizedOwnerLogin : null;
 }
@@ -1329,8 +1361,14 @@ export const make = Effect.gen(function* () {
       { concurrency: "unbounded" },
     );
 
-    const targetRepository =
-      upstreamRepository.repositoryNameWithOwner !== null ? upstreamRepository : originRepository;
+    const forkRepository =
+      remoteRepository.repositoryNameWithOwner ?? originRepository.repositoryNameWithOwner;
+    const upstreamIsRelated = repositoryCoordinatesMatchAsForks(
+      forkRepository,
+      upstreamRepository.repositoryNameWithOwner,
+    );
+    const targetRepository = upstreamIsRelated ? upstreamRepository : originRepository;
+    const targetRemoteName = upstreamIsRelated ? "upstream" : "origin";
     const isCrossRepository =
       remoteRepository.repositoryNameWithOwner !== null &&
       targetRepository.repositoryNameWithOwner !== null
@@ -1376,6 +1414,7 @@ export const make = Effect.gen(function* () {
       preferredHeadSelector:
         ownerHeadSelector && isCrossRepository ? ownerHeadSelector : headBranch,
       remoteName,
+      targetRemoteName,
       headRemoteUrlKey:
         remoteRepository.remoteUrlKey ??
         (remoteName === null ? originRepository.remoteUrlKey : null),
@@ -1729,10 +1768,11 @@ export const make = Effect.gen(function* () {
   const resolveBaseRangeRef = Effect.fn("resolveBaseRangeRef")(function* (
     cwd: string,
     baseBranch: string,
+    targetRemoteName: string | null,
   ) {
-    const remoteName = yield* gitCore
-      .resolvePrimaryRemoteName(cwd)
-      .pipe(Effect.orElseSucceed(() => null));
+    const remoteName =
+      targetRemoteName ??
+      (yield* gitCore.resolvePrimaryRemoteName(cwd).pipe(Effect.orElseSucceed(() => null)));
     if (!remoteName) return baseBranch;
 
     return yield* gitCore
@@ -1958,7 +1998,7 @@ export const make = Effect.gen(function* () {
       phase: "pr",
       label: `Generating ${terms.shortLabel} content...`,
     });
-    const baseRangeRef = yield* resolveBaseRangeRef(cwd, baseBranch);
+    const baseRangeRef = yield* resolveBaseRangeRef(cwd, baseBranch, headContext.targetRemoteName);
     const rangeContext = yield* gitCore.readRangeContext(cwd, baseRangeRef);
     const policy = yield* resolveStylePolicy(cwd, settings);
     const changeRequestTemplate =

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -193,6 +193,7 @@ describe("GitHubCli.layer", () => {
       const result = yield* gh.listOpenPullRequests({
         cwd: "/repo",
         headSelector: "feature/pr-list",
+        repository: "T3Tools/t3code",
       });
 
       assert.deepStrictEqual(result, [
@@ -205,6 +206,26 @@ describe("GitHubCli.layer", () => {
           state: "open",
         },
       ]);
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "pr",
+          "list",
+          "--head",
+          "feature/pr-list",
+          "--state",
+          "open",
+          "--limit",
+          "1",
+          "--repo",
+          "T3Tools/t3code",
+          "--json",
+          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -229,6 +229,135 @@ describe("GitHubCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("creates pull requests against the parent of an origin fork", () =>
+    Effect.gen(function* () {
+      mockRun
+        .mockReturnValueOnce(
+          Effect.succeed(processOutput("github.com/pingdotgg/t3code\tgithub.com/octocat/t3code\n")),
+        )
+        .mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/fork-pr",
+        headRepository: "octocat/t3code",
+        title: "Target upstream",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenNthCalledWith(1, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "repo",
+          "view",
+          "octocat/t3code",
+          "--json",
+          "nameWithOwner,parent,url",
+          "--jq",
+          '. as $repo | (.url | capture("^https?://(?<host>[^/]+)").host) as $host | [if $repo.parent then "\\($host)/\\($repo.parent.owner.login)/\\($repo.parent.name)" else "\\($host)/\\($repo.nameWithOwner)" end, "\\($host)/\\($repo.nameWithOwner)"] | @tsv',
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+      expect(mockRun).toHaveBeenNthCalledWith(2, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "api",
+          "--hostname",
+          "github.com",
+          "repos/pingdotgg/t3code/pulls",
+          "--method",
+          "POST",
+          "-f",
+          "title=Target upstream",
+          "-f",
+          "head=octocat:feature/fork-pr",
+          "-f",
+          "head_repo=t3code",
+          "-f",
+          "base=main",
+          "-F",
+          "body=@/tmp/pr-body.md",
+          "--silent",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("creates pull requests from organization-owned forks through the API", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "acme:feature/fork-pr",
+        repository: "pingdotgg/t3code",
+        headRepository: "acme/t3code",
+        title: "Target upstream",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: expect.arrayContaining([
+          "repos/pingdotgg/t3code/pulls",
+          "head=acme:feature/fork-pr",
+          "head_repo=t3code",
+        ]),
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("uses the normal create command for same-repository pull requests", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/local-pr",
+        repository: "pingdotgg/t3code",
+        headRepository: "pingdotgg/t3code",
+        title: "Local pull request",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "pr",
+          "create",
+          "--base",
+          "main",
+          "--head",
+          "feature/local-pr",
+          "--title",
+          "Local pull request",
+          "--body-file",
+          "/tmp/pr-body.md",
+          "--repo",
+          "github.com/pingdotgg/t3code",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("keeps pull requests from gh versions without headRepository.nameWithOwner", () =>
     // gh < 2.47 (e.g. Ubuntu-packaged 2.46) exports headRepository as
     // {id, name} only. These entries must decode instead of being dropped,

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -298,26 +298,15 @@ describe("GitHubCli.layer", () => {
         Effect.succeed(
           processOutput(
             // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify([
-              {
-                number: 44,
-                title: "Other fork",
-                url: "https://github.com/pingdotgg/t3code/pull/44",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "OPEN",
-                headRepositoryOwner: { login: "other" },
-              },
-              {
-                number: 45,
-                title: "Requested fork",
-                url: "https://github.com/pingdotgg/t3code/pull/45",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "OPEN",
-                headRepositoryOwner: { login: "octocat" },
-              },
-            ]),
+            JSON.stringify({
+              number: 45,
+              title: "Requested fork",
+              url: "https://github.com/pingdotgg/t3code/pull/45",
+              baseRefName: "main",
+              headRefName: "feature/shared",
+              state: "OPEN",
+              headRepositoryOwner: { login: "octocat" },
+            }),
           ),
         ),
       );
@@ -336,11 +325,11 @@ describe("GitHubCli.layer", () => {
       );
       expect(mockRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          args: expect.arrayContaining(["--head", "feature/shared"]),
+          args: expect.arrayContaining(["pr", "view", "octocat:feature/shared"]),
         }),
       );
-      expect(mockRun).toHaveBeenCalledWith(
-        expect.objectContaining({ args: expect.arrayContaining(["--limit", "100"]) }),
+      expect(mockRun).not.toHaveBeenCalledWith(
+        expect.objectContaining({ args: expect.arrayContaining(["--limit"]) }),
       );
     }).pipe(Effect.provide(layer)),
   );

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -282,11 +282,66 @@ describe("GitHubCli.layer", () => {
           "base=main",
           "-F",
           "body=@/tmp/pr-body.md",
+          "-F",
+          "maintainer_can_modify=true",
           "--silent",
         ],
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("filters qualified fork heads after listing the target repository", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 44,
+                title: "Other fork",
+                url: "https://github.com/pingdotgg/t3code/pull/44",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "OPEN",
+                headRepositoryOwner: { login: "other" },
+              },
+              {
+                number: 45,
+                title: "Requested fork",
+                url: "https://github.com/pingdotgg/t3code/pull/45",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "OPEN",
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const pullRequests = yield* gh.listOpenPullRequests({
+        cwd: "/repo",
+        headSelector: "octocat:feature/shared",
+        repository: "pingdotgg/t3code",
+        limit: 1,
+      });
+
+      assert.deepStrictEqual(
+        pullRequests.map((pullRequest) => pullRequest.number),
+        [45],
+      );
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: expect.arrayContaining(["--head", "feature/shared"]),
+        }),
+      );
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({ args: expect.arrayContaining(["--limit", "100"]) }),
+      );
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -308,15 +308,26 @@ describe("GitHubCli.layer", () => {
         Effect.succeed(
           processOutput(
             // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify({
-              number: 45,
-              title: "Requested fork",
-              url: "https://github.com/pingdotgg/t3code/pull/45",
-              baseRefName: "main",
-              headRefName: "feature/shared",
-              state: "OPEN",
-              headRepositoryOwner: { login: "octocat" },
-            }),
+            JSON.stringify([
+              {
+                number: 44,
+                title: "Same branch from another fork",
+                url: "https://github.com/pingdotgg/t3code/pull/44",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "OPEN",
+                headRepositoryOwner: { login: "hubot" },
+              },
+              {
+                number: 45,
+                title: "Requested fork",
+                url: "https://github.com/pingdotgg/t3code/pull/45",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "OPEN",
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
           ),
         ),
       );
@@ -335,11 +346,17 @@ describe("GitHubCli.layer", () => {
       );
       expect(mockRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          args: expect.arrayContaining(["pr", "view", "octocat:feature/shared"]),
+          args: expect.arrayContaining([
+            "pr",
+            "list",
+            "--head",
+            "feature/shared",
+            "--state",
+            "open",
+            "--limit",
+            "100",
+          ]),
         }),
-      );
-      expect(mockRun).not.toHaveBeenCalledWith(
-        expect.objectContaining({ args: expect.arrayContaining(["--limit"]) }),
       );
     }).pipe(Effect.provide(layer)),
   );

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -201,6 +201,7 @@ describe("GitHubCli.layer", () => {
       const result = yield* gh.listOpenPullRequests({
         cwd: "/repo",
         headSelector: "feature/pr-list",
+        repository: "T3Tools/t3code",
       });
 
       assert.deepStrictEqual(result, [
@@ -215,6 +216,26 @@ describe("GitHubCli.layer", () => {
           mergedAt: null,
         },
       ]);
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "pr",
+          "list",
+          "--head",
+          "feature/pr-list",
+          "--state",
+          "open",
+          "--limit",
+          "1",
+          "--repo",
+          "T3Tools/t3code",
+          "--json",
+          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -239,6 +239,135 @@ describe("GitHubCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("creates pull requests against the parent of an origin fork", () =>
+    Effect.gen(function* () {
+      mockRun
+        .mockReturnValueOnce(
+          Effect.succeed(processOutput("github.com/pingdotgg/t3code\tgithub.com/octocat/t3code\n")),
+        )
+        .mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/fork-pr",
+        headRepository: "octocat/t3code",
+        title: "Target upstream",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenNthCalledWith(1, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "repo",
+          "view",
+          "octocat/t3code",
+          "--json",
+          "nameWithOwner,parent,url",
+          "--jq",
+          '. as $repo | (.url | capture("^https?://(?<host>[^/]+)").host) as $host | [if $repo.parent then "\\($host)/\\($repo.parent.owner.login)/\\($repo.parent.name)" else "\\($host)/\\($repo.nameWithOwner)" end, "\\($host)/\\($repo.nameWithOwner)"] | @tsv',
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+      expect(mockRun).toHaveBeenNthCalledWith(2, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "api",
+          "--hostname",
+          "github.com",
+          "repos/pingdotgg/t3code/pulls",
+          "--method",
+          "POST",
+          "-f",
+          "title=Target upstream",
+          "-f",
+          "head=octocat:feature/fork-pr",
+          "-f",
+          "head_repo=t3code",
+          "-f",
+          "base=main",
+          "-F",
+          "body=@/tmp/pr-body.md",
+          "--silent",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("creates pull requests from organization-owned forks through the API", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "acme:feature/fork-pr",
+        repository: "pingdotgg/t3code",
+        headRepository: "acme/t3code",
+        title: "Target upstream",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: expect.arrayContaining([
+          "repos/pingdotgg/t3code/pulls",
+          "head=acme:feature/fork-pr",
+          "head_repo=t3code",
+        ]),
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("uses the normal create command for same-repository pull requests", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/local-pr",
+        repository: "pingdotgg/t3code",
+        headRepository: "pingdotgg/t3code",
+        title: "Local pull request",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: [
+          "pr",
+          "create",
+          "--base",
+          "main",
+          "--head",
+          "feature/local-pr",
+          "--title",
+          "Local pull request",
+          "--body-file",
+          "/tmp/pr-body.md",
+          "--repo",
+          "github.com/pingdotgg/t3code",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("keeps pull requests from gh versions without headRepository.nameWithOwner", () =>
     // gh < 2.47 (e.g. Ubuntu-packaged 2.46) exports headRepository as
     // {id, name} only. These entries must decode instead of being dropped,

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -231,7 +231,7 @@ describe("GitHubCli.layer", () => {
           "--repo",
           "T3Tools/t3code",
           "--json",
-          "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
         ],
         cwd: "/repo",
         timeoutMs: 30_000,

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -231,7 +231,7 @@ describe("GitHubCli.layer", () => {
           "--repo",
           "T3Tools/t3code",
           "--json",
-          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
         ],
         cwd: "/repo",
         timeoutMs: 30_000,

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -292,11 +292,66 @@ describe("GitHubCli.layer", () => {
           "base=main",
           "-F",
           "body=@/tmp/pr-body.md",
+          "-F",
+          "maintainer_can_modify=true",
           "--silent",
         ],
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("filters qualified fork heads after listing the target repository", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 44,
+                title: "Other fork",
+                url: "https://github.com/pingdotgg/t3code/pull/44",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "OPEN",
+                headRepositoryOwner: { login: "other" },
+              },
+              {
+                number: 45,
+                title: "Requested fork",
+                url: "https://github.com/pingdotgg/t3code/pull/45",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "OPEN",
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const pullRequests = yield* gh.listOpenPullRequests({
+        cwd: "/repo",
+        headSelector: "octocat:feature/shared",
+        repository: "pingdotgg/t3code",
+        limit: 1,
+      });
+
+      assert.deepStrictEqual(
+        pullRequests.map((pullRequest) => pullRequest.number),
+        [45],
+      );
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: expect.arrayContaining(["--head", "feature/shared"]),
+        }),
+      );
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({ args: expect.arrayContaining(["--limit", "100"]) }),
+      );
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -353,8 +353,8 @@ describe("GitHubCli.layer", () => {
         cwd: "/repo",
         baseBranch: "main",
         headSelector: "acme:feature/fork-pr",
-        repository: "pingdotgg/t3code",
-        headRepository: "acme/t3code",
+        repository: "github.com/pingdotgg/t3code",
+        headRepository: "github.com/acme/t3code",
         title: "Target upstream",
         bodyFile: "/tmp/pr-body.md",
       });
@@ -383,8 +383,8 @@ describe("GitHubCli.layer", () => {
         cwd: "/repo",
         baseBranch: "main",
         headSelector: "feature/local-pr",
-        repository: "pingdotgg/t3code",
-        headRepository: "pingdotgg/t3code",
+        repository: "github.com/pingdotgg/t3code",
+        headRepository: "github.com/pingdotgg/t3code",
         title: "Local pull request",
         bodyFile: "/tmp/pr-body.md",
       });
@@ -409,6 +409,63 @@ describe("GitHubCli.layer", () => {
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("inherits a GitHub Enterprise host for a host-less fork", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/fork-pr",
+        repository: "github.example.com/pingdotgg/t3code",
+        headRepository: "octocat/t3code",
+        title: "Target Enterprise upstream",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: expect.arrayContaining([
+            "--hostname",
+            "github.example.com",
+            "repos/pingdotgg/t3code/pulls",
+            "head=octocat:feature/fork-pr",
+          ]),
+        }),
+      );
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("omits a GitHub Enterprise HTTPS port from the API hostname", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/fork-pr",
+        repository: "github.example.com:8443/pingdotgg/t3code",
+        headRepository: "github.example.com:8443/octocat/t3code",
+        title: "Target ported Enterprise upstream",
+        bodyFile: "/tmp/pr-body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: expect.arrayContaining([
+            "--hostname",
+            "github.example.com",
+            "repos/pingdotgg/t3code/pulls",
+          ]),
+        }),
+      );
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -458,7 +458,7 @@ describe("GitHubCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
-  it.effect("omits a GitHub Enterprise HTTPS port from the API hostname", () =>
+  it.effect("preserves a GitHub Enterprise HTTPS port in the API hostname", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
 
@@ -478,7 +478,7 @@ describe("GitHubCli.layer", () => {
         expect.objectContaining({
           args: expect.arrayContaining([
             "--hostname",
-            "github.example.com",
+            "github.example.com:8443",
             "repos/pingdotgg/t3code/pulls",
           ]),
         }),

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -308,26 +308,15 @@ describe("GitHubCli.layer", () => {
         Effect.succeed(
           processOutput(
             // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify([
-              {
-                number: 44,
-                title: "Other fork",
-                url: "https://github.com/pingdotgg/t3code/pull/44",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "OPEN",
-                headRepositoryOwner: { login: "other" },
-              },
-              {
-                number: 45,
-                title: "Requested fork",
-                url: "https://github.com/pingdotgg/t3code/pull/45",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "OPEN",
-                headRepositoryOwner: { login: "octocat" },
-              },
-            ]),
+            JSON.stringify({
+              number: 45,
+              title: "Requested fork",
+              url: "https://github.com/pingdotgg/t3code/pull/45",
+              baseRefName: "main",
+              headRefName: "feature/shared",
+              state: "OPEN",
+              headRepositoryOwner: { login: "octocat" },
+            }),
           ),
         ),
       );
@@ -346,11 +335,11 @@ describe("GitHubCli.layer", () => {
       );
       expect(mockRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          args: expect.arrayContaining(["--head", "feature/shared"]),
+          args: expect.arrayContaining(["pr", "view", "octocat:feature/shared"]),
         }),
       );
-      expect(mockRun).toHaveBeenCalledWith(
-        expect.objectContaining({ args: expect.arrayContaining(["--limit", "100"]) }),
+      expect(mockRun).not.toHaveBeenCalledWith(
+        expect.objectContaining({ args: expect.arrayContaining(["--limit"]) }),
       );
     }).pipe(Effect.provide(layer)),
   );

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -212,11 +212,13 @@ export class GitHubCli extends Context.Service<
       readonly cwd: string;
       readonly headSelector: string;
       readonly limit?: number;
+      readonly repository?: string;
     }) => Effect.Effect<ReadonlyArray<GitHubPullRequestSummary>, GitHubCliError>;
 
     readonly getPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
+      readonly repository?: string;
     }) => Effect.Effect<GitHubPullRequestSummary, GitHubCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
@@ -236,16 +238,19 @@ export class GitHubCli extends Context.Service<
       readonly headSelector: string;
       readonly title: string;
       readonly bodyFile: string;
+      readonly repository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
 
     readonly getDefaultBranch: (input: {
       readonly cwd: string;
+      readonly repository?: string;
     }) => Effect.Effect<string | null, GitHubCliError>;
 
     readonly checkoutPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
       readonly force?: boolean;
+      readonly repository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
   }
 >()("t3/sourceControl/GitHubCli") {}
@@ -336,6 +341,7 @@ export const make = Effect.gen(function* () {
           "open",
           "--limit",
           String(input.limit ?? 1),
+          ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
         ],
@@ -370,6 +376,7 @@ export const make = Effect.gen(function* () {
           "pr",
           "view",
           input.reference,
+          ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
         ],
@@ -438,12 +445,21 @@ export const make = Effect.gen(function* () {
           input.title,
           "--body-file",
           input.bodyFile,
+          ...(input.repository ? ["--repo", input.repository] : []),
         ],
       }).pipe(Effect.asVoid),
     getDefaultBranch: (input) =>
       execute({
         cwd: input.cwd,
-        args: ["repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"],
+        args: [
+          "repo",
+          "view",
+          ...(input.repository ? [input.repository] : []),
+          "--json",
+          "defaultBranchRef",
+          "--jq",
+          ".defaultBranchRef.name",
+        ],
       }).pipe(
         Effect.map((value) => {
           const trimmed = value.stdout.trim();
@@ -453,7 +469,13 @@ export const make = Effect.gen(function* () {
     checkoutPullRequest: (input) =>
       execute({
         cwd: input.cwd,
-        args: ["pr", "checkout", input.reference, ...(input.force ? ["--force"] : [])],
+        args: [
+          "pr",
+          "checkout",
+          input.reference,
+          ...(input.force ? ["--force"] : []),
+          ...(input.repository ? ["--repo", input.repository] : []),
+        ],
       }).pipe(Effect.asVoid),
   });
 });

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -448,18 +448,20 @@ export const make = Effect.gen(function* () {
 
   return GitHubCli.of({
     execute,
-    listOpenPullRequests: (input) =>
-      execute({
+    listOpenPullRequests: (input) => {
+      const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
+      const requestedLimit = input.limit ?? 1;
+      return execute({
         cwd: input.cwd,
         args: [
           "pr",
           "list",
           "--head",
-          input.headSelector,
+          qualifiedHead?.[2] ?? input.headSelector,
           "--state",
           "open",
           "--limit",
-          String(input.limit ?? 1),
+          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
           ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -481,13 +483,24 @@ export const make = Effect.gen(function* () {
                     );
                   }
 
+                  const matches = qualifiedHead
+                    ? decoded.success.filter(
+                        (pullRequest) =>
+                          pullRequest.headRefName === qualifiedHead[2] &&
+                          pullRequest.headRepositoryOwnerLogin?.toLowerCase() ===
+                            qualifiedHead[1]?.toLowerCase(),
+                      )
+                    : decoded.success;
                   return Effect.succeed(
-                    decoded.success.map(({ updatedAt: _updatedAt, ...summary }) => summary),
+                    matches
+                      .slice(0, requestedLimit)
+                      .map(({ updatedAt: _updatedAt, ...summary }) => summary),
                   );
                 }),
               ),
         ),
-      ),
+      );
+    },
     getPullRequest: (input) =>
       execute({
         cwd: input.cwd,
@@ -583,6 +596,8 @@ export const make = Effect.gen(function* () {
                 `base=${input.baseBranch}`,
                 "-F",
                 `body=@${input.bodyFile}`,
+                "-F",
+                "maintainer_can_modify=true",
                 "--silent",
               ],
             });

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -486,7 +486,7 @@ export const make = Effect.gen(function* () {
               ? [pullRequest].map(({ updatedAt: _updatedAt, ...summary }) => summary)
               : [],
           ),
-          Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+          Effect.catchTags({ GitHubPullRequestNotFoundError: () => Effect.succeed([]) }),
         );
       }
       return execute({

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -19,6 +19,51 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+interface PullRequestRepositoryContext {
+  readonly baseRepository: string;
+  readonly headRepository: string;
+}
+
+interface GitHubRepositoryCoordinate {
+  readonly host: string;
+  readonly owner: string;
+  readonly name: string;
+}
+
+function parseGitHubRepositoryCoordinate(
+  repository: string,
+): GitHubRepositoryCoordinate | undefined {
+  const parts = repository.split("/").filter((part) => part.length > 0);
+  if (parts.length === 2) {
+    const [owner, name] = parts;
+    return owner && name ? { host: "github.com", owner, name } : undefined;
+  }
+  if (parts.length === 3) {
+    const [host, owner, name] = parts;
+    return host && owner && name ? { host, owner, name } : undefined;
+  }
+  return undefined;
+}
+
+function formatGitHubRepositoryCoordinate(coordinate: GitHubRepositoryCoordinate): string {
+  return `${coordinate.host}/${coordinate.owner}/${coordinate.name}`;
+}
+
+function qualifyPullRequestHead(
+  context: PullRequestRepositoryContext,
+  headSelector: string,
+): string {
+  if (
+    context.baseRepository.toLowerCase() === context.headRepository.toLowerCase() ||
+    /^[^:/\s]+:.+$/u.test(headSelector)
+  ) {
+    return headSelector;
+  }
+
+  const head = parseGitHubRepositoryCoordinate(context.headRepository);
+  return head ? `${head.owner}:${headSelector}` : headSelector;
+}
+
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
   cwd: Schema.String,
@@ -74,6 +119,22 @@ export class GitHubCliCommandError extends Schema.TaggedErrorClass<GitHubCliComm
 
   override get message(): string {
     return `GitHub CLI failed in execute: ${this.detail}`;
+  }
+}
+
+export class GitHubRepositoryContextDecodeError extends Schema.TaggedErrorClass<GitHubRepositoryContextDecodeError>()(
+  "GitHubRepositoryContextDecodeError",
+  {
+    command: Schema.Literal("gh"),
+    cwd: Schema.String,
+  },
+) {
+  get detail(): string {
+    return "GitHub CLI returned invalid pull request repository context.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in resolvePullRequestRepositoryContext: ${this.detail}`;
   }
 }
 
@@ -140,6 +201,7 @@ export const GitHubCliError = Schema.Union([
   GitHubCliAuthenticationError,
   GitHubPullRequestNotFoundError,
   GitHubCliCommandError,
+  GitHubRepositoryContextDecodeError,
   GitHubPullRequestListDecodeError,
   GitHubChangeRequestListDecodeError,
   GitHubPullRequestDecodeError,
@@ -239,6 +301,7 @@ export class GitHubCli extends Context.Service<
       readonly title: string;
       readonly bodyFile: string;
       readonly repository?: string;
+      readonly headRepository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
 
     readonly getDefaultBranch: (input: {
@@ -326,6 +389,62 @@ export const make = Effect.gen(function* () {
         ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
       })
       .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
+
+  const resolvePullRequestRepositoryContext = Effect.fn(
+    "GitHubCli.resolvePullRequestRepositoryContext",
+  )(function* (input: {
+    readonly cwd: string;
+    readonly repository?: string;
+    readonly headRepository?: string;
+  }) {
+    const explicitBase = input.repository
+      ? parseGitHubRepositoryCoordinate(input.repository)
+      : undefined;
+    const explicitHead = input.headRepository
+      ? parseGitHubRepositoryCoordinate(input.headRepository)
+      : undefined;
+
+    if (explicitBase && explicitHead) {
+      return {
+        baseRepository: formatGitHubRepositoryCoordinate(explicitBase),
+        headRepository: formatGitHubRepositoryCoordinate(explicitHead),
+      };
+    }
+
+    const result = yield* execute({
+      cwd: input.cwd,
+      args: [
+        "repo",
+        "view",
+        ...(input.headRepository ? [input.headRepository] : []),
+        "--json",
+        "nameWithOwner,parent,url",
+        "--jq",
+        '. as $repo | (.url | capture("^https?://(?<host>[^/]+)").host) as $host | [if $repo.parent then "\\($host)/\\($repo.parent.owner.login)/\\($repo.parent.name)" else "\\($host)/\\($repo.nameWithOwner)" end, "\\($host)/\\($repo.nameWithOwner)"] | @tsv',
+      ],
+    });
+    const [resolvedBaseValue, resolvedHeadValue] = result.stdout.trim().split("\t");
+    const resolvedBase = resolvedBaseValue
+      ? parseGitHubRepositoryCoordinate(resolvedBaseValue)
+      : undefined;
+    const resolvedHead = resolvedHeadValue
+      ? parseGitHubRepositoryCoordinate(resolvedHeadValue)
+      : undefined;
+    const base = explicitBase ?? resolvedBase;
+    const head = explicitHead ?? resolvedHead;
+
+    if (!base || !head) {
+      return yield* new GitHubRepositoryContextDecodeError({
+        command: "gh",
+        cwd: input.cwd,
+      });
+    }
+
+    return {
+      baseRepository: formatGitHubRepositoryCoordinate(base),
+      headRepository: formatGitHubRepositoryCoordinate(head),
+    };
+  });
 
   return GitHubCli.of({
     execute,
@@ -432,22 +551,63 @@ export const make = Effect.gen(function* () {
         ),
       ),
     createPullRequest: (input) =>
-      execute({
-        cwd: input.cwd,
-        args: [
-          "pr",
-          "create",
-          "--base",
-          input.baseBranch,
-          "--head",
-          input.headSelector,
-          "--title",
-          input.title,
-          "--body-file",
-          input.bodyFile,
-          ...(input.repository ? ["--repo", input.repository] : []),
-        ],
-      }).pipe(Effect.asVoid),
+      resolvePullRequestRepositoryContext(input).pipe(
+        Effect.flatMap((context) => {
+          const base = parseGitHubRepositoryCoordinate(context.baseRepository);
+          const head = parseGitHubRepositoryCoordinate(context.headRepository);
+          if (
+            base &&
+            head &&
+            context.baseRepository.toLowerCase() !== context.headRepository.toLowerCase()
+          ) {
+            const qualifiedHead = qualifyPullRequestHead(context, input.headSelector);
+            const qualifiedHeadMatch = /^([^:/\s]+):(.+)$/u.exec(qualifiedHead);
+            const headOwner = qualifiedHeadMatch?.[1] ?? head.owner;
+            const headBranch = qualifiedHeadMatch?.[2] ?? qualifiedHead;
+            return execute({
+              cwd: input.cwd,
+              args: [
+                "api",
+                "--hostname",
+                base.host,
+                `repos/${base.owner}/${base.name}/pulls`,
+                "--method",
+                "POST",
+                "-f",
+                `title=${input.title}`,
+                "-f",
+                `head=${headOwner}:${headBranch}`,
+                "-f",
+                `head_repo=${head.name}`,
+                "-f",
+                `base=${input.baseBranch}`,
+                "-F",
+                `body=@${input.bodyFile}`,
+                "--silent",
+              ],
+            });
+          }
+
+          return execute({
+            cwd: input.cwd,
+            args: [
+              "pr",
+              "create",
+              "--base",
+              input.baseBranch,
+              "--head",
+              qualifyPullRequestHead(context, input.headSelector),
+              "--title",
+              input.title,
+              "--body-file",
+              input.bodyFile,
+              "--repo",
+              context.baseRepository,
+            ],
+          });
+        }),
+        Effect.asVoid,
+      ),
     getDefaultBranch: (input) =>
       execute({
         cwd: input.cwd,

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -451,17 +451,55 @@ export const make = Effect.gen(function* () {
     listOpenPullRequests: (input) => {
       const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
       const requestedLimit = input.limit ?? 1;
+      if (qualifiedHead) {
+        return execute({
+          cwd: input.cwd,
+          args: [
+            "pr",
+            "view",
+            input.headSelector,
+            ...(input.repository ? ["--repo", input.repository] : []),
+            "--json",
+            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          ],
+        }).pipe(
+          Effect.map((result) => result.stdout.trim()),
+          Effect.flatMap((raw) =>
+            Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
+              Effect.flatMap((decoded) =>
+                Result.isSuccess(decoded)
+                  ? Effect.succeed(decoded.success)
+                  : Effect.fail(
+                      new GitHubPullRequestDecodeError({
+                        command: "gh",
+                        cwd: input.cwd,
+                        cause: decoded.failure,
+                      }),
+                    ),
+              ),
+            ),
+          ),
+          Effect.map((pullRequest) =>
+            pullRequest.state === "open" &&
+            pullRequest.headRefName === qualifiedHead[2] &&
+            pullRequest.headRepositoryOwnerLogin?.toLowerCase() === qualifiedHead[1]?.toLowerCase()
+              ? [pullRequest].map(({ updatedAt: _updatedAt, ...summary }) => summary)
+              : [],
+          ),
+          Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+        );
+      }
       return execute({
         cwd: input.cwd,
         args: [
           "pr",
           "list",
           "--head",
-          qualifiedHead?.[2] ?? input.headSelector,
+          input.headSelector,
           "--state",
           "open",
           "--limit",
-          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+          String(requestedLimit),
           ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -483,16 +521,8 @@ export const make = Effect.gen(function* () {
                     );
                   }
 
-                  const matches = qualifiedHead
-                    ? decoded.success.filter(
-                        (pullRequest) =>
-                          pullRequest.headRefName === qualifiedHead[2] &&
-                          pullRequest.headRepositoryOwnerLogin?.toLowerCase() ===
-                            qualifiedHead[1]?.toLowerCase(),
-                      )
-                    : decoded.success;
                   return Effect.succeed(
-                    matches
+                    decoded.success
                       .slice(0, requestedLimit)
                       .map(({ updatedAt: _updatedAt, ...summary }) => summary),
                   );

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -244,11 +244,13 @@ export class GitHubCli extends Context.Service<
       readonly cwd: string;
       readonly headSelector: string;
       readonly limit?: number;
+      readonly repository?: string;
     }) => Effect.Effect<ReadonlyArray<GitHubPullRequestSummary>, GitHubCliError>;
 
     readonly getPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
+      readonly repository?: string;
     }) => Effect.Effect<GitHubPullRequestSummary, GitHubCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
@@ -268,16 +270,19 @@ export class GitHubCli extends Context.Service<
       readonly headSelector: string;
       readonly title: string;
       readonly bodyFile: string;
+      readonly repository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
 
     readonly getDefaultBranch: (input: {
       readonly cwd: string;
+      readonly repository?: string;
     }) => Effect.Effect<string | null, GitHubCliError>;
 
     readonly checkoutPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
       readonly force?: boolean;
+      readonly repository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
   }
 >()("t3/sourceControl/GitHubCli") {}
@@ -368,6 +373,7 @@ export const make = Effect.gen(function* () {
           "open",
           "--limit",
           String(input.limit ?? 1),
+          ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
         ],
@@ -400,6 +406,7 @@ export const make = Effect.gen(function* () {
           "pr",
           "view",
           input.reference,
+          ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
         ],
@@ -466,12 +473,21 @@ export const make = Effect.gen(function* () {
           input.title,
           "--body-file",
           input.bodyFile,
+          ...(input.repository ? ["--repo", input.repository] : []),
         ],
       }).pipe(Effect.asVoid),
     getDefaultBranch: (input) =>
       execute({
         cwd: input.cwd,
-        args: ["repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"],
+        args: [
+          "repo",
+          "view",
+          ...(input.repository ? [input.repository] : []),
+          "--json",
+          "defaultBranchRef",
+          "--jq",
+          ".defaultBranchRef.name",
+        ],
       }).pipe(
         Effect.map((value) => {
           const trimmed = value.stdout.trim();
@@ -481,7 +497,13 @@ export const make = Effect.gen(function* () {
     checkoutPullRequest: (input) =>
       execute({
         cwd: input.cwd,
-        args: ["pr", "checkout", input.reference, ...(input.force ? ["--force"] : [])],
+        args: [
+          "pr",
+          "checkout",
+          input.reference,
+          ...(input.force ? ["--force"] : []),
+          ...(input.repository ? ["--repo", input.repository] : []),
+        ],
       }).pipe(Effect.asVoid),
   });
 });

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -480,18 +480,20 @@ export const make = Effect.gen(function* () {
 
   return GitHubCli.of({
     execute,
-    listOpenPullRequests: (input) =>
-      execute({
+    listOpenPullRequests: (input) => {
+      const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
+      const requestedLimit = input.limit ?? 1;
+      return execute({
         cwd: input.cwd,
         args: [
           "pr",
           "list",
           "--head",
-          input.headSelector,
+          qualifiedHead?.[2] ?? input.headSelector,
           "--state",
           "open",
           "--limit",
-          String(input.limit ?? 1),
+          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
           ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -513,11 +515,22 @@ export const make = Effect.gen(function* () {
                     );
                   }
 
-                  return Effect.succeed(decoded.success.map(pullRequestSummary));
+                  const matches = qualifiedHead
+                    ? decoded.success.filter(
+                        (pullRequest) =>
+                          pullRequest.headRefName === qualifiedHead[2] &&
+                          pullRequest.headRepositoryOwnerLogin?.toLowerCase() ===
+                            qualifiedHead[1]?.toLowerCase(),
+                      )
+                    : decoded.success;
+                  return Effect.succeed(
+                    matches.slice(0, requestedLimit).map(pullRequestSummary),
+                  );
                 }),
               ),
         ),
-      ),
+      );
+    },
     getPullRequest: (input) =>
       execute({
         cwd: input.cwd,
@@ -611,6 +624,8 @@ export const make = Effect.gen(function* () {
                 `base=${input.baseBranch}`,
                 "-F",
                 `body=@${input.bodyFile}`,
+                "-F",
+                "maintainer_can_modify=true",
                 "--silent",
               ],
             });

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -64,14 +64,6 @@ function formatGitHubRepositoryCoordinate(coordinate: GitHubRepositoryCoordinate
   return `${coordinate.host}/${coordinate.owner}/${coordinate.name}`;
 }
 
-function gitHubApiHostname(host: string): string {
-  try {
-    return new URL(`https://${host}`).hostname;
-  } catch {
-    return host;
-  }
-}
-
 function qualifyPullRequestHead(
   context: PullRequestRepositoryContext,
   headSelector: string,
@@ -650,7 +642,7 @@ export const make = Effect.gen(function* () {
               args: [
                 "api",
                 "--hostname",
-                gitHubApiHostname(base.host),
+                base.host,
                 `repos/${base.owner}/${base.name}/pulls`,
                 "--method",
                 "POST",

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -518,7 +518,7 @@ export const make = Effect.gen(function* () {
               ? [pullRequestSummary(pullRequest)]
               : [],
           ),
-          Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+          Effect.catchTags({ GitHubPullRequestNotFoundError: () => Effect.succeed([]) }),
         );
       }
       return execute({

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -519,55 +519,17 @@ export const make = Effect.gen(function* () {
     listOpenPullRequests: (input) => {
       const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
       const requestedLimit = input.limit ?? 1;
-      if (qualifiedHead) {
-        return execute({
-          cwd: input.cwd,
-          args: [
-            "pr",
-            "view",
-            input.headSelector,
-            ...(input.repository ? ["--repo", input.repository] : []),
-            "--json",
-            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
-          ],
-        }).pipe(
-          Effect.map((result) => result.stdout.trim()),
-          Effect.flatMap((raw) =>
-            Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
-              Effect.flatMap((decoded) =>
-                Result.isSuccess(decoded)
-                  ? Effect.succeed(decoded.success)
-                  : Effect.fail(
-                      new GitHubPullRequestDecodeError({
-                        command: "gh",
-                        cwd: input.cwd,
-                        cause: decoded.failure,
-                      }),
-                    ),
-              ),
-            ),
-          ),
-          Effect.map((pullRequest) =>
-            pullRequest.state === "open" &&
-            pullRequest.headRefName === qualifiedHead[2] &&
-            pullRequest.headRepositoryOwnerLogin?.toLowerCase() === qualifiedHead[1]?.toLowerCase()
-              ? [pullRequestSummary(pullRequest)]
-              : [],
-          ),
-          Effect.catchTags({ GitHubPullRequestNotFoundError: () => Effect.succeed([]) }),
-        );
-      }
       return execute({
         cwd: input.cwd,
         args: [
           "pr",
           "list",
           "--head",
-          input.headSelector,
+          qualifiedHead?.[2] ?? input.headSelector,
           "--state",
           "open",
           "--limit",
-          String(requestedLimit),
+          String(qualifiedHead ? 100 : requestedLimit),
           ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -588,10 +550,16 @@ export const make = Effect.gen(function* () {
                       }),
                     );
                   }
-
-                  return Effect.succeed(
-                    decoded.success.slice(0, requestedLimit).map(pullRequestSummary),
-                  );
+                  const matching = qualifiedHead
+                    ? decoded.success.filter(
+                        (pullRequest) =>
+                          pullRequest.state === "open" &&
+                          pullRequest.headRefName === qualifiedHead[2] &&
+                          pullRequest.headRepositoryOwnerLogin?.toLowerCase() ===
+                            qualifiedHead[1]?.toLowerCase(),
+                      )
+                    : decoded.success;
+                  return Effect.succeed(matching.slice(0, requestedLimit).map(pullRequestSummary));
                 }),
               ),
         ),

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -27,19 +27,23 @@ interface PullRequestRepositoryContext {
   readonly headRepository: string;
 }
 
-interface GitHubRepositoryCoordinate {
-  readonly host: string;
+interface ParsedGitHubRepositoryCoordinate {
+  readonly host?: string;
   readonly owner: string;
   readonly name: string;
 }
 
+interface GitHubRepositoryCoordinate extends ParsedGitHubRepositoryCoordinate {
+  readonly host: string;
+}
+
 function parseGitHubRepositoryCoordinate(
   repository: string,
-): GitHubRepositoryCoordinate | undefined {
+): ParsedGitHubRepositoryCoordinate | undefined {
   const parts = repository.split("/").filter((part) => part.length > 0);
   if (parts.length === 2) {
     const [owner, name] = parts;
-    return owner && name ? { host: "github.com", owner, name } : undefined;
+    return owner && name ? { owner, name } : undefined;
   }
   if (parts.length === 3) {
     const [host, owner, name] = parts;
@@ -48,8 +52,24 @@ function parseGitHubRepositoryCoordinate(
   return undefined;
 }
 
+function resolveGitHubRepositoryCoordinate(
+  coordinate: ParsedGitHubRepositoryCoordinate | undefined,
+  fallbackHost: string | undefined,
+): GitHubRepositoryCoordinate | undefined {
+  const host = coordinate?.host ?? fallbackHost;
+  return coordinate && host ? { ...coordinate, host } : undefined;
+}
+
 function formatGitHubRepositoryCoordinate(coordinate: GitHubRepositoryCoordinate): string {
   return `${coordinate.host}/${coordinate.owner}/${coordinate.name}`;
+}
+
+function gitHubApiHostname(host: string): string {
+  try {
+    return new URL(`https://${host}`).hostname;
+  } catch {
+    return host;
+  }
 }
 
 function qualifyPullRequestHead(
@@ -436,10 +456,18 @@ export const make = Effect.gen(function* () {
       ? parseGitHubRepositoryCoordinate(input.headRepository)
       : undefined;
 
-    if (explicitBase && explicitHead) {
+    const explicitBaseWithHost = resolveGitHubRepositoryCoordinate(
+      explicitBase,
+      explicitHead?.host,
+    );
+    const explicitHeadWithHost = resolveGitHubRepositoryCoordinate(
+      explicitHead,
+      explicitBase?.host,
+    );
+    if (explicitBaseWithHost && explicitHeadWithHost) {
       return {
-        baseRepository: formatGitHubRepositoryCoordinate(explicitBase),
-        headRepository: formatGitHubRepositoryCoordinate(explicitHead),
+        baseRepository: formatGitHubRepositoryCoordinate(explicitBaseWithHost),
+        headRepository: formatGitHubRepositoryCoordinate(explicitHeadWithHost),
       };
     }
 
@@ -456,14 +484,22 @@ export const make = Effect.gen(function* () {
       ],
     });
     const [resolvedBaseValue, resolvedHeadValue] = result.stdout.trim().split("\t");
-    const resolvedBase = resolvedBaseValue
-      ? parseGitHubRepositoryCoordinate(resolvedBaseValue)
-      : undefined;
-    const resolvedHead = resolvedHeadValue
-      ? parseGitHubRepositoryCoordinate(resolvedHeadValue)
-      : undefined;
-    const base = explicitBase ?? resolvedBase;
-    const head = explicitHead ?? resolvedHead;
+    const resolvedBase = resolveGitHubRepositoryCoordinate(
+      resolvedBaseValue ? parseGitHubRepositoryCoordinate(resolvedBaseValue) : undefined,
+      undefined,
+    );
+    const resolvedHead = resolveGitHubRepositoryCoordinate(
+      resolvedHeadValue ? parseGitHubRepositoryCoordinate(resolvedHeadValue) : undefined,
+      undefined,
+    );
+    const base = resolveGitHubRepositoryCoordinate(
+      explicitBase ?? resolvedBase,
+      explicitBase?.host ?? resolvedBase?.host ?? resolvedHead?.host,
+    );
+    const head = resolveGitHubRepositoryCoordinate(
+      explicitHead ?? resolvedHead,
+      explicitHead?.host ?? resolvedHead?.host ?? base?.host,
+    );
 
     if (!base || !head) {
       return yield* new GitHubRepositoryContextDecodeError({
@@ -624,8 +660,14 @@ export const make = Effect.gen(function* () {
     createPullRequest: (input) =>
       resolvePullRequestRepositoryContext(input).pipe(
         Effect.flatMap((context) => {
-          const base = parseGitHubRepositoryCoordinate(context.baseRepository);
-          const head = parseGitHubRepositoryCoordinate(context.headRepository);
+          const base = resolveGitHubRepositoryCoordinate(
+            parseGitHubRepositoryCoordinate(context.baseRepository),
+            undefined,
+          );
+          const head = resolveGitHubRepositoryCoordinate(
+            parseGitHubRepositoryCoordinate(context.headRepository),
+            undefined,
+          );
           if (
             base &&
             head &&
@@ -640,7 +682,7 @@ export const make = Effect.gen(function* () {
               args: [
                 "api",
                 "--hostname",
-                base.host,
+                gitHubApiHostname(base.host),
                 `repos/${base.owner}/${base.name}/pulls`,
                 "--method",
                 "POST",

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -22,6 +22,51 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+interface PullRequestRepositoryContext {
+  readonly baseRepository: string;
+  readonly headRepository: string;
+}
+
+interface GitHubRepositoryCoordinate {
+  readonly host: string;
+  readonly owner: string;
+  readonly name: string;
+}
+
+function parseGitHubRepositoryCoordinate(
+  repository: string,
+): GitHubRepositoryCoordinate | undefined {
+  const parts = repository.split("/").filter((part) => part.length > 0);
+  if (parts.length === 2) {
+    const [owner, name] = parts;
+    return owner && name ? { host: "github.com", owner, name } : undefined;
+  }
+  if (parts.length === 3) {
+    const [host, owner, name] = parts;
+    return host && owner && name ? { host, owner, name } : undefined;
+  }
+  return undefined;
+}
+
+function formatGitHubRepositoryCoordinate(coordinate: GitHubRepositoryCoordinate): string {
+  return `${coordinate.host}/${coordinate.owner}/${coordinate.name}`;
+}
+
+function qualifyPullRequestHead(
+  context: PullRequestRepositoryContext,
+  headSelector: string,
+): string {
+  if (
+    context.baseRepository.toLowerCase() === context.headRepository.toLowerCase() ||
+    /^[^:/\s]+:.+$/u.test(headSelector)
+  ) {
+    return headSelector;
+  }
+
+  const head = parseGitHubRepositoryCoordinate(context.headRepository);
+  return head ? `${head.owner}:${headSelector}` : headSelector;
+}
+
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
   cwd: Schema.String,
@@ -93,6 +138,22 @@ export class GitHubCliCommandError extends Schema.TaggedErrorClass<GitHubCliComm
   }
 }
 
+export class GitHubRepositoryContextDecodeError extends Schema.TaggedErrorClass<GitHubRepositoryContextDecodeError>()(
+  "GitHubRepositoryContextDecodeError",
+  {
+    command: Schema.Literal("gh"),
+    cwd: Schema.String,
+  },
+) {
+  get detail(): string {
+    return "GitHub CLI returned invalid pull request repository context.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in resolvePullRequestRepositoryContext: ${this.detail}`;
+  }
+}
+
 const gitHubCliDecodeFields = {
   command: Schema.Literal("gh"),
   cwd: Schema.String,
@@ -157,6 +218,7 @@ export const GitHubCliError = Schema.Union([
   GitHubCliRateLimitError,
   GitHubPullRequestNotFoundError,
   GitHubCliCommandError,
+  GitHubRepositoryContextDecodeError,
   GitHubPullRequestListDecodeError,
   GitHubChangeRequestListDecodeError,
   GitHubPullRequestDecodeError,
@@ -271,6 +333,7 @@ export class GitHubCli extends Context.Service<
       readonly title: string;
       readonly bodyFile: string;
       readonly repository?: string;
+      readonly headRepository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
 
     readonly getDefaultBranch: (input: {
@@ -358,6 +421,62 @@ export const make = Effect.gen(function* () {
         ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
       })
       .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
+
+  const resolvePullRequestRepositoryContext = Effect.fn(
+    "GitHubCli.resolvePullRequestRepositoryContext",
+  )(function* (input: {
+    readonly cwd: string;
+    readonly repository?: string;
+    readonly headRepository?: string;
+  }) {
+    const explicitBase = input.repository
+      ? parseGitHubRepositoryCoordinate(input.repository)
+      : undefined;
+    const explicitHead = input.headRepository
+      ? parseGitHubRepositoryCoordinate(input.headRepository)
+      : undefined;
+
+    if (explicitBase && explicitHead) {
+      return {
+        baseRepository: formatGitHubRepositoryCoordinate(explicitBase),
+        headRepository: formatGitHubRepositoryCoordinate(explicitHead),
+      };
+    }
+
+    const result = yield* execute({
+      cwd: input.cwd,
+      args: [
+        "repo",
+        "view",
+        ...(input.headRepository ? [input.headRepository] : []),
+        "--json",
+        "nameWithOwner,parent,url",
+        "--jq",
+        '. as $repo | (.url | capture("^https?://(?<host>[^/]+)").host) as $host | [if $repo.parent then "\\($host)/\\($repo.parent.owner.login)/\\($repo.parent.name)" else "\\($host)/\\($repo.nameWithOwner)" end, "\\($host)/\\($repo.nameWithOwner)"] | @tsv',
+      ],
+    });
+    const [resolvedBaseValue, resolvedHeadValue] = result.stdout.trim().split("\t");
+    const resolvedBase = resolvedBaseValue
+      ? parseGitHubRepositoryCoordinate(resolvedBaseValue)
+      : undefined;
+    const resolvedHead = resolvedHeadValue
+      ? parseGitHubRepositoryCoordinate(resolvedHeadValue)
+      : undefined;
+    const base = explicitBase ?? resolvedBase;
+    const head = explicitHead ?? resolvedHead;
+
+    if (!base || !head) {
+      return yield* new GitHubRepositoryContextDecodeError({
+        command: "gh",
+        cwd: input.cwd,
+      });
+    }
+
+    return {
+      baseRepository: formatGitHubRepositoryCoordinate(base),
+      headRepository: formatGitHubRepositoryCoordinate(head),
+    };
+  });
 
   return GitHubCli.of({
     execute,
@@ -460,22 +579,63 @@ export const make = Effect.gen(function* () {
         ),
       ),
     createPullRequest: (input) =>
-      execute({
-        cwd: input.cwd,
-        args: [
-          "pr",
-          "create",
-          "--base",
-          input.baseBranch,
-          "--head",
-          input.headSelector,
-          "--title",
-          input.title,
-          "--body-file",
-          input.bodyFile,
-          ...(input.repository ? ["--repo", input.repository] : []),
-        ],
-      }).pipe(Effect.asVoid),
+      resolvePullRequestRepositoryContext(input).pipe(
+        Effect.flatMap((context) => {
+          const base = parseGitHubRepositoryCoordinate(context.baseRepository);
+          const head = parseGitHubRepositoryCoordinate(context.headRepository);
+          if (
+            base &&
+            head &&
+            context.baseRepository.toLowerCase() !== context.headRepository.toLowerCase()
+          ) {
+            const qualifiedHead = qualifyPullRequestHead(context, input.headSelector);
+            const qualifiedHeadMatch = /^([^:/\s]+):(.+)$/u.exec(qualifiedHead);
+            const headOwner = qualifiedHeadMatch?.[1] ?? head.owner;
+            const headBranch = qualifiedHeadMatch?.[2] ?? qualifiedHead;
+            return execute({
+              cwd: input.cwd,
+              args: [
+                "api",
+                "--hostname",
+                base.host,
+                `repos/${base.owner}/${base.name}/pulls`,
+                "--method",
+                "POST",
+                "-f",
+                `title=${input.title}`,
+                "-f",
+                `head=${headOwner}:${headBranch}`,
+                "-f",
+                `head_repo=${head.name}`,
+                "-f",
+                `base=${input.baseBranch}`,
+                "-F",
+                `body=@${input.bodyFile}`,
+                "--silent",
+              ],
+            });
+          }
+
+          return execute({
+            cwd: input.cwd,
+            args: [
+              "pr",
+              "create",
+              "--base",
+              input.baseBranch,
+              "--head",
+              qualifyPullRequestHead(context, input.headSelector),
+              "--title",
+              input.title,
+              "--body-file",
+              input.bodyFile,
+              "--repo",
+              context.baseRepository,
+            ],
+          });
+        }),
+        Effect.asVoid,
+      ),
     getDefaultBranch: (input) =>
       execute({
         cwd: input.cwd,

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -483,17 +483,55 @@ export const make = Effect.gen(function* () {
     listOpenPullRequests: (input) => {
       const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
       const requestedLimit = input.limit ?? 1;
+      if (qualifiedHead) {
+        return execute({
+          cwd: input.cwd,
+          args: [
+            "pr",
+            "view",
+            input.headSelector,
+            ...(input.repository ? ["--repo", input.repository] : []),
+            "--json",
+            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          ],
+        }).pipe(
+          Effect.map((result) => result.stdout.trim()),
+          Effect.flatMap((raw) =>
+            Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
+              Effect.flatMap((decoded) =>
+                Result.isSuccess(decoded)
+                  ? Effect.succeed(decoded.success)
+                  : Effect.fail(
+                      new GitHubPullRequestDecodeError({
+                        command: "gh",
+                        cwd: input.cwd,
+                        cause: decoded.failure,
+                      }),
+                    ),
+              ),
+            ),
+          ),
+          Effect.map((pullRequest) =>
+            pullRequest.state === "open" &&
+            pullRequest.headRefName === qualifiedHead[2] &&
+            pullRequest.headRepositoryOwnerLogin?.toLowerCase() === qualifiedHead[1]?.toLowerCase()
+              ? [pullRequestSummary(pullRequest)]
+              : [],
+          ),
+          Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+        );
+      }
       return execute({
         cwd: input.cwd,
         args: [
           "pr",
           "list",
           "--head",
-          qualifiedHead?.[2] ?? input.headSelector,
+          input.headSelector,
           "--state",
           "open",
           "--limit",
-          String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+          String(requestedLimit),
           ...(input.repository ? ["--repo", input.repository] : []),
           "--json",
           "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -515,16 +553,8 @@ export const make = Effect.gen(function* () {
                     );
                   }
 
-                  const matches = qualifiedHead
-                    ? decoded.success.filter(
-                        (pullRequest) =>
-                          pullRequest.headRefName === qualifiedHead[2] &&
-                          pullRequest.headRepositoryOwnerLogin?.toLowerCase() ===
-                            qualifiedHead[1]?.toLowerCase(),
-                      )
-                    : decoded.success;
                   return Effect.succeed(
-                    matches.slice(0, requestedLimit).map(pullRequestSummary),
+                    decoded.success.slice(0, requestedLimit).map(pullRequestSummary),
                   );
                 }),
               ),

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -135,6 +135,11 @@ it.effect("uses gh json listing for non-open change request state queries", () =
 
     const changeRequests = yield* provider.listChangeRequests({
       cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "git@github.com:T3Tools/t3code.git",
+      },
       headSelector: "feature/merged",
       state: "all",
       limit: 10,
@@ -149,6 +154,8 @@ it.effect("uses gh json listing for non-open change request state queries", () =
       "all",
       "--limit",
       "10",
+      "--repo",
+      "T3Tools/t3code",
       "--json",
       "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
     ]);
@@ -158,6 +165,31 @@ it.effect("uses gh json listing for non-open change request state queries", () =
       changeRequests[0]?.updatedAt,
       Option.some(DateTime.makeUnsafe("2026-01-02T00:00:00.000Z")),
     );
+  }),
+);
+
+it.effect("targets the upstream repository when listing open pull requests for a fork", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "https://github.com/T3Tools/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "T3Tools/t3code");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -239,6 +239,47 @@ it.effect("creates GitHub PRs through provider-neutral input names", () =>
   }),
 );
 
+it.effect("passes upstream and fork repositories to GitHub PR creation", () =>
+  Effect.gen(function* () {
+    let createInput: Parameters<GitHubCli.GitHubCli["Service"]["createPullRequest"]>[0] | null =
+      null;
+    const provider = yield* makeProvider({
+      createPullRequest: (input) => {
+        createInput = input;
+        return Effect.void;
+      },
+    });
+
+    yield* provider.createChangeRequest({
+      cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "git@github.com:pingdotgg/t3code.git",
+      },
+      source: {
+        refName: "feature/provider",
+        owner: "octocat",
+        repository: "octocat/t3code",
+      },
+      baseRefName: "main",
+      headSelector: "octocat:feature/provider",
+      title: "Provider PR",
+      bodyFile: "/tmp/body.md",
+    });
+
+    assert.deepStrictEqual(createInput, {
+      cwd: "/repo",
+      baseBranch: "main",
+      headSelector: "octocat:feature/provider",
+      title: "Provider PR",
+      bodyFile: "/tmp/body.md",
+      repository: "pingdotgg/t3code",
+      headRepository: "octocat/t3code",
+    });
+  }),
+);
+
 it("accepts active authenticated GitHub accounts when another account fails", () => {
   const auth = GitHubSourceControlProvider.discovery.parseAuth(
     processResult(

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -239,7 +239,7 @@ it.effect("treats empty non-open change request listing output as no results", (
   }),
 );
 
-it.effect("filters qualified fork heads for non-open listings without gh head syntax", () =>
+it.effect("looks up qualified fork heads directly for non-open listings", () =>
   Effect.gen(function* () {
     let args: ReadonlyArray<string> = [];
     const provider = yield* makeProvider({
@@ -247,26 +247,16 @@ it.effect("filters qualified fork heads for non-open listings without gh head sy
         args = input.args;
         return Effect.succeed(
           processResult(
-            JSON.stringify([
-              {
-                number: 51,
-                title: "Other owner",
-                url: "https://github.com/pingdotgg/t3code/pull/51",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "CLOSED",
-                headRepositoryOwner: { login: "other" },
-              },
-              {
-                number: 52,
-                title: "Requested owner",
-                url: "https://github.com/pingdotgg/t3code/pull/52",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "CLOSED",
-                headRepositoryOwner: { login: "octocat" },
-              },
-            ]),
+            JSON.stringify({
+              number: 52,
+              title: "Requested owner",
+              url: "https://github.com/pingdotgg/t3code/pull/52",
+              baseRefName: "main",
+              headRefName: "feature/shared",
+              state: "CLOSED",
+              updatedAt: "2026-01-02T00:00:00.000Z",
+              headRepositoryOwner: { login: "octocat" },
+            }),
           ),
         );
       },
@@ -283,8 +273,8 @@ it.effect("filters qualified fork heads for non-open listings without gh head sy
       changeRequests.map((changeRequest) => changeRequest.number),
       [52],
     );
-    assert.include(args.join(" "), "--head feature/shared");
-    assert.include(args.join(" "), "--limit 100");
+    assert.include(args.join(" "), "pr view octocat:feature/shared");
+    assert.notInclude(args.join(" "), "--limit");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -193,6 +193,35 @@ it.effect("targets the upstream repository when listing open pull requests for a
   }),
 );
 
+it.effect("preserves a GitHub Enterprise host in upstream repository coordinates", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "github",
+          name: "github.example.com",
+          baseUrl: "https://github.example.com",
+        },
+        remoteName: "upstream",
+        remoteUrl: "git@github.example.com:platform/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "github.example.com/platform/t3code");
+  }),
+);
+
 it.effect("treats empty non-open change request listing output as no results", () =>
   Effect.gen(function* () {
     const provider = yield* makeProvider({
@@ -207,6 +236,55 @@ it.effect("treats empty non-open change request listing output as no results", (
     });
 
     assert.deepStrictEqual(changeRequests, []);
+  }),
+);
+
+it.effect("filters qualified fork heads for non-open listings without gh head syntax", () =>
+  Effect.gen(function* () {
+    let args: ReadonlyArray<string> = [];
+    const provider = yield* makeProvider({
+      execute: (input) => {
+        args = input.args;
+        return Effect.succeed(
+          processResult(
+            JSON.stringify([
+              {
+                number: 51,
+                title: "Other owner",
+                url: "https://github.com/pingdotgg/t3code/pull/51",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "CLOSED",
+                headRepositoryOwner: { login: "other" },
+              },
+              {
+                number: 52,
+                title: "Requested owner",
+                url: "https://github.com/pingdotgg/t3code/pull/52",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "CLOSED",
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
+          ),
+        );
+      },
+    });
+
+    const changeRequests = yield* provider.listChangeRequests({
+      cwd: "/repo",
+      headSelector: "octocat:feature/shared",
+      state: "all",
+      limit: 1,
+    });
+
+    assert.deepStrictEqual(
+      changeRequests.map((changeRequest) => changeRequest.number),
+      [52],
+    );
+    assert.include(args.join(" "), "--head feature/shared");
+    assert.include(args.join(" "), "--limit 100");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -193,6 +193,31 @@ it.effect("targets the upstream repository when listing open pull requests for a
   }),
 );
 
+it.effect("normalizes a trailing slash after an upstream Git URL suffix", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "https://github.com/T3Tools/t3code.git/",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "T3Tools/t3code");
+  }),
+);
+
 it.effect("preserves a GitHub Enterprise host in upstream repository coordinates", () =>
   Effect.gen(function* () {
     let repository: string | undefined;

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -247,6 +247,35 @@ it.effect("preserves a GitHub Enterprise host in upstream repository coordinates
   }),
 );
 
+it.effect("preserves a custom GitHub Enterprise port in upstream repository coordinates", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "github",
+          name: "github.example.com:8443",
+          baseUrl: "https://github.example.com:8443",
+        },
+        remoteName: "upstream",
+        remoteUrl: "https://github.example.com:8443/platform/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "github.example.com:8443/platform/t3code");
+  }),
+);
+
 it.effect("treats empty non-open change request listing output as no results", () =>
   Effect.gen(function* () {
     const provider = yield* makeProvider({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -197,6 +197,31 @@ it.effect("targets the upstream repository when listing open pull requests for a
   }),
 );
 
+it.effect("normalizes a trailing slash after an upstream Git URL suffix", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "https://github.com/T3Tools/t3code.git/",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "T3Tools/t3code");
+  }),
+);
+
 it.effect("preserves a GitHub Enterprise host in upstream repository coordinates", () =>
   Effect.gen(function* () {
     let repository: string | undefined;

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -280,6 +280,35 @@ it.effect("preserves a custom GitHub Enterprise port in upstream repository coor
   }),
 );
 
+it.effect("drops SSH ports from GitHub Enterprise repository coordinates", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "github",
+          name: "github.example.com",
+          baseUrl: "https://github.example.com",
+        },
+        remoteName: "upstream",
+        remoteUrl: "ssh://git@github.example.com:2222/platform/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "github.example.com/platform/t3code");
+  }),
+);
+
 it.effect("treats empty non-open change request listing output as no results", () =>
   Effect.gen(function* () {
     const provider = yield* makeProvider({
@@ -297,7 +326,7 @@ it.effect("treats empty non-open change request listing output as no results", (
   }),
 );
 
-it.effect("looks up qualified fork heads directly for non-open listings", () =>
+it.effect("lists every matching qualified fork head for non-open states", () =>
   Effect.gen(function* () {
     let args: ReadonlyArray<string> = [];
     const provider = yield* makeProvider({
@@ -305,16 +334,39 @@ it.effect("looks up qualified fork heads directly for non-open listings", () =>
         args = input.args;
         return Effect.succeed(
           processResult(
-            JSON.stringify({
-              number: 52,
-              title: "Requested owner",
-              url: "https://github.com/pingdotgg/t3code/pull/52",
-              baseRefName: "main",
-              headRefName: "feature/shared",
-              state: "CLOSED",
-              updatedAt: "2026-01-02T00:00:00.000Z",
-              headRepositoryOwner: { login: "octocat" },
-            }),
+            JSON.stringify([
+              {
+                number: 51,
+                title: "Different owner",
+                url: "https://github.com/pingdotgg/t3code/pull/51",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "CLOSED",
+                updatedAt: "2026-01-01T00:00:00.000Z",
+                headRepositoryOwner: { login: "someone-else" },
+              },
+              {
+                number: 52,
+                title: "Requested owner main",
+                url: "https://github.com/pingdotgg/t3code/pull/52",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "CLOSED",
+                updatedAt: "2026-01-02T00:00:00.000Z",
+                headRepositoryOwner: { login: "octocat" },
+              },
+              {
+                number: 53,
+                title: "Requested owner release",
+                url: "https://github.com/pingdotgg/t3code/pull/53",
+                baseRefName: "release",
+                headRefName: "feature/shared",
+                state: "MERGED",
+                mergedAt: "2026-01-03T00:00:00.000Z",
+                updatedAt: "2026-01-03T00:00:00.000Z",
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
           ),
         );
       },
@@ -324,15 +376,14 @@ it.effect("looks up qualified fork heads directly for non-open listings", () =>
       cwd: "/repo",
       headSelector: "octocat:feature/shared",
       state: "all",
-      limit: 1,
+      limit: 2,
     });
 
     assert.deepStrictEqual(
       changeRequests.map((changeRequest) => changeRequest.number),
-      [52],
+      [52, 53],
     );
-    assert.include(args.join(" "), "pr view octocat:feature/shared");
-    assert.notInclude(args.join(" "), "--limit");
+    assert.include(args.join(" "), "pr list --head feature/shared --state all --limit 100");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -197,6 +197,35 @@ it.effect("targets the upstream repository when listing open pull requests for a
   }),
 );
 
+it.effect("preserves a GitHub Enterprise host in upstream repository coordinates", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "github",
+          name: "github.example.com",
+          baseUrl: "https://github.example.com",
+        },
+        remoteName: "upstream",
+        remoteUrl: "git@github.example.com:platform/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "github.example.com/platform/t3code");
+  }),
+);
+
 it.effect("treats empty non-open change request listing output as no results", () =>
   Effect.gen(function* () {
     const provider = yield* makeProvider({
@@ -211,6 +240,55 @@ it.effect("treats empty non-open change request listing output as no results", (
     });
 
     assert.deepStrictEqual(changeRequests, []);
+  }),
+);
+
+it.effect("filters qualified fork heads for non-open listings without gh head syntax", () =>
+  Effect.gen(function* () {
+    let args: ReadonlyArray<string> = [];
+    const provider = yield* makeProvider({
+      execute: (input) => {
+        args = input.args;
+        return Effect.succeed(
+          processResult(
+            JSON.stringify([
+              {
+                number: 51,
+                title: "Other owner",
+                url: "https://github.com/pingdotgg/t3code/pull/51",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "CLOSED",
+                headRepositoryOwner: { login: "other" },
+              },
+              {
+                number: 52,
+                title: "Requested owner",
+                url: "https://github.com/pingdotgg/t3code/pull/52",
+                baseRefName: "main",
+                headRefName: "feature/shared",
+                state: "CLOSED",
+                headRepositoryOwner: { login: "octocat" },
+              },
+            ]),
+          ),
+        );
+      },
+    });
+
+    const changeRequests = yield* provider.listChangeRequests({
+      cwd: "/repo",
+      headSelector: "octocat:feature/shared",
+      state: "all",
+      limit: 1,
+    });
+
+    assert.deepStrictEqual(
+      changeRequests.map((changeRequest) => changeRequest.number),
+      [52],
+    );
+    assert.include(args.join(" "), "--head feature/shared");
+    assert.include(args.join(" "), "--limit 100");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -251,6 +251,35 @@ it.effect("preserves a GitHub Enterprise host in upstream repository coordinates
   }),
 );
 
+it.effect("preserves a custom GitHub Enterprise port in upstream repository coordinates", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: {
+          kind: "github",
+          name: "github.example.com:8443",
+          baseUrl: "https://github.example.com:8443",
+        },
+        remoteName: "upstream",
+        remoteUrl: "https://github.example.com:8443/platform/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "github.example.com:8443/platform/t3code");
+  }),
+);
+
 it.effect("treats empty non-open change request listing output as no results", () =>
   Effect.gen(function* () {
     const provider = yield* makeProvider({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -243,6 +243,47 @@ it.effect("creates GitHub PRs through provider-neutral input names", () =>
   }),
 );
 
+it.effect("passes upstream and fork repositories to GitHub PR creation", () =>
+  Effect.gen(function* () {
+    let createInput: Parameters<GitHubCli.GitHubCli["Service"]["createPullRequest"]>[0] | null =
+      null;
+    const provider = yield* makeProvider({
+      createPullRequest: (input) => {
+        createInput = input;
+        return Effect.void;
+      },
+    });
+
+    yield* provider.createChangeRequest({
+      cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "git@github.com:pingdotgg/t3code.git",
+      },
+      source: {
+        refName: "feature/provider",
+        owner: "octocat",
+        repository: "octocat/t3code",
+      },
+      baseRefName: "main",
+      headSelector: "octocat:feature/provider",
+      title: "Provider PR",
+      bodyFile: "/tmp/body.md",
+    });
+
+    assert.deepStrictEqual(createInput, {
+      cwd: "/repo",
+      baseBranch: "main",
+      headSelector: "octocat:feature/provider",
+      title: "Provider PR",
+      bodyFile: "/tmp/body.md",
+      repository: "pingdotgg/t3code",
+      headRepository: "octocat/t3code",
+    });
+  }),
+);
+
 it("accepts active authenticated GitHub accounts when another account fails", () => {
   const auth = GitHubSourceControlProvider.discovery.parseAuth(
     processResult(

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -138,6 +138,11 @@ it.effect("uses gh json listing for non-open change request state queries", () =
 
     const changeRequests = yield* provider.listChangeRequests({
       cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "git@github.com:T3Tools/t3code.git",
+      },
       headSelector: "feature/merged",
       state: "all",
       limit: 10,
@@ -152,6 +157,8 @@ it.effect("uses gh json listing for non-open change request state queries", () =
       "all",
       "--limit",
       "10",
+      "--repo",
+      "T3Tools/t3code",
       "--json",
       "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
     ]);
@@ -162,6 +169,31 @@ it.effect("uses gh json listing for non-open change request state queries", () =
       changeRequests[0]?.updatedAt,
       Option.some(DateTime.makeUnsafe("2026-01-02T00:00:00.000Z")),
     );
+  }),
+);
+
+it.effect("targets the upstream repository when listing open pull requests for a fork", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const provider = yield* makeProvider({
+      listOpenPullRequests: (input) => {
+        repository = input.repository;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      context: {
+        provider: { kind: "github", name: "github.com", baseUrl: "https://github.com" },
+        remoteName: "upstream",
+        remoteUrl: "https://github.com/T3Tools/t3code.git",
+      },
+      headSelector: "contributor:feature/fork-pr",
+      state: "open",
+    });
+
+    assert.strictEqual(repository, "T3Tools/t3code");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -243,7 +243,7 @@ it.effect("treats empty non-open change request listing output as no results", (
   }),
 );
 
-it.effect("filters qualified fork heads for non-open listings without gh head syntax", () =>
+it.effect("looks up qualified fork heads directly for non-open listings", () =>
   Effect.gen(function* () {
     let args: ReadonlyArray<string> = [];
     const provider = yield* makeProvider({
@@ -251,26 +251,16 @@ it.effect("filters qualified fork heads for non-open listings without gh head sy
         args = input.args;
         return Effect.succeed(
           processResult(
-            JSON.stringify([
-              {
-                number: 51,
-                title: "Other owner",
-                url: "https://github.com/pingdotgg/t3code/pull/51",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "CLOSED",
-                headRepositoryOwner: { login: "other" },
-              },
-              {
-                number: 52,
-                title: "Requested owner",
-                url: "https://github.com/pingdotgg/t3code/pull/52",
-                baseRefName: "main",
-                headRefName: "feature/shared",
-                state: "CLOSED",
-                headRepositoryOwner: { login: "octocat" },
-              },
-            ]),
+            JSON.stringify({
+              number: 52,
+              title: "Requested owner",
+              url: "https://github.com/pingdotgg/t3code/pull/52",
+              baseRefName: "main",
+              headRefName: "feature/shared",
+              state: "CLOSED",
+              updatedAt: "2026-01-02T00:00:00.000Z",
+              headRepositoryOwner: { login: "octocat" },
+            }),
           ),
         );
       },
@@ -287,8 +277,8 @@ it.effect("filters qualified fork heads for non-open listings without gh head sy
       changeRequests.map((changeRequest) => changeRequest.number),
       [52],
     );
-    assert.include(args.join(" "), "--head feature/shared");
-    assert.include(args.join(" "), "--limit 100");
+    assert.include(args.join(" "), "pr view octocat:feature/shared");
+    assert.notInclude(args.join(" "), "--limit");
   }),
 );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -7,6 +7,7 @@ import {
   type ChangeRequest,
   type ChangeRequestState,
 } from "@t3tools/contracts";
+import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
@@ -96,15 +97,30 @@ export const discovery = {
 
 export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
+  const repositoryFromContext = (
+    context: SourceControlProvider.SourceControlProviderContext | undefined,
+  ) =>
+    context?.remoteName === "upstream"
+      ? (parseGitHubRepositoryNameWithOwnerFromRemoteUrl(context.remoteUrl) ?? undefined)
+      : undefined;
+  const withRepositoryFromContext = <Input extends object>(
+    input: Input,
+    context: SourceControlProvider.SourceControlProviderContext | undefined,
+  ): Input | (Input & { readonly repository: string }) => {
+    const repository = repositoryFromContext(context);
+    return repository ? { ...input, repository } : input;
+  };
 
   const listChangeRequests: SourceControlProvider.SourceControlProvider["Service"]["listChangeRequests"] =
     (input) => {
+      const repository = repositoryFromContext(input.context);
       if (input.state === "open") {
         return github
           .listOpenPullRequests({
             cwd: input.cwd,
             headSelector: input.headSelector,
             ...(input.limit !== undefined ? { limit: input.limit } : {}),
+            ...(repository ? { repository } : {}),
           })
           .pipe(
             Effect.map((items) => items.map(toChangeRequest)),
@@ -138,6 +154,7 @@ export const make = Effect.gen(function* () {
             stateArg,
             "--limit",
             String(input.limit ?? 20),
+            ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
           ],
@@ -188,32 +205,47 @@ export const make = Effect.gen(function* () {
     kind: "github",
     listChangeRequests,
     getChangeRequest: (input) =>
-      github.getPullRequest(input).pipe(
-        Effect.map(toChangeRequest),
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "github",
-              operation: "getChangeRequest",
-              command: error.command,
+      github
+        .getPullRequest(
+          withRepositoryFromContext(
+            {
               cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
+              reference: input.reference,
+            },
+            input.context,
+          ),
+        )
+        .pipe(
+          Effect.map(toChangeRequest),
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "github",
+                operation: "getChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
     createChangeRequest: (input) =>
       github
-        .createPullRequest({
-          cwd: input.cwd,
-          baseBranch: input.baseRefName,
-          headSelector: input.headSelector,
-          title: input.title,
-          bodyFile: input.bodyFile,
-        })
+        .createPullRequest(
+          withRepositoryFromContext(
+            {
+              cwd: input.cwd,
+              baseBranch: input.baseRefName,
+              headSelector: input.headSelector,
+              title: input.title,
+              bodyFile: input.bodyFile,
+            },
+            input.context,
+          ),
+        )
         .pipe(
           Effect.mapError(
             (error) =>
@@ -265,7 +297,7 @@ export const make = Effect.gen(function* () {
         ),
       ),
     getDefaultBranch: (input) =>
-      github.getDefaultBranch(input).pipe(
+      github.getDefaultBranch(withRepositoryFromContext({ cwd: input.cwd }, input.context)).pipe(
         Effect.mapError(
           (error) =>
             new SourceControlProviderError({
@@ -279,22 +311,33 @@ export const make = Effect.gen(function* () {
         ),
       ),
     checkoutChangeRequest: (input) =>
-      github.checkoutPullRequest(input).pipe(
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "github",
-              operation: "checkoutChangeRequest",
-              command: error.command,
+      github
+        .checkoutPullRequest(
+          withRepositoryFromContext(
+            {
               cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
+              reference: input.reference,
+              ...(input.force !== undefined ? { force: input.force } : {}),
+            },
+            input.context,
+          ),
+        )
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "github",
+                operation: "checkoutChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
   });
 });
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -242,6 +242,7 @@ export const make = Effect.gen(function* () {
               headSelector: input.headSelector,
               title: input.title,
               bodyFile: input.bodyFile,
+              ...(input.source?.repository ? { headRepository: input.source.repository } : {}),
             },
             input.context,
           ),

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -112,6 +112,7 @@ export const make = Effect.gen(function* () {
     try {
       const parsed = new URL(context.remoteUrl);
       const [owner, name, ...rest] = parsed.pathname
+        .replace(/\/+$/, "")
         .replace(/\.git$/i, "")
         .split("/")
         .filter((part) => part.length > 0);

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -117,9 +117,9 @@ export const make = Effect.gen(function* () {
         .split("/")
         .filter((part) => part.length > 0);
       if (!owner || !name || rest.length > 0) return undefined;
-      return parsed.hostname.toLowerCase() === "github.com"
+      return parsed.host.toLowerCase() === "github.com"
         ? `${owner}/${name}`
-        : `${parsed.hostname}/${owner}/${name}`;
+        : `${parsed.host}/${owner}/${name}`;
     } catch {
       return undefined;
     }

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -207,7 +207,7 @@ export const make = Effect.gen(function* () {
                 ),
               );
             }),
-            Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+            Effect.catchTags({ GitHubPullRequestNotFoundError: () => Effect.succeed([]) }),
             Effect.mapError(
               (error) =>
                 new SourceControlProviderError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -7,7 +7,6 @@ import {
   type ChangeRequest,
   type ChangeRequestState,
 } from "@t3tools/contracts";
-import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
@@ -99,10 +98,28 @@ export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
   const repositoryFromContext = (
     context: SourceControlProvider.SourceControlProviderContext | undefined,
-  ) =>
-    context?.remoteName === "upstream"
-      ? (parseGitHubRepositoryNameWithOwnerFromRemoteUrl(context.remoteUrl) ?? undefined)
-      : undefined;
+  ) => {
+    if (context?.remoteName !== "upstream") return undefined;
+    const scpStyle = /^git@([^:/\s]+):([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(context.remoteUrl);
+    if (scpStyle?.[1] && scpStyle[2] && scpStyle[3]) {
+      return scpStyle[1].toLowerCase() === "github.com"
+        ? `${scpStyle[2]}/${scpStyle[3]}`
+        : `${scpStyle[1]}/${scpStyle[2]}/${scpStyle[3]}`;
+    }
+    try {
+      const parsed = new URL(context.remoteUrl);
+      const [owner, name, ...rest] = parsed.pathname
+        .replace(/\.git$/i, "")
+        .split("/")
+        .filter((part) => part.length > 0);
+      if (!owner || !name || rest.length > 0) return undefined;
+      return parsed.hostname.toLowerCase() === "github.com"
+        ? `${owner}/${name}`
+        : `${parsed.hostname}/${owner}/${name}`;
+    } catch {
+      return undefined;
+    }
+  };
   const withRepositoryFromContext = <Input extends object>(
     input: Input,
     context: SourceControlProvider.SourceControlProviderContext | undefined,
@@ -142,6 +159,8 @@ export const make = Effect.gen(function* () {
       }
 
       const stateArg: ChangeRequestState | "all" = input.state;
+      const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
+      const requestedLimit = input.limit ?? 20;
       return github
         .execute({
           cwd: input.cwd,
@@ -149,11 +168,11 @@ export const make = Effect.gen(function* () {
             "pr",
             "list",
             "--head",
-            input.headSelector,
+            qualifiedHead?.[2] ?? input.headSelector,
             "--state",
             stateArg,
             "--limit",
-            String(input.limit ?? 20),
+            String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
             ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -169,10 +188,20 @@ export const make = Effect.gen(function* () {
               Effect.flatMap((decoded) =>
                 Result.isSuccess(decoded)
                   ? Effect.succeed(
-                      decoded.success.map((item) => ({
-                        ...toChangeRequest(item),
-                        updatedAt: item.updatedAt,
-                      })),
+                      (qualifiedHead
+                        ? decoded.success.filter(
+                            (item) =>
+                              item.headRefName === qualifiedHead[2] &&
+                              item.headRepositoryOwnerLogin?.toLowerCase() ===
+                                qualifiedHead[1]?.toLowerCase(),
+                          )
+                        : decoded.success
+                      )
+                        .slice(0, requestedLimit)
+                        .map((item) => ({
+                          ...toChangeRequest(item),
+                          updatedAt: item.updatedAt,
+                        })),
                     )
                   : Effect.fail(
                       new GitHubCli.GitHubChangeRequestListDecodeError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -10,7 +10,10 @@ import {
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
-import { decodeGitHubPullRequestListJson } from "./gitHubPullRequests.ts";
+import {
+  decodeGitHubPullRequestJson,
+  decodeGitHubPullRequestListJson,
+} from "./gitHubPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import {
   combinedAuthOutput,
@@ -161,6 +164,66 @@ export const make = Effect.gen(function* () {
       const stateArg: ChangeRequestState | "all" = input.state;
       const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
       const requestedLimit = input.limit ?? 20;
+      if (qualifiedHead) {
+        return github
+          .execute({
+            cwd: input.cwd,
+            args: [
+              "pr",
+              "view",
+              input.headSelector,
+              ...(repository ? ["--repo", repository] : []),
+              "--json",
+              "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            ],
+          })
+          .pipe(
+            Effect.flatMap((result) => {
+              const raw = result.stdout.trim();
+              if (raw.length === 0) return Effect.succeed([]);
+              return Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
+                Effect.flatMap((decoded) =>
+                  Result.isSuccess(decoded)
+                    ? Effect.succeed(
+                        decoded.success.headRefName === qualifiedHead[2] &&
+                          decoded.success.headRepositoryOwnerLogin?.toLowerCase() ===
+                            qualifiedHead[1]?.toLowerCase() &&
+                          (stateArg === "all" || decoded.success.state === stateArg)
+                          ? [
+                              {
+                                ...toChangeRequest(decoded.success),
+                                updatedAt: decoded.success.updatedAt,
+                              },
+                            ]
+                          : [],
+                      )
+                    : Effect.fail(
+                        new GitHubCli.GitHubChangeRequestListDecodeError({
+                          command: "gh",
+                          cwd: input.cwd,
+                          cause: decoded.failure,
+                        }),
+                      ),
+                ),
+              );
+            }),
+            Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+            Effect.mapError(
+              (error) =>
+                new SourceControlProviderError({
+                  provider: "github",
+                  operation: "listChangeRequests",
+                  command: error.command,
+                  cwd: input.cwd,
+                  reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                    input.headSelector,
+                  ),
+                  detail: error.detail,
+                  cause: error,
+                }),
+            ),
+          );
+      }
       return github
         .execute({
           cwd: input.cwd,
@@ -168,11 +231,11 @@ export const make = Effect.gen(function* () {
             "pr",
             "list",
             "--head",
-            qualifiedHead?.[2] ?? input.headSelector,
+            input.headSelector,
             "--state",
             stateArg,
             "--limit",
-            String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+            String(requestedLimit),
             ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -188,20 +251,10 @@ export const make = Effect.gen(function* () {
               Effect.flatMap((decoded) =>
                 Result.isSuccess(decoded)
                   ? Effect.succeed(
-                      (qualifiedHead
-                        ? decoded.success.filter(
-                            (item) =>
-                              item.headRefName === qualifiedHead[2] &&
-                              item.headRepositoryOwnerLogin?.toLowerCase() ===
-                                qualifiedHead[1]?.toLowerCase(),
-                          )
-                        : decoded.success
-                      )
-                        .slice(0, requestedLimit)
-                        .map((item) => ({
-                          ...toChangeRequest(item),
-                          updatedAt: item.updatedAt,
-                        })),
+                      decoded.success.slice(0, requestedLimit).map((item) => ({
+                        ...toChangeRequest(item),
+                        updatedAt: item.updatedAt,
+                      })),
                     )
                   : Effect.fail(
                       new GitHubCli.GitHubChangeRequestListDecodeError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -11,7 +11,10 @@ import {
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
-import { decodeGitHubPullRequestListJson } from "./gitHubPullRequests.ts";
+import {
+  decodeGitHubPullRequestJson,
+  decodeGitHubPullRequestListJson,
+} from "./gitHubPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import {
   combinedAuthOutput,
@@ -178,6 +181,77 @@ export const make = Effect.gen(function* () {
       const stateArg: ChangeRequestState | "all" = input.state;
       const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
       const requestedLimit = input.limit ?? 20;
+      if (qualifiedHead) {
+        return github
+          .execute({
+            cwd: input.cwd,
+            args: [
+              "pr",
+              "view",
+              input.headSelector,
+              ...(repository ? ["--repo", repository] : []),
+              "--json",
+              "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            ],
+          })
+          .pipe(
+            Effect.flatMap((result) => {
+              const raw = result.stdout.trim();
+              if (raw.length === 0) return Effect.succeed([]);
+              return Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
+                Effect.flatMap((decoded) =>
+                  Result.isSuccess(decoded)
+                    ? Effect.succeed(() => {
+                        const item = decoded.success;
+                        if (
+                          item.headRefName !== qualifiedHead[2] ||
+                          item.headRepositoryOwnerLogin?.toLowerCase() !==
+                            qualifiedHead[1]?.toLowerCase() ||
+                          (stateArg !== "all" && item.state !== stateArg)
+                        ) {
+                          return [];
+                        }
+                        const { updatedAt, ...summary } = item;
+                        return [
+                          {
+                            ...toChangeRequest({
+                              ...summary,
+                              ...(Option.isSome(updatedAt)
+                                ? { updatedAt: DateTime.formatIso(updatedAt.value) }
+                                : {}),
+                            }),
+                            updatedAt,
+                          },
+                        ];
+                      })
+                    .pipe(Effect.map((build) => build()))
+                    : Effect.fail(
+                        new GitHubCli.GitHubChangeRequestListDecodeError({
+                          command: "gh",
+                          cwd: input.cwd,
+                          cause: decoded.failure,
+                        }),
+                      ),
+                ),
+              );
+            }),
+            Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+            Effect.mapError(
+              (error) =>
+                new SourceControlProviderError({
+                  provider: "github",
+                  operation: "listChangeRequests",
+                  command: error.command,
+                  cwd: input.cwd,
+                  reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                    input.headSelector,
+                  ),
+                  detail: error.detail,
+                  cause: error,
+                }),
+            ),
+          );
+      }
       return github
         .execute({
           cwd: input.cwd,
@@ -185,11 +259,11 @@ export const make = Effect.gen(function* () {
             "pr",
             "list",
             "--head",
-            qualifiedHead?.[2] ?? input.headSelector,
+            input.headSelector,
             "--state",
             stateArg,
             "--limit",
-            String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+            String(requestedLimit),
             ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -203,30 +277,20 @@ export const make = Effect.gen(function* () {
             }
             return Effect.sync(() => decodeGitHubPullRequestListJson(raw)).pipe(
               Effect.flatMap((decoded) =>
-                  Result.isSuccess(decoded)
-                    ? Effect.succeed(
-                      (qualifiedHead
-                        ? decoded.success.filter(
-                            (item) =>
-                              item.headRefName === qualifiedHead[2] &&
-                              item.headRepositoryOwnerLogin?.toLowerCase() ===
-                                qualifiedHead[1]?.toLowerCase(),
-                          )
-                         : decoded.success
-                       )
-                         .slice(0, requestedLimit)
-                        .map((item) => {
-                          const { updatedAt, ...summary } = item;
-                          return {
-                            ...toChangeRequest({
-                              ...summary,
-                              ...(Option.isSome(updatedAt)
-                                ? { updatedAt: DateTime.formatIso(updatedAt.value) }
-                                : {}),
-                            }),
-                            updatedAt,
-                          };
-                        }),
+                Result.isSuccess(decoded)
+                  ? Effect.succeed(
+                      decoded.success.slice(0, requestedLimit).map((item) => {
+                        const { updatedAt, ...summary } = item;
+                        return {
+                          ...toChangeRequest({
+                            ...summary,
+                            ...(Option.isSome(updatedAt)
+                              ? { updatedAt: DateTime.formatIso(updatedAt.value) }
+                              : {}),
+                          }),
+                          updatedAt,
+                        };
+                      }),
                     )
                   : Effect.fail(
                       new GitHubCli.GitHubChangeRequestListDecodeError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -267,6 +267,7 @@ export const make = Effect.gen(function* () {
               headSelector: input.headSelector,
               title: input.title,
               bodyFile: input.bodyFile,
+              ...(input.source?.repository ? { headRepository: input.source.repository } : {}),
             },
             input.context,
           ),

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -129,6 +129,7 @@ export const make = Effect.gen(function* () {
     try {
       const parsed = new URL(context.remoteUrl);
       const [owner, name, ...rest] = parsed.pathname
+        .replace(/\/+$/, "")
         .replace(/\.git$/i, "")
         .split("/")
         .filter((part) => part.length > 0);

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -235,7 +235,7 @@ export const make = Effect.gen(function* () {
                 ),
               );
             }),
-            Effect.catchTag("GitHubPullRequestNotFoundError", () => Effect.succeed([])),
+            Effect.catchTags({ GitHubPullRequestNotFoundError: () => Effect.succeed([]) }),
             Effect.mapError(
               (error) =>
                 new SourceControlProviderError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -8,6 +8,7 @@ import {
   type ChangeRequest,
   type ChangeRequestState,
 } from "@t3tools/contracts";
+import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
@@ -113,15 +114,30 @@ export const discovery = {
 
 export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
+  const repositoryFromContext = (
+    context: SourceControlProvider.SourceControlProviderContext | undefined,
+  ) =>
+    context?.remoteName === "upstream"
+      ? (parseGitHubRepositoryNameWithOwnerFromRemoteUrl(context.remoteUrl) ?? undefined)
+      : undefined;
+  const withRepositoryFromContext = <Input extends object>(
+    input: Input,
+    context: SourceControlProvider.SourceControlProviderContext | undefined,
+  ): Input | (Input & { readonly repository: string }) => {
+    const repository = repositoryFromContext(context);
+    return repository ? { ...input, repository } : input;
+  };
 
   const listChangeRequests: SourceControlProvider.SourceControlProvider["Service"]["listChangeRequests"] =
     (input) => {
+      const repository = repositoryFromContext(input.context);
       if (input.state === "open") {
         return github
           .listOpenPullRequests({
             cwd: input.cwd,
             headSelector: input.headSelector,
             ...(input.limit !== undefined ? { limit: input.limit } : {}),
+            ...(repository ? { repository } : {}),
           })
           .pipe(
             Effect.map((items) => items.map(toChangeRequest)),
@@ -155,6 +171,7 @@ export const make = Effect.gen(function* () {
             stateArg,
             "--limit",
             String(input.limit ?? 20),
+            ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
           ],
@@ -213,32 +230,47 @@ export const make = Effect.gen(function* () {
     kind: "github",
     listChangeRequests,
     getChangeRequest: (input) =>
-      github.getPullRequest(input).pipe(
-        Effect.map(toChangeRequest),
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "github",
-              operation: "getChangeRequest",
-              command: error.command,
+      github
+        .getPullRequest(
+          withRepositoryFromContext(
+            {
               cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
+              reference: input.reference,
+            },
+            input.context,
+          ),
+        )
+        .pipe(
+          Effect.map(toChangeRequest),
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "github",
+                operation: "getChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
     createChangeRequest: (input) =>
       github
-        .createPullRequest({
-          cwd: input.cwd,
-          baseBranch: input.baseRefName,
-          headSelector: input.headSelector,
-          title: input.title,
-          bodyFile: input.bodyFile,
-        })
+        .createPullRequest(
+          withRepositoryFromContext(
+            {
+              cwd: input.cwd,
+              baseBranch: input.baseRefName,
+              headSelector: input.headSelector,
+              title: input.title,
+              bodyFile: input.bodyFile,
+            },
+            input.context,
+          ),
+        )
         .pipe(
           Effect.mapError(
             (error) =>
@@ -290,7 +322,7 @@ export const make = Effect.gen(function* () {
         ),
       ),
     getDefaultBranch: (input) =>
-      github.getDefaultBranch(input).pipe(
+      github.getDefaultBranch(withRepositoryFromContext({ cwd: input.cwd }, input.context)).pipe(
         Effect.mapError(
           (error) =>
             new SourceControlProviderError({
@@ -304,22 +336,33 @@ export const make = Effect.gen(function* () {
         ),
       ),
     checkoutChangeRequest: (input) =>
-      github.checkoutPullRequest(input).pipe(
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "github",
-              operation: "checkoutChangeRequest",
-              command: error.command,
+      github
+        .checkoutPullRequest(
+          withRepositoryFromContext(
+            {
               cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
+              reference: input.reference,
+              ...(input.force !== undefined ? { force: input.force } : {}),
+            },
+            input.context,
+          ),
+        )
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "github",
+                operation: "checkoutChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
   });
 });
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -11,10 +11,7 @@ import {
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
-import {
-  decodeGitHubPullRequestJson,
-  decodeGitHubPullRequestListJson,
-} from "./gitHubPullRequests.ts";
+import { decodeGitHubPullRequestListJson } from "./gitHubPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import {
   combinedAuthOutput,
@@ -134,9 +131,10 @@ export const make = Effect.gen(function* () {
         .split("/")
         .filter((part) => part.length > 0);
       if (!owner || !name || rest.length > 0) return undefined;
-      return parsed.host.toLowerCase() === "github.com"
+      const repositoryHost = parsed.protocol === "ssh:" ? parsed.hostname : parsed.host;
+      return parsed.hostname.toLowerCase() === "github.com"
         ? `${owner}/${name}`
-        : `${parsed.host}/${owner}/${name}`;
+        : `${repositoryHost}/${owner}/${name}`;
     } catch {
       return undefined;
     }
@@ -182,78 +180,6 @@ export const make = Effect.gen(function* () {
       const stateArg: ChangeRequestState | "all" = input.state;
       const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
       const requestedLimit = input.limit ?? 20;
-      if (qualifiedHead) {
-        return github
-          .execute({
-            cwd: input.cwd,
-            args: [
-              "pr",
-              "view",
-              input.headSelector,
-              ...(repository ? ["--repo", repository] : []),
-              "--json",
-              "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
-            ],
-          })
-          .pipe(
-            Effect.flatMap((result) => {
-              const raw = result.stdout.trim();
-              if (raw.length === 0) return Effect.succeed([]);
-              return Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
-                Effect.flatMap((decoded) =>
-                  Result.isSuccess(decoded)
-                    ? Effect.succeed(
-                        (() => {
-                          const item = decoded.success;
-                          if (
-                            item.headRefName !== qualifiedHead[2] ||
-                            item.headRepositoryOwnerLogin?.toLowerCase() !==
-                              qualifiedHead[1]?.toLowerCase() ||
-                            (stateArg !== "all" && item.state !== stateArg)
-                          ) {
-                            return [];
-                          }
-                          const { updatedAt, ...summary } = item;
-                          return [
-                            {
-                              ...toChangeRequest({
-                                ...summary,
-                                ...(Option.isSome(updatedAt)
-                                  ? { updatedAt: DateTime.formatIso(updatedAt.value) }
-                                  : {}),
-                              }),
-                              updatedAt,
-                            },
-                          ];
-                        })(),
-                      )
-                    : Effect.fail(
-                        new GitHubCli.GitHubChangeRequestListDecodeError({
-                          command: "gh",
-                          cwd: input.cwd,
-                          cause: decoded.failure,
-                        }),
-                      ),
-                ),
-              );
-            }),
-            Effect.catchTags({ GitHubPullRequestNotFoundError: () => Effect.succeed([]) }),
-            Effect.mapError(
-              (error) =>
-                new SourceControlProviderError({
-                  provider: "github",
-                  operation: "listChangeRequests",
-                  command: error.command,
-                  cwd: input.cwd,
-                  reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                    input.headSelector,
-                  ),
-                  detail: error.detail,
-                  cause: error,
-                }),
-            ),
-          );
-      }
       return github
         .execute({
           cwd: input.cwd,
@@ -261,11 +187,11 @@ export const make = Effect.gen(function* () {
             "pr",
             "list",
             "--head",
-            input.headSelector,
+            qualifiedHead?.[2] ?? input.headSelector,
             "--state",
             stateArg,
             "--limit",
-            String(requestedLimit),
+            String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
             ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -281,18 +207,27 @@ export const make = Effect.gen(function* () {
               Effect.flatMap((decoded) =>
                 Result.isSuccess(decoded)
                   ? Effect.succeed(
-                      decoded.success.slice(0, requestedLimit).map((item) => {
-                        const { updatedAt, ...summary } = item;
-                        return {
-                          ...toChangeRequest({
-                            ...summary,
-                            ...(Option.isSome(updatedAt)
-                              ? { updatedAt: DateTime.formatIso(updatedAt.value) }
-                              : {}),
-                          }),
-                          updatedAt,
-                        };
-                      }),
+                      decoded.success
+                        .filter(
+                          (item) =>
+                            !qualifiedHead ||
+                            (item.headRefName === qualifiedHead[2] &&
+                              item.headRepositoryOwnerLogin?.toLowerCase() ===
+                                qualifiedHead[1]?.toLowerCase()),
+                        )
+                        .slice(0, requestedLimit)
+                        .map((item) => {
+                          const { updatedAt, ...summary } = item;
+                          return {
+                            ...toChangeRequest({
+                              ...summary,
+                              ...(Option.isSome(updatedAt)
+                                ? { updatedAt: DateTime.formatIso(updatedAt.value) }
+                                : {}),
+                            }),
+                            updatedAt,
+                          };
+                        }),
                     )
                   : Effect.fail(
                       new GitHubCli.GitHubChangeRequestListDecodeError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -134,9 +134,9 @@ export const make = Effect.gen(function* () {
         .split("/")
         .filter((part) => part.length > 0);
       if (!owner || !name || rest.length > 0) return undefined;
-      return parsed.hostname.toLowerCase() === "github.com"
+      return parsed.host.toLowerCase() === "github.com"
         ? `${owner}/${name}`
-        : `${parsed.hostname}/${owner}/${name}`;
+        : `${parsed.host}/${owner}/${name}`;
     } catch {
       return undefined;
     }
@@ -202,30 +202,31 @@ export const make = Effect.gen(function* () {
               return Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
                 Effect.flatMap((decoded) =>
                   Result.isSuccess(decoded)
-                    ? Effect.succeed(() => {
-                        const item = decoded.success;
-                        if (
-                          item.headRefName !== qualifiedHead[2] ||
-                          item.headRepositoryOwnerLogin?.toLowerCase() !==
-                            qualifiedHead[1]?.toLowerCase() ||
-                          (stateArg !== "all" && item.state !== stateArg)
-                        ) {
-                          return [];
-                        }
-                        const { updatedAt, ...summary } = item;
-                        return [
-                          {
-                            ...toChangeRequest({
-                              ...summary,
-                              ...(Option.isSome(updatedAt)
-                                ? { updatedAt: DateTime.formatIso(updatedAt.value) }
-                                : {}),
-                            }),
-                            updatedAt,
-                          },
-                        ];
-                      })
-                    .pipe(Effect.map((build) => build()))
+                    ? Effect.succeed(
+                        (() => {
+                          const item = decoded.success;
+                          if (
+                            item.headRefName !== qualifiedHead[2] ||
+                            item.headRepositoryOwnerLogin?.toLowerCase() !==
+                              qualifiedHead[1]?.toLowerCase() ||
+                            (stateArg !== "all" && item.state !== stateArg)
+                          ) {
+                            return [];
+                          }
+                          const { updatedAt, ...summary } = item;
+                          return [
+                            {
+                              ...toChangeRequest({
+                                ...summary,
+                                ...(Option.isSome(updatedAt)
+                                  ? { updatedAt: DateTime.formatIso(updatedAt.value) }
+                                  : {}),
+                              }),
+                              updatedAt,
+                            },
+                          ];
+                        })(),
+                      )
                     : Effect.fail(
                         new GitHubCli.GitHubChangeRequestListDecodeError({
                           command: "gh",

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -191,7 +191,7 @@ export const make = Effect.gen(function* () {
             "--state",
             stateArg,
             "--limit",
-            String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
+            String(qualifiedHead ? 100 : requestedLimit),
             ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -8,7 +8,6 @@ import {
   type ChangeRequest,
   type ChangeRequestState,
 } from "@t3tools/contracts";
-import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
@@ -116,10 +115,28 @@ export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
   const repositoryFromContext = (
     context: SourceControlProvider.SourceControlProviderContext | undefined,
-  ) =>
-    context?.remoteName === "upstream"
-      ? (parseGitHubRepositoryNameWithOwnerFromRemoteUrl(context.remoteUrl) ?? undefined)
-      : undefined;
+  ) => {
+    if (context?.remoteName !== "upstream") return undefined;
+    const scpStyle = /^git@([^:/\s]+):([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(context.remoteUrl);
+    if (scpStyle?.[1] && scpStyle[2] && scpStyle[3]) {
+      return scpStyle[1].toLowerCase() === "github.com"
+        ? `${scpStyle[2]}/${scpStyle[3]}`
+        : `${scpStyle[1]}/${scpStyle[2]}/${scpStyle[3]}`;
+    }
+    try {
+      const parsed = new URL(context.remoteUrl);
+      const [owner, name, ...rest] = parsed.pathname
+        .replace(/\.git$/i, "")
+        .split("/")
+        .filter((part) => part.length > 0);
+      if (!owner || !name || rest.length > 0) return undefined;
+      return parsed.hostname.toLowerCase() === "github.com"
+        ? `${owner}/${name}`
+        : `${parsed.hostname}/${owner}/${name}`;
+    } catch {
+      return undefined;
+    }
+  };
   const withRepositoryFromContext = <Input extends object>(
     input: Input,
     context: SourceControlProvider.SourceControlProviderContext | undefined,
@@ -159,6 +176,8 @@ export const make = Effect.gen(function* () {
       }
 
       const stateArg: ChangeRequestState | "all" = input.state;
+      const qualifiedHead = /^([^:/\s]+):(.+)$/u.exec(input.headSelector);
+      const requestedLimit = input.limit ?? 20;
       return github
         .execute({
           cwd: input.cwd,
@@ -166,11 +185,11 @@ export const make = Effect.gen(function* () {
             "pr",
             "list",
             "--head",
-            input.headSelector,
+            qualifiedHead?.[2] ?? input.headSelector,
             "--state",
             stateArg,
             "--limit",
-            String(input.limit ?? 20),
+            String(qualifiedHead ? Math.max(requestedLimit, 100) : requestedLimit),
             ...(repository ? ["--repo", repository] : []),
             "--json",
             "number,title,url,baseRefName,headRefName,state,isDraft,mergedAt,closedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
@@ -184,20 +203,30 @@ export const make = Effect.gen(function* () {
             }
             return Effect.sync(() => decodeGitHubPullRequestListJson(raw)).pipe(
               Effect.flatMap((decoded) =>
-                Result.isSuccess(decoded)
-                  ? Effect.succeed(
-                      decoded.success.map((item) => {
-                        const { updatedAt, ...summary } = item;
-                        return {
-                          ...toChangeRequest({
-                            ...summary,
-                            ...(Option.isSome(updatedAt)
-                              ? { updatedAt: DateTime.formatIso(updatedAt.value) }
-                              : {}),
-                          }),
-                          updatedAt,
-                        };
-                      }),
+                  Result.isSuccess(decoded)
+                    ? Effect.succeed(
+                      (qualifiedHead
+                        ? decoded.success.filter(
+                            (item) =>
+                              item.headRefName === qualifiedHead[2] &&
+                              item.headRepositoryOwnerLogin?.toLowerCase() ===
+                                qualifiedHead[1]?.toLowerCase(),
+                          )
+                         : decoded.success
+                       )
+                         .slice(0, requestedLimit)
+                        .map((item) => {
+                          const { updatedAt, ...summary } = item;
+                          return {
+                            ...toChangeRequest({
+                              ...summary,
+                              ...(Option.isSome(updatedAt)
+                                ? { updatedAt: DateTime.formatIso(updatedAt.value) }
+                                : {}),
+                            }),
+                            updatedAt,
+                          };
+                        }),
                     )
                   : Effect.fail(
                       new GitHubCli.GitHubChangeRequestListDecodeError({

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -40,6 +40,7 @@ function makeRegistry(input: {
   }>;
   readonly process?: Partial<VcsProcess.VcsProcess["Service"]>;
   readonly resolve?: VcsDriverRegistry.VcsDriverRegistry["Service"]["resolve"];
+  readonly github?: Partial<GitHubCli.GitHubCli["Service"]>;
 }) {
   const driver = {
     listRemotes: () =>
@@ -90,7 +91,7 @@ function makeRegistry(input: {
         processLayer,
         Layer.mock(AzureDevOpsCli.AzureDevOpsCli)({}),
         Layer.mock(BitbucketApi.BitbucketApi)({}),
-        Layer.mock(GitHubCli.GitHubCli)({}),
+        Layer.mock(GitHubCli.GitHubCli)(input.github ?? {}),
         Layer.mock(GitLabCli.GitLabCli)({}),
         ServerConfig.layerTest(process.cwd(), {
           prefix: "t3-source-control-registry-test-",
@@ -259,5 +260,44 @@ it.effect("falls back to a non-origin remote when origin is not configured", () 
     const provider = yield* registry.resolve({ cwd: "/repo" });
 
     assert.strictEqual(provider.kind, "azure-devops");
+  }),
+);
+
+it.effect("prefers the upstream repository context for conventional GitHub forks", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const registry = yield* makeRegistry({
+      remotes: [
+        { name: "origin", url: "git@github.com:contributor/t3code.git" },
+        { name: "upstream", url: "git@github.com:T3Tools/t3code.git" },
+      ],
+      github: {
+        getDefaultBranch: (input) => {
+          repository = input.repository;
+          return Effect.succeed("main");
+        },
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+    const defaultBranch = yield* provider.getDefaultBranch({ cwd: "/repo" });
+
+    assert.strictEqual(defaultBranch, "main");
+    assert.strictEqual(repository, "T3Tools/t3code");
+  }),
+);
+
+it.effect("does not let an unrelated upstream remote override origin", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [
+        { name: "origin", url: "git@github.com:T3Tools/t3code.git" },
+        { name: "upstream", url: "https://dev.azure.com/acme/project/_git/repo" },
+      ],
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "github");
   }),
 );

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -40,6 +40,7 @@ function makeRegistry(input: {
   }>;
   readonly process?: Partial<VcsProcess.VcsProcess["Service"]>;
   readonly resolve?: VcsDriverRegistry.VcsDriverRegistry["Service"]["resolve"];
+  readonly github?: Partial<GitHubCli.GitHubCli["Service"]>;
 }) {
   const driver = {
     listRemotes: () =>
@@ -90,7 +91,7 @@ function makeRegistry(input: {
         processLayer,
         Layer.mock(AzureDevOpsCli.AzureDevOpsCli)({}),
         Layer.mock(BitbucketApi.BitbucketApi)({}),
-        Layer.mock(GitHubCli.GitHubCli)({}),
+        Layer.mock(GitHubCli.GitHubCli)(input.github ?? {}),
         Layer.mock(GitLabCli.GitLabCli)({}),
         ServerConfig.layerTest(process.cwd(), {
           prefix: "t3-source-control-registry-test-",
@@ -291,5 +292,44 @@ it.effect("falls back to a non-origin remote when origin is not configured", () 
     const provider = yield* registry.resolve({ cwd: "/repo" });
 
     assert.strictEqual(provider.kind, "azure-devops");
+  }),
+);
+
+it.effect("prefers the upstream repository context for conventional GitHub forks", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const registry = yield* makeRegistry({
+      remotes: [
+        { name: "origin", url: "git@github.com:contributor/t3code.git" },
+        { name: "upstream", url: "git@github.com:T3Tools/t3code.git" },
+      ],
+      github: {
+        getDefaultBranch: (input) => {
+          repository = input.repository;
+          return Effect.succeed("main");
+        },
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+    const defaultBranch = yield* provider.getDefaultBranch({ cwd: "/repo" });
+
+    assert.strictEqual(defaultBranch, "main");
+    assert.strictEqual(repository, "T3Tools/t3code");
+  }),
+);
+
+it.effect("does not let an unrelated upstream remote override origin", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [
+        { name: "origin", url: "git@github.com:T3Tools/t3code.git" },
+        { name: "upstream", url: "https://dev.azure.com/acme/project/_git/repo" },
+      ],
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "github");
   }),
 );

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -333,3 +333,26 @@ it.effect("does not let an unrelated upstream remote override origin", () =>
     assert.strictEqual(provider.kind, "github");
   }),
 );
+
+it.effect("does not target an unrelated GitHub upstream repository", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const registry = yield* makeRegistry({
+      remotes: [
+        { name: "origin", url: "git@github.com:contributor/t3code.git" },
+        { name: "upstream", url: "git@github.com:someone/other-project.git" },
+      ],
+      github: {
+        getDefaultBranch: (input) => {
+          repository = input.repository;
+          return Effect.succeed("main");
+        },
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+    yield* provider.getDefaultBranch({ cwd: "/repo" });
+
+    assert.strictEqual(repository, undefined);
+  }),
+);

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -301,3 +301,26 @@ it.effect("does not let an unrelated upstream remote override origin", () =>
     assert.strictEqual(provider.kind, "github");
   }),
 );
+
+it.effect("does not target an unrelated GitHub upstream repository", () =>
+  Effect.gen(function* () {
+    let repository: string | undefined;
+    const registry = yield* makeRegistry({
+      remotes: [
+        { name: "origin", url: "git@github.com:contributor/t3code.git" },
+        { name: "upstream", url: "git@github.com:someone/other-project.git" },
+      ],
+      github: {
+        getDefaultBranch: (input) => {
+          repository = input.repository;
+          return Effect.succeed("main");
+        },
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+    yield* provider.getDefaultBranch({ cwd: "/repo" });
+
+    assert.strictEqual(repository, undefined);
+  }),
+);

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -141,8 +141,17 @@ function selectProviderContext(
     }
   }
 
+  const origin = candidates.find((candidate) => candidate.remoteName === "origin");
+  const conventionalGitHubUpstream = candidates.find(
+    (candidate) =>
+      candidate.remoteName === "upstream" &&
+      candidate.provider.kind === "github" &&
+      origin?.provider.kind === "github",
+  );
+
   return (
-    candidates.find((candidate) => candidate.remoteName === "origin") ??
+    conventionalGitHubUpstream ??
+    origin ??
     candidates.find((candidate) => candidate.provider.kind !== "unknown") ??
     candidates[0] ??
     null

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -142,8 +142,17 @@ function selectProviderContext(
     }
   }
 
+  const origin = candidates.find((candidate) => candidate.remoteName === "origin");
+  const conventionalGitHubUpstream = candidates.find(
+    (candidate) =>
+      candidate.remoteName === "upstream" &&
+      candidate.provider.kind === "github" &&
+      origin?.provider.kind === "github",
+  );
+
   return (
-    candidates.find((candidate) => candidate.remoteName === "origin") ??
+    conventionalGitHubUpstream ??
+    origin ??
     candidates.find((candidate) => candidate.provider.kind !== "unknown") ??
     candidates[0] ??
     null

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -9,6 +9,7 @@ import {
   type SourceControlProviderDiscoveryItem,
 } from "@t3tools/contracts";
 import type { SourceControlProviderKind } from "@t3tools/contracts";
+import { normalizeGitRemoteUrl } from "@t3tools/shared/git";
 import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
 
 import * as AzureDevOpsSourceControlProvider from "./AzureDevOpsSourceControlProvider.ts";
@@ -143,12 +144,28 @@ function selectProviderContext(
   }
 
   const origin = candidates.find((candidate) => candidate.remoteName === "origin");
-  const conventionalGitHubUpstream = candidates.find(
-    (candidate) =>
-      candidate.remoteName === "upstream" &&
-      candidate.provider.kind === "github" &&
-      origin?.provider.kind === "github",
-  );
+  const repositoryCoordinate = (remoteUrl: string) => {
+    const [host, owner, name, ...rest] = normalizeGitRemoteUrl(remoteUrl).split("/");
+    return host && owner && name && rest.length === 0 ? { host, owner, name } : null;
+  };
+  const conventionalGitHubUpstream = candidates.find((candidate) => {
+    if (
+      candidate.remoteName !== "upstream" ||
+      candidate.provider.kind !== "github" ||
+      origin?.provider.kind !== "github"
+    ) {
+      return false;
+    }
+    const originRepository = repositoryCoordinate(origin.remoteUrl);
+    const upstreamRepository = repositoryCoordinate(candidate.remoteUrl);
+    return (
+      originRepository !== null &&
+      upstreamRepository !== null &&
+      originRepository.host === upstreamRepository.host &&
+      originRepository.name === upstreamRepository.name &&
+      originRepository.owner !== upstreamRepository.owner
+    );
+  });
 
   return (
     conventionalGitHubUpstream ??

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -9,6 +9,7 @@ import {
   type SourceControlProviderDiscoveryItem,
 } from "@t3tools/contracts";
 import type { SourceControlProviderKind } from "@t3tools/contracts";
+import { normalizeGitRemoteUrl } from "@t3tools/shared/git";
 import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
 
 import * as AzureDevOpsSourceControlProvider from "./AzureDevOpsSourceControlProvider.ts";
@@ -142,12 +143,28 @@ function selectProviderContext(
   }
 
   const origin = candidates.find((candidate) => candidate.remoteName === "origin");
-  const conventionalGitHubUpstream = candidates.find(
-    (candidate) =>
-      candidate.remoteName === "upstream" &&
-      candidate.provider.kind === "github" &&
-      origin?.provider.kind === "github",
-  );
+  const repositoryCoordinate = (remoteUrl: string) => {
+    const [host, owner, name, ...rest] = normalizeGitRemoteUrl(remoteUrl).split("/");
+    return host && owner && name && rest.length === 0 ? { host, owner, name } : null;
+  };
+  const conventionalGitHubUpstream = candidates.find((candidate) => {
+    if (
+      candidate.remoteName !== "upstream" ||
+      candidate.provider.kind !== "github" ||
+      origin?.provider.kind !== "github"
+    ) {
+      return false;
+    }
+    const originRepository = repositoryCoordinate(origin.remoteUrl);
+    const upstreamRepository = repositoryCoordinate(candidate.remoteUrl);
+    return (
+      originRepository !== null &&
+      upstreamRepository !== null &&
+      originRepository.host === upstreamRepository.host &&
+      originRepository.name === upstreamRepository.name &&
+      originRepository.owner !== upstreamRepository.owner
+    );
+  });
 
   return (
     conventionalGitHubUpstream ??


### PR DESCRIPTION
## Summary

- detect pull requests opened from a fork against the conventional `upstream` GitHub remote
- qualify fork branch lookups as `owner:branch` and target GitHub CLI operations at the upstream repository
- keep unrelated remotes named `upstream` from overriding a valid GitHub `origin`

## Root cause

PR discovery derived the fork-qualified head selector, but GitHub CLI still resolved the repository from the local checkout's `origin`. In a fork checkout, that queried the fork rather than the upstream repository where the pull request exists.

## Impact

Branches pushed to a fork now show their upstream pull request metadata in T3 Code. Related PR operations consistently use the upstream repository context.

## Validation

- focused Git manager fork/upstream regression test
- GitHub CLI, GitHub source-control provider, and provider registry suites
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PR discovery and creation paths across GitManager and GitHub CLI, including cross-repo API calls and remote heuristics; regressions could mis-associate PRs or target the wrong repository despite broad new tests.
> 
> **Overview**
> Fixes fork workflows where PR metadata and GitHub CLI calls were scoped to **origin** instead of the **upstream** repo where cross-fork pull requests actually live.
> 
> **GitManager** now parses GitHub remote coordinates (including Enterprise hosts), treats matching same-repo/different-owner remotes as forks, and builds branch head context with a fork head remote plus an optional **upstream** target. Lookups prefer branch-name `gh pr list` heads (often with `--limit 100`) and filter by fork owner locally; base resolution and diff ranges can follow the tracked base or upstream remote. GitHub PR creation passes an explicit **source** repository when creating change requests.
> 
> **GitHub CLI layer** gains optional `repository` / `headRepository`, resolves base vs head via `gh repo view`, filters qualified `owner:branch` selectors after listing, and creates cross-repository PRs through **`gh api`** instead of plain `gh pr create`.
> 
> **Source control wiring** prefers a conventional **origin + upstream** GitHub fork pair in the registry (without letting unrelated `upstream` remotes override origin) and threads upstream repo coordinates into list/create/get/checkout/default-branch calls. Tests cover fork tracking edge cases, host isolation, and non-GitHub providers omitting GitHub-shaped `source` on create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3e74b77c61ff25f81aa7bfef6407aaf66fd822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect and route pull requests against upstream repositories
> - Adds GitHub remote URL parsing and fork comparison so the system can identify when `origin` and `upstream` are the same repository owned by different accounts on the same host.
> - `resolveBranchHeadContext` in [GitManager.ts](https://github.com/pingdotgg/t3code/pull/3907/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337) now selects the fork as the head repository and upstream as the target remote for cross-repository PRs, and resolves base commits from the selected target remote.
> - `GitHubCli` cross-repository PR creation now uses the GitHub API with explicit base/head repository coordinates instead of the standard CLI command; same-repository creation is unchanged.
> - `listOpenPullRequests` now sends owner-qualified selectors as branch names to the CLI, requests up to 100 candidates, and filters results locally by head owner and branch.
> - `selectProviderContext` in [SourceControlProviderRegistry.ts](https://github.com/pingdotgg/t3code/pull/3907/files#diff-1617d49a52e7bc96a9ab278b5f5b2028c6b5d917e84c91f779119e18ccb935fd) prefers a conventional GitHub `upstream` remote over `origin` during provider resolution.
> - Risk: `GitHubCli.createPullRequest` now resolves repository metadata before creating cross-repository PRs; malformed repository context returns `GitHubRepositoryContextDecodeError` instead of a generic failure. Non-GitHub providers (GitLab, Bitbucket) omit the `source` repository field even when remote URLs look GitHub-shaped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ee3cfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved pull request support for forked repositories, including upstream and target repository detection.
  - Added more reliable pull request creation and lookup across repositories.
  - Added support for GitHub Enterprise hosts, custom ports, and varied remote URL formats.
  - Improved pull request listings by accurately filtering qualified fork branches and respecting result limits.
  - Preserved provider-neutral behavior for non-GitHub repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->