### PR TITLE
WIP: Better defaults for worktree vs local checkout

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -20,6 +20,7 @@ const clientSettings: ClientSettings = {
   diffIgnoreWhitespace: true,
   favorites: [],
   providerModelPreferences: {},
+  projectThreadEnvModeOverrides: {},
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -617,6 +617,13 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     if (workspaceMode !== "worktree" || selectedBranchName !== null) {
       return;
     }
+    // Wait for the environment's settings before auto-writing a workspace
+    // selection: selectBranch persists the current mode into the draft, and
+    // doing that against the pre-config fallback would freeze the wrong
+    // default once the real settings arrive.
+    if (environmentSettings === undefined) {
+      return;
+    }
     const preferredBranch =
       availableBranches.find((branch) => branch.current) ??
       availableBranches.find((branch) => branch.isDefault) ??
@@ -624,7 +631,7 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     if (preferredBranch) {
       selectBranch(preferredBranch);
     }
-  }, [availableBranches, selectBranch, selectedBranchName, workspaceMode]);
+  }, [availableBranches, environmentSettings, selectBranch, selectedBranchName, workspaceMode]);
 
   const setRuntimeMode = useCallback(
     (value: RuntimeMode) => {

--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -12,9 +12,11 @@ import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
+  DEFAULT_SERVER_SETTINGS,
   MessageId,
   ThreadId,
 } from "@t3tools/contracts";
+import { resolveDefaultThreadEnvMode } from "@t3tools/shared/threadEnvMode";
 import * as Arr from "effect/Array";
 import { pipe } from "effect/Function";
 
@@ -345,10 +347,28 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const selectedProjectDraft = useComposerDraft(selectedProjectDraftKey);
   const prompt = selectedProjectDraft.text;
   const attachments = selectedProjectDraft.attachments;
-  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? "local";
+  // Mobile is a detached surface — there is no local checkout in front of
+  // the user — so surface derivation (the default) resolves to an isolated
+  // worktree pinned to the latest remote base. An explicit
+  // defaultThreadEnvMode in the environment settings still applies, and
+  // "Local" remains an explicit per-draft exception.
+  const environmentSettings = selectedEnvironmentServerConfig?.settings;
+  const defaultWorkspaceMode = resolveDefaultThreadEnvMode({
+    deriveFromSurface:
+      environmentSettings?.deriveThreadEnvModeFromSurface ??
+      DEFAULT_SERVER_SETTINGS.deriveThreadEnvModeFromSurface,
+    configuredMode:
+      environmentSettings?.defaultThreadEnvMode ?? DEFAULT_SERVER_SETTINGS.defaultThreadEnvMode,
+    surface: "detached",
+  });
+  const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? defaultWorkspaceMode;
   const selectedBranchName = selectedProjectDraft.workspaceSelection?.branch ?? null;
   const selectedWorktreePath = selectedProjectDraft.workspaceSelection?.worktreePath ?? null;
-  const startFromOrigin = selectedProjectDraft.workspaceSelection?.startFromOrigin ?? false;
+  const startFromOrigin =
+    selectedProjectDraft.workspaceSelection?.startFromOrigin ??
+    (workspaceMode === "worktree" &&
+      (environmentSettings?.newWorktreesStartFromOrigin ??
+        DEFAULT_SERVER_SETTINGS.newWorktreesStartFromOrigin));
   const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode = selectedProjectDraft.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE;
 
@@ -667,7 +687,9 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         return null;
       }
       const workspaceSelection = draft.workspaceSelection;
-      const mode = workspaceSelection?.mode ?? "local";
+      const mode = workspaceSelection?.mode ?? defaultWorkspaceMode;
+      const pendingStartFromOrigin =
+        workspaceSelection?.startFromOrigin ?? (mode === "worktree" && startFromOrigin);
       // When the selection is the stand-in built from the queued snapshot,
       // persist the original (possibly absent) snapshot values — the
       // stand-in's placeholder title/workspaceRoot must never be written back
@@ -696,17 +718,19 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
           workspaceMode: mode,
           branch: workspaceSelection?.branch ?? null,
           worktreePath: mode === "worktree" ? null : (workspaceSelection?.worktreePath ?? null),
-          ...(workspaceSelection?.startFromOrigin ? { startFromOrigin: true } : {}),
+          ...(pendingStartFromOrigin ? { startFromOrigin: true } : {}),
         },
         createdAt: metadata.createdAt,
       };
     },
     [
+      defaultWorkspaceMode,
       editingPendingProject,
       editingPendingTask,
       selectedModel,
       selectedProject,
       selectedProjectDraftKey,
+      startFromOrigin,
     ],
   );
 

--- a/apps/mobile/src/features/threads/use-project-actions.ts
+++ b/apps/mobile/src/features/threads/use-project-actions.ts
@@ -9,7 +9,7 @@ import {
   type ProviderInteractionMode,
   type RuntimeMode,
 } from "@t3tools/contracts";
-import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import { buildThreadWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 
@@ -74,7 +74,7 @@ export function useCreateProjectThread() {
           branch: input.branch,
           worktreePath: input.worktreePath,
           startFromOrigin: input.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+          worktreeBranchName: buildThreadWorktreeBranchName(metadata.threadId, randomHex),
         }),
       });
       if (AsyncResult.isFailure(result)) {

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_RUNTIME_MODE,
   type MessageId,
 } from "@t3tools/contracts";
-import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import { buildThreadWorktreeBranchName } from "@t3tools/shared/git";
 import * as Cause from "effect/Cause";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -269,7 +269,7 @@ export function useThreadOutboxDrain(): void {
           branch: creation.branch,
           worktreePath: creation.worktreePath,
           startFromOrigin: creation.startFromOrigin ?? false,
-          worktreeBranchName: buildTemporaryWorktreeBranchName(randomHex),
+          worktreeBranchName: buildThreadWorktreeBranchName(queuedMessage.threadId, randomHex),
         }),
       });
       return completeDelivery(deliveryResult);

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -42,6 +42,7 @@ export interface ServerDerivedPaths {
   readonly anonymousIdPath: string;
   readonly environmentIdPath: string;
   readonly serverRuntimeStatePath: string;
+  readonly worktreeRegistryPath: string;
   readonly secretsDir: string;
 }
 
@@ -116,6 +117,7 @@ export const deriveServerPaths = Effect.fn(function* (
     anonymousIdPath: join(stateDir, "anonymous-id"),
     environmentIdPath: join(stateDir, "environment-id"),
     serverRuntimeStatePath: join(stateDir, "server-runtime.json"),
+    worktreeRegistryPath: join(stateDir, "worktree-registry.json"),
     secretsDir: join(stateDir, "secrets"),
   };
 });

--- a/apps/server/src/git/WorktreeBasePlanner.ts
+++ b/apps/server/src/git/WorktreeBasePlanner.ts
@@ -108,10 +108,13 @@ export const make = Effect.gen(function* () {
   const runDedupedFetch = (cwd: string): Effect.Effect<boolean> =>
     Effect.gen(function* () {
       const state = getState(cwd);
-      if (state.inFlight) {
-        return yield* Deferred.await(state.inFlight);
+      const existingInFlight = state.inFlight;
+      if (existingInFlight) {
+        return yield* Deferred.await(existingInFlight);
       }
-      const inFlight = yield* Deferred.make<boolean>();
+      // Claim the slot synchronously (no suspension between the check above
+      // and this assignment) so concurrent callers can't both start a fetch.
+      const inFlight = Deferred.makeUnsafe<boolean>();
       state.inFlight = inFlight;
       return yield* gitWorkflow.fetchRemote({ cwd, remoteName: "origin" }).pipe(
         Effect.flatMap(() =>

--- a/apps/server/src/git/WorktreeBasePlanner.ts
+++ b/apps/server/src/git/WorktreeBasePlanner.ts
@@ -1,0 +1,200 @@
+import {
+  GitCommandError,
+  WORKTREE_BASE_FRESHNESS_WINDOW,
+  WORKTREE_BASE_USABLE_HORIZON,
+  type WorktreeBaseProvenance,
+} from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+
+import * as GitWorkflowService from "./GitWorkflowService.ts";
+
+export interface WorktreeBasePin {
+  /** Commit SHA the new worktree is created from. */
+  readonly commitSha: string;
+  /** Remote-tracking ref the SHA was resolved from. */
+  readonly remoteRefName: string;
+  readonly provenance: WorktreeBaseProvenance;
+  /** Time of the successful fetch backing this pin (null when unknown). */
+  readonly fetchedAt: string | null;
+}
+
+export interface EnsureFreshRemoteResult {
+  readonly fetchedAt: string | null;
+  readonly fetchSucceeded: boolean;
+}
+
+/**
+ * Plans the base commit for new worktree threads.
+ *
+ * Freshness ladder ("always current" without a blocking fetch on every send):
+ * 1. A fetch of the repo's primary remote within {@link WORKTREE_BASE_FRESHNESS_WINDOW}
+ *    counts as fresh — pin the remote-tracking commit immediately.
+ * 2. Otherwise fetch now (deduped per repository: concurrent sends and the
+ *    composer-open prefetch share one in-flight fetch).
+ * 3. If that fetch fails but the last successful fetch is within
+ *    {@link WORKTREE_BASE_USABLE_HORIZON}, proceed on the last-known remote
+ *    commit with `provenance: "stale"` (fail-visible).
+ * 4. With no usable fetch, fail closed — the caller surfaces the error and
+ *    never silently falls back to a local ref.
+ */
+export class WorktreeBasePlanner extends Context.Service<
+  WorktreeBasePlanner,
+  {
+    /**
+     * Fetch the repository's primary remote unless a successful fetch is
+     * already within the freshness window. Never fails: fetch failures are
+     * reported through `fetchSucceeded` so composer-open prefetches are
+     * fire-and-forget.
+     */
+    readonly ensureFreshRemote: (input: {
+      readonly cwd: string;
+    }) => Effect.Effect<EnsureFreshRemoteResult>;
+
+    /**
+     * Resolve the pinned base commit for a new worktree from `baseRef`,
+     * applying the freshness ladder above.
+     */
+    readonly pinRemoteBase: (input: {
+      readonly cwd: string;
+      readonly baseRef: string;
+    }) => Effect.Effect<WorktreeBasePin, GitCommandError>;
+  }
+>()("t3/git/WorktreeBasePlanner") {}
+
+interface RepoFetchState {
+  /** Completion time of the last successful fetch (ISO). */
+  lastSuccessAt: string | null;
+  /** Shared in-flight fetch so concurrent callers coalesce. */
+  inFlight: Deferred.Deferred<boolean> | null;
+}
+
+export const make = Effect.gen(function* () {
+  const gitWorkflow = yield* GitWorkflowService.GitWorkflowService;
+
+  // Keyed by cwd. Bootstraps and the composer-open prefetch always pass the
+  // project root, so a per-cwd key deduplicates the flows that matter.
+  const fetchStateByCwd = new Map<string, RepoFetchState>();
+
+  const getState = (cwd: string): RepoFetchState => {
+    const existing = fetchStateByCwd.get(cwd);
+    if (existing) {
+      return existing;
+    }
+    const created: RepoFetchState = { lastSuccessAt: null, inFlight: null };
+    fetchStateByCwd.set(cwd, created);
+    return created;
+  };
+
+  const isWithin = (isoTime: string | null, window: Duration.Duration): Effect.Effect<boolean> =>
+    Effect.gen(function* () {
+      if (isoTime === null) {
+        return false;
+      }
+      const at = Date.parse(isoTime);
+      if (Number.isNaN(at)) {
+        return false;
+      }
+      const now = yield* Clock.currentTimeMillis;
+      return now - at <= Duration.toMillis(window);
+    });
+
+  const runDedupedFetch = (cwd: string): Effect.Effect<boolean> =>
+    Effect.gen(function* () {
+      const state = getState(cwd);
+      if (state.inFlight) {
+        return yield* Deferred.await(state.inFlight);
+      }
+      const inFlight = yield* Deferred.make<boolean>();
+      state.inFlight = inFlight;
+      return yield* gitWorkflow.fetchRemote({ cwd, remoteName: "origin" }).pipe(
+        Effect.flatMap(() =>
+          DateTime.now.pipe(
+            Effect.map((now) => {
+              state.lastSuccessAt = DateTime.formatIso(now);
+              return true;
+            }),
+          ),
+        ),
+        Effect.catch((error) =>
+          Effect.logDebug("worktree base fetch failed", {
+            cwd,
+            detail: error.message,
+          }).pipe(Effect.map(() => false)),
+        ),
+        Effect.onExit((exit) => {
+          state.inFlight = null;
+          return Deferred.done(inFlight, Exit.isSuccess(exit) ? exit : Exit.succeed(false)).pipe(
+            Effect.asVoid,
+          );
+        }),
+      );
+    });
+
+  const ensureFreshRemote: WorktreeBasePlanner["Service"]["ensureFreshRemote"] = Effect.fn(
+    "WorktreeBasePlanner.ensureFreshRemote",
+  )(function* (input) {
+    const state = getState(input.cwd);
+    if (yield* isWithin(state.lastSuccessAt, WORKTREE_BASE_FRESHNESS_WINDOW)) {
+      return { fetchedAt: state.lastSuccessAt, fetchSucceeded: true };
+    }
+    const fetchSucceeded = yield* runDedupedFetch(input.cwd);
+    return { fetchedAt: state.lastSuccessAt, fetchSucceeded };
+  });
+
+  const pinRemoteBase: WorktreeBasePlanner["Service"]["pinRemoteBase"] = Effect.fn(
+    "WorktreeBasePlanner.pinRemoteBase",
+  )(function* (input) {
+    const { fetchedAt, fetchSucceeded } = yield* ensureFreshRemote({ cwd: input.cwd });
+
+    const resolvePin = (provenance: WorktreeBaseProvenance) =>
+      gitWorkflow
+        .resolveRemoteTrackingCommit({
+          cwd: input.cwd,
+          refName: input.baseRef,
+          fallbackRemoteName: "origin",
+        })
+        .pipe(
+          Effect.map(
+            (resolved): WorktreeBasePin => ({
+              commitSha: resolved.commitSha,
+              remoteRefName: resolved.remoteRefName,
+              provenance,
+              fetchedAt,
+            }),
+          ),
+        );
+
+    if (fetchSucceeded) {
+      return yield* resolvePin("fresh");
+    }
+
+    // Fail-visible: the remote is unreachable, but a recent fetch means the
+    // remote-tracking ref is still a sane base. Proceed with stale provenance.
+    if (yield* isWithin(fetchedAt, WORKTREE_BASE_USABLE_HORIZON)) {
+      return yield* resolvePin("stale");
+    }
+
+    // Fail closed: no usable remote data. The caller must not silently fall
+    // back to a local ref — surfacing this error is the contract.
+    return yield* new GitCommandError({
+      operation: "WorktreeBasePlanner.pinRemoteBase",
+      command: "fetch",
+      cwd: input.cwd,
+      detail: `Couldn't prepare a fresh worktree from ${input.baseRef}: the remote could not be reached and no recent fetch is available. Nothing has started and your checkout was not modified.`,
+    });
+  });
+
+  return WorktreeBasePlanner.of({
+    ensureFreshRemote,
+    pinRemoteBase,
+  });
+});
+
+export const layer = Layer.effect(WorktreeBasePlanner, make);

--- a/apps/server/src/git/WorktreeRegistry.ts
+++ b/apps/server/src/git/WorktreeRegistry.ts
@@ -83,7 +83,9 @@ export const make = Effect.gen(function* () {
     return decoded.value;
   });
 
-  const getRegistry = Effect.gen(function* () {
+  // All reads and writes take the semaphore so a first-access disk load can
+  // never overwrite in-memory state that a concurrent mutation just wrote.
+  const getRegistryLocked = Effect.gen(function* () {
     const loaded = yield* Ref.get(loadedRef);
     if (loaded !== null) {
       return loaded;
@@ -93,14 +95,15 @@ export const make = Effect.gen(function* () {
     return fromDisk;
   });
 
+  const getRegistry = Semaphore.withPermit(writeSemaphore)(getRegistryLocked);
+
   const mutate = (
     update: (current: WorktreeRegistryFile) => WorktreeRegistryFile,
   ): Effect.Effect<void> =>
     Semaphore.withPermit(writeSemaphore)(
       Effect.gen(function* () {
-        const current = yield* getRegistry;
+        const current = yield* getRegistryLocked;
         const next = update(current);
-        yield* Ref.set(loadedRef, next);
         const contents = yield* encodeRegistryJson(next);
         yield* writeFileStringAtomically({
           filePath: worktreeRegistryPath,
@@ -109,6 +112,9 @@ export const make = Effect.gen(function* () {
           Effect.provideService(FileSystem.FileSystem, fs),
           Effect.provideService(Path.Path, path),
         );
+        // Memory reflects disk only after the persist succeeds, so `list`
+        // never reports an association that was never durably recorded.
+        yield* Ref.set(loadedRef, next);
       }),
     ).pipe(
       Effect.catchCause((cause) =>

--- a/apps/server/src/git/WorktreeRegistry.ts
+++ b/apps/server/src/git/WorktreeRegistry.ts
@@ -1,0 +1,148 @@
+import { ThreadId, WorktreeBaseProvenance } from "@t3tools/contracts";
+import { fromJsonStringPretty, fromLenientJson } from "@t3tools/shared/schemaJson";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+
+import { writeFileStringAtomically } from "../atomicWrite.ts";
+import * as ServerConfig from "../config.ts";
+
+export const WorktreeRegistryStatus = Schema.Literals(["active", "thread-deleted"]);
+export type WorktreeRegistryStatus = typeof WorktreeRegistryStatus.Type;
+
+/**
+ * One record per worktree this server created for a thread. The registry is
+ * the durable worktree ↔ thread association: attribution never depends on
+ * scanning paths or parsing branch names, which makes lifecycle/GC tooling
+ * cheap to build later.
+ */
+export const WorktreeRegistryRecord = Schema.Struct({
+  threadId: ThreadId,
+  worktreePath: Schema.String,
+  branch: Schema.String,
+  projectCwd: Schema.String,
+  baseRefName: Schema.NullOr(Schema.String),
+  baseCommitSha: Schema.NullOr(Schema.String),
+  baseProvenance: Schema.NullOr(WorktreeBaseProvenance),
+  createdAt: Schema.String,
+  status: WorktreeRegistryStatus,
+});
+export type WorktreeRegistryRecord = typeof WorktreeRegistryRecord.Type;
+
+const WorktreeRegistryFile = Schema.Struct({
+  version: Schema.Number.pipe(Schema.withDecodingDefault(Effect.succeed(1))),
+  worktrees: Schema.Array(WorktreeRegistryRecord).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+});
+type WorktreeRegistryFile = typeof WorktreeRegistryFile.Type;
+
+const decodeRegistryExit = Schema.decodeUnknownExit(fromLenientJson(WorktreeRegistryFile));
+const encodeRegistryJson = Schema.encodeEffect(fromJsonStringPretty(WorktreeRegistryFile));
+
+const EMPTY_REGISTRY: WorktreeRegistryFile = { version: 1, worktrees: [] };
+
+export class WorktreeRegistry extends Context.Service<
+  WorktreeRegistry,
+  {
+    /** Record (or refresh) the worktree created for a thread. Never fails. */
+    readonly register: (record: Omit<WorktreeRegistryRecord, "status">) => Effect.Effect<void>;
+    /** Mark all records for a thread as belonging to a deleted thread. Never fails. */
+    readonly markThreadDeleted: (threadId: ThreadId) => Effect.Effect<void>;
+    /** Remove records whose worktree path was removed from disk. Never fails. */
+    readonly unregisterPath: (worktreePath: string) => Effect.Effect<void>;
+    readonly list: Effect.Effect<ReadonlyArray<WorktreeRegistryRecord>>;
+  }
+>()("t3/git/WorktreeRegistry") {}
+
+export const make = Effect.gen(function* () {
+  const { worktreeRegistryPath } = yield* ServerConfig.ServerConfig;
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const writeSemaphore = yield* Semaphore.make(1);
+  const loadedRef = yield* Ref.make<WorktreeRegistryFile | null>(null);
+
+  const loadFromDisk = Effect.gen(function* () {
+    const exists = yield* fs.exists(worktreeRegistryPath);
+    if (!exists) {
+      return EMPTY_REGISTRY;
+    }
+    const raw = yield* fs.readFileString(worktreeRegistryPath);
+    const decoded = decodeRegistryExit(raw);
+    if (decoded._tag === "Failure") {
+      yield* Effect.logWarning("failed to parse worktree registry, starting fresh", {
+        path: worktreeRegistryPath,
+      });
+      return EMPTY_REGISTRY;
+    }
+    return decoded.value;
+  });
+
+  const getRegistry = Effect.gen(function* () {
+    const loaded = yield* Ref.get(loadedRef);
+    if (loaded !== null) {
+      return loaded;
+    }
+    const fromDisk = yield* loadFromDisk;
+    yield* Ref.set(loadedRef, fromDisk);
+    return fromDisk;
+  });
+
+  const mutate = (
+    update: (current: WorktreeRegistryFile) => WorktreeRegistryFile,
+  ): Effect.Effect<void> =>
+    Semaphore.withPermit(writeSemaphore)(
+      Effect.gen(function* () {
+        const current = yield* getRegistry;
+        const next = update(current);
+        yield* Ref.set(loadedRef, next);
+        const contents = yield* encodeRegistryJson(next);
+        yield* writeFileStringAtomically({
+          filePath: worktreeRegistryPath,
+          contents,
+        }).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+        );
+      }),
+    ).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to persist worktree registry", { cause }),
+      ),
+      Effect.asVoid,
+    );
+
+  return WorktreeRegistry.of({
+    register: (record) =>
+      mutate((current) => ({
+        ...current,
+        worktrees: [
+          ...current.worktrees.filter((entry) => entry.worktreePath !== record.worktreePath),
+          { ...record, status: "active" },
+        ],
+      })),
+    markThreadDeleted: (threadId) =>
+      mutate((current) => ({
+        ...current,
+        worktrees: current.worktrees.map((entry) =>
+          entry.threadId === threadId ? { ...entry, status: "thread-deleted" as const } : entry,
+        ),
+      })),
+    unregisterPath: (worktreePath) =>
+      mutate((current) => ({
+        ...current,
+        worktrees: current.worktrees.filter((entry) => entry.worktreePath !== worktreePath),
+      })),
+    list: getRegistry.pipe(
+      Effect.map((registry) => registry.worktrees),
+      Effect.orElseSucceed(() => []),
+    ),
+  });
+});
+
+export const layer = Layer.effect(WorktreeRegistry, make);

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
 
+import * as WorktreeRegistry from "../../git/WorktreeRegistry.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import * as TerminalManager from "../../terminal/Manager.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
@@ -40,6 +41,7 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const providerService = yield* ProviderService;
   const terminalManager = yield* TerminalManager.TerminalManager;
+  const worktreeRegistry = yield* WorktreeRegistry.WorktreeRegistry;
 
   const stopProviderSession = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
     logCleanupCauseUnlessInterrupted({
@@ -61,6 +63,8 @@ const make = Effect.gen(function* () {
     const { threadId } = event.payload;
     yield* stopProviderSession(threadId);
     yield* closeThreadTerminals(threadId);
+    // Keep the record for future GC tooling; just mark it unowned.
+    yield* worktreeRegistry.markThreadDeleted(threadId);
   });
 
   const processThreadDeletedSafely = (event: ThreadDeletedEvent) =>

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -103,6 +103,8 @@ import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
+import * as WorktreeBasePlanner from "./git/WorktreeBasePlanner.ts";
+import * as WorktreeRegistry from "./git/WorktreeRegistry.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
@@ -503,6 +505,10 @@ const buildAppUnderTest = (options?: {
       Layer.provideMerge(gitVcsDriverLayer),
       Layer.provideMerge(gitManagerLayer),
     );
+    const worktreeBasePlannerLayer = WorktreeBasePlanner.layer.pipe(
+      Layer.provide(gitWorkflowLayer),
+    );
+    const worktreeRegistryLayer = WorktreeRegistry.layer;
     const vcsProvisioningLayer = VcsProvisioningService.layer.pipe(
       Layer.provide(vcsDriverRegistryLayer),
     );
@@ -628,7 +634,9 @@ const buildAppUnderTest = (options?: {
       ),
       Layer.provide(gitManagerLayer),
       Layer.provide(gitVcsDriverLayer),
-      Layer.provide(gitWorkflowLayer),
+      Layer.provide(
+        Layer.mergeAll(gitWorkflowLayer, worktreeBasePlannerLayer, worktreeRegistryLayer),
+      ),
       Layer.provide(reviewLayer),
       Layer.provide(vcsProvisioningLayer),
       Layer.provide(
@@ -6224,12 +6232,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           ),
         );
 
-        assert.equal(response.sequence, 5);
+        assert.equal(response.sequence, 6);
         assert.deepEqual(
           dispatchedCommands.map((command) => command.type),
           [
             "thread.create",
             "thread.meta.update",
+            "thread.activity.append",
             "thread.activity.append",
             "thread.activity.append",
             "thread.turn.start",
@@ -6241,6 +6250,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           newRefName: "t3code/bootstrap-refName",
           baseRefName: "main",
           path: null,
+          uniquifyNewRefName: true,
         });
         assert.deepEqual(fetchRemote.mock.calls[0]?.[0], {
           cwd: "/tmp/project",
@@ -6270,9 +6280,21 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         );
         assert.deepEqual(
           setupActivities.map((command) => command.activity.kind),
-          ["setup-script.requested", "setup-script.started"],
+          ["worktree.base-pinned", "setup-script.requested", "setup-script.started"],
         );
-        const finalCommand = dispatchedCommands[4];
+        const basePinnedActivity = setupActivities[0];
+        assert.deepEqual(basePinnedActivity?.activity.payload, {
+          branch: "t3code/bootstrap-refName",
+          worktreePath: "/tmp/bootstrap-worktree",
+          baseRefName: "origin/main",
+          baseCommitSha: fetchedOriginCommit,
+          baseProvenance: "fresh",
+          baseFetchedAt: basePinnedActivity
+            ? (basePinnedActivity.activity.payload as { baseFetchedAt: string | null })
+                .baseFetchedAt
+            : null,
+        });
+        const finalCommand = dispatchedCommands[5];
         assertTrue(finalCommand?.type === "thread.turn.start");
         if (finalCommand?.type === "thread.turn.start") {
           assert.equal(finalCommand.bootstrap, undefined);
@@ -6367,14 +6389,21 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
 
-      assert.equal(response.sequence, 4);
+      assert.equal(response.sequence, 5);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
-        ["thread.create", "thread.meta.update", "thread.activity.append", "thread.turn.start"],
+        [
+          "thread.create",
+          "thread.meta.update",
+          "thread.activity.append",
+          "thread.activity.append",
+          "thread.turn.start",
+        ],
       );
       const setupFailureActivity = dispatchedCommands.find(
         (command): command is Extract<OrchestrationCommand, { type: "thread.activity.append" }> =>
-          command.type === "thread.activity.append",
+          command.type === "thread.activity.append" &&
+          command.activity.kind.startsWith("setup-script."),
       );
       assert.equal(setupFailureActivity?.activity.kind, "setup-script.failed");
       assert.deepEqual(setupFailureActivity?.activity.payload, {
@@ -6488,14 +6517,21 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
 
-      assert.equal(response.sequence, 4);
+      assert.equal(response.sequence, 5);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
-        ["thread.create", "thread.meta.update", "thread.activity.append", "thread.turn.start"],
+        [
+          "thread.create",
+          "thread.meta.update",
+          "thread.activity.append",
+          "thread.activity.append",
+          "thread.turn.start",
+        ],
       );
       const setupActivities = dispatchedCommands.filter(
         (command): command is Extract<OrchestrationCommand, { type: "thread.activity.append" }> =>
-          command.type === "thread.activity.append",
+          command.type === "thread.activity.append" &&
+          command.activity.kind.startsWith("setup-script."),
       );
       assert.deepEqual(
         setupActivities.map((command) => command.activity.kind),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -163,7 +163,11 @@ const ReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(ProviderRuntimeIngestionLive),
   Layer.provideMerge(ProviderCommandReactorLive),
   Layer.provideMerge(CheckpointReactorLive),
-  Layer.provideMerge(ThreadDeletionReactorLive.pipe(Layer.provide(WorktreeRegistry.layer))),
+  // WorktreeRegistry is deliberately NOT provided here: the reactor must
+  // share the single instance from VcsLayerLive (provided downstream in
+  // RuntimeCoreDependenciesLive) so bootstrap registrations and deletion
+  // markings see the same in-memory state.
+  Layer.provideMerge(ThreadDeletionReactorLive),
   Layer.provideMerge(AgentAwarenessRelay.layer.pipe(Layer.provide(ServerSecretStore.layer))),
   Layer.provideMerge(RuntimeReceiptBusLive),
 );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -65,6 +65,8 @@ import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
+import * as WorktreeBasePlanner from "./git/WorktreeBasePlanner.ts";
+import * as WorktreeRegistry from "./git/WorktreeRegistry.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as SourceControlProviderRegistry from "./sourceControl/SourceControlProviderRegistry.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
@@ -161,7 +163,7 @@ const ReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(ProviderRuntimeIngestionLive),
   Layer.provideMerge(ProviderCommandReactorLive),
   Layer.provideMerge(CheckpointReactorLive),
-  Layer.provideMerge(ThreadDeletionReactorLive),
+  Layer.provideMerge(ThreadDeletionReactorLive.pipe(Layer.provide(WorktreeRegistry.layer))),
   Layer.provideMerge(AgentAwarenessRelay.layer.pipe(Layer.provide(ServerSecretStore.layer))),
   Layer.provideMerge(RuntimeReceiptBusLive),
 );
@@ -212,6 +214,10 @@ const GitWorkflowLayerLive = GitWorkflowService.layer.pipe(
   Layer.provideMerge(GitLayerLive),
 );
 
+const WorktreeBasePlannerLayerLive = WorktreeBasePlanner.layer.pipe(
+  Layer.provide(GitWorkflowLayerLive),
+);
+
 const SourceControlRepositoryServiceLayerLive = SourceControlRepositoryService.layer.pipe(
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
@@ -227,6 +233,8 @@ const VcsLayerLive = Layer.empty.pipe(
   Layer.provideMerge(VcsDriverRegistryLayerLive),
   Layer.provideMerge(VcsProvisioningService.layer.pipe(Layer.provide(VcsDriverRegistryLayerLive))),
   Layer.provideMerge(GitWorkflowLayerLive),
+  Layer.provideMerge(WorktreeBasePlannerLayerLive),
+  Layer.provideMerge(WorktreeRegistry.layer),
   Layer.provideMerge(ReviewLayerLive),
   Layer.provideMerge(SourceControlRepositoryServiceLayerLive),
   Layer.provideMerge(VcsStatusBroadcaster.layer.pipe(Layer.provide(GitWorkflowLayerLive))),

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2242,22 +2242,48 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     },
   );
 
+  const resolveAvailableWorktreeBranchName = Effect.fn("resolveAvailableWorktreeBranchName")(
+    function* (cwd: string, desiredBranch: string) {
+      if (!(yield* branchExists(cwd, desiredBranch))) {
+        return desiredBranch;
+      }
+      for (let suffix = 2; suffix <= 100; suffix += 1) {
+        const candidate = `${desiredBranch}-${suffix}`;
+        if (!(yield* branchExists(cwd, candidate))) {
+          return candidate;
+        }
+      }
+      return yield* new GitCommandError({
+        ...gitCommandContext({
+          operation: "GitVcsDriver.createWorktree",
+          cwd,
+          args: ["worktree", "add", "-b", desiredBranch],
+        }),
+        detail: `Could not find an available worktree branch name for '${desiredBranch}'.`,
+      });
+    },
+  );
+
   const createWorktree: GitVcsDriver.GitVcsDriver["Service"]["createWorktree"] = Effect.fn(
     "createWorktree",
   )(function* (input) {
-    const targetBranch = input.newRefName ?? input.refName;
+    const newRefName =
+      input.newRefName !== undefined && input.uniquifyNewRefName
+        ? yield* resolveAvailableWorktreeBranchName(input.cwd, input.newRefName)
+        : input.newRefName;
+    const targetBranch = newRefName ?? input.refName;
     const sanitizedBranch = targetBranch.replace(/\//g, "-");
     const repoName = path.basename(input.cwd);
     const worktreePath = input.path ?? path.join(worktreesDir, repoName, sanitizedBranch);
-    const args = input.newRefName
-      ? ["worktree", "add", "-b", input.newRefName, worktreePath, input.refName]
+    const args = newRefName
+      ? ["worktree", "add", "-b", newRefName, worktreePath, input.refName]
       : ["worktree", "add", worktreePath, input.refName];
 
     yield* executeGit("GitVcsDriver.createWorktree", input.cwd, args, {
       fallbackErrorDetail: "git worktree add failed",
     });
 
-    if (input.newRefName && input.baseRefName) {
+    if (newRefName && input.baseRefName) {
       const remoteNames = yield* listRemoteNames(input.cwd).pipe(Effect.orElseSucceed(() => []));
       const parsedBaseRef = parseRemoteRefWithRemoteNames(
         input.baseRefName,
@@ -2266,7 +2292,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       const baseBranch = parsedBaseRef?.branchName ?? input.baseRefName;
       yield* runGit("GitVcsDriver.createWorktree.configureBaseRef", input.cwd, [
         "config",
-        `branch.${input.newRefName}.gh-merge-base`,
+        `branch.${newRefName}.gh-merge-base`,
         baseBranch,
       ]);
     }

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -91,6 +91,8 @@ import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
+import * as WorktreeBasePlanner from "./git/WorktreeBasePlanner.ts";
+import * as WorktreeRegistry from "./git/WorktreeRegistry.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
@@ -310,6 +312,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.assetsCreateUrl, AuthOrchestrationReadScope],
   [WS_METHODS.subscribeVcsStatus, AuthOrchestrationReadScope],
   [WS_METHODS.vcsRefreshStatus, AuthOrchestrationReadScope],
+  [WS_METHODS.vcsPrefetchRemote, AuthOrchestrationReadScope],
   [WS_METHODS.vcsPull, AuthOrchestrationOperateScope],
   [WS_METHODS.gitRunStackedAction, AuthOrchestrationOperateScope],
   [WS_METHODS.gitResolvePullRequest, AuthOrchestrationOperateScope],
@@ -401,6 +404,8 @@ const makeWsRpcLayer = (
       const keybindings = yield* Keybindings.Keybindings;
       const externalLauncher = yield* ExternalLauncher.ExternalLauncher;
       const gitWorkflow = yield* GitWorkflowService.GitWorkflowService;
+      const worktreeBasePlanner = yield* WorktreeBasePlanner.WorktreeBasePlanner;
+      const worktreeRegistry = yield* WorktreeRegistry.WorktreeRegistry;
       const review = yield* ReviewService.ReviewService;
       const vcsProvisioning = yield* VcsProvisioningService.VcsProvisioningService;
       const vcsStatusBroadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
@@ -527,7 +532,11 @@ const makeWsRpcLayer = (
 
       const appendSetupScriptActivity = (input: {
         readonly threadId: ThreadId;
-        readonly kind: "setup-script.requested" | "setup-script.started" | "setup-script.failed";
+        readonly kind:
+          | "setup-script.requested"
+          | "setup-script.started"
+          | "setup-script.failed"
+          | "worktree.base-pinned";
         readonly summary: string;
         readonly createdAt: string;
         readonly payload: Record<string, unknown>;
@@ -554,6 +563,53 @@ const makeWsRpcLayer = (
               createdAt: input.createdAt,
             }),
           ),
+        );
+
+      /**
+       * Record where a new worktree thread's base came from as a thread
+       * activity — the durable, user-visible provenance ("pinned at <sha>",
+       * and a warning when the remote was unreachable and the last-known
+       * commit was used instead). Never fails the bootstrap.
+       */
+      const appendWorktreeBaseActivity = (input: {
+        readonly threadId: ThreadId;
+        readonly branch: string;
+        readonly worktreePath: string;
+        readonly baseRefName: string;
+        readonly basePin: WorktreeBasePlanner.WorktreeBasePin | null;
+      }) =>
+        Effect.gen(function* () {
+          const createdAt = yield* nowIso;
+          const shortSha = input.basePin?.commitSha.slice(0, 7);
+          const summary =
+            input.basePin === null
+              ? `Created worktree from local ${input.baseRefName}`
+              : input.basePin.provenance === "stale"
+                ? `Remote unreachable — created worktree from last-known ${input.baseRefName} (${shortSha})`
+                : `Created worktree from ${input.baseRefName} (${shortSha})`;
+          yield* appendSetupScriptActivity({
+            threadId: input.threadId,
+            kind: "worktree.base-pinned",
+            summary,
+            createdAt,
+            payload: {
+              branch: input.branch,
+              worktreePath: input.worktreePath,
+              baseRefName: input.baseRefName,
+              baseCommitSha: input.basePin?.commitSha ?? null,
+              baseProvenance: input.basePin?.provenance ?? "local",
+              baseFetchedAt: input.basePin?.fetchedAt ?? null,
+            },
+            tone: input.basePin?.provenance === "stale" ? "error" : "info",
+          });
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to record worktree base provenance activity", {
+              threadId: input.threadId,
+              cause,
+            }),
+          ),
+          Effect.asVoid,
         );
 
       const toBootstrapDispatchCommandCauseError = (cause: Cause.Cause<unknown>) => {
@@ -836,25 +892,28 @@ const makeWsRpcLayer = (
             }
 
             if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
-              if (bootstrap.prepareWorktree.startFromOrigin) {
-                yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
+              const prepareWorktree = bootstrap.prepareWorktree;
+              let worktreeBaseRef = prepareWorktree.baseBranch;
+              let basePin: WorktreeBasePlanner.WorktreeBasePin | null = null;
+              if (prepareWorktree.startFromOrigin) {
+                // Pin the base to a remote commit via the freshness ladder:
+                // fresh fetch → recent fetch (stale, fail-visible) → fail
+                // closed. Never silently falls back to the local ref.
+                basePin = yield* worktreeBasePlanner.pinRemoteBase({
+                  cwd: prepareWorktree.projectCwd,
+                  baseRef: prepareWorktree.baseBranch,
                 });
-                const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  fallbackRemoteName: "origin",
-                });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
+                worktreeBaseRef = basePin.commitSha;
               }
               const worktree = yield* gitWorkflow.createWorktree({
-                cwd: bootstrap.prepareWorktree.projectCwd,
+                cwd: prepareWorktree.projectCwd,
                 refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
-                baseRefName: bootstrap.prepareWorktree.baseBranch,
+                newRefName: prepareWorktree.branch,
+                baseRefName: prepareWorktree.baseBranch,
                 path: null,
+                // Branch names derive from the thread id, so a resend after a
+                // partial failure may find the branch already exists.
+                uniquifyNewRefName: true,
               });
               targetWorktreePath = worktree.worktree.path;
               yield* orchestrationEngine.dispatch({
@@ -863,6 +922,24 @@ const makeWsRpcLayer = (
                 threadId: command.threadId,
                 branch: worktree.worktree.refName,
                 worktreePath: targetWorktreePath,
+              });
+              yield* worktreeRegistry.register({
+                threadId: command.threadId,
+                worktreePath: targetWorktreePath,
+                branch: worktree.worktree.refName,
+                projectCwd: prepareWorktree.projectCwd,
+                baseRefName: basePin?.remoteRefName ?? prepareWorktree.baseBranch,
+                baseCommitSha: basePin?.commitSha ?? null,
+                baseProvenance:
+                  basePin?.provenance ?? (prepareWorktree.startFromOrigin ? null : "local"),
+                createdAt: yield* nowIso,
+              });
+              yield* appendWorktreeBaseActivity({
+                threadId: command.threadId,
+                branch: worktree.worktree.refName,
+                worktreePath: targetWorktreePath,
+                baseRefName: basePin?.remoteRefName ?? prepareWorktree.baseBranch,
+                basePin,
               });
               yield* refreshGitStatus(targetWorktreePath);
             }
@@ -1536,6 +1613,12 @@ const makeWsRpcLayer = (
             {
               "rpc.aggregate": "vcs",
             },
+          ),
+        [WS_METHODS.vcsPrefetchRemote]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsPrefetchRemote,
+            worktreeBasePlanner.ensureFreshRemote({ cwd: input.cwd }),
+            { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.vcsPull]: (input) =>
           observeRpcEffect(

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -2,6 +2,7 @@ import { EnvironmentId, type VcsRef } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
   dedupeRemoteBranchesWithLocalMatches,
+  derivePinnedWorktreeBase,
   deriveLocalBranchNameFromRemoteRef,
   resolveEnvironmentOptionLabel,
   resolveBranchSelectionTarget,
@@ -11,6 +12,7 @@ import {
   resolveEnvModeLabel,
   resolveBranchToolbarValue,
   resolveLockedWorkspaceLabel,
+  resolvePinnedBaseTitle,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
 
@@ -165,6 +167,75 @@ describe("resolveLockedWorkspaceLabel", () => {
 
   it("uses a shorter label for an attached worktree", () => {
     expect(resolveLockedWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe("Worktree");
+  });
+
+  it("turns the label into the pinned fact once the base is known", () => {
+    expect(
+      resolveLockedWorkspaceLabel("/repo/.t3/worktrees/feature-a", {
+        baseRefName: "origin/main",
+        baseCommitSha: "0123456789abcdef",
+        baseProvenance: "fresh",
+      }),
+    ).toBe("Worktree · 0123456");
+  });
+});
+
+describe("derivePinnedWorktreeBase", () => {
+  it("reads the latest worktree.base-pinned activity payload", () => {
+    expect(
+      derivePinnedWorktreeBase([
+        { kind: "setup-script.started", payload: {} },
+        {
+          kind: "worktree.base-pinned",
+          payload: {
+            baseRefName: "origin/main",
+            baseCommitSha: "0123456789abcdef",
+            baseProvenance: "stale",
+          },
+        },
+      ]),
+    ).toEqual({
+      baseRefName: "origin/main",
+      baseCommitSha: "0123456789abcdef",
+      baseProvenance: "stale",
+    });
+  });
+
+  it("returns null when no pin activity exists", () => {
+    expect(derivePinnedWorktreeBase([{ kind: "tool.started", payload: {} }])).toBeNull();
+  });
+});
+
+describe("resolvePinnedBaseTitle", () => {
+  it("describes fresh pins", () => {
+    expect(
+      resolvePinnedBaseTitle({
+        baseRefName: "origin/main",
+        baseCommitSha: "0123456789abcdef",
+        baseProvenance: "fresh",
+      }),
+    ).toBe("Pinned at 0123456 from latest origin/main");
+  });
+
+  it("discloses stale pins", () => {
+    expect(
+      resolvePinnedBaseTitle({
+        baseRefName: "origin/main",
+        baseCommitSha: "0123456789abcdef",
+        baseProvenance: "stale",
+      }),
+    ).toContain("remote was unreachable");
+  });
+
+  it("returns null without a pinned commit", () => {
+    expect(
+      resolvePinnedBaseTitle({
+        baseRefName: "origin/main",
+        baseCommitSha: null,
+        baseProvenance: "local",
+      }),
+    ).toBeNull();
+    expect(resolvePinnedBaseTitle(null)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -50,8 +50,66 @@ export function resolveCurrentWorkspaceLabel(activeWorktreePath: string | null):
   return activeWorktreePath ? "Current worktree" : resolveEnvModeLabel("local");
 }
 
-export function resolveLockedWorkspaceLabel(activeWorktreePath: string | null): string {
-  return activeWorktreePath ? "Worktree" : "Local checkout";
+/**
+ * Provenance of a worktree thread's pinned base, derived from the
+ * `worktree.base-pinned` activity the server records during bootstrap.
+ */
+export interface WorktreePinnedBase {
+  readonly baseRefName: string;
+  readonly baseCommitSha: string | null;
+  readonly baseProvenance: "fresh" | "stale" | "local";
+}
+
+export function derivePinnedWorktreeBase(
+  activities: ReadonlyArray<{ kind: string; payload: unknown }>,
+): WorktreePinnedBase | null {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (activity?.kind !== "worktree.base-pinned") continue;
+    const payload =
+      activity.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : null;
+    if (!payload) return null;
+    const baseRefName = typeof payload.baseRefName === "string" ? payload.baseRefName : null;
+    if (!baseRefName) return null;
+    const baseCommitSha = typeof payload.baseCommitSha === "string" ? payload.baseCommitSha : null;
+    const baseProvenance =
+      payload.baseProvenance === "fresh" ||
+      payload.baseProvenance === "stale" ||
+      payload.baseProvenance === "local"
+        ? payload.baseProvenance
+        : "local";
+    return { baseRefName, baseCommitSha, baseProvenance };
+  }
+  return null;
+}
+
+/**
+ * Locked (post-send) workspace label. Once the base pin is known the promise
+ * becomes a fact: "Worktree · a1b2c3f" instead of just "Worktree".
+ */
+export function resolveLockedWorkspaceLabel(
+  activeWorktreePath: string | null,
+  pinnedBase?: WorktreePinnedBase | null,
+): string {
+  if (!activeWorktreePath) {
+    return "Local checkout";
+  }
+  const shortSha = pinnedBase?.baseCommitSha?.slice(0, 7);
+  return shortSha ? `Worktree · ${shortSha}` : "Worktree";
+}
+
+export function resolvePinnedBaseTitle(pinnedBase: WorktreePinnedBase | null): string | null {
+  if (!pinnedBase?.baseCommitSha) {
+    return null;
+  }
+  const shortSha = pinnedBase.baseCommitSha.slice(0, 7);
+  return pinnedBase.baseProvenance === "stale"
+    ? `Pinned at ${shortSha} from ${pinnedBase.baseRefName} (remote was unreachable — last-known commit)`
+    : pinnedBase.baseProvenance === "fresh"
+      ? `Pinned at ${shortSha} from latest ${pinnedBase.baseRefName}`
+      : `Pinned at ${shortSha} from local ${pinnedBase.baseRefName}`;
 }
 
 export function resolveEffectiveEnvMode(input: {

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -16,6 +16,7 @@ import { useIsMobile } from "../hooks/useMediaQuery";
 import {
   type EnvMode,
   type EnvironmentOption,
+  derivePinnedWorktreeBase,
   resolveCurrentWorkspaceLabel,
   resolveEnvModeLabel,
   resolveEffectiveEnvMode,
@@ -48,6 +49,12 @@ interface BranchToolbarProps {
   startFromOrigin: boolean;
   onStartFromOriginChange: (startFromOrigin: boolean) => void;
   envLocked: boolean;
+  /** The project checkout has uncommitted changes (pre-send disclosure). */
+  workingTreeDirty?: boolean;
+  /** Mode this project's new threads currently default to. */
+  projectDefaultEnvMode?: EnvMode | null;
+  /** Persist the current mode as this project's default (explicit write). */
+  onSetProjectDefaultEnvMode?: (mode: EnvMode) => void;
   onCheckoutPullRequestRequest?: (reference: string) => void;
   onComposerFocusRequest?: () => void;
   availableEnvironments?: readonly EnvironmentOption[];
@@ -201,6 +208,9 @@ export const BranchToolbar = memo(function BranchToolbar({
   startFromOrigin,
   onStartFromOriginChange,
   envLocked,
+  workingTreeDirty,
+  projectDefaultEnvMode,
+  onSetProjectDefaultEnvMode,
   onCheckoutPullRequestRequest,
   onComposerFocusRequest,
   availableEnvironments,
@@ -222,6 +232,10 @@ export const BranchToolbar = memo(function BranchToolbar({
   const activeProject = useProject(activeProjectRef);
   const hasActiveThread = serverThread !== null || draftThread !== null;
   const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
+  const pinnedBase = useMemo(
+    () => (serverThread ? derivePinnedWorktreeBase(serverThread.activities) : null),
+    [serverThread],
+  );
   const effectiveEnvMode =
     effectiveEnvModeOverride ??
     resolveEffectiveEnvMode({
@@ -238,56 +252,92 @@ export const BranchToolbar = memo(function BranchToolbar({
 
   if (!hasActiveThread || !activeProject) return null;
 
+  // Dirty-state disclosure runs both directions and only while the choice is
+  // still editable: in checkout mode the agent's edits will mix with the
+  // user's uncommitted work; in worktree mode those uncommitted changes won't
+  // be included. Each hint offers the one-click switch to the other mode.
+  const dirtyDisclosure =
+    !envModeLocked && workingTreeDirty && serverThread === null
+      ? effectiveEnvMode === "local"
+        ? {
+            text: "This checkout has uncommitted changes — the agent will work alongside them.",
+            action: "Use a fresh worktree",
+            nextMode: "worktree" as const,
+          }
+        : {
+            text: "Uncommitted changes in this checkout won't be included in the fresh worktree.",
+            action: "Use current checkout",
+            nextMode: "local" as const,
+          }
+      : null;
+
   return (
-    <div className="mx-auto flex w-full max-w-3xl items-center gap-2 px-2.5 pb-3 pt-1 sm:px-3">
-      {isMobile ? (
-        <MobileRunContextSelector
-          envLocked={envLocked}
-          envModeLocked={envModeLocked}
-          environmentId={environmentId}
-          availableEnvironments={availableEnvironments}
-          showEnvironmentPicker={showEnvironmentPicker}
-          onEnvironmentChange={onEnvironmentChange}
-          effectiveEnvMode={effectiveEnvMode}
-          activeWorktreePath={activeWorktreePath}
-          onEnvModeChange={onEnvModeChange}
-        />
-      ) : (
-        <div className="flex min-w-0 shrink-0 items-center gap-1">
-          {showEnvironmentPicker && availableEnvironments && onEnvironmentChange && (
-            <>
-              <BranchToolbarEnvironmentSelector
-                envLocked={envLocked}
-                environmentId={environmentId}
-                availableEnvironments={availableEnvironments}
-                onEnvironmentChange={onEnvironmentChange}
-              />
-              <Separator orientation="vertical" className="mx-0.5 h-3.5!" />
-            </>
-          )}
-          <BranchToolbarEnvModeSelector
-            envLocked={envModeLocked}
+    <div className="mx-auto flex w-full max-w-3xl flex-col px-2.5 pb-3 pt-1 sm:px-3">
+      {dirtyDisclosure ? (
+        <div className="flex items-center gap-1.5 px-1 pb-1 text-xs text-muted-foreground/80">
+          <span className="min-w-0 truncate">{dirtyDisclosure.text}</span>
+          <button
+            type="button"
+            className="shrink-0 font-medium text-foreground/70 underline-offset-2 hover:underline"
+            onClick={() => onEnvModeChange(dirtyDisclosure.nextMode)}
+          >
+            {dirtyDisclosure.action}
+          </button>
+        </div>
+      ) : null}
+      <div className="flex w-full items-center gap-2">
+        {isMobile ? (
+          <MobileRunContextSelector
+            envLocked={envLocked}
+            envModeLocked={envModeLocked}
+            environmentId={environmentId}
+            availableEnvironments={availableEnvironments}
+            showEnvironmentPicker={showEnvironmentPicker}
+            onEnvironmentChange={onEnvironmentChange}
             effectiveEnvMode={effectiveEnvMode}
             activeWorktreePath={activeWorktreePath}
             onEnvModeChange={onEnvModeChange}
           />
-        </div>
-      )}
+        ) : (
+          <div className="flex min-w-0 shrink-0 items-center gap-1">
+            {showEnvironmentPicker && availableEnvironments && onEnvironmentChange && (
+              <>
+                <BranchToolbarEnvironmentSelector
+                  envLocked={envLocked}
+                  environmentId={environmentId}
+                  availableEnvironments={availableEnvironments}
+                  onEnvironmentChange={onEnvironmentChange}
+                />
+                <Separator orientation="vertical" className="mx-0.5 h-3.5!" />
+              </>
+            )}
+            <BranchToolbarEnvModeSelector
+              envLocked={envModeLocked}
+              effectiveEnvMode={effectiveEnvMode}
+              activeWorktreePath={activeWorktreePath}
+              pinnedBase={pinnedBase}
+              projectDefaultEnvMode={projectDefaultEnvMode ?? null}
+              onEnvModeChange={onEnvModeChange}
+              {...(onSetProjectDefaultEnvMode ? { onSetProjectDefaultEnvMode } : {})}
+            />
+          </div>
+        )}
 
-      <BranchToolbarBranchSelector
-        className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
-        environmentId={environmentId}
-        threadId={threadId}
-        {...(draftId ? { draftId } : {})}
-        envLocked={envLocked}
-        {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
-        {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
-        {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
-        startFromOrigin={startFromOrigin}
-        onStartFromOriginChange={onStartFromOriginChange}
-        {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
-        {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}
-      />
+        <BranchToolbarBranchSelector
+          className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"
+          environmentId={environmentId}
+          threadId={threadId}
+          {...(draftId ? { draftId } : {})}
+          envLocked={envLocked}
+          {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
+          {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
+          {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
+          startFromOrigin={startFromOrigin}
+          onStartFromOriginChange={onStartFromOriginChange}
+          {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
+          {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}
+        />
+      </div>
     </div>
   );
 });

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -38,6 +38,8 @@ import {
   resolveEffectiveEnvMode,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
+import { useEnvironmentSettings } from "../hooks/useSettings";
+import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import {
   ChangeRequestStatusIcon,
   prStatusIndicator,
@@ -107,6 +109,7 @@ export function BranchToolbarBranchSelector({
   onComposerFocusRequest,
 }: BranchToolbarBranchSelectorProps) {
   const startFromOriginSwitchId = useId();
+  const settings = useEnvironmentSettings(environmentId);
   const stopThreadSession = useAtomCommand(threadEnvironment.stopSession, "thread session stop");
   const updateThreadMetadata = useAtomCommand(
     threadEnvironment.updateMetadata,
@@ -191,6 +194,16 @@ export function BranchToolbarBranchSelector({
         branch,
         worktreePath,
         envMode: nextDraftEnvMode,
+        // Mode changes re-derive the origin pin from settings so a draft
+        // flipped into worktree mode here doesn't silently skip the fetch.
+        ...(nextDraftEnvMode !== effectiveEnvMode
+          ? {
+              startFromOrigin: resolveNewDraftStartFromOrigin({
+                envMode: nextDraftEnvMode,
+                newWorktreesStartFromOrigin: settings.newWorktreesStartFromOrigin,
+              }),
+            }
+          : {}),
         projectRef: scopeProjectRef(environmentId, activeProject.id),
       });
     },
@@ -202,6 +215,7 @@ export function BranchToolbarBranchSelector({
       hasServerThread,
       onActiveThreadBranchOverrideChange,
       setDraftThreadContext,
+      settings.newWorktreesStartFromOrigin,
       draftId,
       threadRef,
       environmentId,

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -1,11 +1,13 @@
-import { FolderGit2Icon, FolderGitIcon, FolderIcon } from "lucide-react";
+import { FolderGit2Icon, FolderGitIcon, FolderIcon, PinIcon } from "lucide-react";
 import { memo, useMemo } from "react";
 
 import {
   resolveCurrentWorkspaceLabel,
   resolveEnvModeLabel,
   resolveLockedWorkspaceLabel,
+  resolvePinnedBaseTitle,
   type EnvMode,
+  type WorktreePinnedBase,
 } from "./BranchToolbar.logic";
 import {
   Select,
@@ -17,18 +19,36 @@ import {
   SelectValue,
 } from "./ui/select";
 
+/**
+ * Sentinel select value for the "Always for this project" action. Selecting
+ * it never becomes the control's value — it's intercepted in onValueChange
+ * and routed to an explicit settings write instead.
+ */
+const SET_PROJECT_DEFAULT_VALUE = "__set_project_default__";
+
 interface BranchToolbarEnvModeSelectorProps {
   envLocked: boolean;
   effectiveEnvMode: EnvMode;
   activeWorktreePath: string | null;
+  pinnedBase?: WorktreePinnedBase | null;
+  /**
+   * Mode the project's new threads default to today (after overrides). Used
+   * to decide whether the "Always for this project" action is meaningful.
+   */
+  projectDefaultEnvMode?: EnvMode | null;
   onEnvModeChange: (mode: EnvMode) => void;
+  /** Persist the current mode as this project's default (explicit write). */
+  onSetProjectDefaultEnvMode?: (mode: EnvMode) => void;
 }
 
 export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSelector({
   envLocked,
   effectiveEnvMode,
   activeWorktreePath,
+  pinnedBase,
+  projectDefaultEnvMode,
   onEnvModeChange,
+  onSetProjectDefaultEnvMode,
 }: BranchToolbarEnvModeSelectorProps) {
   const envModeItems = useMemo(
     () => [
@@ -37,19 +57,29 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
     ],
     [activeWorktreePath],
   );
+  const showSetProjectDefault =
+    onSetProjectDefaultEnvMode !== undefined &&
+    projectDefaultEnvMode != null &&
+    effectiveEnvMode !== projectDefaultEnvMode;
 
   if (envLocked) {
+    // Post-send the label states the outcome, not the intent: the pinned
+    // base commit (and, on hover, its provenance) replaces "New worktree".
+    const lockedTitle = resolvePinnedBaseTitle(pinnedBase ?? null);
     return (
-      <span className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
+      <span
+        className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs"
+        {...(lockedTitle ? { title: lockedTitle } : {})}
+      >
         {activeWorktreePath ? (
           <>
             <FolderGitIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+            {resolveLockedWorkspaceLabel(activeWorktreePath, pinnedBase)}
           </>
         ) : (
           <>
             <FolderIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+            {resolveLockedWorkspaceLabel(activeWorktreePath, pinnedBase)}
           </>
         )}
       </span>
@@ -60,7 +90,14 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
     <Select
       modal={false}
       value={effectiveEnvMode}
-      onValueChange={(value) => onEnvModeChange(value as EnvMode)}
+      onValueChange={(value) => {
+        const selected = value as string;
+        if (selected === SET_PROJECT_DEFAULT_VALUE) {
+          onSetProjectDefaultEnvMode?.(effectiveEnvMode);
+          return;
+        }
+        onEnvModeChange(selected as EnvMode);
+      }}
       items={envModeItems}
     >
       <SelectTrigger variant="ghost" size="xs" className="font-medium" aria-label="Workspace">
@@ -75,7 +112,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
       </SelectTrigger>
       <SelectPopup>
         <SelectGroup>
-          <SelectGroupLabel>Workspace</SelectGroupLabel>
+          <SelectGroupLabel>Workspace · this draft only</SelectGroupLabel>
           <SelectItem value="local">
             <span className="inline-flex items-center gap-1.5">
               {activeWorktreePath ? (
@@ -93,6 +130,16 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
             </span>
           </SelectItem>
         </SelectGroup>
+        {showSetProjectDefault ? (
+          <SelectGroup>
+            <SelectItem hideIndicator value={SET_PROJECT_DEFAULT_VALUE}>
+              <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                <PinIcon className="size-3" />
+                Always {resolveEnvModeLabel(effectiveEnvMode).toLowerCase()} for this project
+              </span>
+            </SelectItem>
+          </SelectGroup>
+        ) : null}
       </SelectPopup>
     </Select>
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -27,6 +27,7 @@ import {
 } from "@t3tools/client-runtime/connection";
 import {
   parseScopedThreadKey,
+  scopedProjectKey,
   scopedThreadKey,
   scopeProjectRef,
   scopeThreadRef,
@@ -112,7 +113,7 @@ import {
 import { useTheme } from "../hooks/useTheme";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { isCommandPaletteOpen } from "../commandPaletteContext";
-import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import { buildThreadWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import {
@@ -150,7 +151,13 @@ import {
 } from "~/projectScripts";
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
-import { useEnvironmentSettings } from "../hooks/useSettings";
+import {
+  useClientSettings,
+  useEnvironmentSettings,
+  useUpdateClientSettings,
+} from "../hooks/useSettings";
+import { useEnvironmentPresentation } from "../state/presentation";
+import { resolveSurfaceThreadEnvMode } from "../lib/threadSurface";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
@@ -2120,6 +2127,43 @@ function ChatViewContent(props: ChatViewProps) {
           input: { cwd: gitCwd },
         }),
   );
+  const prefetchRemote = useAtomCommand(vcsEnvironment.prefetchRemote, { reportFailure: false });
+  // Prefetch the remote the moment a worktree-mode draft composer is open, so
+  // the send-time freshness check almost always hits the fresh window and the
+  // user never waits on a blocking fetch. Fire-and-forget; the server dedupes
+  // concurrent fetches per repository.
+  const prefetchedDraftCwdRef = useRef<string | null>(null);
+  const draftEnvModeForPrefetch = isLocalDraftThread ? draftThread?.envMode : undefined;
+  const draftStartFromOriginForPrefetch = isLocalDraftThread
+    ? draftThread?.startFromOrigin
+    : undefined;
+  useEffect(() => {
+    const projectCwd = activeProject?.workspaceRoot ?? null;
+    if (
+      !isLocalDraftThread ||
+      draftEnvModeForPrefetch !== "worktree" ||
+      draftStartFromOriginForPrefetch !== true ||
+      projectCwd === null
+    ) {
+      return;
+    }
+    const prefetchKey = `${environmentId}:${projectCwd}`;
+    if (prefetchedDraftCwdRef.current === prefetchKey) {
+      return;
+    }
+    prefetchedDraftCwdRef.current = prefetchKey;
+    void prefetchRemote({
+      environmentId,
+      input: { cwd: projectCwd },
+    });
+  }, [
+    activeProject?.workspaceRoot,
+    draftEnvModeForPrefetch,
+    draftStartFromOriginForPrefetch,
+    environmentId,
+    isLocalDraftThread,
+    prefetchRemote,
+  ]);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
   // Prefer an instance-id match so a custom Codex instance (e.g.
@@ -4154,7 +4198,7 @@ function ChatViewContent(props: ChatViewProps) {
                     prepareWorktree: {
                       projectCwd: activeProject.workspaceRoot,
                       baseBranch: baseBranchForWorktree,
-                      branch: buildTemporaryWorktreeBranchName(randomHex),
+                      branch: buildThreadWorktreeBranchName(threadIdForSend, randomHex),
                       ...(startFromOrigin ? { startFromOrigin: true } : {}),
                     },
                     runSetupScript: true,
@@ -4867,6 +4911,34 @@ function ChatViewContent(props: ChatViewProps) {
     ],
   );
 
+  const projectThreadEnvModeOverrides = useClientSettings(
+    (clientSettings) => clientSettings.projectThreadEnvModeOverrides,
+  );
+  const updateClientSettings = useUpdateClientSettings();
+  const { presentation: activeEnvironmentPresentation } = useEnvironmentPresentation(environmentId);
+  const envModeOverrideProjectKey = activeProjectRef ? scopedProjectKey(activeProjectRef) : null;
+  const projectDefaultEnvMode: DraftThreadEnvMode | null = envModeOverrideProjectKey
+    ? (projectThreadEnvModeOverrides[envModeOverrideProjectKey] ??
+      resolveSurfaceThreadEnvMode({
+        settings,
+        target: activeEnvironmentPresentation?.entry.target ?? null,
+      }))
+    : null;
+  // "Always for this project": the only sanctioned way a composer choice
+  // becomes a default, and it goes through an explicit settings write.
+  const onSetProjectDefaultEnvMode = useCallback(
+    (mode: DraftThreadEnvMode) => {
+      if (!envModeOverrideProjectKey) return;
+      updateClientSettings({
+        projectThreadEnvModeOverrides: {
+          ...projectThreadEnvModeOverrides,
+          [envModeOverrideProjectKey]: mode,
+        },
+      });
+    },
+    [envModeOverrideProjectKey, projectThreadEnvModeOverrides, updateClientSettings],
+  );
+
   const onStartFromOriginChange = (nextStartFromOrigin: boolean) => {
     if (canOverrideServerThreadEnvMode && activeThread) {
       setPendingServerThreadStartFromOriginByThreadId((current) =>
@@ -5232,6 +5304,9 @@ function ChatViewContent(props: ChatViewProps) {
                       onEnvModeChange={onEnvModeChange}
                       startFromOrigin={startFromOrigin}
                       onStartFromOriginChange={onStartFromOriginChange}
+                      workingTreeDirty={Boolean(gitStatusQuery.data?.hasWorkingTreeChanges)}
+                      projectDefaultEnvMode={projectDefaultEnvMode}
+                      onSetProjectDefaultEnvMode={onSetProjectDefaultEnvMode}
                       {...(canOverrideServerThreadEnvMode
                         ? { effectiveEnvModeOverride: envMode }
                         : {})}

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -261,88 +261,20 @@ describe("resolveSidebarNewThreadEnvMode", () => {
 });
 
 describe("resolveSidebarNewThreadSeedContext", () => {
-  it("prefers the default worktree mode over active thread context", () => {
+  it("always starts from the resolved default mode — active thread and draft context never leak in", () => {
     expect(
       resolveSidebarNewThreadSeedContext({
-        projectId: "project-1",
         defaultEnvMode: "worktree",
-        activeThread: {
-          projectId: "project-1",
-          branch: "feature/existing",
-          worktreePath: "/repo/.t3/worktrees/existing",
-        },
-        activeDraftThread: {
-          projectId: "project-1",
-          branch: "feature/draft",
-          worktreePath: "/repo/.t3/worktrees/draft",
-          envMode: "worktree",
-          startFromOrigin: true,
-        },
       }),
     ).toEqual({
       envMode: "worktree",
     });
-  });
-
-  it("inherits the active server thread context when creating a new thread in the same project", () => {
     expect(
       resolveSidebarNewThreadSeedContext({
-        projectId: "project-1",
         defaultEnvMode: "local",
-        activeThread: {
-          projectId: "project-1",
-          branch: "effect-atom",
-          worktreePath: null,
-        },
-        activeDraftThread: null,
       }),
     ).toEqual({
-      branch: "effect-atom",
-      worktreePath: null,
       envMode: "local",
-    });
-  });
-
-  it("prefers the active draft thread context when it matches the target project", () => {
-    expect(
-      resolveSidebarNewThreadSeedContext({
-        projectId: "project-1",
-        defaultEnvMode: "local",
-        activeThread: {
-          projectId: "project-1",
-          branch: "effect-atom",
-          worktreePath: null,
-        },
-        activeDraftThread: {
-          projectId: "project-1",
-          branch: "feature/new-draft",
-          worktreePath: "/repo/worktree",
-          envMode: "worktree",
-          startFromOrigin: true,
-        },
-      }),
-    ).toEqual({
-      branch: "feature/new-draft",
-      worktreePath: "/repo/worktree",
-      envMode: "worktree",
-      startFromOrigin: true,
-    });
-  });
-
-  it("falls back to the default env mode when there is no matching active thread context", () => {
-    expect(
-      resolveSidebarNewThreadSeedContext({
-        projectId: "project-2",
-        defaultEnvMode: "worktree",
-        activeThread: {
-          projectId: "project-1",
-          branch: "effect-atom",
-          worktreePath: null,
-        },
-        activeDraftThread: null,
-      }),
-    ).toEqual({
-      envMode: "worktree",
     });
   });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -184,50 +184,17 @@ export function resolveSidebarNewThreadEnvMode(input: {
   return input.requestedEnvMode ?? input.defaultEnvMode;
 }
 
+/**
+ * New threads always start from the resolved default workspace mode.
+ * Mode/branch/worktree choices on the active thread or draft are draft-only
+ * exceptions and are deliberately NOT inherited — a one-off "use current
+ * checkout" must never retrain what the next new thread does.
+ */
 export function resolveSidebarNewThreadSeedContext(input: {
-  projectId: string;
   defaultEnvMode: SidebarNewThreadEnvMode;
-  activeThread?: {
-    projectId: string;
-    branch: string | null;
-    worktreePath: string | null;
-  } | null;
-  activeDraftThread?: {
-    projectId: string;
-    branch: string | null;
-    worktreePath: string | null;
-    envMode: SidebarNewThreadEnvMode;
-    startFromOrigin: boolean;
-  } | null;
 }): {
-  branch?: string | null;
-  worktreePath?: string | null;
   envMode: SidebarNewThreadEnvMode;
-  startFromOrigin?: boolean;
 } {
-  if (input.defaultEnvMode === "worktree") {
-    return {
-      envMode: "worktree",
-    };
-  }
-
-  if (input.activeDraftThread?.projectId === input.projectId) {
-    return {
-      branch: input.activeDraftThread.branch,
-      worktreePath: input.activeDraftThread.worktreePath,
-      envMode: input.activeDraftThread.envMode,
-      startFromOrigin: input.activeDraftThread.startFromOrigin,
-    };
-  }
-
-  if (input.activeThread?.projectId === input.projectId) {
-    return {
-      branch: input.activeThread.branch,
-      worktreePath: input.activeThread.worktreePath,
-      envMode: input.activeThread.worktreePath ? "worktree" : "local",
-    };
-  }
-
   return {
     envMode: input.defaultEnvMode,
   };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -43,7 +43,6 @@ import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-
 import { CSS } from "@dnd-kit/utilities";
 import {
   type ContextMenuItem,
-  DEFAULT_SERVER_SETTINGS,
   ProjectId,
   type ScopedThreadRef,
   type ResolvedKeybindingsConfig,
@@ -79,10 +78,8 @@ import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform } from "../lib/utils";
 import {
-  readThreadShell,
   useProject,
   useProjects,
-  useServerConfigs,
   useThreadShells,
   useThreadShellsForProjectRefs,
 } from "../state/entities";
@@ -118,11 +115,7 @@ import { useEnvironmentQuery } from "../state/query";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
 import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import {
-  buildThreadRouteParams,
-  resolveThreadRouteRef,
-  resolveThreadRouteTarget,
-} from "../threadRoutes";
+import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
@@ -189,8 +182,6 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   resolveProjectStatusIndicator,
-  resolveSidebarNewThreadSeedContext,
-  resolveSidebarNewThreadEnvMode,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
@@ -1109,7 +1100,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     (settings) => settings.confirmThreadArchive,
   );
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const serverConfigs = useServerConfigs();
   const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
@@ -1836,61 +1826,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
   const createThreadForProjectMember = useCallback(
     (member: SidebarProjectGroupMember) => {
-      const currentRouteParams =
-        router.state.matches[router.state.matches.length - 1]?.params ?? {};
-      const currentRouteTarget = resolveThreadRouteTarget(currentRouteParams);
-      const currentActiveThread =
-        currentRouteTarget?.kind === "server"
-          ? readThreadShell(currentRouteTarget.threadRef)
-          : null;
-      const draftStore = useComposerDraftStore.getState();
-      const currentActiveDraftThread =
-        currentRouteTarget?.kind === "server"
-          ? (draftStore.getDraftThread(currentRouteTarget.threadRef) ?? null)
-          : currentRouteTarget?.kind === "draft"
-            ? (draftStore.getDraftSession(currentRouteTarget.draftId) ?? null)
-            : null;
-      const seedContext = resolveSidebarNewThreadSeedContext({
-        projectId: member.id,
-        defaultEnvMode: resolveSidebarNewThreadEnvMode({
-          defaultEnvMode:
-            serverConfigs.get(member.environmentId)?.settings.defaultThreadEnvMode ??
-            DEFAULT_SERVER_SETTINGS.defaultThreadEnvMode,
-        }),
-        activeThread:
-          currentActiveThread && currentActiveThread.projectId === member.id
-            ? {
-                projectId: currentActiveThread.projectId,
-                branch: currentActiveThread.branch,
-                worktreePath: currentActiveThread.worktreePath,
-              }
-            : null,
-        activeDraftThread:
-          currentActiveDraftThread && currentActiveDraftThread.projectId === member.id
-            ? {
-                projectId: currentActiveDraftThread.projectId,
-                branch: currentActiveDraftThread.branch,
-                worktreePath: currentActiveDraftThread.worktreePath,
-                envMode: currentActiveDraftThread.envMode,
-                startFromOrigin: currentActiveDraftThread.startFromOrigin,
-              }
-            : null,
-      });
       if (isMobile) {
         setOpenMobile(false);
       }
       void (async () => {
+        // No seed context: new threads always start from the resolved
+        // default workspace mode (useNewThreadHandler derives it from the
+        // surface). The active thread's mode/branch is a draft-only
+        // exception and must not leak into the next thread.
         const result = await settlePromise(() =>
-          handleNewThread(scopeProjectRef(member.environmentId, member.id), {
-            ...(seedContext.branch !== undefined ? { branch: seedContext.branch } : {}),
-            ...(seedContext.worktreePath !== undefined
-              ? { worktreePath: seedContext.worktreePath }
-              : {}),
-            envMode: seedContext.envMode,
-            ...(seedContext.startFromOrigin !== undefined
-              ? { startFromOrigin: seedContext.startFromOrigin }
-              : {}),
-          }),
+          handleNewThread(scopeProjectRef(member.environmentId, member.id)),
         );
         if (result._tag === "Failure") {
           const error = squashAtomCommandFailure(result);
@@ -1904,7 +1849,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         }
       })();
     },
-    [handleNewThread, isMobile, router, serverConfigs, setOpenMobile],
+    [handleNewThread, isMobile, setOpenMobile],
   );
 
   const handleCreateThreadClick = useCallback(

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -405,7 +405,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       Duration.toMillis(DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval)
         ? ["Automatic Git fetch interval"]
         : []),
-      ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
+      ...(settings.deriveThreadEnvModeFromSurface !==
+        DEFAULT_UNIFIED_SETTINGS.deriveThreadEnvModeFromSurface ||
+      settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
       ...(settings.newWorktreesStartFromOrigin !==
@@ -430,6 +432,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
+      settings.deriveThreadEnvModeFromSurface,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
       settings.automaticGitFetchInterval,
@@ -460,6 +463,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+      deriveThreadEnvModeFromSurface: DEFAULT_UNIFIED_SETTINGS.deriveThreadEnvModeFromSurface,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
@@ -723,8 +727,10 @@ export function GeneralSettingsPanel() {
 
         <SettingsRow
           title="New threads"
-          description="Pick the default workspace mode for newly created draft threads."
+          description="Pick the default workspace mode for newly created draft threads. Auto uses the current checkout when you're on the same machine as the environment and a fresh worktree everywhere else."
           resetAction={
+            settings.deriveThreadEnvModeFromSurface !==
+              DEFAULT_UNIFIED_SETTINGS.deriveThreadEnvModeFromSurface ||
             settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
             settings.newWorktreesStartFromOrigin !==
               DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
@@ -732,6 +738,8 @@ export function GeneralSettingsPanel() {
                 label="new threads"
                 onClick={() =>
                   updateSettings({
+                    deriveThreadEnvModeFromSurface:
+                      DEFAULT_UNIFIED_SETTINGS.deriveThreadEnvModeFromSurface,
                     defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
                     newWorktreesStartFromOrigin:
                       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
@@ -742,19 +750,35 @@ export function GeneralSettingsPanel() {
           }
           control={
             <Select
-              value={settings.defaultThreadEnvMode}
+              value={
+                settings.deriveThreadEnvModeFromSurface ? "surface" : settings.defaultThreadEnvMode
+              }
               onValueChange={(value) => {
+                if (value === "surface") {
+                  updateSettings({ deriveThreadEnvModeFromSurface: true });
+                  return;
+                }
                 if (value === "local" || value === "worktree") {
-                  updateSettings({ defaultThreadEnvMode: value });
+                  updateSettings({
+                    deriveThreadEnvModeFromSurface: false,
+                    defaultThreadEnvMode: value,
+                  });
                 }
               }}
             >
               <SelectTrigger className="w-full sm:w-44" aria-label="Default thread mode">
                 <SelectValue>
-                  {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
+                  {settings.deriveThreadEnvModeFromSurface
+                    ? "Auto"
+                    : settings.defaultThreadEnvMode === "worktree"
+                      ? "New worktree"
+                      : "Local"}
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="surface">
+                  Auto
+                </SelectItem>
                 <SelectItem hideIndicator value="local">
                   Local
                 </SelectItem>
@@ -766,7 +790,7 @@ export function GeneralSettingsPanel() {
           }
         />
 
-        {settings.defaultThreadEnvMode === "worktree" ? (
+        {settings.deriveThreadEnvModeFromSurface || settings.defaultThreadEnvMode !== "local" ? (
           <SettingsRow
             className="bg-muted/20 sm:pl-9"
             title="Start from origin"

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -136,7 +136,7 @@ export function useNewThreadHandler() {
             reusableStoredDraftThread.draftId,
             {
               threadId: reusableStoredDraftThread.threadId,
-              ...(storedDraftProjectChanged && !hasEnvModeOption
+              ...(storedDraftProjectChanged && !hasEnvModeOption && !hasStartFromOriginOption
                 ? (() => {
                     const envMode = resolveDefaultEnvMode();
                     return {

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -80,6 +80,17 @@ export function useNewThreadHandler() {
       const hasWorktreePathOption = options?.worktreePath !== undefined;
       const hasEnvModeOption = options?.envMode !== undefined;
       const hasStartFromOriginOption = options?.startFromOrigin !== undefined;
+      // The default mode derives from the surface (attached checkout →
+      // local, detached → worktree) unless a project override or an explicit
+      // setting pins a mode. Draft exceptions never retrain this default —
+      // only the project override ("Always for this project") does, and only
+      // through an explicit settings write.
+      const resolveDefaultEnvMode = (): DraftThreadEnvMode =>
+        projectThreadEnvModeOverrides[scopedProjectKey(projectRef)] ??
+        resolveSurfaceThreadEnvMode({
+          settings: environmentSettings,
+          target: environmentPresentationById.get(projectRef.environmentId)?.entry.target ?? null,
+        });
       const storedDraftThread = getDraftSessionByLogicalProjectKey(logicalProjectKey);
       const storedDraftThreadRef = storedDraftThread
         ? scopeThreadRef(storedDraftThread.environmentId, storedDraftThread.threadId)
@@ -96,6 +107,14 @@ export function useNewThreadHandler() {
           ? getDraftThread(currentRouteTarget.threadRef)
           : getDraftSession(currentRouteTarget.draftId)
         : null;
+      // Reusing a stored draft for a different project member must re-derive
+      // the mode from that member's default — otherwise the store's
+      // project-changed reset hard-codes "local" regardless of surface.
+      const storedDraftProjectChanged =
+        reusableStoredDraftThread !== null &&
+        reusableStoredDraftThread !== undefined &&
+        (reusableStoredDraftThread.environmentId !== projectRef.environmentId ||
+          reusableStoredDraftThread.projectId !== projectRef.projectId);
       if (reusableStoredDraftThread) {
         return (async () => {
           if (
@@ -117,6 +136,19 @@ export function useNewThreadHandler() {
             reusableStoredDraftThread.draftId,
             {
               threadId: reusableStoredDraftThread.threadId,
+              ...(storedDraftProjectChanged && !hasEnvModeOption
+                ? (() => {
+                    const envMode = resolveDefaultEnvMode();
+                    return {
+                      envMode,
+                      startFromOrigin: resolveNewDraftStartFromOrigin({
+                        envMode,
+                        newWorktreesStartFromOrigin:
+                          environmentSettings.newWorktreesStartFromOrigin,
+                      }),
+                    };
+                  })()
+                : {}),
             },
           );
           if (
@@ -167,20 +199,7 @@ export function useNewThreadHandler() {
       const draftId = newDraftId();
       const threadId = newThreadId();
       const createdAt = new Date().toISOString();
-      // The default mode derives from the surface (attached checkout →
-      // local, detached → worktree) unless a project override or an explicit
-      // setting pins a mode. Draft exceptions never retrain this default —
-      // only the project override ("Always for this project") does, and only
-      // through an explicit settings write.
-      const projectEnvModeOverride =
-        projectThreadEnvModeOverrides[scopedProjectKey(projectRef)] ?? null;
-      const initialEnvMode =
-        options?.envMode ??
-        projectEnvModeOverride ??
-        resolveSurfaceThreadEnvMode({
-          settings: environmentSettings,
-          target: environmentPresentationById.get(projectRef.environmentId)?.entry.target ?? null,
-        });
+      const initialEnvMode = options?.envMode ?? resolveDefaultEnvMode();
       return (async () => {
         setLogicalProjectDraftThreadId(logicalProjectKey, projectRef, draftId, {
           threadId,

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -136,18 +136,21 @@ export function useNewThreadHandler() {
             reusableStoredDraftThread.draftId,
             {
               threadId: reusableStoredDraftThread.threadId,
-              ...(storedDraftProjectChanged && !hasEnvModeOption && !hasStartFromOriginOption
-                ? (() => {
-                    const envMode = resolveDefaultEnvMode();
-                    return {
-                      envMode,
-                      startFromOrigin: resolveNewDraftStartFromOrigin({
-                        envMode,
-                        newWorktreesStartFromOrigin:
-                          environmentSettings.newWorktreesStartFromOrigin,
-                      }),
-                    };
-                  })()
+              // Independently re-derive whichever values the caller didn't
+              // pin, so the store's project-changed reset (hard-coded
+              // "local"/false) never overrides the target's surface default.
+              ...(storedDraftProjectChanged && !hasEnvModeOption
+                ? { envMode: resolveDefaultEnvMode() }
+                : {}),
+              ...(storedDraftProjectChanged && !hasStartFromOriginOption
+                ? {
+                    startFromOrigin: resolveNewDraftStartFromOrigin({
+                      envMode: hasEnvModeOption
+                        ? (options?.envMode ?? resolveDefaultEnvMode())
+                        : resolveDefaultEnvMode(),
+                      newWorktreesStartFromOrigin: environmentSettings.newWorktreesStartFromOrigin,
+                    }),
+                  }
                 : {}),
             },
           );

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -1,3 +1,4 @@
+import { useAtomValue } from "@effect/atom-react";
 import {
   scopedProjectKey,
   scopeProjectRef,
@@ -10,6 +11,9 @@ import {
 } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
+
+import { environmentPresentations } from "../state/presentation";
+import { resolveSurfaceThreadEnvMode } from "../lib/threadSurface";
 import {
   markPromotedDraftThreadByRef,
   type DraftThreadEnvMode,
@@ -32,7 +36,11 @@ import { useClientSettings } from "./useSettings";
 export function useNewThreadHandler() {
   const projects = useProjects();
   const serverConfigs = useServerConfigs();
+  const environmentPresentationById = useAtomValue(environmentPresentations.presentationsAtom);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const projectThreadEnvModeOverrides = useClientSettings(
+    (settings) => settings.projectThreadEnvModeOverrides,
+  );
   const router = useRouter();
   const getCurrentRouteTarget = useCallback(() => {
     const currentRouteParams = router.state.matches[router.state.matches.length - 1]?.params ?? {};
@@ -159,7 +167,20 @@ export function useNewThreadHandler() {
       const draftId = newDraftId();
       const threadId = newThreadId();
       const createdAt = new Date().toISOString();
-      const initialEnvMode = options?.envMode ?? environmentSettings.defaultThreadEnvMode;
+      // The default mode derives from the surface (attached checkout →
+      // local, detached → worktree) unless a project override or an explicit
+      // setting pins a mode. Draft exceptions never retrain this default —
+      // only the project override ("Always for this project") does, and only
+      // through an explicit settings write.
+      const projectEnvModeOverride =
+        projectThreadEnvModeOverrides[scopedProjectKey(projectRef)] ?? null;
+      const initialEnvMode =
+        options?.envMode ??
+        projectEnvModeOverride ??
+        resolveSurfaceThreadEnvMode({
+          settings: environmentSettings,
+          target: environmentPresentationById.get(projectRef.environmentId)?.entry.target ?? null,
+        });
       return (async () => {
         setLogicalProjectDraftThreadId(logicalProjectKey, projectRef, draftId, {
           threadId,
@@ -183,7 +204,15 @@ export function useNewThreadHandler() {
         });
       })();
     },
-    [getCurrentRouteTarget, projectGroupingSettings, projects, router, serverConfigs],
+    [
+      environmentPresentationById,
+      getCurrentRouteTarget,
+      projectGroupingSettings,
+      projects,
+      projectThreadEnvModeOverrides,
+      router,
+      serverConfigs,
+    ],
   );
 }
 

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -66,7 +66,7 @@ describe("chatThreadActions", () => {
     expect(projectRef).toEqual(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
   });
 
-  it("starts a contextual new thread from the active draft thread", async () => {
+  it("starts a new thread with only the project carried over — draft workspace choices never leak in", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 
     const didStart = await startNewThreadFromContext(
@@ -84,40 +84,10 @@ describe("chatThreadActions", () => {
     );
 
     expect(didStart).toBe(true);
-    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
-      branch: "feature/refactor",
-      worktreePath: "/tmp/worktree",
-      envMode: "worktree",
-      startFromOrigin: true,
-    });
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
   });
 
-  it("preserves an explicitly disabled origin base in contextual thread options", async () => {
-    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
-
-    await startNewThreadFromContext(
-      createContext({
-        activeDraftThread: {
-          environmentId: ENVIRONMENT_ID,
-          projectId: PROJECT_ID,
-          branch: "feature/refactor",
-          worktreePath: "/tmp/worktree",
-          envMode: "worktree",
-          startFromOrigin: false,
-        },
-        handleNewThread,
-      }),
-    );
-
-    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
-      branch: "feature/refactor",
-      worktreePath: "/tmp/worktree",
-      envMode: "worktree",
-      startFromOrigin: false,
-    });
-  });
-
-  it("delegates the target environment defaults to the new-thread handler", async () => {
+  it("starts an explicit current-checkout thread via the local action", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 
     const didStart = await startNewLocalThreadFromContext(
@@ -128,7 +98,9 @@ describe("chatThreadActions", () => {
     );
 
     expect(didStart).toBe(true);
-    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      envMode: "local",
+    });
   });
 
   it("does not start a thread when there is no project context", async () => {

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -26,8 +26,6 @@ interface NewThreadHandler {
   ): Promise<void>;
 }
 
-type NewThreadOptions = NonNullable<Parameters<NewThreadHandler>[1]>;
-
 export interface ChatThreadActionContext {
   readonly activeDraftThread: DraftThreadContextLike | null;
   readonly activeThread: ThreadContextLike | undefined;
@@ -57,25 +55,15 @@ export function resolveThreadActionProjectRef(
   return context.defaultProjectRef;
 }
 
-function buildContextualThreadOptions(context: ChatThreadActionContext): NewThreadOptions {
-  return {
-    branch: context.activeThread?.branch ?? context.activeDraftThread?.branch ?? null,
-    worktreePath:
-      context.activeThread?.worktreePath ?? context.activeDraftThread?.worktreePath ?? null,
-    envMode:
-      context.activeDraftThread?.envMode ??
-      (context.activeThread?.worktreePath ? "worktree" : "local"),
-    ...(context.activeDraftThread
-      ? { startFromOrigin: context.activeDraftThread.startFromOrigin }
-      : {}),
-  };
-}
-
 export async function startNewThreadInProjectFromContext(
   context: ChatThreadActionContext,
   projectRef: ScopedProjectRef,
 ): Promise<void> {
-  await context.handleNewThread(projectRef, buildContextualThreadOptions(context));
+  // Only the project carries over from the active thread. Workspace mode,
+  // branch, and worktree choices are draft-only exceptions — a new thread
+  // always starts from the resolved default so exceptions never become
+  // sticky.
+  await context.handleNewThread(projectRef);
 }
 
 export async function startNewThreadFromContext(
@@ -98,6 +86,7 @@ export async function startNewLocalThreadFromContext(
     return false;
   }
 
-  await context.handleNewThread(projectRef);
+  // chat.newLocal is the explicit current-checkout exception (draft-only).
+  await context.handleNewThread(projectRef, { envMode: "local" });
   return true;
 }

--- a/apps/web/src/lib/threadSurface.ts
+++ b/apps/web/src/lib/threadSurface.ts
@@ -1,0 +1,53 @@
+import type { ConnectionTarget } from "@t3tools/client-runtime/connection";
+import type { ThreadEnvMode, UnifiedSettings } from "@t3tools/contracts";
+import { resolveDefaultThreadEnvMode, type ThreadSurface } from "@t3tools/shared/threadEnvMode";
+
+import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
+import { isElectron } from "../env";
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+function isLoopbackBrowser(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return LOOPBACK_HOSTNAMES.has(window.location.hostname.toLowerCase());
+}
+
+/**
+ * Classify an environment by whether the user's attention is attached to a
+ * local checkout they can see. Two conditions must both hold: the
+ * environment is host-managed (the primary server or a desktop-local
+ * backend, not a saved remote/relay/SSH environment), and the client itself
+ * runs on that host (desktop app, or a browser served from loopback). A
+ * browser reaching the primary server over LAN or a domain is detached —
+ * the checkout lives on another machine the user cannot see, so isolation
+ * is the only coherent default.
+ */
+export function resolveEnvironmentThreadSurface(
+  target: ConnectionTarget | null | undefined,
+): ThreadSurface {
+  if (!target) {
+    return "detached";
+  }
+  const hostManaged =
+    target._tag === "PrimaryConnectionTarget" || isDesktopLocalConnectionTarget(target);
+  if (!hostManaged) {
+    return "detached";
+  }
+  return isElectron || isLoopbackBrowser() ? "attached-checkout" : "detached";
+}
+
+export function resolveSurfaceThreadEnvMode(input: {
+  readonly settings: Pick<
+    UnifiedSettings,
+    "deriveThreadEnvModeFromSurface" | "defaultThreadEnvMode"
+  >;
+  readonly target: ConnectionTarget | null | undefined;
+}): ThreadEnvMode {
+  return resolveDefaultThreadEnvMode({
+    deriveFromSurface: input.settings.deriveThreadEnvModeFromSurface,
+    configuredMode: input.settings.defaultThreadEnvMode,
+    surface: resolveEnvironmentThreadSurface(input.target),
+  });
+}

--- a/packages/client-runtime/src/state/vcs.ts
+++ b/packages/client-runtime/src/state/vcs.ts
@@ -188,6 +188,12 @@ export function createVcsEnvironmentAtoms<R, E>(
       scheduler: vcsCommandScheduler,
       concurrency: vcsCommandConcurrency,
     }),
+    prefetchRemote: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:vcs:prefetch-remote",
+      tag: WS_METHODS.vcsPrefetchRemote,
+      scheduler: vcsCommandScheduler,
+      concurrency: vcsCommandConcurrency,
+    }),
     createWorktree: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:vcs:create-worktree",
       tag: WS_METHODS.vcsCreateWorktree,

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -139,8 +139,30 @@ export const VcsCreateWorktreeInput = Schema.Struct({
   newRefName: Schema.optional(TrimmedNonEmptyStringSchema),
   baseRefName: Schema.optional(TrimmedNonEmptyStringSchema),
   path: Schema.NullOr(TrimmedNonEmptyStringSchema),
+  /**
+   * When `newRefName` already exists (e.g. a resend after a partially failed
+   * bootstrap reusing the deterministic thread-derived branch name), append a
+   * numeric suffix instead of failing.
+   */
+  uniquifyNewRefName: Schema.optional(Schema.Boolean),
 });
 export type VcsCreateWorktreeInput = typeof VcsCreateWorktreeInput.Type;
+
+export const VcsPrefetchRemoteInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type VcsPrefetchRemoteInput = typeof VcsPrefetchRemoteInput.Type;
+
+/**
+ * Result of a composer-open prefetch. `fetchedAt` is the time of the last
+ * successful fetch of the repository's primary remote (`null` when the fetch
+ * failed and no earlier fetch succeeded this session).
+ */
+export const VcsPrefetchRemoteResult = Schema.Struct({
+  fetchedAt: Schema.NullOr(Schema.String),
+  fetchSucceeded: Schema.Boolean,
+});
+export type VcsPrefetchRemoteResult = typeof VcsPrefetchRemoteResult.Type;
 
 export const GitPullRequestRefInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -29,6 +29,8 @@ import {
   GitManagerServiceError,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
+  VcsPrefetchRemoteInput,
+  VcsPrefetchRemoteResult,
   VcsPullInput,
   GitPullRequestRefInput,
   VcsPullResult,
@@ -164,6 +166,7 @@ export const WS_METHODS = {
   // VCS methods
   vcsPull: "vcs.pull",
   vcsRefreshStatus: "vcs.refreshStatus",
+  vcsPrefetchRemote: "vcs.prefetchRemote",
   vcsListRefs: "vcs.listRefs",
   vcsCreateWorktree: "vcs.createWorktree",
   vcsRemoveWorktree: "vcs.removeWorktree",
@@ -412,6 +415,12 @@ export const WsVcsRefreshStatusRpc = Rpc.make(WS_METHODS.vcsRefreshStatus, {
   payload: VcsStatusInput,
   success: VcsStatusResult,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
+});
+
+export const WsVcsPrefetchRemoteRpc = Rpc.make(WS_METHODS.vcsPrefetchRemote, {
+  payload: VcsPrefetchRemoteInput,
+  success: VcsPrefetchRemoteResult,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
 });
 
 export const WsGitRunStackedActionRpc = Rpc.make(WS_METHODS.gitRunStackedAction, {
@@ -709,6 +718,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,
   WsVcsRefreshStatusRpc,
+  WsVcsPrefetchRemoteRpc,
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,
   WsGitPreparePullRequestThreadRpc,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -88,14 +88,31 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
 });
 
 describe("ServerSettings worktree defaults", () => {
-  it("defaults start-from-origin off for legacy configs", () => {
-    expect(decodeServerSettings({}).newWorktreesStartFromOrigin).toBe(false);
+  it("defaults start-from-origin on so new worktrees pin the latest remote base", () => {
+    expect(decodeServerSettings({}).newWorktreesStartFromOrigin).toBe(true);
+  });
+
+  it("defaults to surface-derived thread env mode resolution", () => {
+    const decoded = decodeServerSettings({});
+    expect(decoded.deriveThreadEnvModeFromSurface).toBe(true);
+    // The wire value stays within the legacy literal set so pre-surface
+    // clients can still decode the server config snapshot.
+    expect(decoded.defaultThreadEnvMode).toBe("local");
+  });
+
+  it("accepts explicit env modes for legacy configs", () => {
+    expect(decodeServerSettings({ defaultThreadEnvMode: "worktree" }).defaultThreadEnvMode).toBe(
+      "worktree",
+    );
+    expect(decodeServerSettings({ defaultThreadEnvMode: "local" }).defaultThreadEnvMode).toBe(
+      "local",
+    );
   });
 
   it("accepts start-from-origin updates", () => {
     expect(
-      decodeServerSettingsPatch({ newWorktreesStartFromOrigin: true }).newWorktreesStartFromOrigin,
-    ).toBe(true);
+      decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
+    ).toBe(false);
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -9,6 +9,9 @@ import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.t
 
 // ── Client Settings (local-only) ───────────────────────────────
 
+export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
+export type ThreadEnvMode = typeof ThreadEnvMode.Type;
+
 export const TimestampFormat = Schema.Literals(["locale", "12-hour", "24-hour"]);
 export type TimestampFormat = typeof TimestampFormat.Type;
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
@@ -75,6 +78,12 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
+  // Per-project default workspace mode, keyed by scoped project key. This is
+  // the sanctioned way to retrain the new-thread default for one project —
+  // the composer's draft-only exceptions never write here implicitly.
+  projectThreadEnvModeOverrides: Schema.Record(TrimmedNonEmptyString, ThreadEnvMode).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
   sidebarProjectGroupingOverrides: Schema.Record(
     TrimmedNonEmptyString,
     SidebarProjectGroupingMode,
@@ -98,9 +107,6 @@ export type ClientSettings = typeof ClientSettingsSchema.Type;
 export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientSettingsSchema)({});
 
 // ── Server Settings (server-authoritative) ────────────────────
-
-export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
-export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
@@ -363,6 +369,28 @@ export type ObservabilitySettings = typeof ObservabilitySettings.Type;
 
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 
+/**
+ * A remote fetch younger than this window counts as "fresh": worktree
+ * creation pins the remote-tracking commit without fetching again.
+ */
+export const WORKTREE_BASE_FRESHNESS_WINDOW = Duration.seconds(30);
+
+/**
+ * Fail-visible horizon: when a send-time fetch fails but the last successful
+ * fetch is within this horizon, worktree creation proceeds on the last-known
+ * remote commit and reports stale provenance instead of failing.
+ */
+export const WORKTREE_BASE_USABLE_HORIZON = Duration.hours(1);
+
+/**
+ * Provenance of the commit a worktree thread was pinned to.
+ * - `fresh`: pinned from a remote fetch within the freshness window
+ * - `stale`: remote unreachable; pinned from the last-known remote commit
+ * - `local`: pinned from a local ref without consulting the remote
+ */
+export const WorktreeBaseProvenance = Schema.Literals(["fresh", "stale", "local"]);
+export type WorktreeBaseProvenance = typeof WorktreeBaseProvenance.Type;
+
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
@@ -371,11 +399,23 @@ export const ServerSettings = Schema.Struct({
       Effect.succeed(Duration.toMillis(DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL)),
     ),
   ),
+  /**
+   * When true (the default), the workspace mode for new threads derives from
+   * the surface the client runs on: attached to a visible local checkout
+   * (desktop app, CLI-launched local browser) → current checkout; detached
+   * (remote browser, mobile, relay/SSH environments) → fresh worktree.
+   * `defaultThreadEnvMode` only applies when this is false. A separate
+   * boolean (rather than a third `defaultThreadEnvMode` literal) keeps the
+   * wire value decodable by clients that predate surface derivation.
+   */
+  deriveThreadEnvModeFromSurface: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.succeed(false)),
+    Schema.withDecodingDefault(Effect.succeed(true)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
@@ -506,6 +546,7 @@ export const ServerSettingsPatch = Schema.Struct({
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
+  deriveThreadEnvModeFromSurface: Schema.optionalKey(Schema.Boolean),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
@@ -558,6 +599,9 @@ export const ClientSettingsPatch = Schema.Struct({
         ),
       }),
     ),
+  ),
+  projectThreadEnvModeOverrides: Schema.optionalKey(
+    Schema.Record(TrimmedNonEmptyString, ThreadEnvMode),
   ),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,10 @@
       "types": "./src/git.ts",
       "import": "./src/git.ts"
     },
+    "./threadEnvMode": {
+      "types": "./src/threadEnvMode.ts",
+      "import": "./src/threadEnvMode.ts"
+    },
     "./sourceControl": {
       "types": "./src/sourceControl.ts",
       "import": "./src/sourceControl.ts"

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -72,6 +72,11 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/DEADBEEF`)).toBe(true);
   });
 
+  it("matches uniquified retry suffixes on thread-derived branches", () => {
+    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-2`)).toBe(true);
+    expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-10`)).toBe(true);
+  });
+
   it("rejects non-temporary refName names", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   applyGitStatusStreamEvent,
   buildTemporaryWorktreeBranchName,
+  buildThreadWorktreeBranchName,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
@@ -75,6 +76,32 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(false);
+  });
+});
+
+describe("buildThreadWorktreeBranchName", () => {
+  const failRandomHex = (): string => {
+    throw new Error("randomness must not be used for UUID thread ids");
+  };
+
+  it("derives a deterministic branch from the thread id's UUID prefix", () => {
+    expect(
+      buildThreadWorktreeBranchName("A1B2C3D4-0000-4000-8000-000000000000", failRandomHex),
+    ).toBe(`${WORKTREE_BRANCH_PREFIX}/a1b2c3d4`);
+  });
+
+  it("produces a valid temporary worktree branch shape", () => {
+    expect(
+      isTemporaryWorktreeBranch(
+        buildThreadWorktreeBranchName("deadbeef-1111-4222-8333-444455556666", failRandomHex),
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to randomness for non-UUID thread ids", () => {
+    expect(buildThreadWorktreeBranchName("thread-1", () => "CAFEF00D")).toBe(
+      `${WORKTREE_BRANCH_PREFIX}/cafef00d`,
+    );
   });
 });
 

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -11,7 +11,11 @@ import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
 export const WORKTREE_BRANCH_PREFIX = "t3code";
-const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(`^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}$`);
+// Optional `-N` suffix: bootstrap retries uniquify a taken thread-derived
+// branch name (t3code/a1b2c3d4-2), and those are still temporary branches.
+const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(
+  `^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}(-\\d+)?$`,
+);
 
 /**
  * Sanitize an arbitrary string into a valid, lowercase git refName fragment.

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -93,6 +93,24 @@ export function buildTemporaryWorktreeBranchName(
   return `${WORKTREE_BRANCH_PREFIX}/${token}`;
 }
 
+/**
+ * Deterministic worktree branch name derived from the thread id (the first
+ * UUID segment), so every worktree is attributable to its thread by
+ * construction and resends of the same thread reuse one branch name.
+ * Falls back to the caller-supplied randomness when the id has no usable
+ * hex prefix (non-UUID ids from older clients).
+ */
+export function buildThreadWorktreeBranchName(
+  threadId: string,
+  randomHex: (byteLength: number) => string,
+): string {
+  const token = threadId.trim().toLowerCase().slice(0, 8);
+  if (/^[0-9a-f]{8}$/.test(token)) {
+    return `${WORKTREE_BRANCH_PREFIX}/${token}`;
+  }
+  return buildTemporaryWorktreeBranchName(randomHex);
+}
+
 export function isTemporaryWorktreeBranch(refName: string): boolean {
   return TEMP_WORKTREE_BRANCH_PATTERN.test(refName.trim().toLowerCase());
 }

--- a/packages/shared/src/threadEnvMode.test.ts
+++ b/packages/shared/src/threadEnvMode.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveDefaultThreadEnvMode, surfaceDefaultThreadEnvMode } from "./threadEnvMode.ts";
+
+describe("surfaceDefaultThreadEnvMode", () => {
+  it("uses the current checkout when the user's attention is attached to it", () => {
+    expect(surfaceDefaultThreadEnvMode("attached-checkout")).toBe("local");
+  });
+
+  it("isolates in a worktree on detached surfaces", () => {
+    expect(surfaceDefaultThreadEnvMode("detached")).toBe("worktree");
+  });
+});
+
+describe("resolveDefaultThreadEnvMode", () => {
+  it("derives from the surface when surface derivation is on", () => {
+    expect(
+      resolveDefaultThreadEnvMode({
+        deriveFromSurface: true,
+        configuredMode: "worktree",
+        surface: "attached-checkout",
+      }),
+    ).toBe("local");
+    expect(
+      resolveDefaultThreadEnvMode({
+        deriveFromSurface: true,
+        configuredMode: "local",
+        surface: "detached",
+      }),
+    ).toBe("worktree");
+  });
+
+  it("pins the configured mode on every surface when derivation is off", () => {
+    expect(
+      resolveDefaultThreadEnvMode({
+        deriveFromSurface: false,
+        configuredMode: "worktree",
+        surface: "attached-checkout",
+      }),
+    ).toBe("worktree");
+    expect(
+      resolveDefaultThreadEnvMode({
+        deriveFromSurface: false,
+        configuredMode: "local",
+        surface: "detached",
+      }),
+    ).toBe("local");
+  });
+});

--- a/packages/shared/src/threadEnvMode.ts
+++ b/packages/shared/src/threadEnvMode.ts
@@ -1,0 +1,35 @@
+import type { ThreadEnvMode } from "@t3tools/contracts/settings";
+
+/**
+ * Surfaces a client can run on, for deriving the default workspace mode of a
+ * new thread. The deciding question is whether the user's attention is
+ * attached to a local checkout they can see:
+ *
+ * - `attached-checkout`: the user is looking at the checkout (desktop app on
+ *   a local project, browser opened on the same machine as the server). The
+ *   agent working elsewhere would be invisible to them, so the default is
+ *   the current checkout.
+ * - `detached`: no local checkout in front of the user (remote browser,
+ *   mobile, relay/SSH environments). Isolation in a fresh worktree is the
+ *   only coherent default.
+ */
+export type ThreadSurface = "attached-checkout" | "detached";
+
+export function surfaceDefaultThreadEnvMode(surface: ThreadSurface): ThreadEnvMode {
+  return surface === "attached-checkout" ? "local" : "worktree";
+}
+
+/**
+ * Resolve the effective workspace mode for a new thread.
+ * `deriveFromSurface` (the default) derives the mode from where the client
+ * runs; otherwise the explicit `configuredMode` applies everywhere.
+ */
+export function resolveDefaultThreadEnvMode(input: {
+  readonly deriveFromSurface: boolean;
+  readonly configuredMode: ThreadEnvMode;
+  readonly surface: ThreadSurface;
+}): ThreadEnvMode {
+  return input.deriveFromSurface
+    ? surfaceDefaultThreadEnvMode(input.surface)
+    : input.configuredMode;
+}


### PR DESCRIPTION
Implements the new-thread workspace model ([plan](https://rg1ncx796ppx.postplan.dev)): every new thread starts from the resolved default workspace mode instead of inheriting the previous thread's choices, and worktree threads pin a fresh remote base with visible provenance.

## Surface-derived defaults

- New `deriveThreadEnvModeFromSurface` server setting (default **on**). The attention test decides the default: surfaces attached to a visible local checkout (desktop app, loopback browser on a host-managed environment) default to the **current checkout**; detached surfaces (remote browser, mobile, relay/SSH environments) default to a **fresh worktree**. A browser reaching the primary server over LAN/domain counts as detached — the checkout lives on a machine the user can't see.
- Kept `defaultThreadEnvMode` as the legacy `local | worktree` literal so older clients still decode server-config snapshots; "Auto" is expressed by the new boolean rather than a third literal.
- **Sticky inheritance retired.** Sidebar and shortcut new-thread actions no longer seed mode/branch/worktree from the active thread or draft. `chat.newLocal` remains the explicit current-checkout exception (draft-only).
- **"Always … for this project"** action in the workspace picker writes a per-project override (`projectThreadEnvModeOverrides`, client setting) — the only sanctioned way a composer choice retrains the default. Slots into project scope when the settings-scope architecture lands.

## Fresh worktree bases without a blocking fetch

- `WorktreeBasePlanner` (server): a fetch of origin within the **30s freshness window** counts as fresh and pins immediately; concurrent fetches dedupe per repository; a failed fetch with a successful fetch within the last hour proceeds on the last-known remote commit (**fail-visible**, `stale` provenance); with no usable data the bootstrap **fails closed** — it never silently falls back to a local ref.
- Composer prefetch: opening a worktree-mode draft fires the new `vcs.prefetchRemote` RPC so the send-time check almost always hits the fresh window.
- `newWorktreesStartFromOrigin` now defaults **on**.

## Provenance and registry

- Bootstrap records a `worktree.base-pinned` thread activity (base ref, commit sha, provenance, fetch time). The branch toolbar turns the promise into the fact post-send: "Worktree · `a1b2c3f`", provenance on hover; stale pins get an error-tone activity.
- `WorktreeRegistry` persists thread↔worktree records to `stateDir/worktree-registry.json` (registered at bootstrap, marked on thread deletion) — every worktree is attributable to a thread by construction, groundwork for lifecycle/GC tooling.
- Deterministic branch naming: worktree branches derive from the thread id (`t3code/<first-8-uuid-hex>`), with server-side collision suffixing (`uniquifyNewRefName`).

## Composer UX

- Dirty-checkout disclosure both directions: checkout mode warns edits mix with uncommitted work; worktree mode warns uncommitted changes won't be included — each with a one-click switch.
- Workspace picker labels the mode choice "this draft only".
- Mobile now resolves its defaults from environment settings (detached surface) instead of hard-coding local.

## Verification

- `vp run typecheck`, `vp check`, and `vp run -r test` all pass (full suite incl. server, web, mobile, desktop).
- Independent gpt-5.6-sol (Codex) review ran pre-PR; its findings (wire-compat of the settings literal, remote-primary misclassification, mobile ignoring environment defaults, a stray NUL byte) are all addressed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches git bootstrap, default settings, and thread-creation flows across server, web, and mobile; incorrect surface or fetch logic could start threads in the wrong checkout or fail sends when remotes are down.
> 
> **Overview**
> New threads no longer inherit workspace mode, branch, or worktree from the active thread or draft; they start from a **resolved default** (surface + settings + optional per-project override). **`deriveThreadEnvModeFromSurface`** (default on) maps attached clients to **local** checkout and detached surfaces (mobile, remote browser, relay) to **worktree**; **`projectThreadEnvModeOverrides`** and the branch toolbar **“Always for this project”** action are the only ways to persist a project default.
> 
> Worktree bootstraps now **pin a remote base** via **`WorktreeBasePlanner`** (fresh fetch, deduped prefetch, stale-within-horizon, or fail closed), record **`worktree.base-pinned`** activities, register paths in **`WorktreeRegistry`**, use **thread-id-derived branch names** with collision suffixing, and expose **`vcs.prefetchRemote`** for composer-open warmup. Defaults flip to **`newWorktreesStartFromOrigin: true`**; UI shows dirty-checkout hints, pinned SHA labels, and an **Auto** new-thread mode in settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31b1c810f32052e1d129b224a24b7c3049f74b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add worktree base pinning, a worktree registry, and surface-derived workspace mode defaults
> - Introduces `WorktreeBasePlanner` ([WorktreeBasePlanner.ts](https://github.com/pingdotgg/t3code/pull/3957/files#diff-8ca8f32fdab55e76d04e400c9bc49726c93b1a2cc895e398b4a89ae3eb58a9e7)), which deduplicates remote fetches per repository and resolves a base commit with provenance (`fresh`, `stale`, or `local`) using configurable freshness and usable-horizon windows.
> - Introduces `WorktreeRegistry` ([WorktreeRegistry.ts](https://github.com/pingdotgg/t3code/pull/3957/files#diff-7ede5eb5ba4cd3d9f5204455607240a20d8ee67b689aabefaf9c5cde954e31ab)), a durable JSON-backed service that records worktree-to-thread associations with atomic writes and serialized access; thread deletion marks associated records as unowned.
> - Bootstrap now uses `WorktreeBasePlanner.pinRemoteBase` to select the base commit for new worktrees, appends a `worktree.base-pinned` activity with provenance, and sets `uniquifyNewRefName: true` so retries create a unique branch instead of failing.
> - New threads and reused drafts derive their default env mode (`local`/`worktree`) from the client surface (`attached-checkout` vs `detached`) or a per-project override stored in client settings, replacing hardcoded `local` defaults.
> - The branch toolbar and env mode selector display the pinned base's short commit SHA and provenance in the locked-worktree label and tooltip; the settings UI gains an `Auto` option for surface-derived mode.
> - Adds a `vcsPrefetchRemote` WebSocket RPC and a background prefetch effect in `ChatViewContent` that warms freshness checks when composing a worktree draft with `startFromOrigin=true`.
> - Behavioral Change: `newWorktreesStartFromOrigin` now defaults to `true`; new thread seed context no longer inherits mode, branch, or worktree path from the active thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d31b1c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->