### PR TITLE
fix(mobile): Send composer images in upload wire format

### DIFF
--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -36,7 +36,37 @@ vi.mock("./uuid", () => ({
   uuidv4: () => "attachment-id",
 }));
 
-import { convertPastedImagesToAttachments, isOwnedPastedImageUri } from "./composerImages";
+import {
+  convertPastedImagesToAttachments,
+  isOwnedPastedImageUri,
+  toUploadChatImageAttachments,
+} from "./composerImages";
+
+describe("toUploadChatImageAttachments", () => {
+  it("strips client draft id and previewUri for the startTurn wire shape", () => {
+    expect(
+      toUploadChatImageAttachments([
+        {
+          id: "client-draft-id",
+          type: "image",
+          name: "pasted-image.png",
+          mimeType: "image/png",
+          sizeBytes: 12,
+          dataUrl: "data:image/png;base64,AA==",
+          previewUri: "file:///tmp/preview.png",
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "image",
+        name: "pasted-image.png",
+        mimeType: "image/png",
+        sizeBytes: 12,
+        dataUrl: "data:image/png;base64,AA==",
+      },
+    ]);
+  });
+});
 
 describe("native pasted image cleanup", () => {
   beforeEach(() => {

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -10,6 +10,19 @@ export interface DraftComposerImageAttachment extends UploadChatImageAttachment 
   readonly previewUri: string;
 }
 
+/** Wire shape for startTurn: pure uploads without client draft id / previewUri. */
+export function toUploadChatImageAttachments(
+  attachments: ReadonlyArray<DraftComposerImageAttachment>,
+): ReadonlyArray<UploadChatImageAttachment> {
+  return attachments.map((attachment) => ({
+    type: attachment.type,
+    name: attachment.name,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    dataUrl: attachment.dataUrl,
+  }));
+}
+
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";
 
 function estimateBase64ByteSize(base64: string): number {

--- a/apps/mobile/src/lib/projectThreadStartTurn.ts
+++ b/apps/mobile/src/lib/projectThreadStartTurn.ts
@@ -8,7 +8,7 @@ import {
   type RuntimeMode,
 } from "@t3tools/contracts";
 
-import type { DraftComposerImageAttachment } from "./composerImages";
+import { toUploadChatImageAttachments, type DraftComposerImageAttachment } from "./composerImages";
 
 export function deriveThreadTitleFromPrompt(value: string): string {
   const trimmed = value.trim();
@@ -55,7 +55,7 @@ export function buildProjectThreadStartTurnInput(spec: ProjectThreadStartTurnSpe
       messageId: MessageId.make(spec.messageId),
       role: "user" as const,
       text: spec.text,
-      attachments: spec.attachments,
+      attachments: toUploadChatImageAttachments(spec.attachments),
     },
     modelSelection: spec.modelSelection,
     titleSeed: title,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { scopedThreadKey } from "../lib/scopedEntities";
 import { buildProjectThreadStartTurnInput } from "../lib/projectThreadStartTurn";
+import { toUploadChatImageAttachments } from "../lib/composerImages";
 import { randomHex } from "../lib/uuid";
 import { appAtomRegistry } from "./atom-registry";
 import { useProjects, useThreadShells } from "./entities";
@@ -221,7 +222,7 @@ export function useThreadOutboxDrain(): void {
             messageId: queuedMessage.messageId,
             role: "user",
             text: queuedMessage.text,
-            attachments: queuedMessage.attachments,
+            attachments: toUploadChatImageAttachments(queuedMessage.attachments),
           },
           modelSelection: settings.modelSelection,
           runtimeMode: settings.runtimeMode,


### PR DESCRIPTION
Extracted from #3910.

Converts client-only draft image attachments to the upload wire shape for direct turn starts and queued outbox retries, with focused composer-image tests.

Validation inherited from #3910: `vp check` and mobile native lint passed before the split. The full typecheck is currently blocked in this workspace by unavailable mobile dependencies (`expo-blur`, `expo-quick-actions`, and `@tabler/icons-react-native`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer image attachments to strip client-only fields before upload
> - Adds `toUploadChatImageAttachments` in [`composerImages.ts`](https://github.com/pingdotgg/t3code/pull/4035/files#diff-8723c2d87dbdbb196075db6f79088889d3a7f72c0b472d71bc669adc4b533e51) to map draft attachments to the wire format, omitting `id` and `previewUri`.
> - Updates [`projectThreadStartTurnInput.ts`](https://github.com/pingdotgg/t3code/pull/4035/files#diff-355de8331b65d395443bd9a4d7564a323ecb944d60895f2f503436c6548cae2d) and [`use-thread-outbox-drain.ts`](https://github.com/pingdotgg/t3code/pull/4035/files#diff-c6afd8ca1f9412d0350ad44712f269fd37ea380215bf974fa2fcead4352da5a3) to apply this conversion before sending attachments.
> - Behavioral Change: uploaded image payloads no longer include client-only `id` or `previewUri` fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 519da2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow serialization fix at send boundaries with a unit test; no auth or persistence changes.
> 
> **Overview**
> Composer image drafts keep extra client fields (`id`, `previewUri`) for UI; **`startTurn` expects `UploadChatImageAttachment`**, which only includes `type`, `name`, `mimeType`, `sizeBytes`, and `dataUrl`.
> 
> This PR adds **`toUploadChatImageAttachments`** in `composerImages.ts` and uses it when building turn input in **`buildProjectThreadStartTurnInput`** (new threads / queued creation) and in **`use-thread-outbox-drain`** when retrying queued messages on existing threads. A unit test asserts the stripped wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519da2dfc5a4c69b5c66520f9d408a0051ccd918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->