### PR TITLE
refactor: trim redundant optimizations from the perf PR

### DIFF
--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -294,20 +294,16 @@ export interface SidebarHoverPrewarmController {
 export function createSidebarHoverPrewarmController(input: {
   delayMs: number;
   onPrewarmTargetChange: (threadKey: string | null) => void;
-  setTimeoutFn?: typeof globalThis.setTimeout;
-  clearTimeoutFn?: typeof globalThis.clearTimeout;
 }): SidebarHoverPrewarmController {
-  const setTimeoutFn = input.setTimeoutFn ?? globalThis.setTimeout;
-  const clearTimeoutFn = input.clearTimeoutFn ?? globalThis.clearTimeout;
   let target: string | null = null;
   let pendingKey: string | null = null;
-  let timeoutId: NodeJS.Timeout | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const clearPending = () => {
     if (timeoutId === null) {
       return;
     }
-    clearTimeoutFn(timeoutId);
+    clearTimeout(timeoutId);
     timeoutId = null;
     pendingKey = null;
   };
@@ -334,7 +330,7 @@ export function createSidebarHoverPrewarmController(input: {
 
       clearPending();
       pendingKey = threadKey;
-      timeoutId = setTimeoutFn(() => {
+      timeoutId = setTimeout(() => {
         timeoutId = null;
         pendingKey = null;
         target = threadKey;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -250,7 +250,8 @@ function SidebarThreadDetailPrewarmer({ threadRef }: { readonly threadRef: Scope
 }
 
 // Self-contained so hover changes re-render only this component, never the
-// sidebar tree. Delegated `pointerover` avoids per-row handler props.
+// sidebar tree. Delegated `pointerover` avoids threading a hover callback
+// through the memoized row tree.
 function SidebarHoverThreadPrewarmer() {
   const [prewarmThreadKey, setPrewarmThreadKey] = useState<string | null>(null);
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1815,14 +1815,6 @@ function migratePersistedComposerDraftStoreState(
   };
 }
 
-// Runs on every store update (each prompt keystroke); drafts are immutable
-// snapshots, so unchanged drafts reuse their previously partialized form
-// instead of re-cloning nested contexts/annotations/comments per update.
-const partializedDraftCache = new WeakMap<
-  ComposerThreadDraftState,
-  PersistedComposerThreadDraftState | null
->();
-
 function partializeComposerDraftStoreState(
   state: ComposerDraftStoreState,
 ): PersistedComposerDraftStoreState {
@@ -1833,16 +1825,7 @@ function partializeComposerDraftStoreState(
     if (typeof threadKey !== "string" || threadKey.length === 0) {
       continue;
     }
-    const cached = partializedDraftCache.get(draft);
-    if (cached !== undefined) {
-      if (cached !== null) {
-        persistedDraftsByThreadKey[threadKey] =
-          cached as DeepMutable<PersistedComposerThreadDraftState>;
-      }
-      continue;
-    }
     const persisted = partializeComposerThreadDraft(draft);
-    partializedDraftCache.set(draft, persisted);
     if (persisted !== null) {
       persistedDraftsByThreadKey[threadKey] =
         persisted as DeepMutable<PersistedComposerThreadDraftState>;

--- a/apps/web/src/connection/useDesktopLocalBootstraps.ts
+++ b/apps/web/src/connection/useDesktopLocalBootstraps.ts
@@ -1,5 +1,5 @@
 import type { DesktopEnvironmentBootstrap } from "@t3tools/contracts";
-import { useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
 
 import { readDesktopSecondaryBootstraps } from "./desktopLocal";
 
@@ -26,53 +26,29 @@ function bootstrapsEqual(
   });
 }
 
-// One shared poller for all consumers (sidebar, command palette, ...): a single
-// interval runs only while someone is subscribed, and listeners are notified
-// only when the topology actually changed — each poll returns a fresh array,
-// so publishing it unconditionally would re-render every consumer per tick.
-const listeners = new Set<() => void>();
-let currentSnapshot: ReadonlyArray<DesktopEnvironmentBootstrap> | null = null;
-let pollInterval: ReturnType<typeof setInterval> | null = null;
-
-function poll(): void {
-  const next = readDesktopSecondaryBootstraps();
-  if (currentSnapshot !== null && bootstrapsEqual(currentSnapshot, next)) {
-    return;
-  }
-  currentSnapshot = next;
-  for (const listener of listeners) {
-    listener();
-  }
-}
-
-function subscribe(listener: () => void): () => void {
-  listeners.add(listener);
-  if (pollInterval === null) {
-    poll();
-    pollInterval = setInterval(poll, DESKTOP_LOCAL_BOOTSTRAP_POLL_MS);
-  }
-  return () => {
-    listeners.delete(listener);
-    if (listeners.size === 0 && pollInterval !== null) {
-      clearInterval(pollInterval);
-      pollInterval = null;
-    }
-  };
-}
-
-function getSnapshot(): ReadonlyArray<DesktopEnvironmentBootstrap> {
-  // First read happens during render, before subscribe() has polled.
-  currentSnapshot ??= readDesktopSecondaryBootstraps();
-  return currentSnapshot;
-}
-
 /**
  * Reactively track the desktop's secondary local backends (e.g. a parallel WSL
  * backend). The bridge exposes no change event, so we re-read on an interval;
- * failed reads retain the latest successful snapshot, while a successful empty
- * read clears it. Use this instead of polling the bridge ad hoc so every
- * renderer consumer reads the same topology.
+ * each poll returns a fresh array, so the previous reference is kept when the
+ * topology is unchanged to avoid re-rendering consumers every tick. Use this
+ * instead of polling the bridge ad hoc so every renderer consumer reads the
+ * same topology.
  */
 export function useDesktopLocalBootstraps(): ReadonlyArray<DesktopEnvironmentBootstrap> {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const [bootstraps, setBootstraps] = useState<ReadonlyArray<DesktopEnvironmentBootstrap>>(
+    readDesktopSecondaryBootstraps,
+  );
+
+  useEffect(() => {
+    const read = () =>
+      setBootstraps((previous) => {
+        const next = readDesktopSecondaryBootstraps();
+        return bootstrapsEqual(previous, next) ? previous : next;
+      });
+    read();
+    const interval = setInterval(read, DESKTOP_LOCAL_BOOTSTRAP_POLL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return bootstraps;
 }

--- a/apps/web/src/connection/useDesktopLocalBootstraps.ts
+++ b/apps/web/src/connection/useDesktopLocalBootstraps.ts
@@ -28,11 +28,10 @@ function bootstrapsEqual(
 
 /**
  * Reactively track the desktop's secondary local backends (e.g. a parallel WSL
- * backend). The bridge exposes no change event, so we re-read on an interval;
- * each poll returns a fresh array, so the previous reference is kept when the
- * topology is unchanged to avoid re-rendering consumers every tick. Use this
- * instead of polling the bridge ad hoc so every renderer consumer reads the
- * same topology.
+ * backend). The bridge exposes no change event, so each hook instance re-reads
+ * on its own interval; a poll returns a fresh array, so the previous reference
+ * is kept when the topology is unchanged to avoid re-rendering the consumer
+ * every tick. Use this instead of polling the bridge ad hoc.
  */
 export function useDesktopLocalBootstraps(): ReadonlyArray<DesktopEnvironmentBootstrap> {
   const [bootstraps, setBootstraps] = useState<ReadonlyArray<DesktopEnvironmentBootstrap>>(
@@ -40,11 +39,10 @@ export function useDesktopLocalBootstraps(): ReadonlyArray<DesktopEnvironmentBoo
   );
 
   useEffect(() => {
-    const read = () =>
-      setBootstraps((previous) => {
-        const next = readDesktopSecondaryBootstraps();
-        return bootstrapsEqual(previous, next) ? previous : next;
-      });
+    const read = () => {
+      const next = readDesktopSecondaryBootstraps();
+      setBootstraps((previous) => (bootstrapsEqual(previous, next) ? previous : next));
+    };
     read();
     const interval = setInterval(read, DESKTOP_LOCAL_BOOTSTRAP_POLL_MS);
     return () => clearInterval(interval);

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1366,42 +1366,6 @@ function compareActivityLifecycleRank(kind: string): number {
   return 1;
 }
 
-function isSortedByCreatedAt(rows: ReadonlyArray<TimelineEntry>): boolean {
-  for (let index = 1; index < rows.length; index += 1) {
-    if (rows[index - 1]!.createdAt.localeCompare(rows[index]!.createdAt) > 0) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Stable k-way merge of per-kind rows that are each already in createdAt order
-// (the reducers maintain that invariant). Equal timestamps keep the same order
-// a stable sort of the concatenation would produce.
-function mergeTimelineRows(sources: ReadonlyArray<ReadonlyArray<TimelineEntry>>): TimelineEntry[] {
-  const merged: TimelineEntry[] = [];
-  const cursors = sources.map(() => 0);
-  const total = sources.reduce((sum, rows) => sum + rows.length, 0);
-  while (merged.length < total) {
-    let nextSource = -1;
-    for (let index = 0; index < sources.length; index += 1) {
-      const candidate = sources[index]![cursors[index]!];
-      if (candidate === undefined) {
-        continue;
-      }
-      if (
-        nextSource === -1 ||
-        candidate.createdAt.localeCompare(sources[nextSource]![cursors[nextSource]!]!.createdAt) < 0
-      ) {
-        nextSource = index;
-      }
-    }
-    merged.push(sources[nextSource]![cursors[nextSource]!]!);
-    cursors[nextSource] = cursors[nextSource]! + 1;
-  }
-  return merged;
-}
-
 export function deriveTimelineEntries(
   messages: ReadonlyArray<ChatMessage>,
   proposedPlans: ReadonlyArray<ProposedPlan>,
@@ -1425,10 +1389,9 @@ export function deriveTimelineEntries(
     createdAt: entry.createdAt,
     entry,
   }));
-  const sources = [messageRows, proposedPlanRows, workRows];
-  return sources.every(isSortedByCreatedAt)
-    ? mergeTimelineRows(sources)
-    : sources.flat().toSorted((a, b) => a.createdAt.localeCompare(b.createdAt));
+  return [...messageRows, ...proposedPlanRows, ...workRows].toSorted((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
 }
 
 export function inferCheckpointTurnCountByTurnId(


### PR DESCRIPTION
Follow-up to #3825, based on that branch so the diff shows only the delta. Drops the pieces of the perf PR whose complexity isn't justified by a measurable win, while keeping every hot-path fix (aggregate-indexed replay, bounded shell catch-up, incremental projections, O(append) reducer, skip-persist-while-running, debounced draft serialization, hover prewarm, shared activity ordering cache).

## What's trimmed

**Timeline k-way merge → back to `concat + toSorted` (~45 lines).** V8's sort is TimSort, which is near-linear on nearly-sorted input — and this input is three already-sorted arrays concatenated. The derivation also runs behind a `useMemo` in ChatView, so it fires per event, not per render. The PR retained the `toSorted` fallback path regardless, so the merge was a second implementation of the same ordering. The real win in `session-logic.ts` — the shared `orderActivities` cache that stops four derivations re-sorting the full activity history — is kept.

**`useDesktopLocalBootstraps`: equality bail instead of a module-global store (~40 lines).** There are exactly two consumers (Sidebar, CommandPalette), so collapsing two 2s intervals into one shared refcounted poller saves nothing real. The actual fix — not re-rendering when the topology is unchanged — now lives inside the original hook as `setBootstraps(prev => bootstrapsEqual(prev, next) ? prev : next)`.

**Hover prewarm: dead injection params removed.** `setTimeoutFn`/`clearTimeoutFn` were copied from the jump-hint controller's pattern but nothing passes them — the component uses defaults and the tests use fake timers. The controller and its tests are otherwise kept as-is.

**Composer `partialize`: per-draft WeakMap cache dropped (~17 lines).** Two mechanisms addressed the same keystroke path; `createDebouncedJsonStorage` (kept) removes the per-keystroke `JSON.stringify`, which was the dominant cost. What remains without the cache is shallow-cloning small context arrays for retained drafts — not worth a second caching layer unless measured otherwise.

## Verification

- `pnpm run typecheck` clean
- `Sidebar.logic`, `composerDraftStore`, `session-logic` test files: 193 passed
- `pnpm run lint`: same 30 pre-existing warnings as the base branch, none introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant optimizations from perf-related code in sidebar, draft store, and timeline
> - Removes injectable timer functions from `createSidebarHoverPrewarmController` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/3928/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a), using global `setTimeout`/`clearTimeout` directly.
> - Removes the `WeakMap` draft cache (`partializedDraftCache`) from [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/3928/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a); partialized drafts are now recomputed on every call.
> - Replaces shared `useSyncExternalStore`-based polling in [useDesktopLocalBootstraps.ts](https://github.com/pingdotgg/t3code/pull/3928/files#diff-9091fe1f73c0a727c631437ca3c755bdc49ccf4bfffd819ec054004984a2e394) with per-instance `useState`/`useEffect` intervals; reference equality is preserved when topology is unchanged.
> - Simplifies `deriveTimelineEntries` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/3928/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) by removing the k-way merge path and always using `toSorted` on the concatenated rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bec10f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simplifications with no auth or data-model changes; the only behavioral nuance is two independent bootstrap poll intervals instead of one shared poller, which the authors judged negligible for two consumers.
> 
> **Overview**
> Follow-up cleanup that **removes complexity** from the recent perf work without undoing the meaningful hot-path wins (debounced draft persistence, hover prewarm, shared activity ordering cache, etc.).
> 
> **`deriveTimelineEntries`** in `session-logic.ts` no longer uses a custom k-way merge over three sorted arrays; it **concatenates and `toSorted` by `createdAt`** instead (~45 lines removed).
> 
> **`useDesktopLocalBootstraps`** drops the module-global `useSyncExternalStore` refcounted poller. Each mount now runs its **own 2s interval** and only updates state when `bootstrapsEqual` says the topology changed (Sidebar + Command Palette = two pollers).
> 
> **Composer draft `partialize`** no longer keeps a per-draft **`WeakMap` cache**; unchanged drafts are recomputed on each partialization, relying on **`createDebouncedJsonStorage`** for the heavy cost.
> 
> **`createSidebarHoverPrewarmController`** no longer accepts injectable timer functions; it uses global **`setTimeout` / `clearTimeout`** and `ReturnType<typeof setTimeout>` for the handle type. Sidebar hover prewarm behavior is unchanged; a comment in `Sidebar.tsx` is clarified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec10f9d277bcdb635c7f0dedb7911a042eea36a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline ordering by consistently sorting entries by creation time.
  * Improved draft persistence reliability by recalculating saved draft data.
  * Improved desktop connection state updates while avoiding unnecessary refreshes.

* **Performance**
  * Refined sidebar hover preloading behavior.
  * Reduced unnecessary updates while monitoring desktop connection bootstraps.

* **Documentation**
  * Clarified inline documentation for sidebar hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->