### PR TITLE
Fix fork-only checkout repository grouping

### DIFF
--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -126,6 +126,10 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
       expect(identity).not.toBeNull();
       expect(identity?.locator.remoteName).toBe("upstream");
       expect(identity?.canonicalKey).toBe("github.com/t3tools/t3code");
+      expect(identity?.remoteKeys).toEqual([
+        "github.com/julius/t3code",
+        "github.com/t3tools/t3code",
+      ]);
       expect(identity?.displayName).toBe("t3tools/t3code");
     }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
   );

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -63,9 +63,18 @@ function pickPrimaryRemote(
 function buildRepositoryIdentity(input: {
   readonly remoteName: string;
   readonly remoteUrl: string;
+  readonly remotes: ReadonlyMap<string, string>;
   readonly rootPath: string;
 }): RepositoryIdentity {
   const canonicalKey = normalizeGitRemoteUrl(input.remoteUrl);
+  const remoteKeys = [
+    ...new Set([
+      canonicalKey,
+      ...[...input.remotes.values()]
+        .map(normalizeGitRemoteUrl)
+        .filter((remoteKey) => remoteKey.length > 0),
+    ]),
+  ].toSorted();
   const sourceControlProvider = detectSourceControlProviderFromGitRemoteUrl(input.remoteUrl);
   const repositoryPath = canonicalKey.split("/").slice(1).join("/");
   const repositoryPathSegments = repositoryPath.split("/").filter((segment) => segment.length > 0);
@@ -74,6 +83,7 @@ function buildRepositoryIdentity(input: {
 
   return {
     canonicalKey,
+    remoteKeys,
     locator: {
       source: "git-remote",
       remoteName: input.remoteName,
@@ -131,8 +141,9 @@ const resolveRepositoryIdentityFromCacheKey = Effect.fn(
     return null;
   }
 
-  const remote = pickPrimaryRemote(parseRemoteFetchUrls(remoteResult.value.stdout));
-  return remote ? buildRepositoryIdentity({ ...remote, rootPath: cacheKey }) : null;
+  const remotes = parseRemoteFetchUrls(remoteResult.value.stdout);
+  const remote = pickPrimaryRemote(remotes);
+  return remote ? buildRepositoryIdentity({ ...remote, remotes, rootPath: cacheKey }) : null;
 });
 
 export const make = Effect.fn("RepositoryIdentityResolver.make")(function* (

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3175,8 +3175,8 @@ export default function Sidebar() {
   }, [projectOrder, projects]);
 
   // Build a mapping from physical project key → logical project key for
-  // cross-environment grouping.  Projects that share a repositoryIdentity
-  // canonicalKey are treated as one logical project in the sidebar.
+  // cross-environment grouping. Projects whose repository identities share a
+  // configured remote are treated as one logical project in the sidebar.
   const physicalToLogicalKey = useMemo(() => {
     return buildPhysicalToLogicalProjectKeyMap({
       projects: orderedProjects,

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -1,5 +1,6 @@
 export {
   deriveLogicalProjectKey,
+  deriveLogicalProjectKeyMap,
   deriveLogicalProjectKeyFromRef,
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKey,

--- a/apps/web/src/sidebarProjectGrouping.test.ts
+++ b/apps/web/src/sidebarProjectGrouping.test.ts
@@ -1,0 +1,90 @@
+import { EnvironmentId, ProjectId, ProviderInstanceId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { derivePhysicalProjectKey } from "./logicalProject";
+import {
+  buildPhysicalToLogicalProjectKeyMap,
+  buildSidebarProjectSnapshots,
+} from "./sidebarProjectGrouping";
+import type { Project } from "./types";
+
+const forkKey = "github.com/felixleopold/t3code";
+const upstreamKey = "github.com/pingdotgg/t3code";
+const settings = {
+  sidebarProjectGroupingMode: "repository" as const,
+  sidebarProjectGroupingOverrides: {},
+};
+
+function makeProject(input: {
+  readonly environmentId: EnvironmentId;
+  readonly id: ProjectId;
+  readonly workspaceRoot: string;
+  readonly hasUpstream: boolean;
+}): Project {
+  return {
+    id: input.id,
+    environmentId: input.environmentId,
+    title: input.hasUpstream ? "pingdotgg/t3code" : "felixleopold-t3code",
+    workspaceRoot: input.workspaceRoot,
+    repositoryIdentity: {
+      canonicalKey: input.hasUpstream ? upstreamKey : forkKey,
+      remoteKeys: input.hasUpstream ? [forkKey, upstreamKey] : [forkKey],
+      locator: {
+        source: "git-remote",
+        remoteName: input.hasUpstream ? "upstream" : "origin",
+        remoteUrl: input.hasUpstream
+          ? "git@github.com:pingdotgg/t3code.git"
+          : "git@github.com:felixleopold/t3code.git",
+      },
+      displayName: input.hasUpstream ? "pingdotgg/t3code" : "felixleopold/t3code",
+      provider: "github",
+      owner: input.hasUpstream ? "pingdotgg" : "felixleopold",
+      name: "t3code",
+    },
+    defaultModelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5-codex",
+    },
+    scripts: [],
+    createdAt: "2026-07-13T00:00:00.000Z",
+    updatedAt: "2026-07-13T00:00:00.000Z",
+  };
+}
+
+describe("sidebar project grouping", () => {
+  it("groups a fork-only clone with an upstream checkout regardless of discovery order", () => {
+    const forkOnly = makeProject({
+      environmentId: EnvironmentId.make("env-conductor"),
+      id: ProjectId.make("project-conductor"),
+      workspaceRoot: "/srv/nas_share/conductor/t3-projects/felixleopold-t3code",
+      hasUpstream: false,
+    });
+    const withUpstream = makeProject({
+      environmentId: EnvironmentId.make("env-local"),
+      id: ProjectId.make("project-local"),
+      workspaceRoot: "/srv/nas_share/t3code-src",
+      hasUpstream: true,
+    });
+
+    for (const projects of [
+      [forkOnly, withUpstream],
+      [withUpstream, forkOnly],
+    ]) {
+      const physicalToLogical = buildPhysicalToLogicalProjectKeyMap({ projects, settings });
+      const snapshots = buildSidebarProjectSnapshots({
+        projects,
+        settings,
+        primaryEnvironmentId: EnvironmentId.make("env-local"),
+        resolveEnvironmentLabel: () => null,
+      });
+
+      expect(physicalToLogical.get(derivePhysicalProjectKey(forkOnly))).toBe(upstreamKey);
+      expect(physicalToLogical.get(derivePhysicalProjectKey(withUpstream))).toBe(upstreamKey);
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]).toMatchObject({
+        projectKey: upstreamKey,
+        groupedProjectCount: 2,
+      });
+    }
+  });
+});

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,7 +1,7 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
 import {
-  deriveLogicalProjectKeyFromSettings,
+  deriveLogicalProjectKeyMap,
   derivePhysicalProjectKey,
   deriveProjectGroupLabel,
   type ProjectGroupingSettings,
@@ -35,14 +35,7 @@ export function buildPhysicalToLogicalProjectKeyMap(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;
 }): Map<string, string> {
-  const mapping = new Map<string, string>();
-  for (const project of input.projects) {
-    mapping.set(
-      derivePhysicalProjectKey(project),
-      deriveLogicalProjectKeyFromSettings(project, input.settings),
-    );
-  }
-  return mapping;
+  return deriveLogicalProjectKeyMap(input.projects, input.settings);
 }
 
 export function buildSidebarProjectSnapshots(input: {
@@ -56,9 +49,13 @@ export function buildSidebarProjectSnapshots(input: {
   // legacy behavior.
   isDesktopLocalEnvironment?: (environmentId: EnvironmentId) => boolean;
 }): SidebarProjectSnapshot[] {
+  const logicalKeyByPhysicalKey = deriveLogicalProjectKeyMap(input.projects, input.settings);
+  const getLogicalKey = (project: Project): string =>
+    logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
+    derivePhysicalProjectKey(project);
   const groupedMembers = new Map<string, SidebarProjectGroupMember[]>();
   for (const project of input.projects) {
-    const logicalKey = deriveLogicalProjectKeyFromSettings(project, input.settings);
+    const logicalKey = getLogicalKey(project);
     const member: SidebarProjectGroupMember = {
       ...project,
       physicalProjectKey: derivePhysicalProjectKey(project),
@@ -75,7 +72,7 @@ export function buildSidebarProjectSnapshots(input: {
   const result: SidebarProjectSnapshot[] = [];
   const seen = new Set<string>();
   for (const project of input.projects) {
-    const logicalKey = deriveLogicalProjectKeyFromSettings(project, input.settings);
+    const logicalKey = getLogicalKey(project);
     if (seen.has(logicalKey)) {
       continue;
     }

--- a/packages/client-runtime/src/state/projectGrouping.ts
+++ b/packages/client-runtime/src/state/projectGrouping.ts
@@ -12,6 +12,11 @@ export interface ProjectGroupingSettings {
 
 export type ProjectGroupingMode = SidebarProjectGroupingMode;
 
+type GroupableProject = Pick<
+  EnvironmentProject,
+  "environmentId" | "id" | "workspaceRoot" | "repositoryIdentity"
+>;
+
 export function selectProjectGroupingSettings(settings: ClientSettings): ProjectGroupingSettings {
   return {
     sidebarProjectGroupingMode: settings.sidebarProjectGroupingMode,
@@ -92,27 +97,39 @@ export function resolveProjectGroupingMode(
   );
 }
 
-function deriveRepositoryScopedKey(
+function deriveRepositoryScopedKeys(
   project: Pick<EnvironmentProject, "workspaceRoot" | "repositoryIdentity">,
   groupingMode: SidebarProjectGroupingMode,
-): string | null {
+): string[] {
   const canonicalKey = project.repositoryIdentity?.canonicalKey;
   if (!canonicalKey) {
-    return null;
+    return [];
   }
 
+  const repositoryKeys = uniqueNonEmptyValues([
+    canonicalKey,
+    ...(project.repositoryIdentity?.remoteKeys ?? []),
+  ]);
+
   if (groupingMode === "repository") {
-    return canonicalKey;
+    return repositoryKeys;
   }
 
   const relativeProjectPath = deriveRepositoryRelativeProjectPath(project);
   if (relativeProjectPath === null) {
-    return canonicalKey;
+    return repositoryKeys;
   }
 
   return relativeProjectPath.length === 0
-    ? canonicalKey
-    : `${canonicalKey}::${relativeProjectPath}`;
+    ? repositoryKeys
+    : repositoryKeys.map((repositoryKey) => `${repositoryKey}::${relativeProjectPath}`);
+}
+
+function deriveRepositoryScopedKey(
+  project: Pick<EnvironmentProject, "workspaceRoot" | "repositoryIdentity">,
+  groupingMode: SidebarProjectGroupingMode,
+): string | null {
+  return deriveRepositoryScopedKeys(project, groupingMode)[0] ?? null;
 }
 
 export function deriveLogicalProjectKey(
@@ -146,6 +163,100 @@ export function deriveLogicalProjectKeyFromSettings(
   return deriveLogicalProjectKey(project, {
     groupingMode: resolveProjectGroupingMode(project, settings),
   });
+}
+
+/**
+ * Resolve logical keys for a complete project collection. Repository identities
+ * advertise every configured remote so a fork-only clone can join a checkout
+ * whose preferred identity comes from `upstream`.
+ */
+export function deriveLogicalProjectKeyMap(
+  projects: ReadonlyArray<GroupableProject>,
+  settings: ProjectGroupingSettings,
+): Map<string, string> {
+  const entries = projects.map((project) => {
+    const groupingMode = resolveProjectGroupingMode(project, settings);
+    return {
+      project,
+      physicalKey: derivePhysicalProjectKey(project),
+      logicalKey: deriveLogicalProjectKey(project, { groupingMode }),
+      repositoryKeys:
+        groupingMode === "separate" ? [] : deriveRepositoryScopedKeys(project, groupingMode),
+    };
+  });
+  const parents = entries.map((_entry, index) => index);
+
+  const findRoot = (index: number): number => {
+    let root = index;
+    while (parents[root] !== root) {
+      root = parents[root]!;
+    }
+    while (parents[index] !== index) {
+      const next = parents[index]!;
+      parents[index] = root;
+      index = next;
+    }
+    return root;
+  };
+  const union = (left: number, right: number): void => {
+    const leftRoot = findRoot(left);
+    const rightRoot = findRoot(right);
+    if (leftRoot !== rightRoot) {
+      parents[rightRoot] = leftRoot;
+    }
+  };
+
+  const firstProjectByRepositoryKey = new Map<string, number>();
+  for (const [index, entry] of entries.entries()) {
+    for (const repositoryKey of entry.repositoryKeys) {
+      const existingIndex = firstProjectByRepositoryKey.get(repositoryKey);
+      if (existingIndex === undefined) {
+        firstProjectByRepositoryKey.set(repositoryKey, index);
+      } else {
+        union(existingIndex, index);
+      }
+    }
+  }
+
+  const componentMembers = new Map<number, number[]>();
+  for (const index of entries.keys()) {
+    const root = findRoot(index);
+    const members = componentMembers.get(root);
+    if (members) {
+      members.push(index);
+    } else {
+      componentMembers.set(root, [index]);
+    }
+  }
+
+  const logicalKeyByComponent = new Map<number, string>();
+  for (const [root, memberIndexes] of componentMembers) {
+    const representativeIndex = memberIndexes.toSorted((leftIndex, rightIndex) => {
+      const left = entries[leftIndex]!;
+      const right = entries[rightIndex]!;
+      const upstreamPreference =
+        Number(right.project.repositoryIdentity?.locator.remoteName === "upstream") -
+        Number(left.project.repositoryIdentity?.locator.remoteName === "upstream");
+      if (upstreamPreference !== 0) {
+        return upstreamPreference;
+      }
+
+      const remoteCountPreference = right.repositoryKeys.length - left.repositoryKeys.length;
+      if (remoteCountPreference !== 0) {
+        return remoteCountPreference;
+      }
+
+      return left.logicalKey.localeCompare(right.logicalKey);
+    })[0]!;
+    logicalKeyByComponent.set(root, entries[representativeIndex]!.logicalKey);
+  }
+
+  return new Map(
+    entries.map((entry, index) => [
+      entry.physicalKey,
+      logicalKeyByComponent.get(findRoot(index)) ?? entry.logicalKey,
+    ]),
+  );
 }
 
 export function deriveLogicalProjectKeyFromRef(

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -51,6 +51,7 @@ export type RepositoryIdentityLocator = typeof RepositoryIdentityLocator.Type;
 
 export const RepositoryIdentity = Schema.Struct({
   canonicalKey: TrimmedNonEmptyString,
+  remoteKeys: Schema.optionalKey(Schema.Array(TrimmedNonEmptyString)),
   locator: RepositoryIdentityLocator,
   rootPath: Schema.optionalKey(TrimmedNonEmptyString),
   displayName: Schema.optionalKey(TrimmedNonEmptyString),


### PR DESCRIPTION
## Summary
- expose normalized identities for every configured fetch remote
- merge sidebar project identities when their remote sets overlap
- prefer the explicit `upstream` identity as the stable group key
- keep grouping deterministic regardless of checkout discovery order

## Root cause
Repository identity resolution retained only the preferred remote. A fork-only clone therefore exposed the fork key, while a clone with `upstream` exposed the canonical repository key, leaving the client with no evidence that the checkouts referred to the same repository.

## Validation
- `vp test apps/server/src/project/RepositoryIdentityResolver.test.ts apps/web/src/sidebarProjectGrouping.test.ts`
- `vp check`
- `vp run typecheck`

Fixes #3934

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar grouping for fork-only checkouts by resolving shared repository identity across remotes
> - Adds a `remoteKeys` array to `RepositoryIdentity` (schema + server-side resolver) containing normalized canonical keys for all configured git remotes, enabling cross-remote identity matching.
> - Introduces `deriveLogicalProjectKeyMap` in [`projectGrouping.ts`](https://github.com/pingdotgg/t3code/pull/3935/files#diff-e1879271b5b7e96dc98bc4657072d607871819c1b52045a00379379657cd9a4c), which uses union-find to merge projects sharing any repository-scoped key, so a fork-only clone and its upstream checkout are placed in the same sidebar group.
> - Refactors `buildPhysicalToLogicalProjectKeyMap` and `buildSidebarProjectSnapshots` in [`sidebarProjectGrouping.ts`](https://github.com/pingdotgg/t3code/pull/3935/files#diff-56beffcb94c48f4ebb0f187f3a8be66f26b116bb7a3e13fd196af3753e10d9a9) to delegate to `deriveLogicalProjectKeyMap` instead of per-project direct key derivation.
> - Behavioral Change: sidebar grouping now keys groups by the upstream canonical key rather than the local canonical key when an upstream remote is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acaadf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible sidebar grouping changes and union-find merging could group or label projects differently when multiple remotes or paths are involved; scope is UI/project identity, not auth or data integrity.
> 
> **Overview**
> Fixes sidebar repository grouping when one checkout only has a fork remote and another has `upstream`, by exposing **all** normalized git remotes on repository identity and merging projects when those key sets overlap.
> 
> **Server & contracts:** `RepositoryIdentity` gains optional `remoteKeys` (sorted, deduped normalized URLs from every configured fetch remote). The resolver still picks `upstream`/`origin` for `canonicalKey`, but now passes the full remote map into identity building.
> 
> **Client grouping:** Repository-scoped keys are derived from `canonicalKey` plus `remoteKeys` (including `repository_path` mode variants). New `deriveLogicalProjectKeyMap` runs union-find over projects sharing any repository-scoped key, then picks a stable group logical key (prefer `upstream`, then more remotes, then lexical). Sidebar `buildPhysicalToLogicalProjectKeyMap` / snapshots use this map instead of per-project keys alone.
> 
> **Behavior:** Fork-only and upstream checkouts collapse to one sidebar row keyed by the upstream canonical identity, independent of project discovery order. Regression test added for that scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acaadf6eb57937609f27dc2a92ccdad3a3be0006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->