### PR TITLE
fix(cli): support force removing projects

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -514,11 +514,12 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
       ]);
       const afterRemove = yield* readPersistedSnapshot(baseDir);
       assert.isTrue(
-        afterRemove.projects.find((candidate) => candidate.id === project!.id)?.deletedAt !== null,
+        (afterRemove.projects.find((candidate) => candidate.id === project!.id)?.deletedAt ??
+          null) !== null,
       );
       assert.isTrue(
-        afterRemove.threads.find((thread) => thread.id === "thread-cli-force-remove")?.deletedAt !==
-          null,
+        (afterRemove.threads.find((thread) => thread.id === "thread-cli-force-remove")?.deletedAt ??
+          null) !== null,
       );
     }),
   );

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -6,10 +6,16 @@ import * as NodePath from "node:path";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { EnvironmentOrchestrationHttpApi } from "@t3tools/contracts";
+import {
+  CommandId,
+  EnvironmentOrchestrationHttpApi,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import * as NetService from "@t3tools/shared/Net";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as DateTime from "effect/DateTime";
 import * as Layer from "effect/Layer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServer from "effect/unstable/http/HttpServer";
@@ -22,6 +28,7 @@ import { Command } from "effect/unstable/cli";
 import { cli, makeCli } from "./bin.ts";
 import * as ServerConfig from "./config.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import { orchestrationHttpApiLayer } from "./orchestration/http.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
@@ -457,6 +464,62 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
         (project) => project.id === addedProject?.id,
       );
       assert.isTrue((removedProject?.deletedAt ?? null) !== null);
+    }),
+  );
+
+  it.effect("force removes projects that still contain threads", () =>
+    Effect.gen(function* () {
+      const baseDir = NodeFS.mkdtempSync(
+        NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-force-remove-test-"),
+      );
+      const workspaceRoot = NodeFS.mkdtempSync(
+        NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-force-remove-workspace-"),
+      );
+
+      yield* runCliWithRuntime(["project", "add", workspaceRoot, "--base-dir", baseDir]);
+      const afterAdd = yield* readPersistedSnapshot(baseDir);
+      const project = afterAdd.projects.find(
+        (candidate) => candidate.workspaceRoot === workspaceRoot && candidate.deletedAt === null,
+      );
+      assert.isTrue(project !== undefined);
+
+      const config = yield* makeCliTestServerConfig(baseDir);
+      yield* Effect.gen(function* () {
+        const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+        yield* engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make("cmd-cli-force-remove-thread"),
+          threadId: ThreadId.make("thread-cli-force-remove"),
+          projectId: project!.id,
+          title: "Thread",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          interactionMode: "default",
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt: DateTime.formatIso(yield* DateTime.now),
+        });
+      }).pipe(Effect.provide(makeProjectPersistenceLayer(config)));
+
+      yield* runCliWithRuntime([
+        "project",
+        "remove",
+        project!.id,
+        "--force",
+        "--base-dir",
+        baseDir,
+      ]);
+      const afterRemove = yield* readPersistedSnapshot(baseDir);
+      assert.isTrue(
+        afterRemove.projects.find((candidate) => candidate.id === project!.id)?.deletedAt !== null,
+      );
+      assert.isTrue(
+        afterRemove.threads.find((thread) => thread.id === "thread-cli-force-remove")?.deletedAt !==
+          null,
+      );
     }),
   );
 

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -493,6 +493,10 @@ const projectRemoveCommand = Command.make("remove", {
   project: Argument.string("project").pipe(
     Argument.withDescription("Project id or workspace root to remove."),
   ),
+  force: Flag.boolean("force").pipe(
+    Flag.withDescription("Delete the project and all of its threads."),
+    Flag.withDefault(false),
+  ),
 }).pipe(
   Command.withDescription("Remove a project."),
   Command.withHandler((flags) =>
@@ -515,6 +519,7 @@ const projectRemoveCommand = Command.make("remove", {
           type: "project.delete",
           commandId: CommandId.make(yield* projectCommandUuid),
           projectId: project.id,
+          force: flags.force,
         });
         return `Removed project ${project.id} (${project.title}).`;
       }),


### PR DESCRIPTION
Closes #3855.

## What changed

- add a `--force` flag to `t3 project remove`
- forward the flag to the existing `project.delete` orchestration command
- cover force-removing a project with an active thread in the CLI integration suite

Without this flag, the CLI could not access the server's existing force-delete behavior, so non-empty projects could not be removed from the command line.

## Validation

- `pnpm exec vp test apps/server/src/bin.test.ts --run` (16 tests passed)
- `pnpm exec vp check` (0 errors; 9 pre-existing warnings)
- `pnpm exec vp run typecheck` (all 15 workspaces passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin CLI flag wiring to an existing orchestration command; destructive behavior is opt-in via `--force` and covered by a new integration test.
> 
> **Overview**
> Exposes the server’s existing force-delete path from the CLI so `t3 project remove` can drop projects that still have threads.
> 
> **`project remove`** gains a **`--force`** flag (default off) described as deleting the project and all of its threads. The handler passes **`force`** through on the **`project.delete`** dispatch payload instead of only sending **`projectId`**.
> 
> A CLI integration test adds a project, creates a thread via the orchestration engine, runs **`project remove --force`**, and asserts both the project and thread have **`deletedAt`** set in the persisted snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb362c709c8631416eedce0e89502a31084ea8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--force` flag to `t3 project remove` CLI command
> Adds a boolean `--force` flag (default `false`) to the `project remove` command in [project.ts](https://github.com/pingdotgg/t3code/pull/3922/files#diff-44f1264ca9e5b2f3994c44291b5616390842fc6345021ca54e8447fd8dbbc1cd). The flag value is forwarded in the `project.delete` command payload, allowing callers to signal a force deletion. A new test verifies that running `project remove --force` sets `deletedAt` on both the project and its associated threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb362c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->