### PR TITLE
fix(perf): remove pulsing from terminal icon

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -771,7 +771,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                   />
                 }
               >
-                <TerminalIcon className={`size-3 ${terminalStatus.pulse ? "animate-pulse" : ""}`} />
+                <TerminalIcon className="size-3" />
               </TooltipTrigger>
               <TooltipPopup side="top">{terminalStatus.label}</TooltipPopup>
             </Tooltip>

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -276,7 +276,7 @@ export function ThreadRowTrailingStatus({ thread }: { thread: SidebarThreadSumma
               />
             }
           >
-            <TerminalIcon className={`size-3 ${terminalStatus.pulse ? "animate-pulse" : ""}`} />
+            <TerminalIcon className="size-3" />
           </TooltipTrigger>
           <TooltipPopup side="top">{terminalStatus.label}</TooltipPopup>
         </Tooltip>


### PR DESCRIPTION
## Summary

- remove continuous pulse animations from running terminal icons
- retain the existing terminal status color and tooltip
- avoid keeping the browser compositor active while terminals are running

## Validation

- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI class change on status icons; no logic, auth, or data paths affected.
> 
> **Overview**
> Stops applying **`animate-pulse`** on the running-terminal **`TerminalIcon`** in the sidebar thread row and in **`ThreadRowTrailingStatus`** (e.g. command palette).
> 
> When terminals are active, the icon still uses the teal status color and the same “Terminal process running” tooltip; only the continuous CSS pulse animation is removed so the compositor isn’t kept busy for every visible running terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2451aa39017a44d463eac993a54372d2eef8d194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove pulsing animation from terminal status icon in sidebar
> The `TerminalIcon` in sidebar thread rows previously added an `animate-pulse` class when terminals were running. This removes that conditional, making the icon always static with a fixed `size-3` class. The change applies in both [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/3975/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [ThreadStatusIndicators.tsx](https://github.com/pingdotgg/t3code/pull/3975/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2451aa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->