### PR TITLE
Add global project content search

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -371,6 +371,31 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
+    it.effect("matches punctuation-ended regex queries as whole words", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-regex-punctuation-" });
+        yield* writeTextFile(cwd, "src/words.ts", "foo- foo-bar foo-\n");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.searchContents({
+          cwd,
+          query: "foo-",
+          limit: 100,
+          caseSensitive: true,
+          wholeWord: true,
+          useRegex: true,
+        });
+
+        // wholeWord + useRegex must not silently drop non-word-edged patterns like "foo-"
+        expect(result.matches).toHaveLength(1);
+        expect(result.matches[0]).toMatchObject({
+          path: "src/words.ts",
+          lineNumber: 1,
+        });
+        expect(result.matches[0]?.matchRanges).toHaveLength(2);
+      }),
+    );
+
     it.effect("preserves regex escapes during case-insensitive searches", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-regex-" });

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -292,6 +292,78 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
     );
   });
 
+  describe("searchContents", () => {
+    it.effect("returns content matches with file paths, line numbers, and ranges", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-search-" });
+        yield* writeTextFile(
+          cwd,
+          "src/shapes.ts",
+          "export const square = 4;\nexport const Square = 16;\nexport const squareSize = 8;\n",
+        );
+        yield* writeTextFile(cwd, "src/other.ts", "const circle = true;\n");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.searchContents({
+          cwd,
+          query: "Square",
+          limit: 100,
+          caseSensitive: false,
+          wholeWord: true,
+          useRegex: false,
+        });
+
+        expect(result.matches.map((match) => [match.path, match.lineNumber])).toEqual([
+          ["src/shapes.ts", 1],
+          ["src/shapes.ts", 2],
+        ]);
+        expect(result.matches[0]?.matchRanges).toEqual([{ start: 13, end: 19 }]);
+        expect(result.truncated).toBe(false);
+      }),
+    );
+
+    it.effect("honors case sensitivity and gitignore rules", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-ignore-", git: true });
+        yield* writeTextFile(cwd, ".gitignore", "ignored.txt\n");
+        yield* writeTextFile(cwd, "src/keep.ts", "square\nSquare\n");
+        yield* writeTextFile(cwd, "ignored.txt", "Square\n");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.searchContents({
+          cwd,
+          query: "Square",
+          limit: 100,
+          caseSensitive: true,
+          wholeWord: false,
+          useRegex: false,
+        });
+
+        expect(result.matches).toHaveLength(1);
+        expect(result.matches[0]).toMatchObject({ path: "src/keep.ts", lineNumber: 2 });
+      }),
+    );
+
+    it.effect("preserves regex escapes during case-insensitive searches", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-regex-" });
+        yield* writeTextFile(cwd, "src/shapes.ts", "Square\nsquare\n");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.searchContents({
+          cwd,
+          query: "\\SQUARE",
+          limit: 100,
+          caseSensitive: false,
+          wholeWord: false,
+          useRegex: true,
+        });
+
+        expect(result.matches.map((match) => match.lineNumber)).toEqual([1, 2]);
+      }),
+    );
+  });
+
   describe("browse", () => {
     it.effect("returns matching directories and excludes files", () =>
       Effect.gen(function* () {

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -344,6 +344,33 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
+    it.effect("matches punctuation-ended literal queries as whole words", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-punctuation-" });
+        yield* writeTextFile(cwd, "src/words.ts", "foo- foo-bar foo-\n");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* workspaceEntries.searchContents({
+          cwd,
+          query: "foo-",
+          limit: 100,
+          caseSensitive: true,
+          wholeWord: true,
+          useRegex: false,
+        });
+
+        expect(result.matches).toHaveLength(1);
+        expect(result.matches[0]).toMatchObject({
+          path: "src/words.ts",
+          lineNumber: 1,
+          matchRanges: [
+            { start: 0, end: 4 },
+            { start: 13, end: 17 },
+          ],
+        });
+      }),
+    );
+
     it.effect("preserves regex escapes during case-insensitive searches", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-regex-" });

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -16,6 +16,8 @@ import type {
   ProjectListEntriesResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
+  ProjectSearchContentsInput,
+  ProjectSearchContentsResult,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { isExplicitRelativePath, isWindowsAbsolutePath } from "@t3tools/shared/path";
@@ -93,6 +95,9 @@ export class WorkspaceEntries extends Context.Service<
     readonly search: (
       input: ProjectSearchEntriesInput,
     ) => Effect.Effect<ProjectSearchEntriesResult, WorkspaceEntriesError>;
+    readonly searchContents: (
+      input: ProjectSearchContentsInput,
+    ) => Effect.Effect<ProjectSearchContentsResult, WorkspaceEntriesError>;
     readonly refresh: (cwd: string) => Effect.Effect<void>;
   }
 >()("t3/workspace/WorkspaceEntries") {}
@@ -251,7 +256,17 @@ export const make = Effect.gen(function* () {
     },
   );
 
-  return WorkspaceEntries.of({ browse, list, refresh, search });
+  const searchContents: WorkspaceEntries["Service"]["searchContents"] = Effect.fn(
+    "WorkspaceEntries.searchContents",
+  )(function* (input) {
+    const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
+    return yield* Effect.gen(function* () {
+      const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
+      return yield* searchIndex.searchContents(input);
+    }).pipe(Effect.provide(workspaceSearchIndexes.get(normalizedCwd)));
+  });
+
+  return WorkspaceEntries.of({ browse, list, refresh, search, searchContents });
 });
 
 export const layer = Layer.effect(WorkspaceEntries, make).pipe(

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -85,11 +85,15 @@ it.effect("preserves search and refresh failures with operation context", () =>
     Effect.gen(function* () {
       const searchCause = new Error("native search failed");
       const refreshCause = new Error("native scan failed");
+      const contentSearchCause = new Error("native grep failed");
       const finder = {
         destroy: vi.fn(),
         isScanning: vi.fn(() => false),
         mixedSearch: vi.fn(() => {
           throw searchCause;
+        }),
+        grep: vi.fn(() => {
+          throw contentSearchCause;
         }),
         scanFiles: vi.fn(() => {
           throw refreshCause;
@@ -100,6 +104,15 @@ it.effect("preserves search and refresh failures with operation context", () =>
       const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
       const query = "authorization: Bearer secret-token";
       const searchError = yield* Effect.flip(searchIndex.search(query, 3));
+      const contentSearchError = yield* Effect.flip(
+        searchIndex.searchContents({
+          query,
+          limit: 3,
+          caseSensitive: false,
+          wholeWord: false,
+          useRegex: false,
+        }),
+      );
       const refreshError = yield* Effect.flip(searchIndex.refresh());
 
       expect(searchError).toMatchObject({
@@ -112,6 +125,15 @@ it.effect("preserves search and refresh failures with operation context", () =>
       });
       expect(searchError).not.toHaveProperty("query");
       expect(searchError.message).not.toMatch(/Bearer|secret-token/);
+      expect(contentSearchError).toMatchObject({
+        _tag: "WorkspaceSearchIndexSearchFailed",
+        cwd: "/workspace/project",
+        queryLength: query.length,
+        pageSize: 3,
+        reason: "FileFinder.grep threw unexpectedly.",
+        cause: contentSearchCause,
+      });
+      expect(contentSearchError).not.toHaveProperty("query");
       expect(refreshError).toMatchObject({
         _tag: "WorkspaceSearchIndexRefreshFailed",
         cwd: "/workspace/project",

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -319,11 +319,13 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
     const wordCharacter = /[\p{Letter}\p{Mark}\p{Number}_]/u;
     const firstCharacter = Array.from(input.query).at(0) ?? "";
     const lastCharacter = Array.from(input.query).at(-1) ?? "";
-    const literalWholeWordQuery = `${wordCharacter.test(firstCharacter) ? "\\b" : "(?:^|\\W)"}(?:${escapedQuery})${wordCharacter.test(lastCharacter) ? "\\b" : "(?:$|\\W)"}`;
+    // Use \b only when the pattern edge is a word character; otherwise \b cannot
+    // match (e.g. query "foo-" → \b(?:foo-)\b never matches "foo- "). Fall back to
+    // (?:^|\W)/(?:$|\W) for non-word edges, same as the literal whole-word path.
+    const wrapWholeWord = (pattern: string) =>
+      `${wordCharacter.test(firstCharacter) ? "\\b" : "(?:^|\\W)"}(?:${pattern})${wordCharacter.test(lastCharacter) ? "\\b" : "(?:$|\\W)"}`;
     const query = input.wholeWord
-      ? input.useRegex
-        ? `\\b(?:${input.query})\\b`
-        : literalWholeWordQuery
+      ? wrapWholeWord(input.useRegex ? input.query : escapedQuery)
       : input.query;
     const regexMode = input.useRegex || input.wholeWord;
     const searchQuery = input.caseSensitive

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -9,6 +9,8 @@ import * as Schema from "effect/Schema";
 import type {
   ProjectEntry,
   ProjectListEntriesResult,
+  ProjectSearchContentsInput,
+  ProjectSearchContentsResult,
   ProjectSearchEntriesResult,
 } from "@t3tools/contracts";
 
@@ -97,6 +99,9 @@ export class WorkspaceSearchIndex extends Context.Service<
       query: string,
       limit: number,
     ) => Effect.Effect<ProjectSearchEntriesResult, WorkspaceSearchIndexSearchFailed>;
+    readonly searchContents: (
+      input: Omit<ProjectSearchContentsInput, "cwd">,
+    ) => Effect.Effect<ProjectSearchContentsResult, WorkspaceSearchIndexSearchFailed>;
     readonly refresh: () => Effect.Effect<
       void,
       WorkspaceSearchIndexRefreshFailed | WorkspaceSearchIndexScanTimedOut
@@ -175,7 +180,7 @@ const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (c
       FileFinder.create({
         basePath: cwd,
         disableMmapCache: true,
-        disableContentIndexing: true,
+        disableContentIndexing: false,
         aiMode: false,
         enableFsRootScanning: true,
         enableHomeDirScanning: true,
@@ -307,7 +312,66 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
     return mapMixedSearchResult(result, limit);
   });
 
-  return WorkspaceSearchIndex.of({ list, refresh, search });
+  const searchContents: WorkspaceSearchIndex["Service"]["searchContents"] = Effect.fn(
+    "WorkspaceSearchIndex.searchContents",
+  )(function* (input) {
+    const escapedQuery = input.query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const query = input.wholeWord
+      ? `\\b(?:${input.useRegex ? input.query : escapedQuery})\\b`
+      : input.query;
+    const regexMode = input.useRegex || input.wholeWord;
+    const searchQuery = input.caseSensitive
+      ? query
+      : regexMode
+        ? `(?i:${query})`
+        : query.toLowerCase();
+    const result = yield* Effect.try({
+      try: () =>
+        finder.grep(searchQuery, {
+          mode: regexMode ? "regex" : "plain",
+          smartCase: !input.caseSensitive && !regexMode,
+          maxMatchesPerFile: input.limit,
+          pageSize: input.limit,
+          timeBudgetMs: 250,
+        }),
+      catch: (cause) =>
+        new WorkspaceSearchIndexSearchFailed({
+          cwd,
+          queryLength: input.query.length,
+          pageSize: input.limit,
+          reason: "FileFinder.grep threw unexpectedly.",
+          cause,
+        }),
+    });
+    if (!result.ok) {
+      return yield* new WorkspaceSearchIndexSearchFailed({
+        cwd,
+        queryLength: input.query.length,
+        pageSize: input.limit,
+        reason: result.error,
+      });
+    }
+
+    const byteOffsetToStringIndex = (line: string, byteOffset: number): number =>
+      Buffer.from(line).subarray(0, byteOffset).toString().length;
+    return {
+      matches: result.value.items.map((match) => ({
+        path: toPosixPath(match.relativePath),
+        lineNumber: match.lineNumber,
+        lineContent: match.lineContent,
+        matchRanges: match.matchRanges.map(([start, end]) => ({
+          start: byteOffsetToStringIndex(match.lineContent, start),
+          end: byteOffsetToStringIndex(match.lineContent, end),
+        })),
+      })),
+      truncated: result.value.nextCursor !== null,
+      ...(result.value.regexFallbackError
+        ? { regexFallbackError: result.value.regexFallbackError }
+        : {}),
+    };
+  });
+
+  return WorkspaceSearchIndex.of({ list, refresh, search, searchContents });
 });
 
 /**

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -316,8 +316,14 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
     "WorkspaceSearchIndex.searchContents",
   )(function* (input) {
     const escapedQuery = input.query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const wordCharacter = /[\p{Letter}\p{Mark}\p{Number}_]/u;
+    const firstCharacter = Array.from(input.query).at(0) ?? "";
+    const lastCharacter = Array.from(input.query).at(-1) ?? "";
+    const literalWholeWordQuery = `${wordCharacter.test(firstCharacter) ? "\\b" : "(?:^|\\W)"}(?:${escapedQuery})${wordCharacter.test(lastCharacter) ? "\\b" : "(?:$|\\W)"}`;
     const query = input.wholeWord
-      ? `\\b(?:${input.useRegex ? input.query : escapedQuery})\\b`
+      ? input.useRegex
+        ? `\\b(?:${input.query})\\b`
+        : literalWholeWordQuery
       : input.query;
     const regexMode = input.useRegex || input.wholeWord;
     const searchQuery = input.caseSensitive
@@ -354,15 +360,27 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
 
     const byteOffsetToStringIndex = (line: string, byteOffset: number): number =>
       Buffer.from(line).subarray(0, byteOffset).toString().length;
+    const mapMatchRange = (line: string, startByte: number, endByte: number) => {
+      const start = byteOffsetToStringIndex(line, startByte);
+      const end = byteOffsetToStringIndex(line, endByte);
+      if (!input.wholeWord || input.useRegex) return { start, end };
+
+      const matchedText = line.slice(start, end);
+      const queryIndex = input.caseSensitive
+        ? matchedText.indexOf(input.query)
+        : matchedText.toLocaleLowerCase().indexOf(input.query.toLocaleLowerCase());
+      return queryIndex === -1
+        ? { start, end }
+        : { start: start + queryIndex, end: start + queryIndex + input.query.length };
+    };
     return {
       matches: result.value.items.map((match) => ({
         path: toPosixPath(match.relativePath),
         lineNumber: match.lineNumber,
         lineContent: match.lineContent,
-        matchRanges: match.matchRanges.map(([start, end]) => ({
-          start: byteOffsetToStringIndex(match.lineContent, start),
-          end: byteOffsetToStringIndex(match.lineContent, end),
-        })),
+        matchRanges: match.matchRanges.map(([start, end]) =>
+          mapMatchRange(match.lineContent, start, end),
+        ),
       })),
       truncated: result.value.nextCursor !== null,
       ...(result.value.regexFallbackError

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -42,6 +42,7 @@ import {
   type ProjectFileOperation,
   ProjectListEntriesError,
   ProjectReadFileError,
+  ProjectSearchContentsError,
   ProjectSearchEntriesError,
   ProjectWriteFileError,
   RelayClientInstallFailedError,
@@ -314,6 +315,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.sourceControlPublishRepository, AuthOrchestrationOperateScope],
   [WS_METHODS.projectsListEntries, AuthOrchestrationReadScope],
   [WS_METHODS.projectsReadFile, AuthOrchestrationReadScope],
+  [WS_METHODS.projectsSearchContents, AuthOrchestrationReadScope],
   [WS_METHODS.projectsSearchEntries, AuthOrchestrationReadScope],
   [WS_METHODS.projectsWriteFile, AuthOrchestrationOperateScope],
   [WS_METHODS.shellOpenInEditor, AuthOrchestrationOperateScope],
@@ -1622,6 +1624,23 @@ const makeWsRpcLayer = (
               Effect.mapError(
                 (cause) =>
                   new ProjectSearchEntriesError({
+                    cwd: input.cwd,
+                    queryLength: input.query.length,
+                    limit: input.limit,
+                    ...projectEntriesFailureContext(cause),
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.projectsSearchContents]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.projectsSearchContents,
+            workspaceEntries.searchContents(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProjectSearchContentsError({
                     cwd: input.cwd,
                     queryLength: input.query.length,
                     limit: input.limit,

--- a/apps/web/src/commandPaletteBus.ts
+++ b/apps/web/src/commandPaletteBus.ts
@@ -25,6 +25,7 @@ export function onOpenCommandPalette(
 /** Read at event time so consumers do not subscribe to transient dialog state. */
 export function isCommandPaletteOpen(): boolean {
   return (
-    typeof document !== "undefined" && document.querySelector("[data-command-palette]") !== null
+    typeof document !== "undefined" &&
+    document.querySelector("[data-command-palette], [data-project-search]") !== null
   );
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -88,27 +88,7 @@ import {
   openUrlInPreview,
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
-
-class CodeHighlightErrorBoundary extends React.Component<
-  { fallback: ReactNode; children: ReactNode },
-  { hasError: boolean }
-> {
-  constructor(props: { fallback: ReactNode; children: ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  override render() {
-    if (this.state.hasError) {
-      return this.props.fallback;
-    }
-    return this.props.children;
-  }
-}
+import { RenderErrorBoundary } from "./RenderErrorBoundary";
 
 interface ChatMarkdownProps {
   text: string;
@@ -1489,7 +1469,7 @@ function ChatMarkdown({
             fenceTitle={fenceTitle}
             theme={resolvedTheme}
           >
-            <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
+            <RenderErrorBoundary fallback={<pre {...props}>{children}</pre>}>
               <Suspense fallback={<pre {...props}>{children}</pre>}>
                 <SuspenseShikiCodeBlock
                   className={codeBlock.className}
@@ -1498,7 +1478,7 @@ function ChatMarkdown({
                   isStreaming={isStreaming}
                 />
               </Suspense>
-            </CodeHighlightErrorBoundary>
+            </RenderErrorBoundary>
           </MarkdownCodeBlock>
         );
       },

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1,5 +1,4 @@
 import { useAtomValue } from "@effect/atom-react";
-import { DiffsHighlighter, getSharedHighlighter, SupportedLanguages } from "@pierre/diffs";
 import {
   CheckIcon,
   ChevronRightIcon,
@@ -57,6 +56,7 @@ import { useOpenInPreferredEditor } from "../editorPreferences";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
+import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { useTheme } from "../hooks/useTheme";
 import { getClientSettings } from "../hooks/useSettings";
 import {
@@ -145,7 +145,6 @@ const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_ENTRIES,
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
-const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
 
 function findTaskListMarkerOffset(markdown: string, listItemStart: number): number | null {
   const firstLineEnd = markdown.indexOf("\n", listItemStart);
@@ -294,27 +293,6 @@ function createHighlightCacheKey(code: string, language: string, themeName: Diff
 
 function estimateHighlightedSize(html: string, code: string): number {
   return Math.max(html.length * 2, code.length * 3);
-}
-
-function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
-  const cached = highlighterPromiseCache.get(language);
-  if (cached) return cached;
-
-  const promise = getSharedHighlighter({
-    themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
-    langs: [language as SupportedLanguages],
-    preferredHighlighter: "shiki-js",
-  }).catch((err) => {
-    highlighterPromiseCache.delete(language);
-    if (language === "text") {
-      // "text" itself failed — Shiki cannot initialize at all, surface the error
-      throw err;
-    }
-    // Language not supported by Shiki — fall back to "text"
-    return getHighlighterPromise("text");
-  });
-  highlighterPromiseCache.set(language, promise);
-  return promise;
 }
 
 function readInitialWordWrapSetting(): boolean {
@@ -706,7 +684,7 @@ function UncachedShikiCodeBlock({
   cacheKey,
   isStreaming,
 }: UncachedShikiCodeBlockProps) {
-  const highlighter = use(getHighlighterPromise(language));
+  const highlighter = use(getSyntaxHighlighterPromise(language));
   const highlightedHtml = useMemo(() => {
     try {
       return highlighter.codeToHtml(code, { lang: language, theme: themeName });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -218,6 +218,7 @@ import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
+import { ProjectContentSearchDialog } from "./ProjectContentSearchDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
@@ -1252,6 +1253,7 @@ function ChatViewContent(props: ChatViewProps) {
   >({});
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [projectSearchOpen, setProjectSearchOpen] = useState(false);
   const [maximizedRightPanelThreadKey, setMaximizedRightPanelThreadKey] = useState<string | null>(
     null,
   );
@@ -3008,9 +3010,9 @@ function ChatViewContent(props: ChatViewProps) {
     useRightPanelStore.getState().open(activeThreadRef, "files");
   }, [activeProject, activeThreadRef]);
   const openFileSurface = useCallback(
-    (relativePath: string) => {
+    (relativePath: string, line?: number) => {
       if (!activeThreadRef || !activeProject) return;
-      useRightPanelStore.getState().openFile(activeThreadRef, relativePath);
+      useRightPanelStore.getState().openFile(activeThreadRef, relativePath, line);
     },
     [activeProject, activeThreadRef],
   );
@@ -4262,6 +4264,14 @@ function ChatViewContent(props: ChatViewProps) {
       });
       if (!command) return;
 
+      if (command === "project.searchContents") {
+        if (!activeProject || !activeWorkspaceRoot) return;
+        event.preventDefault();
+        event.stopPropagation();
+        setProjectSearchOpen(true);
+        return;
+      }
+
       if (command === "terminal.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -4373,6 +4383,7 @@ function ChatViewContent(props: ChatViewProps) {
     toggleRightPanel,
     toggleTerminalVisibility,
     composerRef,
+    activeWorkspaceRoot,
   ]);
 
   const onRevertToTurnCount = useCallback(
@@ -5607,6 +5618,16 @@ function ChatViewContent(props: ChatViewProps) {
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+      {activeProject && activeWorkspaceRoot ? (
+        <ProjectContentSearchDialog
+          environmentId={activeProject.environmentId}
+          cwd={activeWorkspaceRoot}
+          projectName={activeProject.title}
+          open={projectSearchOpen}
+          onOpenChange={setProjectSearchOpen}
+          onOpenMatch={openFileSurface}
+        />
+      ) : null}
       {rightPanelOpen && !shouldUsePlanSidebarSheet ? panelLayoutControls : null}
       <div
         className={cn(

--- a/apps/web/src/components/ProjectContentSearchDialog.tsx
+++ b/apps/web/src/components/ProjectContentSearchDialog.tsx
@@ -1,32 +1,16 @@
 import type { EnvironmentId, ProjectContentMatch } from "@t3tools/contracts";
-import { getFiletypeFromFileName } from "@pierre/diffs";
 import { LoaderCircle, Search } from "lucide-react";
-import {
-  Suspense,
-  Component,
-  use,
-  useEffect,
-  useMemo,
-  useState,
-  type CSSProperties,
-  type ReactNode,
-} from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { useTheme } from "~/hooks/useTheme";
-import { resolveDiffThemeName } from "~/lib/diffRendering";
-import { getSyntaxHighlighterPromise } from "~/lib/syntaxHighlighting";
 import { cn } from "~/lib/utils";
-import { projectEnvironment } from "~/state/projects";
-import { useEnvironmentQuery } from "~/state/query";
+import { useProjectContentSearch } from "~/state/queries";
 
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
+import { HighlightedSearchLine } from "./project-search/HighlightedSearchLine";
 import { Dialog, DialogPopup, DialogTitle } from "./ui/dialog";
 import { Input } from "./ui/input";
 import { ScrollArea } from "./ui/scroll-area";
-
-const SEARCH_RESULT_LIMIT = 500;
-const SEARCH_DEBOUNCE_MS = 120;
-const EMPTY_MATCHES: ReadonlyArray<ProjectContentMatch> = [];
 
 interface ProjectContentSearchDialogProps {
   readonly environmentId: EnvironmentId;
@@ -40,21 +24,6 @@ interface ProjectContentSearchDialogProps {
 interface MatchGroup {
   readonly path: string;
   readonly matches: ReadonlyArray<ProjectContentMatch & { readonly resultIndex: number }>;
-}
-
-class SearchSyntaxErrorBoundary extends Component<
-  { readonly children: ReactNode; readonly fallback: ReactNode },
-  { readonly failed: boolean }
-> {
-  override state = { failed: false };
-
-  static getDerivedStateFromError() {
-    return { failed: true };
-  }
-
-  override render() {
-    return this.state.failed ? this.props.fallback : this.props.children;
-  }
 }
 
 function splitPath(path: string): { readonly name: string; readonly directory: string } {
@@ -76,116 +45,6 @@ function groupMatches(matches: ReadonlyArray<ProjectContentMatch>): MatchGroup[]
     }
   });
   return [...groups].map(([path, groupedMatches]) => ({ path, matches: groupedMatches }));
-}
-
-function normalizedMatchRanges(match: ProjectContentMatch) {
-  return match.matchRanges
-    .map((range) => ({
-      start: Math.max(0, Math.min(match.lineContent.length, range.start)),
-      end: Math.max(0, Math.min(match.lineContent.length, range.end)),
-    }))
-    .filter((range) => range.end > range.start)
-    .toSorted((left, right) => left.start - right.start);
-}
-
-function highlightedLine(match: ProjectContentMatch): ReactNode {
-  const ranges = normalizedMatchRanges(match);
-  if (ranges.length === 0) return match.lineContent;
-
-  const parts: ReactNode[] = [];
-  let cursor = 0;
-  ranges.forEach((range) => {
-    if (range.start > cursor) {
-      parts.push(match.lineContent.slice(cursor, range.start));
-    }
-    const start = Math.max(cursor, range.start);
-    if (range.end > start) {
-      parts.push(
-        <mark
-          className="rounded-[2px] bg-primary/22 text-inherit"
-          key={`match-${range.start}-${range.end}`}
-        >
-          {match.lineContent.slice(start, range.end)}
-        </mark>,
-      );
-    }
-    cursor = Math.max(cursor, range.end);
-  });
-  if (cursor < match.lineContent.length) {
-    parts.push(match.lineContent.slice(cursor));
-  }
-  return parts;
-}
-
-function tokenStyle(token: {
-  readonly color?: string;
-  readonly fontStyle?: number;
-}): CSSProperties {
-  const fontStyle = token.fontStyle ?? 0;
-  return {
-    ...(token.color ? { color: token.color } : {}),
-    ...(fontStyle & 1 ? { fontStyle: "italic" } : {}),
-    ...(fontStyle & 2 ? { fontWeight: 700 } : {}),
-    ...(fontStyle & 4 ? { textDecoration: "underline" } : {}),
-  };
-}
-
-function SyntaxHighlightedLine(props: {
-  readonly match: ProjectContentMatch;
-  readonly language: string;
-  readonly themeName: ReturnType<typeof resolveDiffThemeName>;
-}) {
-  const highlighter = use(getSyntaxHighlighterPromise(props.language));
-  const tokens = useMemo(() => {
-    try {
-      return highlighter.codeToTokens(props.match.lineContent, {
-        lang: props.language,
-        theme: props.themeName,
-      }).tokens[0];
-    } catch {
-      return undefined;
-    }
-  }, [highlighter, props.language, props.match.lineContent, props.themeName]);
-
-  if (!tokens || tokens.length === 0) return highlightedLine(props.match);
-
-  const ranges = normalizedMatchRanges(props.match);
-  return tokens.map((token, tokenIndex) => {
-    const tokenStart = token.offset;
-    const tokenEnd = tokenStart + token.content.length;
-    const boundaries = [
-      tokenStart,
-      tokenEnd,
-      ...ranges.flatMap((range) => [
-        Math.max(tokenStart, Math.min(tokenEnd, range.start)),
-        Math.max(tokenStart, Math.min(tokenEnd, range.end)),
-      ]),
-    ].toSorted((left, right) => left - right);
-    const uniqueBoundaries = boundaries.filter(
-      (boundary, index) => index === 0 || boundary !== boundaries[index - 1],
-    );
-
-    return uniqueBoundaries.slice(0, -1).map((start, segmentIndex) => {
-      const end = uniqueBoundaries[segmentIndex + 1] ?? start;
-      if (end <= start) return null;
-      const content = props.match.lineContent.slice(start, end);
-      const isMatch = ranges.some((range) => range.start < end && range.end > start);
-      const key = `${tokenIndex}:${start}:${end}`;
-      return isMatch ? (
-        <mark
-          className="rounded-[2px] bg-primary/25 text-inherit"
-          key={key}
-          style={tokenStyle(token)}
-        >
-          {content}
-        </mark>
-      ) : (
-        <span key={key} style={tokenStyle(token)}>
-          {content}
-        </span>
-      );
-    });
-  });
 }
 
 function SearchOptionButton(props: {
@@ -213,41 +72,26 @@ function SearchOptionButton(props: {
 
 export function ProjectContentSearchDialog(props: ProjectContentSearchDialogProps) {
   const { resolvedTheme } = useTheme();
-  const themeName = resolveDiffThemeName(resolvedTheme);
   const [query, setQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [wholeWord, setWholeWord] = useState(false);
   const [useRegex, setUseRegex] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  useEffect(() => {
-    if (!props.open) {
-      setQuery("");
-      setDebouncedQuery("");
-      return;
-    }
-    const timeout = window.setTimeout(() => setDebouncedQuery(query.trim()), SEARCH_DEBOUNCE_MS);
-    return () => window.clearTimeout(timeout);
-  }, [props.open, query]);
-
-  const search = useEnvironmentQuery(
-    props.open && debouncedQuery.length > 0
-      ? projectEnvironment.searchContents({
-          environmentId: props.environmentId,
-          input: {
-            cwd: props.cwd,
-            query: debouncedQuery,
-            limit: SEARCH_RESULT_LIMIT,
-            caseSensitive,
-            wholeWord,
-            useRegex,
-          },
-        })
-      : null,
-  );
-  const matches = search.data?.matches ?? EMPTY_MATCHES;
+  const search = useProjectContentSearch({
+    environmentId: props.open ? props.environmentId : null,
+    cwd: props.open ? props.cwd : null,
+    query,
+    caseSensitive,
+    wholeWord,
+    useRegex,
+  });
+  const matches = search.matches;
   const groups = useMemo(() => groupMatches(matches), [matches]);
+
+  useEffect(() => {
+    if (!props.open) setQuery("");
+  }, [props.open]);
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -264,8 +108,6 @@ export function ProjectContentSearchDialog(props: ProjectContentSearchDialogProp
     props.onOpenMatch(match.path, match.lineNumber);
   };
   const fileCount = groups.length;
-  const waitingForDebounce = query.trim().length > 0 && query.trim() !== debouncedQuery;
-  const isPending = waitingForDebounce || search.isPending;
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -330,24 +172,24 @@ export function ProjectContentSearchDialog(props: ProjectContentSearchDialogProp
 
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="flex h-9 shrink-0 items-center border-b px-3 text-xs text-muted-foreground">
-            {isPending ? (
+            {search.isPending ? (
               <span className="flex items-center gap-2">
                 <LoaderCircle className="size-3.5 animate-spin" /> Searching…
               </span>
             ) : search.error ? (
               <span className="text-destructive">{search.error}</span>
-            ) : search.data?.regexFallbackError ? (
+            ) : search.invalidRegex ? (
               <span className="text-destructive">Invalid regular expression</span>
-            ) : debouncedQuery.length === 0 ? (
+            ) : !search.hasQuery ? (
               `Search every file in ${props.projectName}`
             ) : (
-              `${matches.length.toLocaleString()}${search.data?.truncated ? "+" : ""} results in ${fileCount.toLocaleString()} files`
+              `${matches.length.toLocaleString()}${search.truncated ? "+" : ""} results in ${fileCount.toLocaleString()} files`
             )}
           </div>
 
           {matches.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
-              {debouncedQuery.length > 0 && !isPending && !search.error
+              {search.hasQuery && !search.isPending && !search.error
                 ? "No results found."
                 : "Type to search across your project."}
             </div>
@@ -392,15 +234,11 @@ export function ProjectContentSearchDialog(props: ProjectContentSearchDialogProp
                             {match.lineNumber}
                           </span>
                           <span className="min-w-0 flex-1 truncate whitespace-pre">
-                            <SearchSyntaxErrorBoundary fallback={highlightedLine(match)}>
-                              <Suspense fallback={highlightedLine(match)}>
-                                <SyntaxHighlightedLine
-                                  match={match}
-                                  language={getFiletypeFromFileName(group.path)}
-                                  themeName={themeName}
-                                />
-                              </Suspense>
-                            </SearchSyntaxErrorBoundary>
+                            <HighlightedSearchLine
+                              match={match}
+                              path={group.path}
+                              theme={resolvedTheme}
+                            />
                           </span>
                         </button>
                       ))}

--- a/apps/web/src/components/ProjectContentSearchDialog.tsx
+++ b/apps/web/src/components/ProjectContentSearchDialog.tsx
@@ -1,0 +1,422 @@
+import type { EnvironmentId, ProjectContentMatch } from "@t3tools/contracts";
+import { getFiletypeFromFileName } from "@pierre/diffs";
+import { LoaderCircle, Search } from "lucide-react";
+import {
+  Suspense,
+  Component,
+  use,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+import { useTheme } from "~/hooks/useTheme";
+import { resolveDiffThemeName } from "~/lib/diffRendering";
+import { getSyntaxHighlighterPromise } from "~/lib/syntaxHighlighting";
+import { cn } from "~/lib/utils";
+import { projectEnvironment } from "~/state/projects";
+import { useEnvironmentQuery } from "~/state/query";
+
+import { PierreEntryIcon } from "./chat/PierreEntryIcon";
+import { Dialog, DialogPopup, DialogTitle } from "./ui/dialog";
+import { Input } from "./ui/input";
+import { ScrollArea } from "./ui/scroll-area";
+
+const SEARCH_RESULT_LIMIT = 500;
+const SEARCH_DEBOUNCE_MS = 120;
+const EMPTY_MATCHES: ReadonlyArray<ProjectContentMatch> = [];
+
+interface ProjectContentSearchDialogProps {
+  readonly environmentId: EnvironmentId;
+  readonly cwd: string;
+  readonly projectName: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onOpenMatch: (relativePath: string, lineNumber: number) => void;
+}
+
+interface MatchGroup {
+  readonly path: string;
+  readonly matches: ReadonlyArray<ProjectContentMatch & { readonly resultIndex: number }>;
+}
+
+class SearchSyntaxErrorBoundary extends Component<
+  { readonly children: ReactNode; readonly fallback: ReactNode },
+  { readonly failed: boolean }
+> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}
+
+function splitPath(path: string): { readonly name: string; readonly directory: string } {
+  const separator = path.lastIndexOf("/");
+  return separator === -1
+    ? { name: path, directory: "" }
+    : { name: path.slice(separator + 1), directory: path.slice(0, separator) };
+}
+
+function groupMatches(matches: ReadonlyArray<ProjectContentMatch>): MatchGroup[] {
+  const groups = new Map<string, Array<ProjectContentMatch & { readonly resultIndex: number }>>();
+  matches.forEach((match, resultIndex) => {
+    const group = groups.get(match.path);
+    const indexedMatch = { ...match, resultIndex };
+    if (group) {
+      group.push(indexedMatch);
+    } else {
+      groups.set(match.path, [indexedMatch]);
+    }
+  });
+  return [...groups].map(([path, groupedMatches]) => ({ path, matches: groupedMatches }));
+}
+
+function normalizedMatchRanges(match: ProjectContentMatch) {
+  return match.matchRanges
+    .map((range) => ({
+      start: Math.max(0, Math.min(match.lineContent.length, range.start)),
+      end: Math.max(0, Math.min(match.lineContent.length, range.end)),
+    }))
+    .filter((range) => range.end > range.start)
+    .toSorted((left, right) => left.start - right.start);
+}
+
+function highlightedLine(match: ProjectContentMatch): ReactNode {
+  const ranges = normalizedMatchRanges(match);
+  if (ranges.length === 0) return match.lineContent;
+
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  ranges.forEach((range) => {
+    if (range.start > cursor) {
+      parts.push(match.lineContent.slice(cursor, range.start));
+    }
+    const start = Math.max(cursor, range.start);
+    if (range.end > start) {
+      parts.push(
+        <mark
+          className="rounded-[2px] bg-primary/22 text-inherit"
+          key={`match-${range.start}-${range.end}`}
+        >
+          {match.lineContent.slice(start, range.end)}
+        </mark>,
+      );
+    }
+    cursor = Math.max(cursor, range.end);
+  });
+  if (cursor < match.lineContent.length) {
+    parts.push(match.lineContent.slice(cursor));
+  }
+  return parts;
+}
+
+function tokenStyle(token: {
+  readonly color?: string;
+  readonly fontStyle?: number;
+}): CSSProperties {
+  const fontStyle = token.fontStyle ?? 0;
+  return {
+    ...(token.color ? { color: token.color } : {}),
+    ...(fontStyle & 1 ? { fontStyle: "italic" } : {}),
+    ...(fontStyle & 2 ? { fontWeight: 700 } : {}),
+    ...(fontStyle & 4 ? { textDecoration: "underline" } : {}),
+  };
+}
+
+function SyntaxHighlightedLine(props: {
+  readonly match: ProjectContentMatch;
+  readonly language: string;
+  readonly themeName: ReturnType<typeof resolveDiffThemeName>;
+}) {
+  const highlighter = use(getSyntaxHighlighterPromise(props.language));
+  const tokens = useMemo(() => {
+    try {
+      return highlighter.codeToTokens(props.match.lineContent, {
+        lang: props.language,
+        theme: props.themeName,
+      }).tokens[0];
+    } catch {
+      return undefined;
+    }
+  }, [highlighter, props.language, props.match.lineContent, props.themeName]);
+
+  if (!tokens || tokens.length === 0) return highlightedLine(props.match);
+
+  const ranges = normalizedMatchRanges(props.match);
+  return tokens.map((token, tokenIndex) => {
+    const tokenStart = token.offset;
+    const tokenEnd = tokenStart + token.content.length;
+    const boundaries = [
+      tokenStart,
+      tokenEnd,
+      ...ranges.flatMap((range) => [
+        Math.max(tokenStart, Math.min(tokenEnd, range.start)),
+        Math.max(tokenStart, Math.min(tokenEnd, range.end)),
+      ]),
+    ].toSorted((left, right) => left - right);
+    const uniqueBoundaries = boundaries.filter(
+      (boundary, index) => index === 0 || boundary !== boundaries[index - 1],
+    );
+
+    return uniqueBoundaries.slice(0, -1).map((start, segmentIndex) => {
+      const end = uniqueBoundaries[segmentIndex + 1] ?? start;
+      if (end <= start) return null;
+      const content = props.match.lineContent.slice(start, end);
+      const isMatch = ranges.some((range) => range.start < end && range.end > start);
+      const key = `${tokenIndex}:${start}:${end}`;
+      return isMatch ? (
+        <mark
+          className="rounded-[2px] bg-primary/25 text-inherit"
+          key={key}
+          style={tokenStyle(token)}
+        >
+          {content}
+        </mark>
+      ) : (
+        <span key={key} style={tokenStyle(token)}>
+          {content}
+        </span>
+      );
+    });
+  });
+}
+
+function SearchOptionButton(props: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={props.label}
+      aria-pressed={props.active}
+      title={props.label}
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center rounded-[5px] font-mono text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+        props.active && "bg-accent text-foreground shadow-sm",
+      )}
+      onClick={props.onClick}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+export function ProjectContentSearchDialog(props: ProjectContentSearchDialogProps) {
+  const { resolvedTheme } = useTheme();
+  const themeName = resolveDiffThemeName(resolvedTheme);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [wholeWord, setWholeWord] = useState(false);
+  const [useRegex, setUseRegex] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    if (!props.open) {
+      setQuery("");
+      setDebouncedQuery("");
+      return;
+    }
+    const timeout = window.setTimeout(() => setDebouncedQuery(query.trim()), SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [props.open, query]);
+
+  const search = useEnvironmentQuery(
+    props.open && debouncedQuery.length > 0
+      ? projectEnvironment.searchContents({
+          environmentId: props.environmentId,
+          input: {
+            cwd: props.cwd,
+            query: debouncedQuery,
+            limit: SEARCH_RESULT_LIMIT,
+            caseSensitive,
+            wholeWord,
+            useRegex,
+          },
+        })
+      : null,
+  );
+  const matches = search.data?.matches ?? EMPTY_MATCHES;
+  const groups = useMemo(() => groupMatches(matches), [matches]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [matches]);
+
+  useEffect(() => {
+    document
+      .querySelector<HTMLElement>(`[data-project-search-result="${selectedIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const openMatch = (match: ProjectContentMatch) => {
+    props.onOpenChange(false);
+    props.onOpenMatch(match.path, match.lineNumber);
+  };
+  const fileCount = groups.length;
+  const waitingForDebounce = query.trim().length > 0 && query.trim() !== debouncedQuery;
+  const isPending = waitingForDebounce || search.isPending;
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogPopup
+        className="h-[min(44rem,82vh)] max-w-3xl overflow-hidden"
+        data-project-search
+        showCloseButton={false}
+        bottomStickOnMobile={false}
+      >
+        <DialogTitle className="sr-only">Search {props.projectName}</DialogTitle>
+        <div className="flex shrink-0 items-center gap-2 border-b p-2">
+          <Search className="ml-1 size-4 shrink-0 text-muted-foreground" />
+          <Input
+            autoFocus
+            nativeInput
+            unstyled
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown" && matches.length > 0) {
+                event.preventDefault();
+                setSelectedIndex((current) => (current + 1) % matches.length);
+              } else if (event.key === "ArrowUp" && matches.length > 0) {
+                event.preventDefault();
+                setSelectedIndex((current) => (current - 1 + matches.length) % matches.length);
+              } else if (event.key === "Enter") {
+                const match = matches[selectedIndex];
+                if (match) {
+                  event.preventDefault();
+                  openMatch(match);
+                }
+              }
+            }}
+            className="h-9 min-w-0 flex-1 px-2 font-mono text-sm"
+            placeholder={`Search in ${props.projectName}`}
+            aria-label={`Search file contents in ${props.projectName}`}
+          />
+          <div className="ml-auto flex shrink-0 items-center gap-0.5 rounded-md border bg-muted/30 p-0.5">
+            <SearchOptionButton
+              active={caseSensitive}
+              label="Match case"
+              onClick={() => setCaseSensitive((current) => !current)}
+            >
+              Aa
+            </SearchOptionButton>
+            <SearchOptionButton
+              active={wholeWord}
+              label="Match whole word"
+              onClick={() => setWholeWord((current) => !current)}
+            >
+              <span className="underline decoration-2 underline-offset-2">ab</span>
+            </SearchOptionButton>
+            <SearchOptionButton
+              active={useRegex}
+              label="Use regular expression"
+              onClick={() => setUseRegex((current) => !current)}
+            >
+              .*
+            </SearchOptionButton>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="flex h-9 shrink-0 items-center border-b px-3 text-xs text-muted-foreground">
+            {isPending ? (
+              <span className="flex items-center gap-2">
+                <LoaderCircle className="size-3.5 animate-spin" /> Searching…
+              </span>
+            ) : search.error ? (
+              <span className="text-destructive">{search.error}</span>
+            ) : search.data?.regexFallbackError ? (
+              <span className="text-destructive">Invalid regular expression</span>
+            ) : debouncedQuery.length === 0 ? (
+              `Search every file in ${props.projectName}`
+            ) : (
+              `${matches.length.toLocaleString()}${search.data?.truncated ? "+" : ""} results in ${fileCount.toLocaleString()} files`
+            )}
+          </div>
+
+          {matches.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+              {debouncedQuery.length > 0 && !isPending && !search.error
+                ? "No results found."
+                : "Type to search across your project."}
+            </div>
+          ) : (
+            <ScrollArea className="min-h-0 flex-1" scrollFade>
+              <div className="py-2">
+                {groups.map((group) => {
+                  const path = splitPath(group.path);
+                  return (
+                    <section className="pb-2" key={group.path}>
+                      <div className="sticky top-0 z-10 flex h-8 items-center gap-2 bg-popover/95 px-3 text-xs backdrop-blur-sm">
+                        <PierreEntryIcon
+                          pathValue={group.path}
+                          kind="file"
+                          theme={resolvedTheme}
+                          className="size-3.5"
+                        />
+                        <span className="font-medium text-foreground">{path.name}</span>
+                        {path.directory ? (
+                          <span className="min-w-0 truncate text-muted-foreground">
+                            {path.directory}
+                          </span>
+                        ) : null}
+                        <span className="ml-auto rounded-full bg-muted px-1.5 py-0.5 tabular-nums text-[10px] text-muted-foreground">
+                          {group.matches.length}
+                        </span>
+                      </div>
+                      {group.matches.map((match) => (
+                        <button
+                          type="button"
+                          key={`${match.path}:${match.lineNumber}:${match.resultIndex}`}
+                          data-project-search-result={match.resultIndex}
+                          className={cn(
+                            "flex h-7 w-full min-w-0 items-center gap-3 px-3 text-left font-mono text-xs hover:bg-accent/60",
+                            match.resultIndex === selectedIndex &&
+                              "bg-accent text-accent-foreground",
+                          )}
+                          onMouseEnter={() => setSelectedIndex(match.resultIndex)}
+                          onClick={() => openMatch(match)}
+                        >
+                          <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground/70">
+                            {match.lineNumber}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate whitespace-pre">
+                            <SearchSyntaxErrorBoundary fallback={highlightedLine(match)}>
+                              <Suspense fallback={highlightedLine(match)}>
+                                <SyntaxHighlightedLine
+                                  match={match}
+                                  language={getFiletypeFromFileName(group.path)}
+                                  themeName={themeName}
+                                />
+                              </Suspense>
+                            </SearchSyntaxErrorBoundary>
+                          </span>
+                        </button>
+                      ))}
+                    </section>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+        <div className="flex h-9 shrink-0 items-center gap-3 border-t px-3 text-[11px] text-muted-foreground">
+          <span>↑↓ Navigate</span>
+          <span>↵ Open file</span>
+          <span>esc Close</span>
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/RenderErrorBoundary.tsx
+++ b/apps/web/src/components/RenderErrorBoundary.tsx
@@ -1,0 +1,16 @@
+import { Component, type ReactNode } from "react";
+
+export class RenderErrorBoundary extends Component<
+  { readonly children: ReactNode; readonly fallback: ReactNode },
+  { readonly failed: boolean }
+> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -23,6 +23,8 @@ interface FileBrowserPanelProps {
   environmentId: EnvironmentId;
   cwd: string;
   projectName: string;
+  selectedPath: string | null;
+  selectedPathRevealId: number;
   onOpenFile: (relativePath: string) => void;
 }
 
@@ -46,6 +48,8 @@ export default function FileBrowserPanel({
   environmentId,
   cwd,
   projectName,
+  selectedPath,
+  selectedPathRevealId,
   onOpenFile,
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
@@ -59,6 +63,7 @@ export default function FileBrowserPanel({
   const entryKindsRef = useRef<ReadonlyMap<string, ProjectEntry["kind"]>>(entryKinds);
   const treePaths = useMemo(() => entries.map(treePath), [entries]);
   const previousTreePathsRef = useRef<readonly string[]>([]);
+  const syncingSelectionRef = useRef(false);
 
   // The tree renders rows in shadow DOM and its anchor rect is unreliable, so
   // capture the right-click position ourselves; contextmenu is a composed
@@ -164,6 +169,7 @@ export default function FileBrowserPanel({
     initialExpansion: 1,
     icons: T3_PIERRE_ICONS,
     onSelectionChange: (selectedPaths) => {
+      if (syncingSelectionRef.current) return;
       dragMention.handleSelectionChange(selectedPaths);
       // Starting a drag selects the dragged row; that selection is a side
       // effect of the gesture, not a request to open the file.
@@ -186,6 +192,30 @@ export default function FileBrowserPanel({
     previousTreePathsRef.current = treePaths;
     model.resetPaths(treePaths);
   }, [entryKinds, model, treePaths]);
+
+  useEffect(() => {
+    if (!selectedPath || entryKinds.get(selectedPath) !== "file") return;
+
+    syncingSelectionRef.current = true;
+    model.closeSearch();
+    for (const path of model.getSelectedPaths()) {
+      model.getItem(path)?.deselect();
+    }
+
+    const segments = selectedPath.split("/");
+    let ancestorPath = "";
+    for (const segment of segments.slice(0, -1)) {
+      ancestorPath = ancestorPath ? `${ancestorPath}/${segment}` : segment;
+      const item = model.getItem(ancestorPath);
+      if (item && "expand" in item) item.expand();
+    }
+
+    model.getItem(selectedPath)?.select();
+    model.scrollToPath(selectedPath, { focus: true, offset: "center" });
+    queueMicrotask(() => {
+      syncingSelectionRef.current = false;
+    });
+  }, [entryKinds, model, selectedPath, selectedPathRevealId, treePaths]);
 
   const fileCount = useMemo(
     () => entries.reduce((count, entry) => count + (entry.kind === "file" ? 1 : 0), 0),

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -941,6 +941,8 @@ export default function FilePreviewPanel({
               environmentId={environmentId}
               cwd={cwd}
               projectName={projectName}
+              selectedPath={relativePath}
+              selectedPathRevealId={revealRequestId}
               onOpenFile={onOpenFile}
             />
           </aside>

--- a/apps/web/src/components/project-search/HighlightedSearchLine.tsx
+++ b/apps/web/src/components/project-search/HighlightedSearchLine.tsx
@@ -1,0 +1,183 @@
+import { getFiletypeFromFileName } from "@pierre/diffs";
+import type { ProjectContentMatch } from "@t3tools/contracts";
+import { memo, Suspense, use, useMemo, type CSSProperties } from "react";
+
+import { resolveDiffThemeName } from "~/lib/diffRendering";
+import { getSyntaxHighlighterPromise } from "~/lib/syntaxHighlighting";
+
+import { RenderErrorBoundary } from "../RenderErrorBoundary";
+
+interface Range {
+  readonly start: number;
+  readonly end: number;
+}
+
+interface CodeToken {
+  readonly content: string;
+  readonly offset: number;
+  readonly color?: string;
+  readonly fontStyle?: number;
+}
+
+interface Segment {
+  readonly content: string;
+  readonly isMatch: boolean;
+  readonly start: number;
+  readonly end: number;
+  readonly token: CodeToken;
+}
+
+function normalizeRanges(match: ProjectContentMatch): Range[] {
+  const ranges = match.matchRanges
+    .map((range) => ({
+      start: Math.max(0, Math.min(match.lineContent.length, range.start)),
+      end: Math.max(0, Math.min(match.lineContent.length, range.end)),
+    }))
+    .filter((range) => range.end > range.start)
+    .toSorted((left, right) => left.start - right.start);
+
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const range of ranges) {
+    const previous = merged.at(-1);
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+
+function splitToken(line: string, token: CodeToken, ranges: ReadonlyArray<Range>): Segment[] {
+  const segments: Segment[] = [];
+  const tokenEnd = token.offset + token.content.length;
+  let cursor = token.offset;
+
+  for (const range of ranges) {
+    if (range.end <= cursor) continue;
+    if (range.start >= tokenEnd) break;
+
+    const matchStart = Math.max(cursor, range.start);
+    if (matchStart > cursor) {
+      segments.push({
+        content: line.slice(cursor, matchStart),
+        isMatch: false,
+        start: cursor,
+        end: matchStart,
+        token,
+      });
+    }
+
+    const matchEnd = Math.min(tokenEnd, range.end);
+    segments.push({
+      content: line.slice(matchStart, matchEnd),
+      isMatch: true,
+      start: matchStart,
+      end: matchEnd,
+      token,
+    });
+    cursor = matchEnd;
+  }
+
+  if (cursor < tokenEnd) {
+    segments.push({
+      content: line.slice(cursor, tokenEnd),
+      isMatch: false,
+      start: cursor,
+      end: tokenEnd,
+      token,
+    });
+  }
+  return segments;
+}
+
+function tokenStyle(token: CodeToken): CSSProperties {
+  const fontStyle = token.fontStyle ?? 0;
+  return {
+    ...(token.color ? { color: token.color } : {}),
+    ...(fontStyle & 1 ? { fontStyle: "italic" } : {}),
+    ...(fontStyle & 2 ? { fontWeight: 700 } : {}),
+    ...(fontStyle & 4 ? { textDecoration: "underline" } : {}),
+  };
+}
+
+function HighlightedTokens(props: {
+  readonly line: string;
+  readonly ranges: ReadonlyArray<Range>;
+  readonly tokens: ReadonlyArray<CodeToken>;
+}) {
+  return props.tokens
+    .flatMap((token) => splitToken(props.line, token, props.ranges))
+    .map((segment) =>
+      segment.isMatch ? (
+        <mark
+          className="rounded-[2px] bg-primary/25 text-inherit"
+          key={`${segment.start}:${segment.end}:match`}
+          style={tokenStyle(segment.token)}
+        >
+          {segment.content}
+        </mark>
+      ) : (
+        <span key={`${segment.start}:${segment.end}:code`} style={tokenStyle(segment.token)}>
+          {segment.content}
+        </span>
+      ),
+    );
+}
+
+function SyntaxHighlightedTokens(props: {
+  readonly line: string;
+  readonly language: string;
+  readonly ranges: ReadonlyArray<Range>;
+  readonly theme: "light" | "dark";
+}) {
+  const highlighter = use(getSyntaxHighlighterPromise(props.language));
+  const tokens = useMemo(() => {
+    try {
+      return highlighter.codeToTokens(props.line, {
+        lang: props.language,
+        theme: resolveDiffThemeName(props.theme),
+      }).tokens[0];
+    } catch {
+      return undefined;
+    }
+  }, [highlighter, props.language, props.line, props.theme]);
+
+  return tokens ? (
+    <HighlightedTokens line={props.line} ranges={props.ranges} tokens={tokens} />
+  ) : (
+    <HighlightedTokens
+      line={props.line}
+      ranges={props.ranges}
+      tokens={[{ content: props.line, offset: 0 }]}
+    />
+  );
+}
+
+export const HighlightedSearchLine = memo(function HighlightedSearchLine(props: {
+  readonly match: ProjectContentMatch;
+  readonly path: string;
+  readonly theme: "light" | "dark";
+}) {
+  const ranges = useMemo(() => normalizeRanges(props.match), [props.match]);
+  const fallback = (
+    <HighlightedTokens
+      line={props.match.lineContent}
+      ranges={ranges}
+      tokens={[{ content: props.match.lineContent, offset: 0 }]}
+    />
+  );
+
+  return (
+    <RenderErrorBoundary fallback={fallback}>
+      <Suspense fallback={fallback}>
+        <SyntaxHighlightedTokens
+          line={props.match.lineContent}
+          language={getFiletypeFromFileName(props.path)}
+          ranges={ranges}
+          theme={props.theme}
+        />
+      </Suspense>
+    </RenderErrorBoundary>
+  );
+});

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -119,6 +119,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("f", { shiftKey: true }),
+    command: "project.searchContents",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("m", { shiftKey: true }),
     command: "modelPicker.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -511,6 +516,23 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
       "commandPalette.toggle",
+    );
+  });
+
+  it("matches project.searchContents shortcut outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "f", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "project.searchContents",
+    );
+    assert.notStrictEqual(
+      resolveShortcutCommand(event({ key: "f", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+      "project.searchContents",
     );
   });
 

--- a/apps/web/src/lib/syntaxHighlighting.ts
+++ b/apps/web/src/lib/syntaxHighlighting.ts
@@ -1,0 +1,26 @@
+import {
+  getSharedHighlighter,
+  type DiffsHighlighter,
+  type SupportedLanguages,
+} from "@pierre/diffs";
+
+import { resolveDiffThemeName } from "./diffRendering";
+
+const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
+
+export function getSyntaxHighlighterPromise(language: string): Promise<DiffsHighlighter> {
+  const cached = highlighterPromiseCache.get(language);
+  if (cached) return cached;
+
+  const promise = getSharedHighlighter({
+    themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
+    langs: [language as SupportedLanguages],
+    preferredHighlighter: "shiki-js",
+  }).catch((error) => {
+    highlighterPromiseCache.delete(language);
+    if (language === "text") throw error;
+    return getSyntaxHighlighterPromise("text");
+  });
+  highlighterPromiseCache.set(language, promise);
+  return promise;
+}

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -7,6 +7,7 @@ import { type VcsRefTarget } from "@t3tools/client-runtime/state/vcs";
 import type {
   EnvironmentId,
   OrchestrationThread,
+  ProjectContentMatch,
   ThreadId,
   VcsListRefsResult,
   VcsRef,
@@ -25,8 +26,11 @@ import { vcsEnvironment } from "./vcs";
 
 const COMPOSER_PATH_SEARCH_DEBOUNCE_MS = 120;
 const COMPOSER_PATH_SEARCH_LIMIT = 80;
+const PROJECT_CONTENT_SEARCH_DEBOUNCE_MS = 120;
+const PROJECT_CONTENT_SEARCH_LIMIT = 500;
 const VCS_REF_LIST_LIMIT = 100;
 const EMPTY_REFS: ReadonlyArray<VcsRef> = [];
+const EMPTY_CONTENT_MATCHES: ReadonlyArray<ProjectContentMatch> = [];
 const INITIAL_BRANCH_CURSORS = [undefined] as const;
 
 export interface ThreadDetailView {
@@ -211,6 +215,47 @@ export function useComposerPathSearch(target: ComposerPathSearchTarget) {
     error: result.error,
     isPending: normalizedTarget.query !== debouncedTarget.query || result.isPending,
     refresh: result.refresh,
+  };
+}
+
+interface ProjectContentSearchTarget {
+  readonly environmentId: EnvironmentId | null;
+  readonly cwd: string | null;
+  readonly query: string;
+  readonly caseSensitive: boolean;
+  readonly wholeWord: boolean;
+  readonly useRegex: boolean;
+}
+
+export function useProjectContentSearch(target: ProjectContentSearchTarget) {
+  const query = target.query.trim();
+  const debouncedQuery = useDebouncedValue(query, PROJECT_CONTENT_SEARCH_DEBOUNCE_MS);
+  const result = useEnvironmentQuery(
+    target.environmentId !== null &&
+      target.cwd !== null &&
+      query.length > 0 &&
+      debouncedQuery.length > 0
+      ? projectEnvironment.searchContents({
+          environmentId: target.environmentId,
+          input: {
+            cwd: target.cwd,
+            query: debouncedQuery,
+            limit: PROJECT_CONTENT_SEARCH_LIMIT,
+            caseSensitive: target.caseSensitive,
+            wholeWord: target.wholeWord,
+            useRegex: target.useRegex,
+          },
+        })
+      : null,
+  );
+
+  return {
+    matches: result.data?.matches ?? EMPTY_CONTENT_MATCHES,
+    error: result.error,
+    isPending: query !== debouncedQuery || result.isPending,
+    hasQuery: query.length > 0,
+    truncated: result.data?.truncated ?? false,
+    invalidRegex: result.data?.regexFallbackError !== undefined,
   };
 }
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -30,6 +30,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+-", "command": "preview.zoomOut", "when": "previewFocus" },
   { "key": "mod+0", "command": "preview.resetZoom", "when": "previewFocus" },
   { "key": "mod+k", "command": "commandPalette.toggle", "when": "!terminalFocus" },
+  { "key": "mod+shift+f", "command": "project.searchContents", "when": "!terminalFocus" },
   { "key": "mod+n", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+o", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
@@ -64,6 +65,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `preview.zoomOut`: zoom the preview viewport out one step (in focused preview context by default)
 - `preview.resetZoom`: reset the preview zoom to 100% (in focused preview context by default)
 - `commandPalette.toggle`: open or close the global command palette
+- `project.searchContents`: search file contents across the active project
 - `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
 - `editor.openFavorite`: open current project/worktree in the last-used editor

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -60,6 +60,12 @@ export function createProjectEnvironmentAtoms<R, E>(
       tag: WS_METHODS.projectsSearchEntries,
       staleTimeMs: 15_000,
     }),
+    searchContents: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:projects:search-contents",
+      tag: WS_METHODS.projectsSearchContents,
+      staleTimeMs: 5_000,
+      idleTtlMs: 60_000,
+    }),
     listEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:list-entries",
       tag: WS_METHODS.projectsListEntries,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -28,6 +28,8 @@ import type {
   ProjectReadFileResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
+  ProjectSearchContentsInput,
+  ProjectSearchContentsResult,
   ProjectWriteFileInput,
   ProjectWriteFileResult,
 } from "./project.ts";
@@ -1192,6 +1194,7 @@ export interface EnvironmentApi {
   projects: {
     listEntries: (input: ProjectListEntriesInput) => Promise<ProjectListEntriesResult>;
     readFile: (input: ProjectReadFileInput) => Promise<ProjectReadFileResult>;
+    searchContents: (input: ProjectSearchContentsInput) => Promise<ProjectSearchContentsResult>;
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
   };

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -59,6 +59,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedCommandPalette.command, "commandPalette.toggle");
 
+    const parsedProjectSearch = yield* decode(KeybindingRule, {
+      key: "mod+shift+f",
+      command: "project.searchContents",
+    });
+    assert.strictEqual(parsedProjectSearch.command, "project.searchContents");
+
     const parsedLocal = yield* decode(KeybindingRule, {
       key: "mod+shift+n",
       command: "chat.newLocal",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -63,6 +63,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "preview.zoomOut",
   "preview.resetZoom",
   "commandPalette.toggle",
+  "project.searchContents",
   "chat.new",
   "chat.newLocal",
   "editor.openFavorite",

--- a/packages/contracts/src/project.test.ts
+++ b/packages/contracts/src/project.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   ProjectReadFileError,
+  ProjectSearchContentsError,
   ProjectSearchEntriesError,
   ProjectWriteFileError,
 } from "./project.ts";
@@ -28,6 +29,13 @@ describe("project RPC errors", () => {
       resolvedPath: "/workspace/src/index.ts",
       cause,
     });
+    const contentSearchError = new ProjectSearchContentsError({
+      cwd: "/workspace",
+      queryLength: "authorization: Bearer secret-token".length,
+      limit: 100,
+      failure: "search_index_search_failed",
+      cause,
+    });
 
     expect(searchError.message).toBe("Failed to search workspace entries in '/workspace'.");
     expect(searchError.message).not.toContain(cause.message);
@@ -39,6 +47,8 @@ describe("project RPC errors", () => {
     expect(readError.message).toBe("Failed to read workspace file 'src/index.ts' in '/workspace'.");
     expect(readError.message).not.toContain(cause.message);
     expect(readError.cause).toBe(cause);
+    expect(contentSearchError.message).toBe("Failed to search workspace contents in '/workspace'.");
+    expect(contentSearchError).not.toHaveProperty("query");
   });
 
   it("decodes legacy message-only errors during rolling upgrades", () => {

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 const PROJECT_SEARCH_ENTRIES_MAX_LIMIT = 200;
+const PROJECT_SEARCH_CONTENTS_MAX_LIMIT = 500;
 const PROJECT_WRITE_FILE_PATH_MAX_LENGTH = 512;
 const PROJECT_READ_FILE_PATH_MAX_LENGTH = 512;
 
@@ -25,6 +26,37 @@ export const ProjectSearchEntriesResult = Schema.Struct({
   truncated: Schema.Boolean,
 });
 export type ProjectSearchEntriesResult = typeof ProjectSearchEntriesResult.Type;
+
+export const ProjectSearchContentsInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  query: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  limit: PositiveInt.check(Schema.isLessThanOrEqualTo(PROJECT_SEARCH_CONTENTS_MAX_LIMIT)),
+  caseSensitive: Schema.Boolean,
+  useRegex: Schema.Boolean,
+  wholeWord: Schema.Boolean,
+});
+export type ProjectSearchContentsInput = typeof ProjectSearchContentsInput.Type;
+
+export const ProjectContentMatchRange = Schema.Struct({
+  start: NonNegativeInt,
+  end: NonNegativeInt,
+});
+export type ProjectContentMatchRange = typeof ProjectContentMatchRange.Type;
+
+export const ProjectContentMatch = Schema.Struct({
+  path: TrimmedNonEmptyString,
+  lineNumber: PositiveInt,
+  lineContent: Schema.String,
+  matchRanges: Schema.Array(ProjectContentMatchRange),
+});
+export type ProjectContentMatch = typeof ProjectContentMatch.Type;
+
+export const ProjectSearchContentsResult = Schema.Struct({
+  matches: Schema.Array(ProjectContentMatch),
+  truncated: Schema.Boolean,
+  regexFallbackError: Schema.optional(Schema.String),
+});
+export type ProjectSearchContentsResult = typeof ProjectSearchContentsResult.Type;
 
 export const ProjectListEntriesInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
@@ -90,6 +122,37 @@ export class ProjectSearchEntriesError extends Schema.TaggedErrorClass<ProjectSe
       message:
         decodedProjectErrorMessage(props) ??
         `Failed to search workspace entries in '${props.cwd}'.`,
+    } as any);
+  }
+}
+
+export class ProjectSearchContentsError extends Schema.TaggedErrorClass<ProjectSearchContentsError>()(
+  "ProjectSearchContentsError",
+  {
+    cwd: Schema.optional(TrimmedNonEmptyString),
+    queryLength: Schema.optional(NonNegativeInt),
+    limit: Schema.optional(PositiveInt),
+    failure: Schema.optional(ProjectEntriesFailure),
+    normalizedCwd: Schema.optional(TrimmedNonEmptyString),
+    timeout: Schema.optional(TrimmedNonEmptyString),
+    detail: Schema.optional(TrimmedNonEmptyString),
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  // @effect-diagnostics-next-line overriddenSchemaConstructor:off
+  constructor(
+    props: ProjectEntriesFailureContext & {
+      readonly cwd: string;
+      readonly queryLength: number;
+      readonly limit: number;
+    },
+  ) {
+    super({
+      ...props,
+      message:
+        decodedProjectErrorMessage(props) ??
+        `Failed to search workspace contents in '${props.cwd}'.`,
     } as any);
   }
 }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -74,6 +74,9 @@ import {
   ProjectSearchEntriesError,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
+  ProjectSearchContentsError,
+  ProjectSearchContentsInput,
+  ProjectSearchContentsResult,
   ProjectWriteFileError,
   ProjectWriteFileInput,
   ProjectWriteFileResult,
@@ -154,6 +157,7 @@ export const WS_METHODS = {
   projectsRemove: "projects.remove",
   projectsListEntries: "projects.listEntries",
   projectsReadFile: "projects.readFile",
+  projectsSearchContents: "projects.searchContents",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
 
@@ -375,6 +379,12 @@ export const WsProjectsSearchEntriesRpc = Rpc.make(WS_METHODS.projectsSearchEntr
   payload: ProjectSearchEntriesInput,
   success: ProjectSearchEntriesResult,
   error: Schema.Union([ProjectSearchEntriesError, EnvironmentAuthorizationError]),
+});
+
+export const WsProjectsSearchContentsRpc = Rpc.make(WS_METHODS.projectsSearchContents, {
+  payload: ProjectSearchContentsInput,
+  success: ProjectSearchContentsResult,
+  error: Schema.Union([ProjectSearchContentsError, EnvironmentAuthorizationError]),
 });
 
 export const WsProjectsListEntriesRpc = Rpc.make(WS_METHODS.projectsListEntries, {
@@ -720,6 +730,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,
   WsProjectsReadFileRpc,
+  WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
   WsShellOpenInEditorRpc,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -35,6 +35,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+-", command: "preview.zoomOut", when: "previewFocus" },
   { key: "mod+0", command: "preview.resetZoom", when: "previewFocus" },
   { key: "mod+k", command: "commandPalette.toggle", when: "!terminalFocus" },
+  { key: "mod+shift+f", command: "project.searchContents", when: "!terminalFocus" },
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },


### PR DESCRIPTION
## Summary

<img width="1709" height="986" alt="Screenshot 2026-07-15 at 9 32 39 AM" src="https://github.com/user-attachments/assets/f09644b3-a1d4-409e-9a51-04e2ff08b125" />
<img width="1715" height="983" alt="Screenshot 2026-07-15 at 9 33 00 AM" src="https://github.com/user-attachments/assets/84e09acf-743e-4fcc-baf9-9a78da4fe6b8" />

- add project-wide content search with `Cmd/Ctrl+Shift+F`
- group matches by file with case-sensitive, whole-word, and regex options
- syntax-highlight result lines and preserve precise match highlighting
- open results at the matching line and reveal the selected file in the explorer

## Why

T3 Code could locate files by name, but it did not provide a fast way to search file contents across an entire project. This adds a VS Code-style global search flow for navigating directly from a text match to its source file.

## Implementation

- adds shared contracts and RPC handling for content-search results
- enables FFF content indexing and uses its native grep implementation with result limits and gitignore support
- adds the default `project.searchContents` keybinding and search dialog
- reuses the shared Shiki highlighter for language-aware result snippets
- synchronizes opened search results with the right-side file explorer
- handles punctuation-ended whole-word queries without including boundary characters in highlighted ranges

## Validation

- `vp check`
- `vp run typecheck`
- 101 focused tests across workspace search, contracts, keybindings, and right-panel state
- punctuation whole-word regression tests
- live browser verification of search options, syntax highlighting, result navigation, line reveal, and explorer selection


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add project-wide content search with `mod+shift+f` keybinding
> - Adds a `ProjectContentSearchDialog` component accessible via `mod+shift+f` (outside terminal focus) that searches file contents across the active project with options for case sensitivity, whole word, and regex modes.
> - Adds a `projects.searchContents` WebSocket RPC endpoint backed by `WorkspaceSearchIndex.searchContents`, which delegates to `FileFinder.grep` and returns per-line matches with byte-accurate ranges; requires orchestration read scope.
> - Renders syntax-highlighted result lines with match highlighting via a new `HighlightedSearchLine` component and a shared `getSyntaxHighlighterPromise` utility.
> - Extends `FileBrowserPanel` to auto-reveal and scroll the currently open file into view when `selectedPath` or `selectedPathRevealId` props change.
> - Behavioral Change: `FileFinder` is now created with content indexing enabled (`disableContentIndexing: false`).
> >
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 35a1864. 19 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling FileFinder content indexing changes workspace index cost/behavior for all projects; grep runs locally on the workspace with read-scope auth only, but search still touches full tree contents.
> 
> **Overview**
> Adds **VS Code-style global content search** for the active project via **`mod+shift+f`** (`project.searchContents`), opening a dialog with case-sensitive, whole-word, and regex options.
> 
> **Backend:** New `projects.searchContents` RPC and `WorkspaceEntries.searchContents` → `WorkspaceSearchIndex.searchContents`, which runs **`FileFinder.grep`** with limits, gitignore behavior, and structured errors (query text not leaked). **Content indexing is turned on** for workspace indexes (`disableContentIndexing: false`). Whole-word matching uses `\b` or non-word boundary fallbacks for punctuation-ended patterns; match ranges are mapped from byte offsets and trimmed for literal whole-word hits.
> 
> **UI:** `ProjectContentSearchDialog` debounces queries, groups results by file, syntax-highlights lines via shared **`getSyntaxHighlighterPromise`**, and opens the right panel at the **matching line**. **`FileBrowserPanel`** syncs selection/reveal when a file is opened from search. Shortcut handling treats the search dialog like the command palette for “palette open” checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a18648d7f73a09f14f8eca04ad7418bffc43b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->