### PR TITLE
Fix iOS terminal Enter input encoding

### DIFF
--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalModule.swift
@@ -7,7 +7,7 @@ public class T3TerminalModule: Module {
     // Bumped when native hardware-keyboard handling changes; surfaced in the JS debug
     // logs so a stale native binary is distinguishable from a broken key pipeline.
     Constants([
-      "hardwareKeyRevision": 2,
+      "hardwareKeyRevision": 3,
     ])
 
     View(T3TerminalView.self) {

--- a/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
+++ b/apps/mobile/modules/t3-terminal/ios/T3TerminalView.swift
@@ -119,6 +119,21 @@ private enum TerminalHardwareKeyEncoder {
   }
 }
 
+private enum TerminalInputSequence {
+  /// Terminal Enter is carriage return. Sending line feed instead is Ctrl+J,
+  /// which raw-mode TUIs may interpret as the literal J key.
+  static let carriageReturn = "\r"
+
+  static func normalizingReturn(_ input: String) -> String {
+    switch input {
+    case "\n", "\r\n":
+      return carriageReturn
+    default:
+      return input
+    }
+  }
+}
+
 private final class TerminalInputField: UITextField {
   var onDeleteBackward: (() -> Void)?
   var onInsert: ((String) -> Void)?
@@ -352,7 +367,9 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
 
   public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
     if !string.isEmpty {
-      emitInput(string)
+      // Some software keyboards deliver Return through this delegate instead of
+      // textFieldShouldReturn, so normalize that path too.
+      emitInput(TerminalInputSequence.normalizingReturn(string))
       return false
     }
 
@@ -360,7 +377,7 @@ public final class T3TerminalView: ExpoView, UITextFieldDelegate {
   }
 
   public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-    emitInput("\n")
+    emitInput(TerminalInputSequence.carriageReturn)
     textField.text = ""
     return false
   }

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -145,7 +145,8 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
           onSubmitEditing={(event) => {
             const text = event.nativeEvent.text;
             if (text.length > 0) {
-              props.onInput(`${text}\n`);
+              // Terminal Enter is CR. LF is Ctrl+J and raw-mode TUIs can treat it as J.
+              props.onInput(`${text}\r`);
             }
           }}
         />


### PR DESCRIPTION
## Summary
- Send terminal Enter as carriage return on iOS instead of line feed.
- Normalize Return input from both native text-field delegate paths.
- Update the native hardware-key revision and fallback terminal submit behavior.

## Testing
- Not run; PR content generated from provided commit and diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to mobile terminal keystroke encoding with no auth, data, or server impact; main risk is subtle TUI/shell edge cases if any consumer expected LF.
> 
> **Overview**
> **iOS mobile terminal Enter** now emits **carriage return (`\r`)** instead of line feed (`\n`), so shells and raw-mode TUIs get standard Enter behavior instead of treating LF as Ctrl+J / a literal `J`.
> 
> Native `T3TerminalView` adds `TerminalInputSequence` to map `\n` and `\r\n` to `\r` on both Return paths (`textFieldShouldReturn` and the delegate path some software keyboards use). The JS **fallback** text input matches the same `\r` suffix on submit. **`hardwareKeyRevision`** is bumped to **3** on iOS so debug logs can spot stale native builds after this keyboard/input change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d61166ebcd0b6aca3c7472ec1d8a7369b4dd90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS terminal Enter key to emit carriage return instead of line feed
> - Updates `T3TerminalView` so that `textFieldShouldReturn` emits `"\r"` instead of `"\n"`, and normalizes any `"\n"` or `"\r\n"` in `shouldChangeCharacters` to `"\r"` before dispatch.
> - Updates `FallbackTerminalSurface` to append `"\r"` instead of `"\n"` on submit.
> - Bumps `hardwareKeyRevision` constant from 2 to 3 to signal the updated encoding behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51d6116.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->