### PR TITLE
feat(chat): support non-image file attachments in the composer

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -198,6 +198,32 @@ describe("AssetAccess", () => {
       expect(yield* resolveAsset(token, "ignored.png")).toEqual({
         kind: "file",
         path: attachmentPath,
+        download: false,
+      });
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("marks non-image attachment capabilities for download", () =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const attachmentId = "thread-1-00000000-0000-4000-8000-000000000002";
+      const attachmentPath = path.join(config.attachmentsDir, `${attachmentId}.pdf`);
+      yield* fileSystem.makeDirectory(config.attachmentsDir, { recursive: true });
+      yield* fileSystem.writeFile(attachmentPath, new Uint8Array([1, 2, 3]));
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "attachment", attachmentId },
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "ignored.pdf")).toEqual({
+        kind: "file",
+        path: attachmentPath,
+        download: true,
       });
     }).pipe(Effect.provide(testLayer)),
   );

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -36,6 +36,7 @@ import {
 } from "../auth/utils.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { resolveAttachmentPathById } from "../attachmentStore.ts";
+import { SAFE_IMAGE_FILE_EXTENSIONS } from "../imageMime.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
@@ -91,7 +92,11 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
+export type ResolvedAsset = {
+  readonly kind: "file";
+  readonly path: string;
+  readonly download?: boolean;
+};
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -383,9 +388,17 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       ),
       Effect.orElseSucceed(() => Option.none()),
     );
-    return Option.isSome(info) && info.value.type === "File"
-      ? ({ kind: "file", path: attachmentPath } satisfies ResolvedAsset)
-      : null;
+    if (!Option.isSome(info) || info.value.type !== "File") {
+      return null;
+    }
+    // Non-image attachments are downloaded rather than rendered inline so the
+    // same-origin asset route never interprets uploaded content (e.g. HTML/XML).
+    const extension = attachmentPath.slice(attachmentPath.lastIndexOf(".")).toLowerCase();
+    return {
+      kind: "file",
+      path: attachmentPath,
+      download: !SAFE_IMAGE_FILE_EXTENSIONS.has(extension),
+    } satisfies ResolvedAsset;
   }
 
   if (claims.kind === "project-favicon") {

--- a/apps/server/src/attachmentPrompt.test.ts
+++ b/apps/server/src/attachmentPrompt.test.ts
@@ -1,0 +1,97 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { appendFileAttachmentPromptText } from "./attachmentPrompt.ts";
+
+const attachmentsDir = NodePath.join(NodePath.sep, "tmp", "t3-attachment-prompt");
+
+describe("attachmentPrompt", () => {
+  it("appends a prompt line for file attachments", () => {
+    const result = appendFileAttachmentPromptText({
+      text: "hello",
+      attachmentsDir,
+      attachments: [
+        {
+          type: "file",
+          id: "thread-1-00000000-0000-4000-8000-000000000001",
+          name: "notes.txt",
+          mimeType: "text/plain",
+          sizeBytes: 2048,
+        },
+      ],
+    });
+    const attachmentPath = NodePath.join(
+      attachmentsDir,
+      "thread-1-00000000-0000-4000-8000-000000000001.txt",
+    );
+    expect(result).toBe(
+      `hello\n\n[Attached file: ${attachmentPath} (notes.txt, text/plain, 2.0 KB). Read it from disk when needed.]`,
+    );
+  });
+
+  it("returns text unchanged when only image attachments are present", () => {
+    expect(
+      appendFileAttachmentPromptText({
+        text: "hello",
+        attachmentsDir,
+        attachments: [
+          {
+            type: "image",
+            id: "thread-1-00000000-0000-4000-8000-000000000002",
+            name: "screen.png",
+            mimeType: "image/png",
+            sizeBytes: 4,
+          },
+        ],
+      }),
+    ).toBe("hello");
+  });
+
+  it("returns only the prompt lines when the text is empty", () => {
+    const result = appendFileAttachmentPromptText({
+      text: "",
+      attachmentsDir,
+      attachments: [
+        {
+          type: "file",
+          id: "thread-1-00000000-0000-4000-8000-000000000003",
+          name: "data.csv",
+          mimeType: "text/csv",
+          sizeBytes: 12,
+        },
+      ],
+    });
+    const attachmentPath = NodePath.join(
+      attachmentsDir,
+      "thread-1-00000000-0000-4000-8000-000000000003.csv",
+    );
+    expect(result).toBe(
+      `[Attached file: ${attachmentPath} (data.csv, text/csv, 12 B). Read it from disk when needed.]`,
+    );
+  });
+
+  it("strips control characters, brackets, and parentheses from attachment names", () => {
+    const result = appendFileAttachmentPromptText({
+      text: "hello",
+      attachmentsDir,
+      attachments: [
+        {
+          type: "file",
+          id: "thread-1-00000000-0000-4000-8000-000000000004",
+          name: "a(b)\u0001[c].txt",
+          mimeType: "text/plain",
+          sizeBytes: 5,
+        },
+      ],
+    });
+    const attachmentPath = NodePath.join(
+      attachmentsDir,
+      "thread-1-00000000-0000-4000-8000-000000000004.txt",
+    );
+    expect(result).toBe(
+      `hello\n\n[Attached file: ${attachmentPath} (a b c .txt, text/plain, 5 B). Read it from disk when needed.]`,
+    );
+  });
+});

--- a/apps/server/src/attachmentPrompt.ts
+++ b/apps/server/src/attachmentPrompt.ts
@@ -1,0 +1,55 @@
+import type { ChatAttachment } from "@t3tools/contracts";
+
+import { resolveAttachmentPath } from "./attachmentStore.ts";
+
+const SIZE_LABEL_UNITS = ["B", "KB", "MB"] as const;
+
+function formatSizeLabel(sizeBytes: number): string {
+  let value = sizeBytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < SIZE_LABEL_UNITS.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const rounded = unitIndex === 0 ? String(value) : value.toFixed(1);
+  return `${rounded} ${SIZE_LABEL_UNITS[unitIndex]}`;
+}
+
+function sanitizePromptFileName(name: string): string {
+  // eslint-disable-next-line no-control-regex
+  return name.replace(/[\u0000-\u001f\u007f()[\]]+/gu, " ").trim();
+}
+
+/**
+ * Non-image attachments are delivered by reference: the file already lives on
+ * the server's disk, so the provider agent reads it with its own tools. Images
+ * keep their native content-block path and are not mentioned here.
+ */
+export function appendFileAttachmentPromptText(input: {
+  readonly text: string;
+  readonly attachmentsDir: string;
+  readonly attachments: ReadonlyArray<ChatAttachment>;
+}): string {
+  const lines: Array<string> = [];
+  for (const attachment of input.attachments) {
+    if (attachment.type !== "file") {
+      continue;
+    }
+    const attachmentPath = resolveAttachmentPath({
+      attachmentsDir: input.attachmentsDir,
+      attachment,
+    });
+    if (!attachmentPath) {
+      continue;
+    }
+    const name = sanitizePromptFileName(attachment.name);
+    lines.push(
+      `[Attached file: ${attachmentPath} (${name}, ${attachment.mimeType}, ${formatSizeLabel(attachment.sizeBytes)}). Read it from disk when needed.]`,
+    );
+  }
+  if (lines.length === 0) {
+    return input.text;
+  }
+  const joined = lines.join("\n");
+  return input.text.trim().length > 0 ? `${input.text}\n\n${joined}` : joined;
+}

--- a/apps/server/src/attachmentStore.test.ts
+++ b/apps/server/src/attachmentStore.test.ts
@@ -6,6 +6,7 @@ import * as NodePath from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  attachmentRelativePath,
   createAttachmentId,
   parseThreadSegmentFromAttachmentId,
   resolveAttachmentPathById,
@@ -42,6 +43,37 @@ describe("attachmentStore", () => {
       return;
     }
     expect(parseThreadSegmentFromAttachmentId(attachmentId)).toBe("thread-foo");
+  });
+
+  it("builds file attachment relative paths with the inferred file extension", () => {
+    expect(
+      attachmentRelativePath({
+        type: "file",
+        id: "thread-1-00000000-0000-4000-8000-000000000001",
+        name: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 5,
+      }),
+    ).toBe("thread-1-00000000-0000-4000-8000-000000000001.pdf");
+  });
+
+  it("resolves attachment path by id for a written file attachment extension", () => {
+    const attachmentsDir = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3code-attachment-store-"),
+    );
+    try {
+      const attachmentId = "thread-1-attachment";
+      const pdfPath = NodePath.join(attachmentsDir, `${attachmentId}.pdf`);
+      NodeFS.writeFileSync(pdfPath, Buffer.from("hello"));
+
+      const resolved = resolveAttachmentPathById({
+        attachmentsDir,
+        attachmentId,
+      });
+      expect(resolved).toBe(pdfPath);
+    } finally {
+      NodeFS.rmSync(attachmentsDir, { recursive: true, force: true });
+    }
   });
 
   it("resolves attachment path by id using the extension that exists on disk", () => {

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -8,9 +8,16 @@ import {
   normalizeAttachmentRelativePath,
   resolveAttachmentRelativePath,
 } from "./attachmentPaths.ts";
-import { inferImageExtension, SAFE_IMAGE_FILE_EXTENSIONS } from "./imageMime.ts";
+import {
+  inferFileExtension,
+  inferImageExtension,
+  SAFE_FILE_EXTENSIONS,
+  SAFE_IMAGE_FILE_EXTENSIONS,
+} from "./imageMime.ts";
 
-const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".bin"];
+const ATTACHMENT_FILENAME_EXTENSIONS = [
+  ...new Set([...SAFE_IMAGE_FILE_EXTENSIONS, ...SAFE_FILE_EXTENSIONS, ".bin"]),
+];
 const ATTACHMENT_ID_THREAD_SEGMENT_MAX_CHARS = 80;
 const ATTACHMENT_ID_THREAD_SEGMENT_PATTERN = "[a-z0-9_]+(?:-[a-z0-9_]+)*";
 const ATTACHMENT_ID_UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
@@ -58,6 +65,13 @@ export function attachmentRelativePath(attachment: ChatAttachment): string {
   switch (attachment.type) {
     case "image": {
       const extension = inferImageExtension({
+        mimeType: attachment.mimeType,
+        fileName: attachment.name,
+      });
+      return `${attachment.id}${extension}`;
+    }
+    case "file": {
+      const extension = inferFileExtension({
         mimeType: attachment.mimeType,
         fileName: attachment.name,
       });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -197,6 +197,11 @@ export const assetRouteLayer = HttpRouter.add(
       headers: {
         "Cache-Control": "private, max-age=3600",
         "X-Content-Type-Options": "nosniff",
+        ...(asset.download
+          ? {
+              "Content-Disposition": `attachment; filename="${asset.path.replace(/^.*[/\\]/, "")}"`,
+            }
+          : {}),
       },
     }).pipe(
       Effect.orElseSucceed(() => HttpServerResponse.text("Internal Server Error", { status: 500 })),

--- a/apps/server/src/imageMime.test.ts
+++ b/apps/server/src/imageMime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { inferImageExtension, parseBase64DataUrl } from "./imageMime.ts";
+import { inferFileExtension, inferImageExtension, parseBase64DataUrl } from "./imageMime.ts";
 
 describe("imageMime", () => {
   it("parses base64 data URL with mime type", () => {
@@ -34,5 +34,40 @@ describe("imageMime", () => {
 
   it("does not read inherited keys from mime extension map", () => {
     expect(inferImageExtension({ mimeType: "constructor" })).toBe(".bin");
+  });
+
+  it("infers file extension from an allowlisted file name extension", () => {
+    expect(
+      inferFileExtension({ mimeType: "application/octet-stream", fileName: "report.PDF" }),
+    ).toBe(".pdf");
+  });
+
+  it("infers file extension from the last segment of a multi-dot file name", () => {
+    expect(inferFileExtension({ mimeType: "application/octet-stream", fileName: "a.b.csv" })).toBe(
+      ".csv",
+    );
+  });
+
+  it("falls back to an allowlisted mime extension when the file name extension is unsafe", () => {
+    expect(inferFileExtension({ mimeType: "application/pdf", fileName: "notes.exe" })).toBe(".pdf");
+  });
+
+  it("falls back to an allowlisted mime extension when the file name has no extension", () => {
+    expect(inferFileExtension({ mimeType: "text/plain", fileName: "notes" })).toBe(".txt");
+  });
+
+  it("defaults file extension to .bin when neither file name nor mime is allowlisted", () => {
+    expect(inferFileExtension({ mimeType: "application/x-unknown", fileName: "payload.exe" })).toBe(
+      ".bin",
+    );
+    expect(inferFileExtension({ mimeType: "application/x-unknown", fileName: "notes" })).toBe(
+      ".bin",
+    );
+  });
+
+  it("defaults dotfile names without an allowlisted mime to .bin", () => {
+    expect(inferFileExtension({ mimeType: "application/x-unknown", fileName: ".env" })).toBe(
+      ".bin",
+    );
   });
 });

--- a/apps/server/src/imageMime.ts
+++ b/apps/server/src/imageMime.ts
@@ -57,6 +57,48 @@ export function parseBase64DataUrl(
   return { mimeType, base64 };
 }
 
+export const SAFE_FILE_EXTENSIONS = new Set([
+  ".csv",
+  ".diff",
+  ".docx",
+  ".gz",
+  ".json",
+  ".jsonl",
+  ".log",
+  ".md",
+  ".patch",
+  ".pdf",
+  ".pptx",
+  ".tar",
+  ".toml",
+  ".tsv",
+  ".txt",
+  ".xlsx",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".zip",
+]);
+
+export function inferFileExtension(input: { mimeType: string; fileName?: string }): string {
+  const fileName = input.fileName?.trim() ?? "";
+  const extensionMatch = /\.([a-z0-9]{1,8})$/i.exec(fileName);
+  const fileNameExtension = extensionMatch ? `.${extensionMatch[1]!.toLowerCase()}` : "";
+  if (SAFE_FILE_EXTENSIONS.has(fileNameExtension)) {
+    return fileNameExtension;
+  }
+
+  // Mime.getExtension returns dot-less extensions ("pdf"), the sets hold
+  // dotted ones (".pdf").
+  const fromMimeExtension = Mime.getExtension(input.mimeType);
+  const dottedMimeExtension = fromMimeExtension ? `.${fromMimeExtension}` : null;
+  if (dottedMimeExtension && SAFE_FILE_EXTENSIONS.has(dottedMimeExtension)) {
+    return dottedMimeExtension;
+  }
+
+  return ".bin";
+}
+
 export function inferImageExtension(input: { mimeType: string; fileName?: string }): string {
   const key = input.mimeType.toLowerCase();
   const fromMime = Object.hasOwn(IMAGE_EXTENSION_BY_MIME_TYPE, key)

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -928,6 +928,214 @@ it.layer(
   );
 });
 
+it.layer(
+  Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-projection-attachments-file-gc-")),
+)("OrchestrationProjectionPipeline", (it) => {
+  it.effect("keeps referenced file attachments and prunes orphans when a thread is reverted", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const { attachmentsDir } = yield* ServerConfig;
+      const now = "2026-01-01T00:00:00.000Z";
+      const threadId = ThreadId.make("Thread Revert.Docs");
+      const keepAttachmentId = "thread-revert-docs-00000000-0000-4000-8000-000000000001";
+      const removeAttachmentId = "thread-revert-docs-00000000-0000-4000-8000-000000000002";
+      const orphanAttachmentId = "thread-revert-docs-00000000-0000-4000-8000-000000000003";
+
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.make("evt-revert-docs-1"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.make("project-revert-docs"),
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-1"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.make("project-revert-docs"),
+          title: "Project Revert Docs",
+          workspaceRoot: "/tmp/project-revert-docs",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.make("evt-revert-docs-2"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-2"),
+        metadata: {},
+        payload: {
+          threadId,
+          projectId: ProjectId.make("project-revert-docs"),
+          title: "Thread Revert Docs",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-revert-docs-3"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-3"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId: TurnId.make("turn-keep"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert-docs/turn/1"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("message-keep"),
+          completedAt: now,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-revert-docs-4"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-4"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("message-keep"),
+          role: "assistant",
+          text: "Keep",
+          attachments: [
+            {
+              type: "file",
+              id: keepAttachmentId,
+              name: "keep.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 5,
+            },
+          ],
+          turnId: TurnId.make("turn-keep"),
+          streaming: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-revert-docs-5"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-5"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-5"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId: TurnId.make("turn-remove"),
+          checkpointTurnCount: 2,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert-docs/turn/2"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("message-remove"),
+          completedAt: now,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-revert-docs-6"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-6"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-6"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("message-remove"),
+          role: "assistant",
+          text: "Remove",
+          attachments: [
+            {
+              type: "file",
+              id: removeAttachmentId,
+              name: "remove.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 5,
+            },
+          ],
+          turnId: TurnId.make("turn-remove"),
+          streaming: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      const keepPath = path.join(attachmentsDir, `${keepAttachmentId}.pdf`);
+      const removePath = path.join(attachmentsDir, `${removeAttachmentId}.pdf`);
+      const orphanPath = path.join(attachmentsDir, `${orphanAttachmentId}.pdf`);
+      yield* fileSystem.makeDirectory(attachmentsDir, { recursive: true });
+      yield* fileSystem.writeFileString(keepPath, "keep");
+      yield* fileSystem.writeFileString(removePath, "remove");
+      yield* fileSystem.writeFileString(orphanPath, "orphan");
+      assert.isTrue(yield* exists(keepPath));
+      assert.isTrue(yield* exists(removePath));
+      assert.isTrue(yield* exists(orphanPath));
+
+      yield* appendAndProject({
+        type: "thread.reverted",
+        eventId: EventId.make("evt-revert-docs-7"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: now,
+        commandId: CommandId.make("cmd-revert-docs-7"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-docs-7"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnCount: 1,
+        },
+      });
+
+      assert.isTrue(yield* exists(keepPath));
+      assert.isFalse(yield* exists(removePath));
+      assert.isFalse(yield* exists(orphanPath));
+    }),
+  );
+});
+
 it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-projection-attachments-revert-")))(
   "OrchestrationProjectionPipeline",
   (it) => {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -338,9 +338,6 @@ function collectThreadAttachmentRelativePaths(
   const relativePaths = new Set<string>();
   for (const message of messages) {
     for (const attachment of message.attachments ?? []) {
-      if (attachment.type !== "image") {
-        continue;
-      }
       const attachmentThreadSegment = parseThreadSegmentFromAttachmentId(attachment.id);
       if (!attachmentThreadSegment || attachmentThreadSegment !== threadSegment) {
         continue;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -466,6 +466,58 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.runtimeMode).toBe("approval-required");
   });
 
+  effectIt.effect(
+    "sends only image attachments to the provider and appends file attachment prompt text",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const now = "2026-01-01T00:00:00.000Z";
+        const imageAttachment = {
+          type: "image" as const,
+          id: "thread-1-00000000-0000-4000-8000-000000000001",
+          name: "screen.png",
+          mimeType: "image/png",
+          sizeBytes: 4,
+        };
+        const fileAttachment = {
+          type: "file" as const,
+          id: "thread-1-00000000-0000-4000-8000-000000000002",
+          name: "notes.txt",
+          mimeType: "text/plain",
+          sizeBytes: 5,
+        };
+        const attachmentsDir = NodePath.join(harness.stateDir, "attachments");
+        const fileAttachmentPath = NodePath.join(attachmentsDir, `${fileAttachment.id}.txt`);
+        NodeFS.mkdirSync(attachmentsDir, { recursive: true });
+        NodeFS.writeFileSync(fileAttachmentPath, "notes");
+
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-file-attachments"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-file-attachments"),
+            role: "user",
+            text: "hello with attachments",
+            attachments: [imageAttachment, fileAttachment],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        });
+
+        yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
+        const request = harness.sendTurn.mock.calls[0]?.[0] as {
+          readonly input?: string;
+          readonly attachments?: ReadonlyArray<unknown>;
+        };
+        expect(request.attachments).toEqual([imageAttachment]);
+        expect(request.input).toBe(
+          `hello with attachments\n\n[Attached file: ${fileAttachmentPath} (notes.txt, text/plain, 5 B). Read it from disk when needed.]`,
+        );
+      }),
+  );
+
   it("generates a thread title on the first turn", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -25,7 +25,9 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
+import { appendFileAttachmentPromptText } from "../../attachmentPrompt.ts";
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
+import { ServerConfig } from "../../config.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
@@ -196,6 +198,7 @@ const make = Effect.gen(function* () {
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
   const serverSettingsService = yield* ServerSettingsService;
+  const serverConfig = yield* ServerConfig;
   const serverCommandId = (tag: string) =>
     crypto.randomUUIDv4.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
   const serverEventId = () => crypto.randomUUIDv4.pipe(Effect.map(EventId.make));
@@ -605,8 +608,18 @@ const make = Effect.gen(function* () {
     if (input.modelSelection !== undefined) {
       threadModelSelections.set(input.threadId, input.modelSelection);
     }
-    const normalizedInput = toNonEmptyProviderInput(input.messageText);
-    const normalizedAttachments = input.attachments ?? [];
+    const normalizedInput = toNonEmptyProviderInput(
+      appendFileAttachmentPromptText({
+        text: input.messageText,
+        attachmentsDir: serverConfig.attachmentsDir,
+        attachments: input.attachments ?? [],
+      }),
+    );
+    // Only image attachments go to the provider as content blocks; file
+    // attachments are delivered by path in the prompt text above.
+    const normalizedAttachments = (input.attachments ?? []).filter(
+      (attachment) => attachment.type === "image",
+    );
     const activeSession = yield* providerService
       .listSessions()
       .pipe(

--- a/apps/server/src/orchestration/Normalizer.test.ts
+++ b/apps/server/src/orchestration/Normalizer.test.ts
@@ -1,0 +1,129 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  MessageId,
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  ThreadId,
+  type ClientOrchestrationCommand,
+  type UploadChatAttachment,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as ServerConfig from "../config.ts";
+import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import { normalizeDispatchCommand } from "./Normalizer.ts";
+
+const testLayer = Layer.mergeAll(
+  ServerConfig.ServerConfig.layerTest(process.cwd(), { prefix: "t3-normalizer-test-" }),
+  WorkspacePaths.layer,
+).pipe(Layer.provideMerge(NodeServices.layer));
+
+const now = "2026-01-01T00:00:00.000Z";
+
+const turnStartCommand = (
+  attachments: ReadonlyArray<UploadChatAttachment>,
+): ClientOrchestrationCommand => ({
+  type: "thread.turn.start",
+  commandId: CommandId.make("cmd-turn-start-1"),
+  threadId: ThreadId.make("thread-1"),
+  message: {
+    messageId: MessageId.make("user-message-1"),
+    role: "user",
+    text: "hello normalizer",
+    attachments,
+  },
+  runtimeMode: "full-access",
+  interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+  createdAt: now,
+});
+
+const asDataUrl = (mimeType: string, bytes: Buffer) =>
+  `data:${mimeType};base64,${bytes.toString("base64")}`;
+
+describe("Normalizer", () => {
+  it.effect("persists file attachments and writes their bytes to the attachments dir", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { attachmentsDir } = yield* ServerConfig.ServerConfig;
+      const bytes = Buffer.from("hello world");
+
+      const normalized = yield* normalizeDispatchCommand(
+        turnStartCommand([
+          {
+            type: "file",
+            name: "notes.txt",
+            mimeType: "text/plain",
+            sizeBytes: bytes.byteLength,
+            dataUrl: asDataUrl("text/plain", bytes),
+          },
+        ]),
+      );
+
+      expect(normalized.type).toBe("thread.turn.start");
+      if (normalized.type !== "thread.turn.start") {
+        return;
+      }
+      const attachment = normalized.message.attachments[0];
+      expect(attachment).toMatchObject({
+        type: "file",
+        name: "notes.txt",
+        mimeType: "text/plain",
+        sizeBytes: bytes.byteLength,
+      });
+      expect(attachment?.id).toMatch(
+        /^thread-1-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      if (!attachment) {
+        return;
+      }
+
+      const attachmentPath = path.join(attachmentsDir, `${attachment.id}.txt`);
+      expect(yield* fileSystem.readFileString(attachmentPath)).toBe("hello world");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects image attachments with a non-image data URL mime type", () =>
+    Effect.gen(function* () {
+      const error = yield* normalizeDispatchCommand(
+        turnStartCommand([
+          {
+            type: "image",
+            name: "fake.png",
+            mimeType: "image/png",
+            sizeBytes: 5,
+            dataUrl: asDataUrl("text/plain", Buffer.from("hello")),
+          },
+        ]),
+      ).pipe(Effect.flip);
+
+      expect(error._tag).toBe("OrchestrationDispatchCommandError");
+      expect(error.message).toBe("Invalid image attachment payload for 'fake.png'.");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects file attachments over the maximum attachment size", () =>
+    Effect.gen(function* () {
+      const bytes = Buffer.alloc(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1, "a");
+      const error = yield* normalizeDispatchCommand(
+        turnStartCommand([
+          {
+            type: "file",
+            name: "big.txt",
+            mimeType: "text/plain",
+            sizeBytes: PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+            dataUrl: asDataUrl("text/plain", bytes),
+          },
+        ]),
+      ).pipe(Effect.flip);
+
+      expect(error._tag).toBe("OrchestrationDispatchCommandError");
+      expect(error.message).toBe("Attachment 'big.txt' is empty or too large.");
+    }).pipe(Effect.provide(testLayer)),
+  );
+});

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -74,16 +74,16 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       (attachment) =>
         Effect.gen(function* () {
           const parsed = parseBase64DataUrl(attachment.dataUrl);
-          if (!parsed || !parsed.mimeType.startsWith("image/")) {
+          if (!parsed || (attachment.type === "image" && !parsed.mimeType.startsWith("image/"))) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Invalid image attachment payload for '${attachment.name}'.`,
+              message: `Invalid ${attachment.type} attachment payload for '${attachment.name}'.`,
             });
           }
 
           const bytes = Buffer.from(parsed.base64, "base64");
           if (bytes.byteLength === 0 || bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Image attachment '${attachment.name}' is empty or too large.`,
+              message: `Attachment '${attachment.name}' is empty or too large.`,
             });
           }
 
@@ -95,7 +95,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
           }
 
           const persistedAttachment = {
-            type: "image" as const,
+            type: attachment.type,
             id: attachmentId,
             name: attachment.name,
             mimeType: parsed.mimeType.toLowerCase(),

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -10,7 +10,7 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { type ChatMessage, type SessionPhase, type Thread } from "../types";
-import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
+import { type ComposerAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentThreadDetails } from "../state/threads";
@@ -193,9 +193,7 @@ export function resolveSendEnvMode(input: {
   return input.isGitRepo ? input.requestedEnvMode : "local";
 }
 
-export function cloneComposerImageForRetry(
-  image: ComposerImageAttachment,
-): ComposerImageAttachment {
+export function cloneComposerImageForRetry(image: ComposerAttachment): ComposerAttachment {
   if (typeof URL === "undefined" || !image.previewUrl.startsWith("blob:")) {
     return image;
   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -160,7 +160,7 @@ import {
 } from "../logicalProject";
 import { buildDraftThreadRouteParams } from "../threadRoutes";
 import {
-  type ComposerImageAttachment,
+  type ComposerAttachment,
   type DraftThreadEnvMode,
   useComposerDraftStore,
   type DraftId,
@@ -250,8 +250,8 @@ import {
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
 
-const IMAGE_ONLY_BOOTSTRAP_PROMPT =
-  "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+const ATTACHMENT_ONLY_BOOTSTRAP_PROMPT =
+  "[User attached one or more files without additional text. Respond using the conversation context and the attached file(s).]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
@@ -1092,7 +1092,7 @@ function ChatViewContent(props: ChatViewProps) {
         : null,
   );
   const promptRef = useRef("");
-  const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
+  const composerImagesRef = useRef<ComposerAttachment[]>([]);
   const composerTerminalContextsRef = useRef<TerminalContextDraft[]>([]);
   const composerElementContextsRef = useRef<ElementContextDraft[]>([]);
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
@@ -4007,11 +4007,11 @@ function ChatViewContent(props: ChatViewProps) {
       model: ctxSelectedModel,
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
-      text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
+      text: messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
     });
     const turnAttachmentsPromise = Promise.all(
       composerImagesSnapshot.map(async (image) => ({
-        type: "image" as const,
+        type: image.type,
         name: image.name,
         mimeType: image.mimeType,
         sizeBytes: image.sizeBytes,
@@ -4019,7 +4019,7 @@ function ChatViewContent(props: ChatViewProps) {
       })),
     );
     const optimisticAttachments = composerImagesSnapshot.map((image) => ({
-      type: "image" as const,
+      type: image.type,
       id: image.id,
       name: image.name,
       mimeType: image.mimeType,
@@ -4081,7 +4081,7 @@ function ChatViewContent(props: ChatViewProps) {
     let titleSeed = trimmed;
     if (!titleSeed) {
       if (firstComposerImageName) {
-        titleSeed = `Image: ${firstComposerImageName}`;
+        titleSeed = `${composerImagesSnapshot[0]?.type === "file" ? "File" : "Image"}: ${firstComposerImageName}`;
       } else if (composerTerminalContextsSnapshot.length > 0) {
         titleSeed = formatTerminalContextLabel(composerTerminalContextsSnapshot[0]!);
       } else if (composerElementContextsSnapshot.length > 0) {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
 import {
-  type ComposerImageAttachment,
+  type ComposerAttachment,
   type DraftId,
   type PersistedComposerImageAttachment,
   useComposerDraftStore,
@@ -95,6 +95,7 @@ import { toastManager } from "../ui/toast";
 import {
   BotIcon,
   CircleAlertIcon,
+  FileTextIcon,
   ListTodoIcon,
   PencilRulerIcon,
   type LucideIcon,
@@ -124,6 +125,7 @@ import {
 import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
 import { searchProviderSkills } from "../../providerSkillSearch";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
+import { formatAttachmentSizeLabel } from "../../lib/attachmentSize";
 import type { ReviewCommentContext } from "../../reviewCommentContext";
 
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
@@ -410,7 +412,7 @@ export interface ChatComposerHandle {
   /** Get the current prompt/effort/model state for use in send. */
   getSendContext: () => {
     prompt: string;
-    images: ComposerImageAttachment[];
+    images: ComposerAttachment[];
     terminalContexts: TerminalContextDraft[];
     elementContexts: ElementContextDraft[];
     previewAnnotations: PreviewAnnotationPayload[];
@@ -499,7 +501,7 @@ export interface ChatComposerProps {
 
   // Refs the parent needs kept in sync
   promptRef: React.RefObject<string>;
-  composerImagesRef: React.RefObject<ComposerImageAttachment[]>;
+  composerImagesRef: React.RefObject<ComposerAttachment[]>;
   composerTerminalContextsRef: React.RefObject<TerminalContextDraft[]>;
   composerElementContextsRef: React.RefObject<ElementContextDraft[]>;
   composerRef: React.RefObject<ChatComposerHandle | null>;
@@ -1151,14 +1153,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
 
   const addComposerImage = useCallback(
-    (image: ComposerImageAttachment) => {
+    (image: ComposerAttachment) => {
       addComposerDraftImage(composerDraftTarget, image);
     },
     [composerDraftTarget, addComposerDraftImage],
   );
 
   const addComposerImagesToDraft = useCallback(
-    (images: ComposerImageAttachment[]) => {
+    (images: ComposerAttachment[]) => {
       addComposerDraftImages(composerDraftTarget, images);
     },
     [composerDraftTarget, addComposerDraftImages],
@@ -1368,6 +1370,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             try {
               const dataUrl = await readFileAsDataUrl(image.file);
               stagedAttachmentById.set(image.id, {
+                type: image.type,
                 id: image.id,
                 name: image.name,
                 mimeType: image.mimeType,
@@ -1765,32 +1768,29 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (pendingUserInputs.length > 0) {
       toastManager.add({
         type: "error",
-        title: "Attach images after answering plan questions.",
+        title: "Attach files after answering plan questions.",
       });
       return;
     }
-    const nextImages: ComposerImageAttachment[] = [];
+    const nextImages: ComposerAttachment[] = [];
     let nextImageCount = composerImagesRef.current.length;
     let error: string | null = null;
     for (const file of files) {
-      if (!file.type.startsWith("image/")) {
-        error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
-        continue;
-      }
       if (file.size > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
         error = `'${file.name}' exceeds the ${IMAGE_SIZE_LIMIT_LABEL} attachment limit.`;
         continue;
       }
       if (nextImageCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
+        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} attachments per message.`;
         break;
       }
+      const isImage = file.type.startsWith("image/");
       const previewUrl = URL.createObjectURL(file);
       nextImages.push({
-        type: "image",
+        type: isImage ? "image" : "file",
         id: randomUUID(),
-        name: file.name || "image",
-        mimeType: file.type,
+        name: file.name || (isImage ? "image" : "file"),
+        mimeType: file.type || "application/octet-stream",
         sizeBytes: file.size,
         previewUrl,
         file,
@@ -1815,10 +1815,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) return;
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
     event.preventDefault();
-    addComposerImages(imageFiles);
+    addComposerImages(files);
   };
 
   const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
@@ -2269,7 +2267,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     removeComposerDraftPreviewAnnotation(composerDraftTarget, annotationId)
                   }
                   onExpandImage={(imageId) => {
-                    const preview = buildExpandedImagePreview(composerImages, imageId);
+                    const preview = buildExpandedImagePreview(
+                      composerImages.filter((attachment) => attachment.type === "image"),
+                      imageId,
+                    );
                     if (preview) onExpandImage(preview);
                   }}
                   className="mb-3"
@@ -2320,15 +2321,34 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     .map((image) => (
                       <div
                         key={image.id}
-                        className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
+                        className={
+                          image.type === "file"
+                            ? "relative flex h-16 w-40 items-center gap-2 overflow-hidden rounded-lg border border-border/80 bg-background px-2"
+                            : "relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
+                        }
                       >
-                        {image.previewUrl ? (
+                        {image.type === "file" ? (
+                          <>
+                            <FileTextIcon className="size-5 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0 pr-5">
+                              <div className="truncate text-xs" title={image.name}>
+                                {image.name}
+                              </div>
+                              <div className="text-[10px] text-muted-foreground/70">
+                                {formatAttachmentSizeLabel(image.sizeBytes)}
+                              </div>
+                            </div>
+                          </>
+                        ) : image.previewUrl ? (
                           <button
                             type="button"
                             className="h-full w-full cursor-zoom-in"
                             aria-label={`Preview ${image.name}`}
                             onClick={() => {
-                              const preview = buildExpandedImagePreview(composerImages, image.id);
+                              const preview = buildExpandedImagePreview(
+                                composerImages.filter((attachment) => attachment.type === "image"),
+                                image.id,
+                              );
                               if (!preview) return;
                               onExpandImage(preview);
                             }}

--- a/apps/web/src/components/chat/ComposerPreviewAnnotationCards.tsx
+++ b/apps/web/src/components/chat/ComposerPreviewAnnotationCards.tsx
@@ -2,13 +2,13 @@ import type { PreviewAnnotationPayload } from "@t3tools/contracts";
 import { Frame, MousePointerClick, Paintbrush, PenLine, X } from "lucide-react";
 import type { ReactNode } from "react";
 
-import type { ComposerImageAttachment } from "~/composerDraftStore";
+import type { ComposerAttachment } from "~/composerDraftStore";
 import { formatElementContextLabel, normalizeElementContextSelection } from "~/lib/elementContext";
 import { cn } from "~/lib/utils";
 
 interface ComposerPreviewAnnotationCardsProps {
   annotations: ReadonlyArray<PreviewAnnotationPayload>;
-  images: ReadonlyArray<ComposerImageAttachment>;
+  images: ReadonlyArray<ComposerAttachment>;
   onRemove: (annotationId: string) => void;
   onExpandImage: (imageId: string) => void;
   className?: string;

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -305,6 +305,88 @@ describe("MessagesTimeline", () => {
     expect(onAnchorSizeChanged).toHaveBeenCalledWith(secondEntry.message.id, 240);
   });
 
+  it("renders file attachments as chips with name and size instead of images", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const entry = {
+      ...buildUserTimelineEntry("Please review the attached report."),
+      message: {
+        ...buildUserTimelineEntry("Please review the attached report.").message,
+        attachments: [
+          {
+            type: "file" as const,
+            id: "attachment-file-1",
+            name: "report.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 2_048,
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[entry]} />,
+    );
+
+    expect(markup).toContain("report.pdf");
+    expect(markup).toContain("2.0 KB");
+    expect(markup).toContain("lucide-file-text");
+    expect(markup).not.toContain("<img");
+  });
+
+  it("renders downloadable file attachment chips when a preview URL is available", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const entry = {
+      ...buildUserTimelineEntry("Here is the file."),
+      message: {
+        ...buildUserTimelineEntry("Here is the file.").message,
+        attachments: [
+          {
+            type: "file" as const,
+            id: "attachment-file-2",
+            name: "notes.txt",
+            mimeType: "text/plain",
+            sizeBytes: 512,
+            previewUrl: "data:text/plain;base64,aGVsbG8=",
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[entry]} />,
+    );
+
+    expect(markup).toContain('download="notes.txt"');
+    expect(markup).toContain('href="data:text/plain;base64,aGVsbG8="');
+    expect(markup).toContain("512 B");
+  });
+
+  it("renders image attachments in the image grid without file chips", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const entry = {
+      ...buildUserTimelineEntry("Take a look."),
+      message: {
+        ...buildUserTimelineEntry("Take a look.").message,
+        attachments: [
+          {
+            type: "image" as const,
+            id: "attachment-image-1",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 1,
+            previewUrl: "data:image/png;base64,iVBORw0KGgo=",
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={[entry]} />,
+    );
+
+    expect(markup).toContain('src="data:image/png;base64,iVBORw0KGgo="');
+    expect(markup).toContain('alt="screenshot.png"');
+    expect(markup).not.toContain("lucide-file-text");
+    expect(markup).not.toContain("download=");
+  });
+
   it("renders collapse controls for long user messages", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -46,6 +46,7 @@ import {
   ChevronRightIcon,
   CircleAlertIcon,
   EyeIcon,
+  FileTextIcon,
   GlobeIcon,
   HammerIcon,
   MessageCircleIcon,
@@ -61,6 +62,7 @@ import {
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
+import { formatAttachmentSizeLabel } from "~/lib/attachmentSize";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
 import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
@@ -844,7 +846,10 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
     ...elementContextState.contexts,
   ];
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
-  const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
+  const regularImages = userImages.filter(
+    (image) => image.type === "image" && !image.name.startsWith("preview-annotation-"),
+  );
+  const fileAttachments = userImages.filter((attachment) => attachment.type === "file");
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
 
   return (
@@ -881,6 +886,38 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
                 )}
               </div>
             ))}
+          </div>
+        )}
+        {fileAttachments.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {fileAttachments.map((attachment) => {
+              const chipContent = (
+                <>
+                  <FileTextIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="max-w-48 truncate">{attachment.name}</span>
+                  <span className="text-muted-foreground/70">
+                    {formatAttachmentSizeLabel(attachment.sizeBytes)}
+                  </span>
+                </>
+              );
+              const chipClassName =
+                "inline-flex items-center gap-1.5 rounded-md border border-border/80 bg-background/70 px-2 py-1 text-[11px]";
+              return attachment.previewUrl ? (
+                <a
+                  key={attachment.id}
+                  href={attachment.previewUrl}
+                  download={attachment.name}
+                  className={`${chipClassName} hover:bg-background`}
+                  aria-label={`Download ${attachment.name}`}
+                >
+                  {chipContent}
+                </a>
+              ) : (
+                <span key={attachment.id} className={chipClassName}>
+                  {chipContent}
+                </span>
+              );
+            })}
           </div>
         )}
         {previewAnnotations.map((annotation, index) => (

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -65,6 +65,7 @@ import {
   markPromotedDraftThreadByRef,
   markPromotedDraftThreads,
   markPromotedDraftThreadsByRef,
+  type ComposerFileAttachment,
   type ComposerImageAttachment,
   useComposerDraftStore,
   DraftId,
@@ -95,6 +96,33 @@ function makeImage(input: {
   });
   return {
     type: "image",
+    id: input.id,
+    name,
+    mimeType,
+    sizeBytes: file.size,
+    previewUrl: input.previewUrl,
+    file,
+  };
+}
+
+function makeFile(input: {
+  id: string;
+  previewUrl: string;
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  lastModified?: number;
+}): ComposerFileAttachment {
+  const name = input.name ?? "report.pdf";
+  const mimeType = input.mimeType ?? "application/pdf";
+  const sizeBytes = input.sizeBytes ?? 4;
+  const lastModified = input.lastModified ?? 1_700_000_000_000;
+  const file = new File([new Uint8Array(sizeBytes).fill(1)], name, {
+    type: mimeType,
+    lastModified,
+  });
+  return {
+    type: "file",
     id: input.id,
     name,
     mimeType,
@@ -342,6 +370,123 @@ describe("composerDraftStore syncPersistedAttachments", () => {
 
     expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.persistedAttachments).toEqual([]);
     expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.nonPersistedImageIds).toEqual([image.id]);
+  });
+});
+
+describe("composerDraftStore file attachments", () => {
+  const threadId = ThreadId.make("thread-file-attachments");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+
+  beforeEach(() => {
+    removeLocalStorageItem(COMPOSER_DRAFT_STORAGE_KEY);
+    resetComposerDraftStore();
+  });
+
+  afterEach(() => {
+    removeLocalStorageItem(COMPOSER_DRAFT_STORAGE_KEY);
+  });
+
+  function mergePersistedDraft(attachment: Record<string, unknown>) {
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    return persistApi.getOptions().merge(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt: "",
+            attachments: [attachment],
+          },
+        },
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectKey: {},
+      },
+      useComposerDraftStore.getInitialState(),
+    );
+  }
+
+  it("hydrates persisted attachments without a type as images (legacy drafts)", () => {
+    const mergedState = mergePersistedDraft({
+      id: "img-legacy",
+      name: "legacy.png",
+      mimeType: "image/png",
+      sizeBytes: 5,
+      dataUrl: "data:image/png;base64,aGVsbG8=",
+    });
+
+    expect(mergedState.draftsByThreadKey[threadKeyFor(threadId)]?.images).toMatchObject([
+      {
+        type: "image",
+        id: "img-legacy",
+        name: "legacy.png",
+        mimeType: "image/png",
+        sizeBytes: 5,
+        previewUrl: "data:image/png;base64,aGVsbG8=",
+      },
+    ]);
+  });
+
+  it("hydrates persisted attachments with type file as file attachments", () => {
+    const mergedState = mergePersistedDraft({
+      type: "file",
+      id: "file-persisted",
+      name: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 5,
+      dataUrl: "data:application/pdf;base64,aGVsbG8=",
+    });
+
+    expect(mergedState.draftsByThreadKey[threadKeyFor(threadId)]?.images).toMatchObject([
+      {
+        type: "file",
+        id: "file-persisted",
+        name: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 5,
+        previewUrl: "data:application/pdf;base64,aGVsbG8=",
+      },
+    ]);
+  });
+
+  it("persists the file type for staged file attachments (round trip)", () => {
+    const attachment = makeFile({
+      id: "file-round-trip",
+      previewUrl: "data:application/pdf;base64,aGVsbG8=",
+    });
+    useComposerDraftStore.getState().addImage(threadRef, attachment);
+    useComposerDraftStore.getState().syncPersistedAttachments(threadRef, [
+      {
+        type: "file",
+        id: attachment.id,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        dataUrl: attachment.previewUrl,
+      },
+    ]);
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+      };
+    };
+    const persisted = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadKey?: Record<string, { attachments?: Array<Record<string, unknown>> }>;
+    };
+
+    expect(
+      persisted.draftsByThreadKey?.[threadKeyFor(threadId, TEST_ENVIRONMENT_ID)]?.attachments?.[0],
+    ).toMatchObject({
+      type: "file",
+      id: "file-round-trip",
+      name: "report.pdf",
+      mimeType: "application/pdf",
+    });
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -33,7 +33,12 @@ import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model"
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatFileAttachment,
+  type ChatImageAttachment,
+} from "./types";
 import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
@@ -79,6 +84,8 @@ if (typeof window !== "undefined" && typeof window.addEventListener === "functio
 }
 
 export const PersistedComposerImageAttachment = Schema.Struct({
+  // Missing on drafts persisted before file attachments existed → "image".
+  type: Schema.optionalKey(Schema.Literals(["image", "file"])),
   id: Schema.String,
   name: Schema.String,
   mimeType: Schema.String,
@@ -91,6 +98,13 @@ export interface ComposerImageAttachment extends Omit<ChatImageAttachment, "prev
   previewUrl: string;
   file: File;
 }
+
+export interface ComposerFileAttachment extends Omit<ChatFileAttachment, "previewUrl"> {
+  previewUrl: string;
+  file: File;
+}
+
+export type ComposerAttachment = ComposerImageAttachment | ComposerFileAttachment;
 
 const PersistedTerminalContextDraft = Schema.Struct({
   id: Schema.String,
@@ -249,7 +263,7 @@ const PersistedComposerDraftStoreStorage = Schema.Struct({
  */
 export interface ComposerThreadDraftState {
   prompt: string;
-  images: ComposerImageAttachment[];
+  images: ComposerAttachment[];
   nonPersistedImageIds: string[];
   persistedAttachments: PersistedComposerImageAttachment[];
   terminalContexts: TerminalContextDraft[];
@@ -434,8 +448,8 @@ interface ComposerDraftStoreState {
     threadRef: ComposerThreadTarget,
     interactionMode: ProviderInteractionMode | null | undefined,
   ) => void;
-  addImage: (threadRef: ComposerThreadTarget, image: ComposerImageAttachment) => void;
-  addImages: (threadRef: ComposerThreadTarget, images: ComposerImageAttachment[]) => void;
+  addImage: (threadRef: ComposerThreadTarget, image: ComposerAttachment) => void;
+  addImages: (threadRef: ComposerThreadTarget, images: ComposerAttachment[]) => void;
   removeImage: (threadRef: ComposerThreadTarget, imageId: string) => void;
   insertTerminalContext: (
     threadRef: ComposerThreadTarget,
@@ -551,7 +565,7 @@ const EMPTY_PERSISTED_DRAFT_STORE_STATE = Object.freeze<PersistedComposerDraftSt
   stickyActiveProvider: null,
 });
 
-const EMPTY_IMAGES: ComposerImageAttachment[] = [];
+const EMPTY_IMAGES: ComposerAttachment[] = [];
 const EMPTY_IDS: string[] = [];
 const EMPTY_PERSISTED_ATTACHMENTS: PersistedComposerImageAttachment[] = [];
 const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
@@ -609,7 +623,7 @@ export function createEmptyThreadDraft(): ComposerThreadDraftState {
   };
 }
 
-function composerImageDedupKey(image: ComposerImageAttachment): string {
+function composerImageDedupKey(image: ComposerAttachment): string {
   // Keep this independent from File.lastModified so dedupe is stable for hydrated
   // images reconstructed from localStorage (which get a fresh lastModified value).
   return `${image.mimeType}\u0000${image.sizeBytes}\u0000${image.name}`;
@@ -1059,7 +1073,9 @@ function normalizePersistedAttachment(value: unknown): PersistedComposerImageAtt
   ) {
     return null;
   }
+  const type = candidate.type;
   return {
+    ...(type === "image" || type === "file" ? { type } : {}),
     id,
     name,
     mimeType,
@@ -2084,21 +2100,21 @@ function hydratePersistedComposerImageAttachment(
 
 function hydrateImagesFromPersisted(
   attachments: ReadonlyArray<PersistedComposerImageAttachment>,
-): ComposerImageAttachment[] {
+): ComposerAttachment[] {
   return attachments.flatMap((attachment) => {
     const file = hydratePersistedComposerImageAttachment(attachment);
     if (!file) return [];
 
     return [
       {
-        type: "image" as const,
+        type: attachment.type ?? ("image" as const),
         id: attachment.id,
         name: attachment.name,
         mimeType: attachment.mimeType,
         sizeBytes: attachment.sizeBytes,
         previewUrl: attachment.dataUrl,
         file,
-      } satisfies ComposerImageAttachment,
+      } satisfies ComposerAttachment,
     ];
   });
 }
@@ -2856,7 +2872,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               existing.images.map((image) => composerImageDedupKey(image)),
             );
             const acceptedPreviewUrls = new Set(existing.images.map((image) => image.previewUrl));
-            const dedupedIncoming: ComposerImageAttachment[] = [];
+            const dedupedIncoming: ComposerAttachment[] = [];
             for (const image of images) {
               const dedupKey = composerImageDedupKey(image);
               if (existingIds.has(image.id) || existingDedupKeys.has(dedupKey)) {

--- a/apps/web/src/historyBootstrap.test.ts
+++ b/apps/web/src/historyBootstrap.test.ts
@@ -136,4 +136,41 @@ describe("buildBootstrapInput", () => {
     expect(result.text).toContain("Attached image");
     expect(result.text).toContain("screenshot.png");
   });
+
+  it("captures mixed image and file attachment context in transcript blocks", () => {
+    const result = buildBootstrapInput(
+      [
+        {
+          id: messageId("u-mixed"),
+          role: "user",
+          text: "Compare the screenshot with the report.",
+          attachments: [
+            {
+              type: "image",
+              id: "img-1",
+              name: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 2_048,
+            },
+            {
+              type: "file",
+              id: "file-1",
+              name: "report.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 4_096,
+            },
+          ],
+          createdAt: "2026-02-09T00:00:00.000Z",
+          turnId: null,
+          updatedAt: "2026-02-09T00:00:00.000Z",
+          streaming: false,
+        },
+      ],
+      "What differs?",
+      1_500,
+    );
+
+    expect(result.text).toContain("[Attached image: screenshot.png]");
+    expect(result.text).toContain("[Attached file: report.pdf]");
+  });
 });

--- a/apps/web/src/historyBootstrap.ts
+++ b/apps/web/src/historyBootstrap.ts
@@ -18,18 +18,30 @@ function messageRoleLabel(message: ChatMessage): "USER" | "ASSISTANT" {
   return message.role === "assistant" ? "ASSISTANT" : "USER";
 }
 
-function attachmentSummary(message: ChatMessage): string | null {
-  const imageAttachments = message.attachments?.filter((attachment) => attachment.type === "image");
-  const count = imageAttachments?.length ?? 0;
+function attachmentSummaryOfType(
+  message: ChatMessage,
+  type: "image" | "file",
+  label: string,
+): string | null {
+  const typedAttachments = message.attachments?.filter((attachment) => attachment.type === type);
+  const count = typedAttachments?.length ?? 0;
   if (count === 0) {
     return null;
   }
 
-  const names = imageAttachments?.slice(0, 3).map((image) => image.name) ?? [];
+  const names = typedAttachments?.slice(0, 3).map((attachment) => attachment.name) ?? [];
   const namesSummary = names.join(", ");
   const extraCount = count - names.length;
   const extraSummary = extraCount > 0 ? ` (+${extraCount} more)` : "";
-  return `[Attached image${count === 1 ? "" : "s"}: ${namesSummary}${extraSummary}]`;
+  return `[Attached ${label}${count === 1 ? "" : "s"}: ${namesSummary}${extraSummary}]`;
+}
+
+function attachmentSummary(message: ChatMessage): string | null {
+  const summaries = [
+    attachmentSummaryOfType(message, "image", "image"),
+    attachmentSummaryOfType(message, "file", "file"),
+  ].filter((summary) => summary !== null);
+  return summaries.length > 0 ? summaries.join("\n") : null;
 }
 
 function buildMessageBlock(message: ChatMessage): string {

--- a/apps/web/src/lib/attachmentSize.test.ts
+++ b/apps/web/src/lib/attachmentSize.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatAttachmentSizeLabel } from "./attachmentSize";
+
+describe("formatAttachmentSizeLabel", () => {
+  it("formats sub-kilobyte sizes in bytes", () => {
+    expect(formatAttachmentSizeLabel(0)).toBe("0 B");
+    expect(formatAttachmentSizeLabel(512)).toBe("512 B");
+    expect(formatAttachmentSizeLabel(1_023)).toBe("1023 B");
+  });
+
+  it("formats kilobyte sizes with one decimal", () => {
+    expect(formatAttachmentSizeLabel(1_024)).toBe("1.0 KB");
+    expect(formatAttachmentSizeLabel(2_048)).toBe("2.0 KB");
+    expect(formatAttachmentSizeLabel(1_024 * 1_024 - 1)).toBe("1024.0 KB");
+  });
+
+  it("formats megabyte sizes with one decimal", () => {
+    expect(formatAttachmentSizeLabel(1_024 * 1_024)).toBe("1.0 MB");
+    expect(formatAttachmentSizeLabel(2_202_010)).toBe("2.1 MB");
+  });
+});

--- a/apps/web/src/lib/attachmentSize.ts
+++ b/apps/web/src/lib/attachmentSize.ts
@@ -1,0 +1,9 @@
+export function formatAttachmentSizeLabel(sizeBytes: number): string {
+  if (sizeBytes >= 1024 * 1024) {
+    return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (sizeBytes >= 1024) {
+    return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  }
+  return `${sizeBytes} B`;
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatFileAttachment as ContractChatFileAttachment,
   ChatImageAttachment as ContractChatImageAttachment,
   OrchestrationCheckpointFile,
   OrchestrationCheckpointSummary,
@@ -35,7 +36,11 @@ export interface ChatImageAttachment extends ContractChatImageAttachment {
   readonly previewUrl?: string;
 }
 
-export type ChatAttachment = ChatImageAttachment;
+export interface ChatFileAttachment extends ContractChatFileAttachment {
+  readonly previewUrl?: string;
+}
+
+export type ChatAttachment = ChatImageAttachment | ChatFileAttachment;
 
 export interface ChatMessage extends Omit<OrchestrationMessage, "attachments"> {
   readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -3,6 +3,9 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import {
+  ChatAttachment,
+  ChatFileAttachment,
+  ChatImageAttachment,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   ModelSelection,
@@ -738,6 +741,83 @@ it.effect("ModelSelection rejects malformed instance ids", () =>
       decodeModelSelection({
         instanceId: "1invalid", // must start with a letter
         model: "x",
+      }),
+    );
+    assert.strictEqual(result._tag, "Failure");
+  }),
+);
+
+// ── ChatAttachment: image/file union ──────────────────────────────────
+
+const decodeChatAttachment = Schema.decodeUnknownEffect(ChatAttachment);
+const decodeChatAttachmentArray = Schema.decodeUnknownEffect(Schema.Array(ChatAttachment));
+const decodeChatImageAttachment = Schema.decodeUnknownEffect(ChatImageAttachment);
+const decodeChatFileAttachment = Schema.decodeUnknownEffect(ChatFileAttachment);
+
+it.effect("ChatAttachment decodes a file attachment with a non-image mime type", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeChatAttachment({
+      type: "file",
+      id: "file-1",
+      name: "report.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_048,
+    });
+    assert.strictEqual(parsed.type, "file");
+    assert.strictEqual(parsed.name, "report.pdf");
+    assert.strictEqual(parsed.mimeType, "application/pdf");
+    assert.strictEqual(parsed.sizeBytes, 2_048);
+  }),
+);
+
+it.effect("ChatAttachment arrays still decode legacy image-only attachments", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeChatAttachmentArray([
+      {
+        type: "image",
+        id: "img-1",
+        name: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 1_024,
+      },
+      {
+        type: "image",
+        id: "img-2",
+        name: "diagram.jpeg",
+        mimeType: "image/jpeg",
+        sizeBytes: 4_096,
+      },
+    ]);
+    assert.strictEqual(parsed.length, 2);
+    assert.strictEqual(parsed[0]?.type, "image");
+    assert.strictEqual(parsed[1]?.type, "image");
+  }),
+);
+
+it.effect("ChatImageAttachment rejects non-image mime types", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.exit(
+      decodeChatImageAttachment({
+        type: "image",
+        id: "img-1",
+        name: "report.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 2_048,
+      }),
+    );
+    assert.strictEqual(result._tag, "Failure");
+  }),
+);
+
+it.effect("ChatFileAttachment rejects sizeBytes over the 10MB limit", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.exit(
+      decodeChatFileAttachment({
+        type: "file",
+        id: "file-1",
+        name: "big.bin",
+        mimeType: "application/octet-stream",
+        sizeBytes: 10 * 1024 * 1024 + 1,
       }),
     );
     assert.strictEqual(result._tag, "Failure");

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -173,9 +173,29 @@ const UploadChatImageAttachment = Schema.Struct({
 });
 export type UploadChatImageAttachment = typeof UploadChatImageAttachment.Type;
 
-export const ChatAttachment = Schema.Union([ChatImageAttachment]);
+export const ChatFileAttachment = Schema.Struct({
+  type: Schema.Literal("file"),
+  id: ChatAttachmentId,
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100)),
+  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)),
+});
+export type ChatFileAttachment = typeof ChatFileAttachment.Type;
+
+const UploadChatFileAttachment = Schema.Struct({
+  type: Schema.Literal("file"),
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100)),
+  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)),
+  dataUrl: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS),
+  ),
+});
+export type UploadChatFileAttachment = typeof UploadChatFileAttachment.Type;
+
+export const ChatAttachment = Schema.Union([ChatImageAttachment, ChatFileAttachment]);
 export type ChatAttachment = typeof ChatAttachment.Type;
-const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
+const UploadChatAttachment = Schema.Union([UploadChatImageAttachment, UploadChatFileAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
 export const ProjectScriptIcon = Schema.Literals([


### PR DESCRIPTION
Implements #4057.

## What

The composer currently rejects anything that isn't an image. This PR lets users drag/paste **any file** (PDF, logs, CSV, …) into the composer and have the agent read it — including on remote environments, where there was previously no way to hand the agent a file at all.

**Images are untouched**: same native image content blocks per provider, same preview tiles, same expand dialog. Limits unchanged (10 MB per attachment, 8 per message).

## How

Non-image files reuse the existing upload path (base64 data URL → server writes to `<stateDir>/attachments/`), and are delivered **by reference** at the single `sendTurn` choke point in `ProviderCommandReactor`:

```
[Attached file: /abs/.../attachments/<id>.csv (vendor-report.csv, text/csv, 40 B). Read it from disk when needed.]
```

is appended to the turn input, and the attachment list passed to the provider is filtered to images only. The agent reads the file with its own tools — **zero changes to the Claude/Codex/Grok adapters**, and remote environments work by construction (the file lands on the machine the agent runs on).

## Details

- New `ChatFileAttachment` contract variant — additive union member; existing persisted image rows and localStorage drafts decode unchanged (persisted draft `type` is optional, missing ⇒ image, no storage-version bump).
- **GC fix**: `collectThreadAttachmentRelativePaths` skipped non-image attachments while the pruning pass deletes anything not in the keep-set — without this, file attachments would be deleted from disk on the next projection pass.
- **Reactor filter is required, not optional**: Codex/Grok adapters wrap *any* attachment in an image block today; only the Claude adapter skips non-images.
- Disk extensions are allowlist-gated (`SAFE_FILE_EXTENSIONS`, `.bin` fallback) so `resolveAttachmentPathById`'s fixed-extension scan keeps working and `.html`-class extensions never land on the same-origin asset route. Non-image asset requests get `Content-Disposition: attachment` (download, never inline render).
- Prompt line sanitizes the file name (control chars/brackets stripped); the on-disk name is `<server-generated-id>.<allowlisted-ext>`, so the original filename never touches a path.
- Timeline renders file attachments as name+size chips that download via the signed asset URL; `historyBootstrap` summarizes them for provider switches.

## Screenshots

Composer with a dropped CSV staged as a chip (images keep their tiles):

![composer chip](https://raw.githubusercontent.com/A1-Events/t3code/assets/file-attachments/composer-chip.png)

Sent message in the timeline with the file chip:

![timeline chip](https://raw.githubusercontent.com/A1-Events/t3code/assets/file-attachments/timeline-chip.png)

## Verified

- `vp check` 0 errors (the new reactor test uses `it.effect` — no new manual-runner debt), `vp run typecheck` clean repo-wide, all package test suites green: server 1419, web 1313, contracts 183, mobile 505, relay 187.
- +19 server tests / +12 contracts+web tests: Normalizer ingestion (new file), GC keep/prune for file attachments, reactor images-only filter + exact injected prompt line, AssetAccess download flag, extension inference, draft persistence compat, timeline chip rendering.
- Live E2E on a dev instance: dropped a CSV in the browser → file persisted server-side with correct id/extension → Codex's own session rollout log shows the turn input containing the exact `[Attached file: …]` line with the resolved path.

## Known version-skew / follow-ups (called out per #4035 precedent)

- Old clients fail to decode a thread snapshot that contains a `type:"file"` attachment (usual wire-evolution surface, handled by the version-mismatch banner).
- Shipped mobile renders file attachments as broken image tiles (it renders every attachment by id as an image). Small mobile render fix is a natural follow-up; kept out to keep this PR single-purpose.
- Possible v2: native document blocks per provider SDK (e.g. Claude PDF blocks) instead of path injection for specific types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches attachment ingestion, same-origin asset serving, and the provider turn pipeline (security-sensitive), though mitigated by extension allowlists, download headers, and image-only provider payloads.
> 
> **Overview**
> Adds **`ChatFileAttachment`** alongside images so the composer can stage PDFs, logs, CSVs, and other files—not only pictures—while keeping the same size/count limits.
> 
> **Server:** uploads persist with allowlisted extensions (`inferFileExtension`, `.bin` fallback); **`ProviderCommandReactor`** appends `[Attached file: …]` paths to turn input and sends **only images** to providers; projection GC now **keeps file attachments** referenced in messages. Non-image assets get **`Content-Disposition: attachment`** on `/api/assets` to avoid inline rendering of risky types.
> 
> **Web:** drag/paste accepts any file type; timeline shows **file chips** (name + size) vs image tiles; drafts persist `type: "file"` with legacy image default when `type` is missing.
> 
> **Contracts:** additive union on `ChatAttachment` / upload payloads; tests cover decode and limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f54a4d4901dbc724226b9032e22546f59d76d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support non-image file attachments in the chat composer and message timeline
> - Extends the composer to accept any file type via paste or drag-and-drop; file attachments render as chips with a file icon and formatted size, while images retain the existing thumbnail grid.
> - Adds `ComposerFileAttachment` and `ComposerAttachment` union types to the draft store so file and image attachments coexist in the same array, with backward-compatible hydration for legacy drafts.
> - Introduces `ChatFileAttachment` and `UploadChatFileAttachment` contract schemas, extending the `ChatAttachment` and `UploadChatAttachment` unions.
> - On the server, file attachments are persisted to disk via the normalizer, appended to the provider prompt as text references (path, name, MIME, size) rather than sent as content blocks, and included in attachment GC during thread revert.
> - Non-image attachments resolved via `AssetAccess` are marked with `download: true`, causing the HTTP asset route to set a `Content-Disposition: attachment` header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f54a4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->