### PR TITLE
Skip stale working-task notifications

### DIFF
--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -137,7 +137,7 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
     expect(AgentAwarenessRelay.eventThreadId(event)).toBe(threadId);
   });
 
-  it("does not publish streaming content or non-awareness activity events", () => {
+  it("does not publish start intents, streaming content, or non-awareness activity events", () => {
     const now = "2026-05-25T00:00:00.000Z";
     const base = {
       sequence: 1,
@@ -191,7 +191,16 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
           streaming: false,
         },
       } as unknown as OrchestrationEvent),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      AgentAwarenessRelay.shouldPublishAgentAwarenessEvent({
+        ...base,
+        type: "thread.turn-start-requested",
+        payload: {
+          threadId: "thread-1" as ThreadId,
+        },
+      } as unknown as OrchestrationEvent),
+    ).toBe(false);
   });
 
   it("deduplicates awareness state updates whose only change is their event timestamp", () => {

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -67,7 +67,13 @@ export function eventThreadId(event: OrchestrationEvent): ThreadId | null {
 export function shouldPublishAgentAwarenessEvent(event: OrchestrationEvent): boolean {
   switch (event.type) {
     case "thread.message-sent":
-      return !event.payload.streaming;
+    case "thread.turn-start-requested":
+      // These events express intent to start work, but the shell still contains
+      // the previous turn's terminal state until the provider acknowledges the
+      // new turn. Publishing that snapshot can queue a fresh "Done" alert just
+      // before the real running state arrives. Provider lifecycle events publish
+      // the authoritative starting/running state instead.
+      return false;
     case "thread.proposed-plan-upserted":
     case "thread.runtime-mode-set":
     case "thread.interaction-mode-set":

--- a/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
@@ -64,6 +64,7 @@ function makeAgentActivityRows(
     remove: () => Effect.void,
     pruneTerminal: () => Effect.void,
     listForUser: () => Effect.succeed([state]),
+    getForUserThread: () => Effect.succeed(state),
     ...overrides,
   };
 }

--- a/infra/relay/src/agentActivity/AgentActivityRows.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.test.ts
@@ -75,6 +75,15 @@ describe("AgentActivityRows", () => {
       const listError = yield* rows.listForUser({ userId: "user-2" }).pipe(Effect.flip);
       expect(listError).toMatchObject({ userId: "user-2", cause });
       expect(listError.message).toBe("Failed to list agent activity state for user user-2.");
+
+      const getError = yield* rows
+        .getForUserThread({
+          userId: "user-2",
+          environmentId: "env-1",
+          threadId: "thread-1",
+        })
+        .pipe(Effect.flip);
+      expect(getError).toMatchObject({ userId: "user-2", cause });
     }).pipe(
       Effect.provide(
         AgentActivityRows.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, failingDb))),

--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -83,6 +83,11 @@ export class AgentActivityRows extends Context.Service<
       ReadonlyArray<RelayAgentActivityState>,
       AgentActivityRowListPersistenceError
     >;
+    readonly getForUserThread: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+      readonly threadId: string;
+    }) => Effect.Effect<RelayAgentActivityState | null, AgentActivityRowListPersistenceError>;
   }
 >()("t3code-relay/agentActivity/AgentActivityRows") {}
 
@@ -232,6 +237,54 @@ export const make = Effect.gen(function* () {
           Effect.map((rows) =>
             rows.flatMap((row) => Option.toArray(decodeRelayAgentActivityStateJson(row))),
           ),
+          Effect.mapError(
+            (cause) =>
+              new AgentActivityRowListPersistenceError({
+                userId: input.userId,
+                cause,
+              }),
+          ),
+        );
+    }),
+
+    getForUserThread: Effect.fn("relay.agent_activity_rows.get_for_user_thread")(function* (input) {
+      return yield* db
+        .select({ stateJson: relayAgentActivityRows.stateJson })
+        .from(relayAgentActivityRows)
+        .innerJoin(
+          relayEnvironmentLinks,
+          and(
+            eq(relayEnvironmentLinks.environmentId, relayAgentActivityRows.environmentId),
+            eq(
+              relayEnvironmentLinks.environmentPublicKey,
+              relayAgentActivityRows.environmentPublicKey,
+            ),
+          ),
+        )
+        .where(
+          and(
+            eq(relayEnvironmentLinks.userId, input.userId),
+            isNull(relayEnvironmentLinks.revokedAt),
+            eq(relayAgentActivityRows.environmentId, input.environmentId),
+            eq(relayAgentActivityRows.threadId, input.threadId),
+          ),
+        )
+        .orderBy(desc(relayAgentActivityRows.updatedAt))
+        .pipe(
+          Effect.flatMap((rows) =>
+            Effect.forEach(rows, (row) => encodeJsonValue(row.stateJson), {
+              concurrency: "unbounded",
+            }),
+          ),
+          Effect.map((rows) => {
+            for (const row of rows) {
+              const decoded = decodeRelayAgentActivityStateJson(row);
+              if (Option.isSome(decoded)) {
+                return decoded.value;
+              }
+            }
+            return null;
+          }),
           Effect.mapError(
             (cause) =>
               new AgentActivityRowListPersistenceError({

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -5,7 +5,6 @@ import type {
 import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
 import { describe, expect, it } from "@effect/vitest";
 import * as NodeCrypto from "node:crypto";
-import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
@@ -161,10 +160,13 @@ function makeLayer(input: {
   >;
   readonly currentTargets?: ReadonlyArray<LiveActivities.TargetRow>;
   readonly config?: RelayConfiguration.RelayConfiguration["Service"];
-  // Live agent-activity rows returned by the delivery-time start recheck.
-  // Defaults to one freshly-updated running thread so queued starts stay
-  // deliverable in tests that don't care about the recheck.
+  // Live agent-activity rows returned by delivery-time state rechecks.
+  // Defaults to the fixture row so queued updates match unless a test is
+  // explicitly exercising stale-state behavior.
   readonly activityStates?: ReadonlyArray<RelayAgentActivityState>;
+  // Current per-thread rows used to reject queued updates/notifications that
+  // have been superseded before APNs delivery.
+  readonly currentActivityStates?: ReadonlyArray<RelayAgentActivityState>;
   readonly execute?: (
     request: HttpClientRequest.HttpClientRequest,
   ) => Effect.Effect<HttpClientResponse.HttpClientResponse>;
@@ -182,9 +184,14 @@ function makeLayer(input: {
           listForUser: () =>
             input.activityStates !== undefined
               ? Effect.succeed([...input.activityStates])
-              : DateTime.now.pipe(
-                  Effect.map((now) => [{ ...state, updatedAt: DateTime.formatIso(now) }]),
-                ),
+              : Effect.succeed([state]),
+          getForUserThread: ({ environmentId, threadId }) =>
+            Effect.succeed(
+              (input.currentActivityStates ?? input.activityStates ?? [state]).find(
+                (current) =>
+                  current.environmentId === environmentId && current.threadId === threadId,
+              ) ?? null,
+            ),
         } satisfies AgentActivityRows.AgentActivityRows["Service"]),
         Layer.succeed(ApnsDeliveryQueue.ApnsDeliveryQueueSender, {
           send: (body) =>
@@ -674,6 +681,8 @@ describe("ApnsDeliveries", () => {
                 environmentId: "env",
                 threadId: "thread",
                 deepLink: "/",
+                phase: "waiting_for_input",
+                updatedAt: state.updatedAt,
               },
             },
           },
@@ -777,6 +786,30 @@ describe("ApnsDeliveries", () => {
       }).pipe(Effect.provide(makeLayer({ attempts, queuedJobs })));
     },
   );
+
+  it.effect("does not queue a push notification when a thread starts working", () => {
+    const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+    const queuedJobs: Array<SignedApnsDeliveryJob> = [];
+
+    return Effect.gen(function* () {
+      const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+      const result = yield* deliveries.sendForTarget({
+        target: {
+          ...target,
+          push_token: "apns-device-token",
+          push_to_start_token: null,
+          activity_push_token: null,
+          remote_started_at: null,
+        },
+        aggregate,
+        nowMs: 5_000,
+      });
+
+      expect(result).toBeNull();
+      expect(queuedJobs).toEqual([]);
+      expect(attempts).toEqual([]);
+    }).pipe(Effect.provide(makeLayer({ attempts, queuedJobs })));
+  });
 
   it.effect("queues bounded alert notification payloads", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
@@ -1176,6 +1209,150 @@ describe("ApnsDeliveries", () => {
     );
   });
 
+  it.effect("skips a queued Done Live Activity update after the thread resumes working", () => {
+    const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+    let executeCount = 0;
+    const completedAt = "1970-01-01T00:00:01.000Z";
+    const completedAggregate: RelayAgentActivityAggregateState = {
+      ...aggregate,
+      activeCount: 0,
+      updatedAt: completedAt,
+      activities: [
+        {
+          ...aggregate.activities[0]!,
+          phase: "completed",
+          status: "Done",
+          updatedAt: completedAt,
+        },
+      ],
+    };
+    const payload = makeApnsDeliveryJobPayload({
+      kind: "live_activity_update",
+      userId: target.user_id,
+      deviceId: target.device_id,
+      token: target.activity_push_token ?? "activity-token",
+      aggregate: completedAggregate,
+      alert: { title: "Thread", body: "Done: Project" },
+      createdAt: completedAt,
+      expiresAt: "1970-01-01T00:10:00.000Z",
+      jobId: "job-update-superseded-by-running",
+    });
+    const signed = signApnsDeliveryJob({
+      secret: config.apnsDeliveryJobSigningSecret,
+      payload,
+    });
+    const execute = (request: HttpClientRequest.HttpClientRequest) =>
+      Effect.sync(() => {
+        executeCount += 1;
+        return HttpClientResponse.fromWeb(request, new Response("", { status: 200 }));
+      });
+
+    return Effect.gen(function* () {
+      const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+      const result = yield* deliveries.processSignedJob(signed);
+
+      expect(result).toMatchObject({
+        kind: "live_activity_update",
+        ok: true,
+        apnsStatus: null,
+        apnsReason: "Stale APNs delivery job skipped.",
+      });
+      expect(executeCount).toBe(0);
+      expect(attempts).toMatchObject([
+        {
+          sourceJobId: "job-update-superseded-by-running",
+          apnsReason: "Stale agent activity state skipped.",
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          attempts,
+          activityStates: [
+            {
+              ...state,
+              phase: "running",
+              headline: "Running",
+              updatedAt: "1970-01-01T00:00:02.000Z",
+            },
+          ],
+          config: signingConfig,
+          execute,
+        }),
+      ),
+    );
+  });
+
+  it.effect("skips a queued Done notification after the thread resumes working", () => {
+    const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+    let executeCount = 0;
+    const completedAt = "1970-01-01T00:00:01.000Z";
+    const payload = makeApnsDeliveryJobPayload({
+      kind: "push_notification",
+      userId: target.user_id,
+      deviceId: target.device_id,
+      token: "apns-device-token",
+      aggregate: null,
+      notification: {
+        title: "Thread",
+        body: "Done: Project",
+        environmentId: "env",
+        threadId: "thread",
+        deepLink: "/",
+        phase: "completed",
+        updatedAt: completedAt,
+      },
+      createdAt: completedAt,
+      expiresAt: "1970-01-01T00:10:00.000Z",
+      jobId: "job-push-superseded-by-running",
+    });
+    const signed = signApnsDeliveryJob({
+      secret: config.apnsDeliveryJobSigningSecret,
+      payload,
+    });
+    const execute = (request: HttpClientRequest.HttpClientRequest) =>
+      Effect.sync(() => {
+        executeCount += 1;
+        return HttpClientResponse.fromWeb(request, new Response("", { status: 200 }));
+      });
+
+    return Effect.gen(function* () {
+      const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+      const result = yield* deliveries.processSignedJob(signed);
+
+      expect(result).toMatchObject({
+        kind: "push_notification",
+        ok: true,
+        apnsStatus: null,
+        apnsReason: "Stale APNs delivery job skipped.",
+      });
+      expect(executeCount).toBe(0);
+      expect(attempts).toMatchObject([
+        {
+          sourceJobId: "job-push-superseded-by-running",
+          apnsReason: "Stale agent activity state skipped.",
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          attempts,
+          currentTargets: [{ ...target, push_token: "apns-device-token" }],
+          currentActivityStates: [
+            {
+              ...state,
+              phase: "running",
+              headline: "Running",
+              updatedAt: "1970-01-01T00:00:02.000Z",
+            },
+          ],
+          config: signingConfig,
+          execute,
+        }),
+      ),
+    );
+  });
+
   it.effect("retries signed queue jobs that are already claimed but not completed", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     let executeCount = 0;
@@ -1327,7 +1504,15 @@ describe("ApnsDeliveries", () => {
           deviceId: target.device_id,
         },
       ]);
-    }).pipe(Effect.provide(makeLayer({ attempts, clearedStarts })));
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          attempts,
+          clearedStarts,
+          activityStates: [{ ...state, updatedAt: "9999-01-01T00:00:00.000Z" }],
+        }),
+      ),
+    );
   });
 
   it.effect("invalidates dead push-to-start tokens after permanent APNs start failures", () => {
@@ -1373,7 +1558,15 @@ describe("ApnsDeliveries", () => {
         },
       ]);
     }).pipe(
-      Effect.provide(makeLayer({ attempts, invalidatedTokens, config: signingConfig, execute })),
+      Effect.provide(
+        makeLayer({
+          attempts,
+          invalidatedTokens,
+          activityStates: [{ ...state, updatedAt: "9999-01-01T00:00:00.000Z" }],
+          config: signingConfig,
+          execute,
+        }),
+      ),
     );
   });
 

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -369,6 +369,8 @@ function notificationForAggregate(input: {
     environmentId: activity.environmentId,
     threadId: activity.threadId,
     deepLink: activity.deepLink,
+    phase: activity.phase,
+    updatedAt: activity.updatedAt,
   };
 }
 
@@ -722,6 +724,87 @@ export const make = Effect.gen(function* () {
     );
   });
 
+  const stateIdentityIsCurrent = Effect.fnUntraced(function* (input: {
+    readonly userId: string;
+    readonly environmentId: string;
+    readonly threadId: string;
+    readonly phase: RelayAgentActivityAggregateState["activities"][number]["phase"];
+    readonly updatedAt: string;
+  }) {
+    return yield* activityRows
+      .getForUserThread({
+        userId: input.userId,
+        environmentId: input.environmentId,
+        threadId: input.threadId,
+      })
+      .pipe(
+        Effect.map(
+          (current) =>
+            current !== null &&
+            current.phase === input.phase &&
+            current.updatedAt === input.updatedAt,
+        ),
+        // A transient persistence failure must not permanently discard a
+        // legitimate alert. Fail open and let the signed job's retry/dedupe
+        // protections handle transport failures as usual.
+        Effect.catchCause((cause) =>
+          Effect.logWarning("agent-activity state recheck failed; allowing queued delivery", {
+            cause,
+            environmentId: input.environmentId,
+            threadId: input.threadId,
+          }).pipe(Effect.as(true)),
+        ),
+      );
+  });
+
+  const aggregateRowsAreCurrent = Effect.fnUntraced(function* (input: {
+    readonly userId: string;
+    readonly aggregate: RelayAgentActivityAggregateState;
+  }) {
+    return yield* activityRows.listForUser({ userId: input.userId }).pipe(
+      Effect.map((currentStates) => {
+        const currentByThread = new Map(
+          currentStates.map((current) => [
+            `${current.environmentId}\u0000${current.threadId}`,
+            current,
+          ]),
+        );
+        return input.aggregate.activities.every((row) => {
+          const current = currentByThread.get(`${row.environmentId}\u0000${row.threadId}`);
+          return (
+            current !== undefined &&
+            current.phase === row.phase &&
+            current.updatedAt === row.updatedAt
+          );
+        });
+      }),
+      Effect.catchCause((cause) =>
+        Effect.logWarning("agent-activity aggregate recheck failed; allowing queued delivery", {
+          cause,
+          userId: input.userId,
+        }).pipe(Effect.as(true)),
+      ),
+    );
+  });
+
+  const notificationStateIsCurrent = Effect.fnUntraced(function* (input: {
+    readonly userId: string;
+    readonly notification: ApnsNotificationPayload;
+  }) {
+    // Jobs from older relay versions do not carry a state identity. Preserve
+    // backwards compatibility and only revalidate newly queued jobs.
+    if (input.notification.phase === undefined || input.notification.updatedAt === undefined) {
+      return true;
+    }
+    return yield* stateIdentityIsCurrent({
+      userId: input.userId,
+      environmentId: input.notification.environmentId,
+      threadId: input.notification.threadId,
+      phase: input.notification.phase,
+      updatedAt: input.notification.updatedAt,
+    });
+  });
+
   const isCurrentSignedJobToken = Effect.fnUntraced(function* (input: {
     readonly target: LiveActivityDeliveryTarget;
     readonly kind: RelayDeliveryKind;
@@ -788,6 +871,20 @@ export const make = Effect.gen(function* () {
         yield* attempts.completeSourceJob({
           sourceJobId: input.sourceJobId,
           apnsReason: "Stale APNs delivery job skipped.",
+        });
+        return staleJobResult({ deviceId: input.target.device_id, kind: input.kind });
+      }
+      if (
+        input.kind !== "live_activity_start" &&
+        aggregate !== null &&
+        !(yield* aggregateRowsAreCurrent({
+          userId: input.target.user_id,
+          aggregate,
+        }))
+      ) {
+        yield* attempts.completeSourceJob({
+          sourceJobId: input.sourceJobId,
+          apnsReason: "Stale agent activity state skipped.",
         });
         return staleJobResult({ deviceId: input.target.device_id, kind: input.kind });
       }
@@ -924,6 +1021,21 @@ export const make = Effect.gen(function* () {
         yield* attempts.completeSourceJob({
           sourceJobId: input.sourceJobId,
           apnsReason: "Stale APNs delivery job skipped.",
+        });
+        return staleJobResult({
+          deviceId: input.target.device_id,
+          kind: "push_notification",
+        });
+      }
+      if (
+        !(yield* notificationStateIsCurrent({
+          userId: input.target.user_id,
+          notification,
+        }))
+      ) {
+        yield* attempts.completeSourceJob({
+          sourceJobId: input.sourceJobId,
+          apnsReason: "Stale agent activity state skipped.",
         });
         return staleJobResult({
           deviceId: input.target.device_id,

--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -86,6 +86,7 @@ function makeAgentActivityRows(
       };
       return Effect.succeed([activeState]);
     },
+    getForUserThread: () => Effect.succeed(null),
     ...overrides,
   };
 }

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
@@ -1,6 +1,10 @@
 import * as NodeCrypto from "node:crypto";
 
-import { RelayAgentActivityAggregateState, type RelayDeliveryKind } from "@t3tools/contracts/relay";
+import {
+  RelayAgentActivityAggregateState,
+  RelayAgentAwarenessPhase,
+  type RelayDeliveryKind,
+} from "@t3tools/contracts/relay";
 import { stableStringify } from "@t3tools/shared/relaySigning";
 import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
@@ -38,6 +42,11 @@ export const ApnsNotificationPayload = Schema.Struct({
   environmentId: Schema.String,
   threadId: Schema.String,
   deepLink: Schema.String,
+  // Optional so delivery jobs queued by older relay builds still decode.
+  // New jobs use these fields to avoid delivering a stale Done/attention
+  // notification after the thread has moved to another phase.
+  phase: Schema.optional(RelayAgentAwarenessPhase),
+  updatedAt: Schema.optional(Schema.String),
 });
 export type ApnsNotificationPayload = typeof ApnsNotificationPayload.Type;
 


### PR DESCRIPTION
## Summary
- Stop publishing working-task awareness for start-intent events that can still carry the previous terminal state.
- Add delivery-time state rechecks for APNs Live Activity updates and push notifications so superseded “Done” alerts are skipped.
- Include activity phase and timestamp identity in newly queued notification jobs while preserving older job compatibility.

## Testing
- `vp test` for relay agent activity and APNs delivery coverage
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile notification delivery and awareness publish filtering; behavior changes are guarded by tests and fail-open on DB errors during rechecks, but wrong staleness logic could drop legitimate alerts.
> 
> **Overview**
> Fixes **spurious "Done" alerts** when a thread starts a new turn while mobile still shows the previous terminal state.
> 
> **Server relay:** `shouldPublishAgentAwarenessEvent` no longer publishes on `thread.message-sent` or `thread.turn-start-requested` (start-intent events can still reflect the prior turn until the provider updates). Awareness updates rely on provider lifecycle events instead.
> 
> **Relay / APNs:** New `AgentActivityRows.getForUserThread` supports **delivery-time rechecks** before signed jobs hit APNs. Live Activity updates compare the queued aggregate to current rows; push notifications compare optional `phase` and `updatedAt` on the job payload (older jobs without those fields still deliver). Superseded **Done** Live Activity updates and notifications are skipped without calling APNs. New notification jobs include phase/timestamp identity when queued.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba371bd9a151c53954aef996a75bb05c84f8d2f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip stale working-task APNs notifications at delivery time
> - Adds delivery-time freshness checks in [`ApnsDeliveries`](https://github.com/pingdotgg/t3code/pull/3961/files#diff-b5f76b7b901b1e00d834ecfbecbc61c1b181e71f588fb216a5c94d753dca03e6): signed jobs are skipped if the referenced agent-activity state is no longer current, completing them with reason `'Stale agent activity state skipped.'`
> - Adds `getForUserThread` to [`AgentActivityRows`](https://github.com/pingdotgg/t3code/pull/3961/files#diff-0c3320c24b3ea3e4c1c221776bf499f81cadd0fa30f1622749621cde23860018) to look up the latest activity state for a specific user/thread, used to verify per-thread state identity before delivering push notifications.
> - Suppresses `shouldPublishAgentAwarenessEvent` for `thread.message-sent` and `thread.turn-start-requested` events in [`AgentAwarenessRelay`](https://github.com/pingdotgg/t3code/pull/3961/files#diff-46d7033397b4a9b5846cacda38ebc024554005dcf6e10f8369546c0dcd1b6573).
> - Extends [`ApnsNotificationPayload`](https://github.com/pingdotgg/t3code/pull/3961/files#diff-5f124fac34224b75c7c5b17f3fcb5d9e2c9b2d881e478aab85953346e58e5fbc) with optional `phase` and `updatedAt` fields to carry state identity through the job queue.
> - Risk: persistence errors during freshness checks fail open — a warning is logged and delivery proceeds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba371bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->