### PR TITLE
Use client-side fallbacks for missing project favicons

### DIFF
--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -3,6 +3,7 @@ import { Image } from "expo-image";
 import { useState } from "react";
 import { View } from "react-native";
 import type { EnvironmentId } from "@t3tools/contracts";
+import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
 import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
 
@@ -24,11 +25,12 @@ export function ProjectFavicon(props: {
       ? null
       : { _tag: "project-favicon", cwd: props.workspaceRoot },
   );
+  const renderableFaviconUrl = isProjectFaviconFallbackUrl(faviconUrl) ? null : faviconUrl;
 
   return (
     <ProjectFaviconImage
       key={faviconUrl}
-      faviconUrl={faviconUrl}
+      faviconUrl={renderableFaviconUrl}
       open={props.open}
       projectTitle={props.projectTitle}
       size={size}

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -1,5 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ThreadId } from "@t3tools/contracts";
+import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -228,6 +229,7 @@ describe("AssetAccess", () => {
       const fallbackResult = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root },
       });
+      expect(fallbackResult.relativeUrl.endsWith(`/${PROJECT_FAVICON_FALLBACK_MARKER}`)).toBe(true);
       const fallbackSuffix = fallbackResult.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
       const fallbackSeparatorIndex = fallbackSuffix.indexOf("/");
       expect(
@@ -235,7 +237,7 @@ describe("AssetAccess", () => {
           fallbackSuffix.slice(0, fallbackSeparatorIndex),
           fallbackSuffix.slice(fallbackSeparatorIndex + 1),
         ),
-      ).toEqual({ kind: "project-favicon-fallback" });
+      ).toBeNull();
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -19,6 +19,7 @@ import {
   WORKSPACE_BROWSER_PREVIEW_EXTENSIONS,
   WORKSPACE_IMAGE_PREVIEW_EXTENSIONS,
 } from "@t3tools/shared/filePreview";
+import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -40,7 +41,6 @@ import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
 export const ASSET_ROUTE_PREFIX = "/api/assets";
-export const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 
 const SIGNING_SECRET_NAME = "asset-access-signing-key";
 const ASSET_TOKEN_TTL_MS = 60 * 60 * 1000;
@@ -91,9 +91,7 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset =
-  | { readonly kind: "file"; readonly path: string }
-  | { readonly kind: "project-favicon-fallback" };
+export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -326,7 +324,7 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         relativePath,
         expiresAt,
       };
-      fileName = relativePath ? path.basename(relativePath) : "favicon.svg";
+      fileName = relativePath ? path.basename(relativePath) : PROJECT_FAVICON_FALLBACK_MARKER;
       break;
     }
   }
@@ -391,9 +389,7 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   }
 
   if (claims.kind === "project-favicon") {
-    if (claims.relativePath === null) {
-      return { kind: "project-favicon-fallback" } satisfies ResolvedAsset;
-    }
+    if (claims.relativePath === null) return null;
     const faviconPath = yield* resolveCanonicalWorkspaceFileForRequest({
       workspaceRoot: claims.workspaceRoot,
       relativePath: claims.relativePath,

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -25,11 +25,7 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import { OtlpTracer } from "effect/unstable/observability";
 
 import * as ServerConfig from "./config.ts";
-import {
-  ASSET_ROUTE_PREFIX,
-  FALLBACK_PROJECT_FAVICON_SVG,
-  resolveAsset,
-} from "./assets/AssetAccess.ts";
+import { ASSET_ROUTE_PREFIX, resolveAsset } from "./assets/AssetAccess.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import { traceRelayRequest } from "./cloud/traceRelayRequest.ts";
@@ -196,17 +192,6 @@ export const assetRouteLayer = HttpRouter.add(
     if (!asset) {
       return HttpServerResponse.text("Not Found", { status: 404 });
     }
-    if (asset.kind === "project-favicon-fallback") {
-      return HttpServerResponse.text(FALLBACK_PROJECT_FAVICON_SVG, {
-        status: 200,
-        contentType: "image/svg+xml",
-        headers: {
-          "Cache-Control": "private, max-age=3600",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    }
-
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
       headers: {

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -1,4 +1,5 @@
 import type { EnvironmentId } from "@t3tools/contracts";
+import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
 import { FolderIcon } from "lucide-react";
 import { useState } from "react";
 import { useAssetUrl } from "../assets/assetUrls";
@@ -15,7 +16,7 @@ export function ProjectFavicon(input: {
     cwd: input.cwd,
   });
 
-  if (!src) {
+  if (!src || isProjectFaviconFallbackUrl(src)) {
     return <ProjectFaviconFallback className={input.className} />;
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./projectFavicon": {
+      "types": "./src/projectFavicon.ts",
+      "import": "./src/projectFavicon.ts"
+    },
     "./model": {
       "types": "./src/model.ts",
       "import": "./src/model.ts"

--- a/packages/shared/src/projectFavicon.test.ts
+++ b/packages/shared/src/projectFavicon.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { isProjectFaviconFallbackUrl, PROJECT_FAVICON_FALLBACK_MARKER } from "./projectFavicon.ts";
+
+describe("project favicon", () => {
+  it("identifies fallback asset URLs by their dedicated filename", () => {
+    expect(
+      isProjectFaviconFallbackUrl(
+        `https://environment.example/api/assets/signed-token/${PROJECT_FAVICON_FALLBACK_MARKER}`,
+      ),
+    ).toBe(true);
+    expect(
+      isProjectFaviconFallbackUrl(`/api/assets/signed-token/${PROJECT_FAVICON_FALLBACK_MARKER}`),
+    ).toBe(true);
+  });
+
+  it("does not mistake real favicons or query parameters for fallbacks", () => {
+    expect(
+      isProjectFaviconFallbackUrl("https://environment.example/api/assets/token/favicon.svg"),
+    ).toBe(false);
+    expect(
+      isProjectFaviconFallbackUrl(
+        `https://environment.example/api/assets/token/favicon.svg?name=${PROJECT_FAVICON_FALLBACK_MARKER}`,
+      ),
+    ).toBe(false);
+    expect(isProjectFaviconFallbackUrl(null)).toBe(false);
+  });
+});

--- a/packages/shared/src/projectFavicon.ts
+++ b/packages/shared/src/projectFavicon.ts
@@ -1,0 +1,12 @@
+export const PROJECT_FAVICON_FALLBACK_MARKER = "project-favicon-missing";
+
+export function isProjectFaviconFallbackUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+
+  try {
+    const pathname = new URL(url, "https://t3.invalid").pathname;
+    return pathname.slice(pathname.lastIndexOf("/") + 1) === PROJECT_FAVICON_FALLBACK_MARKER;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a shared project favicon fallback marker and URL detector.
- Return 404 for missing project favicon assets instead of serving a server-generated SVG fallback.
- Update web and mobile favicon components to render their local fallback UI when the marker URL is returned.
- Add shared favicon fallback tests and update server asset coverage.

## Testing

- `vp check`
- `vp run typecheck`
- `vp test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only asset presentation change with signed URL shape preserved; no auth or data-path changes beyond dropping the special-case SVG response.
> 
> **Overview**
> Missing project favicons no longer get a **server-generated SVG** from the asset route. The server still issues signed asset URLs when no favicon file exists, but uses a dedicated filename marker (`project-favicon-missing`) and **`resolveAsset` returns null** for those tokens—so HTTP responses are **404** instead of inline fallback SVG.
> 
> **Web and mobile** import shared `isProjectFaviconFallbackUrl` and treat marker URLs like “no image,” showing their existing **folder icon** UI without requesting a bogus asset.
> 
> Shared package adds `@t3tools/shared/projectFavicon` (marker constant + URL helper) with unit tests; server asset tests assert marker URLs and null resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dffa12cf2a50a9e5f7eb0fded8df95808cceda9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use client-side fallbacks for missing project favicons instead of serving inline SVG
> - Adds a shared `PROJECT_FAVICON_FALLBACK_MARKER` constant and `isProjectFaviconFallbackUrl()` utility in [`packages/shared/src/projectFavicon.ts`](https://github.com/pingdotgg/t3code/pull/3959/files#diff-d98cde42eca25287dcbb31cdb8d19636183750abb43d8de676195155d4d61a5c) to detect fallback favicon URLs by their filename.
> - The server now embeds the fallback marker in the issued URL when a project favicon is missing, and `resolveAsset` returns `null` for such requests instead of a special `project-favicon-fallback` object.
> - The asset route no longer serves an inline SVG for missing favicons — it returns 404 instead.
> - The web and mobile `ProjectFavicon` components detect the fallback marker client-side and render a local fallback icon without making a network request.
> - Behavioral Change: missing project favicons now result in a 404 from the asset route rather than an inline SVG response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dffa12c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->