### PR TITLE
fix(mobile): Recover thread state reliably after reconnects

### DIFF
--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -31,7 +31,7 @@ import {
   useRemoteEnvironmentRuntime,
 } from "../../state/use-remote-environment-registry";
 import { useKnownTerminalSessions } from "../../state/use-terminal-session";
-import { useSelectedThreadDetailState } from "../../state/use-thread-detail";
+import { useSelectedThreadDetailQuery } from "../../state/use-thread-detail";
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { GitActionProgressOverlay } from "./GitActionProgressOverlay";
 import {
@@ -77,6 +77,11 @@ interface ThreadInspectorSelection {
 }
 
 type NativeHeaderItems = ReadonlyArray<Record<string, unknown>>;
+
+const THREAD_DETAIL_STALL_RETRY_DELAYS_MS = [8_000, 12_000] as const;
+const THREAD_DETAIL_STALL_ERROR_DELAY_MS = 20_000;
+const THREAD_DETAIL_STALL_ERROR =
+  "The conversation did not finish loading. Close and reopen the thread to retry.";
 
 function InspectorPaneRoleActivation() {
   useAdaptiveWorkspacePaneRole("inspector");
@@ -144,7 +149,91 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
     selectedThread === null
       ? null
       : scopedThreadKey(selectedThread.environmentId, selectedThread.id);
-  const selectedThreadDetailState = useSelectedThreadDetailState();
+  const selectedThreadDetailQuery = useSelectedThreadDetailQuery();
+  const selectedThreadDetailState = selectedThreadDetailQuery.state;
+  const selectedThreadDetail = Option.getOrNull(selectedThreadDetailState.data);
+  const detailRefreshAttemptsRef = useRef(new Map<string, number>());
+  const refreshSelectedThreadDetailRef = useRef(selectedThreadDetailQuery.refresh);
+  const [stalledDetailKey, setStalledDetailKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    refreshSelectedThreadDetailRef.current = selectedThreadDetailQuery.refresh;
+  }, [selectedThreadDetailQuery.refresh]);
+
+  useEffect(
+    () => () => {
+      if (routeThreadKey !== null) {
+        detailRefreshAttemptsRef.current.delete(routeThreadKey);
+      }
+    },
+    [routeThreadKey],
+  );
+
+  useEffect(() => {
+    if (routeThreadKey === null) {
+      return;
+    }
+
+    if (selectedThreadKey !== routeThreadKey) {
+      return;
+    }
+
+    if (selectedThreadDetail !== null || selectedThreadDetailState.status === "deleted") {
+      detailRefreshAttemptsRef.current.delete(routeThreadKey);
+      setStalledDetailKey((current) => (current === routeThreadKey ? null : current));
+      return;
+    }
+
+    if (routeConnectionState !== "connected") {
+      detailRefreshAttemptsRef.current.delete(routeThreadKey);
+      setStalledDetailKey((current) => (current === routeThreadKey ? null : current));
+      return;
+    }
+
+    if (stalledDetailKey === routeThreadKey) {
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRetry = () => {
+      const attempts = detailRefreshAttemptsRef.current.get(routeThreadKey) ?? 0;
+      const delayMs =
+        THREAD_DETAIL_STALL_RETRY_DELAYS_MS[attempts] ?? THREAD_DETAIL_STALL_ERROR_DELAY_MS;
+      timer = setTimeout(() => {
+        if (cancelled) {
+          return;
+        }
+        const currentAttempts = detailRefreshAttemptsRef.current.get(routeThreadKey) ?? 0;
+        if (currentAttempts !== attempts) {
+          return;
+        }
+        if (attempts >= THREAD_DETAIL_STALL_RETRY_DELAYS_MS.length) {
+          setStalledDetailKey(routeThreadKey);
+          return;
+        }
+        detailRefreshAttemptsRef.current.set(routeThreadKey, attempts + 1);
+        refreshSelectedThreadDetailRef.current();
+        scheduleRetry();
+      }, delayMs);
+    };
+
+    scheduleRetry();
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    };
+  }, [
+    routeThreadKey,
+    routeConnectionState,
+    selectedThreadKey,
+    selectedThreadDetail,
+    selectedThreadDetailState.status,
+    stalledDetailKey,
+  ]);
 
   if (environmentId === null || threadIdRaw === null) {
     return <OpeningThreadLoadingScreen />;
@@ -155,7 +244,13 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
   // loading placeholder while messages fetch, and the composer's connection
   // pill reports connecting/reconnecting/syncing status.
   if (selectedThread !== null && selectedThreadKey === routeThreadKey) {
-    return <ThreadRouteContent {...props} selectedThreadDetailState={selectedThreadDetailState} />;
+    return (
+      <ThreadRouteContent
+        {...props}
+        detailLoadError={stalledDetailKey === routeThreadKey ? THREAD_DETAIL_STALL_ERROR : null}
+        selectedThreadDetailState={selectedThreadDetailState}
+      />
+    );
   }
 
   const stillHydrating =
@@ -172,7 +267,8 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
 
 function ThreadRouteContent(
   props: ThreadRouteScreenProps & {
-    readonly selectedThreadDetailState: ReturnType<typeof useSelectedThreadDetailState>;
+    readonly detailLoadError: string | null;
+    readonly selectedThreadDetailState: ReturnType<typeof useSelectedThreadDetailQuery>["state"];
   },
 ) {
   const {
@@ -735,7 +831,7 @@ function ThreadRouteContent(
 
   const contentPresentation = projectThreadContentPresentation({
     hasDetail: selectedThreadDetail !== null,
-    detailError: Option.getOrNull(selectedThreadDetailState.error),
+    detailError: Option.getOrNull(selectedThreadDetailState.error) ?? props.detailLoadError,
     detailDeleted: selectedThreadDetailState.status === "deleted",
     connectionState: routeConnectionState,
   });

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -160,14 +160,14 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
     refreshSelectedThreadDetailRef.current = selectedThreadDetailQuery.refresh;
   }, [selectedThreadDetailQuery.refresh]);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    setStalledDetailKey(null);
+    return () => {
       if (routeThreadKey !== null) {
         detailRefreshAttemptsRef.current.delete(routeThreadKey);
       }
-    },
-    [routeThreadKey],
-  );
+    };
+  }, [routeThreadKey]);
 
   useEffect(() => {
     if (routeThreadKey === null) {

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -184,14 +184,6 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
       return;
     }
 
-    // A warm reconnect legitimately has no detail while the runtime catches
-    // up. The watchdog should start only after synchronization settles.
-    if (selectedThreadDetailState.status === "synchronizing") {
-      detailRefreshAttemptsRef.current.delete(routeThreadKey);
-      setStalledDetailKey((current) => (current === routeThreadKey ? null : current));
-      return;
-    }
-
     if (routeConnectionState !== "connected") {
       detailRefreshAttemptsRef.current.delete(routeThreadKey);
       setStalledDetailKey((current) => (current === routeThreadKey ? null : current));

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -184,6 +184,14 @@ export function ThreadRouteScreen(props: ThreadRouteScreenProps) {
       return;
     }
 
+    // A warm reconnect legitimately has no detail while the runtime catches
+    // up. The watchdog should start only after synchronization settles.
+    if (selectedThreadDetailState.status === "synchronizing") {
+      detailRefreshAttemptsRef.current.delete(routeThreadKey);
+      setStalledDetailKey((current) => (current === routeThreadKey ? null : current));
+      return;
+    }
+
     if (routeConnectionState !== "connected") {
       detailRefreshAttemptsRef.current.delete(routeThreadKey);
       setStalledDetailKey((current) => (current === routeThreadKey ? null : current));

--- a/apps/mobile/src/state/query.ts
+++ b/apps/mobile/src/state/query.ts
@@ -1,5 +1,6 @@
 import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
-import * as Cause from "effect/Cause";
+import { causeFailureMessage } from "@t3tools/client-runtime/errors";
+import type * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
@@ -15,10 +16,7 @@ export interface EnvironmentQueryView<A> {
 }
 
 function formatError(cause: Cause.Cause<unknown>): string {
-  const error = Cause.squash(cause);
-  return error instanceof Error && error.message.trim().length > 0
-    ? error.message
-    : "The environment request failed.";
+  return causeFailureMessage(cause, "The environment request failed.");
 }
 
 export function useEnvironmentQuery<A, E>(

--- a/apps/mobile/src/state/threadQueryState.ts
+++ b/apps/mobile/src/state/threadQueryState.ts
@@ -1,0 +1,26 @@
+import {
+  EMPTY_ENVIRONMENT_THREAD_STATE,
+  type EnvironmentThreadState,
+} from "@t3tools/client-runtime/state/threads";
+import { causeFailureMessage } from "@t3tools/client-runtime/errors";
+import type * as Cause from "effect/Cause";
+import * as Option from "effect/Option";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+function formatThreadStateFailure(cause: Cause.Cause<unknown>): string {
+  return causeFailureMessage(cause, "Could not load conversation.");
+}
+
+export function environmentThreadStateFromAsyncResult(
+  result: AsyncResult.AsyncResult<EnvironmentThreadState, unknown>,
+): EnvironmentThreadState {
+  const value = Option.getOrNull(AsyncResult.value(result));
+  if (AsyncResult.isFailure(result)) {
+    return {
+      ...(value ?? EMPTY_ENVIRONMENT_THREAD_STATE),
+      error: Option.some(formatThreadStateFailure(result.cause)),
+    };
+  }
+
+  return value ?? EMPTY_ENVIRONMENT_THREAD_STATE;
+}

--- a/apps/mobile/src/state/threads.test.ts
+++ b/apps/mobile/src/state/threads.test.ts
@@ -1,0 +1,40 @@
+import { EMPTY_ENVIRONMENT_THREAD_STATE } from "@t3tools/client-runtime/state/threads";
+import * as Cause from "effect/Cause";
+import * as Option from "effect/Option";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it } from "vite-plus/test";
+
+import { environmentThreadStateFromAsyncResult } from "./threadQueryState";
+
+describe("environmentThreadStateFromAsyncResult", () => {
+  it("returns the empty state while the first value is loading", () => {
+    expect(environmentThreadStateFromAsyncResult(AsyncResult.initial(true))).toEqual(
+      EMPTY_ENVIRONMENT_THREAD_STATE,
+    );
+  });
+
+  it("surfaces a failure when no previous value exists", () => {
+    const state = environmentThreadStateFromAsyncResult(
+      AsyncResult.failure(Cause.fail("thread sync failed")),
+    );
+
+    expect(Option.getOrNull(state.data)).toBeNull();
+    expect(Option.getOrNull(state.error)).toBe("thread sync failed");
+  });
+
+  it("preserves previous thread data while surfacing a refresh failure", () => {
+    const previousState = {
+      ...EMPTY_ENVIRONMENT_THREAD_STATE,
+      status: "live" as const,
+    };
+    const previousSuccess = AsyncResult.success(previousState);
+    const state = environmentThreadStateFromAsyncResult(
+      AsyncResult.failure(Cause.fail(new Error("refresh failed")), {
+        previousSuccess: Option.some(previousSuccess),
+      }),
+    );
+
+    expect(state.status).toBe("live");
+    expect(Option.getOrNull(state.error)).toBe("refresh failed");
+  });
+});

--- a/apps/mobile/src/state/threads.ts
+++ b/apps/mobile/src/state/threads.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import {
   createEnvironmentThreadDetailAtoms,
   createEnvironmentThreadShellAtoms,
@@ -8,12 +8,12 @@ import {
   createThreadEnvironmentAtoms,
 } from "@t3tools/client-runtime/state/threads";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
 import { environmentSnapshotAtom } from "./shell";
+import { environmentThreadStateFromAsyncResult } from "./threadQueryState";
 
 export const threadEnvironment = createThreadEnvironmentAtoms(connectionAtomRuntime);
 export const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
@@ -29,17 +29,33 @@ const EMPTY_THREAD_STATE_ATOM = Atom.make(AsyncResult.success(EMPTY_ENVIRONMENT_
   Atom.withLabel("mobile-environment-thread:empty"),
 );
 
+export interface EnvironmentThreadQuery {
+  readonly state: EnvironmentThreadState;
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+}
+
+export function useEnvironmentThreadQuery(
+  environmentId: EnvironmentId | null,
+  threadId: ThreadId | null,
+): EnvironmentThreadQuery {
+  const atom =
+    environmentId !== null && threadId !== null
+      ? environmentThreads.stateAtom(environmentId, threadId)
+      : EMPTY_THREAD_STATE_ATOM;
+  const result = useAtomValue(atom);
+  const refresh = useAtomRefresh(atom);
+
+  return {
+    state: environmentThreadStateFromAsyncResult(result),
+    isPending: environmentId !== null && threadId !== null && result.waiting,
+    refresh,
+  };
+}
+
 export function useEnvironmentThread(
   environmentId: EnvironmentId | null,
   threadId: ThreadId | null,
 ): EnvironmentThreadState {
-  const result = useAtomValue(
-    environmentId !== null && threadId !== null
-      ? environmentThreads.stateAtom(environmentId, threadId)
-      : EMPTY_THREAD_STATE_ATOM,
-  );
-  return Option.getOrElse(
-    AsyncResult.value(result),
-    () => EMPTY_ENVIRONMENT_THREAD_STATE,
-  ) as EnvironmentThreadState;
+  return useEnvironmentThreadQuery(environmentId, threadId).state;
 }

--- a/apps/mobile/src/state/use-thread-detail.ts
+++ b/apps/mobile/src/state/use-thread-detail.ts
@@ -1,7 +1,7 @@
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 
-import { useEnvironmentThread } from "./threads";
+import { useEnvironmentThread, useEnvironmentThreadQuery } from "./threads";
 import { useThreadSelection } from "./use-thread-selection";
 
 export interface ThreadDetailTarget {
@@ -13,9 +13,17 @@ export function useThreadDetail(target: ThreadDetailTarget) {
   return useEnvironmentThread(target.environmentId, target.threadId);
 }
 
+export function useThreadDetailQuery(target: ThreadDetailTarget) {
+  return useEnvironmentThreadQuery(target.environmentId, target.threadId);
+}
+
 export function useSelectedThreadDetailState() {
+  return useSelectedThreadDetailQuery().state;
+}
+
+export function useSelectedThreadDetailQuery() {
   const { selectedThread } = useThreadSelection();
-  return useThreadDetail({
+  return useThreadDetailQuery({
     environmentId: selectedThread?.environmentId ?? null,
     threadId: selectedThread?.id ?? null,
   });

--- a/packages/client-runtime/src/errors/causeMessage.test.ts
+++ b/packages/client-runtime/src/errors/causeMessage.test.ts
@@ -1,0 +1,45 @@
+import * as Cause from "effect/Cause";
+import { describe, expect, it } from "vite-plus/test";
+
+import { causeFailureMessage } from "./causeMessage.ts";
+
+describe("causeFailureMessage", () => {
+  it("returns the message of an Error failure", () => {
+    expect(causeFailureMessage(Cause.fail(new Error("boom")), "fallback")).toBe("boom");
+  });
+
+  it("returns a string failure verbatim", () => {
+    expect(causeFailureMessage(Cause.fail("nope"), "fallback")).toBe("nope");
+  });
+
+  it("returns the message of a tagged error object", () => {
+    expect(
+      causeFailureMessage(
+        Cause.fail({ _tag: "RelayInternalError", message: "relay down" }),
+        "fallback",
+      ),
+    ).toBe("relay down");
+  });
+
+  it("falls back for empty Error messages", () => {
+    expect(causeFailureMessage(Cause.fail(new Error("   ")), "fallback")).toBe("fallback");
+  });
+
+  it("falls back for empty string failures", () => {
+    expect(causeFailureMessage(Cause.fail(""), "fallback")).toBe("fallback");
+  });
+
+  it("falls back for objects without a string message", () => {
+    expect(causeFailureMessage(Cause.fail({ code: 500 }), "fallback")).toBe("fallback");
+    expect(causeFailureMessage(Cause.fail({ message: 42 }), "fallback")).toBe("fallback");
+  });
+
+  it("falls back for other primitive failures", () => {
+    expect(causeFailureMessage(Cause.fail(null), "fallback")).toBe("fallback");
+    expect(causeFailureMessage(Cause.fail(42), "fallback")).toBe("fallback");
+  });
+
+  it("returns the defect message for die causes", () => {
+    expect(causeFailureMessage(Cause.die(new Error("defect")), "fallback")).toBe("defect");
+  });
+});

--- a/packages/client-runtime/src/errors/causeMessage.ts
+++ b/packages/client-runtime/src/errors/causeMessage.ts
@@ -1,0 +1,19 @@
+import * as Cause from "effect/Cause";
+
+export function causeFailureMessage(cause: Cause.Cause<unknown>, fallback: string): string {
+  const message = failureMessage(Cause.squash(cause));
+  return message !== null && message.trim().length > 0 ? message : fallback;
+}
+
+export function failureMessage(error: unknown): string | null {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return typeof error.message === "string" ? error.message : null;
+  }
+  return null;
+}

--- a/packages/client-runtime/src/errors/index.ts
+++ b/packages/client-runtime/src/errors/index.ts
@@ -1,3 +1,4 @@
+export * from "./causeMessage.ts";
 export * from "./errorTrace.ts";
 export * from "./safeLog.ts";
 export * from "./transport.ts";

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -15,6 +15,7 @@ import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { Atom } from "effect/unstable/reactivity";
 
+import { causeFailureMessage } from "../errors/causeMessage.ts";
 import { EnvironmentRegistry } from "../connection/registry.ts";
 import { connectionProjectionPhase } from "../connection/model.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
@@ -36,10 +37,7 @@ function statusWithoutLiveData(data: Option.Option<OrchestrationThread>): Enviro
 }
 
 function formatThreadError(cause: Cause.Cause<unknown>): string {
-  const error = Cause.squash(cause);
-  return error instanceof Error && error.message.trim().length > 0
-    ? error.message
-    : "Could not synchronize the thread.";
+  return causeFailureMessage(cause, "Could not synchronize the thread.");
 }
 
 function shouldPersistThread(thread: OrchestrationThread): boolean {


### PR DESCRIPTION
Extracted from #3910.

Makes cached shell and thread state recover predictably after reconnects, preserves actionable error causes, retries stalled detail loading, and adds focused shell/thread synchronization coverage.

Validation inherited from #3910: `vp check` and mobile native lint passed before the split. The full typecheck is currently blocked in this workspace by unavailable mobile dependencies (`expo-blur`, `expo-quick-actions`, and `@tabler/icons-react-native`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover thread state reliably after reconnects using synchronized completion markers
> - Adds a `synchronized` marker item to shell and thread subscription streams so clients know exactly when catch-up is complete after a reconnect, keeping state as `synchronizing` until the marker arrives.
> - Server advertises support via new `shellResumeCompletionMarker` and `threadResumeCompletionMarker` fields in `ServerConfig`; clients request the marker via `requestCompletionMarker` on subscription input.
> - Shell and thread state effects in [`shell.ts`](https://github.com/pingdotgg/t3code/pull/4034/files#diff-538b14bdf595ee51e55aaaa249aab3e8505b533401c51b92360b4d9c37251c83) and [`threads.ts`](https://github.com/pingdotgg/t3code/pull/4034/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815) are reworked to buffer live events during snapshot load, resume via `afterSequence`, and refresh on app foreground via a new `subscribeDynamic` helper.
> - On mobile, [`ThreadRouteScreen`](https://github.com/pingdotgg/t3code/pull/4034/files#diff-6335d58d7c246073ba2e7cd1c773675c00c0019ceaecf67ff39734bed4dea283) adds stall detection: if thread detail doesn't arrive despite an active connection, it retries at 8s and 12s intervals and surfaces an inline error asking the user to reopen the thread.
> - The `WorkspaceConnectionStatus` pill now shows during shell snapshot catch-up (`hasPendingShellSnapshot`) with distinct labels for initial load vs. cached catch-up.
> - Behavioral Change: shell warm caches are replaced by authoritative HTTP snapshots on reconnect; clients that do not send `requestCompletionMarker` see no change in behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a5a299.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket subscription semantics and client sync state machines for shell and thread data—areas that affect reconnect correctness and what users see as “live” vs “syncing.” Server-side event buffering on shell snapshot load adds concurrency risk if mis-ordered.
> 
> **Overview**
> Adds an opt-in **`synchronized`** completion marker on shell and thread WebSocket subscriptions so clients can tell when initial snapshot or catch-up replay is finished before live events. The server advertises this via **`shellResumeCompletionMarker`** / **`threadResumeCompletionMarker`** in config, emits the marker after replay or snapshot (including empty catch-up), and **buffers live shell events** while a full snapshot loads on the fallback path so nothing is missed.
> 
> **Client-runtime** shell and thread state machines now load an **authoritative HTTP snapshot** on each subscribe (replacing warm-cache-only resume), request the completion marker when supported, and stay **`synchronizing`** until **`synchronized`** arrives. Shell sync also **resubscribes on app foreground** via **`subscribeDynamic`**. Shared **`causeFailureMessage`** normalizes Effect failure text; thread refresh failures keep prior data while surfacing the error.
> 
> **Mobile** exposes **`useEnvironmentThreadQuery`** / **`useSelectedThreadDetailQuery`** with **`refresh`** and **`isPending`**, retries stalled thread detail loads on a timer, and shows **“Loading/Syncing threads…”** connection status when **`hasPendingShellSnapshot`** is set (including in the home empty state on iOS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5a299890992069db6743eaf0ef8ad4eb245e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->