### PR TITLE
feat: reference other threads from the composer

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -22,6 +22,8 @@ import {
   PreviewSnapshotToolkit,
   PreviewStandardToolkit,
 } from "./toolkits/preview/tools.ts";
+import { ThreadReferenceToolkitHandlersLive } from "./toolkits/threadReference/handlers.ts";
+import { ThreadReferenceToolkit } from "./toolkits/threadReference/tools.ts";
 
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
@@ -208,10 +210,17 @@ export const PreviewToolkitRegistrationLive = Layer.mergeAll(
   PreviewSnapshotRegistrationLive,
 );
 
+export const ThreadReferenceToolkitRegistrationLive = McpServer.toolkit(
+  ThreadReferenceToolkit,
+).pipe(Layer.provide(ThreadReferenceToolkitHandlersLive));
+
 const McpTransportLive = McpServer.layerHttp({
   name: "T3 Code",
   version: packageJson.version,
   path: "/mcp",
 }).pipe(Layer.provide(McpAuthMiddlewareLive));
 
-export const layer = PreviewToolkitRegistrationLive.pipe(Layer.provideMerge(McpTransportLive));
+export const layer = Layer.mergeAll(
+  PreviewToolkitRegistrationLive,
+  ThreadReferenceToolkitRegistrationLive,
+).pipe(Layer.provideMerge(McpTransportLive));

--- a/apps/server/src/mcp/McpInvocationContext.ts
+++ b/apps/server/src/mcp/McpInvocationContext.ts
@@ -7,7 +7,7 @@ import {
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
-export type McpCapability = "preview";
+export type McpCapability = "preview" | "thread-reference";
 
 export interface McpInvocationScope {
   readonly environmentId: EnvironmentId;
@@ -25,7 +25,7 @@ export class McpInvocationContext extends Context.Service<
 >()("t3/mcp/McpInvocationContext") {}
 
 export const requireMcpCapability = Effect.fn("mcp.requireCapability")(function* (
-  capability: McpCapability,
+  capability: "preview",
 ) {
   const invocation = yield* McpInvocationContext;
   if (!invocation.capabilities.has(capability)) {

--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -47,6 +47,7 @@ it.effect("stores only a token hash, resolves the bearer token, and revokes by t
 
     const resolved = yield* registry.resolve(token);
     expect(resolved?.threadId).toBe(threadId);
+    expect(resolved?.capabilities).toEqual(new Set(["preview", "thread-reference"]));
 
     yield* registry.revokeThread(threadId);
     expect(yield* registry.resolve(token)).toBeUndefined();

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -114,7 +114,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         threadId: ThreadId.make(request.threadId),
         providerSessionId,
         providerInstanceId: ProviderInstanceId.make(request.providerInstanceId),
-        capabilities: new Set(["preview"]),
+        capabilities: new Set(["preview", "thread-reference"]),
         issuedAt,
         expiresAt,
       };

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
@@ -14,10 +14,12 @@ import * as Option from "effect/Option";
 import { McpSchema, McpServer } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { PersistenceSqlError } from "../../../persistence/Errors.ts";
 import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import {
   buildThreadReferencePage,
   hasUserThreadReference,
+  threadRead,
   ThreadReferenceToolkitHandlersLive,
 } from "./handlers.ts";
 import { ThreadReferenceToolkit } from "./tools.ts";
@@ -143,6 +145,19 @@ it("continues pagination across an empty message at a page boundary", () => {
   expect(second.nextCursor).toBeNull();
 });
 
+it.each([":", "0:", ":0", "0:0:garbage"])("rejects malformed cursor %s", (cursor) => {
+  expect(
+    buildThreadReferencePage(thread, {
+      threadId: thread.id,
+      cursor,
+      maxChars: 1_000,
+    } as never),
+  ).toMatchObject({
+    _tag: "ThreadReferenceInvalidCursorError",
+    cursor,
+  });
+});
+
 it("only authorizes user-supplied references from the invoking environment", () => {
   expect(hasUserThreadReference(currentThread, environmentId, thread.id)).toBe(true);
   expect(
@@ -220,3 +235,26 @@ it.effect("rejects a thread that was not referenced by the invoking user", () =>
     Effect.provide(TestLayer),
   ),
 );
+
+it.effect("preserves projection failures when a referenced thread cannot be loaded", () => {
+  const repositoryError = new PersistenceSqlError({
+    operation: "getThreadDetailById",
+    detail: "database unavailable",
+  });
+  return Effect.gen(function* () {
+    const error = yield* Effect.flip(threadRead({ threadId: thread.id }));
+    expect(error).toMatchObject({
+      _tag: "ThreadReferenceUnavailableError",
+      threadId: thread.id,
+    });
+    expect(error.cause).toBe(repositoryError);
+  }).pipe(
+    Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+    Effect.provideService(ProjectionSnapshotQuery, {
+      getThreadDetailById: (threadId: ThreadId) =>
+        threadId === currentThread.id
+          ? Effect.succeed(Option.some(currentThread))
+          : Effect.fail(repositoryError),
+    } as never),
+  );
+});

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "@effect/vitest";
 import {
+  EnvironmentId,
   MessageId,
   ProjectId,
   ProviderInstanceId,
@@ -14,7 +15,11 @@ import { McpSchema, McpServer } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
-import { buildThreadReferencePage, ThreadReferenceToolkitHandlersLive } from "./handlers.ts";
+import {
+  buildThreadReferencePage,
+  hasUserThreadReference,
+  ThreadReferenceToolkitHandlersLive,
+} from "./handlers.ts";
 import { ThreadReferenceToolkit } from "./tools.ts";
 
 const TestLayer = McpServer.toolkit(ThreadReferenceToolkit).pipe(
@@ -22,9 +27,13 @@ const TestLayer = McpServer.toolkit(ThreadReferenceToolkit).pipe(
   Layer.provideMerge(McpServer.McpServer.layer),
 );
 
-const makeMessage = (id: string, text: string): OrchestrationMessage => ({
+const makeMessage = (
+  id: string,
+  text: string,
+  role: OrchestrationMessage["role"] = "user",
+): OrchestrationMessage => ({
   id: MessageId.make(id),
-  role: "user",
+  role,
   text,
   turnId: null,
   streaming: false,
@@ -32,12 +41,53 @@ const makeMessage = (id: string, text: string): OrchestrationMessage => ({
   updatedAt: "2026-01-01T00:00:00.000Z",
 });
 
+const currentThreadId = ThreadId.make("thread-current");
+const environmentId = EnvironmentId.make("environment-1");
 const thread = {
   id: ThreadId.make("thread-referenced"),
   projectId: ProjectId.make("project-1"),
   title: "Referenced work",
   messages: [makeMessage("message-1", "abcdef"), makeMessage("message-2", "ghijkl")],
 } as unknown as OrchestrationThread;
+const currentThread = {
+  ...thread,
+  id: currentThreadId,
+  messages: [
+    makeMessage(
+      "message-reference",
+      `[Referenced work](t3-thread:///${environmentId}/${thread.id})`,
+    ),
+  ],
+} as OrchestrationThread;
+const invocation = {
+  environmentId,
+  threadId: currentThreadId,
+  providerSessionId: "provider-session-1",
+  providerInstanceId: ProviderInstanceId.make("codex"),
+  capabilities: new Set(["thread-reference"] as const),
+  issuedAt: 1,
+  expiresAt: Number.MAX_SAFE_INTEGER,
+};
+const mcpServerClient = {
+  clientId: 1,
+  initializePayload: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "test", version: "1" },
+  },
+  getClient: Effect.die("unused"),
+};
+const projectionQueryFor = (sourceThread: OrchestrationThread) =>
+  ({
+    getThreadDetailById: (threadId: ThreadId) =>
+      Effect.succeed(
+        threadId === sourceThread.id
+          ? Option.some(sourceThread)
+          : threadId === thread.id
+            ? Option.some(thread)
+            : Option.none(),
+      ),
+  }) as never;
 
 it("paginates within a message without losing transcript text", () => {
   const first = buildThreadReferencePage(thread, {
@@ -67,6 +117,67 @@ it("paginates within a message without losing transcript text", () => {
   expect(longSecond.nextCursor).toBeNull();
 });
 
+it("continues pagination across an empty message at a page boundary", () => {
+  const emptyMessageThread = {
+    ...thread,
+    messages: [
+      makeMessage("message-full", "a".repeat(1_000)),
+      makeMessage("message-empty", ""),
+      makeMessage("message-tail", "tail"),
+    ],
+  };
+  const first = buildThreadReferencePage(emptyMessageThread, {
+    threadId: thread.id,
+    maxChars: 1_000,
+  });
+  if ("_tag" in first) throw new Error("unexpected cursor error");
+  expect(first.nextCursor).toBe("1:0");
+
+  const second = buildThreadReferencePage(emptyMessageThread, {
+    threadId: thread.id,
+    cursor: first.nextCursor!,
+    maxChars: 1_000,
+  });
+  if ("_tag" in second) throw new Error("unexpected cursor error");
+  expect(second.messages.map(({ text }) => text)).toEqual(["", "tail"]);
+  expect(second.nextCursor).toBeNull();
+});
+
+it("only authorizes user-supplied references from the invoking environment", () => {
+  expect(hasUserThreadReference(currentThread, environmentId, thread.id)).toBe(true);
+  expect(
+    hasUserThreadReference(
+      {
+        ...currentThread,
+        messages: [
+          makeMessage(
+            "message-assistant-reference",
+            `[Referenced work](t3-thread:///${environmentId}/${thread.id})`,
+            "assistant",
+          ),
+        ],
+      },
+      environmentId,
+      thread.id,
+    ),
+  ).toBe(false);
+  expect(
+    hasUserThreadReference(
+      {
+        ...currentThread,
+        messages: [
+          makeMessage(
+            "message-other-environment",
+            `[Referenced work](t3-thread:///environment-2/${thread.id})`,
+          ),
+        ],
+      },
+      environmentId,
+      thread.id,
+    ),
+  ).toBe(false);
+});
+
 it.effect("reads a referenced thread through the MCP toolkit", () =>
   Effect.gen(function* () {
     const server = yield* McpServer.McpServer;
@@ -81,27 +192,31 @@ it.effect("reads a referenced thread through the MCP toolkit", () =>
       totalMessages: 2,
     });
   }).pipe(
-    Effect.provideService(McpInvocationContext.McpInvocationContext, {
-      environmentId: "environment-1" as never,
-      threadId: ThreadId.make("thread-current"),
-      providerSessionId: "provider-session-1",
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      capabilities: new Set(["thread-reference"] as const),
-      issuedAt: 1,
-      expiresAt: Number.MAX_SAFE_INTEGER,
-    }),
-    Effect.provideService(McpSchema.McpServerClient, {
-      clientId: 1,
-      initializePayload: {
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientInfo: { name: "test", version: "1" },
-      },
-      getClient: Effect.die("unused"),
-    }),
-    Effect.provideService(ProjectionSnapshotQuery, {
-      getThreadDetailById: () => Effect.succeed(Option.some(thread)),
-    } as never),
+    Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+    Effect.provideService(McpSchema.McpServerClient, mcpServerClient),
+    Effect.provideService(ProjectionSnapshotQuery, projectionQueryFor(currentThread)),
+    Effect.provide(TestLayer),
+  ),
+);
+
+it.effect("rejects a thread that was not referenced by the invoking user", () =>
+  Effect.gen(function* () {
+    const server = yield* McpServer.McpServer;
+    const result = yield* server.callTool({
+      name: "thread_read",
+      arguments: { threadId: thread.id },
+    });
+    expect(result.isError).toBe(true);
+  }).pipe(
+    Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+    Effect.provideService(McpSchema.McpServerClient, mcpServerClient),
+    Effect.provideService(
+      ProjectionSnapshotQuery,
+      projectionQueryFor({
+        ...currentThread,
+        messages: [makeMessage("message-without-reference", "No thread reference here.")],
+      }),
+    ),
     Effect.provide(TestLayer),
   ),
 );

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
@@ -19,6 +19,7 @@ import { ProjectionSnapshotQuery } from "../../../orchestration/Services/Project
 import {
   buildThreadReferencePage,
   hasUserThreadReference,
+  normalizeThreadReferenceThreadId,
   threadRead,
   ThreadReferenceToolkitHandlersLive,
 } from "./handlers.ts";
@@ -208,19 +209,44 @@ it("only authorizes user-supplied references from the invoking environment", () 
   ).toBe(false);
 });
 
+it("normalizes model-facing thread reference inputs", () => {
+  expect(normalizeThreadReferenceThreadId(thread.id, environmentId)).toBe(thread.id);
+  expect(
+    normalizeThreadReferenceThreadId(ThreadId.make(`${environmentId}/${thread.id}`), environmentId),
+  ).toBe(thread.id);
+  expect(
+    normalizeThreadReferenceThreadId(
+      ThreadId.make(`t3-thread:///${environmentId}/${thread.id}`),
+      environmentId,
+    ),
+  ).toBe(thread.id);
+  expect(
+    normalizeThreadReferenceThreadId(
+      ThreadId.make(`t3-thread:///environment-2/${thread.id}`),
+      environmentId,
+    ),
+  ).toBe(`t3-thread:///environment-2/${thread.id}`);
+});
+
 it.effect("reads a referenced thread through the MCP toolkit", () =>
   Effect.gen(function* () {
     const server = yield* McpServer.McpServer;
-    const result = yield* server.callTool({
-      name: "thread_read",
-      arguments: { threadId: thread.id },
-    });
-    expect(result.isError).toBe(false);
-    expect(result.structuredContent).toMatchObject({
-      threadId: thread.id,
-      title: thread.title,
-      totalMessages: 2,
-    });
+    for (const threadId of [
+      thread.id,
+      `${environmentId}/${thread.id}`,
+      `t3-thread:///${environmentId}/${thread.id}`,
+    ]) {
+      const result = yield* server.callTool({
+        name: "thread_read",
+        arguments: { threadId },
+      });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent).toMatchObject({
+        threadId: thread.id,
+        title: thread.title,
+        totalMessages: 2,
+      });
+    }
   }).pipe(
     Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
     Effect.provideService(McpSchema.McpServerClient, mcpServerClient),

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
@@ -1,0 +1,107 @@
+import { expect, it } from "@effect/vitest";
+import {
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationMessage,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import { McpSchema, McpServer } from "effect/unstable/ai";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { buildThreadReferencePage, ThreadReferenceToolkitHandlersLive } from "./handlers.ts";
+import { ThreadReferenceToolkit } from "./tools.ts";
+
+const TestLayer = McpServer.toolkit(ThreadReferenceToolkit).pipe(
+  Layer.provide(ThreadReferenceToolkitHandlersLive),
+  Layer.provideMerge(McpServer.McpServer.layer),
+);
+
+const makeMessage = (id: string, text: string): OrchestrationMessage => ({
+  id: MessageId.make(id),
+  role: "user",
+  text,
+  turnId: null,
+  streaming: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const thread = {
+  id: ThreadId.make("thread-referenced"),
+  projectId: ProjectId.make("project-1"),
+  title: "Referenced work",
+  messages: [makeMessage("message-1", "abcdef"), makeMessage("message-2", "ghijkl")],
+} as unknown as OrchestrationThread;
+
+it("paginates within a message without losing transcript text", () => {
+  const first = buildThreadReferencePage(thread, {
+    threadId: thread.id,
+    maxChars: 1_000,
+  });
+  expect(first).toMatchObject({ nextCursor: null, totalMessages: 2 });
+
+  const longThread = {
+    ...thread,
+    messages: [makeMessage("message-long", "a".repeat(1_100))],
+  };
+  const longFirst = buildThreadReferencePage(longThread, {
+    threadId: thread.id,
+    maxChars: 1_000,
+  });
+  expect(longFirst).toMatchObject({ nextCursor: "0:1000" });
+  if ("_tag" in longFirst) throw new Error("unexpected cursor error");
+  const longSecond = buildThreadReferencePage(longThread, {
+    threadId: thread.id,
+    cursor: longFirst.nextCursor!,
+    maxChars: 1_000,
+  });
+  if ("_tag" in longSecond) throw new Error("unexpected cursor error");
+  expect(longFirst.messages[0]?.text.length).toBe(1_000);
+  expect(longSecond.messages[0]?.text.length).toBe(100);
+  expect(longSecond.nextCursor).toBeNull();
+});
+
+it.effect("reads a referenced thread through the MCP toolkit", () =>
+  Effect.gen(function* () {
+    const server = yield* McpServer.McpServer;
+    const result = yield* server.callTool({
+      name: "thread_read",
+      arguments: { threadId: thread.id },
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      threadId: thread.id,
+      title: thread.title,
+      totalMessages: 2,
+    });
+  }).pipe(
+    Effect.provideService(McpInvocationContext.McpInvocationContext, {
+      environmentId: "environment-1" as never,
+      threadId: ThreadId.make("thread-current"),
+      providerSessionId: "provider-session-1",
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      capabilities: new Set(["thread-reference"] as const),
+      issuedAt: 1,
+      expiresAt: Number.MAX_SAFE_INTEGER,
+    }),
+    Effect.provideService(McpSchema.McpServerClient, {
+      clientId: 1,
+      initializePayload: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test", version: "1" },
+      },
+      getClient: Effect.die("unused"),
+    }),
+    Effect.provideService(ProjectionSnapshotQuery, {
+      getThreadDetailById: () => Effect.succeed(Option.some(thread)),
+    } as never),
+    Effect.provide(TestLayer),
+  ),
+);

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.test.ts
@@ -166,6 +166,21 @@ it("only authorizes user-supplied references from the invoking environment", () 
         ...currentThread,
         messages: [
           makeMessage(
+            "message-punctuated-reference",
+            `Continue from [Referenced work](t3-thread:///${environmentId}/${thread.id}), please.`,
+          ),
+        ],
+      },
+      environmentId,
+      thread.id,
+    ),
+  ).toBe(true);
+  expect(
+    hasUserThreadReference(
+      {
+        ...currentThread,
+        messages: [
+          makeMessage(
             "message-assistant-reference",
             `[Referenced work](t3-thread:///${environmentId}/${thread.id})`,
             "assistant",

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.ts
@@ -28,7 +28,9 @@ function decodeCursor(
   thread: OrchestrationThread,
 ): TranscriptPosition | null {
   if (!input.cursor) return { messageIndex: 0, textOffset: 0 };
-  const [messageIndexText, textOffsetText] = input.cursor.split(":");
+  const cursorMatch = /^(\d+):(\d+)$/.exec(input.cursor);
+  if (!cursorMatch) return null;
+  const [, messageIndexText, textOffsetText] = cursorMatch;
   const messageIndex = Number(messageIndexText);
   const textOffset = Number(textOffsetText);
   const message = thread.messages[messageIndex];
@@ -114,7 +116,7 @@ export function hasUserThreadReference(
   );
 }
 
-const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
+export const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
   input: ThreadReferenceReadInput,
 ) {
   const invocation = yield* McpInvocationContext.McpInvocationContext;
@@ -124,7 +126,11 @@ const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
   const snapshotQuery = yield* ProjectionSnapshotQuery;
   const sourceThreadOption = yield* snapshotQuery
     .getThreadDetailById(invocation.threadId)
-    .pipe(Effect.mapError(() => new ThreadReferenceUnavailableError({ threadId: input.threadId })));
+    .pipe(
+      Effect.mapError(
+        (cause) => new ThreadReferenceUnavailableError({ threadId: input.threadId, cause }),
+      ),
+    );
   if (
     Option.isNone(sourceThreadOption) ||
     !hasUserThreadReference(sourceThreadOption.value, invocation.environmentId, input.threadId)
@@ -133,7 +139,11 @@ const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
   }
   const threadOption = yield* snapshotQuery
     .getThreadDetailById(input.threadId)
-    .pipe(Effect.mapError(() => new ThreadReferenceUnavailableError({ threadId: input.threadId })));
+    .pipe(
+      Effect.mapError(
+        (cause) => new ThreadReferenceUnavailableError({ threadId: input.threadId, cause }),
+      ),
+    );
   if (Option.isNone(threadOption)) {
     return yield* new ThreadReferenceNotFoundError({ threadId: input.threadId });
   }

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.ts
@@ -6,8 +6,11 @@ import {
   type ThreadReferenceReadResult,
   type ThreadReferenceTranscriptMessage,
   ThreadReferenceUnavailableError,
+  type EnvironmentId,
   type OrchestrationThread,
+  type ThreadId,
 } from "@t3tools/contracts";
+import { collectComposerThreadReferences } from "@t3tools/shared/composerInlineTokens";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
@@ -35,7 +38,7 @@ function decodeCursor(
     !Number.isSafeInteger(textOffset) ||
     messageIndex < 0 ||
     textOffset < 0 ||
-    (!validEndCursor && (!message || textOffset >= message.text.length))
+    (!validEndCursor && (!message || textOffset > message.text.length))
   ) {
     return null;
   }
@@ -96,6 +99,21 @@ export function buildThreadReferencePage(
   };
 }
 
+export function hasUserThreadReference(
+  sourceThread: OrchestrationThread,
+  environmentId: EnvironmentId,
+  targetThreadId: ThreadId,
+): boolean {
+  return sourceThread.messages.some(
+    (message) =>
+      message.role === "user" &&
+      collectComposerThreadReferences(message.text).some(
+        (reference) =>
+          reference.environmentId === environmentId && reference.threadId === targetThreadId,
+      ),
+  );
+}
+
 const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
   input: ThreadReferenceReadInput,
 ) {
@@ -104,6 +122,15 @@ const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
     return yield* new ThreadReferenceUnavailableError({ threadId: input.threadId });
   }
   const snapshotQuery = yield* ProjectionSnapshotQuery;
+  const sourceThreadOption = yield* snapshotQuery
+    .getThreadDetailById(invocation.threadId)
+    .pipe(Effect.mapError(() => new ThreadReferenceUnavailableError({ threadId: input.threadId })));
+  if (
+    Option.isNone(sourceThreadOption) ||
+    !hasUserThreadReference(sourceThreadOption.value, invocation.environmentId, input.threadId)
+  ) {
+    return yield* new ThreadReferenceUnavailableError({ threadId: input.threadId });
+  }
   const threadOption = yield* snapshotQuery
     .getThreadDetailById(input.threadId)
     .pipe(Effect.mapError(() => new ThreadReferenceUnavailableError({ threadId: input.threadId })));

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.ts
@@ -1,0 +1,122 @@
+import {
+  THREAD_REFERENCE_DEFAULT_MAX_CHARS,
+  ThreadReferenceInvalidCursorError,
+  ThreadReferenceNotFoundError,
+  type ThreadReferenceReadInput,
+  type ThreadReferenceReadResult,
+  type ThreadReferenceTranscriptMessage,
+  ThreadReferenceUnavailableError,
+  type OrchestrationThread,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadReferenceToolkit } from "./tools.ts";
+
+interface TranscriptPosition {
+  readonly messageIndex: number;
+  readonly textOffset: number;
+}
+
+function decodeCursor(
+  input: ThreadReferenceReadInput,
+  thread: OrchestrationThread,
+): TranscriptPosition | null {
+  if (!input.cursor) return { messageIndex: 0, textOffset: 0 };
+  const [messageIndexText, textOffsetText] = input.cursor.split(":");
+  const messageIndex = Number(messageIndexText);
+  const textOffset = Number(textOffsetText);
+  const message = thread.messages[messageIndex];
+  const validEndCursor = messageIndex === thread.messages.length && textOffset === 0;
+  if (
+    !Number.isSafeInteger(messageIndex) ||
+    !Number.isSafeInteger(textOffset) ||
+    messageIndex < 0 ||
+    textOffset < 0 ||
+    (!validEndCursor && (!message || textOffset >= message.text.length))
+  ) {
+    return null;
+  }
+  return { messageIndex, textOffset };
+}
+
+export function buildThreadReferencePage(
+  thread: OrchestrationThread,
+  input: ThreadReferenceReadInput,
+): ThreadReferenceReadResult | ThreadReferenceInvalidCursorError {
+  const position = decodeCursor(input, thread);
+  if (!position) {
+    return new ThreadReferenceInvalidCursorError({
+      threadId: input.threadId,
+      cursor: input.cursor ?? "",
+    });
+  }
+
+  const maxChars = input.maxChars ?? THREAD_REFERENCE_DEFAULT_MAX_CHARS;
+  const messages: ThreadReferenceTranscriptMessage[] = [];
+  let messageIndex = position.messageIndex;
+  let textOffset = position.textOffset;
+  let includedChars = 0;
+
+  while (messageIndex < thread.messages.length && includedChars < maxChars) {
+    const message = thread.messages[messageIndex];
+    if (!message) break;
+    const remainingChars = maxChars - includedChars;
+    const text = message.text.slice(textOffset, textOffset + remainingChars);
+    const textEnd = textOffset + text.length;
+    const textComplete = textEnd >= message.text.length;
+    messages.push({
+      id: message.id,
+      role: message.role,
+      text,
+      textStart: textOffset,
+      textEnd,
+      textComplete,
+      attachments: [...(message.attachments ?? [])],
+      createdAt: message.createdAt,
+    });
+    includedChars += text.length;
+    if (!textComplete) {
+      textOffset = textEnd;
+      break;
+    }
+    messageIndex += 1;
+    textOffset = 0;
+  }
+
+  return {
+    threadId: thread.id,
+    projectId: thread.projectId,
+    title: thread.title,
+    messages,
+    totalMessages: thread.messages.length,
+    nextCursor: messageIndex < thread.messages.length ? `${messageIndex}:${textOffset}` : null,
+  };
+}
+
+const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
+  input: ThreadReferenceReadInput,
+) {
+  const invocation = yield* McpInvocationContext.McpInvocationContext;
+  if (!invocation.capabilities.has("thread-reference")) {
+    return yield* new ThreadReferenceUnavailableError({ threadId: input.threadId });
+  }
+  const snapshotQuery = yield* ProjectionSnapshotQuery;
+  const threadOption = yield* snapshotQuery
+    .getThreadDetailById(input.threadId)
+    .pipe(Effect.mapError(() => new ThreadReferenceUnavailableError({ threadId: input.threadId })));
+  if (Option.isNone(threadOption)) {
+    return yield* new ThreadReferenceNotFoundError({ threadId: input.threadId });
+  }
+  const page = buildThreadReferencePage(threadOption.value, input);
+  if ("_tag" in page) {
+    return yield* page;
+  }
+  return page;
+});
+
+export const ThreadReferenceToolkitHandlersLive = ThreadReferenceToolkit.toLayer({
+  thread_read: threadRead,
+});

--- a/apps/server/src/mcp/toolkits/threadReference/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/handlers.ts
@@ -8,9 +8,10 @@ import {
   ThreadReferenceUnavailableError,
   type EnvironmentId,
   type OrchestrationThread,
-  type ThreadId,
+  ThreadId,
 } from "@t3tools/contracts";
 import { collectComposerThreadReferences } from "@t3tools/shared/composerInlineTokens";
+import { parseComposerThreadLink } from "@t3tools/shared/composerTrigger";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
@@ -116,38 +117,56 @@ export function hasUserThreadReference(
   );
 }
 
+export function normalizeThreadReferenceThreadId(
+  input: ThreadId,
+  environmentId: EnvironmentId,
+): ThreadId {
+  const parsedLink = parseComposerThreadLink(input);
+  if (parsedLink?.environmentId === environmentId) {
+    return ThreadId.make(parsedLink.threadId);
+  }
+
+  const environmentPrefix = `${environmentId}/`;
+  if (input.startsWith(environmentPrefix)) {
+    const threadId = input.slice(environmentPrefix.length);
+    if (threadId && !threadId.includes("/")) {
+      try {
+        return ThreadId.make(decodeURIComponent(threadId));
+      } catch {
+        return input;
+      }
+    }
+  }
+
+  return input;
+}
+
 export const threadRead = Effect.fn("ThreadReferenceToolkit.threadRead")(function* (
   input: ThreadReferenceReadInput,
 ) {
   const invocation = yield* McpInvocationContext.McpInvocationContext;
+  const threadId = normalizeThreadReferenceThreadId(input.threadId, invocation.environmentId);
+  const normalizedInput = { ...input, threadId };
   if (!invocation.capabilities.has("thread-reference")) {
-    return yield* new ThreadReferenceUnavailableError({ threadId: input.threadId });
+    return yield* new ThreadReferenceUnavailableError({ threadId });
   }
   const snapshotQuery = yield* ProjectionSnapshotQuery;
   const sourceThreadOption = yield* snapshotQuery
     .getThreadDetailById(invocation.threadId)
-    .pipe(
-      Effect.mapError(
-        (cause) => new ThreadReferenceUnavailableError({ threadId: input.threadId, cause }),
-      ),
-    );
+    .pipe(Effect.mapError((cause) => new ThreadReferenceUnavailableError({ threadId, cause })));
   if (
     Option.isNone(sourceThreadOption) ||
-    !hasUserThreadReference(sourceThreadOption.value, invocation.environmentId, input.threadId)
+    !hasUserThreadReference(sourceThreadOption.value, invocation.environmentId, threadId)
   ) {
-    return yield* new ThreadReferenceUnavailableError({ threadId: input.threadId });
+    return yield* new ThreadReferenceUnavailableError({ threadId });
   }
   const threadOption = yield* snapshotQuery
-    .getThreadDetailById(input.threadId)
-    .pipe(
-      Effect.mapError(
-        (cause) => new ThreadReferenceUnavailableError({ threadId: input.threadId, cause }),
-      ),
-    );
+    .getThreadDetailById(threadId)
+    .pipe(Effect.mapError((cause) => new ThreadReferenceUnavailableError({ threadId, cause })));
   if (Option.isNone(threadOption)) {
-    return yield* new ThreadReferenceNotFoundError({ threadId: input.threadId });
+    return yield* new ThreadReferenceNotFoundError({ threadId });
   }
-  const page = buildThreadReferencePage(threadOption.value, input);
+  const page = buildThreadReferencePage(threadOption.value, normalizedInput);
   if ("_tag" in page) {
     return yield* page;
   }

--- a/apps/server/src/mcp/toolkits/threadReference/tools.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/tools.ts
@@ -1,0 +1,24 @@
+import {
+  ThreadReferenceReadError,
+  ThreadReferenceReadInput,
+  ThreadReferenceReadResult,
+} from "@t3tools/contracts";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+
+export const ThreadReadTool = Tool.make("thread_read", {
+  description:
+    "Read a T3 Code chat thread referenced by a t3-thread link in the user's message. Pass the threadId from that link. The transcript is paginated; when nextCursor is non-null, call thread_read again with that cursor to continue. Do not call this for unrelated threads that the user did not reference.",
+  parameters: ThreadReferenceReadInput,
+  success: ThreadReferenceReadResult,
+  failure: ThreadReferenceReadError,
+  dependencies: [McpInvocationContext.McpInvocationContext, ProjectionSnapshotQuery],
+})
+  .annotate(Tool.Title, "Read referenced chat thread")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true);
+
+export const ThreadReferenceToolkit = Toolkit.make(ThreadReadTool);

--- a/apps/server/src/mcp/toolkits/threadReference/tools.ts
+++ b/apps/server/src/mcp/toolkits/threadReference/tools.ts
@@ -10,7 +10,7 @@ import { ProjectionSnapshotQuery } from "../../../orchestration/Services/Project
 
 export const ThreadReadTool = Tool.make("thread_read", {
   description:
-    "Read a T3 Code chat thread referenced by a t3-thread link in the user's message. Pass the threadId from that link. The transcript is paginated; when nextCursor is non-null, call thread_read again with that cursor to continue. Do not call this for unrelated threads that the user did not reference.",
+    "Read a T3 Code chat thread referenced by a t3-thread link in the user's message. For t3-thread:///ENVIRONMENT_ID/THREAD_ID, pass the final THREAD_ID as threadId. The full t3-thread link and ENVIRONMENT_ID/THREAD_ID are also accepted. The transcript is paginated; when nextCursor is non-null, call thread_read again with that cursor to continue. Do not call this for unrelated threads that the user did not reference.",
   parameters: ThreadReferenceReadInput,
   success: ThreadReferenceReadResult,
   failure: ThreadReferenceReadError,

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -11,6 +11,13 @@ For browser work, first call \`preview_status\`. If no automation-capable previe
 Do not switch to global browser skills, Chrome, Node REPL browser automation, standalone Playwright, or agent-browser merely because the preview is initially closed or a first call fails. Use an alternative browser system only when the T3 preview tools are absent, the user explicitly requests another browser, or \`preview_open\` returns an explicit unsupported/unavailable error. A failed T3 preview tool call should be inspected and retried with corrected arguments when the error is actionable.
 `;
 
+const T3_CODE_THREAD_REFERENCE_INSTRUCTIONS = `
+
+## T3 Code thread references
+
+The user may reference another chat with a \`t3-thread\` link. Do not treat the link as a web URL and do not assume its contents. Use the read-only \`thread_read\` tool from the \`t3-code\` MCP server with the referenced thread id. Follow \`nextCursor\` until you have read as much of the transcript as the task requires.
+`;
+
 export const CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Plan Mode (Conversational)
 
 You work in 3 phases, and you should *chat your way* to a great plan before finalizing it. A great plan is very detailed-intent- and implementation-wise-so that it can be handed to another engineer or agent to be implemented right away. It must be **decision complete**, where the implementer does not need to make any decisions.
@@ -132,6 +139,7 @@ Do not ask "should I proceed?" in the final output. The user can easily switch o
 
 Only produce at most one \`<proposed_plan>\` block per turn, and only when you are presenting a complete spec.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+${T3_CODE_THREAD_REFERENCE_INSTRUCTIONS}
 </collaboration_mode>`;
 
 export const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Collaboration Mode: Default
@@ -146,6 +154,7 @@ The \`request_user_input\` tool is unavailable in Default mode. If you call it w
 
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+${T3_CODE_THREAD_REFERENCE_INSTRUCTIONS}
 </collaboration_mode>`;
 
 export interface CodexRuntimeInfo {

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -15,7 +15,7 @@ const T3_CODE_THREAD_REFERENCE_INSTRUCTIONS = `
 
 ## T3 Code thread references
 
-The user may reference another chat with a \`t3-thread\` link. Do not treat the link as a web URL and do not assume its contents. Use the read-only \`thread_read\` tool from the \`t3-code\` MCP server with the referenced thread id. Follow \`nextCursor\` until you have read as much of the transcript as the task requires.
+The user may reference another chat with a \`t3-thread\` link. Do not treat the link as a web URL and do not assume its contents. Use the read-only \`thread_read\` tool from the \`t3-code\` MCP server. For \`t3-thread:///ENVIRONMENT_ID/THREAD_ID\`, pass the final \`THREAD_ID\` path segment as \`threadId\`; the tool also accepts the full link. Follow \`nextCursor\` until you have read as much of the transcript as the task requires.
 `;
 
 export const CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Plan Mode (Conversational)

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -274,6 +274,8 @@ describe("T3 browser developer instructions", () => {
       NodeAssert.match(instructions, /t3-code/);
       NodeAssert.match(instructions, /preview_status/);
       NodeAssert.match(instructions, /preview_open/);
+      NodeAssert.match(instructions, /thread_read/);
+      NodeAssert.match(instructions, /t3-thread/);
       NodeAssert.match(instructions, /Do not switch to global browser skills/);
     }
   });

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -7,9 +7,18 @@ import {
   GlobeIcon,
   Maximize2Icon,
   Minimize2Icon,
+  MessagesSquareIcon,
   WrapTextIcon,
 } from "lucide-react";
-import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  type ScopedThreadRef,
+  type ServerProviderSkill,
+  ThreadId,
+} from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { parseComposerThreadLink } from "@t3tools/shared/composerTrigger";
+import { useNavigate } from "@tanstack/react-router";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -83,6 +92,7 @@ import {
   openUrlInPreview,
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
+import { buildThreadRouteParams } from "../threadRoutes";
 
 class CodeHighlightErrorBoundary extends React.Component<
   { fallback: ReactNode; children: ReactNode },
@@ -161,7 +171,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   },
   protocols: {
     ...defaultSchema.protocols,
-    href: [...(defaultSchema.protocols?.href ?? []), "file"],
+    href: [...(defaultSchema.protocols?.href ?? []), "file", "t3-thread"],
   },
 } satisfies Parameters<typeof rehypeSanitize>[0];
 
@@ -1258,6 +1268,7 @@ function ChatMarkdown({
   lineBreaks = false,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
+  const navigate = useNavigate();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
     reportFailure: false,
   });
@@ -1292,6 +1303,7 @@ function ChatMarkdown({
     return buildFileLinkParentSuffixByPath(filePaths);
   }, [markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
+    if (parseComposerThreadLink(href)) return href;
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
   // Re-emit highlighted content as markdown so copying out of the rendered
@@ -1391,6 +1403,43 @@ function ChatMarkdown({
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
+        const threadReference = normalizedHref ? parseComposerThreadLink(normalizedHref) : null;
+        if (threadReference) {
+          const target = scopeThreadRef(
+            EnvironmentId.make(threadReference.environmentId),
+            ThreadId.make(threadReference.threadId),
+          );
+          const link = (
+            <a
+              {...props}
+              href={normalizedHref}
+              className={cn(
+                CHAT_FILE_TAG_CHIP_CLASS_NAME,
+                "cursor-pointer gap-1.5 transition-colors hover:bg-accent/70",
+              )}
+              data-markdown-copy={`[${plainHastText(node)}](${normalizedHref})`}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                void navigate({
+                  to: "/$environmentId/$threadId",
+                  params: buildThreadRouteParams(target),
+                });
+              }}
+            >
+              <MessagesSquareIcon className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>{children}</span>
+            </a>
+          );
+          return (
+            <Tooltip>
+              <TooltipTrigger render={link} />
+              <TooltipPopup side="top" className="max-w-120 whitespace-normal leading-tight">
+                Open referenced thread
+              </TooltipPopup>
+            </Tooltip>
+          );
+        }
         const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalLinkHost(href);
@@ -1543,6 +1592,7 @@ function ChatMarkdown({
       fileLinkParentSuffixByPath,
       isStreaming,
       markdownFileLinkMetaByHref,
+      navigate,
       onTaskListChange,
       openInPreferredEditor,
       openExternalLinkInPreview,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -6,7 +6,11 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
 import { type ServerProviderSkill } from "@t3tools/contracts";
-import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import {
+  serializeComposerFileLink,
+  serializeComposerThreadLink,
+} from "@t3tools/shared/composerTrigger";
+import { MessagesSquareIcon } from "lucide-react";
 import {
   $applyNodeReplacement,
   $createRangeSelectionFromDom,
@@ -114,6 +118,17 @@ type SerializedComposerSkillNode = Spread<
     skillLabel?: string;
     skillDescription?: string;
     type: "composer-skill";
+    version: 1;
+  },
+  SerializedLexicalNode
+>;
+
+type SerializedComposerThreadNode = Spread<
+  {
+    environmentId: string;
+    threadId: string;
+    title: string;
+    type: "composer-thread";
     version: 1;
   },
   SerializedLexicalNode
@@ -360,6 +375,103 @@ function $createComposerSkillNode(
   return $applyNodeReplacement(new ComposerSkillNode(skillName, skillLabel, skillDescription));
 }
 
+function ComposerThreadDecorator(props: { title: string; threadId: string }) {
+  const chip = (
+    <span
+      className={COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME}
+      contentEditable={false}
+      spellCheck={false}
+      data-composer-thread-chip="true"
+    >
+      <MessagesSquareIcon className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME} aria-hidden="true" />
+      <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>{props.title}</span>
+    </span>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={chip} />
+      <TooltipPopup side="top" className="max-w-120 whitespace-normal leading-tight">
+        Thread reference · {props.threadId}
+      </TooltipPopup>
+    </Tooltip>
+  );
+}
+
+class ComposerThreadNode extends DecoratorNode<React.ReactElement> {
+  __environmentId: string;
+  __threadId: string;
+  __title: string;
+
+  static override getType(): string {
+    return "composer-thread";
+  }
+
+  static override clone(node: ComposerThreadNode): ComposerThreadNode {
+    return new ComposerThreadNode(node.__environmentId, node.__threadId, node.__title, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerThreadNode): ComposerThreadNode {
+    return $createComposerThreadNode(
+      serializedNode.environmentId,
+      serializedNode.threadId,
+      serializedNode.title,
+    ).updateFromJSON(serializedNode);
+  }
+
+  constructor(environmentId: string, threadId: string, title: string, key?: NodeKey) {
+    super(key);
+    this.__environmentId = environmentId;
+    this.__threadId = threadId;
+    this.__title = title;
+  }
+
+  override exportJSON(): SerializedComposerThreadNode {
+    return {
+      ...super.exportJSON(),
+      environmentId: this.__environmentId,
+      threadId: this.__threadId,
+      title: this.__title,
+      type: "composer-thread",
+      version: 1,
+    };
+  }
+
+  override createDOM(): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = "inline-flex align-middle leading-none";
+    return dom;
+  }
+
+  override updateDOM(): false {
+    return false;
+  }
+
+  override getTextContent(): string {
+    return serializeComposerThreadLink({
+      environmentId: this.__environmentId,
+      threadId: this.__threadId,
+      title: this.__title,
+    });
+  }
+
+  override isInline(): true {
+    return true;
+  }
+
+  override decorate(): React.ReactElement {
+    return <ComposerThreadDecorator title={this.__title} threadId={this.__threadId} />;
+  }
+}
+
+function $createComposerThreadNode(
+  environmentId: string,
+  threadId: string,
+  title: string,
+): ComposerThreadNode {
+  return $applyNodeReplacement(new ComposerThreadNode(environmentId, threadId, title));
+}
+
 function ComposerTerminalContextDecorator(props: { context: TerminalContextDraft }) {
   return <ComposerPendingTerminalContextChip context={props.context} />;
 }
@@ -427,12 +539,14 @@ function $createComposerTerminalContextNode(
 type ComposerInlineTokenNode =
   | ComposerMentionNode
   | ComposerSkillNode
+  | ComposerThreadNode
   | ComposerTerminalContextNode;
 
 function isComposerInlineTokenNode(candidate: unknown): candidate is ComposerInlineTokenNode {
   return (
     candidate instanceof ComposerMentionNode ||
     candidate instanceof ComposerSkillNode ||
+    candidate instanceof ComposerThreadNode ||
     candidate instanceof ComposerTerminalContextNode
   );
 }
@@ -841,6 +955,12 @@ function $setComposerEditorPrompt(
           metadata?.label ?? formatProviderSkillDisplayName({ name: segment.name }),
           metadata?.description ?? null,
         ),
+      );
+      continue;
+    }
+    if (segment.type === "thread") {
+      paragraph.append(
+        $createComposerThreadNode(segment.environmentId, segment.threadId, segment.title),
       );
       continue;
     }
@@ -1806,7 +1926,12 @@ export function ComposerPromptEditor({
     () => ({
       namespace: "t3tools-composer-editor",
       editable: true,
-      nodes: [ComposerMentionNode, ComposerSkillNode, ComposerTerminalContextNode],
+      nodes: [
+        ComposerMentionNode,
+        ComposerSkillNode,
+        ComposerThreadNode,
+        ComposerTerminalContextNode,
+      ],
       editorState: () => {
         $setComposerEditorPrompt(
           initialValueRef.current,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -22,7 +22,10 @@ import {
   connectionStatusText,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
-import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import {
+  serializeComposerFileLink,
+  serializeComposerThreadLink,
+} from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
   memo,
@@ -131,6 +134,8 @@ import { formatProviderSkillDisplayName } from "../../providerSkillPresentation"
 import { searchProviderSkills } from "../../providerSkillSearch";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import type { ReviewCommentContext } from "../../reviewCommentContext";
+import { useThreadShells } from "../../state/entities";
+import { searchThreadReferences } from "../../threadReferenceSearch";
 
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
 
@@ -639,6 +644,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerPreviewAnnotations = composerDraft.previewAnnotations;
   const composerReviewComments = composerDraft.reviewComments;
   const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
+  const threadShells = useThreadShells();
 
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
@@ -1024,8 +1030,30 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         }),
       );
     }
+    if (composerTrigger.kind === "thread") {
+      const candidates = threadShells.filter(
+        (thread) => thread.environmentId === environmentId && thread.id !== routeThreadRef.threadId,
+      );
+      return searchThreadReferences(candidates, composerTrigger.query).map((thread) => ({
+        id: `thread:${thread.environmentId}:${thread.id}`,
+        type: "thread" as const,
+        environmentId: thread.environmentId,
+        threadId: thread.id,
+        title: thread.title,
+        label: thread.title,
+        description: thread.branch ?? `Thread ${thread.id}`,
+      }));
+    }
     return [];
-  }, [composerTrigger, selectedProvider, selectedProviderStatus, workspaceEntries.entries]);
+  }, [
+    composerTrigger,
+    environmentId,
+    routeThreadRef.threadId,
+    selectedProvider,
+    selectedProviderStatus,
+    threadShells,
+    workspaceEntries.entries,
+  ]);
 
   const composerMenuOpen = Boolean(composerTrigger);
   const composerMenuSearchKey = composerTrigger
@@ -1094,6 +1122,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerMenuEmptyState = useMemo(() => {
     if (composerTriggerKind === "skill") {
       return "No skills found. Try / to browse provider commands.";
+    }
+    if (composerTriggerKind === "thread") {
+      return "No matching threads in this environment.";
     }
     return composerTriggerKind === "path"
       ? "No matching files or folders."
@@ -1580,6 +1611,28 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       if (!trigger) return;
       if (item.type === "path") {
         const replacement = `${serializeComposerFileLink(item.path)} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+        );
+        if (applied) {
+          setComposerHighlightedItemId(null);
+        }
+        return;
+      }
+      if (item.type === "thread") {
+        const replacement = `${serializeComposerThreadLink({
+          environmentId: item.environmentId,
+          threadId: item.threadId,
+          title: item.title,
+        })} `;
         const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
           snapshot.value,
           trigger.rangeEnd,

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -1,10 +1,12 @@
 import {
+  type EnvironmentId,
   type ProjectEntry,
   type ProviderDriverKind,
   type ServerProviderSkill,
   type ServerProviderSlashCommand,
+  type ThreadId,
 } from "@t3tools/contracts";
-import { BotIcon } from "lucide-react";
+import { BotIcon, MessagesSquareIcon } from "lucide-react";
 import { memo, useLayoutEffect, useMemo, useRef } from "react";
 
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
@@ -51,6 +53,15 @@ export type ComposerCommandItem =
       skill: ServerProviderSkill;
       label: string;
       description: string;
+    }
+  | {
+      id: string;
+      type: "thread";
+      environmentId: EnvironmentId;
+      threadId: ThreadId;
+      title: string;
+      label: string;
+      description: string;
     };
 
 type ComposerCommandGroup = {
@@ -85,6 +96,9 @@ function groupCommandItems(
 ): ComposerCommandGroup[] {
   if (triggerKind === "skill") {
     return items.length > 0 ? [{ id: "skills", label: "Skills", items }] : [];
+  }
+  if (triggerKind === "thread") {
+    return items.length > 0 ? [{ id: "threads", label: "Threads", items }] : [];
   }
   if (triggerKind !== "slash-command" || !groupSlashCommandSections) {
     return [{ id: "default", label: null, items }];
@@ -170,16 +184,20 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
           </CommandList>
         ) : (
           <div className="px-5 py-3.5">
-            {props.triggerKind === "skill" ? (
+            {props.triggerKind === "skill" || props.triggerKind === "thread" ? (
               <CommandGroup>
                 <CommandGroupLabel className="px-0 pt-0 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/55">
-                  Skills
+                  {props.triggerKind === "thread" ? "Threads" : "Skills"}
                 </CommandGroupLabel>
                 <p className="text-muted-foreground/70 text-xs">
                   {props.isLoading
-                    ? "Searching workspace skills..."
+                    ? props.triggerKind === "thread"
+                      ? "Searching threads..."
+                      : "Searching workspace skills..."
                     : (props.emptyStateText ??
-                      "No skills found. Try / to browse provider commands.")}
+                      (props.triggerKind === "thread"
+                        ? "No matching threads."
+                        : "No skills found. Try / to browse provider commands."))}
                 </p>
               </CommandGroup>
             ) : (
@@ -246,6 +264,9 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <span className="inline-flex size-4 shrink-0 items-center justify-center text-muted-foreground/80">
           <SkillGlyph className="size-3.5" />
         </span>
+      ) : null}
+      {props.item.type === "thread" ? (
+        <MessagesSquareIcon className="size-4 shrink-0 text-muted-foreground/80" />
       ) : null}
       <span className="flex min-w-0 flex-1 items-center gap-2">
         <span className="shrink-0">{props.item.label}</span>

--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -71,6 +71,24 @@ describe("splitPromptIntoComposerSegments", () => {
     ).toEqual([{ type: "text", text: "Read [the docs](https://example.com/docs) first" }]);
   });
 
+  it("splits T3 thread links into thread segments", () => {
+    expect(
+      splitPromptIntoComposerSegments(
+        "Continue from [Prior chat](t3-thread:///environment-1/thread-2) please",
+      ),
+    ).toEqual([
+      { type: "text", text: "Continue from " },
+      {
+        type: "thread",
+        environmentId: "environment-1",
+        threadId: "thread-2",
+        title: "Prior chat",
+        source: "[Prior chat](t3-thread:///environment-1/thread-2)",
+      },
+      { type: "text", text: " please" },
+    ]);
+  });
+
   it("decodes reserved path characters from generated links", () => {
     expect(
       splitPromptIntoComposerSegments(

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -22,6 +22,13 @@ export type ComposerPromptSegment =
       name: string;
     }
   | {
+      type: "thread";
+      environmentId: string;
+      threadId: string;
+      title: string;
+      source: string;
+    }
+  | {
       type: "terminal-context";
       context: TerminalContextDraft | null;
     };
@@ -145,6 +152,14 @@ function splitPromptTextIntoComposerSegments(text: string): ComposerPromptSegmen
       segments.push({
         type: "mention",
         path: match.value,
+        source: match.source,
+      });
+    } else if (match.type === "thread") {
+      segments.push({
+        type: "thread",
+        environmentId: match.environmentId,
+        threadId: match.threadId,
+        title: match.title,
         source: match.source,
       });
     } else {

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -106,6 +106,17 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("detects #thread trigger at cursor", () => {
+    const text = "Continue from #auth";
+
+    expect(detectComposerTrigger(text, text.length)).toEqual({
+      kind: "thread",
+      query: "auth",
+      rangeStart: "Continue from ".length,
+      rangeEnd: text.length,
+    });
+  });
+
   it("detects @path trigger in the middle of existing text", () => {
     // User typed @ between "inspect " and "in this sentence"
     const text = "Please inspect @in this sentence";

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -1,7 +1,7 @@
 import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
-export type ComposerTriggerKind = "path" | "slash-command" | "skill";
+export type ComposerTriggerKind = "path" | "slash-command" | "skill" | "thread";
 export type ComposerSlashCommand = "model" | "plan" | "default";
 
 export interface ComposerTrigger {
@@ -22,6 +22,7 @@ const isInlineTokenSegment = (
   segment:
     | { type: "text"; text: string }
     | { type: "mention" }
+    | { type: "thread" }
     | { type: "skill" }
     | { type: "terminal-context" },
 ): boolean => segment.type !== "text";
@@ -60,7 +61,7 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
   let expandedCursor = 0;
 
   for (const segment of segments) {
-    if (segment.type === "mention") {
+    if (segment.type === "mention" || segment.type === "thread") {
       const expandedLength = segment.source.length;
       if (remaining <= 1) {
         return expandedCursor + (remaining === 0 ? 0 : expandedLength);
@@ -102,6 +103,7 @@ function collapsedSegmentLength(
   segment:
     | { type: "text"; text: string }
     | { type: "mention" }
+    | { type: "thread" }
     | { type: "skill" }
     | { type: "terminal-context" },
 ): number {
@@ -115,6 +117,7 @@ function clampCollapsedComposerCursorForSegments(
   segments: ReadonlyArray<
     | { type: "text"; text: string }
     | { type: "mention" }
+    | { type: "thread" }
     | { type: "skill" }
     | { type: "terminal-context" }
   >,
@@ -148,7 +151,7 @@ export function collapseExpandedComposerCursor(text: string, cursorInput: number
   let collapsedCursor = 0;
 
   for (const segment of segments) {
-    if (segment.type === "mention") {
+    if (segment.type === "mention" || segment.type === "thread") {
       const expandedLength = segment.source.length;
       if (remaining === 0) {
         return collapsedCursor;
@@ -245,6 +248,14 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
   if (token.startsWith("$")) {
     return {
       kind: "skill",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
+  if (token.startsWith("#")) {
+    return {
+      kind: "thread",
       query: token.slice(1),
       rangeStart: tokenStart,
       rangeEnd: cursor,

--- a/apps/web/src/threadReferenceSearch.test.ts
+++ b/apps/web/src/threadReferenceSearch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { searchThreadReferences } from "./threadReferenceSearch";
+
+const thread = (id: string, title: string, updatedAt: string, branch: string | null = null) =>
+  ({ id, title, updatedAt, branch }) as never;
+
+describe("searchThreadReferences", () => {
+  it("shows recently updated threads when the query is empty", () => {
+    const result = searchThreadReferences(
+      [
+        thread("one", "Older", "2026-01-01T00:00:00.000Z"),
+        thread("two", "Newer", "2026-02-01T00:00:00.000Z"),
+      ],
+      "",
+    );
+
+    expect(result.map(({ id }) => id)).toEqual(["two", "one"]);
+  });
+
+  it("ranks title, branch, and id matches", () => {
+    const threads = [
+      thread("thread-auth", "Authentication follow-up", "2026-01-01T00:00:00.000Z"),
+      thread("thread-two", "Unrelated", "2026-01-02T00:00:00.000Z", "feat/auth-flow"),
+    ];
+
+    expect(searchThreadReferences(threads, "auth").map(({ id }) => id)).toEqual([
+      "thread-auth",
+      "thread-two",
+    ]);
+  });
+});

--- a/apps/web/src/threadReferenceSearch.ts
+++ b/apps/web/src/threadReferenceSearch.ts
@@ -1,0 +1,53 @@
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import {
+  compareRankedSearchResults,
+  normalizeSearchQuery,
+  scoreQueryMatch,
+  type RankedSearchResult,
+} from "@t3tools/shared/searchRanking";
+
+const DEFAULT_THREAD_REFERENCE_LIMIT = 20;
+
+function scoreThread(thread: EnvironmentThreadShell, query: string): number | null {
+  const fields = [thread.title, thread.branch ?? "", thread.id];
+  let best: number | null = null;
+  for (const field of fields) {
+    const score = scoreQueryMatch({
+      value: field.toLowerCase(),
+      query,
+      exactBase: 0,
+      prefixBase: 10,
+      boundaryBase: 30,
+      includesBase: 50,
+      fuzzyBase: 100,
+    });
+    if (score !== null && (best === null || score < best)) {
+      best = score;
+    }
+  }
+  return best;
+}
+
+export function searchThreadReferences(
+  threads: ReadonlyArray<EnvironmentThreadShell>,
+  queryInput: string,
+  limit = DEFAULT_THREAD_REFERENCE_LIMIT,
+): EnvironmentThreadShell[] {
+  const query = normalizeSearchQuery(queryInput, { trimLeadingPattern: /^#/ });
+  if (!query) {
+    return threads
+      .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, limit);
+  }
+
+  const ranked: RankedSearchResult<EnvironmentThreadShell>[] = [];
+  for (const thread of threads) {
+    const score = scoreThread(thread, query);
+    if (score === null) continue;
+    ranked.push({ item: thread, score, tieBreaker: `${thread.title}:${thread.id}` });
+  }
+  return ranked
+    .sort(compareRankedSearchResults)
+    .slice(0, limit)
+    .map(({ item }) => item);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -25,4 +25,5 @@ export * from "./assets.ts";
 export * from "./review.ts";
 export * from "./preview.ts";
 export * from "./previewAutomation.ts";
+export * from "./threadReference.ts";
 export * from "./rpc.ts";

--- a/packages/contracts/src/threadReference.ts
+++ b/packages/contracts/src/threadReference.ts
@@ -79,7 +79,7 @@ export class ThreadReferenceInvalidCursorError extends Schema.TaggedErrorClass<T
 
 export class ThreadReferenceUnavailableError extends Schema.TaggedErrorClass<ThreadReferenceUnavailableError>()(
   "ThreadReferenceUnavailableError",
-  { threadId: ThreadId },
+  { threadId: ThreadId, cause: Schema.optional(Schema.Defect()) },
 ) {
   override get message(): string {
     return `Referenced thread '${this.threadId}' could not be read.`;

--- a/packages/contracts/src/threadReference.ts
+++ b/packages/contracts/src/threadReference.ts
@@ -22,7 +22,8 @@ export type ThreadReferenceCursor = typeof ThreadReferenceCursor.Type;
 
 export const ThreadReferenceReadInput = Schema.Struct({
   threadId: ThreadId.annotate({
-    description: "Thread id from a t3-thread reference in the user's message.",
+    description:
+      "Referenced thread id. Prefer the final THREAD_ID path segment; full t3-thread:///ENVIRONMENT_ID/THREAD_ID links and ENVIRONMENT_ID/THREAD_ID are also accepted.",
   }),
   cursor: Schema.optional(ThreadReferenceCursor).annotate({
     description: "nextCursor from the previous page. Omit for the first page.",

--- a/packages/contracts/src/threadReference.ts
+++ b/packages/contracts/src/threadReference.ts
@@ -1,0 +1,94 @@
+import * as Schema from "effect/Schema";
+
+import { ChatAttachment, OrchestrationMessageRole } from "./orchestration.ts";
+import {
+  IsoDateTime,
+  MessageId,
+  NonNegativeInt,
+  ProjectId,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "./baseSchemas.ts";
+
+export const THREAD_REFERENCE_DEFAULT_MAX_CHARS = 40_000;
+export const THREAD_REFERENCE_MAX_CHARS = 80_000;
+
+export const ThreadReferenceCursor = Schema.String.check(
+  Schema.isPattern(/^\d+:\d+$/, {
+    description: "Opaque transcript cursor returned by a previous thread_read call.",
+  }),
+);
+export type ThreadReferenceCursor = typeof ThreadReferenceCursor.Type;
+
+export const ThreadReferenceReadInput = Schema.Struct({
+  threadId: ThreadId.annotate({
+    description: "Thread id from a t3-thread reference in the user's message.",
+  }),
+  cursor: Schema.optional(ThreadReferenceCursor).annotate({
+    description: "nextCursor from the previous page. Omit for the first page.",
+  }),
+  maxChars: Schema.optional(
+    Schema.Int.check(Schema.isGreaterThanOrEqualTo(1_000))
+      .check(Schema.isLessThanOrEqualTo(THREAD_REFERENCE_MAX_CHARS))
+      .annotate({
+        description: `Maximum message-text characters to return. Defaults to ${THREAD_REFERENCE_DEFAULT_MAX_CHARS}; maximum ${THREAD_REFERENCE_MAX_CHARS}.`,
+      }),
+  ),
+});
+export type ThreadReferenceReadInput = typeof ThreadReferenceReadInput.Type;
+
+export const ThreadReferenceTranscriptMessage = Schema.Struct({
+  id: MessageId,
+  role: OrchestrationMessageRole,
+  text: Schema.String,
+  textStart: NonNegativeInt,
+  textEnd: NonNegativeInt,
+  textComplete: Schema.Boolean,
+  attachments: Schema.Array(ChatAttachment),
+  createdAt: IsoDateTime,
+});
+export type ThreadReferenceTranscriptMessage = typeof ThreadReferenceTranscriptMessage.Type;
+
+export const ThreadReferenceReadResult = Schema.Struct({
+  threadId: ThreadId,
+  projectId: ProjectId,
+  title: TrimmedNonEmptyString,
+  messages: Schema.Array(ThreadReferenceTranscriptMessage),
+  totalMessages: NonNegativeInt,
+  nextCursor: Schema.NullOr(ThreadReferenceCursor),
+});
+export type ThreadReferenceReadResult = typeof ThreadReferenceReadResult.Type;
+
+export class ThreadReferenceNotFoundError extends Schema.TaggedErrorClass<ThreadReferenceNotFoundError>()(
+  "ThreadReferenceNotFoundError",
+  { threadId: ThreadId },
+) {
+  override get message(): string {
+    return `Referenced thread '${this.threadId}' was not found.`;
+  }
+}
+
+export class ThreadReferenceInvalidCursorError extends Schema.TaggedErrorClass<ThreadReferenceInvalidCursorError>()(
+  "ThreadReferenceInvalidCursorError",
+  { threadId: ThreadId, cursor: Schema.String },
+) {
+  override get message(): string {
+    return `Cursor '${this.cursor}' is invalid for referenced thread '${this.threadId}'.`;
+  }
+}
+
+export class ThreadReferenceUnavailableError extends Schema.TaggedErrorClass<ThreadReferenceUnavailableError>()(
+  "ThreadReferenceUnavailableError",
+  { threadId: ThreadId },
+) {
+  override get message(): string {
+    return `Referenced thread '${this.threadId}' could not be read.`;
+  }
+}
+
+export const ThreadReferenceReadError = Schema.Union([
+  ThreadReferenceNotFoundError,
+  ThreadReferenceInvalidCursorError,
+  ThreadReferenceUnavailableError,
+]);
+export type ThreadReferenceReadError = typeof ThreadReferenceReadError.Type;

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -96,4 +96,17 @@ describe("collectComposerInlineTokens", () => {
   it("ignores malformed thread links", () => {
     expect(collectComposerInlineTokens("Read [chat](t3-thread:///missing) first")).toEqual([]);
   });
+
+  it("collects a complete thread reference at the end of the prompt", () => {
+    expect(
+      collectComposerInlineTokens("Read [chat](t3-thread:///environment-1/thread-1)"),
+    ).toMatchObject([
+      {
+        type: "thread",
+        environmentId: "environment-1",
+        threadId: "thread-1",
+        title: "chat",
+      },
+    ]);
+  });
 });

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -109,4 +109,25 @@ describe("collectComposerInlineTokens", () => {
       },
     ]);
   });
+
+  it.each([".", ",", ";", ":", "!", "?", ")", '"'])(
+    "collects a thread reference followed by %s without consuming the punctuation",
+    (punctuation) => {
+      const reference = "[chat](t3-thread:///environment-1/thread-1)";
+      const text = `Read ${reference}${punctuation}`;
+      const referenceEnd = 5 + reference.length;
+
+      expect(collectComposerInlineTokens(text)).toMatchObject([
+        {
+          type: "thread",
+          environmentId: "environment-1",
+          threadId: "thread-1",
+          source: reference,
+          start: 5,
+          end: referenceEnd,
+        },
+      ]);
+      expect(text.slice(referenceEnd)).toBe(punctuation);
+    },
+  );
 });

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 import { collectComposerInlineTokens } from "./composerInlineTokens.ts";
 
 describe("collectComposerInlineTokens", () => {
-  it("collects file links, mentions, and skills with source ranges", () => {
-    const text = "Use $ui and inspect [Chat.tsx](src/Chat.tsx) with @AGENTS.md please";
+  it("collects file links, mentions, skills, and thread references with source ranges", () => {
+    const text =
+      "Use $ui and inspect [Chat.tsx](src/Chat.tsx) with @AGENTS.md then [Prior chat](t3-thread:///env-1/thread-2) please";
 
     expect(collectComposerInlineTokens(text)).toEqual([
       {
@@ -27,6 +28,16 @@ describe("collectComposerInlineTokens", () => {
         source: "@AGENTS.md",
         start: 50,
         end: 60,
+      },
+      {
+        type: "thread",
+        environmentId: "env-1",
+        threadId: "thread-2",
+        title: "Prior chat",
+        value: "Prior chat",
+        source: "[Prior chat](t3-thread:///env-1/thread-2)",
+        start: 66,
+        end: 107,
       },
     ]);
   });
@@ -80,5 +91,9 @@ describe("collectComposerInlineTokens", () => {
 
   it("ignores normal web links", () => {
     expect(collectComposerInlineTokens("Read [docs](https://example.com) first")).toEqual([]);
+  });
+
+  it("ignores malformed thread links", () => {
+    expect(collectComposerInlineTokens("Read [chat](t3-thread:///missing) first")).toEqual([]);
   });
 });

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -30,15 +30,20 @@ export interface CollectComposerInlineTokensOptions {
   readonly preserveTrailingFrom?: ReadonlyArray<ComposerInlineToken>;
 }
 
+type ComposerThreadInlineToken = Extract<ComposerInlineToken, { type: "thread" }>;
+
 const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 const FILE_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s)/g;
-const THREAD_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\((t3-thread:\/\/\/[^)\s]+)\)(?=\s)/g;
+const THREAD_LINK_TOKEN_REGEX =
+  /(^|\s)\[((?:\\.|[^\]\\])*)\]\((t3-thread:\/\/\/[^)\s]+)\)(?=\s|$)/g;
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 
-function collectThreadTokens(text: string): ComposerInlineToken[] {
-  const matches: ComposerInlineToken[] = [];
+export function collectComposerThreadReferences(
+  text: string,
+): ReadonlyArray<ComposerThreadInlineToken> {
+  const matches: ComposerThreadInlineToken[] = [];
 
   for (const match of text.matchAll(THREAD_LINK_TOKEN_REGEX)) {
     const fullMatch = match[0];
@@ -122,7 +127,7 @@ export function collectComposerInlineTokens(
   text: string,
   options: CollectComposerInlineTokensOptions = {},
 ): ReadonlyArray<ComposerInlineToken> {
-  const matches = [...collectMentionTokens(text), ...collectThreadTokens(text)];
+  const matches = [...collectMentionTokens(text), ...collectComposerThreadReferences(text)];
 
   for (const match of text.matchAll(SKILL_TOKEN_REGEX)) {
     const fullMatch = match[0];

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -35,8 +35,7 @@ type ComposerThreadInlineToken = Extract<ComposerInlineToken, { type: "thread" }
 const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 const FILE_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s)/g;
-const THREAD_LINK_TOKEN_REGEX =
-  /(^|\s)\[((?:\\.|[^\]\\])*)\]\((t3-thread:\/\/\/[^)\s]+)\)(?=\s|$)/g;
+const THREAD_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\((t3-thread:\/\/\/[^)\s]+)\)/g;
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -1,3 +1,5 @@
+import { parseComposerThreadLink } from "./composerTrigger.ts";
+
 export type ComposerInlineToken =
   | {
       readonly type: "mention";
@@ -12,6 +14,16 @@ export type ComposerInlineToken =
       readonly source: string;
       readonly start: number;
       readonly end: number;
+    }
+  | {
+      readonly type: "thread";
+      readonly environmentId: string;
+      readonly threadId: string;
+      readonly title: string;
+      readonly value: string;
+      readonly source: string;
+      readonly start: number;
+      readonly end: number;
     };
 
 export interface CollectComposerInlineTokensOptions {
@@ -21,8 +33,37 @@ export interface CollectComposerInlineTokensOptions {
 const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 const FILE_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s)/g;
+const THREAD_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\((t3-thread:\/\/\/[^)\s]+)\)(?=\s)/g;
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+
+function collectThreadTokens(text: string): ComposerInlineToken[] {
+  const matches: ComposerInlineToken[] = [];
+
+  for (const match of text.matchAll(THREAD_LINK_TOKEN_REGEX)) {
+    const fullMatch = match[0];
+    const prefix = match[1] ?? "";
+    const title = (match[2] ?? "").replace(/\\(.)/g, "$1");
+    const destination = match[3] ?? "";
+    const reference = parseComposerThreadLink(destination);
+    if (reference && title) {
+      const start = (match.index ?? 0) + prefix.length;
+      const end = start + fullMatch.length - prefix.length;
+      matches.push({
+        type: "thread",
+        environmentId: reference.environmentId,
+        threadId: reference.threadId,
+        title,
+        value: title,
+        source: text.slice(start, end),
+        start,
+        end,
+      });
+    }
+  }
+
+  return matches;
+}
 
 function collectMentionTokens(text: string): ComposerInlineToken[] {
   const matches: ComposerInlineToken[] = [];
@@ -81,7 +122,7 @@ export function collectComposerInlineTokens(
   text: string,
   options: CollectComposerInlineTokensOptions = {},
 ): ReadonlyArray<ComposerInlineToken> {
-  const matches = collectMentionTokens(text);
+  const matches = [...collectMentionTokens(text), ...collectThreadTokens(text)];
 
   for (const match of text.matchAll(SKILL_TOKEN_REGEX)) {
     const fullMatch = match[0];

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -1,4 +1,4 @@
-export type ComposerTriggerKind = "path" | "slash-command" | "slash-model" | "skill";
+export type ComposerTriggerKind = "path" | "slash-command" | "slash-model" | "skill" | "thread";
 export type ComposerSlashCommand = "model" | "plan" | "default";
 
 export interface ComposerTrigger {
@@ -33,6 +33,42 @@ function encodeMarkdownLinkDestination(path: string): string {
     .replaceAll("#", "%23")
     .replaceAll("?", "%3F")
     .replaceAll("\\", "%5C");
+}
+
+export interface ComposerThreadReference {
+  readonly environmentId: string;
+  readonly threadId: string;
+  readonly title: string;
+}
+
+export const COMPOSER_THREAD_REFERENCE_SCHEME = "t3-thread:";
+
+export function parseComposerThreadLink(
+  destination: string,
+): Pick<ComposerThreadReference, "environmentId" | "threadId"> | null {
+  try {
+    const url = new URL(destination);
+    const segments = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+    const [environmentId, threadId] = segments;
+    if (
+      url.protocol !== COMPOSER_THREAD_REFERENCE_SCHEME ||
+      !environmentId ||
+      !threadId ||
+      segments.length !== 2
+    ) {
+      return null;
+    }
+    return { environmentId, threadId };
+  } catch {
+    return null;
+  }
+}
+
+export function serializeComposerThreadLink(reference: ComposerThreadReference): string {
+  const label = escapeMarkdownLinkLabel(reference.title);
+  const environmentId = encodeURIComponent(reference.environmentId);
+  const threadId = encodeURIComponent(reference.threadId);
+  return `[${label}](${COMPOSER_THREAD_REFERENCE_SCHEME}///${environmentId}/${threadId})`;
 }
 
 export function serializeComposerFileLink(path: string): string {
@@ -107,6 +143,14 @@ export function detectComposerTrigger(
   if (token.startsWith("$")) {
     return {
       kind: "skill",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
+  if (token.startsWith("#")) {
+    return {
+      kind: "thread",
       query: token.slice(1),
       rangeStart: tokenStart,
       rangeEnd: cursor,


### PR DESCRIPTION
## What changed

- Type `#` in the composer to search recently active threads in the current environment.
- Insert a compact `t3-thread` reference chip instead of copying the referenced transcript into the prompt.
- Render sent references as clickable chips that navigate back to the source thread.
- Add a read-only, paginated `thread_read` MCP tool so an agent can fetch only the referenced context it needs.
- Tell Codex sessions how to resolve `t3-thread` references through the local T3 Code MCP server.

## Why

Long-running work is often split across planning, implementation, and debugging threads. Referencing the source thread lets a new conversation recover that context without manually restating the work or injecting an entire transcript up front.

This implements the use case described in #1286 while keeping prompt size bounded and transcript access explicit.

Closes #1286.

## Design notes

- `#` is intentionally separate from `@` file mentions and `$` skills.
- The picker excludes the current thread and is limited to active threads in the same environment.
- References use a compact `t3-thread:///environment-id/thread-id` URI carried in Markdown.
- `thread_read` returns message text in bounded pages (40,000 characters by default, 80,000 maximum) and provides `nextCursor` for continuation.
- The MCP tool is marked read-only, non-destructive, and idempotent.
- Malformed references and cursors fail with typed errors.

## Verification

- `pnpm exec vp check` — passed with 0 errors
- `pnpm exec vp run typecheck` — passed
- Focused feature tests — 81 passed across 7 files
- Full test suite — 4,619 passed across 586 files; 7 expected skips
- React Doctor against `upstream/main` — no diagnostics in changed React files
- `git diff --check upstream/main...HEAD` — passed

## UI

<img width="757" height="471" alt="image" src="https://github.com/user-attachments/assets/18b4b0d9-c16a-4766-9ff3-d06cb3f42d1f" />

<img width="343" height="189" alt="image" src="https://github.com/user-attachments/assets/c679de35-66c6-428c-899a-21bcd5dd8ce0" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread reference support to the composer with `thread_read` MCP tool
> - Typing `#<query>` in the composer opens a thread search menu; selecting a result inserts an inline thread chip serialized as a `t3-thread` markdown link.
> - Thread chips render in `ChatMarkdown` as styled internal links with a tooltip icon that navigate within the app instead of triggering default browser navigation.
> - A new `thread_read` MCP tool is registered on the server, gated by a `thread-reference` capability, that returns paginated transcripts of referenced threads after verifying the source thread contains a user-authored reference to the target.
> - Shared parsing utilities (`parseComposerThreadLink`, `serializeComposerThreadLink`) and inline token collection are extended to recognize `t3-thread` references alongside existing mentions and skills.
> - The typed contract for inputs, outputs, and errors is defined in [`threadReference.ts`](https://github.com/pingdotgg/t3code/pull/4010/files#diff-ed7059692dd78edb7155a07e787423f4e27e704b53b6c187d256ad8603309f76).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd72a1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cross-thread transcript reads are security-sensitive, but access is scoped to user-authored references in the invoking thread and same environment; incorrect authorization would be the main risk.
> 
> **Overview**
> Adds **cross-thread references** so users can point a conversation at prior work without pasting full transcripts.
> 
> **Composer & UI:** Typing `#` opens a thread picker (same environment, excludes current thread). Selection inserts a `t3-thread:///…` markdown link shown as an inline chip in the editor. Sent messages render those links as navigable chips in chat markdown.
> 
> **Agent access:** Registers a read-only **`thread_read`** MCP tool with paginated transcript output (`nextCursor`, bounded `maxChars`). Issued MCP sessions gain a **`thread-reference`** capability alongside preview. Access is allowed only when a **user** message on the invoking thread contains a matching `t3-thread` link for that target in the same environment.
> 
> **Contracts & Codex:** New `threadReference` schemas/errors; Codex developer instructions document using `thread_read` for `t3-thread` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd72a1e00379f828318eb94b47676b5a0728cd9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->