### PR TITLE
fix(server): stabilize non-repository Git diagnostics

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -6,6 +6,9 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 import * as Scope from "effect/Scope";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
@@ -19,6 +22,21 @@ const TestLayer = GitVcsDriver.layer.pipe(
   Layer.provide(ServerConfigLayer),
   Layer.provideMerge(NodeServices.layer),
 );
+
+const makeNonRepositoryHandle = () =>
+  ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(128)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.empty,
+    stderr: Stream.encodeText(Stream.make("fatal: not a git repository")),
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
 
 const makeTmpDir = (
   prefix = "git-vcs-driver-test-",
@@ -77,7 +95,62 @@ const initRepoWithCommit = (
     return { initialBranch };
   });
 
+it.effect("uses stable diagnostics for every parsed non-repository command", () => {
+  const commands: Array<{ readonly args: ReadonlyArray<string>; readonly lcAll?: string }> = [];
+  const spawner = ChildProcessSpawner.make((command) =>
+    Effect.sync(() => {
+      if (!ChildProcess.isStandardCommand(command)) {
+        return assert.fail("expected a standard Git command");
+      }
+      commands.push({
+        args: command.args,
+        ...(command.options.env?.LC_ALL ? { lcAll: command.options.env.LC_ALL } : {}),
+      });
+      return makeNonRepositoryHandle();
+    }),
+  );
+  const nodeServicesLayer = Layer.merge(
+    NodeServices.layer,
+    Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+  );
+  const layer = GitVcsDriver.layer.pipe(
+    Layer.provide(ServerConfigLayer),
+    Layer.provideMerge(nodeServicesLayer),
+  );
+
+  return Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.GitVcsDriver;
+    const cwd = "/repo";
+
+    yield* driver.statusDetailsLocal(cwd);
+    yield* driver.statusDetailsRemote(cwd, { refreshUpstream: false });
+    yield* driver.listRefs({ cwd });
+
+    assert.deepStrictEqual(commands, [
+      { args: ["status", "--porcelain=2", "--branch"], lcAll: "C" },
+      { args: ["rev-parse", "--abbrev-ref", "HEAD"], lcAll: "C" },
+      { args: ["branch", "--no-color", "--no-column"], lcAll: "C" },
+    ]);
+  }).pipe(Effect.provide(layer));
+});
+
 it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
+  describe("process environment", () => {
+    it.effect("preserves the caller locale for general Git subprocesses", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+
+        const locale = yield* git(
+          cwd,
+          ["-c", 'alias.print-locale=!printf "%s" "$LC_ALL"', "print-locale"],
+          { LC_ALL: "zh_CN.UTF-8" },
+        );
+
+        assert.equal(locale, "zh_CN.UTF-8");
+      }),
+    );
+  });
+
   describe("structured errors", () => {
     it.effect("preserves structured spawn context and the platform cause", () =>
       Effect.gen(function* () {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -830,6 +830,20 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       }),
     );
 
+  const executeGitWithStableDiagnostics = (
+    operation: string,
+    cwd: string,
+    args: readonly string[],
+    options: ExecuteGitOptions = {},
+  ): Effect.Effect<GitVcsDriver.ExecuteGitResult, GitCommandError> =>
+    executeGit(operation, cwd, args, {
+      ...options,
+      env: {
+        ...options.env,
+        LC_ALL: "C",
+      },
+    });
+
   const runGit = (
     operation: string,
     cwd: string,
@@ -1184,7 +1198,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   });
 
   const readStatusDetailsRemote = Effect.fn("readStatusDetailsRemote")(function* (cwd: string) {
-    const branchResult = yield* executeGit(
+    const branchResult = yield* executeGitWithStableDiagnostics(
       "GitVcsDriver.statusDetailsRemote.branch",
       cwd,
       ["rev-parse", "--abbrev-ref", "HEAD"],
@@ -1304,7 +1318,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   });
 
   const readStatusDetailsLocal = Effect.fn("readStatusDetailsLocal")(function* (cwd: string) {
-    const statusResult = yield* executeGit(
+    const statusResult = yield* executeGitWithStableDiagnostics(
       "GitVcsDriver.statusDetails.status",
       cwd,
       ["status", "--porcelain=2", "--branch"],
@@ -1985,7 +1999,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       const branchRecencyPromise = readBranchRecency(input.cwd).pipe(
         Effect.orElseSucceed(() => new Map<string, number>()),
       );
-      const localBranchResult = yield* executeGit(
+      const localBranchResult = yield* executeGitWithStableDiagnostics(
         "GitVcsDriver.listRefs.branchNoColor",
         input.cwd,
         ["branch", "--no-color", "--no-column"],


### PR DESCRIPTION
## What Changed

- Add a private `executeGitWithStableDiagnostics` path that applies `LC_ALL=C` without changing the default Git execution environment.
- Route all three commands that parse the localized `not a git repository` diagnostic through that path.
- Add regression coverage proving general Git commands preserve the caller locale and every parsed non-repository command receives the stable locale.

## Why

T3 Code identifies a non-repository result by matching Git's English diagnostic text. Git localizes that diagnostic through gettext, while these subprocesses previously inherited the host locale. On systems with Git translations installed, a normal non-repository status could therefore be misclassified as a `GitCommandError`.

The dedicated execution path keeps this policy consistent for current and future diagnostic parsing without changing locale behavior for unrelated Git operations or hooks. It uses command-scoped `LC_ALL` rather than only `LC_MESSAGES` so the behavior remains deterministic when the host already defines `LC_ALL`, which takes precedence over individual locale categories.

## Validation

- `vp check`
- `vp run typecheck`
- `vp test apps/server/src/vcs/GitVcsDriverCore.test.ts` (26 tests)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force `LC_ALL=C` for Git diagnostics commands in `GitVcsDriverCore`
> Git output for commands like `status --porcelain=2`, `rev-parse`, and `branch` can vary based on the caller's locale, causing unreliable parsing. A new `executeGitWithStableDiagnostics` helper in [`GitVcsDriverCore.ts`](https://github.com/pingdotgg/t3code/pull/4077/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) wraps `executeGit` and forces `LC_ALL=C`, overriding any caller-provided environment. This is applied to the three commands used by `statusDetailsLocal`, `statusDetailsRemote`, and `listRefs`. Behavioral Change: `LC_ALL` is now always `C` for these Git subprocesses, regardless of the caller's locale — general Git subprocesses retain the caller's locale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07fc4cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted VCS change with regression tests; misclassification risk is reduced rather than introduced.
> 
> **Overview**
> Non-repository detection matches Git stderr for the English phrase `not a git repository`. On hosts with translated Git messages, that check could fail and surface a `GitCommandError` instead of treating the path as not a repo.
> 
> This PR adds **`executeGitWithStableDiagnostics`**, which runs selected subprocesses with **`LC_ALL=C`** so those diagnostics stay English. Only the three commands that feed that parsing are switched: **`status --porcelain=2 --branch`**, **`rev-parse --abbrev-ref HEAD`**, and **`branch --no-color --no-column`** in `statusDetailsLocal`, `statusDetailsRemote`, and `listRefs`. Other Git calls still use the caller’s locale.
> 
> Tests mock a non-repo exit and assert all three paths set `LC_ALL=C`, and an integration test confirms general `execute` still passes through a custom `LC_ALL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fc4cf1a81d2ef5c8d92d80a2945d289bb9640d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->