### PR TITLE
fix(web): show command output in work log

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -44,6 +44,59 @@ describe("projectActivityPayload agent-field survival", () => {
     expect(data.somethingClientNeverReads).toBeUndefined();
   });
 
+  it("keeps a bounded Codex command output summary", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        data: {
+          item: {
+            command: "/bin/zsh -lc 'printf hello'",
+            aggregatedOutput: `hello from codex\n${"x".repeat(5000)}`,
+          },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.item).toEqual({
+      command: "/bin/zsh -lc 'printf hello'",
+      aggregatedOutput: "hello from codex",
+    });
+    expect(JSON.stringify(projected.payload).length).toBeLessThan(500);
+  });
+
+  it("keeps bounded Claude and ACP command output summaries", () => {
+    const claude = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        data: {
+          command: "printf hello",
+          rawOutput: { stdout: `hello from claude\n${"y".repeat(5000)}` },
+        },
+      }),
+    );
+    const acp = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        data: {
+          command: "printf hello",
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: `hello from acp\n${"z".repeat(5000)}` },
+            },
+          ],
+        },
+      }),
+    );
+
+    const claudeData = (claude.payload as Record<string, unknown>).data as Record<string, unknown>;
+    const acpData = (acp.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(claudeData.rawOutput).toEqual({ content: "hello from claude" });
+    expect(acpData.rawOutput).toEqual({ content: "hello from acp" });
+    expect(JSON.stringify(claude.payload).length).toBeLessThan(500);
+    expect(JSON.stringify(acp.payload).length).toBeLessThan(500);
+  });
+
   it("slims Codex-shaped mcp_tool_call items to rendered fields plus a result summary", () => {
     const projected = projectActivityPayload(
       activity({

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -91,14 +91,35 @@ function projectCommandData(data: Record<string, unknown>): Record<string, unkno
     projectedItem.command = item.command;
   }
 
+  const aggregatedOutput = asTrimmedString(item.aggregatedOutput);
+  if (aggregatedOutput) {
+    const summary = summarizeToolTextOutput(aggregatedOutput);
+    if (summary) {
+      projectedItem.aggregatedOutput = summary;
+    }
+  }
+
   const input = asRecord(item.input);
   if (input && "command" in input) {
     projectedItem.input = { command: input.command };
   }
 
   const result = asRecord(item.result);
-  if (result && "command" in result) {
-    projectedItem.result = { command: result.command };
+  if (result) {
+    const projectedResult: Record<string, unknown> = {};
+    if ("command" in result) {
+      projectedResult.command = result.command;
+    }
+    const content = asTrimmedString(result.content);
+    if (content) {
+      const summary = summarizeToolTextOutput(content);
+      if (summary) {
+        projectedResult.content = summary;
+      }
+    }
+    if (Object.keys(projectedResult).length > 0) {
+      projectedItem.result = projectedResult;
+    }
   }
 
   return Object.keys(projectedItem).length > 0 ? projectedItem : undefined;
@@ -232,6 +253,12 @@ function projectMcpToolCallData(data: Record<string, unknown>): Record<string, u
 }
 
 function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
+  const direct = asTrimmedString(value);
+  if (direct) {
+    const summary = summarizeToolTextOutput(direct);
+    return summary ? { content: summary } : undefined;
+  }
+
   const rawOutput = asRecord(value);
   if (!rawOutput) {
     return undefined;
@@ -256,7 +283,32 @@ function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
     return summary ? { content: summary } : undefined;
   }
 
+  const stderr = asTrimmedString(rawOutput.stderr);
+  if (stderr) {
+    const summary = summarizeToolTextOutput(stderr);
+    return summary ? { content: summary } : undefined;
+  }
+
   return undefined;
+}
+
+function projectAcpContent(value: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const text = value
+    .map((entryValue) => {
+      const entry = asRecord(entryValue);
+      const content = asRecord(entry?.content);
+      return entry?.type === "content" && content?.type === "text"
+        ? asTrimmedString(content.text)
+        : null;
+    })
+    .filter((entry): entry is string => entry !== null)
+    .join("\n");
+  const summary = summarizeToolTextOutput(text);
+  return summary ? { content: summary } : undefined;
 }
 
 /**
@@ -305,7 +357,7 @@ export function projectActivityPayload(
     projectedData.kind = data.kind;
   }
 
-  const rawOutput = projectRawOutput(data.rawOutput);
+  const rawOutput = projectRawOutput(data.rawOutput) ?? projectAcpContent(data.content);
   if (rawOutput) {
     projectedData.rawOutput = rawOutput;
   }

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -24,11 +24,12 @@ describe("deriveWorkLogEntries command output", () => {
       makeCommandActivity("codex-command", {
         itemType: "command_execution",
         title: "Ran command",
-        detail: "printf hello",
+        detail: "/bin/zsh -lc \"printf 'hello\\n'\"",
         data: {
           item: {
             type: "commandExecution",
-            command: "printf hello",
+            command: "/bin/zsh -lc \"printf 'hello\\n'\"",
+            commandActions: [{ command: "printf 'hello\\n'", type: "unknown" }],
             aggregatedOutput: "hello\n<exited with exit code 0>",
             status: "completed",
           },
@@ -37,7 +38,8 @@ describe("deriveWorkLogEntries command output", () => {
     ]);
 
     expect(entry).toMatchObject({
-      command: "printf hello",
+      command: "printf 'hello\\n'",
+      rawCommand: "/bin/zsh -lc \"printf 'hello\\n'\"",
       detail: "hello",
     });
   });

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -1,0 +1,83 @@
+import { EventId, TurnId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveWorkLogEntries } from "./session-logic";
+
+function makeCommandActivity(
+  id: string,
+  payload: Record<string, unknown>,
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(id),
+    createdAt: "2026-07-17T10:00:00.000Z",
+    kind: "tool.completed",
+    summary: "Ran command",
+    tone: "tool",
+    payload,
+    turnId: TurnId.make("turn-1"),
+  };
+}
+
+describe("deriveWorkLogEntries command output", () => {
+  it("uses Codex aggregated output instead of repeating the command", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("codex-command", {
+        itemType: "command_execution",
+        title: "Ran command",
+        detail: "printf hello",
+        data: {
+          item: {
+            type: "commandExecution",
+            command: "printf hello",
+            aggregatedOutput: "hello\n<exited with exit code 0>",
+            status: "completed",
+          },
+        },
+      }),
+    ]);
+
+    expect(entry).toMatchObject({
+      command: "printf hello",
+      detail: "hello",
+    });
+  });
+
+  it("uses Claude ACP stdout instead of repeating the command", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("claude-command", {
+        itemType: "command_execution",
+        title: "Ran command",
+        detail: "printf hello",
+        data: {
+          kind: "execute",
+          command: "printf hello",
+          rawOutput: {
+            stdout: "hello from claude\n",
+          },
+        },
+      }),
+    ]);
+
+    expect(entry).toMatchObject({
+      command: "printf hello",
+      detail: "hello from claude",
+    });
+  });
+
+  it("drops duplicated command detail when the command has no output", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("empty-command", {
+        itemType: "command_execution",
+        title: "Ran command",
+        detail: "true",
+        data: {
+          kind: "execute",
+          command: "true",
+        },
+      }),
+    ]);
+
+    expect(entry?.command).toBe("true");
+    expect(entry?.detail).toBeUndefined();
+  });
+});

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -44,7 +44,7 @@ describe("deriveWorkLogEntries command output", () => {
     });
   });
 
-  it("uses Claude ACP stdout instead of repeating the command", () => {
+  it("uses a projected Claude output summary instead of repeating the command", () => {
     const [entry] = deriveWorkLogEntries([
       makeCommandActivity("claude-command", {
         itemType: "command_execution",
@@ -54,7 +54,7 @@ describe("deriveWorkLogEntries command output", () => {
           kind: "execute",
           command: "printf hello",
           rawOutput: {
-            stdout: "hello from claude\n",
+            content: "hello from claude",
           },
         },
       }),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1234,13 +1234,18 @@ function extractToolDetail(
   const normalizedHeading = normalizePreviewForComparison(heading);
   const normalizedDetail = normalizePreviewForComparison(detail);
   const commandTool = isCommandToolDetail(payload, heading);
-  const command = commandTool ? extractToolCommand(payload).command : null;
+  const commandPreview = commandTool
+    ? extractToolCommand(payload)
+    : { command: null, rawCommand: null };
+  const command = commandPreview.command;
   const normalizedCommand = normalizePreviewForComparison(command);
+  const normalizedRawCommand = normalizePreviewForComparison(commandPreview.rawCommand);
 
   if (
     detail &&
     normalizedHeading !== normalizedDetail &&
-    (!commandTool || normalizedCommand !== normalizedDetail)
+    (!commandTool ||
+      (normalizedCommand !== normalizedDetail && normalizedRawCommand !== normalizedDetail))
   ) {
     return detail;
   }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1149,6 +1149,70 @@ function summarizeToolRawOutput(payload: Record<string, unknown> | null): string
   return null;
 }
 
+function extractAcpTextContent(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const chunks: string[] = [];
+  for (const entryValue of value) {
+    const entry = asRecord(entryValue);
+    if (entry?.type !== "content") {
+      continue;
+    }
+    const content = asRecord(entry.content);
+    if (content?.type !== "text") {
+      continue;
+    }
+    const text = asTrimmedString(content.text);
+    if (text) {
+      chunks.push(text);
+    }
+  }
+
+  return chunks.length > 0 ? chunks.join("\n") : null;
+}
+
+function extractToolOutput(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  const rawOutput = asRecord(data?.rawOutput);
+
+  const outputStreams: string[] = [];
+  const stdout = asTrimmedString(rawOutput?.stdout);
+  const stderr = asTrimmedString(rawOutput?.stderr);
+  if (stdout) {
+    outputStreams.push(stdout);
+  }
+  if (stderr) {
+    outputStreams.push(stderr);
+  }
+
+  const candidates: unknown[] = [
+    item?.aggregatedOutput,
+    itemResult?.content,
+    data?.rawOutput,
+    rawOutput?.content,
+    outputStreams.length > 0 ? outputStreams.join("\n") : null,
+    rawOutput?.output,
+    extractAcpTextContent(data?.content),
+  ];
+
+  for (const candidate of candidates) {
+    const text = asTrimmedString(candidate);
+    if (!text) {
+      continue;
+    }
+    const output = stripTrailingExitCode(text).output;
+    if (output) {
+      return output;
+    }
+  }
+
+  return null;
+}
+
 function isCommandToolDetail(payload: Record<string, unknown> | null, heading: string): boolean {
   const data = asRecord(payload?.data);
   const kind = asTrimmedString(data?.kind)?.toLowerCase();
@@ -1169,12 +1233,32 @@ function extractToolDetail(
   const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
   const normalizedHeading = normalizePreviewForComparison(heading);
   const normalizedDetail = normalizePreviewForComparison(detail);
+  const commandTool = isCommandToolDetail(payload, heading);
+  const command = commandTool ? extractToolCommand(payload).command : null;
+  const normalizedCommand = normalizePreviewForComparison(command);
 
-  if (detail && normalizedHeading !== normalizedDetail) {
+  if (
+    detail &&
+    normalizedHeading !== normalizedDetail &&
+    (!commandTool || normalizedCommand !== normalizedDetail)
+  ) {
     return detail;
   }
 
-  if (isCommandToolDetail(payload, heading)) {
+  if (commandTool) {
+    if (!command) {
+      return null;
+    }
+
+    const output = extractToolOutput(payload);
+    const normalizedOutput = normalizePreviewForComparison(output);
+    if (
+      output &&
+      normalizedOutput !== normalizedHeading &&
+      normalizedOutput !== normalizedCommand
+    ) {
+      return output;
+    }
     return null;
   }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1382,6 +1382,70 @@ function summarizeToolRawOutput(payload: Record<string, unknown> | null): string
   return null;
 }
 
+function extractAcpTextContent(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const chunks: string[] = [];
+  for (const entryValue of value) {
+    const entry = asRecord(entryValue);
+    if (entry?.type !== "content") {
+      continue;
+    }
+    const content = asRecord(entry.content);
+    if (content?.type !== "text") {
+      continue;
+    }
+    const text = asTrimmedString(content.text);
+    if (text) {
+      chunks.push(text);
+    }
+  }
+
+  return chunks.length > 0 ? chunks.join("\n") : null;
+}
+
+function extractToolOutput(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  const rawOutput = asRecord(data?.rawOutput);
+
+  const outputStreams: string[] = [];
+  const stdout = asTrimmedString(rawOutput?.stdout);
+  const stderr = asTrimmedString(rawOutput?.stderr);
+  if (stdout) {
+    outputStreams.push(stdout);
+  }
+  if (stderr) {
+    outputStreams.push(stderr);
+  }
+
+  const candidates: unknown[] = [
+    item?.aggregatedOutput,
+    itemResult?.content,
+    data?.rawOutput,
+    rawOutput?.content,
+    outputStreams.length > 0 ? outputStreams.join("\n") : null,
+    rawOutput?.output,
+    extractAcpTextContent(data?.content),
+  ];
+
+  for (const candidate of candidates) {
+    const text = asTrimmedString(candidate);
+    if (!text) {
+      continue;
+    }
+    const output = stripTrailingExitCode(text).output;
+    if (output) {
+      return output;
+    }
+  }
+
+  return null;
+}
+
 function isCommandToolDetail(payload: Record<string, unknown> | null, heading: string): boolean {
   const data = asRecord(payload?.data);
   const kind = asTrimmedString(data?.kind)?.toLowerCase();
@@ -1402,12 +1466,32 @@ function extractToolDetail(
   const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
   const normalizedHeading = normalizePreviewForComparison(heading);
   const normalizedDetail = normalizePreviewForComparison(detail);
+  const commandTool = isCommandToolDetail(payload, heading);
+  const command = commandTool ? extractToolCommand(payload).command : null;
+  const normalizedCommand = normalizePreviewForComparison(command);
 
-  if (detail && normalizedHeading !== normalizedDetail) {
+  if (
+    detail &&
+    normalizedHeading !== normalizedDetail &&
+    (!commandTool || normalizedCommand !== normalizedDetail)
+  ) {
     return detail;
   }
 
-  if (isCommandToolDetail(payload, heading)) {
+  if (commandTool) {
+    if (!command) {
+      return null;
+    }
+
+    const output = extractToolOutput(payload);
+    const normalizedOutput = normalizePreviewForComparison(output);
+    if (
+      output &&
+      normalizedOutput !== normalizedHeading &&
+      normalizedOutput !== normalizedCommand
+    ) {
+      return output;
+    }
     return null;
   }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1467,13 +1467,18 @@ function extractToolDetail(
   const normalizedHeading = normalizePreviewForComparison(heading);
   const normalizedDetail = normalizePreviewForComparison(detail);
   const commandTool = isCommandToolDetail(payload, heading);
-  const command = commandTool ? extractToolCommand(payload).command : null;
+  const commandPreview = commandTool
+    ? extractToolCommand(payload)
+    : { command: null, rawCommand: null };
+  const command = commandPreview.command;
   const normalizedCommand = normalizePreviewForComparison(command);
+  const normalizedRawCommand = normalizePreviewForComparison(commandPreview.rawCommand);
 
   if (
     detail &&
     normalizedHeading !== normalizedDetail &&
-    (!commandTool || normalizedCommand !== normalizedDetail)
+    (!commandTool ||
+      (normalizedCommand !== normalizedDetail && normalizedRawCommand !== normalizedDetail))
   ) {
     return detail;
   }


### PR DESCRIPTION
## What Changed

Fixes #4076.

Updated command work-log entries so they display:

* The executed command once
* The actual command output underneath it

The fix supports output from Codex and ACP-based providers such as Claude.

It also preserves the existing Cursor behavior when stdout is available but the original command input is missing.

Added focused regression tests covering:

* Codex command output
* Claude ACP stdout
* Commands with no output
* Cursor events without command metadata

## Why

Command execution entries were sometimes showing the command twice instead of showing the command followed by its output.

This happened because the command text could be stored as both the command and detail, while the real provider output was not being selected for the expanded work-log entry.

The updated logic extracts the actual output only when the original command is available, preventing duplicated command text and avoiding misleading output-only rows.

## UI Changes

This changes the content shown when expanding a command work-log entry:

**Before**

```text
printf hello

printf hello
```

**After**

```text
printf hello

hello
```

There are no visual styling or layout changes.

## Testing

* `vp test apps/web/src/session-logic.command-output.test.ts` — 3 tests passed
* `vp test apps/web/src/session-logic.test.ts` — 59 tests passed
* `vp check` — completed with 0 errors
* `git diff --check` — passed
* `vp run test` — attempted, but unrelated `oxlint-plugin-t3code` tests could not spawn the local Windows `oxlint` executable (`ENOENT`)

## Checklist

* [x] This PR is small and focused
* [x] I explained what changed and why
* [ ] I included before/after screenshots for any UI changes
* [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and payload-slimming only; no auth or persistence changes, with behavior covered by new unit tests.
> 
> **Overview**
> Fixes work-log command rows that showed the **command twice** instead of **command + output** by teaching `deriveWorkLogEntries` / `extractToolDetail` to pull real stdout-style text from Codex (`aggregatedOutput`), Claude (`rawOutput`), and ACP (`content` arrays), and to **omit `detail`** when it would only repeat the command or there is no output.
> 
> On the wire path, **`projectActivityPayload`** now **summarizes and bounds** the same command-output fields (including Codex `aggregatedOutput`, result `content`, `stderr`, and ACP text folded into `rawOutput`) so clients still get usable previews without huge payloads.
> 
> Adds focused regression tests in **`session-logic.command-output.test.ts`** and **`ActivityPayloadProjection.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c35fbda526d709bbe55ca89993fff34a1960824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show command output in work log entries for command execution activities
> - Adds `extractToolOutput` in [`session-logic.ts`](https://github.com/pingdotgg/t3code/pull/4083/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to pull command output from multiple payload shapes: `aggregatedOutput`, `result.content`, `rawOutput` (string or object), stdout/stderr, and ACP content arrays.
> - Updates `extractToolDetail` to prefer actual tool output as the detail for command tools, and suppresses detail entirely when output is absent or duplicates the command string.
> - Extends [`ActivityPayloadProjection.ts`](https://github.com/pingdotgg/t3code/pull/4083/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) to project bounded summaries of `aggregatedOutput`, `result.content`, stderr, and ACP content arrays into the activity payload.
> - Behavioral Change: command execution work log entries now show output as detail instead of echoing the command; entries with no output omit detail entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c35fbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->