### PR TITLE
perf(web): duty-cycle status animations and remove fixed noise overlay

### DIFF
--- a/apps/web/src/components/ConnectionStatusDot.tsx
+++ b/apps/web/src/components/ConnectionStatusDot.tsx
@@ -17,7 +17,7 @@ export function ConnectionStatusDot({
       {pingClassName ? (
         <span
           className={cn(
-            "absolute inline-flex h-full w-full animate-ping rounded-full",
+            "absolute inline-flex h-full w-full animate-status-ping rounded-full",
             pingClassName,
           )}
         />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -771,7 +771,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                   />
                 }
               >
-                <TerminalIcon className={`size-3 ${terminalStatus.pulse ? "animate-pulse" : ""}`} />
+                <TerminalIcon
+                  className={`size-3 ${terminalStatus.pulse ? "animate-status-pulse" : ""}`}
+                />
               </TooltipTrigger>
               <TooltipPopup side="top">{terminalStatus.label}</TooltipPopup>
             </Tooltip>
@@ -2226,7 +2228,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                 <span className="absolute inset-0 flex items-center justify-center transition-opacity duration-150 group-hover/project-header:opacity-0">
                   <span
                     className={`size-[9px] rounded-full ${projectStatus.dotClass} ${
-                      projectStatus.pulse ? "animate-pulse" : ""
+                      projectStatus.pulse ? "animate-status-pulse" : ""
                     }`}
                   />
                 </span>

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -149,7 +149,7 @@ export function ThreadStatusLabel({
         >
           <span
             className={`size-[9px] rounded-full ${status.dotClass} ${
-              status.pulse ? "animate-pulse" : ""
+              status.pulse ? "animate-status-pulse" : ""
             }`}
           />
         </TooltipTrigger>
@@ -170,7 +170,7 @@ export function ThreadStatusLabel({
       >
         <span
           className={`h-1.5 w-1.5 rounded-full ${status.dotClass} ${
-            status.pulse ? "animate-pulse" : ""
+            status.pulse ? "animate-status-pulse" : ""
           }`}
         />
         <span className="hidden md:inline">{status.label}</span>
@@ -276,7 +276,9 @@ export function ThreadRowTrailingStatus({ thread }: { thread: SidebarThreadSumma
               />
             }
           >
-            <TerminalIcon className={`size-3 ${terminalStatus.pulse ? "animate-pulse" : ""}`} />
+            <TerminalIcon
+              className={`size-3 ${terminalStatus.pulse ? "animate-status-pulse" : ""}`}
+            />
           </TooltipTrigger>
           <TooltipPopup side="top">{terminalStatus.label}</TooltipPopup>
         </Tooltip>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1055,9 +1055,9 @@ function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "workin
     <div className="py-0.5 pl-1.5">
       <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70 tabular-nums">
         <span className="inline-flex items-center gap-[3px]">
-          <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />
-          <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:200ms]" />
-          <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
+          <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse" />
+          <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse [animation-delay:200ms]" />
+          <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-status-pulse [animation-delay:400ms]" />
         </span>
         <span>
           {row.createdAt ? (

--- a/apps/web/src/components/preview/AgentBrowserCursor.tsx
+++ b/apps/web/src/components/preview/AgentBrowserCursor.tsx
@@ -66,7 +66,7 @@ function AgentBrowserCursorEvent(props: {
       {event.phase === "click" ? (
         <span
           key={event.sequence}
-          className="absolute left-0.5 top-0.5 size-4 animate-ping rounded-full bg-primary/25 motion-reduce:animate-none"
+          className="absolute left-0.5 top-0.5 size-4 animate-status-ping rounded-full bg-primary/25 motion-reduce:animate-none"
         />
       ) : null}
       <MousePointer2

--- a/apps/web/src/components/preview/PreviewChromeRow.tsx
+++ b/apps/web/src/components/preview/PreviewChromeRow.tsx
@@ -266,7 +266,7 @@ export function PreviewChromeRow({
             >
               <Camera className={cn(recording && "text-destructive")} />
               {recording ? (
-                <span className="absolute right-0.5 top-0.5 size-1.5 animate-pulse rounded-full bg-destructive" />
+                <span className="absolute right-0.5 top-0.5 size-1.5 animate-status-pulse rounded-full bg-destructive" />
               ) : null}
             </TooltipTrigger>
             <TooltipPopup>

--- a/apps/web/src/components/preview/PreviewLocalServerCard.tsx
+++ b/apps/web/src/components/preview/PreviewLocalServerCard.tsx
@@ -36,7 +36,7 @@ function describeServer(server: PreviewableServer): string {
 function PulsingDot() {
   return (
     <span aria-label="Listening" className="relative inline-flex size-2 shrink-0">
-      <span className="absolute inset-0 animate-ping rounded-full bg-success opacity-60" />
+      <span className="absolute inset-0 animate-status-ping rounded-full bg-success opacity-60" />
       <span className="relative inline-flex size-2 rounded-full bg-success" />
     </span>
   );

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -216,7 +216,7 @@ function Sidebar({
       <SidebarInstanceContext value={instanceContextValue}>
         <div
           className={cn(
-            "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+            "flex h-full w-(--sidebar-width) flex-col bg-sidebar surface-grain text-sidebar-foreground",
             className,
           )}
           data-slot="sidebar"
@@ -234,7 +234,7 @@ function Sidebar({
         <Sheet onOpenChange={setOpenMobile} open={openMobile} {...props}>
           <SheetPopup
             className={cn(
-              "w-(--sidebar-width) max-w-none bg-sidebar p-0 text-sidebar-foreground",
+              "w-(--sidebar-width) max-w-none bg-sidebar surface-grain p-0 text-sidebar-foreground",
               className,
             )}
             data-mobile="true"
@@ -304,7 +304,7 @@ function Sidebar({
           {...props}
         >
           <div
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm/5"
+            className="flex h-full w-full flex-col bg-sidebar surface-grain group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm/5"
             data-sidebar="sidebar"
             data-slot="sidebar-inner"
           >
@@ -622,7 +622,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   return (
     <main
       className={cn(
-        "relative flex min-w-0 w-full flex-1 flex-col bg-background",
+        "relative flex min-w-0 w-full flex-1 flex-col bg-background surface-grain",
         "md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm/5",
         className,
       )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -186,9 +186,16 @@
     padding-inline-end: calc(env(safe-area-inset-right) + 0.75rem);
   }
 
-  .chat-composer-glass,
-  .chat-composer-lower-chrome {
+  .chat-composer-glass {
     background: color-mix(in srgb, var(--card) 20%, transparent);
+  }
+
+  /* Mix from --background (not --card): the lower chrome is a full-width
+     strip over the main view, and a card-tinted wash reads as a lighter
+     seam against it when no content is scrolled underneath. The backdrop
+     blur, not the tint, carries the frosted effect. */
+  .chat-composer-lower-chrome {
+    background: color-mix(in srgb, var(--background) 20%, transparent);
   }
 
   .chat-composer-glass {
@@ -202,9 +209,12 @@
     backdrop-filter: blur(16px);
   }
 
-  .dark .chat-composer-glass,
-  .dark .chat-composer-lower-chrome {
+  .dark .chat-composer-glass {
     background: color-mix(in srgb, var(--card) 45%, transparent);
+  }
+
+  .dark .chat-composer-lower-chrome {
+    background: color-mix(in srgb, var(--background) 45%, transparent);
   }
 
   .dark .chat-composer-glass {
@@ -227,9 +237,12 @@
   }
 
   @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-    .chat-composer-glass,
-    .chat-composer-lower-chrome {
+    .chat-composer-glass {
       background: var(--card);
+    }
+
+    .chat-composer-lower-chrome {
+      background: var(--background);
     }
   }
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -36,6 +36,11 @@
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
+  /* Duty-cycled indicator animations: long opacity holds with short stepped
+     ramps, so the compositor only produces frames while the value changes
+     (~20% of the cycle) instead of every vsync. Keep flat holds dominant. */
+  --animate-status-pulse: status-pulse 2s infinite;
+  --animate-status-ping: status-ping 2s infinite;
   --font-sans:
     "DM Sans Variable", "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
     sans-serif;
@@ -76,6 +81,36 @@
   @keyframes skeleton {
     to {
       background-position: -200% 0;
+    }
+  }
+  @keyframes status-pulse {
+    0%,
+    40% {
+      opacity: 1;
+      animation-timing-function: steps(6);
+    }
+    50%,
+    90% {
+      opacity: 0.5;
+      animation-timing-function: steps(6);
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+  @keyframes status-ping {
+    /* Burst first (immediate feedback for click ripples), then hold
+       invisible for the rest of the cycle. Mirrors animate-ping's
+       75%-scale start. */
+    0% {
+      opacity: 0.9;
+      scale: 0.75;
+      animation-timing-function: steps(8);
+    }
+    40%,
+    100% {
+      opacity: 0;
+      scale: 2;
     }
   }
 }
@@ -320,13 +355,12 @@ body {
   padding-top: max(env(safe-area-inset-top), 0px);
 }
 
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0.035;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+/* App-chrome grain. Baked into the body background (behind content) rather
+   than a fixed overlay on top: a full-viewport overlay forces the compositor
+   to re-blend every frame any animation produces, which multiplied idle GPU
+   cost. The overlay's 0.035 opacity lives in the SVG rect instead. */
+body {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
   background-repeat: repeat;
   background-size: 256px 256px;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -250,6 +250,15 @@
   padding-right: max(env(safe-area-inset-right), 0px);
 }
 
+/* Grain texture for chrome surfaces that float above the body (see the
+   --surface-grain note). Layered over the element's background-color, so it
+   composes with bg-* utilities. */
+@utility surface-grain {
+  background-image: var(--surface-grain);
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
 /* Suppress all transitions during theme changes */
 .no-transitions,
 .no-transitions *,
@@ -355,12 +364,19 @@ body {
   padding-top: max(env(safe-area-inset-top), 0px);
 }
 
-/* App-chrome grain. Baked into the body background (behind content) rather
-   than a fixed overlay on top: a full-viewport overlay forces the compositor
-   to re-blend every frame any animation produces, which multiplied idle GPU
-   cost. The overlay's 0.035 opacity lives in the SVG rect instead. */
+/* App-chrome grain. Baked into each surface's own background (behind
+   content) rather than a fixed overlay on top: a full-viewport overlay
+   forces the compositor to re-blend every frame any animation produces,
+   which multiplied idle GPU cost. The overlay's 0.035 opacity lives in the
+   SVG rect instead. Surfaces that float over the body (e.g. the inset main
+   card) must opt in via the surface-grain utility, or they lose the
+   grain's subtle brightening and stand out against the body. */
+:root {
+  --surface-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+}
+
 body {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+  background-image: var(--surface-grain);
   background-repeat: repeat;
   background-size: 256px 256px;
 }


### PR DESCRIPTION
## Problem

CSS animations were pegging the GPU (30%+ utilization) on high-refresh displays while the app was visually idle. Two compounding causes, isolated via in-prod experiments:

1. **Infinite `animate-pulse`/`animate-ping` indicators** force the compositor to produce a full frame every vsync — 120fps on 120Hz displays — even though only a 12px icon is fading. Killing all animations dropped GPU by 90%.
2. **The fixed full-viewport noise overlay** (`body::after`, `position: fixed; inset: 0`) sat on top of all content, so every animation-produced frame required re-blending the entire ~8MP window. Disabling decorative overlays cut the animation cost from 30%+ to ~7-10%.

## Fix

Both levers, multiplied:

- **Duty-cycled keyframes** (`status-pulse`, `status-ping` in `index.css`): long flat opacity holds with short `steps()` ramps. Chromium's damage tracking skips presenting frames when the sampled value hasn't changed, so frames are only produced ~20% of the cycle instead of 100%. Visually still a gentle breathing pulse (verified in prod console before implementing).
- **Noise moved behind content**: the feTurbulence grain now lives on `body`'s own background (opacity 0.035 baked into the SVG rect) instead of a fixed overlay above everything, taking it out of the per-frame blend path.

All infinite `animate-pulse`/`animate-ping` sites swapped to the new utilities (sidebar status dots, terminal icon, thread indicators, connection dot, preview recording dot, local-server ping, agent cursor click ripple, timeline typing dots). Finite/loading `animate-spin` left untouched.

## Measured impact

On a 120Hz display with active status indicators: idle GPU utilization **30%+ → ~4%** (console-prototype of the same keyframes; floor with animations fully disabled is ~3%).

## Notes for review

- `status-ping` bursts at cycle start then holds invisible, so click ripples (`AgentBrowserCursor`) get immediate feedback on mount.
- Grain no longer composites over images/video/diff surfaces — at 0.035 opacity this is imperceptible, but flagging as an intentional visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/rendering and animation tweaks only; no auth, data, or API changes. Grain no longer composites over all content (intentional, subtle at 0.035 opacity).
> 
> **Overview**
> Reduces idle GPU cost by replacing always-on Tailwind **`animate-pulse`** / **`animate-ping`** on status indicators with duty-cycled **`animate-status-pulse`** and **`animate-status-ping`** keyframes (long flat holds + stepped ramps), wired through sidebar, thread/connection dots, preview chrome, and chat timeline “working” dots.
> 
> Removes the fixed full-viewport **`body::after`** noise overlay and bakes the same grain into **`body`** and floating chrome via **`--surface-grain`** and a new **`surface-grain`** utility on sidebar shells and **`SidebarInset`**.
> 
> Also retints **`.chat-composer-lower-chrome`** (and dark / no-backdrop-filter fallbacks) from **`--card`** to **`--background`** so the frosted strip matches the main view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d316c7632c68891ccaf9deabab00da7e23877fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Duty-cycle status animations and move grain rendering to per-surface backgrounds
> - Introduces `status-pulse` and `status-ping` keyframes in [index.css](https://github.com/pingdotgg/t3code/pull/3978/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) with duty-cycled opacity/scale timing, replacing generic `animate-pulse` and `animate-ping` across all status indicators, loading dots, and cursor ripples.
> - Removes the fixed `body::after` grain overlay and replaces it with a `--surface-grain` CSS variable applied as a per-surface `background-image` via a new `surface-grain` utility class.
> - Adds `surface-grain` to sidebar containers and `SidebarInset` in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/3978/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd) and [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/3978/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
> - Adjusts the chat composer lower chrome background to blend from `--background` instead of `--card`, with matching dark-mode and no-backdrop-filter fallbacks.
> - Behavioral Change: grain texture now only appears on elements that opt into `surface-grain`; areas not using the class will no longer show grain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d316c76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->