### PR TITLE
Allow preview panel to grow on wide displays

### DIFF
--- a/apps/web/src/components/preview/PreviewPanelShell.test.ts
+++ b/apps/web/src/components/preview/PreviewPanelShell.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getPreviewPanelMaxWidth } from "./PreviewPanelShell";
+
+describe("getPreviewPanelMaxWidth", () => {
+  it("allows the panel to use 70% of an ultra-wide viewport without a pixel ceiling", () => {
+    expect(getPreviewPanelMaxWidth(6_000)).toBe(4_200);
+  });
+
+  it("rounds fractional CSS pixels down", () => {
+    expect(getPreviewPanelMaxWidth(2_001)).toBe(1_400);
+  });
+});

--- a/apps/web/src/components/preview/PreviewPanelShell.tsx
+++ b/apps/web/src/components/preview/PreviewPanelShell.tsx
@@ -10,11 +10,13 @@ export type PreviewPanelMode = "inline" | "sheet" | "sidebar" | "embedded";
 
 const PREVIEW_PANEL_WIDTH_STORAGE_KEY = "t3code:preview-panel-width";
 const PREVIEW_PANEL_MIN_WIDTH = 360;
-/** Hard ceiling so a wide monitor can't yield a panel that swallows the chat. */
-const PREVIEW_PANEL_MAX_WIDTH_PX = 1400;
-/** Fraction of the viewport allowed; the panel is min(this · vw, MAX_PX). */
+/** Fraction of the viewport allowed, preserving the remaining space for chat. */
 const PREVIEW_PANEL_MAX_WIDTH_FRACTION = 0.7;
 const PREVIEW_PANEL_DEFAULT_WIDTH = 540;
+
+export function getPreviewPanelMaxWidth(viewportWidth: number): number {
+  return Math.floor(viewportWidth * PREVIEW_PANEL_MAX_WIDTH_FRACTION);
+}
 
 /**
  * Shell for the preview panel. In inline mode the panel is user-resizable
@@ -82,5 +84,5 @@ function useViewportClampedMaxWidth(): number {
       if (frame !== 0) window.cancelAnimationFrame(frame);
     };
   }, []);
-  return Math.min(PREVIEW_PANEL_MAX_WIDTH_PX, Math.floor(vw * PREVIEW_PANEL_MAX_WIDTH_FRACTION));
+  return getPreviewPanelMaxWidth(vw);
 }


### PR DESCRIPTION
Fixes #3893.

## What Changed

Removed the fixed 1400px maximum width on the resizable inline right panel. The panel can now use up to 70% of the display.

## Why

The right panel hosts the integrated browser. On high-resolution and ultra-wide displays, the fixed 1440px maximum width on the sidebar limited it even while plenty of room remained for chat. 

This is highly uncomfortable when the integrated browser is used to display large desktop resolutions, the page in the browser gets so small it's difficult to read, while there are a ton of negative space available around the chat (see screenshots before/after).

## Screenshots

### After

Maximum sidebar size on a 6k monitor:

<img width="6118" height="3395" alt="image" src="https://github.com/user-attachments/assets/1c3deede-c204-423c-acbd-335ba54411b7" />


### Before

Same integrated browser viewport size on the same monitor, constrained as the sidebar does not resize to more than 1440px:

<img width="6128" height="3404" alt="image" src="https://github.com/user-attachments/assets/bd5b3997-99fa-43ce-9ba7-a4b6f0671e91" />


## Testing

- `vp test apps/web/src/components/preview/PreviewPanelShell.test.ts`
- `vp check`
- `vp run typecheck`
- Manually verified on a 6K display with the integrated browser at 100% zoom


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow preview panel to grow beyond 1400px on wide displays
> Removes the hard 1400px ceiling from `useViewportClampedMaxWidth` in [PreviewPanelShell.tsx](https://github.com/pingdotgg/t3code/pull/4044/files#diff-2bc30e0009261fedf96201eed47a807896930a736b4d944b9393ec09c4a72396). The max width is now computed by a new `getPreviewPanelMaxWidth` helper as `Math.floor(viewportWidth * 0.7)`, so the panel scales with the viewport on wide screens. Behavioral Change: panels on viewports wider than ~2000px will now expand beyond 1400px.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3ae60c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout clamp change for the resizable preview shell; no auth, data, or API impact.
> 
> **Overview**
> The inline preview panel’s resize limit no longer stops at **1400px**. Max width is now **70% of the viewport** (floored), so on ultra-wide displays the integrated browser can grow instead of leaving unused space beside chat.
> 
> Logic moves into an exported **`getPreviewPanelMaxWidth`** helper used by **`useViewportClampedMaxWidth`**, with unit tests for wide viewports and fractional pixel rounding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ae60cd0b96a59b1c7e01e8a9cd69d161d71818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->