### PR TITLE
feat(server): default Claude context window to 1M

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3042,7 +3042,7 @@ describe("ClaudeAdapterLive", () => {
         attachments: [],
       });
 
-      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6"]);
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -3140,10 +3140,11 @@ describe("ClaudeAdapterLive", () => {
       yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "hello again",
-        modelSelection: {
-          instanceId: ProviderInstanceId.make("claudeAgent"),
-          model: "claude-opus-4-6",
-        },
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "200k" }],
+        ),
         attachments: [],
       });
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -76,6 +76,7 @@ import {
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
+  resolveClaudeContextWindow,
   resolveClaudeEffort,
 } from "./ClaudeProvider.ts";
 import {
@@ -340,24 +341,18 @@ function selectedClaudeContextWindow(
   switch (modelSelection?.model) {
     case "claude-opus-4-8":
     case "claude-opus-4-7":
+      // Always 1M at the API; these models expose no contextWindow option.
       return 1_000_000;
   }
 
-  const optionValue = getModelSelectionStringOptionValue(modelSelection, "contextWindow");
-  if (optionValue === "1m") {
-    return 1_000_000;
+  switch (resolveClaudeContextWindow(modelSelection)) {
+    case "1m":
+      return 1_000_000;
+    case "200k":
+      return 200_000;
+    default:
+      return undefined;
   }
-  if (optionValue === "200k") {
-    return 200_000;
-  }
-  const caps = getClaudeModelCapabilities(modelSelection?.model);
-  const hasContextWindowOption = getProviderOptionDescriptors({ caps }).some(
-    (descriptor) => descriptor.type === "select" && descriptor.id === "contextWindow",
-  );
-  if (hasContextWindowOption) {
-    return 200_000;
-  }
-  return undefined;
 }
 
 function finiteNonNegativeInteger(value: unknown): number | undefined {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -77,8 +77,8 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
           id: "contextWindow",
           label: "Context Window",
           options: [
-            { value: "200k", label: "200k", isDefault: true },
-            { value: "1m", label: "1M" },
+            { value: "200k", label: "200k" },
+            { value: "1m", label: "1M", isDefault: true },
           ],
         }),
       ],
@@ -163,8 +163,8 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
           id: "contextWindow",
           label: "Context Window",
           options: [
-            { value: "200k", label: "200k", isDefault: true },
-            { value: "1m", label: "1M" },
+            { value: "200k", label: "200k" },
+            { value: "1m", label: "1M", isDefault: true },
           ],
         }),
       ],
@@ -216,8 +216,8 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
           id: "contextWindow",
           label: "Context Window",
           options: [
-            { value: "200k", label: "200k", isDefault: true },
-            { value: "1m", label: "1M" },
+            { value: "200k", label: "200k" },
+            { value: "1m", label: "1M", isDefault: true },
           ],
         }),
       ],
@@ -245,8 +245,8 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
           id: "contextWindow",
           label: "Context Window",
           options: [
-            { value: "200k", label: "200k", isDefault: true },
-            { value: "1m", label: "1M" },
+            { value: "200k", label: "200k" },
+            { value: "1m", label: "1M", isDefault: true },
           ],
         }),
       ],
@@ -370,8 +370,22 @@ export function isClaudeUltracodeEffort(effort: string | null | undefined): bool
   return effort === "ultracode";
 }
 
+export function resolveClaudeContextWindow(
+  modelSelection: ModelSelection | undefined,
+): string | undefined {
+  const caps = getClaudeModelCapabilities(modelSelection?.model);
+  const raw = getModelSelectionStringOptionValue(modelSelection, "contextWindow");
+  const descriptors = getProviderOptionDescriptors({
+    caps,
+    ...(raw ? { selections: [{ id: "contextWindow", value: raw }] } : {}),
+  });
+  const descriptor = descriptors.find((candidate) => candidate.id === "contextWindow");
+  const value = getProviderOptionCurrentValue(descriptor);
+  return typeof value === "string" ? value : undefined;
+}
+
 export function resolveClaudeApiModelId(modelSelection: ModelSelection): string {
-  switch (getModelSelectionStringOptionValue(modelSelection, "contextWindow")) {
+  switch (resolveClaudeContextWindow(modelSelection)) {
     case "1m":
       return `${modelSelection.model}[1m]`;
     default:


### PR DESCRIPTION
## Summary
- Flips the `contextWindow` option default from `200k` to `1m` for the toggle-capable Claude models (Fable 5, Opus 4.6, Sonnet 5, Sonnet 4.6). `200k` remains selectable.
- Adds `resolveClaudeContextWindow` (mirroring `resolveClaudeEffort`) so a selection with no explicit `contextWindow` option resolves through the descriptor default instead of implicitly meaning 200k. Both `resolveClaudeApiModelId` (which appends the `[1m]` model-ID suffix for the CLI) and the adapter's `selectedClaudeContextWindow` (which seeds the context meter's `maxTokens`) now share it.
- Opus 4.8/4.7 are unchanged: no toggle, hard-coded 1M, bare slug sent to the CLI (now with a comment explaining the asymmetry).

## Why
The 200k default came from #1556, when 1M context was gated behind premium Claude subscriptions and carried a long-context pricing premium — that PR flipped the default from 1M to 200k and promoted 1M back only for detected Max/Enterprise/Team plans. #1899 then removed the subscription detection but kept the conservative default for everyone.

Anthropic has since made 1M the default for every model that supports it: no beta header, no tier gate, and standard pricing for long-context requests. Opus 4.8 and Fable 5 — the models most users run — are 1M by default upstream, so the 200k default only created a mismatch for the toggle models.

Users whose saved drafts explicitly selected `200k` keep that selection; only option-less selections move to 1M.

## Testing
- `bun run typecheck` — clean
- `bun run lint` — clean
- `apps/server` full test suite — 1399 passed
- `packages/shared` model tests — 256 passed
- `apps/web` composerProviderState + TraitsPicker tests — passed
- Updated `ClaudeAdapter.test.ts`: a bare opus-4-6 selection now dispatches `claude-opus-4-6[1m]`; the model-change test passes an explicit `200k` to keep exercising the suffix transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default context size and CLI model IDs for selections without an explicit window, which affects billing/limits and token metering; behavior is localized to Claude provider/adapter with tests updated.
> 
> **Overview**
> **Default Claude context window is now 1M** for models that expose a `contextWindow` toggle (Fable 5, Opus 4.6, Sonnet 5, Sonnet 4.6). The option descriptor default moves from `200k` to `1m`; explicit `200k` selections are unchanged.
> 
> A new **`resolveClaudeContextWindow`** helper resolves the effective window through model capability descriptors (same pattern as effort), so missing `contextWindow` on a selection no longer implicitly means 200k. **`resolveClaudeApiModelId`** and the adapter’s **`selectedClaudeContextWindow`** (CLI `[1m]` suffix and context-meter `maxTokens`) both use this helper. Opus 4.8/4.7 stay fixed at 1M with no toggle.
> 
> Tests expect bare Opus 4.6 selections to call `setModel` with `claude-opus-4-6[1m]` and use an explicit `200k` on the second turn to assert the suffix transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05bdd13255efbbe5eb5a33d7d6548d1f2b15b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default Claude context window to 1M for supported models
> - Sets `1m` as the default `contextWindow` option for `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-5`, and `claude-sonnet-4-6` in `BUILT_IN_MODELS`, replacing the previous `200k` default.
> - Adds `resolveClaudeContextWindow` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/3950/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) to derive the effective context window from model capability descriptors and any explicit selection, so defaults are respected without manual parsing.
> - Updates `resolveClaudeApiModelId` and `selectedClaudeContextWindow` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/3950/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to use `resolveClaudeContextWindow`, ensuring the `[1m]` model ID suffix is applied when the resolved value is `1m`.
> - Behavioral Change: users who previously relied on the `200k` default will now have `1m` selected by default for the affected models.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b05bdd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->