### PR TITLE
feat: make worktree branch prefix configurable

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -735,6 +735,9 @@ export function NewTaskDraftScreen(props: {
       branch: creationBranch,
       worktreePath: workspaceMode === "worktree" ? null : selectedWorktreePath,
       startFromOrigin,
+      ...(selectedEnvironmentServerConfig
+        ? { worktreeBranchPrefix: selectedEnvironmentServerConfig.settings.worktreeBranchPrefix }
+        : {}),
       runtimeMode,
       interactionMode,
       initialMessageText,

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -8,6 +8,7 @@ import {
   type ModelSelection,
   type ProviderInteractionMode,
   type RuntimeMode,
+  type WorktreeBranchPrefix,
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
@@ -33,6 +34,7 @@ export function useCreateProjectThread() {
       readonly branch: string | null;
       readonly worktreePath: string | null;
       readonly startFromOrigin?: boolean;
+      readonly worktreeBranchPrefix?: WorktreeBranchPrefix;
       readonly runtimeMode: RuntimeMode;
       readonly interactionMode: ProviderInteractionMode;
       readonly initialMessageText: string;
@@ -74,7 +76,10 @@ export function useCreateProjectThread() {
           branch: input.branch,
           worktreePath: input.worktreePath,
           startFromOrigin: input.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+          worktreeBranchName: buildTemporaryWorktreeBranchName(
+            randomHex,
+            input.worktreeBranchPrefix,
+          ),
         }),
       });
       if (AsyncResult.isFailure(result)) {

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -21,6 +21,7 @@ import { toUploadChatImageAttachments } from "../lib/composerImages";
 import { randomHex } from "../lib/uuid";
 import { appAtomRegistry } from "./atom-registry";
 import { useProjects, useThreadShells } from "./entities";
+import { serverEnvironment } from "./server";
 import {
   confirmThreadOutboxMessageQueued,
   ensureThreadOutboxLoaded,
@@ -256,6 +257,11 @@ export function useThreadOutboxDrain(): void {
         return false;
       }
       const { completeDelivery } = makeDeliveryHelpers(queuedMessage);
+      // Dispatch-time snapshot: the queued creation should use whatever prefix
+      // the environment reports when the message finally sends.
+      const environmentServerConfig = appAtomRegistry.get(
+        serverEnvironment.configValueAtom(queuedMessage.environmentId),
+      );
       const deliveryResult = await startTurn({
         environmentId: queuedMessage.environmentId,
         input: buildProjectThreadStartTurnInput({
@@ -274,7 +280,10 @@ export function useThreadOutboxDrain(): void {
           branch: creation.branch,
           worktreePath: creation.worktreePath,
           startFromOrigin: creation.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+          worktreeBranchName: buildTemporaryWorktreeBranchName(
+            randomHex,
+            environmentServerConfig?.settings.worktreeBranchPrefix,
+          ),
         }),
       });
       return completeDelivery(deliveryResult);

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -35,7 +35,7 @@ import * as VcsDriverRegistry from "../../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
-import { layerTest as serverSettingsLayerTest } from "../../serverSettings.ts";
+import * as ServerSettings from "../../serverSettings.ts";
 import { CheckpointReactorLive } from "./CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
@@ -350,7 +350,7 @@ describe("CheckpointReactor", () => {
       ),
       Layer.provideMerge(WorkspacePaths.layer),
       Layer.provideMerge(VcsProcess.layer),
-      Layer.provideMerge(serverSettingsLayerTest()),
+      Layer.provideMerge(ServerSettings.layerTest()),
       Layer.provideMerge(ServerConfigLayer),
       Layer.provideMerge(NodeServices.layer),
     );

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -35,6 +35,7 @@ import * as VcsDriverRegistry from "../../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
+import { layerTest as serverSettingsLayerTest } from "../../serverSettings.ts";
 import { CheckpointReactorLive } from "./CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
@@ -349,6 +350,7 @@ describe("CheckpointReactor", () => {
       ),
       Layer.provideMerge(WorkspacePaths.layer),
       Layer.provideMerge(VcsProcess.layer),
+      Layer.provideMerge(serverSettingsLayerTest()),
       Layer.provideMerge(ServerConfigLayer),
       Layer.provideMerge(NodeServices.layer),
     );

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -8,6 +8,7 @@ import {
   TurnId,
   type OrchestrationEvent,
   type ProviderRuntimeEvent,
+  type ServerSettingsError,
   type VcsStatusLocalResult,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -30,6 +31,7 @@ import * as CheckpointStore from "../../checkpointing/CheckpointStore.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { CheckpointReactor, type CheckpointReactorShape } from "../Services/CheckpointReactor.ts";
 import { forkParked } from "../../serverActivation.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
@@ -88,6 +90,7 @@ const make = Effect.gen(function* () {
   const receiptBus = yield* RuntimeReceiptBus;
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
+  const serverSettingsService = yield* ServerSettingsService;
 
   const appendRevertFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -568,14 +571,19 @@ const make = Effect.gen(function* () {
     readonly cwd: string;
     readonly local: VcsStatusLocalResult;
   }) {
-    // Detached HEAD has no branch to adopt; a temporary placeholder checkout
-    // means the first-turn auto-rename is still in flight — don't race it.
+    // Detached HEAD has no branch to adopt.
     const checkedOutBranch = input.local.refName;
-    if (checkedOutBranch === null || isTemporaryWorktreeBranch(checkedOutBranch)) {
+    if (checkedOutBranch === null) {
       return;
     }
 
     yield* Effect.gen(function* () {
+      // A temporary placeholder checkout means the first-turn auto-rename is
+      // still in flight — don't race it.
+      const { worktreeBranchPrefix } = yield* serverSettingsService.getSettings;
+      if (isTemporaryWorktreeBranch(checkedOutBranch, worktreeBranchPrefix)) {
+        return;
+      }
       const thread = yield* projectionSnapshotQuery
         .getThreadShellById(input.threadId)
         .pipe(Effect.map(Option.getOrUndefined));
@@ -585,7 +593,7 @@ const make = Effect.gen(function* () {
         thread.branch === checkedOutBranch ||
         thread.worktreePath === null ||
         thread.worktreePath !== input.cwd ||
-        isTemporaryWorktreeBranch(thread.branch)
+        isTemporaryWorktreeBranch(thread.branch, worktreeBranchPrefix)
       ) {
         return;
       }
@@ -891,7 +899,10 @@ const make = Effect.gen(function* () {
     input: ReactorInput,
   ): Effect.Effect<
     void,
-    CheckpointStoreError | OrchestrationDispatchError | PlatformError.PlatformError,
+    | CheckpointStoreError
+    | OrchestrationDispatchError
+    | PlatformError.PlatformError
+    | ServerSettingsError,
     never
   > =>
     input.source === "domain" ? processDomainEvent(input.event) : processRuntimeEvent(input.event);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -607,7 +607,7 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Reconnect spinner resume bug");
   });
 
-  it("generates a worktree branch name for the first turn", async () => {
+  it("preserves the temporary branch prefix when naming the first turn", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -616,24 +616,13 @@ describe("ProviderCommandReactor", () => {
         type: "thread.meta.update",
         commandId: CommandId.make("cmd-thread-branch"),
         threadId: ThreadId.make("thread-1"),
-        branch: "t3code/1234abcd",
+        branch: "codex/team/1234abcd",
         worktreePath: "/tmp/provider-project-worktree",
       }),
     );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({ branch: "feature/reconnect-backoff" }),
     );
 
     await Effect.runPromise(
@@ -657,6 +646,10 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
     expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
       message: "Add a safer reconnect backoff.",
+    });
+    expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+      oldBranch: "codex/team/1234abcd",
+      newBranch: "codex/team/feature/reconnect-backoff",
     });
     expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -145,6 +145,7 @@ describe("ProviderCommandReactor", () => {
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
+    readonly worktreeBranchPrefix?: string;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -368,7 +369,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.worktreeBranchPrefix
+            ? { worktreeBranchPrefix: input.worktreeBranchPrefix }
+            : undefined,
+        ),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -608,7 +615,7 @@ describe("ProviderCommandReactor", () => {
   });
 
   it("preserves the temporary branch prefix when naming the first turn", async () => {
-    const harness = await createHarness();
+    const harness = await createHarness({ worktreeBranchPrefix: "codex/team" });
     const now = "2026-01-01T00:00:00.000Z";
 
     await Effect.runPromise(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -614,52 +614,58 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Reconnect spinner resume bug");
   });
 
-  it("preserves the temporary branch prefix when naming the first turn", async () => {
-    const harness = await createHarness({ worktreeBranchPrefix: "codex/team" });
-    const now = "2026-01-01T00:00:00.000Z";
+  it.each([
+    ["configured", "codex/team/1234abcd", "codex/team/feature/reconnect-backoff"],
+    ["legacy", "t3code/1234abcd", "t3code/feature/reconnect-backoff"],
+  ] as const)(
+    "preserves the %s temporary branch prefix when naming the first turn",
+    async (_kind, temporaryBranch, expectedBranch) => {
+      const harness = await createHarness({ worktreeBranchPrefix: "codex/team" });
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-thread-branch"),
-        threadId: ThreadId.make("thread-1"),
-        branch: "codex/team/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make("cmd-thread-branch"),
+          threadId: ThreadId.make("thread-1"),
+          branch: temporaryBranch,
+          worktreePath: "/tmp/provider-project-worktree",
+        }),
+      );
 
-    harness.generateBranchName.mockImplementation(() =>
-      Effect.succeed({ branch: "feature/reconnect-backoff" }),
-    );
+      harness.generateBranchName.mockImplementation(() =>
+        Effect.succeed({ branch: "feature/reconnect-backoff" }),
+      );
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-branch-model"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-branch-model"),
-          role: "user",
-          text: "Add a safer reconnect backoff.",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-branch-model"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-branch-model"),
+            role: "user",
+            text: "Add a safer reconnect backoff.",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      );
 
-    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
-    await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
-    expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
-      message: "Add a safer reconnect backoff.",
-    });
-    expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
-      oldBranch: "codex/team/1234abcd",
-      newBranch: "codex/team/feature/reconnect-backoff",
-    });
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
-  });
+      await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
+      await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
+      expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
+        message: "Add a safer reconnect backoff.",
+      });
+      expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+        oldBranch: temporaryBranch,
+        newBranch: expectedBranch,
+      });
+      expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+    },
+  );
 
   it("forwards codex model options through session start and turn send", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -60,7 +60,7 @@ import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Clock from "effect/Clock";
-import { ServerSettingsService } from "../../serverSettings.ts";
+import * as ServerSettings from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as GitWorkflowService from "../../git/GitWorkflowService.ts";
 
@@ -414,7 +414,7 @@ describe("ProviderCommandReactor", () => {
         }),
       ),
       Layer.provideMerge(
-        ServerSettingsService.layerTest(
+        ServerSettings.layerTest(
           input?.worktreeBranchPrefix
             ? { worktreeBranchPrefix: input.worktreeBranchPrefix }
             : undefined,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1465,9 +1465,9 @@ describe("ProviderCommandReactor", () => {
 
   it.each([
     ["configured", "codex/team/1234abcd", "codex/team/feature/reconnect-backoff"],
-    ["legacy", "t3code/1234abcd", "t3code/feature/reconnect-backoff"],
+    ["legacy", "t3code/1234abcd", "codex/team/feature/reconnect-backoff"],
   ] as const)(
-    "preserves the %s temporary branch prefix when naming the first turn",
+    "renames the %s temporary branch into the configured prefix on the first turn",
     async (_kind, temporaryBranch, expectedBranch) => {
       const harness = await createHarness({ worktreeBranchPrefix: "codex/team" });
       const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -153,6 +153,7 @@ describe("ProviderCommandReactor", () => {
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
+    readonly worktreeBranchPrefix?: string;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -412,7 +413,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.worktreeBranchPrefix
+            ? { worktreeBranchPrefix: input.worktreeBranchPrefix }
+            : undefined,
+        ),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -1456,59 +1463,58 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Reconnect spinner resume bug");
   });
 
-  it("generates a worktree branch name for the first turn", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  it.each([
+    ["configured", "codex/team/1234abcd", "codex/team/feature/reconnect-backoff"],
+    ["legacy", "t3code/1234abcd", "t3code/feature/reconnect-backoff"],
+  ] as const)(
+    "preserves the %s temporary branch prefix when naming the first turn",
+    async (_kind, temporaryBranch, expectedBranch) => {
+      const harness = await createHarness({ worktreeBranchPrefix: "codex/team" });
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-thread-branch"),
-        threadId: ThreadId.make("thread-1"),
-        branch: "t3code/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make("cmd-thread-branch"),
+          threadId: ThreadId.make("thread-1"),
+          branch: temporaryBranch,
+          worktreePath: "/tmp/provider-project-worktree",
+        }),
+      );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
-    );
+      harness.generateBranchName.mockImplementation(() =>
+        Effect.succeed({ branch: "feature/reconnect-backoff" }),
+      );
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-branch-model"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-branch-model"),
-          role: "user",
-          text: "Add a safer reconnect backoff.",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-branch-model"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-branch-model"),
+            role: "user",
+            text: "Add a safer reconnect backoff.",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      );
 
-    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
-    await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
-    expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
-      message: "Add a safer reconnect backoff.",
-    });
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
-  });
+      await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
+      await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
+      expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
+        message: "Add a safer reconnect backoff.",
+      });
+      expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+        oldBranch: temporaryBranch,
+        newBranch: expectedBranch,
+      });
+      expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+    },
+  );
 
   it("forwards codex model options through session start and turn send", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,11 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import {
+  buildGeneratedWorktreeBranchName,
+  extractTemporaryWorktreeBranchPrefix,
+  isTemporaryWorktreeBranch,
+} from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -161,29 +165,6 @@ function stalePendingRequestDetail(
   requestId: string,
 ): string {
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
-}
-
-function buildGeneratedWorktreeBranchName(raw: string): string {
-  const normalized = raw
-    .trim()
-    .toLowerCase()
-    .replace(/^refs\/heads\//, "")
-    .replace(/['"`]/g, "");
-
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
-
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
 }
 
 const make = Effect.gen(function* () {
@@ -675,7 +656,10 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        generated.branch,
+        extractTemporaryWorktreeBranchPrefix(oldBranch),
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -15,7 +15,6 @@ import {
 import {
   buildGeneratedWorktreeBranchName,
   extractTemporaryWorktreeBranchPrefix,
-  isTemporaryWorktreeBranch,
 } from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
@@ -637,16 +636,16 @@ const make = Effect.gen(function* () {
     if (!input.branch || !input.worktreePath) {
       return;
     }
-    if (!isTemporaryWorktreeBranch(input.branch)) {
-      return;
-    }
-
     const oldBranch = input.branch;
     const cwd = input.worktreePath;
     const attachments = input.attachments ?? [];
     yield* Effect.gen(function* () {
-      const { textGenerationModelSelection: modelSelection } =
+      const { textGenerationModelSelection: modelSelection, worktreeBranchPrefix: expectedPrefix } =
         yield* serverSettingsService.getSettings;
+      const temporaryPrefix = extractTemporaryWorktreeBranchPrefix(oldBranch, expectedPrefix);
+      if (!temporaryPrefix) {
+        return;
+      }
 
       const generated = yield* textGeneration.generateBranchName({
         cwd,
@@ -656,10 +655,7 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(
-        generated.branch,
-        extractTemporaryWorktreeBranchPrefix(oldBranch),
-      );
+      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch, temporaryPrefix);
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,10 +12,7 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import {
-  buildGeneratedWorktreeBranchName,
-  extractTemporaryWorktreeBranchPrefix,
-} from "@t3tools/shared/git";
+import { buildGeneratedWorktreeBranchName, isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -785,11 +782,10 @@ const make = Effect.gen(function* () {
               settings,
               yield* providerRegistry.getProviders,
             );
-      const temporaryPrefix = extractTemporaryWorktreeBranchPrefix(
-        oldBranch,
-        settings.worktreeBranchPrefix,
-      );
-      if (!temporaryPrefix) {
+      // Rename into the configured prefix even when the temporary branch was
+      // created under the legacy default (e.g. a client that had not loaded
+      // the setting yet), so a stale namespace heals on the first turn.
+      if (!isTemporaryWorktreeBranch(oldBranch, settings.worktreeBranchPrefix)) {
         return;
       }
 
@@ -801,7 +797,10 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch, temporaryPrefix);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        generated.branch,
+        settings.worktreeBranchPrefix,
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,10 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import {
+  buildGeneratedWorktreeBranchName,
+  extractTemporaryWorktreeBranchPrefix,
+} from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -273,29 +276,6 @@ function stalePendingRequestDetail(
   requestId: string,
 ): string {
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
-}
-
-function buildGeneratedWorktreeBranchName(raw: string): string {
-  const normalized = raw
-    .trim()
-    .toLowerCase()
-    .replace(/^refs\/heads\//, "")
-    .replace(/['"`]/g, "");
-
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
-
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
 }
 
 const make = Effect.gen(function* () {
@@ -793,10 +773,6 @@ const make = Effect.gen(function* () {
     if (!input.branch || !input.worktreePath) {
       return;
     }
-    if (!isTemporaryWorktreeBranch(input.branch)) {
-      return;
-    }
-
     const oldBranch = input.branch;
     const cwd = input.worktreePath;
     const attachments = input.attachments ?? [];
@@ -809,6 +785,13 @@ const make = Effect.gen(function* () {
               settings,
               yield* providerRegistry.getProviders,
             );
+      const temporaryPrefix = extractTemporaryWorktreeBranchPrefix(
+        oldBranch,
+        settings.worktreeBranchPrefix,
+      );
+      if (!temporaryPrefix) {
+        return;
+      }
 
       const generated = yield* textGeneration.generateBranchName({
         cwd,
@@ -818,7 +801,7 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch, temporaryPrefix);
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4154,7 +4154,10 @@ function ChatViewContent(props: ChatViewProps) {
                     prepareWorktree: {
                       projectCwd: activeProject.workspaceRoot,
                       baseBranch: baseBranchForWorktree,
-                      branch: buildTemporaryWorktreeBranchName(randomHex),
+                      branch: buildTemporaryWorktreeBranchName(
+                        randomHex,
+                        settings.worktreeBranchPrefix,
+                      ),
                       ...(startFromOrigin ? { startFromOrigin: true } : {}),
                     },
                     runSetupScript: true,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5433,7 +5433,10 @@ function ChatViewContent(props: ChatViewProps) {
                     prepareWorktree: {
                       projectCwd: activeProject.workspaceRoot,
                       baseBranch: baseBranchForWorktree,
-                      branch: buildTemporaryWorktreeBranchName(randomHex),
+                      branch: buildTemporaryWorktreeBranchName(
+                        randomHex,
+                        settings.worktreeBranchPrefix,
+                      ),
                       ...(startFromOrigin ? { startFromOrigin: true } : {}),
                     },
                     runSetupScript: true,

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1,4 +1,4 @@
-import type { VcsStatusResult } from "@t3tools/contracts";
+import { DEFAULT_WORKTREE_BRANCH_PREFIX, type VcsStatusResult } from "@t3tools/contracts";
 import { assert, describe, it } from "vite-plus/test";
 import {
   buildGitActionProgressStages,
@@ -1059,6 +1059,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "feature/old-ref",
       gitStatus: status({ refName: "effect-atom" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.deepEqual(update, {
@@ -1070,6 +1071,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "feature/old-ref",
       gitStatus: null,
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1079,6 +1081,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "effect-atom",
       gitStatus: status({ refName: "effect-atom" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1088,6 +1091,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "effect-atom",
       gitStatus: status({ refName: null }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1097,6 +1101,17 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "t3code/github-query-rate-limit",
       gitStatus: status({ refName: "t3code/bda76797" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
+    });
+
+    assert.equal(update, null);
+  });
+
+  it("does not regress a semantic legacy ref after the prefix changes", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "t3code/github-query-rate-limit",
+      gitStatus: status({ refName: "t3code/bda76797" }),
+      worktreeBranchPrefix: "codex/team",
     });
 
     assert.equal(update, null);
@@ -1106,9 +1121,20 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "t3code/a9628676",
       gitStatus: status({ refName: "feature/diff-panel-toggle" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.deepEqual(update, { branch: "feature/diff-panel-toggle" });
+  });
+
+  it("reconciles an eight-hex branch outside the configured worktree prefix", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "feature/current",
+      gitStatus: status({ refName: "release/20260714" }),
+      worktreeBranchPrefix: "codex/team",
+    });
+
+    assert.deepEqual(update, { branch: "release/20260714" });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1,4 +1,4 @@
-import type { VcsStatusResult } from "@t3tools/contracts";
+import { DEFAULT_WORKTREE_BRANCH_PREFIX, type VcsStatusResult } from "@t3tools/contracts";
 import { assert, describe, it } from "vite-plus/test";
 import {
   buildGitActionProgressStages,
@@ -1059,6 +1059,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "feature/old-ref",
       gitStatus: status({ refName: "effect-atom" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.deepEqual(update, {
@@ -1070,6 +1071,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "feature/old-ref",
       gitStatus: null,
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1079,6 +1081,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "effect-atom",
       gitStatus: status({ refName: "effect-atom" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1088,6 +1091,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "effect-atom",
       gitStatus: status({ refName: null }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1097,6 +1101,7 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "t3code/github-query-rate-limit",
       gitStatus: status({ refName: "t3code/bda76797" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.equal(update, null);
@@ -1106,9 +1111,20 @@ describe("resolveLiveThreadBranchUpdate", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "t3code/a9628676",
       gitStatus: status({ refName: "feature/diff-panel-toggle" }),
+      worktreeBranchPrefix: DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
 
     assert.deepEqual(update, { branch: "feature/diff-panel-toggle" });
+  });
+
+  it("reconciles an eight-hex branch outside the configured worktree prefix", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "feature/current",
+      gitStatus: status({ refName: "release/20260714" }),
+      worktreeBranchPrefix: "codex/team",
+    });
+
+    assert.deepEqual(update, { branch: "release/20260714" });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1107,6 +1107,16 @@ describe("resolveLiveThreadBranchUpdate", () => {
     assert.equal(update, null);
   });
 
+  it("does not regress a semantic legacy ref after the prefix changes", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "t3code/github-query-rate-limit",
+      gitStatus: status({ refName: "t3code/bda76797" }),
+      worktreeBranchPrefix: "codex/team",
+    });
+
+    assert.equal(update, null);
+  });
+
   it("allows a temporary worktree ref to reconcile to a semantic branch", () => {
     const update = resolveLiveThreadBranchUpdate({
       threadBranch: "t3code/a9628676",

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -2,6 +2,7 @@ import type {
   GitRunStackedActionResult,
   GitStackedAction,
   VcsStatusResult,
+  WorktreeBranchPrefix,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 import {
@@ -386,6 +387,7 @@ export function resolveThreadBranchMetadataPatch(
 export function resolveLiveThreadBranchUpdate(input: {
   threadBranch: string | null;
   gitStatus: VcsStatusResult | null;
+  worktreeBranchPrefix: WorktreeBranchPrefix;
 }): { branch: string | null } | null {
   if (!input.gitStatus) {
     return null;
@@ -402,8 +404,8 @@ export function resolveLiveThreadBranchUpdate(input: {
   if (
     input.threadBranch !== null &&
     input.gitStatus.refName !== null &&
-    !isTemporaryWorktreeBranch(input.threadBranch) &&
-    isTemporaryWorktreeBranch(input.gitStatus.refName)
+    !isTemporaryWorktreeBranch(input.threadBranch, input.worktreeBranchPrefix) &&
+    isTemporaryWorktreeBranch(input.gitStatus.refName, input.worktreeBranchPrefix)
   ) {
     return null;
   }

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
-import { type ScopedThreadRef } from "@t3tools/contracts";
+import { DEFAULT_WORKTREE_BRANCH_PREFIX, type ScopedThreadRef } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -1124,6 +1124,8 @@ export default function GitActionsControl({
     const branchUpdate = resolveLiveThreadBranchUpdate({
       threadBranch: activeServerThread?.branch ?? activeDraftThread?.branch ?? null,
       gitStatus: gitStatusForActions,
+      worktreeBranchPrefix:
+        serverConfig?.settings.worktreeBranchPrefix ?? DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
     if (!branchUpdate) {
       return;
@@ -1137,6 +1139,7 @@ export default function GitActionsControl({
     isGitActionRunning,
     isSelectingWorktreeBase,
     persistThreadBranchSync,
+    serverConfig?.settings.worktreeBranchPrefix,
   ]);
 
   const isDefaultRef = useMemo(() => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
-import { DEFAULT_WORKTREE_BRANCH_PREFIX, type ScopedThreadRef } from "@t3tools/contracts";
+import { type ScopedThreadRef } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -1127,16 +1127,23 @@ export default function GitActionsControl({
     activeDraftThread?.envMode === "worktree" &&
     activeDraftThread.worktreePath === null;
 
+  const worktreeBranchPrefix = serverConfig?.settings.worktreeBranchPrefix;
+
   useEffect(() => {
     if (isGitActionRunning || isSelectingWorktreeBase || activeServerThread) {
+      return;
+    }
+    // Without the server config the configured prefix is unknown, and
+    // classifying against the default could persist a temporary branch as
+    // semantic. Reconciliation resumes once the config loads.
+    if (worktreeBranchPrefix === undefined) {
       return;
     }
 
     const branchUpdate = resolveLiveThreadBranchUpdate({
       threadBranch: activeDraftThread?.branch ?? null,
       gitStatus: gitStatusForActions,
-      worktreeBranchPrefix:
-        serverConfig?.settings.worktreeBranchPrefix ?? DEFAULT_WORKTREE_BRANCH_PREFIX,
+      worktreeBranchPrefix,
     });
     if (!branchUpdate) {
       return;
@@ -1150,7 +1157,7 @@ export default function GitActionsControl({
     isGitActionRunning,
     isSelectingWorktreeBase,
     persistThreadBranchSync,
-    serverConfig?.settings.worktreeBranchPrefix,
+    worktreeBranchPrefix,
   ]);
 
   const isDefaultRef = useMemo(() => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
-import { type ScopedThreadRef } from "@t3tools/contracts";
+import { DEFAULT_WORKTREE_BRANCH_PREFIX, type ScopedThreadRef } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -1135,6 +1135,8 @@ export default function GitActionsControl({
     const branchUpdate = resolveLiveThreadBranchUpdate({
       threadBranch: activeDraftThread?.branch ?? null,
       gitStatus: gitStatusForActions,
+      worktreeBranchPrefix:
+        serverConfig?.settings.worktreeBranchPrefix ?? DEFAULT_WORKTREE_BRANCH_PREFIX,
     });
     if (!branchUpdate) {
       return;
@@ -1148,6 +1150,7 @@ export default function GitActionsControl({
     isGitActionRunning,
     isSelectingWorktreeBase,
     persistThreadBranchSync,
+    serverConfig?.settings.worktreeBranchPrefix,
   ]);
 
   const isDefaultRef = useMemo(() => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -19,6 +19,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { normalizeWorktreeBranchPrefix } from "@t3tools/shared/git";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
@@ -412,6 +413,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix
+        ? ["Worktree branch prefix"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -431,6 +435,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeBranchPrefix,
       settings.diffIgnoreWhitespace,
       settings.automaticGitFetchInterval,
       settings.enableAssistantStreaming,
@@ -462,6 +467,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -727,7 +733,8 @@ export function GeneralSettingsPanel() {
           resetAction={
             settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
             settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ||
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
               <SettingResetButton
                 label="new threads"
                 onClick={() =>
@@ -735,6 +742,7 @@ export function GeneralSettingsPanel() {
                     defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
                     newWorktreesStartFromOrigin:
                       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
                   })
                 }
               />
@@ -767,34 +775,73 @@ export function GeneralSettingsPanel() {
         />
 
         {settings.defaultThreadEnvMode === "worktree" ? (
-          <SettingsRow
-            className="bg-muted/20 sm:pl-9"
-            title="Start from origin"
-            description="Creates the worktree from the latest matching branch on origin instead of your local branch."
-            resetAction={
-              settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
-                <SettingResetButton
-                  label="new worktrees start from origin"
-                  onClick={() =>
-                    updateSettings({
-                      newWorktreesStartFromOrigin:
-                        DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-                    })
+          <>
+            <SettingsRow
+              className="bg-muted/20 sm:pl-9"
+              title="Start from origin"
+              description="Creates the worktree from the latest matching branch on origin instead of your local branch."
+              resetAction={
+                settings.newWorktreesStartFromOrigin !==
+                DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+                  <SettingResetButton
+                    label="new worktrees start from origin"
+                    onClick={() =>
+                      updateSettings({
+                        newWorktreesStartFromOrigin:
+                          DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.newWorktreesStartFromOrigin}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
                   }
+                  aria-label="Start new worktrees from origin by default"
                 />
-              ) : null
-            }
-            control={
-              <Switch
-                checked={settings.newWorktreesStartFromOrigin}
-                onCheckedChange={(checked) =>
-                  updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
-                }
-                aria-label="Start new worktrees from origin by default"
-              />
-            }
-          />
+              }
+            />
+            <SettingsRow
+              className="bg-muted/20 sm:pl-9"
+              title="Branch prefix"
+              description="Prefixes branches T3 Code creates for new worktrees."
+              resetAction={
+                settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+                  <SettingResetButton
+                    label="worktree branch prefix"
+                    onClick={() =>
+                      updateSettings({
+                        worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <div className="flex w-full items-center gap-1.5 sm:w-auto">
+                  <DraftInput
+                    className="w-full font-mono sm:w-44"
+                    value={settings.worktreeBranchPrefix}
+                    onCommit={(next) =>
+                      updateSettings({
+                        worktreeBranchPrefix: normalizeWorktreeBranchPrefix(next),
+                      })
+                    }
+                    aria-label="Worktree branch prefix"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                  />
+                  <span className="font-mono text-xs text-muted-foreground" aria-hidden>
+                    /
+                  </span>
+                </div>
+              }
+            />
+          </>
         ) : null}
 
         <SettingsRow

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -36,6 +36,7 @@ import {
   MIN_TERMINAL_FONT_SIZE,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import { normalizeWorktreeBranchPrefix } from "@t3tools/shared/git";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -523,6 +524,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix
+        ? ["Worktree branch prefix"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -556,6 +560,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeBranchPrefix,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
       settings.fontFamilyCode,
@@ -662,6 +667,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2191,7 +2197,8 @@ export function GeneralSettingsPanel() {
           resetAction={
             settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
             settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ||
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
               <SettingResetButton
                 label="new threads"
                 onClick={() =>
@@ -2199,6 +2206,7 @@ export function GeneralSettingsPanel() {
                     defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
                     newWorktreesStartFromOrigin:
                       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
                   })
                 }
               />
@@ -2231,34 +2239,73 @@ export function GeneralSettingsPanel() {
         />
 
         {settings.defaultThreadEnvMode === "worktree" ? (
-          <SettingsRow
-            className="bg-muted/20 sm:pl-9"
-            title={searchableSetting("start-from-origin").title}
-            description="Creates the worktree from the latest matching branch on origin instead of your local branch."
-            resetAction={
-              settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
-                <SettingResetButton
-                  label="new worktrees start from origin"
-                  onClick={() =>
-                    updateSettings({
-                      newWorktreesStartFromOrigin:
-                        DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-                    })
+          <>
+            <SettingsRow
+              className="bg-muted/20 sm:pl-9"
+              title={searchableSetting("start-from-origin").title}
+              description="Creates the worktree from the latest matching branch on origin instead of your local branch."
+              resetAction={
+                settings.newWorktreesStartFromOrigin !==
+                DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+                  <SettingResetButton
+                    label="new worktrees start from origin"
+                    onClick={() =>
+                      updateSettings({
+                        newWorktreesStartFromOrigin:
+                          DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.newWorktreesStartFromOrigin}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
                   }
+                  aria-label="Start new worktrees from origin by default"
                 />
-              ) : null
-            }
-            control={
-              <Switch
-                checked={settings.newWorktreesStartFromOrigin}
-                onCheckedChange={(checked) =>
-                  updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
-                }
-                aria-label="Start new worktrees from origin by default"
-              />
-            }
-          />
+              }
+            />
+            <SettingsRow
+              className="bg-muted/20 sm:pl-9"
+              title={searchableSetting("worktree-branch-prefix").title}
+              description="Prefixes branches T3 Code creates for new worktrees."
+              resetAction={
+                settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+                  <SettingResetButton
+                    label="worktree branch prefix"
+                    onClick={() =>
+                      updateSettings({
+                        worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <div className="flex w-full items-center gap-1.5 sm:w-auto">
+                  <DraftInput
+                    className="w-full font-mono sm:w-44"
+                    value={settings.worktreeBranchPrefix}
+                    onCommit={(next) =>
+                      updateSettings({
+                        worktreeBranchPrefix: normalizeWorktreeBranchPrefix(next),
+                      })
+                    }
+                    aria-label="Worktree branch prefix"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                  />
+                  <span className="font-mono text-xs text-muted-foreground" aria-hidden>
+                    /
+                  </span>
+                </div>
+              }
+            />
+          </>
         ) : null}
 
         <SettingsRow

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -97,6 +97,7 @@ import {
 } from "../ui/dialog";
 import { DraftInput } from "../ui/draft-input";
 import { Input } from "../ui/input";
+import { InputGroup, InputGroupAddon, InputGroupText } from "../ui/input-group";
 import {
   DEFAULT_CODE_FONT_STACK,
   DEFAULT_SANS_FONT_STACK,
@@ -2285,9 +2286,10 @@ export function GeneralSettingsPanel() {
                 ) : null
               }
               control={
-                <div className="flex w-full items-center gap-1.5 sm:w-auto">
+                <InputGroup className="w-full sm:w-44">
                   <DraftInput
-                    className="w-full font-mono sm:w-44"
+                    unstyled
+                    className="font-mono"
                     value={settings.worktreeBranchPrefix}
                     onCommit={(next) =>
                       updateSettings({
@@ -2299,10 +2301,10 @@ export function GeneralSettingsPanel() {
                     autoCorrect="off"
                     spellCheck={false}
                   />
-                  <span className="font-mono text-xs text-muted-foreground" aria-hidden>
-                    /
-                  </span>
-                </div>
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupText>/</InputGroupText>
+                  </InputGroupAddon>
+                </InputGroup>
               }
             />
           </>

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -148,6 +148,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "new-threads",
   },
   {
+    id: "worktree-branch-prefix",
+    title: "Branch prefix",
+    to: "/settings/general",
+    targetId: "new-threads",
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/packages/client-runtime/src/state/gitActions.ts
+++ b/packages/client-runtime/src/state/gitActions.ts
@@ -3,6 +3,7 @@ import type {
   GitRunStackedActionResult,
   GitStackedAction,
   VcsStatusResult,
+  WorktreeBranchPrefix,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
@@ -412,6 +413,7 @@ export function resolveThreadBranchUpdate(
 export function resolveLiveThreadBranchUpdate(input: {
   threadBranch: string | null;
   gitStatus: VcsStatusResult | null;
+  worktreeBranchPrefix: WorktreeBranchPrefix;
 }): { branch: string | null } | null {
   if (!input.gitStatus) {
     return null;
@@ -428,8 +430,8 @@ export function resolveLiveThreadBranchUpdate(input: {
   if (
     input.threadBranch !== null &&
     input.gitStatus.refName !== null &&
-    !isTemporaryWorktreeBranch(input.threadBranch) &&
-    isTemporaryWorktreeBranch(input.gitStatus.refName)
+    !isTemporaryWorktreeBranch(input.threadBranch, input.worktreeBranchPrefix) &&
+    isTemporaryWorktreeBranch(input.gitStatus.refName, input.worktreeBranchPrefix)
   ) {
     return null;
   }

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -88,14 +88,23 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
 });
 
 describe("ServerSettings worktree defaults", () => {
-  it("defaults start-from-origin off for legacy configs", () => {
-    expect(decodeServerSettings({}).newWorktreesStartFromOrigin).toBe(false);
+  it("defaults legacy configs to local branches with the T3 Code prefix", () => {
+    const settings = decodeServerSettings({});
+    expect(settings.newWorktreesStartFromOrigin).toBe(false);
+    expect(settings.worktreeBranchPrefix).toBe("t3code");
   });
 
-  it("accepts start-from-origin updates", () => {
-    expect(
-      decodeServerSettingsPatch({ newWorktreesStartFromOrigin: true }).newWorktreesStartFromOrigin,
-    ).toBe(true);
+  it("accepts worktree default updates", () => {
+    const patch = decodeServerSettingsPatch({
+      newWorktreesStartFromOrigin: true,
+      worktreeBranchPrefix: "codex/feature",
+    });
+    expect(patch.newWorktreesStartFromOrigin).toBe(true);
+    expect(patch.worktreeBranchPrefix).toBe("codex/feature");
+  });
+
+  it("rejects branch prefixes that are not canonical Git namespaces", () => {
+    expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix: "Codex Branch" })).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -105,6 +105,7 @@ describe("ServerSettings worktree defaults", () => {
 
   it("rejects branch prefixes that are not canonical Git namespaces", () => {
     expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix: "Codex Branch" })).toThrow();
+    expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix: "team//feature" })).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -246,6 +246,21 @@ describe("ServerSettings worktree defaults", () => {
       decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
     ).toBe(false);
   });
+
+  it("defaults legacy configs to the T3 Code branch prefix", () => {
+    expect(decodeServerSettings({}).worktreeBranchPrefix).toBe("t3code");
+  });
+
+  it("accepts branch prefix updates", () => {
+    expect(
+      decodeServerSettingsPatch({ worktreeBranchPrefix: "codex/feature" }).worktreeBranchPrefix,
+    ).toBe("codex/feature");
+  });
+
+  it("rejects branch prefixes that are not canonical Git namespaces", () => {
+    expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix: "Codex Branch" })).toThrow();
+    expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix: "team//feature" })).toThrow();
+  });
 });
 
 describe("ServerSettings.sourceControlWritingStyle", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -102,6 +102,13 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
 export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 
+export const DEFAULT_WORKTREE_BRANCH_PREFIX = "t3code";
+export const WorktreeBranchPrefix = TrimmedNonEmptyString.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?$/),
+);
+export type WorktreeBranchPrefix = typeof WorktreeBranchPrefix.Type;
+
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
     Schema.decodeTo(
@@ -377,6 +384,9 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(false)),
   ),
+  worktreeBranchPrefix: WorktreeBranchPrefix.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_WORKTREE_BRANCH_PREFIX)),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -508,6 +518,7 @@ export const ServerSettingsPatch = Schema.Struct({
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeBranchPrefix: Schema.optionalKey(WorktreeBranchPrefix),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   observability: Schema.optionalKey(

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -105,7 +105,7 @@ export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 export const DEFAULT_WORKTREE_BRANCH_PREFIX = "t3code";
 export const WorktreeBranchPrefix = TrimmedNonEmptyString.check(
   Schema.isMaxLength(64),
-  Schema.isPattern(/^[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?$/),
+  Schema.isPattern(/^(?!.*\/\/)[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?$/),
 );
 export type WorktreeBranchPrefix = typeof WorktreeBranchPrefix.Type;
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -265,6 +265,13 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 // import cycle; re-exported here for compatibility with deep imports.
 export { ThreadEnvMode } from "./environment.ts";
 
+export const DEFAULT_WORKTREE_BRANCH_PREFIX = "t3code";
+export const WorktreeBranchPrefix = TrimmedNonEmptyString.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^(?!.*\/\/)[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?$/),
+);
+export type WorktreeBranchPrefix = typeof WorktreeBranchPrefix.Type;
+
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
     Schema.decodeTo(
@@ -638,6 +645,9 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  worktreeBranchPrefix: WorktreeBranchPrefix.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_WORKTREE_BRANCH_PREFIX)),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -837,6 +847,7 @@ export const ServerSettingsPatch = Schema.Struct({
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeBranchPrefix: Schema.optionalKey(WorktreeBranchPrefix),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -3,11 +3,14 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   applyGitStatusStreamEvent,
+  buildGeneratedWorktreeBranchName,
   buildTemporaryWorktreeBranchName,
+  DEFAULT_WORKTREE_BRANCH_PREFIX,
+  extractTemporaryWorktreeBranchPrefix,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
+  normalizeWorktreeBranchPrefix,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
-  WORKTREE_BRANCH_PREFIX,
 } from "./git.ts";
 
 describe("normalizeGitRemoteUrl", () => {
@@ -66,15 +69,39 @@ describe("isTemporaryWorktreeBranch", () => {
   });
 
   it("matches generated temporary worktree refs", () => {
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
-    expect(isTemporaryWorktreeBranch(` ${WORKTREE_BRANCH_PREFIX}/deadbeef `)).toBe(true);
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/DEADBEEF`)).toBe(true);
+    expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
+    expect(isTemporaryWorktreeBranch(` ${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef `)).toBe(true);
+    expect(isTemporaryWorktreeBranch("codex/feature/DEADBEEF")).toBe(true);
   });
 
   it("rejects non-temporary refName names", () => {
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
+    expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(false);
+    expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(
+      false,
+    );
+  });
+});
+
+describe("worktree branch prefixes", () => {
+  it("normalizes user input into a stable Git namespace", () => {
+    expect(normalizeWorktreeBranchPrefix(" refs/heads/Codex Team//Feature/ ")).toBe(
+      "codex-team/feature",
+    );
+    expect(normalizeWorktreeBranchPrefix(" ")).toBe(DEFAULT_WORKTREE_BRANCH_PREFIX);
+  });
+
+  it("uses the configured prefix for temporary and generated branches", () => {
+    expect(buildTemporaryWorktreeBranchName(() => "DEADBEEF", "codex/feature")).toBe(
+      "codex/feature/deadbeef",
+    );
+    expect(extractTemporaryWorktreeBranchPrefix("codex/feature/deadbeef")).toBe("codex/feature");
+    expect(buildGeneratedWorktreeBranchName("codex/feature/add-search", "codex/feature")).toBe(
+      "codex/feature/add-search",
+    );
+    expect(buildGeneratedWorktreeBranchName("Fix Search", "codex/feature")).toBe(
+      "codex/feature/fix-search",
+    );
   });
 });
 

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -101,6 +101,9 @@ describe("worktree branch prefixes", () => {
     expect(extractTemporaryWorktreeBranchPrefix("codex/feature/deadbeef", "codex/feature")).toBe(
       "codex/feature",
     );
+    expect(extractTemporaryWorktreeBranchPrefix("t3code/deadbeef", "codex/feature")).toBe(
+      DEFAULT_WORKTREE_BRANCH_PREFIX,
+    );
     expect(buildGeneratedWorktreeBranchName("codex/feature/add-search", "codex/feature")).toBe(
       "codex/feature/add-search",
     );

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -71,7 +71,7 @@ describe("isTemporaryWorktreeBranch", () => {
   it("matches generated temporary worktree refs", () => {
     expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
     expect(isTemporaryWorktreeBranch(` ${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef `)).toBe(true);
-    expect(isTemporaryWorktreeBranch("codex/feature/DEADBEEF")).toBe(true);
+    expect(isTemporaryWorktreeBranch("codex/feature/DEADBEEF", "codex/feature")).toBe(true);
   });
 
   it("rejects non-temporary refName names", () => {
@@ -80,6 +80,9 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(
       false,
     );
+    expect(isTemporaryWorktreeBranch("release/20260714")).toBe(false);
+    expect(isTemporaryWorktreeBranch("codex/feature/deadbeef", "codex/team")).toBe(false);
+    expect(isTemporaryWorktreeBranch("codex/team/release/deadbeef", "codex/team")).toBe(false);
   });
 });
 
@@ -95,7 +98,9 @@ describe("worktree branch prefixes", () => {
     expect(buildTemporaryWorktreeBranchName(() => "DEADBEEF", "codex/feature")).toBe(
       "codex/feature/deadbeef",
     );
-    expect(extractTemporaryWorktreeBranchPrefix("codex/feature/deadbeef")).toBe("codex/feature");
+    expect(extractTemporaryWorktreeBranchPrefix("codex/feature/deadbeef", "codex/feature")).toBe(
+      "codex/feature",
+    );
     expect(buildGeneratedWorktreeBranchName("codex/feature/add-search", "codex/feature")).toBe(
       "codex/feature/add-search",
     );

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -3,11 +3,14 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   applyGitStatusStreamEvent,
+  buildGeneratedWorktreeBranchName,
   buildTemporaryWorktreeBranchName,
+  DEFAULT_WORKTREE_BRANCH_PREFIX,
+  extractTemporaryWorktreeBranchPrefix,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
+  normalizeWorktreeBranchPrefix,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
-  WORKTREE_BRANCH_PREFIX,
 } from "./git.ts";
 
 describe("normalizeGitRemoteUrl", () => {
@@ -75,38 +78,76 @@ describe("isTemporaryWorktreeBranch", () => {
   });
 
   it("matches generated temporary worktree refs", () => {
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
-    expect(isTemporaryWorktreeBranch(` ${WORKTREE_BRANCH_PREFIX}/deadbeef `)).toBe(true);
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/DEADBEEF`)).toBe(true);
+    expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef`)).toBe(true);
+    expect(isTemporaryWorktreeBranch(` ${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef `)).toBe(true);
+    expect(isTemporaryWorktreeBranch("codex/feature/DEADBEEF", "codex/feature")).toBe(true);
   });
 
   it("normalizes a UUID-shaped random callback to the canonical 8-hex form", () => {
     expect(buildTemporaryWorktreeBranchName(() => "f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12")).toBe(
-      `${WORKTREE_BRANCH_PREFIX}/f4ae4e0e`,
+      `${DEFAULT_WORKTREE_BRANCH_PREFIX}/f4ae4e0e`,
     );
   });
 
   it("matches legacy UUID-shaped temporary worktree refs from older mobile builds", () => {
     expect(
-      isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12`),
+      isTemporaryWorktreeBranch(
+        `${DEFAULT_WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12`,
+      ),
     ).toBe(true);
   });
 
   it("rejects UUID-shaped refs that are not RFC 4122 v4", () => {
     // version nibble is not 4
     expect(
-      isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-1d48-b4f2-9cf0aa54ab12`),
+      isTemporaryWorktreeBranch(
+        `${DEFAULT_WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-1d48-b4f2-9cf0aa54ab12`,
+      ),
     ).toBe(false);
     // variant nibble is not [89ab]
     expect(
-      isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-4d48-c4f2-9cf0aa54ab12`),
+      isTemporaryWorktreeBranch(
+        `${DEFAULT_WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-4d48-c4f2-9cf0aa54ab12`,
+      ),
     ).toBe(false);
   });
 
   it("rejects non-temporary refName names", () => {
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
+    expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);
-    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(false);
+    expect(isTemporaryWorktreeBranch(`${DEFAULT_WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(
+      false,
+    );
+    expect(isTemporaryWorktreeBranch("release/20260714")).toBe(false);
+    expect(isTemporaryWorktreeBranch("codex/feature/deadbeef", "codex/team")).toBe(false);
+    expect(isTemporaryWorktreeBranch("codex/team/release/deadbeef", "codex/team")).toBe(false);
+  });
+});
+
+describe("worktree branch prefixes", () => {
+  it("normalizes user input into a stable Git namespace", () => {
+    expect(normalizeWorktreeBranchPrefix(" refs/heads/Codex Team//Feature/ ")).toBe(
+      "codex-team/feature",
+    );
+    expect(normalizeWorktreeBranchPrefix(" ")).toBe(DEFAULT_WORKTREE_BRANCH_PREFIX);
+  });
+
+  it("uses the configured prefix for temporary and generated branches", () => {
+    expect(buildTemporaryWorktreeBranchName(() => "DEADBEEF", "codex/feature")).toBe(
+      "codex/feature/deadbeef",
+    );
+    expect(extractTemporaryWorktreeBranchPrefix("codex/feature/deadbeef", "codex/feature")).toBe(
+      "codex/feature",
+    );
+    expect(extractTemporaryWorktreeBranchPrefix("t3code/deadbeef", "codex/feature")).toBe(
+      DEFAULT_WORKTREE_BRANCH_PREFIX,
+    );
+    expect(buildGeneratedWorktreeBranchName("codex/feature/add-search", "codex/feature")).toBe(
+      "codex/feature/add-search",
+    );
+    expect(buildGeneratedWorktreeBranchName("Fix Search", "codex/feature")).toBe(
+      "codex/feature/fix-search",
+    );
   });
 });
 

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -5,13 +5,14 @@ import type {
   VcsStatusRemoteResult,
   VcsStatusResult,
   VcsStatusStreamEvent,
+  WorktreeBranchPrefix,
 } from "@t3tools/contracts";
+import { DEFAULT_WORKTREE_BRANCH_PREFIX } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
-export const WORKTREE_BRANCH_PREFIX = "t3code";
-const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(`^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}$`);
+export { DEFAULT_WORKTREE_BRANCH_PREFIX };
 
 /**
  * Sanitize an arbitrary string into a valid, lowercase git refName fragment.
@@ -33,6 +34,59 @@ export function sanitizeBranchFragment(raw: string): string {
     .replace(/[./_-]+$/g, "");
 
   return branchFragment.length > 0 ? branchFragment : "update";
+}
+
+/**
+ * Canonicalize the namespace used for branches created by T3 Code. Keeping
+ * this at the Git boundary makes settings, temporary branches, and generated
+ * names obey the same ref rules.
+ */
+export function normalizeWorktreeBranchPrefix(
+  raw: string | null | undefined,
+): WorktreeBranchPrefix {
+  const normalized = raw
+    ? raw
+        .trim()
+        .toLowerCase()
+        .replace(/^refs\/heads\//, "")
+        .replace(/['"`]/g, "")
+    : "";
+  const prefix = normalized
+    .replace(/[^a-z0-9/_-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/-+/g, "-")
+    .replace(/^[./_-]+|[./_-]+$/g, "")
+    .slice(0, 64)
+    .replace(/[./_-]+$/g, "");
+
+  return prefix.length > 0 ? prefix : DEFAULT_WORKTREE_BRANCH_PREFIX;
+}
+
+export function extractTemporaryWorktreeBranchPrefix(refName: string): WorktreeBranchPrefix | null {
+  const normalized = refName
+    .trim()
+    .toLowerCase()
+    .replace(/^refs\/heads\//, "");
+  const match = /^(?<prefix>.+)\/(?<token>[0-9a-f]{8})$/u.exec(normalized);
+  const prefix = match?.groups?.prefix?.trim();
+  return prefix ? normalizeWorktreeBranchPrefix(prefix) : null;
+}
+
+export function buildGeneratedWorktreeBranchName(
+  raw: string,
+  prefix: string | null | undefined,
+): string {
+  const normalizedPrefix = normalizeWorktreeBranchPrefix(prefix);
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/^refs\/heads\//, "")
+    .replace(/['"`]/g, "");
+  const withoutPrefix = normalized.startsWith(`${normalizedPrefix}/`)
+    ? normalized.slice(`${normalizedPrefix}/`.length)
+    : normalized;
+
+  return `${normalizedPrefix}/${sanitizeBranchFragment(withoutPrefix)}`;
 }
 
 /**
@@ -88,13 +142,14 @@ export function deriveLocalBranchNameFromRemoteRef(branchName: string): string {
 
 export function buildTemporaryWorktreeBranchName(
   randomHex: (byteLength: number) => string,
+  prefix?: string | null,
 ): string {
   const token = randomHex(4).toLowerCase();
-  return `${WORKTREE_BRANCH_PREFIX}/${token}`;
+  return `${normalizeWorktreeBranchPrefix(prefix)}/${token}`;
 }
 
 export function isTemporaryWorktreeBranch(refName: string): boolean {
-  return TEMP_WORKTREE_BRANCH_PATTERN.test(refName.trim().toLowerCase());
+  return extractTemporaryWorktreeBranchPrefix(refName) !== null;
 }
 
 /**

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -62,14 +62,25 @@ export function normalizeWorktreeBranchPrefix(
   return prefix.length > 0 ? prefix : DEFAULT_WORKTREE_BRANCH_PREFIX;
 }
 
-export function extractTemporaryWorktreeBranchPrefix(refName: string): WorktreeBranchPrefix | null {
+/**
+ * Require the configured namespace because an eight-hex suffix alone also
+ * matches ordinary branches such as release dates.
+ */
+export function extractTemporaryWorktreeBranchPrefix(
+  refName: string,
+  expectedPrefix: WorktreeBranchPrefix = DEFAULT_WORKTREE_BRANCH_PREFIX,
+): WorktreeBranchPrefix | null {
   const normalized = refName
     .trim()
     .toLowerCase()
     .replace(/^refs\/heads\//, "");
-  const match = /^(?<prefix>.+)\/(?<token>[0-9a-f]{8})$/u.exec(normalized);
-  const prefix = match?.groups?.prefix?.trim();
-  return prefix ? normalizeWorktreeBranchPrefix(prefix) : null;
+  const prefixWithSeparator = `${expectedPrefix}/`;
+  if (!normalized.startsWith(prefixWithSeparator)) {
+    return null;
+  }
+
+  const token = normalized.slice(prefixWithSeparator.length);
+  return /^[0-9a-f]{8}$/u.test(token) ? expectedPrefix : null;
 }
 
 export function buildGeneratedWorktreeBranchName(
@@ -148,8 +159,11 @@ export function buildTemporaryWorktreeBranchName(
   return `${normalizeWorktreeBranchPrefix(prefix)}/${token}`;
 }
 
-export function isTemporaryWorktreeBranch(refName: string): boolean {
-  return extractTemporaryWorktreeBranchPrefix(refName) !== null;
+export function isTemporaryWorktreeBranch(
+  refName: string,
+  expectedPrefix: WorktreeBranchPrefix = DEFAULT_WORKTREE_BRANCH_PREFIX,
+): boolean {
+  return extractTemporaryWorktreeBranchPrefix(refName, expectedPrefix) !== null;
 }
 
 /**

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -63,8 +63,8 @@ export function normalizeWorktreeBranchPrefix(
 }
 
 /**
- * Require the configured namespace because an eight-hex suffix alone also
- * matches ordinary branches such as release dates.
+ * Limit temporary branch detection to the configured namespace or the legacy
+ * default so ordinary branches with an eight-hex suffix remain untouched.
  */
 export function extractTemporaryWorktreeBranchPrefix(
   refName: string,
@@ -74,13 +74,22 @@ export function extractTemporaryWorktreeBranchPrefix(
     .trim()
     .toLowerCase()
     .replace(/^refs\/heads\//, "");
-  const prefixWithSeparator = `${expectedPrefix}/`;
-  if (!normalized.startsWith(prefixWithSeparator)) {
-    return null;
-  }
+  const matchPrefix = (prefix: WorktreeBranchPrefix): WorktreeBranchPrefix | null => {
+    const prefixWithSeparator = `${prefix}/`;
+    if (!normalized.startsWith(prefixWithSeparator)) {
+      return null;
+    }
 
-  const token = normalized.slice(prefixWithSeparator.length);
-  return /^[0-9a-f]{8}$/u.test(token) ? expectedPrefix : null;
+    const token = normalized.slice(prefixWithSeparator.length);
+    return /^[0-9a-f]{8}$/u.test(token) ? prefix : null;
+  };
+
+  return (
+    matchPrefix(expectedPrefix) ??
+    (expectedPrefix === DEFAULT_WORKTREE_BRANCH_PREFIX
+      ? null
+      : matchPrefix(DEFAULT_WORKTREE_BRANCH_PREFIX))
+  );
 }
 
 export function buildGeneratedWorktreeBranchName(

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -5,19 +5,21 @@ import type {
   VcsStatusRemoteResult,
   VcsStatusResult,
   VcsStatusStreamEvent,
+  WorktreeBranchPrefix,
 } from "@t3tools/contracts";
+import { DEFAULT_WORKTREE_BRANCH_PREFIX } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
-export const WORKTREE_BRANCH_PREFIX = "t3code";
-// Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
+export { DEFAULT_WORKTREE_BRANCH_PREFIX };
+
+// Canonical form is `<prefix>/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
 // via Crypto.randomUUID() (always RFC 4122 v4), so the matcher also accepts exactly
 // that shape — version nibble `4`, variant nibble `[89ab]` — to keep those threads
 // eligible for branch regeneration without loosening beyond what was ever generated.
-const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(
-  `^${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$`,
-);
+const TEMP_WORKTREE_BRANCH_TOKEN_PATTERN =
+  /^(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/;
 
 /**
  * Sanitize an arbitrary string into a valid, lowercase git refName fragment.
@@ -39,6 +41,79 @@ export function sanitizeBranchFragment(raw: string): string {
     .replace(/[./_-]+$/g, "");
 
   return branchFragment.length > 0 ? branchFragment : "update";
+}
+
+/**
+ * Canonicalize the namespace used for branches created by T3 Code. Keeping
+ * this at the Git boundary makes settings, temporary branches, and generated
+ * names obey the same ref rules.
+ */
+export function normalizeWorktreeBranchPrefix(
+  raw: string | null | undefined,
+): WorktreeBranchPrefix {
+  const normalized = raw
+    ? raw
+        .trim()
+        .toLowerCase()
+        .replace(/^refs\/heads\//, "")
+        .replace(/['"`]/g, "")
+    : "";
+  const prefix = normalized
+    .replace(/[^a-z0-9/_-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/-+/g, "-")
+    .replace(/^[./_-]+|[./_-]+$/g, "")
+    .slice(0, 64)
+    .replace(/[./_-]+$/g, "");
+
+  return prefix.length > 0 ? prefix : DEFAULT_WORKTREE_BRANCH_PREFIX;
+}
+
+/**
+ * Limit temporary branch detection to the configured namespace or the legacy
+ * default so ordinary branches with an eight-hex suffix remain untouched.
+ */
+export function extractTemporaryWorktreeBranchPrefix(
+  refName: string,
+  expectedPrefix: WorktreeBranchPrefix = DEFAULT_WORKTREE_BRANCH_PREFIX,
+): WorktreeBranchPrefix | null {
+  const normalized = refName
+    .trim()
+    .toLowerCase()
+    .replace(/^refs\/heads\//, "");
+  const matchPrefix = (prefix: WorktreeBranchPrefix): WorktreeBranchPrefix | null => {
+    const prefixWithSeparator = `${prefix}/`;
+    if (!normalized.startsWith(prefixWithSeparator)) {
+      return null;
+    }
+
+    const token = normalized.slice(prefixWithSeparator.length);
+    return TEMP_WORKTREE_BRANCH_TOKEN_PATTERN.test(token) ? prefix : null;
+  };
+
+  return (
+    matchPrefix(expectedPrefix) ??
+    (expectedPrefix === DEFAULT_WORKTREE_BRANCH_PREFIX
+      ? null
+      : matchPrefix(DEFAULT_WORKTREE_BRANCH_PREFIX))
+  );
+}
+
+export function buildGeneratedWorktreeBranchName(
+  raw: string,
+  prefix: string | null | undefined,
+): string {
+  const normalizedPrefix = normalizeWorktreeBranchPrefix(prefix);
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/^refs\/heads\//, "")
+    .replace(/['"`]/g, "");
+  const withoutPrefix = normalized.startsWith(`${normalizedPrefix}/`)
+    ? normalized.slice(`${normalizedPrefix}/`.length)
+    : normalized;
+
+  return `${normalizedPrefix}/${sanitizeBranchFragment(withoutPrefix)}`;
 }
 
 /**
@@ -94,6 +169,7 @@ export function deriveLocalBranchNameFromRemoteRef(branchName: string): string {
 
 export function buildTemporaryWorktreeBranchName(
   randomHex: (byteLength: number) => string,
+  prefix?: string | null,
 ): string {
   // Normalize to exactly 8 lowercase hex chars so a UUID-shaped callback
   // still produces the canonical temporary branch form.
@@ -101,11 +177,14 @@ export function buildTemporaryWorktreeBranchName(
     .toLowerCase()
     .replace(/[^0-9a-f]/g, "")
     .slice(0, 8);
-  return `${WORKTREE_BRANCH_PREFIX}/${token}`;
+  return `${normalizeWorktreeBranchPrefix(prefix)}/${token}`;
 }
 
-export function isTemporaryWorktreeBranch(refName: string): boolean {
-  return TEMP_WORKTREE_BRANCH_PATTERN.test(refName.trim().toLowerCase());
+export function isTemporaryWorktreeBranch(
+  refName: string,
+  expectedPrefix: WorktreeBranchPrefix = DEFAULT_WORKTREE_BRANCH_PREFIX,
+): boolean {
+  return extractTemporaryWorktreeBranchPrefix(refName, expectedPrefix) !== null;
 }
 
 /**


### PR DESCRIPTION
## What Changed

- Added a persisted `worktreeBranchPrefix` setting with `t3code` as the default.
- Added a "Branch prefix" field below "Start from origin" when new threads use worktrees.
- Applied the configured prefix to temporary worktree branches and preserved it during the first-turn branch rename.
- Centralized branch construction and detection in shared git utilities, with focused contract, utility, and reactor tests.
- Rebased onto current main: kept the legacy UUID-shaped temporary branch matcher and the source control writer model selection, and registered the new field in settings search.
- Applied the prefix to the call sites main added since the original branch: mobile thread creation (draft screen and outbox drain) and the checkpoint reactor's branch drift check.

## Why

New worktrees currently force every generated branch into the `t3code/` namespace. That leaks the tool name into repository state and conflicts with teams that require their own branch naming conventions.

This implements the smallest useful scope requested in #3651: one persisted prefix setting that covers both temporary branch creation and the generated branch rename. It also addresses the configurable-prefix path discussed in #272.

Closes #3651
Related to #272

## UI Changes

**Before:**

_Note: taken from the app._

<img width="1235" height="776" alt="image" src="https://github.com/user-attachments/assets/3f54dac7-a3e8-4902-82e4-fd66f1003994" />

**After:**

_Note: taken from the dev server launched in the Codex browser, so minor other differences from the app screenshot above._

<img width="2420" height="1742" alt="image" src="https://github.com/user-attachments/assets/cc32567a-983c-4b3f-b868-1039c09bbe5e" />


<img width="2420" height="1742" alt="image" src="https://github.com/user-attachments/assets/6a96bb4b-892d-44f6-86df-298b8d087d36" />


## Testing

- Typecheck for contracts, shared, client-runtime, server, web, and mobile.
- `vp test run packages/contracts/src/settings.test.ts packages/shared/src/git.test.ts apps/web/src/components/GitActionsControl.logic.test.ts apps/web/src/components/settings/settingsSearch.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/orchestration/Layers/CheckpointReactor.test.ts` (195 tests)
- `vp fmt` and `vp lint` on the touched files.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] A video is not applicable because the change does not depend on animation or interaction timing

Co-authored-by: Codex <noreply@openai.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make worktree branch prefix configurable across shared git utilities and callers
> - Adds `worktreeBranchPrefix` to `ServerSettings` with default `t3code`, a validation schema (`WorktreeBranchPrefix`), and `DEFAULT_WORKTREE_BRANCH_PREFIX` in [settings.ts](https://github.com/pingdotgg/t3code/pull/3954/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c)
> - Updates [git.ts](https://github.com/pingdotgg/t3code/pull/3954/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) so `buildTemporaryWorktreeBranchName`, `isTemporaryWorktreeBranch`, `extractTemporaryWorktreeBranchPrefix`, and `buildGeneratedWorktreeBranchName` all accept and respect a configurable prefix instead of the old hardcoded `WORKTREE_BRANCH_PREFIX`
> - Updates all callers (mobile, web, server orchestration, client-runtime) to derive the prefix from server config and pass it through branch creation and reconciliation paths
> - Adds a settings UI input row in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/3954/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) with normalization and reset-to-default support
> - Behavioral Change: `resolveLiveThreadBranchUpdate` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/3954/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) and [gitActions.ts](https://github.com/pingdotgg/t3code/pull/3954/files#diff-056843e714dffa8cdcebb4fdb83cbed68894e82a446be8f7fb85a220a841b4d0) now requires `worktreeBranchPrefix`; reconciliation early-returns in `GitActionsControl` until the prefix is loaded. `CheckpointReactor` drift-following and `ProviderCommandReactor` branch rename now classify temporary branches using the configured prefix. The old constant `WORKTREE_BRANCH_PREFIX` is removed from `packages/shared/src/git.ts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2091ae0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git branch naming, first-turn rename, and live branch reconciliation across web, mobile, and server. Misclassification of temporary vs semantic branches could persist the wrong ref, but the change is well-tested and defaults to the existing `t3code` prefix.
> 
> **Overview**
> Lets teams choose the Git namespace for new worktrees instead of always using `t3code/`. A persisted `worktreeBranchPrefix` setting (default `t3code`, validated as a lowercase Git namespace) drives both placeholder branches and the first-turn generated rename.
> 
> Shared git helpers now take the prefix: temporary detection still matches the configured namespace *or* the legacy default, so stale `t3code/<hex>` checkouts still rename into the new prefix. Web, mobile (including outbox drain), and the checkpoint/provider reactors all pass the setting through.
> 
> General settings adds a **Branch prefix** field under new-worktree mode. Live branch reconciliation waits for server config so it does not treat a custom-prefix placeholder as a semantic branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2091ae03fccb934f11b443ae0cd342627524c1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

