### PR TITLE
Isolate native diff highlight grammar state

### DIFF
--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
@@ -85,6 +85,43 @@ describe("highlightNativeReviewDiffVisibleRows", () => {
     expect(highlighted.tokensByRowId[exportRow.id]).toEqual(standalone.tokensByRowId[exportRow.id]);
   });
 
+  it("keeps grammar state across inline comment rows", async () => {
+    const openingRow = makeLine({
+      id: "template-open",
+      content: "const message = `open",
+      change: "add",
+      oldLineNumber: null,
+      newLineNumber: 1,
+    });
+    const closingRow = makeLine({
+      id: "template-close",
+      content: "closed`;",
+      change: "add",
+      oldLineNumber: null,
+      newLineNumber: 2,
+    });
+    const trailingRow = makeLine({
+      id: "trailing-row",
+      content: "export const answer = 42;",
+      change: "add",
+      oldLineNumber: null,
+      newLineNumber: 3,
+    });
+    const commentRow: NativeReviewDiffRow = {
+      kind: "comment",
+      id: "comment-1",
+      fileId: TYPESCRIPT_FILE.id,
+      commentText: "Review note",
+    };
+
+    const [withComment, contiguous] = await Promise.all([
+      highlight([openingRow, commentRow, closingRow, trailingRow]),
+      highlight([openingRow, closingRow, trailingRow]),
+    ]);
+
+    expect(withComment.tokensByRowId).toEqual(contiguous.tokensByRowId);
+  });
+
   it("does not join unhighlighted rows across cached gaps", async () => {
     const trailingRow = makeLine({
       id: "trailing-row",

--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { NativeReviewDiffRow } from "./nativeReviewDiffSurface";
+import type { NativeReviewDiffFile } from "./nativeReviewDiffTypes";
+import { highlightNativeReviewDiffVisibleRows } from "./nativeReviewDiffHighlighter";
+
+const TYPESCRIPT_FILE: NativeReviewDiffFile = {
+  id: "file-1",
+  path: "example.ts",
+  language: "typescript",
+  additions: 0,
+  deletions: 0,
+};
+
+function makeLine(
+  input: Pick<NativeReviewDiffRow, "id" | "content" | "change" | "oldLineNumber" | "newLineNumber">,
+): NativeReviewDiffRow {
+  return {
+    kind: "line",
+    fileId: TYPESCRIPT_FILE.id,
+    ...input,
+  };
+}
+
+function makeHunk(id: string): NativeReviewDiffRow {
+  return {
+    kind: "hunk",
+    id,
+    fileId: TYPESCRIPT_FILE.id,
+    text: "@@",
+  };
+}
+
+function highlight(
+  rows: ReadonlyArray<NativeReviewDiffRow>,
+  alreadyHighlightedRowIds?: ReadonlySet<string>,
+) {
+  return highlightNativeReviewDiffVisibleRows({
+    rows,
+    files: [TYPESCRIPT_FILE],
+    scheme: "dark",
+    engine: "javascript",
+    firstRowIndex: 0,
+    lastRowIndex: rows.length - 1,
+    overscanRows: 0,
+    maxRows: 100,
+    alreadyHighlightedRowIds,
+  });
+}
+
+describe("highlightNativeReviewDiffVisibleRows", () => {
+  it("does not carry grammar state across hunk boundaries", async () => {
+    const exportRow = makeLine({
+      id: "export-row",
+      content: "export async function run() {}",
+      change: "add",
+      oldLineNumber: null,
+      newLineNumber: 100,
+    });
+    const rows = [
+      makeHunk("hunk-1"),
+      makeLine({
+        id: "import-open",
+        content: "import {",
+        change: "context",
+        oldLineNumber: 1,
+        newLineNumber: 1,
+      }),
+      makeLine({
+        id: "import-entry",
+        content: "  Model,",
+        change: "context",
+        oldLineNumber: 2,
+        newLineNumber: 2,
+      }),
+      makeHunk("hunk-2"),
+      exportRow,
+    ];
+
+    const [highlighted, standalone] = await Promise.all([
+      highlight(rows),
+      highlight([makeHunk("standalone-hunk"), exportRow]),
+    ]);
+
+    expect(highlighted.tokensByRowId[exportRow.id]).toEqual(standalone.tokensByRowId[exportRow.id]);
+  });
+
+  it("does not join unhighlighted rows across cached gaps", async () => {
+    const trailingRow = makeLine({
+      id: "trailing-row",
+      content: "export const answer = 42;",
+      change: "add",
+      oldLineNumber: null,
+      newLineNumber: 3,
+    });
+    const rows = [
+      makeLine({
+        id: "template-open",
+        content: "const message = `open",
+        change: "add",
+        oldLineNumber: null,
+        newLineNumber: 1,
+      }),
+      makeLine({
+        id: "template-close",
+        content: "closed`;",
+        change: "add",
+        oldLineNumber: null,
+        newLineNumber: 2,
+      }),
+      trailingRow,
+    ];
+
+    const [highlighted, standalone] = await Promise.all([
+      highlight(rows, new Set(["template-close"])),
+      highlight([trailingRow]),
+    ]);
+
+    expect(highlighted.tokensByRowId[trailingRow.id]).toEqual(
+      standalone.tokensByRowId[trailingRow.id],
+    );
+  });
+
+  it("keeps deletion grammar state out of addition rows", async () => {
+    const additionRow = makeLine({
+      id: "addition-row",
+      content: "export const answer = 42;",
+      change: "add",
+      oldLineNumber: null,
+      newLineNumber: 1,
+    });
+    const rows = [
+      makeLine({
+        id: "deletion-row",
+        content: "const removed = `open",
+        change: "delete",
+        oldLineNumber: 1,
+        newLineNumber: null,
+      }),
+      additionRow,
+    ];
+
+    const [highlighted, standalone] = await Promise.all([
+      highlight(rows),
+      highlight([additionRow]),
+    ]);
+
+    expect(highlighted.tokensByRowId[additionRow.id]).toEqual(
+      standalone.tokensByRowId[additionRow.id],
+    );
+  });
+});

--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
@@ -56,6 +56,11 @@ interface NativeReviewDiffLineRow extends NativeReviewDiffRow {
   readonly content: string;
 }
 
+interface IndexedNativeReviewDiffLineRow {
+  readonly row: NativeReviewDiffLineRow;
+  readonly rowIndex: number;
+}
+
 export interface NativeReviewDiffTokenChunk {
   readonly chunkIndex: number;
   readonly fileId: string;
@@ -308,6 +313,41 @@ function isHighlightableLineRow(row: NativeReviewDiffRow): row is NativeReviewDi
   return row.kind === "line" && typeof row.fileId === "string" && typeof row.content === "string";
 }
 
+function hasConsecutiveLineNumbers(
+  previous: number | null | undefined,
+  next: number | null | undefined,
+): boolean {
+  return typeof previous === "number" && typeof next === "number" && next === previous + 1;
+}
+
+function canShareGrammarContext(
+  previous: IndexedNativeReviewDiffLineRow,
+  next: IndexedNativeReviewDiffLineRow,
+): boolean {
+  if (next.rowIndex !== previous.rowIndex + 1 || next.row.fileId !== previous.row.fileId) {
+    return false;
+  }
+
+  if (previous.row.change === "delete" || next.row.change === "delete") {
+    return (
+      previous.row.change !== "add" &&
+      next.row.change !== "add" &&
+      hasConsecutiveLineNumbers(previous.row.oldLineNumber, next.row.oldLineNumber)
+    );
+  }
+
+  if (previous.row.change === "add" || next.row.change === "add") {
+    return hasConsecutiveLineNumbers(previous.row.newLineNumber, next.row.newLineNumber);
+  }
+
+  return (
+    previous.row.change === "context" &&
+    next.row.change === "context" &&
+    hasConsecutiveLineNumbers(previous.row.oldLineNumber, next.row.oldLineNumber) &&
+    hasConsecutiveLineNumbers(previous.row.newLineNumber, next.row.newLineNumber)
+  );
+}
+
 function groupLineRowsByFileId(rows: ReadonlyArray<NativeReviewDiffRow>) {
   const rowsByFileId = new Map<string, NativeReviewDiffLineRow[]>();
   for (const row of rows) {
@@ -360,7 +400,7 @@ export async function highlightNativeReviewDiffVisibleRows(
   const maxRows = input.maxRows ?? NATIVE_REVIEW_DIFF_VISIBLE_MAX_ROWS;
   const startIndex = clampRowIndex(input.firstRowIndex - overscanRows, input.rows);
   const endIndex = clampRowIndex(input.lastRowIndex + overscanRows, input.rows);
-  const selectedRows: NativeReviewDiffLineRow[] = [];
+  const selectedRows: IndexedNativeReviewDiffLineRow[] = [];
 
   for (
     let rowIndex = startIndex;
@@ -374,12 +414,12 @@ export async function highlightNativeReviewDiffVisibleRows(
       !input.alreadyHighlightedRowIds?.has(row.id) &&
       fileMap.has(row.fileId)
     ) {
-      selectedRows.push(row);
+      selectedRows.push({ row, rowIndex });
     }
   }
 
   const tokensByRowId: Record<string, ReadonlyArray<NativeReviewDiffToken>> = {};
-  let segmentRows: NativeReviewDiffLineRow[] = [];
+  let segmentRows: IndexedNativeReviewDiffLineRow[] = [];
   let segmentFile: NativeReviewDiffFile | undefined;
 
   const flushSegment = () => {
@@ -389,27 +429,33 @@ export async function highlightNativeReviewDiffVisibleRows(
       return;
     }
 
-    const code = segmentRows.map((row) => row.content).join("\n");
+    const code = segmentRows.map(({ row }) => row.content).join("\n");
     const tokenLines = highlighter.tokenize(code, { lang: segmentFile.language, theme });
-    segmentRows.forEach((row, rowIndex) => {
+    segmentRows.forEach(({ row }, rowIndex) => {
       tokensByRowId[row.id] = tokenLines[rowIndex] ?? makePlainTokenFallback(row);
     });
     segmentRows = [];
     segmentFile = undefined;
   };
 
-  for (const row of selectedRows) {
+  for (const selectedRow of selectedRows) {
+    const { row } = selectedRow;
     const file = fileMap.get(row.fileId);
     if (!file) {
       continue;
     }
 
-    if (segmentFile && segmentFile.id !== file.id) {
+    const previousRow = segmentRows.at(-1);
+    if (
+      segmentFile &&
+      (segmentFile.id !== file.id ||
+        (previousRow !== undefined && !canShareGrammarContext(previousRow, selectedRow)))
+    ) {
       flushSegment();
     }
 
     segmentFile = file;
-    segmentRows.push(row);
+    segmentRows.push(selectedRow);
   }
   flushSegment();
 

--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
@@ -320,11 +320,28 @@ function hasConsecutiveLineNumbers(
   return typeof previous === "number" && typeof next === "number" && next === previous + 1;
 }
 
+function hasOnlyCommentRowsBetween(
+  rows: ReadonlyArray<NativeReviewDiffRow>,
+  previousRowIndex: number,
+  nextRowIndex: number,
+): boolean {
+  for (let rowIndex = previousRowIndex + 1; rowIndex < nextRowIndex; rowIndex += 1) {
+    if (rows[rowIndex]?.kind !== "comment") {
+      return false;
+    }
+  }
+  return true;
+}
+
 function canShareGrammarContext(
   previous: IndexedNativeReviewDiffLineRow,
   next: IndexedNativeReviewDiffLineRow,
+  rows: ReadonlyArray<NativeReviewDiffRow>,
 ): boolean {
-  if (next.rowIndex !== previous.rowIndex + 1 || next.row.fileId !== previous.row.fileId) {
+  if (
+    next.row.fileId !== previous.row.fileId ||
+    !hasOnlyCommentRowsBetween(rows, previous.rowIndex, next.rowIndex)
+  ) {
     return false;
   }
 
@@ -449,7 +466,8 @@ export async function highlightNativeReviewDiffVisibleRows(
     if (
       segmentFile &&
       (segmentFile.id !== file.id ||
-        (previousRow !== undefined && !canShareGrammarContext(previousRow, selectedRow)))
+        (previousRow !== undefined &&
+          !canShareGrammarContext(previousRow, selectedRow, input.rows)))
     ) {
       flushSegment();
     }


### PR DESCRIPTION
## Summary
- Split native review diff highlighting into contiguous grammar segments instead of carrying tokenizer state across unrelated rows.
- Prevent grammar context from leaking across hunk boundaries, cached row gaps, and add/delete transitions.
- Add focused tests covering hunk boundaries, cached gaps, and deletion-to-addition highlighting behavior.

## Testing
- `vp test apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile diff highlighting behavior only; no auth, data, or API changes, with regression coverage for edge cases.
> 
> **Overview**
> Fixes incorrect syntax highlighting in the native review diff viewer by **splitting visible rows into tokenization segments** instead of joining every selected line into one string.
> 
> `highlightNativeReviewDiffVisibleRows` now tracks each line with its list index and uses **`canShareGrammarContext`** to decide whether adjacent lines can be highlighted together. Segments flush on file changes, non-comment rows between lines (e.g. **hunk headers**), gaps where a line was already cached (`alreadyHighlightedRowIds`), and **delete vs add** boundaries so tokenizer state does not leak across unrelated source.
> 
> **Comment-only rows** between lines still allow shared grammar (e.g. multi-line templates). Add/delete/context rows require **consecutive old or new line numbers** as appropriate.
> 
> Adds **`nativeReviewDiffHighlighter.test.ts`** with focused cases for hunks, inline comments, cached gaps, and delete-to-add transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3138b75d96c99573f564b04f456ab5960302189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate grammar state across hunk boundaries in native diff highlighter
> - Adds `canShareGrammarContext` logic to `highlightNativeReviewDiffVisibleRows` in [nativeReviewDiffHighlighter.ts](https://github.com/pingdotgg/t3code/pull/4029/files#diff-e9a194e1d1abaf0c5153c9bef83d10657d6f3a6d309c808ec335f9af53f4d53e) to split tokenization segments when adjacent rows cannot share grammar state.
> - Grammar state is no longer carried across hunk boundaries or skipped lines, is preserved across inline comment rows, and addition/deletion contexts are isolated unless their per-side line numbers are consecutive.
> - Introduces `IndexedNativeReviewDiffLineRow`, `hasConsecutiveLineNumbers`, and `hasOnlyCommentRowsBetween` helpers to support adjacency and segmentation logic.
> - Behavioral Change: tokenization segments are now split more aggressively, meaning syntax highlighting may differ for rows that were previously grouped with unrelated hunks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3138b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->