### PR TITLE
fix: default new worktrees to latest origin main

### DIFF
--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -348,7 +348,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
   const workspaceMode = selectedProjectDraft.workspaceSelection?.mode ?? "local";
   const selectedBranchName = selectedProjectDraft.workspaceSelection?.branch ?? null;
   const selectedWorktreePath = selectedProjectDraft.workspaceSelection?.worktreePath ?? null;
-  const startFromOrigin = selectedProjectDraft.workspaceSelection?.startFromOrigin ?? false;
+  const startFromOrigin =
+    selectedProjectDraft.workspaceSelection?.startFromOrigin ??
+    selectedEnvironmentServerConfig?.settings.newWorktreesStartFromOrigin ??
+    true;
   const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode = selectedProjectDraft.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE;
 
@@ -598,8 +601,8 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
       return;
     }
     const preferredBranch =
-      availableBranches.find((branch) => branch.current) ??
       availableBranches.find((branch) => branch.isDefault) ??
+      availableBranches.find((branch) => branch.current) ??
       null;
     if (preferredBranch) {
       selectBranch(preferredBranch);

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -523,6 +523,26 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("marks the origin default ref as default when no local copy exists", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", initialBranch]);
+        yield* git(cwd, ["remote", "set-head", "origin", initialBranch]);
+        yield* git(cwd, ["checkout", "-b", "feature/only-local"]);
+        yield* git(cwd, ["branch", "-D", initialBranch]);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        const refs = yield* driver.listRefs({ cwd });
+        const remoteDefault = refs.refs.find((ref) => ref.name === `origin/${initialBranch}`);
+        assert.equal(remoteDefault?.isRemote, true);
+        assert.equal(remoteDefault?.isDefault, true);
+      }),
+    );
+
     it.effect("creates, checks out, renames, and lists refs", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2202,7 +2202,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
                 name: refName.name,
                 current: false,
                 isRemote: true,
-                isDefault: false,
+                // origin/HEAD's target is the repo default even when no local
+                // copy of the default branch exists.
+                isDefault:
+                  defaultBranch !== null &&
+                  parsedRemoteRef?.remoteName === "origin" &&
+                  parsedRemoteRef.branchName === defaultBranch,
                 worktreePath: null,
               };
               if (parsedRemoteRef) {

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -422,17 +422,32 @@ export function BranchToolbarBranchSelector({
     });
   };
 
+  // Default the worktree base to the repo default branch (origin/HEAD), only
+  // falling back to the checked-out branch when no default is known.
+  const defaultBranchName = useMemo(
+    () => refs.find((refName) => refName.isDefault)?.name ?? null,
+    [refs],
+  );
+  const worktreeBaseBranchCandidate = isInitialBranchesLoadPending
+    ? null
+    : (defaultBranchName ?? currentGitBranch);
   useEffect(() => {
     if (
       effectiveEnvMode !== "worktree" ||
       activeWorktreePath ||
       activeThreadBranch ||
-      !currentGitBranch
+      !worktreeBaseBranchCandidate
     ) {
       return;
     }
-    setThreadBranch(currentGitBranch, null);
-  }, [activeThreadBranch, activeWorktreePath, currentGitBranch, effectiveEnvMode, setThreadBranch]);
+    setThreadBranch(worktreeBaseBranchCandidate, null);
+  }, [
+    activeThreadBranch,
+    activeWorktreePath,
+    effectiveEnvMode,
+    setThreadBranch,
+    worktreeBaseBranchCandidate,
+  ]);
 
   // ---------------------------------------------------------------------------
   // Combobox / list plumbing

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -88,14 +88,14 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
 });
 
 describe("ServerSettings worktree defaults", () => {
-  it("defaults start-from-origin off for legacy configs", () => {
-    expect(decodeServerSettings({}).newWorktreesStartFromOrigin).toBe(false);
+  it("defaults start-from-origin on for legacy configs", () => {
+    expect(decodeServerSettings({}).newWorktreesStartFromOrigin).toBe(true);
   });
 
   it("accepts start-from-origin updates", () => {
     expect(
-      decodeServerSettingsPatch({ newWorktreesStartFromOrigin: true }).newWorktreesStartFromOrigin,
-    ).toBe(true);
+      decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
+    ).toBe(false);
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -375,7 +375,7 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.succeed(false)),
+    Schema.withDecodingDefault(Effect.succeed(true)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(


### PR DESCRIPTION
## Summary

New worktrees now default to being based on the latest `origin/main` (the repo default branch), and the **Start from origin** toggle is now opt-out instead of opt-in.

- **`newWorktreesStartFromOrigin` defaults to `true`** (`packages/contracts/src/settings.ts`). Since the server writes `settings.json` sparsely (defaults stripped), existing installs that never touched the toggle pick up the new default automatically; explicit values are preserved.
- **Web branch selector** (`BranchToolbarBranchSelector.tsx`): when entering New worktree mode, the auto-picked base branch now prefers the `isDefault` ref (derived from `origin/HEAD`, i.e. main) and only falls back to the checked-out branch when no default is known. It waits for the initial ref list load so the default branch wins the race.
- **Mobile** (`new-task-flow-provider.tsx`): new-task drafts resolve `startFromOrigin` from the environment's server setting (previously hardcoded `false`), and the preferred base branch is now `isDefault ?? current` instead of `current ?? isDefault`.
- Updated the contracts tests pinning the old default.

Everything downstream is unchanged: turning the toggle off still skips the fetch and bases the worktree on the local branch, and picking a different base branch works as before.

## Test plan

- [x] `bun run typecheck` clean across all packages
- [x] contracts (179), web (1280), mobile (464), server (1399) tests pass
- [x] Lint shows only pre-existing warnings in unrelated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior changes for all installs that never set `newWorktreesStartFromOrigin` explicitly, affecting worktree base resolution and fetch behavior; VCS ref semantics change for edge cases without a local default branch.
> 
> **Overview**
> New worktrees now default to the **repo default branch** (via `origin/HEAD`) and **start from origin** unless users opt out.
> 
> **`newWorktreesStartFromOrigin`** defaults to **`true`** in server settings (legacy sparse configs pick this up). Mobile new-task drafts read that setting instead of treating start-from-origin as off, with **`true`** as the final fallback.
> 
> **Web** worktree mode waits for refs to load, then auto-selects the ref marked **`isDefault`**, falling back to the checked-out branch. **Mobile** prefers **`isDefault`** over **`current`** when picking a worktree base branch.
> 
> **`GitVcsDriverCore.listRefs`** marks matching **`origin/<default>`** remote refs as **`isDefault`** even when there is no local default branch; a test covers that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e65de2ee3d8b0a2e7f5408a4dbb1784106297a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default new worktrees to start from latest origin main
> - Changes the default for `newWorktreesStartFromOrigin` in `ServerSettings` from `false` to `true`, so new worktrees start from the latest origin by default.
> - Updates automatic branch selection in worktree mode to prefer the repository default branch (`isDefault`) over the current branch in both the mobile flow provider and web branch selector.
> - Fixes `listRefs` in `GitVcsDriverCore` to mark the origin default remote ref as `isDefault=true` even when no local copy of the branch exists.
> - Behavioral Change: existing server configs without an explicit `newWorktreesStartFromOrigin` value will now decode as `true` instead of `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e65de2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->