### PR TITLE
Fix Legal modal header crash

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -115,7 +115,7 @@ const LEGAL_DOCUMENT_HEADER_OPTIONS: AppScreenOptions = {
   ...SHEET_SOLID_HEADER_OPTIONS,
   headerBackVisible: false,
   headerLeft: SettingsLegalDocumentCloseHeaderButton,
-  headerRight: SettingsLegalDocumentExternalHeaderButton,
+  headerRight: () => <SettingsLegalDocumentExternalHeaderButton />,
   presentation: "fullScreenModal",
 };
 

--- a/apps/mobile/src/features/settings/components/SettingsLegalDocumentRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/components/SettingsLegalDocumentRouteScreen.tsx
@@ -1,11 +1,5 @@
-import {
-  type NavigationProp,
-  type ParamListBase,
-  type RouteProp,
-  useNavigation,
-  useRoute,
-} from "@react-navigation/native";
-import { useCallback, useState } from "react";
+import { type NavigationProp, type ParamListBase, useNavigation } from "@react-navigation/native";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { ActivityIndicator, Linking, Pressable, View } from "react-native";
 import { WebView } from "react-native-webview";
 
@@ -14,10 +8,6 @@ import { LoadingStrip } from "../../../components/LoadingStrip";
 import { SymbolView } from "../../../components/AppSymbol";
 import { useThemeColor } from "../../../lib/useThemeColor";
 import { isLegalDocumentUrl, LEGAL_URL } from "../lib/legal-document-url";
-
-type SettingsLegalRouteParams = {
-  SettingsLegal: { readonly externalUrl?: string } | undefined;
-};
 
 export function SettingsLegalDocumentCloseHeaderButton() {
   const navigation = useNavigation();
@@ -42,20 +32,20 @@ export function SettingsLegalDocumentCloseHeaderButton() {
   );
 }
 
-export function SettingsLegalDocumentExternalHeaderButton() {
+export function SettingsLegalDocumentExternalHeaderButton({
+  externalUrl = LEGAL_URL,
+}: {
+  readonly externalUrl?: string;
+}) {
   const iconColor = useThemeColor("--color-icon");
-  const route = useRoute<RouteProp<SettingsLegalRouteParams, "SettingsLegal">>();
-  const externalUrl =
-    route.params?.externalUrl && isLegalDocumentUrl(route.params.externalUrl)
-      ? route.params.externalUrl
-      : LEGAL_URL;
+  const safeExternalUrl = isLegalDocumentUrl(externalUrl) ? externalUrl : LEGAL_URL;
 
   return (
     <Pressable
       accessibilityLabel="Open legal documents in external browser"
       accessibilityRole="button"
       hitSlop={12}
-      onPress={() => void Linking.openURL(externalUrl).catch(() => undefined)}
+      onPress={() => void Linking.openURL(safeExternalUrl).catch(() => undefined)}
       className="p-2 active:opacity-60"
     >
       <SymbolView
@@ -83,6 +73,17 @@ export function SettingsLegalDocumentRouteScreen({
   const [reloadKey, setReloadKey] = useState(0);
   const [loadProgress, setLoadProgress] = useState(0);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [externalUrl, setExternalUrl] = useState(documentUrl);
+  const renderExternalHeaderButton = useCallback(
+    () => <SettingsLegalDocumentExternalHeaderButton externalUrl={externalUrl} />,
+    [externalUrl],
+  );
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: renderExternalHeaderButton,
+    });
+  }, [navigation, renderExternalHeaderButton]);
 
   const openExternalUrl = useCallback((url: string) => {
     void Linking.openURL(url).catch(() => undefined);
@@ -160,7 +161,7 @@ export function SettingsLegalDocumentRouteScreen({
         }}
         onLoadEnd={(event) => {
           if (isLegalDocumentUrl(event.nativeEvent.url)) {
-            navigation.setParams({ externalUrl: event.nativeEvent.url });
+            setExternalUrl(event.nativeEvent.url);
           }
           setLoadProgress(0);
         }}


### PR DESCRIPTION
## Summary
- stop calling `useRoute()` from the native-stack header renderer
- pass the active legal document URL to the Safari header button through screen options
- remove route-param mutation from WebView load completion

## Verification
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`
- `vp test apps/mobile/src/features/settings/lib/legal-document-url.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation/header wiring change in settings legal WebView; no auth or data-layer impact.
> 
> **Overview**
> Fixes a crash when opening the legal document full-screen modal by **removing `useRoute()` from the Safari header button**, which native-stack can render outside the screen’s route context.
> 
> The external-open URL is now held in **screen state** (initialized from `documentUrl`, updated when the WebView finishes loading a legal URL) and injected via **`navigation.setOptions({ headerRight })`** in a `useLayoutEffect`. `SettingsLegalDocumentExternalHeaderButton` takes an optional `externalUrl` prop with the same `isLegalDocumentUrl` fallback as before.
> 
> Static stack config uses a **render function** for `headerRight` until the screen overrides it; **`navigation.setParams({ externalUrl })` on load end** is removed in favor of local state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5246b6cc50208d846af13fa6ce80ffc07a5089d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Legal modal header crash by managing external URL in component state
> - Replaces the direct component reference in `headerRight` with a render function in [Stack.tsx](https://github.com/pingdotgg/t3code/pull/4000/files#diff-6c445d1d9bb762a38688d21c21790ec36c9a0b882fd17c04888c694ba76736ab), which was the source of the crash.
> - Refactors `SettingsLegalDocumentRouteScreen` to store `externalUrl` in component state and wire `headerRight` via `useLayoutEffect` instead of updating route params on navigation events.
> - `SettingsLegalDocumentExternalHeaderButton` now accepts `externalUrl` as a prop (validated against `isLegalDocumentUrl`, falling back to `LEGAL_URL`) rather than reading from route params.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5246b6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->