### PR TITLE
Support per-file review diff truncation

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -243,6 +243,62 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         );
       }),
     );
+
+    it.effect("applies the preview limit per tracked file", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* writeTextFile(cwd, "bun.lock", "initial lockfile\n");
+        const smallFilePrefix = [1, 2, 3, 4]
+          .map((value) => `export const stable${value} = true;\n`)
+          .join("");
+        yield* writeTextFile(cwd, "z-before.ts", `${smallFilePrefix}export const before = true;\n`);
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "add preview fixtures"]);
+        const baseRef = yield* git(cwd, ["rev-parse", "HEAD"]);
+        yield* git(cwd, ["checkout", "-b", "feature/large-diff"]);
+        yield* git(cwd, ["mv", "z-before.ts", "z-after.ts"]);
+
+        const oversizedLockfile = Array.from(
+          { length: 20_000 },
+          (_, index) => `package-${index} = "1.0.0"\n`,
+        ).join("");
+        yield* writeTextFile(cwd, "bun.lock", oversizedLockfile);
+        yield* writeTextFile(cwd, "z-after.ts", `${smallFilePrefix}export const after = true;\n`);
+
+        const workingTreePreview = yield* driver.getReviewDiffPreview({ cwd, baseRef });
+        const workingTreeSource = workingTreePreview.sources.find(
+          (source) => source.kind === "working-tree",
+        );
+        assert.isTrue(workingTreeSource?.truncated);
+        assert.deepStrictEqual(workingTreeSource?.truncatedFilePaths, ["bun.lock"]);
+        assert.include(workingTreeSource?.diff ?? "", "diff --git a/z-before.ts b/z-after.ts");
+        assert.include(workingTreeSource?.diff ?? "", "+export const after = true;");
+
+        const expandedWorkingTreePreview = yield* driver.getReviewDiffPreview({
+          cwd,
+          baseRef,
+          expandedFilePaths: ["bun.lock"],
+        });
+        const expandedWorkingTreeSource = expandedWorkingTreePreview.sources.find(
+          (source) => source.kind === "working-tree",
+        );
+        assert.isFalse(expandedWorkingTreeSource?.truncated);
+        assert.deepStrictEqual(expandedWorkingTreeSource?.truncatedFilePaths, []);
+        assert.include(expandedWorkingTreeSource?.diff ?? "", '+package-19999 = "1.0.0"');
+
+        yield* git(cwd, ["add", "."]);
+        yield* git(cwd, ["commit", "-m", "change large and small files"]);
+
+        const branchPreview = yield* driver.getReviewDiffPreview({ cwd, baseRef });
+        const branchSource = branchPreview.sources.find((source) => source.kind === "branch-range");
+        assert.isTrue(branchSource?.truncated);
+        assert.deepStrictEqual(branchSource?.truncatedFilePaths, ["bun.lock"]);
+        assert.include(branchSource?.diff ?? "", "diff --git a/z-before.ts b/z-after.ts");
+        assert.include(branchSource?.diff ?? "", "+export const after = true;");
+      }),
+    );
   });
 
   describe("repository status", () => {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -44,9 +44,10 @@ const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
 const RANGE_COMMIT_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
 const RANGE_DIFF_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
 const RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES = 59_000;
-const REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES = 120_000;
-const REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES = 80_000;
+const REVIEW_DIFF_FILE_MAX_OUTPUT_BYTES = 120_000;
+const REVIEW_DIFF_EXPANDED_FILE_MAX_OUTPUT_BYTES = 10_000_000;
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 120_000;
+const EMPTY_REVIEW_DIFF = { diff: "", truncated: false, truncatedFilePaths: [] } as const;
 const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 
@@ -225,6 +226,42 @@ export function splitNullSeparatedGitStdoutPaths(
   result: Pick<GitVcsDriver.ExecuteGitResult, "stdout" | "stdoutTruncated">,
 ): string[] {
   return splitNullSeparatedPaths(result.stdout, result.stdoutTruncated);
+}
+
+function parseReviewDiffFiles(
+  result: Pick<GitVcsDriver.ExecuteGitResult, "stdout" | "stdoutTruncated">,
+): ReadonlyArray<{ readonly filePath: string; readonly pathspecs: ReadonlyArray<string> }> {
+  const fields = splitNullSeparatedPaths(result.stdout, result.stdoutTruncated);
+  const files: Array<{ filePath: string; pathspecs: string[] }> = [];
+  for (let index = 0; index < fields.length; ) {
+    const status = fields[index++];
+    const pathCount = status?.startsWith("R") || status?.startsWith("C") ? 2 : 1;
+    const pathspecs = fields.slice(index, index + pathCount);
+    const filePath = pathspecs.at(-1);
+    if (!status || !filePath || pathspecs.length < pathCount) break;
+    files.push({ filePath, pathspecs });
+    index += pathCount;
+  }
+  return files;
+}
+
+function combineReviewDiffs(
+  pathsResult: Pick<GitVcsDriver.ExecuteGitResult, "stdoutTruncated">,
+  diffs: ReadonlyArray<{
+    readonly filePath: string;
+    readonly result: GitVcsDriver.ExecuteGitResult;
+  }>,
+) {
+  return {
+    diff: diffs
+      .map(({ result }) => result.stdout.trim())
+      .filter((diff) => diff.length > 0)
+      .join("\n"),
+    truncated: pathsResult.stdoutTruncated || diffs.some(({ result }) => result.stdoutTruncated),
+    truncatedFilePaths: diffs
+      .filter(({ result }) => result.stdoutTruncated)
+      .map(({ filePath }) => filePath),
+  };
 }
 
 function sanitizeRemoteName(value: string): string {
@@ -1807,7 +1844,56 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     };
   });
 
-  const readUntrackedReviewDiffs = Effect.fn("readUntrackedReviewDiffs")(function* (cwd: string) {
+  const readTrackedReviewDiffs = Effect.fn("readTrackedReviewDiffs")(function* (input: {
+    readonly cwd: string;
+    readonly range: string;
+    readonly ignoreWhitespace: boolean;
+    readonly operation: string;
+    readonly expandedFilePaths: ReadonlySet<string>;
+  }) {
+    const whitespaceArgs = input.ignoreWhitespace ? ["--ignore-all-space"] : [];
+    const changedFilesResult = yield* executeGit(
+      `${input.operation}.list`,
+      input.cwd,
+      ["diff", "--no-ext-diff", "--name-status", "-z", ...whitespaceArgs, input.range, "--"],
+      {
+        maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
+        appendTruncationMarker: true,
+      },
+    );
+    const files = parseReviewDiffFiles(changedFilesResult);
+    const diffs = yield* Effect.forEach(
+      files,
+      ({ filePath, pathspecs }) =>
+        executeGit(
+          `${input.operation}.file`,
+          input.cwd,
+          [
+            "diff",
+            "--no-ext-diff",
+            "--patch",
+            "--minimal",
+            ...whitespaceArgs,
+            input.range,
+            "--",
+            ...pathspecs,
+          ],
+          {
+            maxOutputBytes: input.expandedFilePaths.has(filePath)
+              ? REVIEW_DIFF_EXPANDED_FILE_MAX_OUTPUT_BYTES
+              : REVIEW_DIFF_FILE_MAX_OUTPUT_BYTES,
+            appendTruncationMarker: true,
+          },
+        ).pipe(Effect.map((result) => ({ filePath, result }))),
+      { concurrency: 4 },
+    );
+    return combineReviewDiffs(changedFilesResult, diffs);
+  });
+
+  const readUntrackedReviewDiffs = Effect.fn("readUntrackedReviewDiffs")(function* (
+    cwd: string,
+    expandedFilePaths: ReadonlySet<string>,
+  ) {
     const untrackedResult = yield* executeGit(
       "GitVcsDriver.readUntrackedReviewDiffs.list",
       cwd,
@@ -1818,10 +1904,6 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       },
     );
     const untrackedPaths = splitNullSeparatedGitStdoutPaths(untrackedResult);
-    if (untrackedPaths.length === 0) {
-      return { diff: "", truncated: untrackedResult.stdoutTruncated };
-    }
-
     const diffs = yield* Effect.forEach(
       untrackedPaths,
       (relativePath) =>
@@ -1831,19 +1913,16 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           ["diff", "--no-index", "--patch", "--minimal", "--", "/dev/null", relativePath],
           {
             allowNonZeroExit: true,
-            maxOutputBytes: REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES,
+            maxOutputBytes: expandedFilePaths.has(relativePath)
+              ? REVIEW_DIFF_EXPANDED_FILE_MAX_OUTPUT_BYTES
+              : REVIEW_DIFF_FILE_MAX_OUTPUT_BYTES,
             appendTruncationMarker: true,
           },
-        ),
+        ).pipe(Effect.map((result) => ({ filePath: relativePath, result }))),
       { concurrency: 4 },
     );
 
-    return {
-      diff: Arr.filterMap(diffs, (result) =>
-        result.stdout.trim().length > 0 ? Result.succeed(result.stdout) : Result.failVoid,
-      ).join("\n"),
-      truncated: untrackedResult.stdoutTruncated || diffs.some((result) => result.stdoutTruncated),
-    };
+    return combineReviewDiffs(untrackedResult, diffs);
   });
 
   const getReviewDiffPreview = Effect.fn("getReviewDiffPreview")(function* (
@@ -1859,6 +1938,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     }
 
     const branch = details.branch;
+    const expandedFilePaths = new Set(input.expandedFilePaths ?? []);
     const baseRef =
       input.baseRef ??
       (branch
@@ -1867,64 +1947,31 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           )
         : null);
 
-    const dirtyTrackedResult = yield* executeGit(
-      "GitVcsDriver.getReviewDiffPreview.dirtyTracked",
-      input.cwd,
-      [
-        "diff",
-        "--patch",
-        "--minimal",
-        ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
-        "HEAD",
-        "--",
-      ],
-      {
-        maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
-        appendTruncationMarker: true,
-      },
-    ).pipe(
-      Effect.orElseSucceed(() => ({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-        stdoutTruncated: false,
-        stderrTruncated: false,
-      })),
+    const dirtyTracked = yield* readTrackedReviewDiffs({
+      cwd: input.cwd,
+      range: "HEAD",
+      ignoreWhitespace: input.ignoreWhitespace ?? false,
+      operation: "GitVcsDriver.getReviewDiffPreview.dirtyTracked",
+      expandedFilePaths,
+    }).pipe(Effect.orElseSucceed(() => EMPTY_REVIEW_DIFF));
+    const dirtyUntracked = yield* readUntrackedReviewDiffs(input.cwd, expandedFilePaths).pipe(
+      Effect.orElseSucceed(() => EMPTY_REVIEW_DIFF),
     );
-    const dirtyUntracked = yield* readUntrackedReviewDiffs(input.cwd).pipe(
-      Effect.orElseSucceed(() => ({ diff: "", truncated: false })),
-    );
-    const dirtyDiff = [dirtyTrackedResult.stdout.trimEnd(), dirtyUntracked.diff.trimEnd()]
+    const dirtyDiff = [dirtyTracked.diff.trimEnd(), dirtyUntracked.diff.trimEnd()]
       .filter((diff) => diff.length > 0)
       .join("\n");
 
     const baseResult =
       baseRef && branch
-        ? yield* executeGit(
-            "GitVcsDriver.getReviewDiffPreview.base",
-            input.cwd,
-            [
-              "diff",
-              "--patch",
-              "--minimal",
-              ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
-              `${baseRef}...HEAD`,
-            ],
-            {
-              maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
-              appendTruncationMarker: true,
-            },
-          ).pipe(
-            Effect.orElseSucceed(() => ({
-              exitCode: 0,
-              stdout: "",
-              stderr: "",
-              stdoutTruncated: false,
-              stderrTruncated: false,
-            })),
-          )
+        ? yield* readTrackedReviewDiffs({
+            cwd: input.cwd,
+            range: `${baseRef}...HEAD`,
+            ignoreWhitespace: input.ignoreWhitespace ?? false,
+            operation: "GitVcsDriver.getReviewDiffPreview.base",
+            expandedFilePaths,
+          }).pipe(Effect.orElseSucceed(() => EMPTY_REVIEW_DIFF))
         : null;
-    const baseDiff = baseResult?.stdout ?? "";
+    const baseDiff = baseResult?.diff ?? "";
     const hashDiff = (diff: string) =>
       crypto.digest("SHA-256", new TextEncoder().encode(diff)).pipe(
         Effect.map(Encoding.encodeHex),
@@ -1953,7 +2000,11 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         headRef: null,
         diff: dirtyDiff,
         diffHash: dirtyDiffHash,
-        truncated: dirtyTrackedResult.stdoutTruncated || dirtyUntracked.truncated,
+        truncated: dirtyTracked.truncated || dirtyUntracked.truncated,
+        truncatedFilePaths: [
+          ...dirtyTracked.truncatedFilePaths,
+          ...dirtyUntracked.truncatedFilePaths,
+        ],
       },
       {
         id: "branch-range",
@@ -1963,7 +2014,8 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         headRef: branch ?? "HEAD",
         diff: baseDiff,
         diffHash: baseDiffHash,
-        truncated: baseResult?.stdoutTruncated ?? false,
+        truncated: baseResult?.truncated ?? false,
+        truncatedFilePaths: baseResult?.truncatedFilePaths ?? [],
       },
     ];
 

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -75,7 +75,13 @@ interface CollapsedDiffFilesState {
   readonly fileKeys: ReadonlySet<string>;
 }
 
+interface ExpandedDiffFilesState {
+  readonly scopeKey: string | null;
+  readonly filePaths: ReadonlyArray<string>;
+}
+
 const EMPTY_COLLAPSED_DIFF_FILE_KEYS: ReadonlySet<string> = new Set();
+const EMPTY_EXPANDED_DIFF_FILE_PATHS: ReadonlyArray<string> = [];
 
 const DIFF_PANEL_UNSAFE_CSS = `
 [data-diffs-header],
@@ -193,6 +199,10 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     scopeKey: null,
     fileKeys: EMPTY_COLLAPSED_DIFF_FILE_KEYS,
   }));
+  const [expandedDiffFiles, setExpandedDiffFiles] = useState<ExpandedDiffFilesState>(() => ({
+    scopeKey: null,
+    filePaths: EMPTY_EXPANDED_DIFF_FILE_PATHS,
+  }));
   const codeViewRef = useRef<AnnotatableCodeViewHandle>(null);
 
   const routeThreadRef = useParams({
@@ -286,6 +296,10 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     collapsedDiffFiles.scopeKey === collapseScopeKey
       ? collapsedDiffFiles.fileKeys
       : EMPTY_COLLAPSED_DIFF_FILE_KEYS;
+  const expandedDiffFilePaths =
+    expandedDiffFiles.scopeKey === collapseScopeKey
+      ? expandedDiffFiles.filePaths
+      : EMPTY_EXPANDED_DIFF_FILE_PATHS;
   const reviewSectionTitle = selectedTurn
     ? `Turn ${selectedCheckpointTurnCount ?? "?"}`
     : selectedGitScope === "unstaged"
@@ -320,6 +334,9 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
             cwd: activeCwd,
             ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
             ignoreWhitespace: diffIgnoreWhitespace,
+            ...(expandedDiffFilePaths.length > 0
+              ? { expandedFilePaths: [...expandedDiffFilePaths] }
+              : {}),
           },
         })
       : null,
@@ -337,6 +354,9 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
             cwd: serverConfig.cwd,
             ...(selectedBaseRef ? { baseRef: selectedBaseRef } : {}),
             ignoreWhitespace: diffIgnoreWhitespace,
+            ...(expandedDiffFilePaths.length > 0
+              ? { expandedFilePaths: [...expandedDiffFilePaths] }
+              : {}),
           },
         })
       : null,
@@ -396,6 +416,8 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     ...matchingBaseRefChoices.map(valueForBaseRefChoice),
   ];
   const gitDiff = selectedGitSource?.diff;
+  const truncatedFilePaths = selectedGitSource?.truncatedFilePaths ?? [];
+  const truncatedFilePathSet = useMemo(() => new Set(truncatedFilePaths), [truncatedFilePaths]);
 
   const selectedPatch = selectedTurn ? activeCheckpointDiff.data?.diff : gitDiff;
   const isSelectedPatchTruncated = !selectedTurn && selectedGitSource?.truncated === true;
@@ -427,14 +449,16 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     () =>
       renderableFiles.map((fileDiff) => {
         const fileKey = buildFileDiffRenderKey(fileDiff);
+        const filePath = resolveFileDiffPath(fileDiff);
         return {
           fileDiff,
-          filePath: resolveFileDiffPath(fileDiff),
+          filePath,
           fileKey,
           collapsed: collapsedDiffFileKeys.has(fileKey),
+          truncated: truncatedFilePathSet.has(filePath),
         };
       }),
-    [collapsedDiffFileKeys, renderableFiles],
+    [collapsedDiffFileKeys, renderableFiles, truncatedFilePathSet],
   );
 
   useEffect(() => {
@@ -481,6 +505,17 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
           next.add(fileKey);
         }
         return { scopeKey: collapseScopeKey, fileKeys: next };
+      });
+    },
+    [collapseScopeKey],
+  );
+  const loadDiffFile = useCallback(
+    (filePath: string) => {
+      setExpandedDiffFiles((current) => {
+        const filePaths = current.scopeKey === collapseScopeKey ? current.filePaths : [];
+        return filePaths.includes(filePath)
+          ? current
+          : { scopeKey: collapseScopeKey, filePaths: [...filePaths, filePath] };
       });
     },
     [collapseScopeKey],
@@ -755,7 +790,7 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
       ) : (
         <>
           <div className="diff-panel-viewport flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-            {isSelectedPatchTruncated && (
+            {isSelectedPatchTruncated && truncatedFilePaths.length === 0 && (
               <p className="shrink-0 border-b border-border/70 bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
                 This diff was truncated because it exceeded the preview limit. The changes shown are
                 incomplete.
@@ -807,6 +842,21 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
                   sectionId={reviewSectionId}
                   sectionTitle={reviewSectionTitle}
                   composerDraftTarget={composerDraftTarget}
+                  renderTruncatedFile={(_fileDiff, filePath) => (
+                    <div className="flex items-center gap-2 font-sans text-xs">
+                      <span className="text-muted-foreground">Diff too large to show.</span>
+                      <button
+                        type="button"
+                        className="font-medium text-primary underline-offset-2 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          loadDiffFile(filePath);
+                        }}
+                      >
+                        Load diff
+                      </button>
+                    </div>
+                  )}
                   renderHeaderPrefix={(fileDiff, fileKey, collapsed) => {
                     const filePath = resolveFileDiffPath(fileDiff);
                     return (

--- a/apps/web/src/components/diffs/AnnotatableCodeView.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.tsx
@@ -76,6 +76,7 @@ interface AnnotatableCodeViewProps {
     filePath: string;
     fileKey: string;
     collapsed: boolean;
+    truncated: boolean;
   }>;
   sectionId: string;
   sectionTitle: string;
@@ -88,6 +89,19 @@ interface AnnotatableCodeViewProps {
     fileKey: string,
     collapsed: boolean,
   ) => ReactNode;
+  renderTruncatedFile: (fileDiff: FileDiffMetadata, filePath: string) => ReactNode;
+}
+
+function buildTruncatedFileDiff(fileDiff: FileDiffMetadata): FileDiffMetadata {
+  return {
+    ...fileDiff,
+    additionLines: [],
+    deletionLines: [],
+    splitLineCount: 0,
+    unifiedLineCount: 0,
+    cacheKey: `${fileDiff.cacheKey ?? fileDiff.name}:truncated`,
+    hunks: [],
+  };
 }
 
 interface DiffSelectionContext {
@@ -103,6 +117,7 @@ export function AnnotatableCodeView({
   viewerRef,
   className,
   renderHeaderPrefix,
+  renderTruncatedFile,
 }: AnnotatableCodeViewProps) {
   const addReviewComment = useComposerDraftStore((store) => store.addReviewComment);
   const removeReviewComment = useComposerDraftStore((store) => store.removeReviewComment);
@@ -121,8 +136,8 @@ export function AnnotatableCodeView({
   const filesByKey = useMemo(() => new Map(files.map((file) => [file.fileKey, file])), [files]);
   const items = useMemo<CodeViewDiffItem<DiffCommentAnnotationGroup>[]>(
     () =>
-      files.map(({ fileDiff, filePath, fileKey, collapsed }) => {
-        const persisted = reviewComments
+      files.map(({ fileDiff, filePath, fileKey, collapsed, truncated }) => {
+        const persisted = (truncated ? [] : reviewComments)
           .filter(
             (comment) =>
               comment.sectionId === sectionId &&
@@ -141,15 +156,15 @@ export function AnnotatableCodeView({
             });
           }, []);
         const annotations =
-          draft?.fileKey === fileKey ? [...persisted, draft.annotation] : persisted;
+          !truncated && draft?.fileKey === fileKey ? [...persisted, draft.annotation] : persisted;
         return {
           id: fileKey,
           type: "diff",
-          fileDiff,
+          fileDiff: truncated ? buildTruncatedFileDiff(fileDiff) : fileDiff,
           annotations,
           collapsed,
           version: fnv1a32(
-            `${collapsed ? "1" : "0"}:${annotations
+            `${collapsed ? "1" : "0"}:${truncated ? "1" : "0"}:${annotations
               .flatMap((annotation) =>
                 annotation.metadata.entries.map(
                   (entry) => `${entry.id}:${entry.rangeLabel}:${entry.text}`,
@@ -248,6 +263,11 @@ export function AnnotatableCodeView({
           ? renderHeaderPrefix(item.fileDiff, item.id, item.collapsed === true)
           : null
       }
+      renderHeaderMetadata={(item) => {
+        if (item.type !== "diff") return null;
+        const file = filesByKey.get(item.id);
+        return file?.truncated ? renderTruncatedFile(item.fileDiff, file.filePath) : null;
+      }}
       renderAnnotation={(annotation) => (
         <div className="py-1">
           {annotation.metadata.entries.map((entry) => (

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -81,4 +81,32 @@ describe("getRenderablePatch", () => {
     if (parsed?.kind !== "files") return;
     expect(parsed.files[0]?.hunks[0]?.unifiedLineStart).toBe(47);
   });
+
+  it("parses files that follow a truncated per-file patch", () => {
+    const patch = [
+      "diff --git a/bun.lock b/bun.lock",
+      "index 1111111..2222222 100644",
+      "--- a/bun.lock",
+      "+++ b/bun.lock",
+      "@@ -1,1 +1,10000 @@",
+      "-before",
+      "+partial output",
+      "",
+      "[truncated]",
+      "diff --git a/z-after.ts b/z-after.ts",
+      "index 3333333..4444444 100644",
+      "--- a/z-after.ts",
+      "+++ b/z-after.ts",
+      "@@ -1,1 +1,1 @@",
+      "-export const before = true;",
+      "+export const after = true;",
+    ].join("\n");
+
+    const parsed = getRenderablePatch(patch, "per-file-truncation", {
+      compactPartialHunkOffsets: true,
+    });
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files") return;
+    expect(parsed.files.map((file) => file.name)).toContain("z-after.ts");
+  });
 });

--- a/packages/contracts/src/review.ts
+++ b/packages/contracts/src/review.ts
@@ -7,6 +7,9 @@ export const ReviewDiffPreviewInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   baseRef: Schema.optional(TrimmedNonEmptyString),
   ignoreWhitespace: Schema.optionalKey(Schema.Boolean),
+  expandedFilePaths: Schema.optional(
+    Schema.Array(TrimmedNonEmptyString).check(Schema.isMaxLength(100)),
+  ),
 });
 export type ReviewDiffPreviewInput = typeof ReviewDiffPreviewInput.Type;
 
@@ -22,6 +25,7 @@ export const ReviewDiffPreviewSource = Schema.Struct({
   diff: Schema.String,
   diffHash: TrimmedNonEmptyString,
   truncated: Schema.Boolean,
+  truncatedFilePaths: Schema.optional(Schema.Array(TrimmedNonEmptyString)),
 });
 export type ReviewDiffPreviewSource = typeof ReviewDiffPreviewSource.Type;
 


### PR DESCRIPTION
## Summary

- apply review diff preview limits per file so one large change cannot hide later files
- identify truncated files in the review contract and let users load an expanded version on demand
- preserve rename handling and continue rendering files that follow a truncated patch

## Why

Review previews previously used one output budget for the entire tracked diff. A large file such as a lockfile could consume that budget before Git emitted later files, making valid changes disappear from the review panel.

The server now discovers changed paths first and generates bounded patches per file. Truncated files render as lightweight placeholders with an explicit load action, while smaller files remain available immediately.

## Validation

- `pnpm exec vp check`
- `pnpm exec vp run typecheck`
- `pnpm exec vp test apps/server/src/vcs/GitVcsDriverCore.test.ts apps/web/src/lib/diffRendering.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes review diff generation (more git invocations, larger expanded output) and API contract fields; behavior is covered by integration tests but expanded loads can be heavy for huge files.
> 
> **Overview**
> Review diff previews no longer use one global output cap for the whole patch. **Git VcsDriver** lists changed paths first, then fetches a bounded patch per file (tracked and untracked), merges them, and reports **`truncatedFilePaths`** alongside the existing **`truncated`** flag. Paths in **`expandedFilePaths`** use a much higher per-file byte limit (up to 100 paths in the contract).
> 
> The **review contract** adds optional **`expandedFilePaths`** on input and **`truncatedFilePaths`** on each preview source. **DiffPanel** tracks expanded files per review scope, passes them into **`diffPreview`**, marks truncated files in the code view, shows a **Load diff** action instead of hunks, and only shows the global “incomplete diff” banner when truncation isn’t attributed to specific files.
> 
> **AnnotatableCodeView** renders truncated files as empty hunks with header metadata and disables line comments on those placeholders. A **diff rendering** test covers parsing patches where one file’s output ends with **`[truncated]`** and later files still parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a91d6604315a63eeb8eeed64eb7cf6e6fb2f8542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-file diff truncation and on-demand expansion to review diff preview
> - Replaces single global diff size limits with per-file limits (`REVIEW_DIFF_FILE_MAX_OUTPUT_BYTES` / `REVIEW_DIFF_EXPANDED_FILE_MAX_OUTPUT_BYTES`) applied independently to each tracked and untracked file in [`GitVcsDriverCore.ts`](https://github.com/pingdotgg/t3code/pull/3945/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8).
> - The diff preview API now accepts `expandedFilePaths` (up to 100 paths) to fetch full content for specific files, and responses include `truncatedFilePaths` to identify oversized files.
> - In [`DiffPanel.tsx`](https://github.com/pingdotgg/t3code/pull/3945/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), truncated files are marked individually; a 'Load diff' button lets users expand a single file on demand without reloading the whole diff.
> - [`AnnotatableCodeView.tsx`](https://github.com/pingdotgg/t3code/pull/3945/files#diff-9491b561e63bb44221dbe3a46e59657908cb1e448fa6085f7604aa607082acd6) renders truncated files as empty placeholders and disables annotations until the file is expanded.
> - Behavioral Change: the global truncation banner is suppressed when per-file truncation paths are present; truncation is now scoped per file rather than being a single flag on the whole diff.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a91d660. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->