### PR TITLE
Add GPT-5 verbosity model options to Codex and OpenCode

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -345,6 +345,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
           modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
             { id: "reasoningEffort", value: "high" },
             { id: "serviceTier", value: "priority" },
+            { id: "verbosity", value: "high" },
           ]),
           attachments: [],
         }),
@@ -355,6 +356,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
         model: "gpt-5.3-codex",
         effort: "high",
         serviceTier: "priority",
+        verbosity: "high",
       });
     }),
   );
@@ -399,6 +401,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
             [
               { id: "reasoningEffort", value: "high" },
               { id: "serviceTier", value: "flex" },
+              { id: "verbosity", value: "medium" },
             ],
           ),
           attachments: [],
@@ -410,6 +413,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
         model: "gpt-5.3-codex",
         effort: "high",
         serviceTier: "flex",
+        verbosity: "medium",
       });
     }).pipe(Effect.provide(customLayer));
   });

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -55,7 +55,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
-  type CodexSessionRuntimeSendTurnInput,
+  isCodexVerbosity,
   makeCodexSessionRuntime,
   type CodexSessionRuntimeError,
   type CodexSessionRuntimeOptions,
@@ -1536,27 +1536,23 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getCodexServiceTierOptionValue(input.modelSelection)
         : undefined;
-    const verbosity =
+    const selectedVerbosity =
       input.modelSelection?.instanceId === boundInstanceId
         ? getModelSelectionStringOptionValue(input.modelSelection, "verbosity")
         : undefined;
-    const turnInput = {
-      ...(input.input !== undefined ? { input: input.input } : {}),
-      ...(input.modelSelection?.instanceId === boundInstanceId
-        ? { model: input.modelSelection.model }
-        : {}),
-      ...(reasoningEffort
-        ? {
-            effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
-          }
-        : {}),
-      ...(serviceTier ? { serviceTier } : {}),
-      ...(verbosity ? { verbosity } : {}),
-      ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
-      ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
-    } as CodexSessionRuntimeSendTurnInput & { readonly verbosity?: string };
+    const verbosity = isCodexVerbosity(selectedVerbosity) ? selectedVerbosity : undefined;
     return yield* session.runtime
-      .sendTurn(turnInput)
+      .sendTurn({
+        ...(input.input !== undefined ? { input: input.input } : {}),
+        ...(input.modelSelection?.instanceId === boundInstanceId
+          ? { model: input.modelSelection.model }
+          : {}),
+        ...(reasoningEffort ? { effort: reasoningEffort } : {}),
+        ...(serviceTier ? { serviceTier } : {}),
+        ...(verbosity ? { verbosity } : {}),
+        ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+        ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
+      })
       .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
   });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -55,6 +55,7 @@ import { ServerConfig } from "../../config.ts";
 import {
   CodexResumeCursorSchema,
   CodexSessionRuntimeThreadIdMissingError,
+  type CodexSessionRuntimeSendTurnInput,
   makeCodexSessionRuntime,
   type CodexSessionRuntimeError,
   type CodexSessionRuntimeOptions,
@@ -1535,21 +1536,27 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getCodexServiceTierOptionValue(input.modelSelection)
         : undefined;
+    const verbosity =
+      input.modelSelection?.instanceId === boundInstanceId
+        ? getModelSelectionStringOptionValue(input.modelSelection, "verbosity")
+        : undefined;
+    const turnInput = {
+      ...(input.input !== undefined ? { input: input.input } : {}),
+      ...(input.modelSelection?.instanceId === boundInstanceId
+        ? { model: input.modelSelection.model }
+        : {}),
+      ...(reasoningEffort
+        ? {
+            effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
+          }
+        : {}),
+      ...(serviceTier ? { serviceTier } : {}),
+      ...(verbosity ? { verbosity } : {}),
+      ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+      ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
+    } as CodexSessionRuntimeSendTurnInput & { readonly verbosity?: string };
     return yield* session.runtime
-      .sendTurn({
-        ...(input.input !== undefined ? { input: input.input } : {}),
-        ...(input.modelSelection?.instanceId === boundInstanceId
-          ? { model: input.modelSelection.model }
-          : {}),
-        ...(reasoningEffort
-          ? {
-              effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
-            }
-          : {}),
-        ...(serviceTier ? { serviceTier } : {}),
-        ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
-        ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
-      })
+      .sendTurn(turnInput)
       .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
   });
 

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -64,6 +64,86 @@ it("maps current Codex model capability fields", () => {
   ]);
 });
 
+it("adds verbosity for GPT-5 Codex models", () => {
+  const capabilities = mapCodexModelCapabilities({
+    additionalSpeedTiers: [],
+    defaultReasoningEffort: "medium",
+    description: "Test model",
+    displayName: "GPT-5.3-Codex-Spark",
+    hidden: false,
+    id: "gpt-5.3-codex-spark",
+    isDefault: true,
+    model: "gpt-5.3-codex-spark",
+    defaultServiceTier: "fast",
+    serviceTiers: [
+      {
+        id: "priority",
+        name: "Priority",
+        description: "Lower latency responses.",
+      },
+      {
+        id: "fast",
+        name: "Fast",
+        description: "Lower-cost asynchronous routing.",
+      },
+    ],
+    supportedReasoningEfforts: [
+      {
+        description: "Balanced",
+        reasoningEffort: "medium",
+      },
+      {
+        description: "Best",
+        reasoningEffort: "high",
+      },
+    ],
+  });
+
+  assert.deepStrictEqual(capabilities.optionDescriptors, [
+    {
+      id: "reasoningEffort",
+      label: "Reasoning",
+      type: "select",
+      options: [
+        { id: "medium", label: "Medium", isDefault: true },
+        { id: "high", label: "High" },
+      ],
+      currentValue: "medium",
+    },
+    {
+      id: "serviceTier",
+      label: "Service Tier",
+      type: "select",
+      options: [
+        { id: "default", label: "Standard" },
+        {
+          id: "priority",
+          label: "Priority",
+          description: "Lower latency responses.",
+        },
+        {
+          id: "fast",
+          label: "Fast",
+          description: "Lower-cost asynchronous routing.",
+          isDefault: true,
+        },
+      ],
+      currentValue: "fast",
+    },
+    {
+      id: "verbosity",
+      label: "Verbosity",
+      type: "select",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "medium", label: "Medium", isDefault: true },
+        { id: "high", label: "High" },
+      ],
+      currentValue: "medium",
+    },
+  ]);
+});
+
 it("uses standard routing when the catalog has no default service tier", () => {
   const capabilities = mapCodexModelCapabilities({
     additionalSpeedTiers: ["fast"],
@@ -101,4 +181,30 @@ it("uses standard routing when the catalog has no default service tier", () => {
       currentValue: "default",
     },
   ]);
+});
+
+it("does not expose verbosity for non-GPT-5 models", () => {
+  const capabilities = mapCodexModelCapabilities({
+    additionalSpeedTiers: ["fast"],
+    defaultReasoningEffort: "medium",
+    description: "Test model",
+    displayName: "GPT Test",
+    hidden: false,
+    id: "gpt-test",
+    isDefault: true,
+    model: "gpt-test",
+    serviceTiers: [
+      {
+        id: "priority",
+        name: "Fast",
+        description: "1.5x speed, increased usage",
+      },
+    ],
+    supportedReasoningEfforts: [],
+  });
+
+  assert.deepStrictEqual(
+    capabilities.optionDescriptors?.some((descriptor) => descriptor.id === "verbosity"),
+    false,
+  );
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -61,6 +61,9 @@ const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
 };
 
 const DEFAULT_SERVICE_TIER_ID = "default";
+function isGpt5Model(modelID: string): boolean {
+  return modelID.toLowerCase().startsWith("gpt-5");
+}
 
 function reasoningEffortLabel(reasoningEffort: string): string {
   return REASONING_EFFORT_LABELS[reasoningEffort] ?? reasoningEffort;
@@ -109,6 +112,7 @@ function codexAccountEmail(account: CodexSchema.V2GetAccountResponse["account"])
 export function mapCodexModelCapabilities(
   model: CodexSchema.V2ModelListResponse__Model,
 ): ModelCapabilities {
+  const hasGpt5Verbosity = isGpt5Model(model.id);
   const reasoningOptions = model.supportedReasoningEfforts.map(({ reasoningEffort }) =>
     reasoningEffort === model.defaultReasoningEffort
       ? {
@@ -136,6 +140,14 @@ export function mapCodexModelCapabilities(
     ? model.defaultServiceTier
     : null;
   const defaultServiceTier = catalogDefaultServiceTier ?? DEFAULT_SERVICE_TIER_ID;
+  const verbosityOptions = [
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium" },
+    { id: "high", label: "High" },
+  ];
+  const defaultVerbosity = hasGpt5Verbosity
+    ? (verbosityOptions.find((option) => option.id === "medium")?.id ?? verbosityOptions[0]?.id)
+    : undefined;
   const optionDescriptors: ProviderOptionDescriptor[] = [];
 
   if (reasoningOptions.length > 0) {
@@ -166,6 +178,15 @@ export function mapCodexModelCapabilities(
         })),
       ],
       currentValue: defaultServiceTier,
+    });
+  }
+  if (hasGpt5Verbosity) {
+    optionDescriptors.push({
+      id: "verbosity",
+      label: "Verbosity",
+      type: "select",
+      options: verbosityOptions,
+      ...(defaultVerbosity ? { currentValue: defaultVerbosity } : {}),
     });
   }
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -95,6 +95,7 @@ describe("buildTurnStartParams", () => {
         prompt: "Make a plan",
         model: "gpt-5.3-codex",
         effort: "medium",
+        verbosity: "high",
         interactionMode: "plan",
       }),
     );
@@ -113,6 +114,7 @@ describe("buildTurnStartParams", () => {
       ],
       model: "gpt-5.3-codex",
       effort: "medium",
+      verbosity: "high",
       collaborationMode: {
         mode: "plan",
         settings: {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -75,19 +75,21 @@ const CodexUserInputAnswerObject = Schema.Struct({
 const isCodexResumeCursorSchema = Schema.is(CodexResumeCursorSchema);
 const isCodexUserInputAnswerObject = Schema.is(CodexUserInputAnswerObject);
 
+export const CodexVerbosity = Schema.Literals(["low", "medium", "high"]);
+export type CodexVerbosity = typeof CodexVerbosity.Type;
+export const isCodexVerbosity = Schema.is(CodexVerbosity);
+
 // TODO: Verify `packages/effect-codex-app-server/scripts/generate.ts` so the generated
-// `V2TurnStartParams` schema includes `collaborationMode` directly.
-const CodexTurnStartParamsWithCollaborationMode = EffectCodexSchema.V2TurnStartParams.pipe(
+// `V2TurnStartParams` schema includes `collaborationMode` and `verbosity` directly.
+const CodexTurnStartParams = EffectCodexSchema.V2TurnStartParams.pipe(
   Schema.fieldsAssign({
     collaborationMode: Schema.optionalKey(EffectCodexSchema.V2TurnStartParams__CollaborationMode),
+    verbosity: Schema.optionalKey(CodexVerbosity),
   }),
 );
-const decodeCodexTurnStartParamsWithCollaborationMode = Schema.decodeUnknownEffect(
-  CodexTurnStartParamsWithCollaborationMode,
-);
+const decodeCodexTurnStartParams = Schema.decodeUnknownEffect(CodexTurnStartParams);
 
-export type CodexTurnStartParamsWithCollaborationMode =
-  typeof CodexTurnStartParamsWithCollaborationMode.Type;
+export type CodexTurnStartParams = typeof CodexTurnStartParams.Type;
 
 export type CodexResumeCursor = typeof CodexResumeCursorSchema.Type;
 type CodexServiceTier = NonNullable<EffectCodexSchema.V2ThreadStartParams["serviceTier"]>;
@@ -118,6 +120,7 @@ export interface CodexSessionRuntimeSendTurnInput {
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort | undefined;
+  readonly verbosity?: CodexVerbosity | undefined;
   readonly interactionMode?: ProviderInteractionMode;
 }
 
@@ -355,11 +358,9 @@ export function buildTurnStartParams(input: {
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;
+  readonly verbosity?: CodexVerbosity;
   readonly interactionMode?: ProviderInteractionMode;
-}): Effect.Effect<
-  CodexTurnStartParamsWithCollaborationMode,
-  CodexErrors.CodexAppServerProtocolParseError
-> {
+}): Effect.Effect<CodexTurnStartParams, CodexErrors.CodexAppServerProtocolParseError> {
   const turnInput: Array<EffectCodexSchema.V2TurnStartParams__UserInput> = [];
   if (input.prompt) {
     turnInput.push({
@@ -378,7 +379,7 @@ export function buildTurnStartParams(input: {
     ...(input.effort ? { effort: input.effort } : {}),
   });
 
-  return decodeCodexTurnStartParamsWithCollaborationMode({
+  return decodeCodexTurnStartParams({
     threadId: input.threadId,
     input: turnInput,
     approvalPolicy: config.approvalPolicy,
@@ -386,6 +387,7 @@ export function buildTurnStartParams(input: {
     ...(input.model ? { model: input.model } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
     ...(input.effort ? { effort: input.effort } : {}),
+    ...(input.verbosity ? { verbosity: input.verbosity } : {}),
     ...(collaborationMode ? { collaborationMode } : {}),
   }).pipe(
     Effect.mapError((cause) =>
@@ -1285,6 +1287,7 @@ export const makeCodexSessionRuntime = (
             ...(normalizedModel ? { model: normalizedModel } : {}),
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
             ...(input.effort ? { effort: input.effort } : {}),
+            ...(input.verbosity ? { verbosity: input.verbosity } : {}),
             ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
           });
           const rawResponse = yield* client.raw.request("turn/start", params);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -474,52 +474,57 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("passes agent and variant options for the adapter's bound custom instance id", () => {
-    const instanceId = ProviderInstanceId.make("opencode_zen");
-    const adapterLayer = Layer.effect(
-      OpenCodeAdapter,
-      makeOpenCodeAdapter(openCodeAdapterTestSettings, { instanceId }),
-    ).pipe(
-      Layer.provideMerge(Layer.succeed(OpenCodeRuntime, OpenCodeRuntimeTestDouble)),
-      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
-      Layer.provideMerge(providerSessionDirectoryTestLayer),
-      Layer.provideMerge(NodeServices.layer),
-    );
+  it.effect(
+    "passes agent, variant, and verbosity options for the adapter's bound custom instance id",
+    () => {
+      const instanceId = ProviderInstanceId.make("opencode_zen");
+      const adapterLayer = Layer.effect(
+        OpenCodeAdapter,
+        makeOpenCodeAdapter(openCodeAdapterTestSettings, { instanceId }),
+      ).pipe(
+        Layer.provideMerge(Layer.succeed(OpenCodeRuntime, OpenCodeRuntimeTestDouble)),
+        Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+        Layer.provideMerge(ServerSettingsService.layerTest()),
+        Layer.provideMerge(providerSessionDirectoryTestLayer),
+        Layer.provideMerge(NodeServices.layer),
+      );
 
-    return Effect.gen(function* () {
-      const adapter = yield* OpenCodeAdapter;
-      yield* adapter.startSession({
-        provider: ProviderDriverKind.make("opencode"),
-        threadId: asThreadId("thread-custom-instance"),
-        runtimeMode: "full-access",
-      });
+      return Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId: asThreadId("thread-custom-instance"),
+          runtimeMode: "full-access",
+        });
 
-      yield* adapter.sendTurn({
-        threadId: asThreadId("thread-custom-instance"),
-        input: "Fix it",
-        modelSelection: createModelSelection(
-          ProviderInstanceId.make("opencode_zen"),
-          "anthropic/claude-sonnet-4-5",
-          [
-            { id: "agent", value: "github-copilot" },
-            { id: "variant", value: "high" },
-          ],
-        ),
-      });
+        yield* adapter.sendTurn({
+          threadId: asThreadId("thread-custom-instance"),
+          input: "Fix it",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode_zen"),
+            "anthropic/claude-sonnet-4-5",
+            [
+              { id: "agent", value: "github-copilot" },
+              { id: "variant", value: "high" },
+              { id: "verbosity", value: "high" },
+            ],
+          ),
+        });
 
-      NodeAssert.deepEqual(runtimeMock.state.promptCalls.at(-1), {
-        sessionID: "http://127.0.0.1:9999/session",
-        model: {
-          providerID: "anthropic",
-          modelID: "claude-sonnet-4-5",
-        },
-        agent: "github-copilot",
-        variant: "high",
-        parts: [{ type: "text", text: "Fix it" }],
-      });
-    }).pipe(Effect.provide(adapterLayer));
-  });
+        NodeAssert.deepEqual(runtimeMock.state.promptCalls.at(-1), {
+          sessionID: "http://127.0.0.1:9999/session",
+          model: {
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-5",
+          },
+          agent: "github-copilot",
+          variant: "high",
+          verbosity: "high",
+          parts: [{ type: "text", text: "Fix it" }],
+        });
+      }).pipe(Effect.provide(adapterLayer));
+    },
+  );
 
   it.effect("uses the bound custom instance id for fallback sendTurn model selection", () => {
     const instanceId = ProviderInstanceId.make("opencode_zen");

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1213,6 +1213,7 @@ export function makeOpenCodeAdapter(
 
       const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
       const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
+      const verbosity = getModelSelectionStringOptionValue(modelSelection, "verbosity");
 
       context.activeTurnId = turnId;
       context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
@@ -1244,6 +1245,7 @@ export function makeOpenCodeAdapter(
           model: parsedModel,
           ...(context.activeAgent ? { agent: context.activeAgent } : {}),
           ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+          ...(verbosity ? { verbosity } : {}),
           parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
         }),
       ).pipe(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -186,6 +186,15 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
         variantDescriptor.options.find((option) => option.isDefault === true)?.id,
         "medium",
       );
+      const verbosityDescriptor = model.capabilities?.optionDescriptors?.find(
+        (descriptor) => descriptor.id === "verbosity" && descriptor.type === "select",
+      );
+      NodeAssert.ok(verbosityDescriptor && verbosityDescriptor.type === "select");
+      NodeAssert.deepEqual(
+        verbosityDescriptor.options.map((option) => option.id),
+        ["low", "medium", "high"],
+      );
+      NodeAssert.equal(verbosityDescriptor.currentValue, "medium");
       const agentDescriptor = model.capabilities?.optionDescriptors?.find(
         (descriptor) => descriptor.id === "agent" && descriptor.type === "select",
       );
@@ -194,6 +203,85 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
         agentDescriptor.options.find((option) => option.isDefault === true)?.id,
         "build",
       );
+    }),
+  );
+
+  it.effect("does not expose verbosity for non-GPT-5 models", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["openai"],
+          all: [
+            {
+              id: "openai",
+              name: "OpenAI",
+              models: {
+                "gpt-4.1": {
+                  id: "gpt-4.1",
+                  name: "GPT-4.1",
+                  variants: {
+                    low: {},
+                    high: {},
+                  },
+                },
+              },
+            },
+          ],
+          default: {},
+        },
+        agents: [],
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const model = snapshot.models.find((entry) => entry.slug === "openai/gpt-4.1");
+
+      NodeAssert.ok(model);
+      const verbosityDescriptor = model.capabilities?.optionDescriptors?.find(
+        (descriptor) => descriptor.id === "verbosity",
+      );
+      NodeAssert.equal(verbosityDescriptor, undefined);
+    }),
+  );
+
+  it.effect("exposes verbosity for GPT-5 models across providers", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["partner-ai"],
+          all: [
+            {
+              id: "partner-ai",
+              name: "Partner AI",
+              models: {
+                "gpt-5.4": {
+                  id: "gpt-5.4",
+                  name: "GPT-5.4",
+                  variants: {
+                    low: {},
+                    medium: {},
+                  },
+                },
+              },
+            },
+          ],
+          default: {},
+        },
+        agents: [],
+      };
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+      const model = snapshot.models.find((entry) => entry.slug === "partner-ai/gpt-5.4");
+
+      NodeAssert.ok(model);
+      const verbosityDescriptor = model.capabilities?.optionDescriptors?.find(
+        (descriptor) => descriptor.id === "verbosity" && descriptor.type === "select",
+      );
+      NodeAssert.ok(verbosityDescriptor && verbosityDescriptor.type === "select");
+      NodeAssert.deepEqual(
+        verbosityDescriptor.options.map((option) => option.id),
+        ["low", "medium", "high"],
+      );
+      NodeAssert.equal(verbosityDescriptor.currentValue, "medium");
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -170,11 +170,16 @@ const DEFAULT_OPENCODE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabi
   optionDescriptors: [],
 });
 
+function isGpt5Model(modelID: string): boolean {
+  return modelID.startsWith("gpt-5");
+}
+
 function openCodeCapabilitiesForModel(input: {
   readonly providerID: string;
   readonly model: ProviderListResponse["all"][number]["models"][string];
   readonly agents: ReadonlyArray<Agent>;
 }): ModelCapabilities {
+  const hasGpt5Verbosity = isGpt5Model(input.model.id);
   const variantValues = Object.keys(input.model.variants ?? {});
   const defaultVariant = inferDefaultVariant(input.providerID, variantValues);
   const variantOptions = variantValues.map((value) =>
@@ -191,6 +196,14 @@ function openCodeCapabilitiesForModel(input: {
       ? { id: agent.name, label: titleCaseSlug(agent.name), isDefault: true as const }
       : { id: agent.name, label: titleCaseSlug(agent.name) },
   );
+  const verbosityOptions = [
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium" },
+    { id: "high", label: "High" },
+  ];
+  const defaultVerbosity = hasGpt5Verbosity
+    ? (verbosityOptions.find((option) => option.id === "medium")?.id ?? verbosityOptions[0]?.id)
+    : undefined;
   return createModelCapabilities({
     optionDescriptors: [
       ...(variantOptions.length > 0
@@ -212,6 +225,17 @@ function openCodeCapabilitiesForModel(input: {
               type: "select" as const,
               options: agentOptions,
               ...(defaultAgent ? { currentValue: defaultAgent } : {}),
+            },
+          ]
+        : []),
+      ...(hasGpt5Verbosity
+        ? [
+            {
+              id: "verbosity",
+              label: "Verbosity",
+              type: "select" as const,
+              options: verbosityOptions,
+              ...(defaultVerbosity ? { currentValue: defaultVerbosity } : {}),
             },
           ]
         : []),


### PR DESCRIPTION
## Summary
- Expose a new `verbosity` model option (`low`, `medium`, `high`, default `medium`) for GPT-5 family models in both providers.
- Keep existing controls intact (`reasoningEffort`, `serviceTier`, and OpenCode `agent` behavior).
- Forward selected `verbosity` in OpenCode and Codex turn requests.
- Extend provider and adapter tests in:
  - `OpenCodeProvider.test.ts`
  - `OpenCodeAdapter.test.ts`
  - `CodexProvider.test.ts`
  - `CodexAdapter.test.ts`

## Validation
- `vp check`
- `vp run typecheck`
- `pnpm run dist:desktop:dmg`
- Opened the generated `.dmg` artifact directly from `release/`

## Notes
- This update addresses missing verbosity in Codex-backed GPT-5 models such as `codex/GPT-5.3-Codex-Spark`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive provider option plumbing with schema validation and broad test coverage; no auth or data-path changes.
> 
> **Overview**
> Adds a **`verbosity`** model option (`low` / `medium` / `high`, default **medium**) for **GPT-5** models in Codex and OpenCode model capabilities, while leaving non–GPT-5 models unchanged.
> 
> **Codex** exposes the option via `mapCodexModelCapabilities`, validates selections with `CodexVerbosity` / `isCodexVerbosity`, and threads `verbosity` through `CodexAdapter.sendTurn` into `buildTurnStartParams` and `turn/start`. **OpenCode** adds the same capability descriptor for GPT-5 models and passes `verbosity` from model selection into `session.promptAsync`.
> 
> Provider and adapter tests cover capability exposure, GPT-5 gating, and end-to-end forwarding on turns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192c97b4865cbe625c18157d04582e36a3c74806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GPT-5 verbosity model option to Codex and OpenCode adapters
> - Adds a `verbosity` select option (low, medium, high, default: medium) to model capabilities for GPT-5 models in both [`CodexProvider`](https://github.com/pingdotgg/t3code/pull/3944/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) and [`OpenCodeProvider`](https://github.com/pingdotgg/t3code/pull/3944/files#diff-4477b51690b8bf5db4f32c13ac9bb4ed2be7798d366111f84b38be236cc034bd); non-GPT-5 models are unaffected.
> - Extends [`CodexSessionRuntime`](https://github.com/pingdotgg/t3code/pull/3944/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) with a `CodexVerbosity` schema (`low | medium | high`) and threads the value through `buildTurnStartParams` into the turn/start payload.
> - Updates [`CodexAdapter`](https://github.com/pingdotgg/t3code/pull/3944/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) and [`OpenCodeAdapter`](https://github.com/pingdotgg/t3code/pull/3944/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to read `verbosity` from `modelSelection` and forward it to the respective session runtimes when present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 192c97b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->