### PR TITLE
fix(server): stabilize non-repository Git diagnostics

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -78,6 +78,22 @@ const initRepoWithCommit = (
   });
 
 it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
+  describe("process environment", () => {
+    it.effect("preserves the caller locale for general Git subprocesses", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+
+        const locale = yield* git(
+          cwd,
+          ["-c", 'alias.print-locale=!printf "%s" "$LC_ALL"', "print-locale"],
+          { LC_ALL: "zh_CN.UTF-8" },
+        );
+
+        assert.equal(locale, "zh_CN.UTF-8");
+      }),
+    );
+  });
+
   describe("structured errors", () => {
     it.effect("preserves structured spawn context and the platform cause", () =>
       Effect.gen(function* () {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -370,6 +370,8 @@ function isNonRepositoryGitStderr(stderr: string): boolean {
   return stderr.toLowerCase().includes("not a git repository");
 }
 
+const NON_REPOSITORY_DETECTION_ENV = { LC_ALL: "C" } as const;
+
 interface Trace2Monitor {
   readonly env: NodeJS.ProcessEnv;
   readonly flush: Effect.Effect<void, never>;
@@ -1310,6 +1312,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       ["status", "--porcelain=2", "--branch"],
       {
         allowNonZeroExit: true,
+        env: NON_REPOSITORY_DETECTION_ENV,
       },
     ).pipe(
       Effect.catchTags({
@@ -1992,6 +1995,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         {
           timeoutMs: 10_000,
           allowNonZeroExit: true,
+          env: NON_REPOSITORY_DETECTION_ENV,
         },
       ).pipe(
         Effect.catchTags({


### PR DESCRIPTION
## What Changed

- Use `LC_ALL=C` only for the two Git commands whose non-repository control flow parses an English diagnostic.
- Add an integration test that verifies general Git subprocesses continue to preserve a caller-provided locale.

## Why

T3 Code identifies a non-repository result by matching Git's English diagnostic text. Git localizes that diagnostic through gettext, while the subprocess previously inherited the host locale. On systems with Git translations installed, a normal non-repository status could therefore be misclassified as a `GitCommandError`.

Using the C locale at these two call sites makes the parsed diagnostic deterministic without changing locale behavior for unrelated Git operations. `LC_ALL` is scoped to the commands instead of using only `LC_MESSAGES` so the fix also works when the host already defines `LC_ALL`, which takes precedence over individual locale categories.

## Validation

- `vp check`
- `vp run typecheck`
- `vp test apps/server/src/vcs/GitVcsDriverCore.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
