### PR TITLE
Add native mobile share target support

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -35,8 +35,8 @@ vp run ios:dev
 ```
 
 If your Xcode account only has a Personal Team, use a bundle identifier you control and opt into the
-reduced-capability local build. Personal Team builds omit the widget extension, push entitlement, and
-native Sign in with Apple entitlement; builds without this opt-in are unchanged.
+reduced-capability local build. Personal Team builds omit the widget and share extensions, push
+entitlement, and native Sign in with Apple entitlement; builds without this opt-in are unchanged.
 
 ```bash
 T3CODE_IOS_PERSONAL_TEAM=1 \

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -84,6 +84,9 @@ function resolveAppVariant(value: string | undefined): AppVariant {
 }
 
 const variant = VARIANT_CONFIG[APP_VARIANT];
+const iosBundleIdentifier = isIosPersonalTeamBuild
+  ? personalTeamBundleIdentifier!
+  : variant.iosBundleIdentifier;
 
 const dmSansFonts = {
   regular: "@expo-google-fonts/dm-sans/400Regular/DMSans_400Regular.ttf",
@@ -94,8 +97,8 @@ const dmSansFonts = {
 const widgetsPlugin: NonNullable<ExpoConfig["plugins"]>[number] = [
   "expo-widgets",
   {
-    bundleIdentifier: `${variant.iosBundleIdentifier}.widgets`,
-    groupIdentifier: `group.${variant.iosBundleIdentifier}`,
+    bundleIdentifier: `${iosBundleIdentifier}.widgets`,
+    groupIdentifier: `group.${iosBundleIdentifier}`,
     enablePushNotifications: true,
     // Agent activity can update many times an hour; without the
     // frequent-updates entitlement iOS throttles the update budget sooner.
@@ -108,6 +111,30 @@ const widgetsPlugin: NonNullable<ExpoConfig["plugins"]>[number] = [
         supportedFamilies: ["systemSmall", "systemMedium", "accessoryRectangular"],
       },
     ],
+  },
+];
+
+const sharingPlugin: NonNullable<ExpoConfig["plugins"]>[number] = [
+  "expo-sharing",
+  {
+    ios: {
+      // Personal Teams cannot sign App Groups or extension targets. Keep the
+      // reduced-capability local build usable while release builds expose the
+      // real system share target.
+      enabled: !isIosPersonalTeamBuild,
+      extensionBundleIdentifier: `${iosBundleIdentifier}.sharing`,
+      appGroupId: `group.${iosBundleIdentifier}`,
+      activationRule: {
+        supportsText: true,
+        supportsWebUrlWithMaxCount: 1,
+        supportsImageWithMaxCount: 8,
+      },
+    },
+    android: {
+      enabled: true,
+      singleShareMimeTypes: ["text/plain", "image/*"],
+      multipleShareMimeTypes: ["image/*"],
+    },
   },
 ];
 
@@ -140,7 +167,7 @@ const config: ExpoConfig = {
   ios: {
     icon: variant.assets.iosIcon,
     supportsTablet: true,
-    bundleIdentifier: variant.iosBundleIdentifier,
+    bundleIdentifier: iosBundleIdentifier,
     // Pin code signing to the T3 Tools team so non-interactive `expo run:ios`
     // does not fall back to a personal team (which cannot sign app groups,
     // Sign in with Apple, or push notification entitlements).
@@ -202,6 +229,9 @@ const config: ExpoConfig = {
     ],
     "expo-secure-store",
     "expo-sqlite",
+    ...(isIosPersonalTeamBuild
+      ? [sharingPlugin]
+      : ["./plugins/withShareExtensionDisplayName.cjs", sharingPlugin]),
     [
       "expo-notifications",
       {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -91,6 +91,7 @@
     "expo-paste-input": "^0.1.15",
     "expo-quick-actions": "^6.0.2",
     "expo-secure-store": "~56.0.4",
+    "expo-sharing": "~56.0.18",
     "expo-splash-screen": "~56.0.10",
     "expo-sqlite": "~56.0.5",
     "expo-symbols": "~56.0.6",

--- a/apps/mobile/plugins/withShareExtensionDisplayName.cjs
+++ b/apps/mobile/plugins/withShareExtensionDisplayName.cjs
@@ -44,14 +44,14 @@ function withDisplayNamePlist(config, displayName) {
         );
       }
       const source = fs.readFileSync(plistPath, "utf8");
-      const next = source.replace(
-        /(<key>CFBundleDisplayName<\/key>\s*<string>)[^<]*(<\/string>)/,
-        `$1${escapeXml(displayName)}$2`,
-      );
-      if (next === source) {
+      const displayNamePattern = /(<key>CFBundleDisplayName<\/key>\s*<string>)[^<]*(<\/string>)/;
+      if (!displayNamePattern.test(source)) {
         throw new Error(`Could not update CFBundleDisplayName in ${plistPath}.`);
       }
-      fs.writeFileSync(plistPath, next);
+      const next = source.replace(displayNamePattern, `$1${escapeXml(displayName)}$2`);
+      if (next !== source) {
+        fs.writeFileSync(plistPath, next);
+      }
       return cfg;
     },
   ]);

--- a/apps/mobile/plugins/withShareExtensionDisplayName.cjs
+++ b/apps/mobile/plugins/withShareExtensionDisplayName.cjs
@@ -1,0 +1,93 @@
+"use strict";
+
+// expo-sharing intentionally uses a fixed target name and also uses that
+// internal target name as CFBundleDisplayName. Brand the extension while
+// leaving its initially-empty signing team intact: Expo uses that state to
+// select ios.appleTeamId and enable first-time profile provisioning.
+//
+// ORDERING: list this plugin BEFORE expo-sharing. Expo runs same-type mods in
+// reverse registration order, so this executes after the extension exists.
+
+const fs = require("fs");
+const path = require("path");
+const { withDangerousMod, withXcodeProject } = require("expo/config-plugins");
+
+const TARGET_NAME = "expo-sharing-extension";
+
+function stripComments(section) {
+  return Object.fromEntries(
+    Object.entries(section ?? {}).filter(([key]) => !key.endsWith("_comment")),
+  );
+}
+
+function findByName(section, name) {
+  return Object.entries(stripComments(section)).find(([, value]) => value?.name === name) ?? null;
+}
+
+function escapeXml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function withDisplayNamePlist(config, displayName) {
+  return withDangerousMod(config, [
+    "ios",
+    (cfg) => {
+      const plistPath = path.join(cfg.modRequest.platformProjectRoot, TARGET_NAME, "Info.plist");
+      if (!fs.existsSync(plistPath)) {
+        throw new Error(
+          `${TARGET_NAME}/Info.plist was not generated. Register withShareExtensionDisplayName before expo-sharing.`,
+        );
+      }
+      const source = fs.readFileSync(plistPath, "utf8");
+      const next = source.replace(
+        /(<key>CFBundleDisplayName<\/key>\s*<string>)[^<]*(<\/string>)/,
+        `$1${escapeXml(displayName)}$2`,
+      );
+      if (next === source) {
+        throw new Error(`Could not update CFBundleDisplayName in ${plistPath}.`);
+      }
+      fs.writeFileSync(plistPath, next);
+      return cfg;
+    },
+  ]);
+}
+
+function withExtensionDisplayNameBuildSetting(config, displayName) {
+  return withXcodeProject(config, (cfg) => {
+    const objects = cfg.modResults.hash.project.objects;
+    const targetEntry = findByName(objects.PBXNativeTarget, TARGET_NAME);
+    if (!targetEntry) {
+      throw new Error(
+        `${TARGET_NAME} Xcode target was not generated. Register withShareExtensionDisplayName before expo-sharing.`,
+      );
+    }
+    const target = targetEntry[1];
+    const configurationList = stripComments(objects.XCConfigurationList)[
+      target.buildConfigurationList
+    ];
+    if (!configurationList) {
+      throw new Error(`Could not find build configurations for ${TARGET_NAME}.`);
+    }
+    const buildConfigurations = stripComments(objects.XCBuildConfiguration);
+    for (const reference of configurationList.buildConfigurations ?? []) {
+      const buildConfiguration = buildConfigurations[reference.value];
+      if (buildConfiguration?.buildSettings) {
+        buildConfiguration.buildSettings.INFOPLIST_KEY_CFBundleDisplayName = `"${displayName}"`;
+      }
+    }
+    return cfg;
+  });
+}
+
+module.exports = function withShareExtensionDisplayName(config) {
+  const displayName = config.name;
+  return withExtensionDisplayNameBuildSetting(
+    withDisplayNamePlist(config, displayName),
+    displayName,
+  );
+};

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -11,6 +11,7 @@ import { createStaticNavigation, DarkTheme, DefaultTheme } from "@react-navigati
 import { RegistryContext } from "@effect/atom-react";
 import { ConfirmDialogHost } from "./components/ConfirmDialogHost";
 import { CloudAuthProvider } from "./features/cloud/CloudAuthProvider";
+import { IncomingShareProvider } from "./features/sharing/IncomingShareProvider";
 import { AppearancePreferencesProvider } from "./features/settings/appearance/AppearancePreferencesProvider";
 import { RootStack } from "./Stack";
 import { appAtomRegistry } from "./state/atom-registry";
@@ -26,7 +27,10 @@ const appLinking = {
   // <scheme>://expo-development-client/?url=<packager> — that URL addresses
   // the launcher, not app navigation. Without this filter it falls through
   // to the NotFound wildcard route on every dev launch.
-  filter: (url: string) => !url.includes("expo-development-client"),
+  // expo-sharing uses a private lifecycle URL only to wake the app. The
+  // persisted share inbox below owns navigation once the payload is durable.
+  filter: (url: string) =>
+    !url.includes("expo-development-client") && !url.includes("://expo-sharing"),
 };
 
 const Navigation = createStaticNavigation(RootStack);
@@ -58,10 +62,12 @@ export default function App() {
                     the system is in dark mode. */}
                 {/* Blur target for Android dropdown backdrops — see appBlurTarget.ts. */}
                 <BlurTargetView ref={appBlurTargetRef} style={{ flex: 1 }}>
-                  <Navigation
-                    linking={appLinking}
-                    theme={colorScheme === "dark" ? DarkTheme : DefaultTheme}
-                  />
+                  <IncomingShareProvider>
+                    <Navigation
+                      linking={appLinking}
+                      theme={colorScheme === "dark" ? DarkTheme : DefaultTheme}
+                    />
+                  </IncomingShareProvider>
                   <ConfirmDialogHost />
                 </BlurTargetView>
                 {/* Anchored-menu overlays render here — in-window, so the

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -287,18 +287,29 @@ function RootStackLayout(props: {
   // Launcher app shortcuts: routes shortcut taps and tracks opened threads.
   useAppShortcuts(props.state);
   useEffect(() => {
+    const topRouteName = props.state.routes[props.state.index]?.name;
+    if (topRouteName === "NewTaskSheet") {
+      return;
+    }
+
+    if (presentedShareIdRef.current !== null) {
+      const previouslyPresentedShareId = presentedShareIdRef.current;
+      presentedShareIdRef.current = null;
+      // A dismissal leaves the share queued, but must not instantly trap the
+      // user in a reopened sheet. A later navigation/lifecycle update can
+      // present it again. If the old share was consumed and another is queued,
+      // continue below and present that distinct share immediately.
+      if (pendingShare?.id === previouslyPresentedShareId) {
+        return;
+      }
+    }
+
     if (!pendingShare) {
       // Allow a later, intentional share of identical text/URL content to
       // present again after the previous inbox item was fully consumed.
-      presentedShareIdRef.current = null;
       return;
     }
     if (presentedShareIdRef.current === pendingShare.id) {
-      return;
-    }
-    // Do not replace an in-progress task flow. A second queued share opens
-    // after the current sheet is sent or dismissed.
-    if (props.state.routes[props.state.index]?.name === "NewTaskSheet") {
       return;
     }
     presentedShareIdRef.current = pendingShare.id;

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -10,6 +10,7 @@ import {
   createNativeStackScreen,
   type NativeStackNavigationOptions,
 } from "@react-navigation/native-stack";
+import { useEffect, useRef } from "react";
 import { DynamicColorIOS, Platform, Pressable, ScrollView, StyleSheet } from "react-native";
 import { useResolveClassNames } from "uniwind";
 
@@ -52,6 +53,7 @@ import {
   SettingsLegalDocumentExternalHeaderButton,
 } from "./features/settings/components/SettingsLegalDocumentRouteScreen";
 import { useAppShortcuts } from "./features/shortcuts/useAppShortcuts";
+import { useIncomingShare } from "./features/sharing/IncomingShareProvider";
 import { nativeHeaderScrollEdgeEffects } from "./native/StackHeader";
 import { useThreadOutboxDrain } from "./state/use-thread-outbox-drain";
 
@@ -275,12 +277,30 @@ function RootStackLayout(props: {
   readonly children: React.ReactNode;
   readonly state: NavigationState;
 }) {
+  const navigation = useNavigation();
+  const { pendingShare } = useIncomingShare();
+  const presentedShareIdRef = useRef<string | null>(null);
   useAgentNotificationNavigation();
   useThreadOutboxDrain();
   // Presents the T3 Connect onboarding sheet after an in-session sign-in.
   useConnectOnboardingNavigation();
   // Launcher app shortcuts: routes shortcut taps and tracks opened threads.
   useAppShortcuts(props.state);
+  useEffect(() => {
+    if (!pendingShare || presentedShareIdRef.current === pendingShare.id) {
+      return;
+    }
+    // Do not replace an in-progress task flow. A second queued share opens
+    // after the current sheet is sent, saved, or dismissed.
+    if (props.state.routes[props.state.index]?.name === "NewTaskSheet") {
+      return;
+    }
+    presentedShareIdRef.current = pendingShare.id;
+    navigation.navigate("NewTaskSheet", {
+      screen: "NewTask",
+      params: { incomingShareId: pendingShare.id },
+    });
+  }, [navigation, pendingShare, props.state]);
   // Full pathname (sheets included) for keyboard-command scoping; the
   // workspace layout only reacts to the underlying non-overlay route.
   const path = getPathFromState(props.state, navigationPathConfig);

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -287,11 +287,17 @@ function RootStackLayout(props: {
   // Launcher app shortcuts: routes shortcut taps and tracks opened threads.
   useAppShortcuts(props.state);
   useEffect(() => {
-    if (!pendingShare || presentedShareIdRef.current === pendingShare.id) {
+    if (!pendingShare) {
+      // Allow a later, intentional share of identical text/URL content to
+      // present again after the previous inbox item was fully consumed.
+      presentedShareIdRef.current = null;
+      return;
+    }
+    if (presentedShareIdRef.current === pendingShare.id) {
       return;
     }
     // Do not replace an in-progress task flow. A second queued share opens
-    // after the current sheet is sent, saved, or dismissed.
+    // after the current sheet is sent or dismissed.
     if (props.state.routes[props.state.index]?.name === "NewTaskSheet") {
       return;
     }

--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -54,6 +54,10 @@ import {
 } from "./features/settings/components/SettingsLegalDocumentRouteScreen";
 import { useAppShortcuts } from "./features/shortcuts/useAppShortcuts";
 import { useIncomingShare } from "./features/sharing/IncomingShareProvider";
+import {
+  EMPTY_INCOMING_SHARE_PRESENTATION_STATE,
+  transitionIncomingSharePresentation,
+} from "./features/sharing/incoming-share-presentation";
 import { nativeHeaderScrollEdgeEffects } from "./native/StackHeader";
 import { useThreadOutboxDrain } from "./state/use-thread-outbox-drain";
 
@@ -279,7 +283,7 @@ function RootStackLayout(props: {
 }) {
   const navigation = useNavigation();
   const { pendingShare } = useIncomingShare();
-  const presentedShareIdRef = useRef<string | null>(null);
+  const sharePresentationRef = useRef(EMPTY_INCOMING_SHARE_PRESENTATION_STATE);
   useAgentNotificationNavigation();
   useThreadOutboxDrain();
   // Presents the T3 Connect onboarding sheet after an in-session sign-in.
@@ -288,34 +292,17 @@ function RootStackLayout(props: {
   useAppShortcuts(props.state);
   useEffect(() => {
     const topRouteName = props.state.routes[props.state.index]?.name;
-    if (topRouteName === "NewTaskSheet") {
+    const transition = transitionIncomingSharePresentation(sharePresentationRef.current, {
+      isShareSheetPresented: topRouteName === "NewTaskSheet",
+      pendingShareId: pendingShare?.id ?? null,
+    });
+    sharePresentationRef.current = transition.state;
+    if (!transition.shareIdToPresent) {
       return;
     }
-
-    if (presentedShareIdRef.current !== null) {
-      const previouslyPresentedShareId = presentedShareIdRef.current;
-      presentedShareIdRef.current = null;
-      // A dismissal leaves the share queued, but must not instantly trap the
-      // user in a reopened sheet. A later navigation/lifecycle update can
-      // present it again. If the old share was consumed and another is queued,
-      // continue below and present that distinct share immediately.
-      if (pendingShare?.id === previouslyPresentedShareId) {
-        return;
-      }
-    }
-
-    if (!pendingShare) {
-      // Allow a later, intentional share of identical text/URL content to
-      // present again after the previous inbox item was fully consumed.
-      return;
-    }
-    if (presentedShareIdRef.current === pendingShare.id) {
-      return;
-    }
-    presentedShareIdRef.current = pendingShare.id;
     navigation.navigate("NewTaskSheet", {
       screen: "NewTask",
-      params: { incomingShareId: pendingShare.id },
+      params: { incomingShareId: transition.shareIdToPresent },
     });
   }, [navigation, pendingShare, props.state]);
   // Full pathname (sheets included) for keyboard-command scoping; the

--- a/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
+++ b/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
@@ -84,14 +84,25 @@ async function removeOwnedFile(uri: string): Promise<void> {
   }
 }
 
-async function removeRawImagePayloadFiles(payloads: ReadonlyArray<SharePayload>): Promise<void> {
-  const removals: Promise<void>[] = [];
+async function removeReplayedImagePayloadFiles(
+  payloads: ReadonlyArray<SharePayload>,
+): Promise<void> {
+  const uris = new Set<string>();
   for (const payload of payloads) {
     if (payload.shareType === "image") {
-      removals.push(removeOwnedFile(payload.value));
+      uris.add(payload.value);
     }
   }
-  await Promise.all(removals);
+  if (uris.size === 0) {
+    return;
+  }
+  const resolvedPayloads = await resolvedPayloadsForImages();
+  for (const payload of resolvedPayloads) {
+    if (payload.shareType === "image" && payload.contentUri) {
+      uris.add(payload.contentUri);
+    }
+  }
+  await Promise.all([...uris].map(removeOwnedFile));
 }
 
 // Keep one operation queue across provider remounts (including development
@@ -127,7 +138,7 @@ const incomingShareInbox = new IncomingShareInbox({
       },
     };
   },
-  cleanupReplayedPayloads: removeRawImagePayloadFiles,
+  cleanupReplayedPayloads: removeReplayedImagePayloadFiles,
   idForPayloads: incomingShareIdForPayloads,
   now: () => new Date().toISOString(),
   onClearError: (error) => {

--- a/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
+++ b/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
@@ -1,0 +1,223 @@
+import Constants from "expo-constants";
+import {
+  clearSharedPayloads,
+  getResolvedSharedPayloadsAsync,
+  getSharedPayloads,
+  type ResolvedSharePayload,
+  type SharePayload,
+} from "expo-sharing";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Alert, AppState, Platform } from "react-native";
+
+import { uuidv4 } from "../../lib/uuid";
+import {
+  buildIncomingShareDraft,
+  hasIncomingShareContent,
+  type IncomingShareDraft,
+} from "./incoming-share-model";
+import {
+  loadIncomingShareDrafts,
+  removeIncomingShareDraft,
+  writeIncomingShareDraft,
+} from "./incoming-share-storage";
+
+type IncomingShareContextValue = {
+  readonly pendingShare: IncomingShareDraft | null;
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+  readonly consumeShare: (shareId: string) => Promise<void>;
+  readonly refresh: () => Promise<void>;
+};
+
+const IncomingShareContext = React.createContext<IncomingShareContextValue | null>(null);
+
+function receiveSharingEnabled(): boolean {
+  if (Platform.OS === "android") {
+    return true;
+  }
+  if (Platform.OS !== "ios") {
+    return false;
+  }
+  return Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
+}
+
+function sortAndDedupe(
+  drafts: ReadonlyArray<IncomingShareDraft>,
+): ReadonlyArray<IncomingShareDraft> {
+  return [...new Map(drafts.map((draft) => [draft.id, draft])).values()].sort((left, right) =>
+    right.createdAt.localeCompare(left.createdAt),
+  );
+}
+
+async function resolvedPayloadsForImages(): Promise<ReadonlyArray<ResolvedSharePayload>> {
+  try {
+    return await getResolvedSharedPayloadsAsync();
+  } catch (error) {
+    // iOS already gives the containing app a copied file:// URL, so raw
+    // payloads remain usable. Android normally resolves content:// into a
+    // private cache file; its modern File API can still read the raw URI when
+    // resolution fails.
+    console.warn("[incoming-share] could not resolve shared file metadata", error);
+    return [];
+  }
+}
+
+async function readBase64(uri: string): Promise<string> {
+  const { File } = await import("expo-file-system");
+  return new File(uri).base64();
+}
+
+async function removeOwnedFile(uri: string): Promise<void> {
+  if (!uri.startsWith("file:")) {
+    return;
+  }
+  try {
+    const { File } = await import("expo-file-system");
+    const file = new File(uri);
+    if (file.exists) {
+      file.delete();
+    }
+  } catch (error) {
+    console.warn("[incoming-share] could not remove temporary shared file", error);
+  }
+}
+
+export function IncomingShareProvider(props: React.PropsWithChildren) {
+  const enabled = receiveSharingEnabled();
+  const [drafts, setDrafts] = useState<ReadonlyArray<IncomingShareDraft>>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    const operation = (async () => {
+      let payloads: SharePayload[];
+      try {
+        payloads = getSharedPayloads();
+      } catch (cause) {
+        setError(cause instanceof Error ? cause : new Error("Could not read shared content."));
+        return;
+      }
+      if (payloads.length === 0) {
+        return;
+      }
+
+      try {
+        const resolvedPayloads = payloads.some((payload) => payload.shareType === "image")
+          ? await resolvedPayloadsForImages()
+          : [];
+        const draft = await buildIncomingShareDraft({
+          payloads,
+          resolvedPayloads,
+          fileReader: { readBase64, removeOwnedFile },
+          id: uuidv4(),
+          createdAt: new Date().toISOString(),
+        });
+        if (!hasIncomingShareContent(draft)) {
+          throw new Error(
+            draft.warnings[0] ?? "The shared content is not supported by the composer.",
+          );
+        }
+        // Persist before acknowledging the native handoff. If the process is
+        // killed while the user chooses a project, the next launch recovers it.
+        await writeIncomingShareDraft(draft);
+        setDrafts((current) => sortAndDedupe([draft, ...current]));
+        setError(null);
+      } catch (cause) {
+        setError(cause instanceof Error ? cause : new Error("Could not import shared content."));
+      } finally {
+        // A failed/unsupported payload must not reopen the share flow forever.
+        try {
+          clearSharedPayloads();
+        } catch (cause) {
+          console.warn("[incoming-share] could not acknowledge native payload", cause);
+        }
+      }
+    })().finally(() => {
+      refreshPromiseRef.current = null;
+    });
+
+    refreshPromiseRef.current = operation;
+    return operation;
+  }, [enabled]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadIncomingShareDrafts()
+      .then((persisted) => {
+        if (!cancelled) {
+          setDrafts((current) => sortAndDedupe([...current, ...persisted]));
+        }
+      })
+      .catch((cause) => {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause : new Error("Could not load shared drafts."));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+          void refresh();
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        void refresh();
+      }
+    });
+    return () => subscription.remove();
+  }, [enabled, refresh]);
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+    Alert.alert("Could not import shared content", error.message, [
+      { text: "OK", onPress: () => setError(null) },
+    ]);
+  }, [error]);
+
+  const consumeShare = useCallback(async (shareId: string) => {
+    await removeIncomingShareDraft(shareId);
+    setDrafts((current) => current.filter((draft) => draft.id !== shareId));
+  }, []);
+
+  const value = useMemo<IncomingShareContextValue>(
+    () => ({
+      pendingShare: drafts[0] ?? null,
+      isLoading,
+      error,
+      consumeShare,
+      refresh,
+    }),
+    [consumeShare, drafts, error, isLoading, refresh],
+  );
+
+  return (
+    <IncomingShareContext.Provider value={value}>{props.children}</IncomingShareContext.Provider>
+  );
+}
+
+export function useIncomingShare(): IncomingShareContextValue {
+  const value = React.use(IncomingShareContext);
+  if (value === null) {
+    throw new Error("useIncomingShare must be used within IncomingShareProvider.");
+  }
+  return value;
+}

--- a/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
+++ b/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
@@ -28,6 +28,10 @@ type IncomingShareContextValue = {
   readonly error: Error | null;
   readonly getShare: (shareId: string) => IncomingShareDraft | null;
   readonly reserveShare: (shareId: string, destination: IncomingShareDestination) => Promise<void>;
+  readonly releaseShareReservation: (
+    shareId: string,
+    expectedDestination: IncomingShareDestination,
+  ) => Promise<void>;
   readonly consumeShare: (shareId: string) => Promise<void>;
   readonly refresh: () => Promise<void>;
 };
@@ -255,6 +259,15 @@ export function IncomingShareProvider(props: React.PropsWithChildren) {
     },
     [],
   );
+  const releaseShareReservation = useCallback(
+    async (shareId: string, expectedDestination: IncomingShareDestination) => {
+      const snapshot = await incomingShareInbox.releaseReservation(shareId, expectedDestination);
+      if (mountedRef.current) {
+        setDrafts(snapshot);
+      }
+    },
+    [],
+  );
   const getShare = useCallback(
     (shareId: string) => drafts.find((draft) => draft.id === shareId) ?? null,
     [drafts],
@@ -266,11 +279,21 @@ export function IncomingShareProvider(props: React.PropsWithChildren) {
       isLoading,
       error,
       getShare,
+      releaseShareReservation,
       reserveShare,
       consumeShare,
       refresh,
     }),
-    [consumeShare, drafts, error, getShare, isLoading, refresh, reserveShare],
+    [
+      consumeShare,
+      drafts,
+      error,
+      getShare,
+      isLoading,
+      refresh,
+      releaseShareReservation,
+      reserveShare,
+    ],
   );
 
   return (

--- a/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
+++ b/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
@@ -1,4 +1,5 @@
 import Constants from "expo-constants";
+import * as Crypto from "expo-crypto";
 import {
   clearSharedPayloads,
   getResolvedSharedPayloadsAsync,
@@ -6,15 +7,11 @@ import {
   type ResolvedSharePayload,
   type SharePayload,
 } from "expo-sharing";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { Alert, AppState, Platform } from "react-native";
 
-import { uuidv4 } from "../../lib/uuid";
-import {
-  buildIncomingShareDraft,
-  hasIncomingShareContent,
-  type IncomingShareDraft,
-} from "./incoming-share-model";
+import { buildIncomingShareDraft, type IncomingShareDraft } from "./incoming-share-model";
+import { IncomingShareInbox } from "./incoming-share-inbox";
 import {
   loadIncomingShareDrafts,
   removeIncomingShareDraft,
@@ -25,6 +22,7 @@ type IncomingShareContextValue = {
   readonly pendingShare: IncomingShareDraft | null;
   readonly isLoading: boolean;
   readonly error: Error | null;
+  readonly getShare: (shareId: string) => IncomingShareDraft | null;
   readonly consumeShare: (shareId: string) => Promise<void>;
   readonly refresh: () => Promise<void>;
 };
@@ -41,14 +39,6 @@ function receiveSharingEnabled(): boolean {
   return Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
 }
 
-function sortAndDedupe(
-  drafts: ReadonlyArray<IncomingShareDraft>,
-): ReadonlyArray<IncomingShareDraft> {
-  return [...new Map(drafts.map((draft) => [draft.id, draft])).values()].sort((left, right) =>
-    right.createdAt.localeCompare(left.createdAt),
-  );
-}
-
 async function resolvedPayloadsForImages(): Promise<ReadonlyArray<ResolvedSharePayload>> {
   try {
     return await getResolvedSharedPayloadsAsync();
@@ -60,6 +50,18 @@ async function resolvedPayloadsForImages(): Promise<ReadonlyArray<ResolvedShareP
     console.warn("[incoming-share] could not resolve shared file metadata", error);
     return [];
   }
+}
+
+async function incomingShareIdForPayloads(payloads: ReadonlyArray<SharePayload>): Promise<string> {
+  const fingerprint = JSON.stringify(
+    payloads.map((payload) => ({
+      shareType: payload.shareType,
+      mimeType: payload.mimeType ?? null,
+      value: payload.value,
+    })),
+  );
+  const digest = await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, fingerprint);
+  return `share-${digest}`;
 }
 
 async function readBase64(uri: string): Promise<string> {
@@ -82,62 +84,96 @@ async function removeOwnedFile(uri: string): Promise<void> {
   }
 }
 
+async function removeRawImagePayloadFiles(payloads: ReadonlyArray<SharePayload>): Promise<void> {
+  const removals: Promise<void>[] = [];
+  for (const payload of payloads) {
+    if (payload.shareType === "image") {
+      removals.push(removeOwnedFile(payload.value));
+    }
+  }
+  await Promise.all(removals);
+}
+
+// Keep one operation queue across provider remounts (including development
+// Strict Mode remounts) so two app lifecycle notifications cannot ingest the
+// same native handoff independently.
+const incomingShareInbox = new IncomingShareInbox({
+  loadDrafts: loadIncomingShareDrafts,
+  writeDraft: writeIncomingShareDraft,
+  removeDraft: removeIncomingShareDraft,
+  getPayloads: getSharedPayloads,
+  clearPayloads: clearSharedPayloads,
+  buildDraft: async ({ payloads, id, createdAt }) => {
+    const cleanupUris = new Set<string>();
+    const resolvedPayloads = payloads.some((payload) => payload.shareType === "image")
+      ? await resolvedPayloadsForImages()
+      : [];
+    const draft = await buildIncomingShareDraft({
+      payloads,
+      resolvedPayloads,
+      fileReader: {
+        readBase64,
+        removeOwnedFile: (uri) => {
+          cleanupUris.add(uri);
+        },
+      },
+      id,
+      createdAt,
+    });
+    return {
+      draft,
+      cleanup: async () => {
+        await Promise.all([...cleanupUris].map(removeOwnedFile));
+      },
+    };
+  },
+  cleanupReplayedPayloads: removeRawImagePayloadFiles,
+  idForPayloads: incomingShareIdForPayloads,
+  now: () => new Date().toISOString(),
+  onClearError: (error) => {
+    console.warn("[incoming-share] could not acknowledge native payload", error);
+  },
+  onCleanupError: (error) => {
+    console.warn("[incoming-share] could not remove temporary shared file", error);
+  },
+});
+
 export function IncomingShareProvider(props: React.PropsWithChildren) {
   const enabled = receiveSharingEnabled();
   const [drafts, setDrafts] = useState<ReadonlyArray<IncomingShareDraft>>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const refreshPromiseRef = useRef<Promise<void> | null>(null);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const refresh = useCallback(async () => {
-    if (!enabled) {
-      return;
-    }
     if (refreshPromiseRef.current) {
       return refreshPromiseRef.current;
     }
 
     const operation = (async () => {
-      let payloads: SharePayload[];
       try {
-        payloads = getSharedPayloads();
-      } catch (cause) {
-        setError(cause instanceof Error ? cause : new Error("Could not read shared content."));
-        return;
-      }
-      if (payloads.length === 0) {
-        return;
-      }
-
-      try {
-        const resolvedPayloads = payloads.some((payload) => payload.shareType === "image")
-          ? await resolvedPayloadsForImages()
-          : [];
-        const draft = await buildIncomingShareDraft({
-          payloads,
-          resolvedPayloads,
-          fileReader: { readBase64, removeOwnedFile },
-          id: uuidv4(),
-          createdAt: new Date().toISOString(),
-        });
-        if (!hasIncomingShareContent(draft)) {
-          throw new Error(
-            draft.warnings[0] ?? "The shared content is not supported by the composer.",
-          );
+        const snapshot = await incomingShareInbox.refresh({ ingestNative: enabled });
+        if (mountedRef.current) {
+          setDrafts(snapshot);
+          setError(null);
         }
-        // Persist before acknowledging the native handoff. If the process is
-        // killed while the user chooses a project, the next launch recovers it.
-        await writeIncomingShareDraft(draft);
-        setDrafts((current) => sortAndDedupe([draft, ...current]));
-        setError(null);
       } catch (cause) {
-        setError(cause instanceof Error ? cause : new Error("Could not import shared content."));
-      } finally {
-        // A failed/unsupported payload must not reopen the share flow forever.
-        try {
-          clearSharedPayloads();
-        } catch (cause) {
-          console.warn("[incoming-share] could not acknowledge native payload", cause);
+        const persisted = await incomingShareInbox
+          .refresh({ ingestNative: false })
+          .catch(() => null);
+        if (mountedRef.current) {
+          if (persisted) {
+            setDrafts(persisted);
+          }
+          setError(cause instanceof Error ? cause : new Error("Could not import shared content."));
         }
       }
     })().finally(() => {
@@ -149,28 +185,16 @@ export function IncomingShareProvider(props: React.PropsWithChildren) {
   }, [enabled]);
 
   useEffect(() => {
-    let cancelled = false;
-    void loadIncomingShareDrafts()
-      .then((persisted) => {
-        if (!cancelled) {
-          setDrafts((current) => sortAndDedupe([...current, ...persisted]));
-        }
-      })
-      .catch((cause) => {
-        if (!cancelled) {
-          setError(cause instanceof Error ? cause : new Error("Could not load shared drafts."));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoading(false);
-          void refresh();
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
+    void refresh().finally(() => {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    });
   }, [refresh]);
+
+  const refreshOnAppActive = useEffectEvent(() => {
+    void refresh();
+  });
 
   useEffect(() => {
     if (!enabled) {
@@ -178,35 +202,49 @@ export function IncomingShareProvider(props: React.PropsWithChildren) {
     }
     const subscription = AppState.addEventListener("change", (state) => {
       if (state === "active") {
-        void refresh();
+        refreshOnAppActive();
       }
     });
     return () => subscription.remove();
-  }, [enabled, refresh]);
+  }, [enabled]);
 
   useEffect(() => {
     if (!error) {
       return;
     }
     Alert.alert("Could not import shared content", error.message, [
-      { text: "OK", onPress: () => setError(null) },
+      { text: "Dismiss", style: "cancel", onPress: () => setError(null) },
+      {
+        text: "Retry",
+        onPress: () => {
+          setError(null);
+          void refresh();
+        },
+      },
     ]);
-  }, [error]);
+  }, [error, refresh]);
 
   const consumeShare = useCallback(async (shareId: string) => {
-    await removeIncomingShareDraft(shareId);
-    setDrafts((current) => current.filter((draft) => draft.id !== shareId));
+    const snapshot = await incomingShareInbox.consume(shareId);
+    if (mountedRef.current) {
+      setDrafts(snapshot);
+    }
   }, []);
+  const getShare = useCallback(
+    (shareId: string) => drafts.find((draft) => draft.id === shareId) ?? null,
+    [drafts],
+  );
 
   const value = useMemo<IncomingShareContextValue>(
     () => ({
       pendingShare: drafts[0] ?? null,
       isLoading,
       error,
+      getShare,
       consumeShare,
       refresh,
     }),
-    [consumeShare, drafts, error, isLoading, refresh],
+    [consumeShare, drafts, error, getShare, isLoading, refresh],
   );
 
   return (

--- a/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
+++ b/apps/mobile/src/features/sharing/IncomingShareProvider.tsx
@@ -10,7 +10,11 @@ import {
 import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { Alert, AppState, Platform } from "react-native";
 
-import { buildIncomingShareDraft, type IncomingShareDraft } from "./incoming-share-model";
+import {
+  buildIncomingShareDraft,
+  type IncomingShareDestination,
+  type IncomingShareDraft,
+} from "./incoming-share-model";
 import { IncomingShareInbox } from "./incoming-share-inbox";
 import {
   loadIncomingShareDrafts,
@@ -23,6 +27,7 @@ type IncomingShareContextValue = {
   readonly isLoading: boolean;
   readonly error: Error | null;
   readonly getShare: (shareId: string) => IncomingShareDraft | null;
+  readonly reserveShare: (shareId: string, destination: IncomingShareDestination) => Promise<void>;
   readonly consumeShare: (shareId: string) => Promise<void>;
   readonly refresh: () => Promise<void>;
 };
@@ -241,6 +246,15 @@ export function IncomingShareProvider(props: React.PropsWithChildren) {
       setDrafts(snapshot);
     }
   }, []);
+  const reserveShare = useCallback(
+    async (shareId: string, destination: IncomingShareDestination) => {
+      const snapshot = await incomingShareInbox.reserve(shareId, destination);
+      if (mountedRef.current) {
+        setDrafts(snapshot);
+      }
+    },
+    [],
+  );
   const getShare = useCallback(
     (shareId: string) => drafts.find((draft) => draft.id === shareId) ?? null,
     [drafts],
@@ -252,10 +266,11 @@ export function IncomingShareProvider(props: React.PropsWithChildren) {
       isLoading,
       error,
       getShare,
+      reserveShare,
       consumeShare,
       refresh,
     }),
-    [consumeShare, drafts, error, getShare, isLoading, refresh],
+    [consumeShare, drafts, error, getShare, isLoading, refresh, reserveShare],
   );
 
   return (

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
@@ -61,11 +61,13 @@ describe("IncomingShareInbox", () => {
       draft: draft(id, createdAt),
       cleanup: async () => undefined,
     }));
-    const { inbox, persisted } = createHarness({ buildDraft });
+    const cleanupReplayedPayloads = vi.fn(async () => undefined);
+    const { inbox, persisted } = createHarness({ buildDraft, cleanupReplayedPayloads });
     persisted.set("share-stable", draft("share-stable"));
 
     await expect(inbox.refresh({ ingestNative: true })).resolves.toEqual([draft("share-stable")]);
     expect(buildDraft).not.toHaveBeenCalled();
+    expect(cleanupReplayedPayloads).toHaveBeenCalledWith([PAYLOAD]);
   });
 
   it("serializes concurrent refreshes so one native payload creates one inbox item", async () => {
@@ -110,9 +112,23 @@ describe("IncomingShareInbox", () => {
     persisted.set("legacy-first", draft("legacy-first", "2026-07-16T07:59:00.000Z"));
     persisted.set("legacy-second", draft("legacy-second"));
 
-    await expect(inbox.refresh({ ingestNative: false })).resolves.toEqual([draft("legacy-second")]);
+    await expect(inbox.refresh({ ingestNative: false })).resolves.toEqual([
+      draft("legacy-second"),
+      draft("legacy-first", "2026-07-16T07:59:00.000Z"),
+    ]);
     await expect(inbox.consume("legacy-second")).resolves.toEqual([]);
     expect([...persisted.values()]).toEqual([]);
+  });
+
+  it("keeps content-identical shares addressable by their own ids", async () => {
+    const { inbox, persisted } = createHarness();
+    persisted.set("share-open-flow", draft("share-open-flow", "2026-07-16T07:59:00.000Z"));
+    persisted.set("share-newer", draft("share-newer"));
+
+    await expect(inbox.refresh({ ingestNative: false })).resolves.toEqual([
+      draft("share-newer"),
+      draft("share-open-flow", "2026-07-16T07:59:00.000Z"),
+    ]);
   });
 
   it("does not acknowledge a supported payload when its durable write fails", async () => {

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
@@ -181,4 +181,43 @@ describe("IncomingShareInbox", () => {
     ).rejects.toThrow("already reserved");
     expect(persisted.get("share-stable")?.destination?.projectId).toBe("project-1");
   });
+
+  it("conditionally releases a reservation when its project is unavailable", async () => {
+    const { inbox, persisted } = createHarness();
+    const destination = { environmentId: "environment-1", projectId: "project-1" };
+    persisted.set("share-stable", { ...draft("share-stable"), destination });
+
+    await expect(inbox.releaseReservation("share-stable", destination)).resolves.toEqual([
+      draft("share-stable"),
+    ]);
+    expect(persisted.get("share-stable")?.destination).toBeUndefined();
+
+    await expect(
+      inbox.reserve("share-stable", {
+        environmentId: "environment-2",
+        projectId: "project-2",
+      }),
+    ).resolves.toEqual([
+      {
+        ...draft("share-stable"),
+        destination: { environmentId: "environment-2", projectId: "project-2" },
+      },
+    ]);
+  });
+
+  it("does not release a reservation that changed concurrently", async () => {
+    const { inbox, persisted } = createHarness();
+    persisted.set("share-stable", {
+      ...draft("share-stable"),
+      destination: { environmentId: "environment-2", projectId: "project-2" },
+    });
+
+    await expect(
+      inbox.releaseReservation("share-stable", {
+        environmentId: "environment-1",
+        projectId: "project-1",
+      }),
+    ).rejects.toThrow("reservation changed");
+    expect(persisted.get("share-stable")?.destination?.projectId).toBe("project-2");
+  });
 });

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
@@ -220,4 +220,17 @@ describe("IncomingShareInbox", () => {
     ).rejects.toThrow("reservation changed");
     expect(persisted.get("share-stable")?.destination?.projectId).toBe("project-2");
   });
+
+  it("treats an already-removed share as an already-released reservation", async () => {
+    const { inbox, persisted } = createHarness();
+    persisted.set("share-other", draft("share-other"));
+
+    await expect(
+      inbox.releaseReservation("share-stable", {
+        environmentId: "environment-1",
+        projectId: "project-1",
+      }),
+    ).resolves.toEqual([draft("share-other")]);
+    expect([...persisted.values()]).toEqual([draft("share-other")]);
+  });
 });

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
@@ -107,17 +107,19 @@ describe("IncomingShareInbox", () => {
     expect([...persisted.values()]).toEqual([]);
   });
 
-  it("consumes duplicate records left by a replay from the legacy random-id inbox", async () => {
+  it("consumes only the addressed share when another share has identical content", async () => {
     const { inbox, persisted } = createHarness();
-    persisted.set("legacy-first", draft("legacy-first", "2026-07-16T07:59:00.000Z"));
-    persisted.set("legacy-second", draft("legacy-second"));
+    persisted.set("share-first", draft("share-first", "2026-07-16T07:59:00.000Z"));
+    persisted.set("share-second", draft("share-second"));
 
     await expect(inbox.refresh({ ingestNative: false })).resolves.toEqual([
-      draft("legacy-second"),
-      draft("legacy-first", "2026-07-16T07:59:00.000Z"),
+      draft("share-second"),
+      draft("share-first", "2026-07-16T07:59:00.000Z"),
     ]);
-    await expect(inbox.consume("legacy-second")).resolves.toEqual([]);
-    expect([...persisted.values()]).toEqual([]);
+    await expect(inbox.consume("share-second")).resolves.toEqual([
+      draft("share-first", "2026-07-16T07:59:00.000Z"),
+    ]);
+    expect([...persisted.values()]).toEqual([draft("share-first", "2026-07-16T07:59:00.000Z")]);
   });
 
   it("keeps content-identical shares addressable by their own ids", async () => {

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
@@ -151,4 +151,34 @@ describe("IncomingShareInbox", () => {
     expect(clearPayloads).not.toHaveBeenCalled();
     expect(cleanup).not.toHaveBeenCalled();
   });
+
+  it("durably reserves a share for one project before draft import", async () => {
+    const { inbox, persisted } = createHarness();
+    persisted.set("share-stable", draft("share-stable"));
+    const destination = { environmentId: "environment-1", projectId: "project-1" };
+
+    await expect(inbox.reserve("share-stable", destination)).resolves.toEqual([
+      { ...draft("share-stable"), destination },
+    ]);
+    expect(persisted.get("share-stable")?.destination).toEqual(destination);
+    await expect(inbox.reserve("share-stable", destination)).resolves.toEqual([
+      { ...draft("share-stable"), destination },
+    ]);
+  });
+
+  it("rejects moving a reserved share to another project", async () => {
+    const { inbox, persisted } = createHarness();
+    persisted.set("share-stable", {
+      ...draft("share-stable"),
+      destination: { environmentId: "environment-1", projectId: "project-1" },
+    });
+
+    await expect(
+      inbox.reserve("share-stable", {
+        environmentId: "environment-1",
+        projectId: "project-2",
+      }),
+    ).rejects.toThrow("already reserved");
+    expect(persisted.get("share-stable")?.destination?.projectId).toBe("project-1");
+  });
 });

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import type { SharePayload } from "expo-sharing";
+
+import type { IncomingShareDraft } from "./incoming-share-model";
+import { IncomingShareInbox, type IncomingShareInboxDependencies } from "./incoming-share-inbox";
+
+const PAYLOAD: SharePayload = {
+  shareType: "text",
+  mimeType: "text/plain",
+  value: "Fix this",
+};
+
+function draft(id: string, createdAt = "2026-07-16T08:00:00.000Z"): IncomingShareDraft {
+  return {
+    schemaVersion: 1,
+    id,
+    createdAt,
+    text: PAYLOAD.value,
+    attachments: [],
+    warnings: [],
+  };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function createHarness(overrides: Partial<IncomingShareInboxDependencies> = {}) {
+  const persisted = new Map<string, IncomingShareDraft>();
+  let payloads: ReadonlyArray<SharePayload> = [PAYLOAD];
+  const dependencies: IncomingShareInboxDependencies = {
+    loadDrafts: async () => [...persisted.values()],
+    writeDraft: async (value) => {
+      persisted.set(value.id, value);
+    },
+    removeDraft: async (shareId) => {
+      persisted.delete(shareId);
+    },
+    getPayloads: () => payloads,
+    clearPayloads: () => {
+      payloads = [];
+    },
+    buildDraft: async ({ id, createdAt }) => ({
+      draft: draft(id, createdAt),
+      cleanup: async () => undefined,
+    }),
+    idForPayloads: async () => "share-stable",
+    now: () => "2026-07-16T08:00:00.000Z",
+    ...overrides,
+  };
+  return { inbox: new IncomingShareInbox(dependencies), persisted };
+}
+
+describe("IncomingShareInbox", () => {
+  it("coalesces a replay of an already-persisted native handoff", async () => {
+    const buildDraft = vi.fn(async ({ id, createdAt }) => ({
+      draft: draft(id, createdAt),
+      cleanup: async () => undefined,
+    }));
+    const { inbox, persisted } = createHarness({ buildDraft });
+    persisted.set("share-stable", draft("share-stable"));
+
+    await expect(inbox.refresh({ ingestNative: true })).resolves.toEqual([draft("share-stable")]);
+    expect(buildDraft).not.toHaveBeenCalled();
+  });
+
+  it("serializes concurrent refreshes so one native payload creates one inbox item", async () => {
+    const building = deferred();
+    const buildDraft = vi.fn(async ({ id, createdAt }) => {
+      await building.promise;
+      return { draft: draft(id, createdAt), cleanup: async () => undefined };
+    });
+    const { inbox } = createHarness({ buildDraft });
+
+    const first = inbox.refresh({ ingestNative: true });
+    const second = inbox.refresh({ ingestNative: true });
+    building.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [draft("share-stable")],
+      [draft("share-stable")],
+    ]);
+    expect(buildDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("orders consumption after an in-flight refresh without restoring stale state", async () => {
+    const building = deferred();
+    const { inbox, persisted } = createHarness({
+      buildDraft: async ({ id, createdAt }) => {
+        await building.promise;
+        return { draft: draft(id, createdAt), cleanup: async () => undefined };
+      },
+    });
+
+    const refresh = inbox.refresh({ ingestNative: true });
+    const consume = inbox.consume("share-stable");
+    building.resolve();
+
+    await expect(refresh).resolves.toEqual([draft("share-stable")]);
+    await expect(consume).resolves.toEqual([]);
+    expect([...persisted.values()]).toEqual([]);
+  });
+
+  it("consumes duplicate records left by a replay from the legacy random-id inbox", async () => {
+    const { inbox, persisted } = createHarness();
+    persisted.set("legacy-first", draft("legacy-first", "2026-07-16T07:59:00.000Z"));
+    persisted.set("legacy-second", draft("legacy-second"));
+
+    await expect(inbox.refresh({ ingestNative: false })).resolves.toEqual([draft("legacy-second")]);
+    await expect(inbox.consume("legacy-second")).resolves.toEqual([]);
+    expect([...persisted.values()]).toEqual([]);
+  });
+
+  it("does not acknowledge a supported payload when its durable write fails", async () => {
+    const clearPayloads = vi.fn();
+    const cleanup = vi.fn(async () => undefined);
+    const { inbox } = createHarness({
+      clearPayloads,
+      buildDraft: async ({ id, createdAt }) => ({
+        draft: draft(id, createdAt),
+        cleanup,
+      }),
+      writeDraft: async () => {
+        throw new Error("disk full");
+      },
+    });
+
+    await expect(inbox.refresh({ ingestNative: true })).rejects.toThrow("disk full");
+    expect(clearPayloads).not.toHaveBeenCalled();
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.ts
@@ -1,5 +1,6 @@
 import type { SharePayload } from "expo-sharing";
 
+import { SerializedAsyncQueue } from "../../lib/serialized-async-queue";
 import { hasIncomingShareContent, type IncomingShareDraft } from "./incoming-share-model";
 
 export interface IncomingShareInboxDependencies {
@@ -27,16 +28,13 @@ export function sortAndDedupeIncomingShares(
   drafts: ReadonlyArray<IncomingShareDraft>,
 ): ReadonlyArray<IncomingShareDraft> {
   const ids = new Set<string>();
-  const contentKeys = new Set<string>();
   return [...drafts]
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
     .filter((draft) => {
-      const contentKey = incomingShareContentKey(draft);
-      if (ids.has(draft.id) || contentKeys.has(contentKey)) {
+      if (ids.has(draft.id)) {
         return false;
       }
       ids.add(draft.id);
-      contentKeys.add(contentKey);
       return true;
     });
 }
@@ -58,17 +56,12 @@ function incomingShareContentKey(draft: IncomingShareDraft): string {
  * or a foreground refresh from restoring an item after it has been consumed.
  */
 export class IncomingShareInbox {
-  private operationTail: Promise<void> = Promise.resolve();
+  private readonly operations = new SerializedAsyncQueue();
 
   constructor(private readonly dependencies: IncomingShareInboxDependencies) {}
 
   private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.operationTail.then(operation, operation);
-    this.operationTail = result.then(
-      () => undefined,
-      () => undefined,
-    );
-    return result;
+    return this.operations.run(operation);
   }
 
   private clearNativePayloads(): void {

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.ts
@@ -160,4 +160,32 @@ export class IncomingShareInbox {
       );
     });
   }
+
+  releaseReservation(
+    shareId: string,
+    expectedDestination: IncomingShareDestination,
+  ): Promise<ReadonlyArray<IncomingShareDraft>> {
+    return this.runExclusive(async () => {
+      const persisted = await this.dependencies.loadDrafts();
+      const target = persisted.find((draft) => draft.id === shareId);
+      if (!target) {
+        throw new Error("The shared content is no longer available.");
+      }
+      if (!target.destination) {
+        return sortAndDedupeIncomingShares(persisted);
+      }
+      if (
+        target.destination.environmentId !== expectedDestination.environmentId ||
+        target.destination.projectId !== expectedDestination.projectId
+      ) {
+        throw new Error("The shared content reservation changed before it could be released.");
+      }
+
+      const { destination: _destination, ...unreserved } = target;
+      await this.dependencies.writeDraft(unreserved);
+      return sortAndDedupeIncomingShares(
+        persisted.map((draft) => (draft.id === shareId ? unreserved : draft)),
+      );
+    });
+  }
 }

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.ts
@@ -169,7 +169,9 @@ export class IncomingShareInbox {
       const persisted = await this.dependencies.loadDrafts();
       const target = persisted.find((draft) => draft.id === shareId);
       if (!target) {
-        throw new Error("The shared content is no longer available.");
+        // Conditional release is idempotent: if another operation already
+        // consumed the share, no reservation remains to clean up.
+        return sortAndDedupeIncomingShares(persisted);
       }
       if (!target.destination) {
         return sortAndDedupeIncomingShares(persisted);

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.ts
@@ -1,0 +1,166 @@
+import type { SharePayload } from "expo-sharing";
+
+import { hasIncomingShareContent, type IncomingShareDraft } from "./incoming-share-model";
+
+export interface IncomingShareInboxDependencies {
+  readonly loadDrafts: () => Promise<ReadonlyArray<IncomingShareDraft>>;
+  readonly writeDraft: (draft: IncomingShareDraft) => Promise<void>;
+  readonly removeDraft: (shareId: string) => Promise<void>;
+  readonly getPayloads: () => ReadonlyArray<SharePayload>;
+  readonly clearPayloads: () => void;
+  readonly buildDraft: (input: {
+    readonly payloads: ReadonlyArray<SharePayload>;
+    readonly id: string;
+    readonly createdAt: string;
+  }) => Promise<{
+    readonly draft: IncomingShareDraft;
+    readonly cleanup: () => Promise<void>;
+  }>;
+  readonly cleanupReplayedPayloads?: (payloads: ReadonlyArray<SharePayload>) => Promise<void>;
+  readonly idForPayloads: (payloads: ReadonlyArray<SharePayload>) => Promise<string>;
+  readonly now: () => string;
+  readonly onClearError?: (error: unknown) => void;
+  readonly onCleanupError?: (error: unknown) => void;
+}
+
+export function sortAndDedupeIncomingShares(
+  drafts: ReadonlyArray<IncomingShareDraft>,
+): ReadonlyArray<IncomingShareDraft> {
+  const ids = new Set<string>();
+  const contentKeys = new Set<string>();
+  return [...drafts]
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+    .filter((draft) => {
+      const contentKey = incomingShareContentKey(draft);
+      if (ids.has(draft.id) || contentKeys.has(contentKey)) {
+        return false;
+      }
+      ids.add(draft.id);
+      contentKeys.add(contentKey);
+      return true;
+    });
+}
+
+function incomingShareContentKey(draft: IncomingShareDraft): string {
+  return JSON.stringify([
+    draft.text,
+    draft.attachments.map((attachment) => [
+      attachment.name,
+      attachment.mimeType,
+      attachment.sizeBytes,
+      attachment.dataUrl,
+    ]),
+  ]);
+}
+
+/**
+ * Serializes every durable inbox mutation. This prevents a stale storage load
+ * or a foreground refresh from restoring an item after it has been consumed.
+ */
+export class IncomingShareInbox {
+  private operationTail: Promise<void> = Promise.resolve();
+
+  constructor(private readonly dependencies: IncomingShareInboxDependencies) {}
+
+  private runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationTail.then(operation, operation);
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private clearNativePayloads(): void {
+    try {
+      this.dependencies.clearPayloads();
+    } catch (error) {
+      this.dependencies.onClearError?.(error);
+    }
+  }
+
+  private async cleanup(operation: () => Promise<void>): Promise<void> {
+    try {
+      await operation();
+    } catch (error) {
+      this.dependencies.onCleanupError?.(error);
+    }
+  }
+
+  refresh(options: { readonly ingestNative: boolean }): Promise<ReadonlyArray<IncomingShareDraft>> {
+    return this.runExclusive(async () => {
+      const loaded = await this.dependencies.loadDrafts();
+      const persisted = sortAndDedupeIncomingShares(loaded);
+      if (!options.ingestNative) {
+        return persisted;
+      }
+
+      const payloads = this.dependencies.getPayloads();
+      if (payloads.length === 0) {
+        return persisted;
+      }
+
+      // A share extension payload remains available until the containing app
+      // acknowledges it. Use a content-derived id so a crash after the durable
+      // write but before acknowledgement reuses the same inbox item.
+      const shareId = await this.dependencies.idForPayloads(payloads);
+      if (loaded.some((draft) => draft.id === shareId)) {
+        if (this.dependencies.cleanupReplayedPayloads) {
+          await this.cleanup(() => this.dependencies.cleanupReplayedPayloads!(payloads));
+        }
+        this.clearNativePayloads();
+        return persisted;
+      }
+
+      const built = await this.dependencies.buildDraft({
+        payloads,
+        id: shareId,
+        createdAt: this.dependencies.now(),
+      });
+      const { draft } = built;
+      if (!hasIncomingShareContent(draft)) {
+        // Unsupported native payloads cannot become actionable on retry and
+        // would otherwise reopen the project picker on every foreground.
+        await this.cleanup(built.cleanup);
+        this.clearNativePayloads();
+        throw new Error(
+          draft.warnings[0] ?? "The shared content is not supported by the composer.",
+        );
+      }
+
+      // The durable inbox write is the transaction boundary. Never clear the
+      // native handoff first: a process termination must leave one recoverable
+      // copy on one side of the boundary.
+      await this.dependencies.writeDraft(draft);
+      await this.cleanup(built.cleanup);
+      this.clearNativePayloads();
+      return sortAndDedupeIncomingShares([draft, ...persisted]);
+    });
+  }
+
+  consume(shareId: string): Promise<ReadonlyArray<IncomingShareDraft>> {
+    return this.runExclusive(async () => {
+      const persisted = await this.dependencies.loadDrafts();
+      const target = persisted.find((draft) => draft.id === shareId);
+      const targetContentKey = target ? incomingShareContentKey(target) : null;
+      const consumedIds = targetContentKey
+        ? [
+            ...persisted
+              .filter(
+                (draft) =>
+                  draft.id !== shareId && incomingShareContentKey(draft) === targetContentKey,
+              )
+              .map((draft) => draft.id),
+            // Remove the item the UI knows about last. If duplicate cleanup
+            // fails midway, a retry can still find this item and its content
+            // key to finish the whole operation.
+            shareId,
+          ]
+        : [shareId];
+      for (const consumedId of new Set(consumedIds)) {
+        await this.dependencies.removeDraft(consumedId);
+      }
+      return sortAndDedupeIncomingShares(await this.dependencies.loadDrafts());
+    });
+  }
+}

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.ts
@@ -1,7 +1,11 @@
 import type { SharePayload } from "expo-sharing";
 
 import { SerializedAsyncQueue } from "../../lib/serialized-async-queue";
-import { hasIncomingShareContent, type IncomingShareDraft } from "./incoming-share-model";
+import {
+  hasIncomingShareContent,
+  type IncomingShareDestination,
+  type IncomingShareDraft,
+} from "./incoming-share-model";
 
 export interface IncomingShareInboxDependencies {
   readonly loadDrafts: () => Promise<ReadonlyArray<IncomingShareDraft>>;
@@ -126,6 +130,34 @@ export class IncomingShareInbox {
       // users may intentionally share identical content more than once.
       await this.dependencies.removeDraft(shareId);
       return sortAndDedupeIncomingShares(await this.dependencies.loadDrafts());
+    });
+  }
+
+  reserve(
+    shareId: string,
+    destination: IncomingShareDestination,
+  ): Promise<ReadonlyArray<IncomingShareDraft>> {
+    return this.runExclusive(async () => {
+      const persisted = await this.dependencies.loadDrafts();
+      const target = persisted.find((draft) => draft.id === shareId);
+      if (!target) {
+        throw new Error("The shared content is no longer available.");
+      }
+      if (target.destination) {
+        if (
+          target.destination.environmentId !== destination.environmentId ||
+          target.destination.projectId !== destination.projectId
+        ) {
+          throw new Error("The shared content is already reserved for another project draft.");
+        }
+        return sortAndDedupeIncomingShares(persisted);
+      }
+
+      const reserved = { ...target, destination };
+      await this.dependencies.writeDraft(reserved);
+      return sortAndDedupeIncomingShares(
+        persisted.map((draft) => (draft.id === shareId ? reserved : draft)),
+      );
     });
   }
 }

--- a/apps/mobile/src/features/sharing/incoming-share-inbox.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-inbox.ts
@@ -39,18 +39,6 @@ export function sortAndDedupeIncomingShares(
     });
 }
 
-function incomingShareContentKey(draft: IncomingShareDraft): string {
-  return JSON.stringify([
-    draft.text,
-    draft.attachments.map((attachment) => [
-      attachment.name,
-      attachment.mimeType,
-      attachment.sizeBytes,
-      attachment.dataUrl,
-    ]),
-  ]);
-}
-
 /**
  * Serializes every durable inbox mutation. This prevents a stale storage load
  * or a foreground refresh from restoring an item after it has been consumed.
@@ -133,26 +121,10 @@ export class IncomingShareInbox {
 
   consume(shareId: string): Promise<ReadonlyArray<IncomingShareDraft>> {
     return this.runExclusive(async () => {
-      const persisted = await this.dependencies.loadDrafts();
-      const target = persisted.find((draft) => draft.id === shareId);
-      const targetContentKey = target ? incomingShareContentKey(target) : null;
-      const consumedIds = targetContentKey
-        ? [
-            ...persisted
-              .filter(
-                (draft) =>
-                  draft.id !== shareId && incomingShareContentKey(draft) === targetContentKey,
-              )
-              .map((draft) => draft.id),
-            // Remove the item the UI knows about last. If duplicate cleanup
-            // fails midway, a retry can still find this item and its content
-            // key to finish the whole operation.
-            shareId,
-          ]
-        : [shareId];
-      for (const consumedId of new Set(consumedIds)) {
-        await this.dependencies.removeDraft(consumedId);
-      }
+      // The stable payload-derived id already coalesces retries of the same
+      // native handoff. Payload equality cannot identify duplicate handoffs:
+      // users may intentionally share identical content more than once.
+      await this.dependencies.removeDraft(shareId);
       return sortAndDedupeIncomingShares(await this.dependencies.loadDrafts());
     });
   }

--- a/apps/mobile/src/features/sharing/incoming-share-model.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.test.ts
@@ -120,4 +120,77 @@ describe("incoming native shares", () => {
     expect(readBase64).toHaveBeenCalledTimes(PROVIDER_SEND_TURN_MAX_ATTACHMENTS);
     expect(removeOwnedFile).toHaveBeenCalledTimes(payloads.length);
   });
+
+  it("maps duplicate image payloads to distinct resolved files", async () => {
+    const duplicate: SharePayload = {
+      shareType: "image",
+      value: "content://shared/screenshot",
+      mimeType: "image/png",
+    };
+    const resolvedPayloads: ResolvedSharePayload[] = [
+      {
+        ...duplicate,
+        contentUri: "file:///cache/first.png",
+        contentType: "image",
+        contentMimeType: "image/png",
+        contentSize: 3,
+        originalName: "first.png",
+      },
+      {
+        ...duplicate,
+        contentUri: "file:///cache/second.png",
+        contentType: "image",
+        contentMimeType: "image/png",
+        contentSize: 3,
+        originalName: "second.png",
+      },
+    ];
+    const readBase64 = vi.fn(async (uri: string) =>
+      uri.includes("first") ? "Zmlyc3Q=" : "c2Vjb25k",
+    );
+    const removeOwnedFile = vi.fn(async () => undefined);
+
+    const result = await buildIncomingShareDraft({
+      id: "share-duplicates",
+      createdAt: "2026-07-16T08:00:00.000Z",
+      payloads: [duplicate, duplicate],
+      resolvedPayloads,
+      fileReader: { readBase64, removeOwnedFile },
+    });
+
+    expect(readBase64.mock.calls.map(([uri]) => uri)).toEqual([
+      "file:///cache/first.png",
+      "file:///cache/second.png",
+    ]);
+    expect(result.attachments.map((attachment) => attachment.name)).toEqual([
+      "first.png",
+      "second.png",
+    ]);
+    expect(removeOwnedFile).toHaveBeenCalledWith("file:///cache/first.png");
+    expect(removeOwnedFile).toHaveBeenCalledWith("file:///cache/second.png");
+  });
+
+  it("keeps imported content when temporary-file cleanup fails", async () => {
+    const image: SharePayload = {
+      shareType: "image",
+      value: "file:///shared/screenshot.png",
+      mimeType: "image/png",
+    };
+
+    const result = await buildIncomingShareDraft({
+      id: "share-cleanup-failure",
+      createdAt: "2026-07-16T08:00:00.000Z",
+      payloads: [image],
+      resolvedPayloads: [],
+      fileReader: {
+        readBase64: async () => "YWJj",
+        removeOwnedFile: async () => {
+          throw new Error("file is busy");
+        },
+      },
+    });
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.warnings).toEqual([]);
+  });
 });

--- a/apps/mobile/src/features/sharing/incoming-share-model.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import {
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+} from "@t3tools/contracts";
+import type { ResolvedSharePayload, SharePayload } from "expo-sharing";
+
+import { buildIncomingShareDraft, hasIncomingShareContent } from "./incoming-share-model";
+
+describe("incoming native shares", () => {
+  it("converts shared text, URLs, and images into a durable composer draft", async () => {
+    const image: SharePayload = {
+      shareType: "image",
+      value: "file:///shared/Screenshot.png",
+      mimeType: "image/png",
+    };
+    const payloads: SharePayload[] = [
+      { shareType: "text", value: "Please explain this error" },
+      { shareType: "url", value: "https://example.com/issue/1" },
+      { shareType: "text", value: "Please explain this error" },
+      image,
+    ];
+    const resolvedImage: ResolvedSharePayload = {
+      ...image,
+      contentUri: image.value,
+      contentType: "image",
+      contentMimeType: "image/png",
+      contentSize: 3,
+      originalName: "Screenshot.png",
+    };
+    const removeOwnedFile = vi.fn(() => Promise.resolve());
+
+    const result = await buildIncomingShareDraft({
+      id: "share-1",
+      createdAt: "2026-07-15T10:00:00.000Z",
+      payloads,
+      resolvedPayloads: [resolvedImage],
+      fileReader: {
+        readBase64: async () => "YWJj",
+        removeOwnedFile,
+      },
+    });
+
+    expect(result).toEqual({
+      schemaVersion: 1,
+      id: "share-1",
+      createdAt: "2026-07-15T10:00:00.000Z",
+      text: "Please explain this error\n\nhttps://example.com/issue/1",
+      attachments: [
+        {
+          id: "share-1:image:3",
+          type: "image",
+          name: "Screenshot.png",
+          mimeType: "image/png",
+          sizeBytes: 3,
+          dataUrl: "data:image/png;base64,YWJj",
+          previewUri: "data:image/png;base64,YWJj",
+        },
+      ],
+      warnings: [],
+    });
+    expect(removeOwnedFile).toHaveBeenCalledWith(image.value);
+    expect(hasIncomingShareContent(result)).toBe(true);
+  });
+
+  it("skips oversized images and releases the temporary native file", async () => {
+    const image: SharePayload = {
+      shareType: "image",
+      value: "file:///shared/huge.png",
+      mimeType: "image/png",
+    };
+    const readBase64 = vi.fn(async () => "unused");
+    const removeOwnedFile = vi.fn(() => Promise.resolve());
+
+    const result = await buildIncomingShareDraft({
+      id: "share-2",
+      createdAt: "2026-07-15T10:00:00.000Z",
+      payloads: [image],
+      resolvedPayloads: [
+        {
+          ...image,
+          contentUri: image.value,
+          contentType: "image",
+          contentMimeType: "image/png",
+          contentSize: PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1,
+          originalName: "huge.png",
+        },
+      ],
+      fileReader: { readBase64, removeOwnedFile },
+    });
+
+    expect(result.attachments).toEqual([]);
+    expect(result.warnings).toEqual(["'huge.png' exceeds the 10 MB attachment limit."]);
+    expect(readBase64).not.toHaveBeenCalled();
+    expect(removeOwnedFile).toHaveBeenCalledWith(image.value);
+    expect(hasIncomingShareContent(result)).toBe(false);
+  });
+
+  it("releases every temporary file when a share exceeds the attachment limit", async () => {
+    const payloads = Array.from({ length: PROVIDER_SEND_TURN_MAX_ATTACHMENTS + 1 }, (_, index) => ({
+      shareType: "image" as const,
+      value: `file:///shared/${index}.png`,
+      mimeType: "image/png",
+    }));
+    const removeOwnedFile = vi.fn(() => Promise.resolve());
+    const readBase64 = vi.fn(async () => "YWJj");
+
+    const result = await buildIncomingShareDraft({
+      id: "share-3",
+      createdAt: "2026-07-15T10:00:00.000Z",
+      payloads,
+      resolvedPayloads: [],
+      fileReader: { readBase64, removeOwnedFile },
+    });
+
+    expect(result.attachments).toHaveLength(PROVIDER_SEND_TURN_MAX_ATTACHMENTS);
+    expect(result.warnings).toEqual([
+      `Only the first ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} shared images were attached.`,
+    ]);
+    expect(readBase64).toHaveBeenCalledTimes(PROVIDER_SEND_TURN_MAX_ATTACHMENTS);
+    expect(removeOwnedFile).toHaveBeenCalledTimes(payloads.length);
+  });
+});

--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -59,14 +59,42 @@ function resolvedImageFor(
   payload: SharePayload,
   index: number,
   resolvedPayloads: ReadonlyArray<ResolvedSharePayload>,
+  consumedIndexes: Set<number>,
 ): ResolvedSharePayload | undefined {
   const sameIndex = resolvedPayloads[index];
-  if (sameIndex?.shareType === payload.shareType && sameIndex.value === payload.value) {
+  if (
+    !consumedIndexes.has(index) &&
+    sameIndex?.shareType === payload.shareType &&
+    sameIndex.value === payload.value
+  ) {
+    consumedIndexes.add(index);
     return sameIndex;
   }
-  return resolvedPayloads.find(
-    (candidate) => candidate.shareType === payload.shareType && candidate.value === payload.value,
+  const matchingIndex = resolvedPayloads.findIndex(
+    (candidate, candidateIndex) =>
+      !consumedIndexes.has(candidateIndex) &&
+      candidate.shareType === payload.shareType &&
+      candidate.value === payload.value,
   );
+  if (matchingIndex < 0) {
+    return undefined;
+  }
+  consumedIndexes.add(matchingIndex);
+  return resolvedPayloads[matchingIndex];
+}
+
+async function releaseOwnedFiles(
+  fileReader: IncomingShareFileReader,
+  uris: ReadonlyArray<string | undefined>,
+): Promise<void> {
+  for (const uri of new Set(uris.filter((candidate): candidate is string => Boolean(candidate)))) {
+    try {
+      await fileReader.removeOwnedFile(uri);
+    } catch {
+      // Temporary-file cleanup is best-effort and must never discard content
+      // that was successfully converted into a durable composer attachment.
+    }
+  }
 }
 
 function fallbackName(uri: string, index: number, mimeType: string): string {
@@ -91,13 +119,19 @@ export async function buildIncomingShareDraft(input: {
 }): Promise<IncomingShareDraft> {
   const attachments: DraftComposerImageAttachment[] = [];
   const warnings: string[] = [];
+  const consumedResolvedPayloadIndexes = new Set<number>();
   let warnedAttachmentLimit = false;
 
   for (const [index, payload] of input.payloads.entries()) {
     if (payload.shareType !== "image") {
       continue;
     }
-    const resolved = resolvedImageFor(payload, index, input.resolvedPayloads);
+    const resolved = resolvedImageFor(
+      payload,
+      index,
+      input.resolvedPayloads,
+      consumedResolvedPayloadIndexes,
+    );
     const uri = resolved?.contentUri ?? payload.value;
     if (attachments.length >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
       if (!warnedAttachmentLimit) {
@@ -106,15 +140,14 @@ export async function buildIncomingShareDraft(input: {
         );
         warnedAttachmentLimit = true;
       }
-      if (uri) {
-        await input.fileReader.removeOwnedFile(uri);
-      }
+      await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
       continue;
     }
 
     const mimeType = (resolved?.contentMimeType ?? payload.mimeType ?? "image/png").toLowerCase();
     if (!uri || !mimeType.startsWith("image/")) {
       warnings.push("One shared item was not a supported image.");
+      await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
       continue;
     }
     if (
@@ -125,7 +158,7 @@ export async function buildIncomingShareDraft(input: {
       warnings.push(
         `'${resolved.originalName ?? fallbackName(uri, index, mimeType)}' exceeds the 10 MB attachment limit.`,
       );
-      await input.fileReader.removeOwnedFile(uri);
+      await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
       continue;
     }
 
@@ -153,7 +186,7 @@ export async function buildIncomingShareDraft(input: {
     } catch {
       warnings.push(`Could not read '${fallbackName(uri, index, mimeType)}'.`);
     } finally {
-      await input.fileReader.removeOwnedFile(uri);
+      await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
     }
   }
 

--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -1,0 +1,172 @@
+import {
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import type { ResolvedSharePayload, SharePayload } from "expo-sharing";
+
+import { DraftComposerImageAttachmentSchema } from "../../lib/composer-image-schema";
+import type { DraftComposerImageAttachment } from "../../lib/composerImages";
+import { estimateBase64ByteSize } from "../../lib/base64";
+
+export interface IncomingShareDraft {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly createdAt: string;
+  readonly text: string;
+  readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
+  readonly warnings: ReadonlyArray<string>;
+}
+
+export const IncomingShareDraftSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(1),
+  id: Schema.String,
+  createdAt: Schema.String,
+  text: Schema.String,
+  attachments: Schema.Array(DraftComposerImageAttachmentSchema),
+  warnings: Schema.Array(Schema.String),
+});
+
+const decodeIncomingShareDraftSync = Schema.decodeUnknownSync(IncomingShareDraftSchema);
+
+export function decodeIncomingShareDraft(value: unknown): IncomingShareDraft {
+  return decodeIncomingShareDraftSync(value);
+}
+
+export interface IncomingShareFileReader {
+  readonly readBase64: (uri: string) => Promise<string>;
+  readonly removeOwnedFile: (uri: string) => Promise<void> | void;
+}
+
+function sharedText(payloads: ReadonlyArray<SharePayload>): string {
+  const seen = new Set<string>();
+  const values: string[] = [];
+  for (const payload of payloads) {
+    if (payload.shareType !== "text" && payload.shareType !== "url") {
+      continue;
+    }
+    const value = payload.value.trim();
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    values.push(value);
+  }
+  return values.join("\n\n");
+}
+
+function resolvedImageFor(
+  payload: SharePayload,
+  index: number,
+  resolvedPayloads: ReadonlyArray<ResolvedSharePayload>,
+): ResolvedSharePayload | undefined {
+  const sameIndex = resolvedPayloads[index];
+  if (sameIndex?.shareType === payload.shareType && sameIndex.value === payload.value) {
+    return sameIndex;
+  }
+  return resolvedPayloads.find(
+    (candidate) => candidate.shareType === payload.shareType && candidate.value === payload.value,
+  );
+}
+
+function fallbackName(uri: string, index: number, mimeType: string): string {
+  try {
+    const pathName = new URL(uri).pathname.split("/").findLast((segment) => segment.length > 0);
+    if (pathName) {
+      return decodeURIComponent(pathName);
+    }
+  } catch {
+    // Fall through to a deterministic attachment name.
+  }
+  const extension = mimeType.split("/")[1]?.replace(/[^a-z0-9.+-]/gi, "") || "png";
+  return `shared-image-${index + 1}.${extension}`;
+}
+
+export async function buildIncomingShareDraft(input: {
+  readonly payloads: ReadonlyArray<SharePayload>;
+  readonly resolvedPayloads: ReadonlyArray<ResolvedSharePayload>;
+  readonly fileReader: IncomingShareFileReader;
+  readonly id: string;
+  readonly createdAt: string;
+}): Promise<IncomingShareDraft> {
+  const attachments: DraftComposerImageAttachment[] = [];
+  const warnings: string[] = [];
+  let warnedAttachmentLimit = false;
+
+  for (const [index, payload] of input.payloads.entries()) {
+    if (payload.shareType !== "image") {
+      continue;
+    }
+    const resolved = resolvedImageFor(payload, index, input.resolvedPayloads);
+    const uri = resolved?.contentUri ?? payload.value;
+    if (attachments.length >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+      if (!warnedAttachmentLimit) {
+        warnings.push(
+          `Only the first ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} shared images were attached.`,
+        );
+        warnedAttachmentLimit = true;
+      }
+      if (uri) {
+        await input.fileReader.removeOwnedFile(uri);
+      }
+      continue;
+    }
+
+    const mimeType = (resolved?.contentMimeType ?? payload.mimeType ?? "image/png").toLowerCase();
+    if (!uri || !mimeType.startsWith("image/")) {
+      warnings.push("One shared item was not a supported image.");
+      continue;
+    }
+    if (
+      resolved?.contentSize !== null &&
+      resolved?.contentSize !== undefined &&
+      resolved.contentSize > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+    ) {
+      warnings.push(
+        `'${resolved.originalName ?? fallbackName(uri, index, mimeType)}' exceeds the 10 MB attachment limit.`,
+      );
+      await input.fileReader.removeOwnedFile(uri);
+      continue;
+    }
+
+    try {
+      const base64 = await input.fileReader.readBase64(uri);
+      const sizeBytes = resolved?.contentSize ?? estimateBase64ByteSize(base64);
+      if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+        warnings.push(
+          `'${resolved?.originalName ?? fallbackName(uri, index, mimeType)}' exceeds the 10 MB attachment limit.`,
+        );
+        continue;
+      }
+      const dataUrl = `data:${mimeType};base64,${base64}`;
+      attachments.push({
+        id: `${input.id}:image:${index}`,
+        type: "image",
+        name: resolved?.originalName ?? fallbackName(uri, index, mimeType),
+        mimeType,
+        sizeBytes,
+        dataUrl,
+        // The share provider's file is temporary. A data-backed preview keeps
+        // the composer valid after its source file and App Group entry are gone.
+        previewUri: dataUrl,
+      });
+    } catch {
+      warnings.push(`Could not read '${fallbackName(uri, index, mimeType)}'.`);
+    } finally {
+      await input.fileReader.removeOwnedFile(uri);
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    id: input.id,
+    createdAt: input.createdAt,
+    text: sharedText(input.payloads),
+    attachments,
+    warnings,
+  };
+}
+
+export function hasIncomingShareContent(draft: IncomingShareDraft): boolean {
+  return draft.text.trim().length > 0 || draft.attachments.length > 0;
+}

--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -13,15 +13,27 @@ export interface IncomingShareDraft {
   readonly schemaVersion: 1;
   readonly id: string;
   readonly createdAt: string;
+  readonly destination?: IncomingShareDestination;
   readonly text: string;
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
   readonly warnings: ReadonlyArray<string>;
 }
 
+export interface IncomingShareDestination {
+  readonly environmentId: string;
+  readonly projectId: string;
+}
+
+const IncomingShareDestinationSchema = Schema.Struct({
+  environmentId: Schema.String,
+  projectId: Schema.String,
+});
+
 export const IncomingShareDraftSchema = Schema.Struct({
   schemaVersion: Schema.Literal(1),
   id: Schema.String,
   createdAt: Schema.String,
+  destination: Schema.optional(IncomingShareDestinationSchema),
   text: Schema.String,
   attachments: Schema.Array(DraftComposerImageAttachmentSchema),
   warnings: Schema.Array(Schema.String),

--- a/apps/mobile/src/features/sharing/incoming-share-presentation.test.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-presentation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  EMPTY_INCOMING_SHARE_PRESENTATION_STATE,
+  transitionIncomingSharePresentation,
+} from "./incoming-share-presentation";
+
+describe("incoming share presentation", () => {
+  it("does not reopen a dismissed share when refresh returns a new object for the same id", () => {
+    const presented = transitionIncomingSharePresentation(EMPTY_INCOMING_SHARE_PRESENTATION_STATE, {
+      isShareSheetPresented: false,
+      pendingShareId: "share-1",
+    });
+    expect(presented.shareIdToPresent).toBe("share-1");
+
+    const whilePresented = transitionIncomingSharePresentation(presented.state, {
+      isShareSheetPresented: true,
+      pendingShareId: "share-1",
+    });
+    expect(whilePresented).toEqual({ state: presented.state, shareIdToPresent: null });
+
+    const dismissed = transitionIncomingSharePresentation(whilePresented.state, {
+      isShareSheetPresented: false,
+      pendingShareId: "share-1",
+    });
+    expect(dismissed.state.dismissedShareId).toBe("share-1");
+
+    expect(
+      transitionIncomingSharePresentation(dismissed.state, {
+        isShareSheetPresented: false,
+        pendingShareId: "share-1",
+      }),
+    ).toEqual({ state: dismissed.state, shareIdToPresent: null });
+  });
+
+  it("presents the next queued share immediately after the previous sheet closes", () => {
+    const first = transitionIncomingSharePresentation(EMPTY_INCOMING_SHARE_PRESENTATION_STATE, {
+      isShareSheetPresented: false,
+      pendingShareId: "share-1",
+    });
+
+    const next = transitionIncomingSharePresentation(first.state, {
+      isShareSheetPresented: false,
+      pendingShareId: "share-2",
+    });
+    expect(next.shareIdToPresent).toBe("share-2");
+    expect(next.state).toEqual({ presentedShareId: "share-2", dismissedShareId: null });
+  });
+
+  it("forgets dismissal after consumption so a later handoff may reuse the id", () => {
+    const dismissed = {
+      presentedShareId: null,
+      dismissedShareId: "share-1",
+    };
+    const consumed = transitionIncomingSharePresentation(dismissed, {
+      isShareSheetPresented: false,
+      pendingShareId: null,
+    });
+    expect(consumed.state).toEqual(EMPTY_INCOMING_SHARE_PRESENTATION_STATE);
+
+    expect(
+      transitionIncomingSharePresentation(consumed.state, {
+        isShareSheetPresented: false,
+        pendingShareId: "share-1",
+      }).shareIdToPresent,
+    ).toBe("share-1");
+  });
+
+  it("forgets a consumed presentation while its sheet is still mounted", () => {
+    const presented = {
+      presentedShareId: "share-1",
+      dismissedShareId: null,
+    };
+    const consumed = transitionIncomingSharePresentation(presented, {
+      isShareSheetPresented: true,
+      pendingShareId: null,
+    });
+    expect(consumed.state).toEqual(EMPTY_INCOMING_SHARE_PRESENTATION_STATE);
+
+    const replacementWhileOpen = transitionIncomingSharePresentation(consumed.state, {
+      isShareSheetPresented: true,
+      pendingShareId: "share-1",
+    });
+    expect(replacementWhileOpen.shareIdToPresent).toBeNull();
+    expect(
+      transitionIncomingSharePresentation(replacementWhileOpen.state, {
+        isShareSheetPresented: false,
+        pendingShareId: "share-1",
+      }).shareIdToPresent,
+    ).toBe("share-1");
+  });
+});

--- a/apps/mobile/src/features/sharing/incoming-share-presentation.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-presentation.ts
@@ -1,0 +1,71 @@
+export interface IncomingSharePresentationState {
+  readonly presentedShareId: string | null;
+  readonly dismissedShareId: string | null;
+}
+
+export interface IncomingSharePresentationTransition {
+  readonly state: IncomingSharePresentationState;
+  readonly shareIdToPresent: string | null;
+}
+
+export const EMPTY_INCOMING_SHARE_PRESENTATION_STATE: IncomingSharePresentationState = {
+  presentedShareId: null,
+  dismissedShareId: null,
+};
+
+/**
+ * Tracks presentation by durable share id rather than object identity. A user
+ * dismissal suppresses only that inbox item until it is consumed or replaced.
+ */
+export function transitionIncomingSharePresentation(
+  state: IncomingSharePresentationState,
+  input: {
+    readonly isShareSheetPresented: boolean;
+    readonly pendingShareId: string | null;
+  },
+): IncomingSharePresentationTransition {
+  if (input.isShareSheetPresented) {
+    if (state.presentedShareId !== null && input.pendingShareId !== state.presentedShareId) {
+      // Consumption may happen while the sheet remains mounted. Forget the
+      // old presentation immediately so a later handoff may reuse its id.
+      return {
+        state: EMPTY_INCOMING_SHARE_PRESENTATION_STATE,
+        shareIdToPresent: null,
+      };
+    }
+    return { state, shareIdToPresent: null };
+  }
+
+  let nextState = state;
+  if (state.presentedShareId !== null) {
+    if (input.pendingShareId === state.presentedShareId) {
+      return {
+        state: {
+          presentedShareId: null,
+          dismissedShareId: state.presentedShareId,
+        },
+        shareIdToPresent: null,
+      };
+    }
+    nextState = { ...state, presentedShareId: null };
+  }
+
+  if (input.pendingShareId === null) {
+    return {
+      state: EMPTY_INCOMING_SHARE_PRESENTATION_STATE,
+      shareIdToPresent: null,
+    };
+  }
+
+  if (nextState.dismissedShareId === input.pendingShareId) {
+    return { state: nextState, shareIdToPresent: null };
+  }
+
+  return {
+    state: {
+      presentedShareId: input.pendingShareId,
+      dismissedShareId: null,
+    },
+    shareIdToPresent: input.pendingShareId,
+  };
+}

--- a/apps/mobile/src/features/sharing/incoming-share-storage.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-storage.ts
@@ -1,0 +1,80 @@
+import * as Schema from "effect/Schema";
+
+import { decodeIncomingShareDraft, type IncomingShareDraft } from "./incoming-share-model";
+
+const INCOMING_SHARE_DIRECTORY = "incoming-shares";
+
+export class IncomingShareStorageError extends Schema.TaggedErrorClass<IncomingShareStorageError>()(
+  "IncomingShareStorageError",
+  {
+    operation: Schema.Literals(["load", "write", "remove"]),
+    shareId: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Incoming share storage operation ${this.operation} failed for ${this.shareId ?? "unknown"}.`;
+  }
+}
+
+function fileName(shareId: string): string {
+  return `${encodeURIComponent(shareId)}.json`;
+}
+
+async function getDirectory() {
+  const { Directory, Paths } = await import("expo-file-system");
+  const directory = new Directory(Paths.document, INCOMING_SHARE_DIRECTORY);
+  directory.create({ idempotent: true, intermediates: true });
+  return directory;
+}
+
+async function getFile(shareId: string) {
+  const { File } = await import("expo-file-system");
+  return new File(await getDirectory(), fileName(shareId));
+}
+
+export async function loadIncomingShareDrafts(): Promise<ReadonlyArray<IncomingShareDraft>> {
+  try {
+    const { File } = await import("expo-file-system");
+    const drafts: IncomingShareDraft[] = [];
+    for (const entry of (await getDirectory()).list()) {
+      if (!(entry instanceof File) || !entry.name.endsWith(".json")) {
+        continue;
+      }
+      try {
+        drafts.push(decodeIncomingShareDraft(JSON.parse(await entry.text()) as unknown));
+      } catch (cause) {
+        console.warn(
+          "[incoming-share] ignored invalid persisted share",
+          new IncomingShareStorageError({ operation: "load", shareId: null, cause }),
+        );
+      }
+    }
+    return drafts.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  } catch (cause) {
+    throw new IncomingShareStorageError({ operation: "load", shareId: null, cause });
+  }
+}
+
+export async function writeIncomingShareDraft(draft: IncomingShareDraft): Promise<void> {
+  try {
+    const file = await getFile(draft.id);
+    if (!file.exists) {
+      file.create({ intermediates: true, overwrite: true });
+    }
+    file.write(JSON.stringify(draft));
+  } catch (cause) {
+    throw new IncomingShareStorageError({ operation: "write", shareId: draft.id, cause });
+  }
+}
+
+export async function removeIncomingShareDraft(shareId: string): Promise<void> {
+  try {
+    const file = await getFile(shareId);
+    if (file.exists) {
+      file.delete();
+    }
+  } catch (cause) {
+    throw new IncomingShareStorageError({ operation: "remove", shareId, cause });
+  }
+}

--- a/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftRouteScreen.tsx
@@ -9,6 +9,7 @@ type NewTaskDraftRouteParams = {
   readonly projectId?: string | string[];
   readonly title?: string | string[];
   readonly pendingTaskId?: string | string[];
+  readonly incomingShareId?: string | string[];
 };
 
 export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraftRouteParams>) {
@@ -36,6 +37,9 @@ export function NewTaskDraftRouteScreen({ route }: StaticScreenProps<NewTaskDraf
       />
       <NewTaskDraftScreen
         initialProjectRef={initialProjectRef}
+        incomingShareId={
+          Array.isArray(params.incomingShareId) ? params.incomingShareId[0] : params.incomingShareId
+        }
         pendingTaskId={
           Array.isArray(params.pendingTaskId) ? params.pendingTaskId[0] : params.pendingTaskId
         }

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,4 +1,4 @@
-import { NativeStackScreenOptions } from "../../native/StackHeader";
+import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
@@ -35,7 +35,11 @@ import {
   resolveProviderOptionDescriptors,
 } from "../../lib/providerOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
-import { getComposerDraftSnapshot } from "../../state/use-composer-drafts";
+import {
+  flushComposerDrafts,
+  getComposerDraftSnapshot,
+  mergeComposerDraftContent,
+} from "../../state/use-composer-drafts";
 import { useProjects } from "../../state/entities";
 import { deriveThreadTitleFromPrompt } from "../../lib/projectThreadStartTurn";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
@@ -43,6 +47,7 @@ import { enqueueThreadOutboxMessage, removeThreadOutboxMessage } from "../../sta
 import { useRemoteConnectionStatus } from "../../state/use-remote-environment-registry";
 import { branchBadgeLabel, useNewTaskFlow } from "./new-task-flow-provider";
 import { useCreateProjectThread } from "./use-project-actions";
+import { useIncomingShare } from "../sharing/IncomingShareProvider";
 
 function formatWorkspaceLabel(input: {
   readonly workspaceMode: string;
@@ -63,11 +68,14 @@ export function NewTaskDraftScreen(props: {
   };
   /** Queued outbox message id when editing an existing pending task. */
   readonly pendingTaskId?: string;
+  /** Durable native share inbox item to merge into this project draft. */
+  readonly incomingShareId?: string;
 }) {
   const projects = useProjects();
   const createProjectThread = useCreateProjectThread();
   const flow = useNewTaskFlow();
   const navigation = useNavigation();
+  const { consumeShare, pendingShare } = useIncomingShare();
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
@@ -82,6 +90,12 @@ export function NewTaskDraftScreen(props: {
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
+  const [isImportingShare, setIsImportingShare] = useState(false);
+  const [importedIncomingShareId, setImportedIncomingShareId] = useState<string | null>(null);
+  const [shareImportAttempt, setShareImportAttempt] = useState(0);
+  const appliedIncomingShareIdRef = useRef<string | null>(null);
+  const isIncomingShareReady =
+    !props.incomingShareId || importedIncomingShareId === props.incomingShareId;
   const appliedInitialProjectKeyRef = useRef<string | null>(null);
   useEffect(() => {
     return () => {
@@ -197,6 +211,53 @@ export function NewTaskDraftScreen(props: {
     loadedBranchesProjectKeyRef.current = projectKey;
     void flow.loadBranches();
   }, [flow.loadBranches, selectedProject]);
+
+  useEffect(() => {
+    const shareId = props.incomingShareId;
+    const draftKey = flow.draftKey;
+    if (
+      !shareId ||
+      !draftKey ||
+      pendingShare?.id !== shareId ||
+      appliedIncomingShareIdRef.current === shareId
+    ) {
+      return;
+    }
+
+    appliedIncomingShareIdRef.current = shareId;
+    setIsImportingShare(true);
+    void mergeComposerDraftContent(draftKey, {
+      text: pendingShare.text,
+      attachments: pendingShare.attachments,
+    })
+      .then(async ({ skippedAttachmentCount }) => {
+        await consumeShare(shareId);
+        setImportedIncomingShareId(shareId);
+        const warnings = [...pendingShare.warnings];
+        if (skippedAttachmentCount > 0) {
+          warnings.push(
+            `${skippedAttachmentCount} shared image${skippedAttachmentCount === 1 ? " was" : "s were"} skipped because this draft reached the attachment limit.`,
+          );
+        }
+        if (warnings.length > 0) {
+          Alert.alert("Some shared content was skipped", warnings.join("\n"));
+        }
+      })
+      .catch((error) => {
+        appliedIncomingShareIdRef.current = null;
+        Alert.alert(
+          "Could not import shared content",
+          error instanceof Error ? error.message : "The shared content could not be saved.",
+          [
+            {
+              text: "Retry",
+              onPress: () => setShareImportAttempt((attempt) => attempt + 1),
+            },
+          ],
+        );
+      })
+      .finally(() => setIsImportingShare(false));
+  }, [consumeShare, flow.draftKey, pendingShare, props.incomingShareId, shareImportAttempt]);
 
   useEffect(() => {
     // Android starts with the collapsed composer pill (like an open thread)
@@ -450,6 +511,21 @@ export function NewTaskDraftScreen(props: {
     }
   }
 
+  async function handleSaveDraft(): Promise<void> {
+    if (!flow.draftKey || !isIncomingShareReady || isImportingShare || flow.submitting) {
+      return;
+    }
+    try {
+      await flushComposerDrafts();
+      navigation.getParent()?.goBack();
+    } catch (error) {
+      Alert.alert(
+        "Could not save draft",
+        error instanceof Error ? error.message : "The task draft could not be saved.",
+      );
+    }
+  }
+
   const handleNativePasteImages = useCallback(
     async (uris: ReadonlyArray<string>) => {
       try {
@@ -620,6 +696,8 @@ export function NewTaskDraftScreen(props: {
     Boolean(flow.selectedProject) &&
     Boolean(flow.selectedModel) &&
     flow.prompt.trim().length > 0 &&
+    isIncomingShareReady &&
+    !isImportingShare &&
     !flow.submitting &&
     !(flow.workspaceMode === "worktree" && !flow.selectedBranchName);
   const promptEditor = (
@@ -724,7 +802,22 @@ export function NewTaskDraftScreen(props: {
     return (
       <View className="flex-1 bg-screen">
         <NativeStackScreenOptions options={{ headerShown: false }} />
-        <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
+        <AndroidScreenHeader
+          title="New Thread"
+          onBack={() => navigation.goBack()}
+          actions={
+            props.incomingShareId
+              ? [
+                  {
+                    accessibilityLabel: "Save task draft",
+                    icon: "archivebox",
+                    onPress: () => void handleSaveDraft(),
+                    disabled: !isIncomingShareReady || isImportingShare || flow.submitting,
+                  },
+                ]
+              : undefined
+          }
+        />
 
         <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
           <View className="flex-1" />
@@ -798,6 +891,17 @@ export function NewTaskDraftScreen(props: {
   return (
     <View className="flex-1 bg-sheet">
       <NativeStackScreenOptions options={{ title: selectedProject.title }} />
+      {props.incomingShareId ? (
+        <NativeHeaderToolbar placement="right">
+          <NativeHeaderToolbar.Button
+            accessibilityLabel="Save task draft"
+            disabled={!isIncomingShareReady || isImportingShare || flow.submitting}
+            label="Save draft"
+            onPress={() => void handleSaveDraft()}
+            separateBackground
+          />
+        </NativeHeaderToolbar>
+      ) : null}
 
       <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
         <View className="min-h-0 flex-1 px-5 pt-2">{promptEditor}</View>

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -90,9 +90,16 @@ export function NewTaskDraftScreen(props: {
   const promptInputRef = useRef<ComposerEditorHandle>(null);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
-  const [isImportingShare, setIsImportingShare] = useState(false);
+  const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
   const [shareImportAttempt, setShareImportAttempt] = useState(0);
-  const appliedIncomingShareIdRef = useRef<string | null>(null);
+  const startedShareImportKeyRef = useRef<string | null>(null);
+  const activeShareImportTokenRef = useRef<symbol | null>(null);
+  const shareImportMountedRef = useRef(true);
+  const latestDraftKeyRef = useRef(flow.draftKey);
+  const latestIncomingShareIdRef = useRef(props.incomingShareId);
+  latestDraftKeyRef.current = flow.draftKey;
+  latestIncomingShareIdRef.current = props.incomingShareId;
+  const isImportingShare = importingShareKey !== null;
   const alertedUnavailableIncomingShareIdRef = useRef<string | null>(null);
   const incomingShare = props.incomingShareId ? getShare(props.incomingShareId) : null;
   const hasImportedIncomingShare = Boolean(
@@ -112,8 +119,14 @@ export function NewTaskDraftScreen(props: {
     isIncomingShareUnavailable;
   const appliedInitialProjectKeyRef = useRef<string | null>(null);
   useEffect(() => {
+    if (!shareImportMountedRef.current) {
+      startedShareImportKeyRef.current = null;
+    }
+    shareImportMountedRef.current = true;
     return () => {
       appliedInitialProjectKeyRef.current = null;
+      shareImportMountedRef.current = false;
+      activeShareImportTokenRef.current = null;
     };
   }, []);
 
@@ -229,31 +242,11 @@ export function NewTaskDraftScreen(props: {
   useEffect(() => {
     const shareId = props.incomingShareId;
     const draftKey = flow.draftKey;
-    if (!shareId || !draftKey || appliedIncomingShareIdRef.current === shareId) {
+    if (!shareId || !draftKey) {
       return;
     }
-
-    if (hasImportedIncomingShare) {
-      appliedIncomingShareIdRef.current = shareId;
-      if (!incomingShare) {
-        return;
-      }
-      setIsImportingShare(true);
-      void consumeShare(shareId)
-        .catch((error) => {
-          appliedIncomingShareIdRef.current = null;
-          Alert.alert(
-            "Could not finish importing shared content",
-            error instanceof Error ? error.message : "The shared content could not be removed.",
-            [
-              {
-                text: "Retry",
-                onPress: () => setShareImportAttempt((attempt) => attempt + 1),
-              },
-            ],
-          );
-        })
-        .finally(() => setIsImportingShare(false));
+    const importKey = `${shareId}:${draftKey}`;
+    if (startedShareImportKeyRef.current === importKey) {
       return;
     }
 
@@ -271,15 +264,30 @@ export function NewTaskDraftScreen(props: {
     if (alertedUnavailableIncomingShareIdRef.current === shareId) {
       alertedUnavailableIncomingShareIdRef.current = null;
     }
-    appliedIncomingShareIdRef.current = shareId;
-    setIsImportingShare(true);
+    startedShareImportKeyRef.current = importKey;
+    const importToken = Symbol(importKey);
+    activeShareImportTokenRef.current = importToken;
+    setImportingShareKey(importKey);
     void mergeComposerDraftContent(draftKey, {
       text: incomingShare.text,
       attachments: incomingShare.attachments,
       sourceShareId: shareId,
     })
       .then(async ({ skippedAttachmentCount }) => {
+        if (
+          !shareImportMountedRef.current ||
+          activeShareImportTokenRef.current !== importToken ||
+          latestDraftKeyRef.current !== draftKey ||
+          latestIncomingShareIdRef.current !== shareId
+        ) {
+          // Project/route changes do not acknowledge this inbox item. The new
+          // destination can safely retry the idempotent import by share id.
+          return;
+        }
         await consumeShare(shareId);
+        if (!shareImportMountedRef.current || activeShareImportTokenRef.current !== importToken) {
+          return;
+        }
         const warnings = [...incomingShare.warnings];
         if (skippedAttachmentCount > 0) {
           warnings.push(
@@ -291,7 +299,12 @@ export function NewTaskDraftScreen(props: {
         }
       })
       .catch((error) => {
-        appliedIncomingShareIdRef.current = null;
+        if (!shareImportMountedRef.current || activeShareImportTokenRef.current !== importToken) {
+          return;
+        }
+        if (startedShareImportKeyRef.current === importKey) {
+          startedShareImportKeyRef.current = null;
+        }
         Alert.alert(
           "Could not import shared content",
           error instanceof Error ? error.message : "The shared content could not be saved.",
@@ -303,7 +316,12 @@ export function NewTaskDraftScreen(props: {
           ],
         );
       })
-      .finally(() => setIsImportingShare(false));
+      .finally(() => {
+        if (shareImportMountedRef.current && activeShareImportTokenRef.current === importToken) {
+          activeShareImportTokenRef.current = null;
+          setImportingShareKey(null);
+        }
+      });
   }, [
     consumeShare,
     flow.draftKey,
@@ -340,10 +358,11 @@ export function NewTaskDraftScreen(props: {
       flow.environments.map((environment) => ({
         id: `environment:${environment.environmentId}`,
         title: environment.environmentLabel,
+        attributes: isImportingShare ? { disabled: true } : undefined,
         state:
           flow.selectedEnvironmentId === environment.environmentId ? ("on" as const) : undefined,
       })),
-    [flow.environments, flow.selectedEnvironmentId],
+    [flow.environments, flow.selectedEnvironmentId, isImportingShare],
   );
 
   const modelMenuActions = useMemo(
@@ -515,7 +534,7 @@ export function NewTaskDraftScreen(props: {
   }
 
   function handleEnvironmentMenuAction(event: string) {
-    if (!event.startsWith("environment:")) {
+    if (isImportingShare || !event.startsWith("environment:")) {
       return;
     }
     flow.selectEnvironment(EnvironmentId.make(event.slice("environment:".length)));
@@ -804,6 +823,7 @@ export function NewTaskDraftScreen(props: {
       >
         <ComposerToolbarTrigger
           accessibilityLabel="Environment"
+          disabled={isImportingShare}
           icon="desktopcomputer"
           label={selectedEnvironmentLabel}
         />

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -39,6 +39,8 @@ import {
   clearComposerDraftContent,
   getComposerDraftSnapshot,
   mergeComposerDraftContent,
+  restoreComposerDraftSnapshot,
+  type ComposerDraft,
 } from "../../state/use-composer-drafts";
 import { useProjects } from "../../state/entities";
 import { deriveThreadTitleFromPrompt } from "../../lib/projectThreadStartTurn";
@@ -79,6 +81,7 @@ export function NewTaskDraftScreen(props: {
     consumeShare,
     getShare,
     isLoading: isIncomingShareInboxLoading,
+    releaseShareReservation,
     reserveShare,
   } = useIncomingShare();
   const insets = useSafeAreaInsets();
@@ -96,8 +99,11 @@ export function NewTaskDraftScreen(props: {
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
+  const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
+  const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
   const [shareImportAttempt, setShareImportAttempt] = useState(0);
   const startedShareImportKeyRef = useRef<string | null>(null);
+  const shareImportDraftBackupRef = useRef(new Map<string, ComposerDraft>());
   const activeShareImportTokenRef = useRef<symbol | null>(null);
   const shareImportMountedRef = useRef(true);
   const latestDraftKeyRef = useRef(flow.draftKey);
@@ -107,8 +113,10 @@ export function NewTaskDraftScreen(props: {
   const isImportingShare = importingShareKey !== null;
   const alertedUnavailableIncomingShareIdRef = useRef<string | null>(null);
   const incomingShare = props.incomingShareId ? getShare(props.incomingShareId) : null;
-  const isIncomingShareTransferPending = incomingShare !== null;
-  usePreventRemove(isIncomingShareTransferPending, () => undefined);
+  const isIncomingShareTransferPending = Boolean(
+    incomingShare && cancelledIncomingShareId !== props.incomingShareId,
+  );
+  usePreventRemove(isIncomingShareTransferPending || isCancellingShareImport, () => undefined);
   const hasImportedIncomingShare = Boolean(
     props.incomingShareId &&
     flow.draftKey &&
@@ -125,6 +133,11 @@ export function NewTaskDraftScreen(props: {
     (hasImportedIncomingShare && !incomingShare) ||
     isIncomingShareUnavailable;
   const appliedInitialProjectKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (cancelledIncomingShareId === props.incomingShareId) {
+      navigation.goBack();
+    }
+  }, [cancelledIncomingShareId, navigation, props.incomingShareId]);
   useEffect(() => {
     if (!shareImportMountedRef.current) {
       startedShareImportKeyRef.current = null;
@@ -211,6 +224,16 @@ export function NewTaskDraftScreen(props: {
         setProject(directProject);
         return;
       }
+
+      if (projects.length > 0) {
+        // Never fall through to the flow provider's temporary first-project
+        // default. Return to the picker with the share id intact so the user
+        // can choose an available destination.
+        navigation.dispatch(
+          StackActions.replace("NewTask", { incomingShareId: props.incomingShareId }),
+        );
+      }
+      return;
     }
 
     if (selectedProject) {
@@ -227,6 +250,7 @@ export function NewTaskDraftScreen(props: {
     logicalProjects,
     projects,
     props.initialProjectRef,
+    props.incomingShareId,
     props.pendingTaskId,
     navigation,
     selectedProject,
@@ -250,7 +274,20 @@ export function NewTaskDraftScreen(props: {
     const shareId = props.incomingShareId;
     const draftKey = flow.draftKey;
     const destinationProject = selectedProject;
-    if (!shareId || !draftKey || !destinationProject) {
+    const initialEnvironmentId = props.initialProjectRef?.environmentId;
+    const initialProjectId = props.initialProjectRef?.projectId;
+    const selectedProjectMatchesRoute =
+      !initialEnvironmentId ||
+      !initialProjectId ||
+      (destinationProject?.environmentId === initialEnvironmentId &&
+        destinationProject.id === initialProjectId);
+    if (
+      !shareId ||
+      !draftKey ||
+      !destinationProject ||
+      !selectedProjectMatchesRoute ||
+      cancelledIncomingShareId === shareId
+    ) {
       return;
     }
     const importKey = `${shareId}:${draftKey}`;
@@ -273,6 +310,9 @@ export function NewTaskDraftScreen(props: {
       alertedUnavailableIncomingShareIdRef.current = null;
     }
     startedShareImportKeyRef.current = importKey;
+    const draftBackup =
+      shareImportDraftBackupRef.current.get(importKey) ?? getComposerDraftSnapshot(draftKey);
+    shareImportDraftBackupRef.current.set(importKey, draftBackup);
     const importToken = Symbol(importKey);
     activeShareImportTokenRef.current = importToken;
     setImportingShareKey(importKey);
@@ -317,6 +357,7 @@ export function NewTaskDraftScreen(props: {
       if (warnings.length > 0) {
         Alert.alert("Some shared content was skipped", warnings.join("\n"));
       }
+      shareImportDraftBackupRef.current.delete(importKey);
     })()
       .catch((error) => {
         if (!shareImportMountedRef.current || activeShareImportTokenRef.current !== importToken) {
@@ -326,6 +367,55 @@ export function NewTaskDraftScreen(props: {
           "Could not import shared content",
           error instanceof Error ? error.message : "The shared content could not be saved.",
           [
+            {
+              text: "Cancel import",
+              style: "cancel",
+              onPress: () => {
+                const cancelImport = async (): Promise<void> => {
+                  if (!shareImportMountedRef.current) {
+                    return;
+                  }
+                  setIsCancellingShareImport(true);
+                  try {
+                    const currentDraft = getComposerDraftSnapshot(draftKey);
+                    if (currentDraft.importedShareIds?.includes(shareId)) {
+                      await restoreComposerDraftSnapshot(draftKey, draftBackup);
+                    }
+                    await releaseShareReservation(shareId, {
+                      environmentId: String(destinationProject.environmentId),
+                      projectId: String(destinationProject.id),
+                    });
+                    shareImportDraftBackupRef.current.delete(importKey);
+                    if (shareImportMountedRef.current) {
+                      setIsCancellingShareImport(false);
+                      setCancelledIncomingShareId(shareId);
+                    }
+                  } catch (cancelError) {
+                    if (!shareImportMountedRef.current) {
+                      return;
+                    }
+                    setIsCancellingShareImport(false);
+                    Alert.alert(
+                      "Could not cancel import",
+                      cancelError instanceof Error
+                        ? cancelError.message
+                        : "The shared content could not be restored safely.",
+                      [
+                        {
+                          text: "Retry import",
+                          onPress: () => setShareImportAttempt((attempt) => attempt + 1),
+                        },
+                        {
+                          text: "Retry cancel",
+                          onPress: () => void cancelImport(),
+                        },
+                      ],
+                    );
+                  }
+                };
+                void cancelImport();
+              },
+            },
             {
               text: "Retry",
               onPress: () => setShareImportAttempt((attempt) => attempt + 1),
@@ -346,12 +436,16 @@ export function NewTaskDraftScreen(props: {
       });
   }, [
     consumeShare,
+    cancelledIncomingShareId,
     flow.draftKey,
     hasImportedIncomingShare,
     incomingShare,
     isIncomingShareInboxLoading,
     isIncomingShareUnavailable,
     props.incomingShareId,
+    props.initialProjectRef?.environmentId,
+    props.initialProjectRef?.projectId,
+    releaseShareReservation,
     reserveShare,
     selectedProject,
     shareImportAttempt,
@@ -551,7 +645,7 @@ export function NewTaskDraftScreen(props: {
     [currentBranchName, flow.selectedBranchName, flow.workspaceMode],
   );
   function handleModelMenuAction(event: string) {
-    if (!event.startsWith("model:")) {
+    if (isIncomingShareTransferPending || !event.startsWith("model:")) {
       return;
     }
     flow.setSelectedModelKey(event.slice("model:".length));
@@ -565,6 +659,9 @@ export function NewTaskDraftScreen(props: {
   }
 
   function handleOptionsMenuAction(event: string) {
+    if (isIncomingShareTransferPending) {
+      return;
+    }
     const providerOptions = applyProviderOptionMenuEvent(providerOptionDescriptors, event);
     if (providerOptions) {
       flow.setSelectedModelOptions(providerOptions);
@@ -584,6 +681,9 @@ export function NewTaskDraftScreen(props: {
   }
 
   function handleWorkspaceMenuAction(event: string) {
+    if (isIncomingShareTransferPending) {
+      return;
+    }
     if (event.startsWith("workspace:mode:")) {
       flow.setWorkspaceMode(
         event.slice("workspace:mode:".length) as Parameters<typeof flow.setWorkspaceMode>[0],
@@ -604,6 +704,9 @@ export function NewTaskDraftScreen(props: {
   }
 
   async function handlePickImages(): Promise<void> {
+    if (isIncomingShareTransferPending) {
+      return;
+    }
     const result = await pickComposerImages({ existingCount: flow.attachments.length });
     if (result.images.length > 0) {
       flow.appendAttachments(result.images);
@@ -829,6 +932,7 @@ export function NewTaskDraftScreen(props: {
       >
         <ComposerToolbarTrigger
           accessibilityLabel="Model"
+          disabled={isIncomingShareTransferPending}
           iconNode={<ProviderIcon provider={flow.selectedModelOption?.providerDriver} size={16} />}
           label={flow.selectedModelOption?.label ?? "Model"}
         />
@@ -839,6 +943,7 @@ export function NewTaskDraftScreen(props: {
       >
         <ComposerToolbarTrigger
           accessibilityLabel="Configuration"
+          disabled={isIncomingShareTransferPending}
           icon="slider.horizontal.3"
           label={configurationLabel}
         />
@@ -860,6 +965,7 @@ export function NewTaskDraftScreen(props: {
       >
         <ComposerToolbarTrigger
           accessibilityLabel="Workspace"
+          disabled={isIncomingShareTransferPending}
           icon="point.topleft.down.curvedto.point.bottomright.up"
           label={workspaceLabel}
         />

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -422,6 +422,7 @@ export function NewTaskDraftScreen(props: {
                           onPress: () => void cancelImport(),
                         },
                       ],
+                      { cancelable: false },
                     );
                   }
                 };
@@ -433,6 +434,7 @@ export function NewTaskDraftScreen(props: {
               onPress: () => setShareImportAttempt((attempt) => attempt + 1),
             },
           ],
+          { cancelable: false },
         );
       })
       .finally(() => {

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,5 +1,5 @@
 import { NativeStackScreenOptions } from "../../native/StackHeader";
-import { StackActions, useNavigation } from "@react-navigation/native";
+import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
 import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
@@ -75,7 +75,12 @@ export function NewTaskDraftScreen(props: {
   const createProjectThread = useCreateProjectThread();
   const flow = useNewTaskFlow();
   const navigation = useNavigation();
-  const { consumeShare, getShare, isLoading: isIncomingShareInboxLoading } = useIncomingShare();
+  const {
+    consumeShare,
+    getShare,
+    isLoading: isIncomingShareInboxLoading,
+    reserveShare,
+  } = useIncomingShare();
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
@@ -102,6 +107,8 @@ export function NewTaskDraftScreen(props: {
   const isImportingShare = importingShareKey !== null;
   const alertedUnavailableIncomingShareIdRef = useRef<string | null>(null);
   const incomingShare = props.incomingShareId ? getShare(props.incomingShareId) : null;
+  const isIncomingShareTransferPending = incomingShare !== null;
+  usePreventRemove(isIncomingShareTransferPending, () => undefined);
   const hasImportedIncomingShare = Boolean(
     props.incomingShareId &&
     flow.draftKey &&
@@ -242,7 +249,8 @@ export function NewTaskDraftScreen(props: {
   useEffect(() => {
     const shareId = props.incomingShareId;
     const draftKey = flow.draftKey;
-    if (!shareId || !draftKey) {
+    const destinationProject = selectedProject;
+    if (!shareId || !draftKey || !destinationProject) {
       return;
     }
     const importKey = `${shareId}:${draftKey}`;
@@ -268,42 +276,51 @@ export function NewTaskDraftScreen(props: {
     const importToken = Symbol(importKey);
     activeShareImportTokenRef.current = importToken;
     setImportingShareKey(importKey);
-    void mergeComposerDraftContent(draftKey, {
-      text: incomingShare.text,
-      attachments: incomingShare.attachments,
-      sourceShareId: shareId,
-    })
-      .then(async ({ skippedAttachmentCount }) => {
-        if (
-          !shareImportMountedRef.current ||
-          activeShareImportTokenRef.current !== importToken ||
-          latestDraftKeyRef.current !== draftKey ||
-          latestIncomingShareIdRef.current !== shareId
-        ) {
-          // Project/route changes do not acknowledge this inbox item. The new
-          // destination can safely retry the idempotent import by share id.
-          return;
-        }
-        await consumeShare(shareId);
-        if (!shareImportMountedRef.current || activeShareImportTokenRef.current !== importToken) {
-          return;
-        }
-        const warnings = [...incomingShare.warnings];
-        if (skippedAttachmentCount > 0) {
-          warnings.push(
-            `${skippedAttachmentCount} shared image${skippedAttachmentCount === 1 ? " was" : "s were"} skipped because this draft reached the attachment limit.`,
-          );
-        }
-        if (warnings.length > 0) {
-          Alert.alert("Some shared content was skipped", warnings.join("\n"));
-        }
-      })
+    void (async () => {
+      await reserveShare(shareId, {
+        environmentId: String(destinationProject.environmentId),
+        projectId: String(destinationProject.id),
+      });
+      if (
+        !shareImportMountedRef.current ||
+        activeShareImportTokenRef.current !== importToken ||
+        latestDraftKeyRef.current !== draftKey ||
+        latestIncomingShareIdRef.current !== shareId
+      ) {
+        return;
+      }
+      const { skippedAttachmentCount } = await mergeComposerDraftContent(draftKey, {
+        text: incomingShare.text,
+        attachments: incomingShare.attachments,
+        sourceShareId: shareId,
+      });
+      if (
+        !shareImportMountedRef.current ||
+        activeShareImportTokenRef.current !== importToken ||
+        latestDraftKeyRef.current !== draftKey ||
+        latestIncomingShareIdRef.current !== shareId
+      ) {
+        // The durable reservation makes an interrupted transfer resume only
+        // in this project instead of copying into a second project draft.
+        return;
+      }
+      await consumeShare(shareId);
+      if (!shareImportMountedRef.current || activeShareImportTokenRef.current !== importToken) {
+        return;
+      }
+      const warnings = [...incomingShare.warnings];
+      if (skippedAttachmentCount > 0) {
+        warnings.push(
+          `${skippedAttachmentCount} shared image${skippedAttachmentCount === 1 ? " was" : "s were"} skipped because this draft reached the attachment limit.`,
+        );
+      }
+      if (warnings.length > 0) {
+        Alert.alert("Some shared content was skipped", warnings.join("\n"));
+      }
+    })()
       .catch((error) => {
         if (!shareImportMountedRef.current || activeShareImportTokenRef.current !== importToken) {
           return;
-        }
-        if (startedShareImportKeyRef.current === importKey) {
-          startedShareImportKeyRef.current = null;
         }
         Alert.alert(
           "Could not import shared content",
@@ -317,6 +334,11 @@ export function NewTaskDraftScreen(props: {
         );
       })
       .finally(() => {
+        if (startedShareImportKeyRef.current === importKey) {
+          // Every terminal path, including an invalidated operation, must
+          // release the synchronous start latch so this transfer can retry.
+          startedShareImportKeyRef.current = null;
+        }
         if (shareImportMountedRef.current && activeShareImportTokenRef.current === importToken) {
           activeShareImportTokenRef.current = null;
           setImportingShareKey(null);
@@ -330,6 +352,8 @@ export function NewTaskDraftScreen(props: {
     isIncomingShareInboxLoading,
     isIncomingShareUnavailable,
     props.incomingShareId,
+    reserveShare,
+    selectedProject,
     shareImportAttempt,
   ]);
 
@@ -358,11 +382,11 @@ export function NewTaskDraftScreen(props: {
       flow.environments.map((environment) => ({
         id: `environment:${environment.environmentId}`,
         title: environment.environmentLabel,
-        attributes: isImportingShare ? { disabled: true } : undefined,
+        attributes: isIncomingShareTransferPending ? { disabled: true } : undefined,
         state:
           flow.selectedEnvironmentId === environment.environmentId ? ("on" as const) : undefined,
       })),
-    [flow.environments, flow.selectedEnvironmentId, isImportingShare],
+    [flow.environments, flow.selectedEnvironmentId, isIncomingShareTransferPending],
   );
 
   const modelMenuActions = useMemo(
@@ -534,7 +558,7 @@ export function NewTaskDraftScreen(props: {
   }
 
   function handleEnvironmentMenuAction(event: string) {
-    if (isImportingShare || !event.startsWith("environment:")) {
+    if (isIncomingShareTransferPending || !event.startsWith("environment:")) {
       return;
     }
     flow.selectEnvironment(EnvironmentId.make(event.slice("environment:".length)));
@@ -762,6 +786,7 @@ export function NewTaskDraftScreen(props: {
     <ComposerEditor
       ref={promptInputRef}
       autoFocus={!isAndroid}
+      editable={!isIncomingShareTransferPending}
       multiline
       scrollEnabled={isExpanded}
       value={flow.prompt}
@@ -796,6 +821,7 @@ export function NewTaskDraftScreen(props: {
         icon="plus"
         onPress={() => void handlePickImages()}
         showChevron={false}
+        disabled={isIncomingShareTransferPending}
       />
       <ControlPillMenu
         actions={modelMenuActions}
@@ -823,7 +849,7 @@ export function NewTaskDraftScreen(props: {
       >
         <ComposerToolbarTrigger
           accessibilityLabel="Environment"
-          disabled={isImportingShare}
+          disabled={isIncomingShareTransferPending}
           icon="desktopcomputer"
           label={selectedEnvironmentLabel}
         />
@@ -900,7 +926,9 @@ export function NewTaskDraftScreen(props: {
                 <View className="pb-2.5">
                   <ComposerAttachmentStrip
                     attachments={flow.attachments}
-                    onRemove={flow.removeAttachment}
+                    onRemove={
+                      isIncomingShareTransferPending ? () => undefined : flow.removeAttachment
+                    }
                   />
                 </View>
               ) : null}
@@ -944,7 +972,7 @@ export function NewTaskDraftScreen(props: {
             <View className="px-4 pt-3">
               <ComposerAttachmentStrip
                 attachments={flow.attachments}
-                onRemove={flow.removeAttachment}
+                onRemove={isIncomingShareTransferPending ? () => undefined : flow.removeAttachment}
                 imageSize={88}
                 imageBorderRadius={20}
               />

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -101,6 +101,7 @@ export function NewTaskDraftScreen(props: {
   const [importingShareKey, setImportingShareKey] = useState<string | null>(null);
   const [isCancellingShareImport, setIsCancellingShareImport] = useState(false);
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
+  const [isReturningToProjectPicker, setIsReturningToProjectPicker] = useState(false);
   const [shareImportAttempt, setShareImportAttempt] = useState(0);
   const startedShareImportKeyRef = useRef<string | null>(null);
   const cancellingShareImportKeyRef = useRef<string | null>(null);
@@ -117,7 +118,10 @@ export function NewTaskDraftScreen(props: {
   const isIncomingShareTransferPending = Boolean(
     incomingShare && cancelledIncomingShareId !== props.incomingShareId,
   );
-  usePreventRemove(isIncomingShareTransferPending || isCancellingShareImport, () => undefined);
+  usePreventRemove(
+    (isIncomingShareTransferPending && !isReturningToProjectPicker) || isCancellingShareImport,
+    () => undefined,
+  );
   const hasImportedIncomingShare = Boolean(
     props.incomingShareId &&
     flow.draftKey &&
@@ -139,6 +143,19 @@ export function NewTaskDraftScreen(props: {
       navigation.goBack();
     }
   }, [cancelledIncomingShareId, navigation, props.incomingShareId]);
+  useEffect(() => {
+    if (!isReturningToProjectPicker) {
+      return;
+    }
+    // Let usePreventRemove commit its disabled state before replacing this
+    // route, otherwise the transfer guard can swallow the fallback action.
+    const frame = requestAnimationFrame(() => {
+      navigation.dispatch(
+        StackActions.replace("NewTask", { incomingShareId: props.incomingShareId }),
+      );
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isReturningToProjectPicker, navigation, props.incomingShareId]);
   useEffect(() => {
     if (!shareImportMountedRef.current) {
       startedShareImportKeyRef.current = null;
@@ -231,9 +248,7 @@ export function NewTaskDraftScreen(props: {
         // Never fall through to the flow provider's temporary first-project
         // default. Return to the picker with the share id intact so the user
         // can choose an available destination.
-        navigation.dispatch(
-          StackActions.replace("NewTask", { incomingShareId: props.incomingShareId }),
-        );
+        setIsReturningToProjectPicker(true);
       }
       return;
     }

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -115,11 +115,22 @@ export function NewTaskDraftScreen(props: {
   const isImportingShare = importingShareKey !== null;
   const alertedUnavailableIncomingShareIdRef = useRef<string | null>(null);
   const incomingShare = props.incomingShareId ? getShare(props.incomingShareId) : null;
+  const requestedInitialProjectAvailable = Boolean(
+    props.initialProjectRef?.environmentId &&
+    props.initialProjectRef.projectId &&
+    projects.some(
+      (project) =>
+        project.environmentId === props.initialProjectRef?.environmentId &&
+        project.id === props.initialProjectRef?.projectId,
+    ),
+  );
+  const isProjectPickerReturnActive =
+    isReturningToProjectPicker && !requestedInitialProjectAvailable;
   const isIncomingShareTransferPending = Boolean(
     incomingShare && cancelledIncomingShareId !== props.incomingShareId,
   );
   usePreventRemove(
-    (isIncomingShareTransferPending && !isReturningToProjectPicker) || isCancellingShareImport,
+    (isIncomingShareTransferPending && !isProjectPickerReturnActive) || isCancellingShareImport,
     () => undefined,
   );
   const hasImportedIncomingShare = Boolean(
@@ -147,6 +158,10 @@ export function NewTaskDraftScreen(props: {
     if (!isReturningToProjectPicker) {
       return;
     }
+    if (requestedInitialProjectAvailable) {
+      setIsReturningToProjectPicker(false);
+      return;
+    }
     // Let usePreventRemove commit its disabled state before replacing this
     // route, otherwise the transfer guard can swallow the fallback action.
     const frame = requestAnimationFrame(() => {
@@ -155,7 +170,12 @@ export function NewTaskDraftScreen(props: {
       );
     });
     return () => cancelAnimationFrame(frame);
-  }, [isReturningToProjectPicker, navigation, props.incomingShareId]);
+  }, [
+    isReturningToProjectPicker,
+    navigation,
+    props.incomingShareId,
+    requestedInitialProjectAvailable,
+  ]);
   useEffect(() => {
     if (!shareImportMountedRef.current) {
       startedShareImportKeyRef.current = null;

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -320,6 +320,7 @@ export function NewTaskDraftScreen(props: {
     shareImportDraftBackupRef.current.set(importKey, draftBackup);
     const importToken = Symbol(importKey);
     let didReserveShare = false;
+    let needsDraftRestore = false;
     activeShareImportTokenRef.current = importToken;
     setImportingShareKey(importKey);
     void (async () => {
@@ -336,6 +337,7 @@ export function NewTaskDraftScreen(props: {
       ) {
         return;
       }
+      needsDraftRestore = true;
       const { skippedAttachmentCount } = await mergeComposerDraftContent(draftKey, {
         text: incomingShare.text,
         attachments: incomingShare.attachments,
@@ -388,9 +390,9 @@ export function NewTaskDraftScreen(props: {
                   cancellingShareImportKeyRef.current = importKey;
                   setIsCancellingShareImport(true);
                   try {
-                    const currentDraft = getComposerDraftSnapshot(draftKey);
-                    if (currentDraft.importedShareIds?.includes(shareId)) {
+                    if (needsDraftRestore) {
                       await restoreComposerDraftSnapshot(draftKey, draftBackup);
+                      needsDraftRestore = false;
                     }
                     if (didReserveShare) {
                       await releaseShareReservation(shareId, {

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1,4 +1,4 @@
-import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
+import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
@@ -36,7 +36,7 @@ import {
 } from "../../lib/providerOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import {
-  flushComposerDrafts,
+  clearComposerDraftContent,
   getComposerDraftSnapshot,
   mergeComposerDraftContent,
 } from "../../state/use-composer-drafts";
@@ -75,7 +75,7 @@ export function NewTaskDraftScreen(props: {
   const createProjectThread = useCreateProjectThread();
   const flow = useNewTaskFlow();
   const navigation = useNavigation();
-  const { consumeShare, pendingShare } = useIncomingShare();
+  const { consumeShare, getShare, isLoading: isIncomingShareInboxLoading } = useIncomingShare();
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
@@ -91,11 +91,25 @@ export function NewTaskDraftScreen(props: {
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [isImportingShare, setIsImportingShare] = useState(false);
-  const [importedIncomingShareId, setImportedIncomingShareId] = useState<string | null>(null);
   const [shareImportAttempt, setShareImportAttempt] = useState(0);
   const appliedIncomingShareIdRef = useRef<string | null>(null);
+  const alertedUnavailableIncomingShareIdRef = useRef<string | null>(null);
+  const incomingShare = props.incomingShareId ? getShare(props.incomingShareId) : null;
+  const hasImportedIncomingShare = Boolean(
+    props.incomingShareId &&
+    flow.draftKey &&
+    getComposerDraftSnapshot(flow.draftKey).importedShareIds?.includes(props.incomingShareId),
+  );
+  const isIncomingShareUnavailable = Boolean(
+    props.incomingShareId &&
+    !isIncomingShareInboxLoading &&
+    !incomingShare &&
+    !hasImportedIncomingShare,
+  );
   const isIncomingShareReady =
-    !props.incomingShareId || importedIncomingShareId === props.incomingShareId;
+    !props.incomingShareId ||
+    (hasImportedIncomingShare && !incomingShare) ||
+    isIncomingShareUnavailable;
   const appliedInitialProjectKeyRef = useRef<string | null>(null);
   useEffect(() => {
     return () => {
@@ -215,25 +229,58 @@ export function NewTaskDraftScreen(props: {
   useEffect(() => {
     const shareId = props.incomingShareId;
     const draftKey = flow.draftKey;
-    if (
-      !shareId ||
-      !draftKey ||
-      pendingShare?.id !== shareId ||
-      appliedIncomingShareIdRef.current === shareId
-    ) {
+    if (!shareId || !draftKey || appliedIncomingShareIdRef.current === shareId) {
       return;
     }
 
+    if (hasImportedIncomingShare) {
+      appliedIncomingShareIdRef.current = shareId;
+      if (!incomingShare) {
+        return;
+      }
+      setIsImportingShare(true);
+      void consumeShare(shareId)
+        .catch((error) => {
+          appliedIncomingShareIdRef.current = null;
+          Alert.alert(
+            "Could not finish importing shared content",
+            error instanceof Error ? error.message : "The shared content could not be removed.",
+            [
+              {
+                text: "Retry",
+                onPress: () => setShareImportAttempt((attempt) => attempt + 1),
+              },
+            ],
+          );
+        })
+        .finally(() => setIsImportingShare(false));
+      return;
+    }
+
+    if (!incomingShare) {
+      if (isIncomingShareUnavailable && alertedUnavailableIncomingShareIdRef.current !== shareId) {
+        alertedUnavailableIncomingShareIdRef.current = shareId;
+        Alert.alert(
+          "Shared content unavailable",
+          "The shared content is no longer in the inbox. You can continue editing this task draft.",
+        );
+      }
+      return;
+    }
+
+    if (alertedUnavailableIncomingShareIdRef.current === shareId) {
+      alertedUnavailableIncomingShareIdRef.current = null;
+    }
     appliedIncomingShareIdRef.current = shareId;
     setIsImportingShare(true);
     void mergeComposerDraftContent(draftKey, {
-      text: pendingShare.text,
-      attachments: pendingShare.attachments,
+      text: incomingShare.text,
+      attachments: incomingShare.attachments,
+      sourceShareId: shareId,
     })
       .then(async ({ skippedAttachmentCount }) => {
         await consumeShare(shareId);
-        setImportedIncomingShareId(shareId);
-        const warnings = [...pendingShare.warnings];
+        const warnings = [...incomingShare.warnings];
         if (skippedAttachmentCount > 0) {
           warnings.push(
             `${skippedAttachmentCount} shared image${skippedAttachmentCount === 1 ? " was" : "s were"} skipped because this draft reached the attachment limit.`,
@@ -257,7 +304,16 @@ export function NewTaskDraftScreen(props: {
         );
       })
       .finally(() => setIsImportingShare(false));
-  }, [consumeShare, flow.draftKey, pendingShare, props.incomingShareId, shareImportAttempt]);
+  }, [
+    consumeShare,
+    flow.draftKey,
+    hasImportedIncomingShare,
+    incomingShare,
+    isIncomingShareInboxLoading,
+    isIncomingShareUnavailable,
+    props.incomingShareId,
+    shareImportAttempt,
+  ]);
 
   useEffect(() => {
     // Android starts with the collapsed composer pill (like an open thread)
@@ -511,21 +567,6 @@ export function NewTaskDraftScreen(props: {
     }
   }
 
-  async function handleSaveDraft(): Promise<void> {
-    if (!flow.draftKey || !isIncomingShareReady || isImportingShare || flow.submitting) {
-      return;
-    }
-    try {
-      await flushComposerDrafts();
-      navigation.getParent()?.goBack();
-    } catch (error) {
-      Alert.alert(
-        "Could not save draft",
-        error instanceof Error ? error.message : "The task draft could not be saved.",
-      );
-    }
-  }
-
   const handleNativePasteImages = useCallback(
     async (uris: ReadonlyArray<string>) => {
       try {
@@ -602,8 +643,7 @@ export function NewTaskDraftScreen(props: {
       if (editingPendingTask) {
         flow.finishEditingPendingTask();
       } else {
-        flow.setPrompt("");
-        flow.clearAttachments();
+        clearComposerDraftContent(draftKey);
       }
       navigation.getParent()?.goBack();
       return;
@@ -661,8 +701,7 @@ export function NewTaskDraftScreen(props: {
       }
       flow.finishEditingPendingTask();
     } else {
-      flow.setPrompt("");
-      flow.clearAttachments();
+      clearComposerDraftContent(draftKey);
     }
     navigation.dispatch(
       StackActions.replace("Thread", {
@@ -802,22 +841,7 @@ export function NewTaskDraftScreen(props: {
     return (
       <View className="flex-1 bg-screen">
         <NativeStackScreenOptions options={{ headerShown: false }} />
-        <AndroidScreenHeader
-          title="New Thread"
-          onBack={() => navigation.goBack()}
-          actions={
-            props.incomingShareId
-              ? [
-                  {
-                    accessibilityLabel: "Save task draft",
-                    icon: "archivebox",
-                    onPress: () => void handleSaveDraft(),
-                    disabled: !isIncomingShareReady || isImportingShare || flow.submitting,
-                  },
-                ]
-              : undefined
-          }
-        />
+        <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
 
         <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
           <View className="flex-1" />
@@ -891,17 +915,6 @@ export function NewTaskDraftScreen(props: {
   return (
     <View className="flex-1 bg-sheet">
       <NativeStackScreenOptions options={{ title: selectedProject.title }} />
-      {props.incomingShareId ? (
-        <NativeHeaderToolbar placement="right">
-          <NativeHeaderToolbar.Button
-            accessibilityLabel="Save task draft"
-            disabled={!isIncomingShareReady || isImportingShare || flow.submitting}
-            label="Save draft"
-            onPress={() => void handleSaveDraft()}
-            separateBackground
-          />
-        </NativeHeaderToolbar>
-      ) : null}
 
       <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
         <View className="min-h-0 flex-1 px-5 pt-2">{promptEditor}</View>

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -319,6 +319,7 @@ export function NewTaskDraftScreen(props: {
       shareImportDraftBackupRef.current.get(importKey) ?? getComposerDraftSnapshot(draftKey);
     shareImportDraftBackupRef.current.set(importKey, draftBackup);
     const importToken = Symbol(importKey);
+    let didReserveShare = false;
     activeShareImportTokenRef.current = importToken;
     setImportingShareKey(importKey);
     void (async () => {
@@ -326,6 +327,7 @@ export function NewTaskDraftScreen(props: {
         environmentId: String(destinationProject.environmentId),
         projectId: String(destinationProject.id),
       });
+      didReserveShare = true;
       if (
         !shareImportMountedRef.current ||
         activeShareImportTokenRef.current !== importToken ||
@@ -390,10 +392,12 @@ export function NewTaskDraftScreen(props: {
                     if (currentDraft.importedShareIds?.includes(shareId)) {
                       await restoreComposerDraftSnapshot(draftKey, draftBackup);
                     }
-                    await releaseShareReservation(shareId, {
-                      environmentId: String(destinationProject.environmentId),
-                      projectId: String(destinationProject.id),
-                    });
+                    if (didReserveShare) {
+                      await releaseShareReservation(shareId, {
+                        environmentId: String(destinationProject.environmentId),
+                        projectId: String(destinationProject.id),
+                      });
+                    }
                     shareImportDraftBackupRef.current.delete(importKey);
                     if (shareImportMountedRef.current) {
                       setIsCancellingShareImport(false);

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -103,6 +103,7 @@ export function NewTaskDraftScreen(props: {
   const [cancelledIncomingShareId, setCancelledIncomingShareId] = useState<string | null>(null);
   const [shareImportAttempt, setShareImportAttempt] = useState(0);
   const startedShareImportKeyRef = useRef<string | null>(null);
+  const cancellingShareImportKeyRef = useRef<string | null>(null);
   const shareImportDraftBackupRef = useRef(new Map<string, ComposerDraft>());
   const activeShareImportTokenRef = useRef<symbol | null>(null);
   const shareImportMountedRef = useRef(true);
@@ -147,6 +148,7 @@ export function NewTaskDraftScreen(props: {
       appliedInitialProjectKeyRef.current = null;
       shareImportMountedRef.current = false;
       activeShareImportTokenRef.current = null;
+      cancellingShareImportKeyRef.current = null;
     };
   }, []);
 
@@ -291,7 +293,10 @@ export function NewTaskDraftScreen(props: {
       return;
     }
     const importKey = `${shareId}:${draftKey}`;
-    if (startedShareImportKeyRef.current === importKey) {
+    if (
+      startedShareImportKeyRef.current === importKey ||
+      cancellingShareImportKeyRef.current === importKey
+    ) {
       return;
     }
 
@@ -375,6 +380,10 @@ export function NewTaskDraftScreen(props: {
                   if (!shareImportMountedRef.current) {
                     return;
                   }
+                  // Latch synchronously before restoring the draft. The
+                  // restore publishes atom state and can re-run the import
+                  // effect before React commits the cancelling state update.
+                  cancellingShareImportKeyRef.current = importKey;
                   setIsCancellingShareImport(true);
                   try {
                     const currentDraft = getComposerDraftSnapshot(draftKey);
@@ -394,7 +403,6 @@ export function NewTaskDraftScreen(props: {
                     if (!shareImportMountedRef.current) {
                       return;
                     }
-                    setIsCancellingShareImport(false);
                     Alert.alert(
                       "Could not cancel import",
                       cancelError instanceof Error
@@ -403,7 +411,11 @@ export function NewTaskDraftScreen(props: {
                       [
                         {
                           text: "Retry import",
-                          onPress: () => setShareImportAttempt((attempt) => attempt + 1),
+                          onPress: () => {
+                            cancellingShareImportKeyRef.current = null;
+                            setIsCancellingShareImport(false);
+                            setShareImportAttempt((attempt) => attempt + 1);
+                          },
                         },
                         {
                           text: "Retry cancel",

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -1,5 +1,5 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { useMemo } from "react";
@@ -16,6 +16,11 @@ import type { WorkspaceState } from "../../state/workspaceModel";
 import { useWorkspaceState } from "../../state/workspace";
 import { groupProjectsByRepository } from "../../lib/repositoryGroups";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
+import { useIncomingShare } from "../sharing/IncomingShareProvider";
+
+type NewTaskRouteParams = {
+  readonly incomingShareId?: string | string[];
+};
 
 function deriveProjectEmptyState(catalogState: WorkspaceState): {
   readonly title: string;
@@ -72,7 +77,7 @@ function deriveProjectEmptyState(catalogState: WorkspaceState): {
   };
 }
 
-export function NewTaskRouteScreen() {
+export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRouteParams | undefined>) {
   const projects = useProjects();
   const threads = useThreadShells();
   const { state: catalogState } = useWorkspaceState();
@@ -81,6 +86,11 @@ export function NewTaskRouteScreen() {
   const insets = useSafeAreaInsets();
   const chevronColor = useThemeColor("--color-chevron");
   const accentColor = useThemeColor("--color-icon-muted");
+  const { pendingShare } = useIncomingShare();
+  const routeShareId = Array.isArray(route.params?.incomingShareId)
+    ? route.params.incomingShareId[0]
+    : route.params?.incomingShareId;
+  const incomingShare = pendingShare?.id === routeShareId ? pendingShare : null;
   const repositoryGroups = useMemo(
     () => groupProjectsByRepository({ projects, threads }),
     [projects, threads],
@@ -152,10 +162,22 @@ export function NewTaskRouteScreen() {
         className="flex-1"
         contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
+          gap: 12,
           paddingHorizontal: 20,
           paddingTop: 8,
         }}
       >
+        {incomingShare ? (
+          <View className="gap-1 rounded-[24px] bg-primary/10 px-5 py-4">
+            <Text className="text-base font-t3-bold text-foreground">Shared content ready</Text>
+            <Text className="text-sm leading-normal text-foreground-muted">
+              Choose a project, then send it as-is or save it as a draft for more editing.
+              {incomingShare.attachments.length > 0
+                ? ` ${incomingShare.attachments.length} shared image${incomingShare.attachments.length === 1 ? "" : "s"} will be attached.`
+                : ""}
+            </Text>
+          </View>
+        ) : null}
         {items.length === 0 ? (
           <View collapsable={false} className="items-center gap-3 rounded-[24px] bg-card px-6 py-8">
             {projectEmptyState.loading ? <ActivityIndicator color={accentColor} /> : null}
@@ -201,6 +223,7 @@ export function NewTaskRouteScreen() {
                         environmentId: item.environmentId,
                         projectId: item.id,
                         title: item.title,
+                        incomingShareId: incomingShare?.id,
                       },
                     })
                   }

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -3,7 +3,7 @@ import { useIsFocused, useNavigation, type StaticScreenProps } from "@react-navi
 import { SymbolView } from "../../components/AppSymbol";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { useEffect, useMemo, useRef } from "react";
-import { ActivityIndicator, Platform, Pressable, ScrollView, View } from "react-native";
+import { ActivityIndicator, Alert, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { cn } from "../../lib/cn";
@@ -87,7 +87,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
   const insets = useSafeAreaInsets();
   const chevronColor = useThemeColor("--color-chevron");
   const accentColor = useThemeColor("--color-icon-muted");
-  const { getShare } = useIncomingShare();
+  const { getShare, releaseShareReservation } = useIncomingShare();
   const routeShareId = Array.isArray(route.params?.incomingShareId)
     ? route.params.incomingShareId[0]
     : route.params?.incomingShareId;
@@ -121,6 +121,38 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
   }, [repositoryGroups]);
   const projectEmptyState = deriveProjectEmptyState(catalogState);
   const resumedDestinationKeyRef = useRef<string | null>(null);
+  const reservedDestinationProject = incomingShare?.destination
+    ? (projects.find(
+        (project) =>
+          project.environmentId === incomingShare.destination?.environmentId &&
+          project.id === incomingShare.destination?.projectId,
+      ) ?? null)
+    : null;
+
+  async function selectProject(item: (typeof items)[number]): Promise<void> {
+    if (incomingShare?.destination && !reservedDestinationProject) {
+      try {
+        await releaseShareReservation(incomingShare.id, incomingShare.destination);
+      } catch (error) {
+        Alert.alert(
+          "Could not change project",
+          error instanceof Error
+            ? error.message
+            : "The shared content reservation could not be updated.",
+        );
+        return;
+      }
+    }
+    navigation.navigate("NewTaskSheet", {
+      screen: "NewTaskDraft",
+      params: {
+        environmentId: item.environmentId,
+        projectId: item.id,
+        title: item.title,
+        incomingShareId: incomingShare?.id,
+      },
+    });
+  }
 
   useEffect(() => {
     const destination = incomingShare?.destination;
@@ -135,24 +167,20 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     if (resumedDestinationKeyRef.current === destinationKey) {
       return;
     }
-    const destinationProject = projects.find(
-      (project) =>
-        project.environmentId === destination.environmentId && project.id === destination.projectId,
-    );
-    if (!destinationProject) {
+    if (!reservedDestinationProject) {
       return;
     }
     resumedDestinationKeyRef.current = destinationKey;
     navigation.navigate("NewTaskSheet", {
       screen: "NewTaskDraft",
       params: {
-        environmentId: destinationProject.environmentId,
-        projectId: destinationProject.id,
-        title: destinationProject.title,
+        environmentId: reservedDestinationProject.environmentId,
+        projectId: reservedDestinationProject.id,
+        title: reservedDestinationProject.title,
         incomingShareId: incomingShare.id,
       },
     });
-  }, [incomingShare, isFocused, navigation, projects]);
+  }, [incomingShare, isFocused, navigation, reservedDestinationProject]);
 
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
@@ -250,18 +278,8 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
               return (
                 <Pressable
                   key={item.key}
-                  disabled={incomingShare?.destination !== undefined}
-                  onPress={() =>
-                    navigation.navigate("NewTaskSheet", {
-                      screen: "NewTaskDraft",
-                      params: {
-                        environmentId: item.environmentId,
-                        projectId: item.id,
-                        title: item.title,
-                        incomingShareId: incomingShare?.id,
-                      },
-                    })
-                  }
+                  disabled={reservedDestinationProject !== null}
+                  onPress={() => void selectProject(item)}
                   className={cn(
                     "bg-card px-4 py-3.5",
                     !isFirst && "border-t border-border-subtle",

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -86,11 +86,11 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
   const insets = useSafeAreaInsets();
   const chevronColor = useThemeColor("--color-chevron");
   const accentColor = useThemeColor("--color-icon-muted");
-  const { pendingShare } = useIncomingShare();
+  const { getShare } = useIncomingShare();
   const routeShareId = Array.isArray(route.params?.incomingShareId)
     ? route.params.incomingShareId[0]
     : route.params?.incomingShareId;
-  const incomingShare = pendingShare?.id === routeShareId ? pendingShare : null;
+  const incomingShare = routeShareId ? getShare(routeShareId) : null;
   const repositoryGroups = useMemo(
     () => groupProjectsByRepository({ projects, threads }),
     [projects, threads],
@@ -171,7 +171,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           <View className="gap-1 rounded-[24px] bg-primary/10 px-5 py-4">
             <Text className="text-base font-t3-bold text-foreground">Shared content ready</Text>
             <Text className="text-sm leading-normal text-foreground-muted">
-              Choose a project, then send it as-is or save it as a draft for more editing.
+              Choose a project to start a task with this shared content.
               {incomingShare.attachments.length > 0
                 ? ` ${incomingShare.attachments.length} shared image${incomingShare.attachments.length === 1 ? "" : "s"} will be attached.`
                 : ""}

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -161,6 +161,9 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
       return;
     }
     if (!isFocused) {
+      // Returning from the reserved draft is a fresh resume attempt. Keeping
+      // this latch set would leave every project row disabled with no route.
+      resumedDestinationKeyRef.current = null;
       return;
     }
     const destinationKey = `${incomingShare.id}:${destination.environmentId}:${destination.projectId}`;

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -1,8 +1,8 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
-import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
+import { useIsFocused, useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { ActivityIndicator, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -82,6 +82,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
   const threads = useThreadShells();
   const { state: catalogState } = useWorkspaceState();
   const navigation = useNavigation();
+  const isFocused = useIsFocused();
   const { layout } = useAdaptiveWorkspaceLayout();
   const insets = useSafeAreaInsets();
   const chevronColor = useThemeColor("--color-chevron");
@@ -119,6 +120,39 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     return nextItems;
   }, [repositoryGroups]);
   const projectEmptyState = deriveProjectEmptyState(catalogState);
+  const resumedDestinationKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const destination = incomingShare?.destination;
+    if (!destination) {
+      resumedDestinationKeyRef.current = null;
+      return;
+    }
+    if (!isFocused) {
+      return;
+    }
+    const destinationKey = `${incomingShare.id}:${destination.environmentId}:${destination.projectId}`;
+    if (resumedDestinationKeyRef.current === destinationKey) {
+      return;
+    }
+    const destinationProject = projects.find(
+      (project) =>
+        project.environmentId === destination.environmentId && project.id === destination.projectId,
+    );
+    if (!destinationProject) {
+      return;
+    }
+    resumedDestinationKeyRef.current = destinationKey;
+    navigation.navigate("NewTaskSheet", {
+      screen: "NewTaskDraft",
+      params: {
+        environmentId: destinationProject.environmentId,
+        projectId: destinationProject.id,
+        title: destinationProject.title,
+        incomingShareId: incomingShare.id,
+      },
+    });
+  }, [incomingShare, isFocused, navigation, projects]);
 
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
@@ -216,6 +250,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
               return (
                 <Pressable
                   key={item.key}
+                  disabled={incomingShare?.destination !== undefined}
                   onPress={() =>
                     navigation.navigate("NewTaskSheet", {
                       screen: "NewTaskDraft",

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -92,6 +92,14 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     ? route.params.incomingShareId[0]
     : route.params?.incomingShareId;
   const incomingShare = routeShareId ? getShare(routeShareId) : null;
+  const incomingShareSubtitle = incomingShare
+    ? incomingShare.attachments.length === 0
+      ? "Choose a project for what you shared"
+      : incomingShare.attachments.length === 1
+        ? "Choose a project for the image you shared"
+        : `Choose a project for the ${incomingShare.attachments.length} images you shared`
+    : null;
+  const screenTitle = incomingShare ? "Start a task" : "Choose project";
   const repositoryGroups = useMemo(
     () => groupProjectsByRepository({ projects, threads }),
     [projects, threads],
@@ -192,7 +200,8 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           {/* Android renders its own in-screen header instead of the native bar. */}
           <NativeStackScreenOptions options={{ headerShown: false }} />
           <AndroidScreenHeader
-            title="Choose project"
+            title={screenTitle}
+            subtitle={incomingShareSubtitle}
             onBack={layout.usesSplitView ? () => navigation.goBack() : undefined}
             actions={[
               {
@@ -204,21 +213,29 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           />
         </>
       ) : (
-        <NativeHeaderToolbar placement="right">
-          {layout.usesSplitView ? (
+        <>
+          <NativeStackScreenOptions
+            options={{
+              title: screenTitle,
+              unstable_headerSubtitle: incomingShareSubtitle ?? undefined,
+            }}
+          />
+          <NativeHeaderToolbar placement="right">
+            {layout.usesSplitView ? (
+              <NativeHeaderToolbar.Button
+                accessibilityLabel="Close new task"
+                icon="xmark"
+                onPress={() => navigation.goBack()}
+                separateBackground
+              />
+            ) : null}
             <NativeHeaderToolbar.Button
-              accessibilityLabel="Close new task"
-              icon="xmark"
-              onPress={() => navigation.goBack()}
+              icon="plus"
+              onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
               separateBackground
             />
-          ) : null}
-          <NativeHeaderToolbar.Button
-            icon="plus"
-            onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
-            separateBackground
-          />
-        </NativeHeaderToolbar>
+          </NativeHeaderToolbar>
+        </>
       )}
 
       <ScrollView
@@ -232,17 +249,6 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           paddingTop: 8,
         }}
       >
-        {incomingShare ? (
-          <View className="gap-1 rounded-[24px] bg-primary/10 px-5 py-4">
-            <Text className="text-base font-t3-bold text-foreground">Shared content ready</Text>
-            <Text className="text-sm leading-normal text-foreground-muted">
-              Choose a project to start a task with this shared content.
-              {incomingShare.attachments.length > 0
-                ? ` ${incomingShare.attachments.length} shared image${incomingShare.attachments.length === 1 ? "" : "s"} will be attached.`
-                : ""}
-            </Text>
-          </View>
-        ) : null}
         {items.length === 0 ? (
           <View collapsable={false} className="items-center gap-3 rounded-[24px] bg-card px-6 py-8">
             {projectEmptyState.loading ? <ActivityIndicator color={accentColor} /> : null}

--- a/apps/mobile/src/lib/base64.ts
+++ b/apps/mobile/src/lib/base64.ts
@@ -1,0 +1,4 @@
+export function estimateBase64ByteSize(base64: string): number {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -3,6 +3,7 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   type UploadChatImageAttachment,
 } from "@t3tools/contracts";
+import { estimateBase64ByteSize } from "./base64";
 import { uuidv4 } from "./uuid";
 
 export interface DraftComposerImageAttachment extends UploadChatImageAttachment {
@@ -11,11 +12,6 @@ export interface DraftComposerImageAttachment extends UploadChatImageAttachment 
 }
 
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";
-
-function estimateBase64ByteSize(base64: string): number {
-  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
-  return Math.floor((base64.length * 3) / 4) - padding;
-}
 
 async function loadImagePicker() {
   try {

--- a/apps/mobile/src/lib/serialized-async-queue.test.ts
+++ b/apps/mobile/src/lib/serialized-async-queue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { SerializedAsyncQueue } from "./serialized-async-queue";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("SerializedAsyncQueue", () => {
+  it("does not let a newer operation overtake an in-flight operation", async () => {
+    const queue = new SerializedAsyncQueue();
+    const firstGate = deferred();
+    const events: string[] = [];
+
+    const first = queue.run(async () => {
+      events.push("first:start");
+      await firstGate.promise;
+      events.push("first:end");
+    });
+    const second = queue.run(async () => {
+      events.push("second");
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(["first:start"]);
+    firstGate.resolve();
+    await Promise.all([first, second]);
+    expect(events).toEqual(["first:start", "first:end", "second"]);
+  });
+
+  it("continues after a rejected operation", async () => {
+    const queue = new SerializedAsyncQueue();
+    const first = queue.run(async () => {
+      throw new Error("failed");
+    });
+    const second = queue.run(async () => "recovered");
+
+    await expect(first).rejects.toThrow("failed");
+    await expect(second).resolves.toBe("recovered");
+  });
+});

--- a/apps/mobile/src/lib/serialized-async-queue.ts
+++ b/apps/mobile/src/lib/serialized-async-queue.ts
@@ -1,0 +1,16 @@
+/**
+ * Runs asynchronous operations in call order while keeping the queue usable
+ * after an individual operation rejects.
+ */
+export class SerializedAsyncQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(operation, operation);
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}

--- a/apps/mobile/src/native/StackHeader.tsx
+++ b/apps/mobile/src/native/StackHeader.tsx
@@ -195,7 +195,7 @@ function convertToolbarChild(child: ReactNode): NativeStackHeaderItem | null {
   if (typeName === "NativeHeaderToolbarButton") {
     return {
       type: "button",
-      label: "",
+      label: typeof child.props.label === "string" ? child.props.label : "",
       accessibilityLabel:
         typeof child.props.accessibilityLabel === "string"
           ? child.props.accessibilityLabel
@@ -293,6 +293,7 @@ function NativeHeaderToolbarButton(_props: {
   readonly accessibilityLabel?: string;
   readonly disabled?: boolean;
   readonly icon?: string;
+  readonly label?: string;
   readonly onPress?: () => void;
   readonly separateBackground?: boolean;
   readonly tintColor?: ColorValue;

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -8,6 +8,7 @@ import {
   decodePersistedComposerDrafts,
   type ComposerDraft,
   getComposerDraftSnapshot,
+  mergeComposerDraftContentState,
   removeComposerDraftsForEnvironment,
 } from "./use-composer-drafts";
 
@@ -129,6 +130,55 @@ describe("mobile composer drafts", () => {
     appAtomRegistry.set(composerDraftsAtom, { [draftKey]: selectedDraft });
 
     expect(getComposerDraftSnapshot(draftKey)).toEqual(selectedDraft);
+  });
+
+  it("merges shared content into a project draft without duplicating retries", () => {
+    const draftKey = "new-task:environment-1:project-1";
+    const sharedAttachment = {
+      id: "share-1:image:0",
+      type: "image" as const,
+      name: "Screenshot.png",
+      mimeType: "image/png",
+      sizeBytes: 3,
+      dataUrl: "data:image/png;base64,YWJj",
+      previewUri: "data:image/png;base64,YWJj",
+    };
+    const existing: Record<string, ComposerDraft> = {
+      [draftKey]: { text: "Existing context", attachments: [] },
+    };
+    const content = { text: "Shared note", attachments: [sharedAttachment] };
+
+    const merged = mergeComposerDraftContentState(existing, draftKey, content);
+    expect(merged[draftKey]).toMatchObject({
+      text: "Existing context\n\nShared note",
+      attachments: [sharedAttachment],
+    });
+    expect(mergeComposerDraftContentState(merged, draftKey, content)).toBe(merged);
+  });
+
+  it("preserves existing images when shared content exceeds the draft attachment limit", () => {
+    const draftKey = "new-task:environment-1:project-1";
+    const image = (id: string) => ({
+      id,
+      type: "image" as const,
+      name: `${id}.png`,
+      mimeType: "image/png",
+      sizeBytes: 3,
+      dataUrl: "data:image/png;base64,YWJj",
+      previewUri: "data:image/png;base64,YWJj",
+    });
+    const existingImage = image("existing");
+    const sharedImages = Array.from({ length: 8 }, (_, index) => image(`shared-${index}`));
+
+    const merged = mergeComposerDraftContentState(
+      { [draftKey]: { text: "", attachments: [existingImage] } },
+      draftKey,
+      { text: "", attachments: sharedImages },
+    );
+
+    expect(merged[draftKey]?.attachments).toHaveLength(8);
+    expect(merged[draftKey]?.attachments[0]).toEqual(existingImage);
+    expect(merged[draftKey]?.attachments.at(-1)?.id).toBe("shared-6");
   });
 
   it("removes only drafts owned by the selected environment", () => {

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -95,6 +95,7 @@ describe("mobile composer drafts", () => {
     const draft: ComposerDraft = {
       text: "send this",
       attachments: [],
+      importedShareIds: ["share-1"],
       modelSelection: {
         instanceId: ProviderInstanceId.make("codex"),
         model: "gpt-5.4",
@@ -109,7 +110,8 @@ describe("mobile composer drafts", () => {
 
     expect(clearComposerDraftContentState({ [draftKey]: draft }, draftKey)).toEqual({
       [draftKey]: {
-        ...draft,
+        modelSelection: draft.modelSelection,
+        workspaceSelection: draft.workspaceSelection,
         text: "",
         attachments: [],
       },
@@ -146,14 +148,25 @@ describe("mobile composer drafts", () => {
     const existing: Record<string, ComposerDraft> = {
       [draftKey]: { text: "Existing context", attachments: [] },
     };
-    const content = { text: "Shared note", attachments: [sharedAttachment] };
+    const content = {
+      text: "Shared note",
+      attachments: [sharedAttachment],
+      sourceShareId: "share-1",
+    };
 
     const merged = mergeComposerDraftContentState(existing, draftKey, content);
     expect(merged[draftKey]).toMatchObject({
       text: "Existing context\n\nShared note",
       attachments: [sharedAttachment],
+      importedShareIds: ["share-1"],
     });
     expect(mergeComposerDraftContentState(merged, draftKey, content)).toBe(merged);
+
+    const edited = {
+      ...merged,
+      [draftKey]: { ...merged[draftKey]!, text: "User edited the imported context" },
+    };
+    expect(mergeComposerDraftContentState(edited, draftKey, content)).toBe(edited);
   });
 
   it("preserves existing images when shared content exceeds the draft attachment limit", () => {

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -10,6 +10,7 @@ import {
   getComposerDraftSnapshot,
   mergeComposerDraftContentState,
   removeComposerDraftsForEnvironment,
+  restoreComposerDraftSnapshotState,
 } from "./use-composer-drafts";
 
 const DRAFT: ComposerDraft = {
@@ -192,6 +193,30 @@ describe("mobile composer drafts", () => {
     expect(merged[draftKey]?.attachments).toHaveLength(8);
     expect(merged[draftKey]?.attachments[0]).toEqual(existingImage);
     expect(merged[draftKey]?.attachments.at(-1)?.id).toBe("shared-6");
+  });
+
+  it("restores the exact draft captured before an interrupted share import", () => {
+    const draftKey = "new-task:environment-1:project-1";
+    const beforeImport: ComposerDraft = {
+      text: "Existing context",
+      attachments: [],
+      runtimeMode: "approval-required",
+    };
+    const imported: ComposerDraft = {
+      ...beforeImport,
+      text: "Existing context\n\nShared note",
+      importedShareIds: ["share-1"],
+    };
+
+    expect(
+      restoreComposerDraftSnapshotState({ [draftKey]: imported }, draftKey, beforeImport),
+    ).toEqual({ [draftKey]: beforeImport });
+    expect(
+      restoreComposerDraftSnapshotState({ [draftKey]: imported }, draftKey, {
+        text: "",
+        attachments: [],
+      }),
+    ).toEqual({});
   });
 
   it("removes only drafts owned by the selected environment", () => {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -15,6 +15,7 @@ import { Atom } from "effect/unstable/reactivity";
 
 import { DraftComposerImageAttachmentSchema } from "../lib/composer-image-schema";
 import type { DraftComposerImageAttachment } from "../lib/composerImages";
+import { SerializedAsyncQueue } from "../lib/serialized-async-queue";
 import { appAtomRegistry } from "./atom-registry";
 
 const COMPOSER_DRAFTS_SCHEMA_VERSION = 1;
@@ -102,6 +103,7 @@ export const composerDraftsAtom = Atom.make<Record<string, ComposerDraft>>({}).p
 
 let loadPromise: Promise<void> | null = null;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
+const persistenceQueue = new SerializedAsyncQueue();
 
 function normalizeDraft(draft: ComposerDraft | undefined): ComposerDraft {
   if (!draft) {
@@ -202,7 +204,7 @@ async function writePersistedComposerDrafts(drafts: Record<string, ComposerDraft
 
 async function savePersistedComposerDrafts(drafts: Record<string, ComposerDraft>): Promise<void> {
   try {
-    await writePersistedComposerDrafts(drafts);
+    await persistenceQueue.run(() => writePersistedComposerDrafts(drafts));
   } catch (error) {
     console.warn("[composer-drafts] failed to persist drafts", error);
     // Draft persistence is best-effort; in-memory drafts still keep working.
@@ -450,24 +452,6 @@ export function mergeComposerDraftContentState(
   };
 }
 
-function markComposerDraftShareImportedState(
-  current: Record<string, ComposerDraft>,
-  draftKey: string,
-  shareId: string,
-): Record<string, ComposerDraft> {
-  const existing = normalizeDraft(current[draftKey]);
-  if (existing.importedShareIds?.includes(shareId)) {
-    return current;
-  }
-  return {
-    ...current,
-    [draftKey]: {
-      ...existing,
-      importedShareIds: [...(existing.importedShareIds ?? []), shareId],
-    },
-  };
-}
-
 /**
  * Atomically moves an incoming share into a project-scoped composer draft.
  * The durable write happens before the share inbox item can be acknowledged.
@@ -485,8 +469,7 @@ export async function mergeComposerDraftContent(
     persistTimer = null;
   }
   const current = appAtomRegistry.get(composerDraftsAtom);
-  const { sourceShareId, ...contentWithoutReceipt } = content;
-  const next = mergeComposerDraftContentState(current, draftKey, contentWithoutReceipt);
+  const next = mergeComposerDraftContentState(current, draftKey, content);
   const currentAttachmentIds = new Set(
     normalizeDraft(current[draftKey]).attachments.map((attachment) => attachment.id),
   );
@@ -497,27 +480,13 @@ export async function mergeComposerDraftContent(
     (attachment) =>
       !currentAttachmentIds.has(attachment.id) && !nextAttachmentIds.has(attachment.id),
   ).length;
-  // Publish the content before the filesystem await so typing that happens
-  // during persistence is applied on top of the import rather than being
-  // overwritten by an older snapshot.
+  // Publish the content and its import receipt together before the filesystem
+  // await. Typing during persistence then builds on the receipt-bearing state,
+  // and its debounced write is serialized after this transaction.
   if (next !== current) {
     appAtomRegistry.set(composerDraftsAtom, next);
   }
-
-  const latest = appAtomRegistry.get(composerDraftsAtom);
-  const durable = sourceShareId
-    ? markComposerDraftShareImportedState(latest, draftKey, sourceShareId)
-    : latest;
-  await writePersistedComposerDrafts(durable);
-
-  if (sourceShareId) {
-    // Commit the receipt against the latest in-memory draft after the durable
-    // write. This preserves edits made while the write was in flight and makes
-    // interrupted acknowledgement safe to retry without merging twice.
-    updateComposerDrafts((drafts) =>
-      markComposerDraftShareImportedState(drafts, draftKey, sourceShareId),
-    );
-  }
+  await persistenceQueue.run(() => writePersistedComposerDrafts(next));
   return { skippedAttachmentCount };
 }
 

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -1,6 +1,7 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   ModelSelection as ModelSelectionSchema,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   ProviderInteractionMode as ProviderInteractionModeSchema,
   RuntimeMode as RuntimeModeSchema,
   type EnvironmentId,
@@ -42,6 +43,11 @@ export interface ComposerDraft {
   readonly runtimeMode?: RuntimeMode;
   readonly interactionMode?: ProviderInteractionMode;
   readonly workspaceSelection?: ComposerDraftWorkspaceSelection;
+}
+
+export interface ComposerDraftContent {
+  readonly text: string;
+  readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
 }
 
 export interface ComposerDraftWorkspaceSelection {
@@ -380,6 +386,101 @@ export function clearComposerDraftContentState(
     ...current,
     [draftKey]: draft,
   };
+}
+
+function mergeComposerDraftText(existing: string, incoming: string): string {
+  if (incoming.length === 0) {
+    return existing;
+  }
+  if (existing.length === 0) {
+    return incoming;
+  }
+  // Import retries are possible after an interrupted native handoff. Keep the
+  // operation idempotent when the same shared text is already present.
+  if (existing === incoming || existing.endsWith(`\n\n${incoming}`)) {
+    return existing;
+  }
+  return `${existing}\n\n${incoming}`;
+}
+
+export function mergeComposerDraftContentState(
+  current: Record<string, ComposerDraft>,
+  draftKey: string,
+  content: ComposerDraftContent,
+): Record<string, ComposerDraft> {
+  const existing = normalizeDraft(current[draftKey]);
+  const attachmentIds = new Set(existing.attachments.map((attachment) => attachment.id));
+  const incomingAttachments = content.attachments.filter((attachment) => {
+    if (attachmentIds.has(attachment.id)) {
+      return false;
+    }
+    attachmentIds.add(attachment.id);
+    return true;
+  });
+  const attachments = [...existing.attachments, ...incomingAttachments].slice(
+    0,
+    PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  );
+  const text = mergeComposerDraftText(existing.text, content.text);
+  if (text === existing.text && attachments.length === existing.attachments.length) {
+    return current;
+  }
+  return {
+    ...current,
+    [draftKey]: {
+      ...existing,
+      text,
+      attachments,
+    },
+  };
+}
+
+/**
+ * Atomically moves an incoming share into a project-scoped composer draft.
+ * The durable write happens before the share inbox item can be acknowledged.
+ */
+export async function mergeComposerDraftContent(
+  draftKey: string,
+  content: ComposerDraftContent,
+): Promise<{ readonly skippedAttachmentCount: number }> {
+  ensureComposerDraftsLoaded();
+  if (loadPromise !== null) {
+    await loadPromise;
+  }
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+  const current = appAtomRegistry.get(composerDraftsAtom);
+  const next = mergeComposerDraftContentState(current, draftKey, content);
+  const currentAttachmentIds = new Set(
+    normalizeDraft(current[draftKey]).attachments.map((attachment) => attachment.id),
+  );
+  const nextAttachmentIds = new Set(
+    normalizeDraft(next[draftKey]).attachments.map((attachment) => attachment.id),
+  );
+  const skippedAttachmentCount = content.attachments.filter(
+    (attachment) =>
+      !currentAttachmentIds.has(attachment.id) && !nextAttachmentIds.has(attachment.id),
+  ).length;
+  if (next === current) {
+    return { skippedAttachmentCount };
+  }
+  await writePersistedComposerDrafts(next);
+  appAtomRegistry.set(composerDraftsAtom, next);
+  return { skippedAttachmentCount };
+}
+
+export async function flushComposerDrafts(): Promise<void> {
+  ensureComposerDraftsLoaded();
+  if (loadPromise !== null) {
+    await loadPromise;
+  }
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+  await writePersistedComposerDrafts(appAtomRegistry.get(composerDraftsAtom));
 }
 
 export function clearComposerDraftContent(draftKey: string): void {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -394,6 +394,20 @@ export function clearComposerDraftContentState(
   };
 }
 
+export function restoreComposerDraftSnapshotState(
+  current: Record<string, ComposerDraft>,
+  draftKey: string,
+  snapshot: ComposerDraft,
+): Record<string, ComposerDraft> {
+  const next = { ...current };
+  if (isEmptyDraft(snapshot)) {
+    delete next[draftKey];
+  } else {
+    next[draftKey] = snapshot;
+  }
+  return next;
+}
+
 function mergeComposerDraftText(existing: string, incoming: string): string {
   if (incoming.length === 0) {
     return existing;
@@ -488,6 +502,28 @@ export async function mergeComposerDraftContent(
   }
   await persistenceQueue.run(() => writePersistedComposerDrafts(next));
   return { skippedAttachmentCount };
+}
+
+/** Restores the exact content/settings captured before an interrupted import. */
+export async function restoreComposerDraftSnapshot(
+  draftKey: string,
+  snapshot: ComposerDraft,
+): Promise<void> {
+  ensureComposerDraftsLoaded();
+  if (loadPromise !== null) {
+    await loadPromise;
+  }
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+  const next = restoreComposerDraftSnapshotState(
+    appAtomRegistry.get(composerDraftsAtom),
+    draftKey,
+    snapshot,
+  );
+  appAtomRegistry.set(composerDraftsAtom, next);
+  await persistenceQueue.run(() => writePersistedComposerDrafts(next));
 }
 
 export function clearComposerDraftContent(draftKey: string): void {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -39,6 +39,7 @@ export class ComposerDraftPersistenceError extends Schema.TaggedErrorClass<Compo
 export interface ComposerDraft {
   readonly text: string;
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
+  readonly importedShareIds?: ReadonlyArray<string>;
   readonly modelSelection?: ModelSelection;
   readonly runtimeMode?: RuntimeMode;
   readonly interactionMode?: ProviderInteractionMode;
@@ -48,6 +49,7 @@ export interface ComposerDraft {
 export interface ComposerDraftContent {
   readonly text: string;
   readonly attachments: ReadonlyArray<DraftComposerImageAttachment>;
+  readonly sourceShareId?: string;
 }
 
 export interface ComposerDraftWorkspaceSelection {
@@ -72,6 +74,7 @@ const ComposerDraftWorkspaceSelectionSchema = Schema.Struct({
 const ComposerDraftSchema = Schema.Struct({
   text: Schema.String,
   attachments: Schema.Array(DraftComposerImageAttachmentSchema),
+  importedShareIds: Schema.optional(Schema.Array(Schema.String)),
   modelSelection: Schema.optional(ModelSelectionSchema),
   runtimeMode: Schema.optional(RuntimeModeSchema),
   interactionMode: Schema.optional(ProviderInteractionModeSchema),
@@ -372,8 +375,9 @@ export function clearComposerDraftContentState(
   if (!existing) {
     return current;
   }
+  const { importedShareIds: _importedShareIds, ...retained } = existing;
   const draft = {
-    ...existing,
+    ...retained,
     text: "",
     attachments: [],
   };
@@ -409,6 +413,9 @@ export function mergeComposerDraftContentState(
   content: ComposerDraftContent,
 ): Record<string, ComposerDraft> {
   const existing = normalizeDraft(current[draftKey]);
+  if (content.sourceShareId && existing.importedShareIds?.includes(content.sourceShareId)) {
+    return current;
+  }
   const attachmentIds = new Set(existing.attachments.map((attachment) => attachment.id));
   const incomingAttachments = content.attachments.filter((attachment) => {
     if (attachmentIds.has(attachment.id)) {
@@ -422,7 +429,14 @@ export function mergeComposerDraftContentState(
     PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   );
   const text = mergeComposerDraftText(existing.text, content.text);
-  if (text === existing.text && attachments.length === existing.attachments.length) {
+  const importedShareIds = content.sourceShareId
+    ? [...(existing.importedShareIds ?? []), content.sourceShareId]
+    : existing.importedShareIds;
+  if (
+    text === existing.text &&
+    attachments.length === existing.attachments.length &&
+    importedShareIds === existing.importedShareIds
+  ) {
     return current;
   }
   return {
@@ -431,6 +445,25 @@ export function mergeComposerDraftContentState(
       ...existing,
       text,
       attachments,
+      ...(importedShareIds ? { importedShareIds } : {}),
+    },
+  };
+}
+
+function markComposerDraftShareImportedState(
+  current: Record<string, ComposerDraft>,
+  draftKey: string,
+  shareId: string,
+): Record<string, ComposerDraft> {
+  const existing = normalizeDraft(current[draftKey]);
+  if (existing.importedShareIds?.includes(shareId)) {
+    return current;
+  }
+  return {
+    ...current,
+    [draftKey]: {
+      ...existing,
+      importedShareIds: [...(existing.importedShareIds ?? []), shareId],
     },
   };
 }
@@ -452,7 +485,8 @@ export async function mergeComposerDraftContent(
     persistTimer = null;
   }
   const current = appAtomRegistry.get(composerDraftsAtom);
-  const next = mergeComposerDraftContentState(current, draftKey, content);
+  const { sourceShareId, ...contentWithoutReceipt } = content;
+  const next = mergeComposerDraftContentState(current, draftKey, contentWithoutReceipt);
   const currentAttachmentIds = new Set(
     normalizeDraft(current[draftKey]).attachments.map((attachment) => attachment.id),
   );
@@ -463,24 +497,28 @@ export async function mergeComposerDraftContent(
     (attachment) =>
       !currentAttachmentIds.has(attachment.id) && !nextAttachmentIds.has(attachment.id),
   ).length;
-  if (next === current) {
-    return { skippedAttachmentCount };
+  // Publish the content before the filesystem await so typing that happens
+  // during persistence is applied on top of the import rather than being
+  // overwritten by an older snapshot.
+  if (next !== current) {
+    appAtomRegistry.set(composerDraftsAtom, next);
   }
-  await writePersistedComposerDrafts(next);
-  appAtomRegistry.set(composerDraftsAtom, next);
-  return { skippedAttachmentCount };
-}
 
-export async function flushComposerDrafts(): Promise<void> {
-  ensureComposerDraftsLoaded();
-  if (loadPromise !== null) {
-    await loadPromise;
+  const latest = appAtomRegistry.get(composerDraftsAtom);
+  const durable = sourceShareId
+    ? markComposerDraftShareImportedState(latest, draftKey, sourceShareId)
+    : latest;
+  await writePersistedComposerDrafts(durable);
+
+  if (sourceShareId) {
+    // Commit the receipt against the latest in-memory draft after the durable
+    // write. This preserves edits made while the write was in flight and makes
+    // interrupted acknowledgement safe to retry without merging twice.
+    updateComposerDrafts((drafts) =>
+      markComposerDraftShareImportedState(drafts, draftKey, sourceShareId),
+    );
   }
-  if (persistTimer !== null) {
-    clearTimeout(persistTimer);
-    persistTimer = null;
-  }
-  await writePersistedComposerDrafts(appAtomRegistry.get(composerDraftsAtom));
+  return { skippedAttachmentCount };
 }
 
 export function clearComposerDraftContent(draftKey: string): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,8 @@ overrides:
   '@types/node': 24.12.4
   effect: 4.0.0-beta.78
   expo-modules-jsi: 56.0.10
+  expo-sharing>@expo/config-plugins: 56.0.9
+  expo-sharing>@expo/config-types: 56.0.6
   vite: npm:@voidzero-dev/vite-plus-core@0.2.2
   yaml: ^2.9.0
 
@@ -2425,17 +2427,11 @@ packages:
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
 
-  '@expo/config-plugins@56.0.13':
-    resolution: {integrity: sha512-BWtRkvUKLb4xaMLTRXmrHPHl+RI5nKF2MKJEXODHmLtVgUlXOz66XSCU4bEvjfr8yYTx+8DQ0JO54Y7Y0kwokA==}
-
-  '@expo/config-plugins@56.0.8':
-    resolution: {integrity: sha512-phTuyBhgVLfqUHMjQkAfRtbyoY6yTxoKja1awtpVnEkoJDxPJuXx1KX5uvq1eZtt4bJQ08OBJ6P95INqRSHpRg==}
-
   '@expo/config-plugins@56.0.9':
     resolution: {integrity: sha512-/6a/S9USwx8OC9tGjHxbviLFiBHyueN3aoNWMLvWDEJoZ1CIVW800ZBzwXq/FYNK2qzcN1LxFmQtzD1zeFQKNA==}
 
-  '@expo/config-types@56.0.7':
-    resolution: {integrity: sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==}
+  '@expo/config-types@56.0.6':
+    resolution: {integrity: sha512-4Y6Aum5J4Re5NnxGVofRNe1aDwUBOmWhQYkynZsqzRtX/zEA1ADUeyHXuEckv9YD9djiyT7bKtLt5gKL3mA6VQ==}
 
   '@expo/config@56.0.9':
     resolution: {integrity: sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==}
@@ -2544,14 +2540,6 @@ packages:
 
   '@expo/require-utils@56.1.3':
     resolution: {integrity: sha512-KyLeOn/zzQSvuPpV5YhB/FPKnpQytno4luN918bGdPDssLBoS3N/0UbC3W0rJAn9kSFu+XpfR81eABRVsSdfgQ==}
-    peerDependencies:
-      typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@expo/require-utils@56.1.5':
-    resolution: {integrity: sha512-3wsdJLSpELhRPEMZCCREqAAFRGG23BUWJHGKIUxyqGkWvy5KPdzlBxGlVVb/6h9gNOflqgTtvTWaP2EuHoQ1HQ==}
     peerDependencies:
       typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
     peerDependenciesMeta:
@@ -12082,7 +12070,7 @@ snapshots:
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@6.0.3)
-      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
       '@expo/devcert': 1.2.1
       '@expo/env': 2.3.0
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
@@ -12158,7 +12146,7 @@ snapshots:
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@6.0.3)
-      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
       '@expo/devcert': 1.2.1
       '@expo/env': 2.3.0
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
@@ -12235,47 +12223,9 @@ snapshots:
     dependencies:
       node-forge: 1.4.0
 
-  '@expo/config-plugins@56.0.13(typescript@6.0.3)':
-    dependencies:
-      '@expo/config-types': 56.0.7
-      '@expo/json-file': 10.2.0
-      '@expo/plist': 0.7.0
-      '@expo/require-utils': 56.1.5(typescript@6.0.3)
-      '@expo/sdk-runtime-versions': 1.0.0
-      chalk: 4.1.2
-      debug: 4.4.3
-      getenv: 2.0.0
-      glob: 13.0.6
-      semver: 7.8.5
-      slugify: 1.6.9
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@expo/config-plugins@56.0.8(typescript@6.0.3)':
-    dependencies:
-      '@expo/config-types': 56.0.7
-      '@expo/json-file': 10.2.0
-      '@expo/plist': 0.7.0
-      '@expo/require-utils': 56.1.3(typescript@6.0.3)
-      '@expo/sdk-runtime-versions': 1.0.0
-      chalk: 4.1.2
-      debug: 4.4.3
-      getenv: 2.0.0
-      glob: 13.0.6
-      semver: 7.8.5
-      slugify: 1.6.9
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@expo/config-plugins@56.0.9(typescript@6.0.3)':
     dependencies:
-      '@expo/config-types': 56.0.7
+      '@expo/config-types': 56.0.6
       '@expo/json-file': 10.2.0
       '@expo/plist': 0.7.0
       '@expo/require-utils': 56.1.3(typescript@6.0.3)
@@ -12292,12 +12242,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/config-types@56.0.7': {}
+  '@expo/config-types@56.0.6': {}
 
   '@expo/config@56.0.9(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
-      '@expo/config-types': 56.0.7
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
+      '@expo/config-types': 56.0.6
       '@expo/json-file': 10.2.0
       '@expo/require-utils': 56.1.3(typescript@6.0.3)
       deepmerge: 4.3.1
@@ -12399,7 +12349,7 @@ snapshots:
 
   '@expo/inline-modules@0.0.12(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12550,8 +12500,8 @@ snapshots:
   '@expo/prebuild-config@56.0.16(typescript@6.0.3)':
     dependencies:
       '@expo/config': 56.0.9(typescript@6.0.3)
-      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
-      '@expo/config-types': 56.0.7
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
+      '@expo/config-types': 56.0.6
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.85.3
@@ -12574,16 +12524,6 @@ snapshots:
       - supports-color
 
   '@expo/require-utils@56.1.3(typescript@6.0.3)':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/require-utils@56.1.5(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7
@@ -17082,8 +17022,8 @@ snapshots:
 
   expo-sharing@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
     dependencies:
-      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
-      '@expo/config-types': 56.0.7
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
+      '@expo/config-types': 56.0.6
       '@expo/plist': 0.7.0
       expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
       react: 19.2.3
@@ -17094,7 +17034,7 @@ snapshots:
 
   expo-splash-screen@56.0.10(expo@56.0.12)(typescript@6.0.3):
     dependencies:
-      '@expo/config-plugins': 56.0.8(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
       expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
       xml2js: 0.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       expo-secure-store:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.12)
+      expo-sharing:
+        specifier: ~56.0.18
+        version: 56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       expo-splash-screen:
         specifier: ~56.0.10
         version: 56.0.10(expo@56.0.12)(typescript@6.0.3)
@@ -2422,17 +2425,17 @@ packages:
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
 
+  '@expo/config-plugins@56.0.13':
+    resolution: {integrity: sha512-BWtRkvUKLb4xaMLTRXmrHPHl+RI5nKF2MKJEXODHmLtVgUlXOz66XSCU4bEvjfr8yYTx+8DQ0JO54Y7Y0kwokA==}
+
   '@expo/config-plugins@56.0.8':
     resolution: {integrity: sha512-phTuyBhgVLfqUHMjQkAfRtbyoY6yTxoKja1awtpVnEkoJDxPJuXx1KX5uvq1eZtt4bJQ08OBJ6P95INqRSHpRg==}
 
   '@expo/config-plugins@56.0.9':
     resolution: {integrity: sha512-/6a/S9USwx8OC9tGjHxbviLFiBHyueN3aoNWMLvWDEJoZ1CIVW800ZBzwXq/FYNK2qzcN1LxFmQtzD1zeFQKNA==}
 
-  '@expo/config-types@56.0.5':
-    resolution: {integrity: sha512-GsAHO/MwW9ZRdgnmyfRXqVGLCP/zejD6rWnp5OROp8mBGRObKm4HfrjlUyT1skjMwCj1OrURx9ZfIc6yeBAkIA==}
-
-  '@expo/config-types@56.0.6':
-    resolution: {integrity: sha512-4Y6Aum5J4Re5NnxGVofRNe1aDwUBOmWhQYkynZsqzRtX/zEA1ADUeyHXuEckv9YD9djiyT7bKtLt5gKL3mA6VQ==}
+  '@expo/config-types@56.0.7':
+    resolution: {integrity: sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==}
 
   '@expo/config@56.0.9':
     resolution: {integrity: sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==}
@@ -2541,6 +2544,14 @@ packages:
 
   '@expo/require-utils@56.1.3':
     resolution: {integrity: sha512-KyLeOn/zzQSvuPpV5YhB/FPKnpQytno4luN918bGdPDssLBoS3N/0UbC3W0rJAn9kSFu+XpfR81eABRVsSdfgQ==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@expo/require-utils@56.1.5':
+    resolution: {integrity: sha512-3wsdJLSpELhRPEMZCCREqAAFRGG23BUWJHGKIUxyqGkWvy5KPdzlBxGlVVb/6h9gNOflqgTtvTWaP2EuHoQ1HQ==}
     peerDependencies:
       typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
     peerDependenciesMeta:
@@ -6724,6 +6735,13 @@ packages:
   expo-server@56.0.5:
     resolution: {integrity: sha512-SmM2p2g3Jrktpiazcst+OxhjSzOHXKAY4BPURHYHXvApzzoybMmrNF4IEZ8DKZ145BhSe4ydAmlEFCRTsdtgUQ==}
     engines: {node: '>=20.16.0'}
+
+  expo-sharing@56.0.18:
+    resolution: {integrity: sha512-45w4BWNFmdTczp+fJX6YfwJrn9sX+VeRWz2VWLhauygcCrym44HtVDXX5yVYPB9TW9ZesLcEI+CCrCBNWL7smQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-splash-screen@56.0.10:
     resolution: {integrity: sha512-vDIlo8hzt9HlCZQ0kSY66v83D1WEXOJbVMeyPDfXDu9tbDdPMNUyDpi4WGJXikAjxnAKfbt5Mv5NnEbxINy+VA==}
@@ -12064,7 +12082,7 @@ snapshots:
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@6.0.3)
-      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
       '@expo/devcert': 1.2.1
       '@expo/env': 2.3.0
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
@@ -12140,7 +12158,7 @@ snapshots:
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@6.0.3)
-      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
       '@expo/devcert': 1.2.1
       '@expo/env': 2.3.0
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
@@ -12217,9 +12235,28 @@ snapshots:
     dependencies:
       node-forge: 1.4.0
 
+  '@expo/config-plugins@56.0.13(typescript@6.0.3)':
+    dependencies:
+      '@expo/config-types': 56.0.7
+      '@expo/json-file': 10.2.0
+      '@expo/plist': 0.7.0
+      '@expo/require-utils': 56.1.5(typescript@6.0.3)
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      semver: 7.8.5
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@expo/config-plugins@56.0.8(typescript@6.0.3)':
     dependencies:
-      '@expo/config-types': 56.0.5
+      '@expo/config-types': 56.0.7
       '@expo/json-file': 10.2.0
       '@expo/plist': 0.7.0
       '@expo/require-utils': 56.1.3(typescript@6.0.3)
@@ -12238,7 +12275,7 @@ snapshots:
 
   '@expo/config-plugins@56.0.9(typescript@6.0.3)':
     dependencies:
-      '@expo/config-types': 56.0.6
+      '@expo/config-types': 56.0.7
       '@expo/json-file': 10.2.0
       '@expo/plist': 0.7.0
       '@expo/require-utils': 56.1.3(typescript@6.0.3)
@@ -12255,14 +12292,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/config-types@56.0.5': {}
-
-  '@expo/config-types@56.0.6': {}
+  '@expo/config-types@56.0.7': {}
 
   '@expo/config@56.0.9(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
-      '@expo/config-types': 56.0.5
+      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
+      '@expo/config-types': 56.0.7
       '@expo/json-file': 10.2.0
       '@expo/require-utils': 56.1.3(typescript@6.0.3)
       deepmerge: 4.3.1
@@ -12364,7 +12399,7 @@ snapshots:
 
   '@expo/inline-modules@0.0.12(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
+      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12515,8 +12550,8 @@ snapshots:
   '@expo/prebuild-config@56.0.16(typescript@6.0.3)':
     dependencies:
       '@expo/config': 56.0.9(typescript@6.0.3)
-      '@expo/config-plugins': 56.0.9(typescript@6.0.3)
-      '@expo/config-types': 56.0.6
+      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
+      '@expo/config-types': 56.0.7
       '@expo/image-utils': 0.10.1(typescript@6.0.3)
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.85.3
@@ -12539,6 +12574,16 @@ snapshots:
       - supports-color
 
   '@expo/require-utils@56.1.3(typescript@6.0.3)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/require-utils@56.1.5(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7
@@ -17034,6 +17079,18 @@ snapshots:
       expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
 
   expo-server@56.0.5: {}
+
+  expo-sharing@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3):
+    dependencies:
+      '@expo/config-plugins': 56.0.13(typescript@6.0.3)
+      '@expo/config-types': 56.0.7
+      '@expo/plist': 0.7.0
+      expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-splash-screen@56.0.10(expo@56.0.12)(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,8 @@ overrides:
   "@types/node": "catalog:"
   effect: "catalog:"
   expo-modules-jsi: 56.0.10
+  "expo-sharing>@expo/config-plugins": 56.0.9
+  "expo-sharing>@expo/config-types": 56.0.6
   vite: "catalog:"
   yaml: "catalog:"
 


### PR DESCRIPTION
## Summary
- Add Expo native share target configuration for iOS and Android, including branded iOS share extension display name handling.
- Persist incoming shared text, URLs, and image attachments into durable composer drafts, with validation for attachment limits and oversized images.
- Route pending native shares into the new task flow and add draft merge/flush support so shared content survives project selection and app restarts.

## Testing
- `vp test apps/mobile/src/features/sharing/incoming-share-model.test.ts apps/mobile/src/state/use-composer-drafts.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new mobile surface (extensions, file I/O, navigation guards, persisted drafts) with crash/retry edge cases; iOS Personal Team builds intentionally skip the share extension.
> 
> **Overview**
> Adds **native share target** support so users can share text, URLs, and images from other apps into T3 Code on Android and signed iOS builds (disabled for Personal Team local iOS where App Groups/extensions cannot be signed).
> 
> **Build & config:** `expo-sharing` is wired in `app.config.ts` with app-group IDs aligned to widgets; a `withShareExtensionDisplayName` config plugin brands the iOS share extension. Personal Team docs now note that share extensions are omitted alongside widgets.
> 
> **Ingestion pipeline:** New `IncomingShareProvider` + `IncomingShareInbox` ingest `expo-sharing` payloads into durable on-disk drafts (content-derived IDs, serialized mutations, reserve/release per project). Shared images are converted to composer attachments with contract size/count limits; `expo-sharing` lifecycle URLs are filtered from deep linking.
> 
> **UX flow:** Root navigation auto-opens `NewTaskSheet` when a pending share exists (with dismissal/re-queue logic). Project picker and `NewTaskDraftScreen` accept `incomingShareId`, merge shared content via new `mergeComposerDraftContent` / `restoreComposerDraftSnapshot` on composer drafts, block editing during transfer, and clear draft text/attachments on send using `clearComposerDraftContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1381fc9700195f5748e3110de906873431dd5138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native mobile share target support for iOS and Android
> - Adds an `expo-sharing` share extension to iOS (non-personal-team builds) and Android, allowing the app to receive content shared from other apps.
> - Implements `IncomingShareInbox` with durable storage, idempotent ingestion, and a serialized async queue to safely handle concurrent operations across app lifecycles.
> - Adds `IncomingShareProvider` and `useIncomingShare` hook to expose pending shares app-wide; `RootStackLayout` auto-presents the `NewTaskSheet` when a share arrives.
> - Integrates share import into `NewTaskDraftScreen`: reserves the share for a destination project, merges text and image attachments into the composer draft, blocks navigation during transfer, and supports retry/cancel with draft snapshot restoration.
> - Adds `mergeComposerDraftContent` and `restoreComposerDraftSnapshot` to the composer drafts state, with idempotent merging capped at `PROVIDER_SEND_TURN_MAX_ATTACHMENTS` and serialized persistence writes.
> - Risk: share extension is excluded from iOS personal-team builds; Android always enables it regardless of build type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1381fc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->