### PR TITLE
fix(docs): correct CI task-runner commands in ci.md

### DIFF
--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -1,6 +1,6 @@
 # CI quality gates
 
-- `.github/workflows/ci.yml` runs `bun run lint`, `bun run typecheck`, and `bun run test` on pull requests and pushes to `main`.
+- `.github/workflows/ci.yml` runs `vp check` (lint + typecheck), `vpr typecheck`, and `vp run test` on pull requests and pushes to `main`.
 - `.github/workflows/release.yml` builds macOS (`arm64` and `x64`), Linux (`x64`), and Windows (`x64`) desktop artifacts from a single `v*.*.*` tag and publishes one GitHub release.
 - The release workflow auto-enables signing only when platform credentials are present. macOS passkey builds additionally require `APPLE_TEAM_ID` and the `MACOS_PROVISIONING_PROFILE` secret; Windows uses Azure Trusted Signing. Without the core signing credentials, it still releases unsigned artifacts.
 - See [Release Checklist](./release.md) for the full release/signing setup checklist.


### PR DESCRIPTION
docs/operations/ci.md stated CI runs bun run lint, bun run typecheck, and bun run test, which is wrong and could lead a contributor to run the wrong task runner and fail to match the real CI gates. Fixed it by updating the line to the actual Vite+ commands vp check, vpr typecheck, and vp run test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or CI workflow impact.
> 
> **Overview**
> Updates **`docs/operations/ci.md`** so the CI quality-gates bullet matches **`.github/workflows/ci.yml`**: it now documents **`vp check`** (lint + typecheck), **`vpr typecheck`**, and **`vp run test`** instead of the outdated **`bun run lint`**, **`bun run typecheck`**, and **`bun run test`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304d8275154362ae70d34a8079e4a61e63f4a38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI task-runner commands in ci.md documentation
> Updates [docs/operations/ci.md](https://github.com/pingdotgg/t3code/pull/3990/files#diff-034c5add250f6b6e506856fd6d080b2a955e9538787bda0fd2c5e9ac0408fa02) to reflect the correct commands used in `.github/workflows/ci.yml`, replacing `bun run lint`, `bun run typecheck`, and `bun run test` with `vp check`, `vpr typecheck`, and `vp run test` respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 304d827.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->