### PR TITLE
Normalize over-indented markdown list items

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -32,7 +32,7 @@ import React, {
   useState,
   type ReactNode,
 } from "react";
-import type { Components } from "react-markdown";
+import type { Components, Options as ReactMarkdownOptions } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import { defaultUrlTransform } from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -164,6 +164,24 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     href: [...(defaultSchema.protocols?.href ?? []), "file"],
   },
 } satisfies Parameters<typeof rehypeSanitize>[0];
+
+const CHAT_MARKDOWN_REMARK_PLUGINS = [
+  remarkGfm,
+  remarkNormalizeListItemIndentation,
+  remarkPreserveCodeMeta,
+] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
+
+const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
+  remarkGfm,
+  remarkNormalizeListItemIndentation,
+  remarkBreaks,
+  remarkPreserveCodeMeta,
+] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
+
+const CHAT_MARKDOWN_REHYPE_PLUGINS = [
+  rehypeRaw,
+  [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
+] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
 function extractFenceLanguage(className: string | undefined): string {
   const match = className?.match(CODE_FENCE_LANGUAGE_REGEX);
@@ -1546,11 +1564,9 @@ function ChatMarkdown({
     >
       <ReactMarkdown
         remarkPlugins={
-          lineBreaks
-            ? [remarkGfm, remarkNormalizeListItemIndentation, remarkBreaks, remarkPreserveCodeMeta]
-            : [remarkGfm, remarkNormalizeListItemIndentation, remarkPreserveCodeMeta]
+          lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
         }
-        rehypePlugins={[rehypeRaw, [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA]]}
+        rehypePlugins={CHAT_MARKDOWN_REHYPE_PLUGINS}
         components={markdownComponents}
         urlTransform={markdownUrlTransform}
       >

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1547,7 +1547,7 @@ function ChatMarkdown({
       <ReactMarkdown
         remarkPlugins={
           lineBreaks
-            ? [remarkGfm, remarkBreaks, remarkNormalizeListItemIndentation, remarkPreserveCodeMeta]
+            ? [remarkGfm, remarkNormalizeListItemIndentation, remarkBreaks, remarkPreserveCodeMeta]
             : [remarkGfm, remarkNormalizeListItemIndentation, remarkPreserveCodeMeta]
         }
         rehypePlugins={[rehypeRaw, [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA]]}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -60,6 +60,7 @@ import {
   serializeTableElementToCsv,
   serializeTableElementToMarkdown,
 } from "../markdown-clipboard";
+import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   normalizeMarkdownLinkDestination,
   resolveMarkdownFileLinkMeta,
@@ -1546,8 +1547,8 @@ function ChatMarkdown({
       <ReactMarkdown
         remarkPlugins={
           lineBreaks
-            ? [remarkGfm, remarkBreaks, remarkPreserveCodeMeta]
-            : [remarkGfm, remarkPreserveCodeMeta]
+            ? [remarkGfm, remarkBreaks, remarkNormalizeListItemIndentation, remarkPreserveCodeMeta]
+            : [remarkGfm, remarkNormalizeListItemIndentation, remarkPreserveCodeMeta]
         }
         rehypePlugins={[rehypeRaw, [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA]]}
         components={markdownComponents}

--- a/apps/web/src/markdown-list-indentation.test.tsx
+++ b/apps/web/src/markdown-list-indentation.test.tsx
@@ -1,12 +1,15 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { describe, expect, it } from "vite-plus/test";
 
 import { remarkNormalizeListItemIndentation } from "./markdown-list-indentation";
 
 function renderMarkdown(markdown: string): string {
   return renderToStaticMarkup(
-    <ReactMarkdown remarkPlugins={[remarkNormalizeListItemIndentation]}>{markdown}</ReactMarkdown>,
+    <ReactMarkdown remarkPlugins={[remarkGfm, remarkNormalizeListItemIndentation]}>
+      {markdown}
+    </ReactMarkdown>,
   );
 }
 
@@ -24,6 +27,18 @@ describe("remarkNormalizeListItemIndentation", () => {
     expect(html).toContain("<li>for (const step of rest.steps) {</li>");
     expect(html).toContain("<li>if (step.request.body) {</li>");
     expect(html).toContain("<li>step.request.body = &quot;&lt;redacted&gt;&quot;;</li>");
+  });
+
+  it("parses inline markdown in recovered list content", () => {
+    const html = renderMarkdown(
+      "-       **important** [docs](https://example.com) use `inline code`, not ~~plain text~~",
+    );
+
+    expect(html).toContain("<strong>important</strong>");
+    expect(html).toContain('<a href="https://example.com">docs</a>');
+    expect(html).toContain("<code>inline code</code>");
+    expect(html).toContain("<del>plain text</del>");
+    expect(html).not.toContain("**important**");
   });
 
   it("preserves fenced code blocks within list items", () => {

--- a/apps/web/src/markdown-list-indentation.test.tsx
+++ b/apps/web/src/markdown-list-indentation.test.tsx
@@ -50,6 +50,15 @@ describe("remarkNormalizeListItemIndentation", () => {
     expect(html).toContain('<a href="https://example.com">second block</a>');
   });
 
+  it("recursively normalizes lists in recovered tail blocks", () => {
+    const html = renderMarkdown(`-       first block
+
+        -       nested block`);
+
+    expect(html).not.toContain("<pre>");
+    expect(html).toContain("<li>nested block</li>");
+  });
+
   it("preserves fenced code blocks within list items", () => {
     const html = renderMarkdown(`- \`\`\`ts
   const value = 1;

--- a/apps/web/src/markdown-list-indentation.test.tsx
+++ b/apps/web/src/markdown-list-indentation.test.tsx
@@ -41,6 +41,15 @@ describe("remarkNormalizeListItemIndentation", () => {
     expect(html).not.toContain("**important**");
   });
 
+  it("preserves every recovered block separated by blank lines", () => {
+    const html = renderMarkdown(`-       **first block**
+
+        [second block](https://example.com)`);
+
+    expect(html).toContain("<strong>first block</strong>");
+    expect(html).toContain('<a href="https://example.com">second block</a>');
+  });
+
   it("preserves fenced code blocks within list items", () => {
     const html = renderMarkdown(`- \`\`\`ts
   const value = 1;

--- a/apps/web/src/markdown-list-indentation.test.tsx
+++ b/apps/web/src/markdown-list-indentation.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import { describe, expect, it } from "vite-plus/test";
+
+import { remarkNormalizeListItemIndentation } from "./markdown-list-indentation";
+
+function renderMarkdown(markdown: string): string {
+  return renderToStaticMarkup(
+    <ReactMarkdown remarkPlugins={[remarkNormalizeListItemIndentation]}>{markdown}</ReactMarkdown>,
+  );
+}
+
+describe("remarkNormalizeListItemIndentation", () => {
+  it("renders same-line over-indented list content as list text", () => {
+    const html = renderMarkdown(`why did you do this?
+
+-       for (const step of rest.steps) {
+-           if (step.request.body) {
+-               step.request.body = "<redacted>";
+-           }
+-       }`);
+
+    expect(html).not.toContain("<pre>");
+    expect(html).toContain("<li>for (const step of rest.steps) {</li>");
+    expect(html).toContain("<li>if (step.request.body) {</li>");
+    expect(html).toContain("<li>step.request.body = &quot;&lt;redacted&gt;&quot;;</li>");
+  });
+
+  it("preserves fenced code blocks within list items", () => {
+    const html = renderMarkdown(`- \`\`\`ts
+  const value = 1;
+  \`\`\``);
+
+    expect(html).toContain('<pre><code class="language-ts">const value = 1;');
+  });
+
+  it("preserves indented code blocks that start below a list marker", () => {
+    const html = renderMarkdown(`-
+      const value = 1;`);
+
+    expect(html).toContain("<pre><code>const value = 1;");
+  });
+
+  it("preserves same-line code blocks without excess indentation", () => {
+    const html = renderMarkdown("-     const value = 1;");
+
+    expect(html).toContain("<pre><code>const value = 1;");
+  });
+});

--- a/apps/web/src/markdown-list-indentation.ts
+++ b/apps/web/src/markdown-list-indentation.ts
@@ -16,6 +16,12 @@ interface MarkdownFile {
   readonly value?: unknown;
 }
 
+interface MarkdownParser {
+  parse(markdown: string): unknown;
+}
+
+const INLINE_PARSE_PREFIX = "t3-markdown-inline-prefix:";
+
 function isSameLineOverIndentedCode(
   node: MarkdownAstNode,
   parent: MarkdownAstNode | undefined,
@@ -45,11 +51,31 @@ function isSameLineOverIndentedCode(
   return sourceCharacter !== "`" && sourceCharacter !== "~";
 }
 
-function paragraphFromIndentedCode(node: MarkdownAstNode): MarkdownAstNode {
+function parseInlineMarkdown(value: string, parser: MarkdownParser): MarkdownAstNode[] {
+  // A text prefix forces block-looking input into a paragraph while preserving
+  // the processor's configured inline extensions (for example, GFM syntax).
+  const document = parser.parse(`${INLINE_PARSE_PREFIX}${value}`) as MarkdownAstNode;
+  const paragraph = document.children?.[0];
+  const children = paragraph?.type === "paragraph" ? paragraph.children : undefined;
+  const first = children?.[0];
+  if (
+    !children ||
+    first?.type !== "text" ||
+    typeof first.value !== "string" ||
+    !first.value.startsWith(INLINE_PARSE_PREFIX)
+  ) {
+    return [{ type: "text", value }];
+  }
+
+  const firstValue = first.value.slice(INLINE_PARSE_PREFIX.length);
+  return [...(firstValue ? [{ ...first, value: firstValue }] : []), ...children.slice(1)];
+}
+
+function paragraphFromIndentedCode(node: MarkdownAstNode, parser: MarkdownParser): MarkdownAstNode {
   const value = typeof node.value === "string" ? node.value.trim() : "";
   return {
     type: "paragraph",
-    children: [{ type: "text", value }],
+    children: parseInlineMarkdown(value, parser),
     ...(node.position ? { position: node.position } : {}),
   };
 }
@@ -62,7 +88,7 @@ function paragraphFromIndentedCode(node: MarkdownAstNode): MarkdownAstNode {
  * start on the marker's own line; explicit fences and conventional indented
  * blocks remain code.
  */
-export function remarkNormalizeListItemIndentation() {
+function attachListItemIndentationNormalizer(this: MarkdownParser) {
   return (tree: MarkdownAstNode, file: MarkdownFile) => {
     if (typeof file.value !== "string") {
       return;
@@ -75,7 +101,7 @@ export function remarkNormalizeListItemIndentation() {
       }
       node.children = node.children.map((child) => {
         if (isSameLineOverIndentedCode(child, node, markdown)) {
-          return paragraphFromIndentedCode(child);
+          return paragraphFromIndentedCode(child, this);
         }
         visit(child);
         return child;
@@ -85,3 +111,5 @@ export function remarkNormalizeListItemIndentation() {
     visit(tree);
   };
 }
+
+export const remarkNormalizeListItemIndentation = attachListItemIndentationNormalizer;

--- a/apps/web/src/markdown-list-indentation.ts
+++ b/apps/web/src/markdown-list-indentation.ts
@@ -51,14 +51,18 @@ function isSameLineOverIndentedCode(
   return sourceCharacter !== "`" && sourceCharacter !== "~";
 }
 
-function parseInlineMarkdown(value: string, parser: MarkdownParser): MarkdownAstNode[] {
+function parseRecoveredMarkdown(value: string, parser: MarkdownParser): MarkdownAstNode[] {
   // A text prefix forces block-looking input into a paragraph while preserving
   // the processor's configured inline extensions (for example, GFM syntax).
+  // Later root children are kept as blocks so blank-line-separated content is
+  // never discarded.
   const document = parser.parse(`${INLINE_PARSE_PREFIX}${value}`) as MarkdownAstNode;
-  const paragraph = document.children?.[0];
+  const blocks = document.children;
+  const paragraph = blocks?.[0];
   const children = paragraph?.type === "paragraph" ? paragraph.children : undefined;
   const first = children?.[0];
   if (
+    !blocks ||
     !children ||
     first?.type !== "text" ||
     typeof first.value !== "string" ||
@@ -68,16 +72,23 @@ function parseInlineMarkdown(value: string, parser: MarkdownParser): MarkdownAst
   }
 
   const firstValue = first.value.slice(INLINE_PARSE_PREFIX.length);
-  return [...(firstValue ? [{ ...first, value: firstValue }] : []), ...children.slice(1)];
+  return [
+    {
+      ...paragraph,
+      type: "paragraph",
+      children: [...(firstValue ? [{ ...first, value: firstValue }] : []), ...children.slice(1)],
+    },
+    ...blocks.slice(1),
+  ];
 }
 
-function paragraphFromIndentedCode(node: MarkdownAstNode, parser: MarkdownParser): MarkdownAstNode {
+function blocksFromIndentedCode(node: MarkdownAstNode, parser: MarkdownParser): MarkdownAstNode[] {
   const value = typeof node.value === "string" ? node.value.trim() : "";
-  return {
-    type: "paragraph",
-    children: parseInlineMarkdown(value, parser),
-    ...(node.position ? { position: node.position } : {}),
-  };
+  const blocks = parseRecoveredMarkdown(value, parser);
+  const first = blocks[0];
+  return first && node.position
+    ? [{ ...first, position: node.position }, ...blocks.slice(1)]
+    : blocks;
 }
 
 /**
@@ -99,12 +110,12 @@ function attachListItemIndentationNormalizer(this: MarkdownParser) {
       if (!node.children) {
         return;
       }
-      node.children = node.children.map((child) => {
+      node.children = node.children.flatMap((child) => {
         if (isSameLineOverIndentedCode(child, node, markdown)) {
-          return paragraphFromIndentedCode(child, this);
+          return blocksFromIndentedCode(child, this);
         }
         visit(child);
-        return child;
+        return [child];
       });
     };
 

--- a/apps/web/src/markdown-list-indentation.ts
+++ b/apps/web/src/markdown-list-indentation.ts
@@ -1,0 +1,87 @@
+interface MarkdownPosition {
+  readonly start?: {
+    readonly line?: number;
+    readonly offset?: number;
+  };
+}
+
+interface MarkdownAstNode {
+  readonly type: string;
+  readonly value?: unknown;
+  readonly position?: MarkdownPosition;
+  children?: MarkdownAstNode[];
+}
+
+interface MarkdownFile {
+  readonly value?: unknown;
+}
+
+function isSameLineOverIndentedCode(
+  node: MarkdownAstNode,
+  parent: MarkdownAstNode | undefined,
+  markdown: string,
+): boolean {
+  if (
+    node.type !== "code" ||
+    parent?.type !== "listItem" ||
+    typeof node.value !== "string" ||
+    !/^[\t ]/.test(node.value)
+  ) {
+    return false;
+  }
+
+  const nodeStart = node.position?.start;
+  const parentStart = parent.position?.start;
+  if (
+    nodeStart?.line === undefined ||
+    nodeStart.offset === undefined ||
+    parentStart?.line === undefined ||
+    nodeStart.line !== parentStart.line
+  ) {
+    return false;
+  }
+
+  const sourceCharacter = markdown[nodeStart.offset];
+  return sourceCharacter !== "`" && sourceCharacter !== "~";
+}
+
+function paragraphFromIndentedCode(node: MarkdownAstNode): MarkdownAstNode {
+  const value = typeof node.value === "string" ? node.value.trim() : "";
+  return {
+    type: "paragraph",
+    children: [{ type: "text", value }],
+    ...(node.position ? { position: node.position } : {}),
+  };
+}
+
+/**
+ * CommonMark treats four or more spaces after a list marker as an indented
+ * code block. In chat output, excessive spacing is commonly accidental
+ * alignment such as `-       text`, which otherwise produces a full code card
+ * for every bullet. Only normalize blocks that retain excess indentation and
+ * start on the marker's own line; explicit fences and conventional indented
+ * blocks remain code.
+ */
+export function remarkNormalizeListItemIndentation() {
+  return (tree: MarkdownAstNode, file: MarkdownFile) => {
+    if (typeof file.value !== "string") {
+      return;
+    }
+    const markdown = file.value;
+
+    const visit = (node: MarkdownAstNode) => {
+      if (!node.children) {
+        return;
+      }
+      node.children = node.children.map((child) => {
+        if (isSameLineOverIndentedCode(child, node, markdown)) {
+          return paragraphFromIndentedCode(child);
+        }
+        visit(child);
+        return child;
+      });
+    };
+
+    visit(tree);
+  };
+}

--- a/apps/web/src/markdown-list-indentation.ts
+++ b/apps/web/src/markdown-list-indentation.ts
@@ -20,6 +20,11 @@ interface MarkdownParser {
   parse(markdown: string): unknown;
 }
 
+interface RecoveredMarkdown {
+  readonly blocks: MarkdownAstNode[];
+  readonly source: string;
+}
+
 const INLINE_PARSE_PREFIX = "t3-markdown-inline-prefix:";
 
 function isSameLineOverIndentedCode(
@@ -51,12 +56,13 @@ function isSameLineOverIndentedCode(
   return sourceCharacter !== "`" && sourceCharacter !== "~";
 }
 
-function parseRecoveredMarkdown(value: string, parser: MarkdownParser): MarkdownAstNode[] {
+function parseRecoveredMarkdown(value: string, parser: MarkdownParser): RecoveredMarkdown {
   // A text prefix forces block-looking input into a paragraph while preserving
   // the processor's configured inline extensions (for example, GFM syntax).
   // Later root children are kept as blocks so blank-line-separated content is
   // never discarded.
-  const document = parser.parse(`${INLINE_PARSE_PREFIX}${value}`) as MarkdownAstNode;
+  const source = `${INLINE_PARSE_PREFIX}${value}`;
+  const document = parser.parse(source) as MarkdownAstNode;
   const blocks = document.children;
   const paragraph = blocks?.[0];
   const children = paragraph?.type === "paragraph" ? paragraph.children : undefined;
@@ -68,27 +74,34 @@ function parseRecoveredMarkdown(value: string, parser: MarkdownParser): Markdown
     typeof first.value !== "string" ||
     !first.value.startsWith(INLINE_PARSE_PREFIX)
   ) {
-    return [{ type: "text", value }];
+    return { blocks: [{ type: "text", value }], source };
   }
 
   const firstValue = first.value.slice(INLINE_PARSE_PREFIX.length);
-  return [
-    {
-      ...paragraph,
-      type: "paragraph",
-      children: [...(firstValue ? [{ ...first, value: firstValue }] : []), ...children.slice(1)],
-    },
-    ...blocks.slice(1),
-  ];
+  return {
+    blocks: [
+      {
+        ...paragraph,
+        type: "paragraph",
+        children: [...(firstValue ? [{ ...first, value: firstValue }] : []), ...children.slice(1)],
+      },
+      ...blocks.slice(1),
+    ],
+    source,
+  };
 }
 
-function blocksFromIndentedCode(node: MarkdownAstNode, parser: MarkdownParser): MarkdownAstNode[] {
+function blocksFromIndentedCode(node: MarkdownAstNode, parser: MarkdownParser): RecoveredMarkdown {
   const value = typeof node.value === "string" ? node.value.trim() : "";
-  const blocks = parseRecoveredMarkdown(value, parser);
-  const first = blocks[0];
-  return first && node.position
-    ? [{ ...first, position: node.position }, ...blocks.slice(1)]
-    : blocks;
+  const recovered = parseRecoveredMarkdown(value, parser);
+  const first = recovered.blocks[0];
+  return {
+    ...recovered,
+    blocks:
+      first && node.position
+        ? [{ ...first, position: node.position }, ...recovered.blocks.slice(1)]
+        : recovered.blocks,
+  };
 }
 
 /**
@@ -106,20 +119,24 @@ function attachListItemIndentationNormalizer(this: MarkdownParser) {
     }
     const markdown = file.value;
 
-    const visit = (node: MarkdownAstNode) => {
+    const visit = (node: MarkdownAstNode, source: string) => {
       if (!node.children) {
         return;
       }
       node.children = node.children.flatMap((child) => {
-        if (isSameLineOverIndentedCode(child, node, markdown)) {
-          return blocksFromIndentedCode(child, this);
+        if (isSameLineOverIndentedCode(child, node, source)) {
+          const recovered = blocksFromIndentedCode(child, this);
+          for (const block of recovered.blocks) {
+            visit(block, recovered.source);
+          }
+          return recovered.blocks;
         }
-        visit(child);
+        visit(child, source);
         return [child];
       });
     };
 
-    visit(tree);
+    visit(tree, markdown);
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a remark plugin that converts accidental same-line over-indented list item content back into normal paragraph text.
- Preserve explicit fenced code blocks and conventional indented code blocks inside list items.
- Register the normalization plugin in chat markdown rendering and cover the behavior with focused tests.

## Testing
- `vp test apps/web/src/markdown-list-indentation.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped chat markdown rendering change with tests; only reclassifies accidental same-line over-indentation, not fences or normal indented code.
> 
> **Overview**
> Chat markdown now runs a new **`remarkNormalizeListItemIndentation`** plugin so bullets like `-       some text` no longer render as full code blocks when the extra spaces trigger CommonMark’s indented-code rules.
> 
> The plugin finds same-line over-indented `code` nodes inside list items, re-parses the trimmed content as inline/blocks (GFM still applies), and recurses for nested lists and blank-line-separated tails. **Fenced** code and **indented** code that starts on the line below the marker are unchanged.
> 
> `ChatMarkdown` registers the plugin in both remark pipelines (with and without `remarkBreaks`) and pulls remark/rehype plugin lists into shared constants. Tests in `markdown-list-indentation.test.tsx` cover the main cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b897ebd8a5f248098d455bf227794163250b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize over-indented markdown list items in ChatMarkdown rendering
> - Adds a new remark plugin [`remarkNormalizeListItemIndentation`](https://github.com/pingdotgg/t3code/pull/4020/files#diff-5d06e8318e446d4913e7589d42b7c38d4e81d25ebdfface4d21bc8616e479347) that detects same-line, over-indented code blocks inside list items and replaces them with parsed text or block content.
> - Fenced code blocks and conventionally indented code blocks within list items are left unchanged; only same-line over-indented content is affected.
> - Inline markdown (e.g. GFM) within recovered content is preserved, and blank-line-separated content yields multiple blocks. Nested lists are recursively normalized.
> - Integrates the plugin into [`ChatMarkdown`](https://github.com/pingdotgg/t3code/pull/4020/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) via shared plugin constants for both `lineBreaks` and non-`lineBreaks` render paths.
> - Behavioral Change: chat messages with over-indented list item content that previously rendered as `<pre>` code blocks will now render as plain text or inline markdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1b897e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->