### PR TITLE
feat: add diff tab workspace rewind

### DIFF
--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -114,6 +114,41 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
     );
   });
 
+  describe("restoreCheckpoint", () => {
+    it.effect("restores only requested files", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const checkpointRef = checkpointRefForThreadTurn(ThreadId.make("thread-scoped-restore"), 0);
+        const siblingPath = NodePath.join(tmp, "sibling.txt");
+        const addedPath = NodePath.join(tmp, "added.txt");
+
+        yield* writeTextFile(siblingPath, "before\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add sibling"]);
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+
+        yield* writeTextFile(NodePath.join(tmp, "README.md"), "changed\n");
+        yield* writeTextFile(siblingPath, "keep this change\n");
+        yield* writeTextFile(addedPath, "remove me\n");
+
+        expect(
+          yield* checkpointStore.restoreCheckpoint({
+            cwd: tmp,
+            checkpointRef,
+            filePaths: ["README.md", "added.txt"],
+          }),
+        ).toBe(true);
+
+        expect(yield* fileSystem.readFileString(NodePath.join(tmp, "README.md"))).toBe("# test\n");
+        expect(yield* fileSystem.readFileString(siblingPath)).toBe("keep this change\n");
+        expect(yield* fileSystem.exists(addedPath)).toBe(false);
+      }),
+    );
+  });
+
   describe("diffCheckpoints", () => {
     it.effect("returns full oversized checkpoint diffs without truncation", () =>
       Effect.gen(function* () {

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -147,6 +147,41 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(yield* fileSystem.exists(addedPath)).toBe(false);
       }),
     );
+
+    it.effect("rejects empty filePaths without resetting the index", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const checkpointRef = checkpointRefForThreadTurn(
+          ThreadId.make("thread-empty-file-paths"),
+          0,
+        );
+
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+        yield* writeTextFile(NodePath.join(tmp, "README.md"), "staged change\n");
+        yield* git(tmp, ["add", "README.md"]);
+
+        const error = yield* checkpointStore
+          .restoreCheckpoint({
+            cwd: tmp,
+            checkpointRef,
+            filePaths: [],
+          })
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("VcsProcessExitError");
+        if (error._tag === "VcsProcessExitError") {
+          expect(error.detail).toBe("At least one file path is required for a scoped restore.");
+        }
+
+        expect(yield* fileSystem.readFileString(NodePath.join(tmp, "README.md"))).toBe(
+          "staged change\n",
+        );
+        expect(yield* git(tmp, ["diff", "--cached", "--name-only"])).toBe("README.md");
+      }),
+    );
   });
 
   describe("diffCheckpoints", () => {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -31,6 +31,7 @@ export interface RestoreCheckpointInput {
   readonly cwd: string;
   readonly checkpointRef: CheckpointRef;
   readonly fallbackToHead?: boolean;
+  readonly filePaths?: ReadonlyArray<string>;
 }
 
 export interface DiffCheckpointsInput {

--- a/apps/server/src/checkpointing/CheckpointWorkspaceLock.ts
+++ b/apps/server/src/checkpointing/CheckpointWorkspaceLock.ts
@@ -1,0 +1,18 @@
+import * as Effect from "effect/Effect";
+import * as Semaphore from "effect/Semaphore";
+
+// ponytail: per-cwd mutex shared by restore and capture so neither validates or
+// mutates workspace checkpoints against a concurrent peer for the same cwd.
+const workspaceCheckpointLocks = new Map<string, Semaphore.Semaphore>();
+
+export const withWorkspaceCheckpointLock = <A, E, R>(
+  cwd: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => {
+  let lock = workspaceCheckpointLocks.get(cwd);
+  if (!lock) {
+    lock = Semaphore.makeUnsafe(1);
+    workspaceCheckpointLocks.set(cwd, lock);
+  }
+  return lock.withPermit(effect);
+};

--- a/apps/server/src/checkpointing/CheckpointWorkspaceRestore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointWorkspaceRestore.test.ts
@@ -1,5 +1,12 @@
 import { assert, it } from "@effect/vitest";
-import { CheckpointRef, ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  CheckpointRef,
+  type OrchestrationThreadShell,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -12,6 +19,38 @@ import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
 import * as CheckpointWorkspaceRestore from "./CheckpointWorkspaceRestore.ts";
 import { checkpointRefForThreadTurn } from "./Utils.ts";
+
+const idleThreadShell = (threadId: ThreadId): OrchestrationThreadShell =>
+  ({
+    id: threadId,
+    projectId: ProjectId.make("project-1"),
+    title: "Thread",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: "/workspace/worktree",
+    latestTurn: null,
+    createdAt: "2026-07-17T00:00:00.000Z",
+    updatedAt: "2026-07-17T00:00:00.000Z",
+    archivedAt: null,
+    session: {
+      threadId,
+      status: "ready",
+      providerName: "codex",
+      runtimeMode: "full-access",
+      activeTurnId: null,
+      lastError: null,
+      updatedAt: "2026-07-17T00:00:00.000Z",
+    },
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+  }) as OrchestrationThreadShell;
 
 it.effect("restores workspace files without mutating thread history", () =>
   Effect.gen(function* () {
@@ -57,6 +96,7 @@ it.effect("restores workspace files without mutating thread history", () =>
               ],
             }),
           ),
+        getThreadShellById: () => Effect.succeed(Option.some(idleThreadShell(threadId))),
       }),
       Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint, captureCheckpoint }),
       Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: refreshEntries }),
@@ -131,6 +171,7 @@ it.effect("rejects restores for non-latest turns", () =>
               ],
             }),
           ),
+        getThreadShellById: () => Effect.succeed(Option.some(idleThreadShell(threadId))),
       }),
       Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint }),
       Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: () => Effect.void }),
@@ -164,5 +205,327 @@ it.effect("rejects restores for non-latest turns", () =>
       assert.strictEqual(error.detail, "Only the latest workspace checkpoint can be rewound.");
     }
     assert.strictEqual(restoreCheckpoint.mock.calls.length, 0);
+  }),
+);
+
+it.effect("rejects empty filePaths for scoped restores", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread-1");
+    const checkpointRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1");
+    const restoreCheckpoint = vi.fn((_input: CheckpointStore.RestoreCheckpointInput) =>
+      Effect.succeed(true),
+    );
+
+    const dependencies = Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getThreadCheckpointContext: () =>
+          Effect.succeed(
+            Option.some({
+              threadId,
+              projectId: ProjectId.make("project-1"),
+              workspaceRoot: "/workspace",
+              worktreePath: "/workspace/worktree",
+              checkpoints: [
+                {
+                  turnId: TurnId.make("turn-1"),
+                  checkpointTurnCount: 1,
+                  checkpointRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:00:00.000Z",
+                },
+              ],
+            }),
+          ),
+        getThreadShellById: () => Effect.succeed(Option.some(idleThreadShell(threadId))),
+      }),
+      Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint }),
+      Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: () => Effect.void }),
+      Layer.mock(WorkspacePaths.WorkspacePaths)({
+        resolveRelativePathWithinRoot: ({ workspaceRoot, relativePath }) =>
+          Effect.succeed({
+            absolutePath: `${workspaceRoot}/${relativePath}`,
+            relativePath,
+          }),
+      }),
+      Layer.mock(VcsStatusBroadcaster.VcsStatusBroadcaster)({
+        refreshLocalStatus: () =>
+          Effect.succeed({
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: true,
+            refName: "main",
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+          }),
+      }),
+    );
+
+    const error = yield* CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint({
+      threadId,
+      turnCount: 1,
+      filePaths: [],
+    }).pipe(Effect.provide(dependencies), Effect.flip);
+
+    assert.strictEqual(error._tag, "CheckpointWorkspaceRestoreFailedError");
+    if (error._tag === "CheckpointWorkspaceRestoreFailedError") {
+      assert.strictEqual(error.detail, "At least one file path is required for a scoped restore.");
+    }
+    assert.strictEqual(restoreCheckpoint.mock.calls.length, 0);
+  }),
+);
+
+it.effect("rejects restores while a turn is in progress", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread-1");
+    const checkpointRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1");
+    const restoreCheckpoint = vi.fn((_input: CheckpointStore.RestoreCheckpointInput) =>
+      Effect.succeed(true),
+    );
+    const runningShell: OrchestrationThreadShell = {
+      ...idleThreadShell(threadId),
+      session: {
+        threadId,
+        status: "running",
+        providerName: "codex",
+        runtimeMode: "full-access",
+        activeTurnId: TurnId.make("turn-in-progress"),
+        lastError: null,
+        updatedAt: "2026-07-17T00:02:00.000Z",
+      },
+    };
+
+    const dependencies = Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getThreadCheckpointContext: () =>
+          Effect.succeed(
+            Option.some({
+              threadId,
+              projectId: ProjectId.make("project-1"),
+              workspaceRoot: "/workspace",
+              worktreePath: "/workspace/worktree",
+              checkpoints: [
+                {
+                  turnId: TurnId.make("turn-1"),
+                  checkpointTurnCount: 1,
+                  checkpointRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:00:00.000Z",
+                },
+              ],
+            }),
+          ),
+        getThreadShellById: () => Effect.succeed(Option.some(runningShell)),
+      }),
+      Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint }),
+      Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: () => Effect.void }),
+      Layer.mock(WorkspacePaths.WorkspacePaths)({
+        resolveRelativePathWithinRoot: ({ workspaceRoot, relativePath }) =>
+          Effect.succeed({
+            absolutePath: `${workspaceRoot}/${relativePath}`,
+            relativePath,
+          }),
+      }),
+      Layer.mock(VcsStatusBroadcaster.VcsStatusBroadcaster)({
+        refreshLocalStatus: () =>
+          Effect.succeed({
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: true,
+            refName: "main",
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+          }),
+      }),
+    );
+
+    const error = yield* CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint({
+      threadId,
+      turnCount: 1,
+    }).pipe(Effect.provide(dependencies), Effect.flip);
+
+    assert.strictEqual(error._tag, "CheckpointWorkspaceRestoreFailedError");
+    if (error._tag === "CheckpointWorkspaceRestoreFailedError") {
+      assert.strictEqual(
+        error.detail,
+        "Interrupt the current turn before rewinding workspace changes.",
+      );
+    }
+    assert.strictEqual(restoreCheckpoint.mock.calls.length, 0);
+  }),
+);
+
+it.effect("rejects when a newer checkpoint lands before the restore lock is held", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread-1");
+    const firstRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1");
+    const secondRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/2");
+    const restoreCheckpoint = vi.fn((_input: CheckpointStore.RestoreCheckpointInput) =>
+      Effect.succeed(true),
+    );
+    let contextReads = 0;
+
+    const dependencies = Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getThreadCheckpointContext: () => {
+          contextReads += 1;
+          if (contextReads === 1) {
+            return Effect.succeed(
+              Option.some({
+                threadId,
+                projectId: ProjectId.make("project-1"),
+                workspaceRoot: "/workspace",
+                worktreePath: "/workspace/worktree",
+                checkpoints: [
+                  {
+                    turnId: TurnId.make("turn-1"),
+                    checkpointTurnCount: 1,
+                    checkpointRef: firstRef,
+                    status: "ready",
+                    files: [],
+                    assistantMessageId: null,
+                    completedAt: "2026-07-17T00:00:00.000Z",
+                  },
+                ],
+              }),
+            );
+          }
+          return Effect.succeed(
+            Option.some({
+              threadId,
+              projectId: ProjectId.make("project-1"),
+              workspaceRoot: "/workspace",
+              worktreePath: "/workspace/worktree",
+              checkpoints: [
+                {
+                  turnId: TurnId.make("turn-1"),
+                  checkpointTurnCount: 1,
+                  checkpointRef: firstRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:00:00.000Z",
+                },
+                {
+                  turnId: TurnId.make("turn-2"),
+                  checkpointTurnCount: 2,
+                  checkpointRef: secondRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:01:00.000Z",
+                },
+              ],
+            }),
+          );
+        },
+        getThreadShellById: () => Effect.succeed(Option.some(idleThreadShell(threadId))),
+      }),
+      Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint }),
+      Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: () => Effect.void }),
+      Layer.mock(WorkspacePaths.WorkspacePaths)({
+        resolveRelativePathWithinRoot: ({ workspaceRoot, relativePath }) =>
+          Effect.succeed({
+            absolutePath: `${workspaceRoot}/${relativePath}`,
+            relativePath,
+          }),
+      }),
+      Layer.mock(VcsStatusBroadcaster.VcsStatusBroadcaster)({
+        refreshLocalStatus: () =>
+          Effect.succeed({
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: true,
+            refName: "main",
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+          }),
+      }),
+    );
+
+    const error = yield* CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint({
+      threadId,
+      turnCount: 1,
+    }).pipe(Effect.provide(dependencies), Effect.flip);
+
+    assert.strictEqual(error._tag, "CheckpointWorkspaceRestoreFailedError");
+    if (error._tag === "CheckpointWorkspaceRestoreFailedError") {
+      assert.strictEqual(error.detail, "Only the latest workspace checkpoint can be rewound.");
+    }
+    assert.strictEqual(restoreCheckpoint.mock.calls.length, 0);
+    assert.strictEqual(contextReads, 2);
+  }),
+);
+
+it.effect("returns success when recapturing the restored checkpoint fails", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread-1");
+    const checkpointRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1");
+    const restoreCheckpoint = vi.fn((_input: CheckpointStore.RestoreCheckpointInput) =>
+      Effect.succeed(true),
+    );
+    const captureCheckpoint = vi.fn((_input: CheckpointStore.CaptureCheckpointInput) =>
+      Effect.die(new Error("capture failed")),
+    );
+    const refreshEntries = vi.fn((_cwd: string) => Effect.void);
+
+    const dependencies = Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getThreadCheckpointContext: () =>
+          Effect.succeed(
+            Option.some({
+              threadId,
+              projectId: ProjectId.make("project-1"),
+              workspaceRoot: "/workspace",
+              worktreePath: "/workspace/worktree",
+              checkpoints: [
+                {
+                  turnId: TurnId.make("turn-1"),
+                  checkpointTurnCount: 1,
+                  checkpointRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:00:00.000Z",
+                },
+              ],
+            }),
+          ),
+        getThreadShellById: () => Effect.succeed(Option.some(idleThreadShell(threadId))),
+      }),
+      Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint, captureCheckpoint }),
+      Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: refreshEntries }),
+      Layer.mock(WorkspacePaths.WorkspacePaths)({
+        resolveRelativePathWithinRoot: ({ workspaceRoot, relativePath }) =>
+          Effect.succeed({
+            absolutePath: `${workspaceRoot}/${relativePath}`,
+            relativePath,
+          }),
+      }),
+      Layer.mock(VcsStatusBroadcaster.VcsStatusBroadcaster)({
+        refreshLocalStatus: () =>
+          Effect.succeed({
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: true,
+            refName: "main",
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+          }),
+      }),
+    );
+
+    const result = yield* CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint({
+      threadId,
+      turnCount: 1,
+    }).pipe(Effect.provide(dependencies));
+
+    assert.deepStrictEqual(result, { restored: true });
+    assert.strictEqual(restoreCheckpoint.mock.calls.length, 1);
+    assert.strictEqual(captureCheckpoint.mock.calls.length, 1);
+    assert.strictEqual(refreshEntries.mock.calls.length, 1);
   }),
 );

--- a/apps/server/src/checkpointing/CheckpointWorkspaceRestore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointWorkspaceRestore.test.ts
@@ -1,0 +1,168 @@
+import { assert, it } from "@effect/vitest";
+import { CheckpointRef, ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import { vi } from "vite-plus/test";
+
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as VcsStatusBroadcaster from "../vcs/VcsStatusBroadcaster.ts";
+import * as WorkspaceEntries from "../workspace/WorkspaceEntries.ts";
+import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import * as CheckpointStore from "./CheckpointStore.ts";
+import * as CheckpointWorkspaceRestore from "./CheckpointWorkspaceRestore.ts";
+import { checkpointRefForThreadTurn } from "./Utils.ts";
+
+it.effect("restores workspace files without mutating thread history", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread-1");
+    const checkpointRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1");
+    const restoreCheckpoint = vi.fn((_input: CheckpointStore.RestoreCheckpointInput) =>
+      Effect.succeed(true),
+    );
+    const captureCheckpoint = vi.fn(
+      (_input: CheckpointStore.CaptureCheckpointInput) => Effect.void,
+    );
+    const refreshEntries = vi.fn((_cwd: string) => Effect.void);
+    const refreshLocalStatus = vi.fn((_cwd: string) =>
+      Effect.succeed({
+        isRepo: true,
+        hasPrimaryRemote: false,
+        isDefaultRef: true,
+        refName: "main",
+        hasWorkingTreeChanges: false,
+        workingTree: { files: [], insertions: 0, deletions: 0 },
+      }),
+    );
+
+    const dependencies = Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getThreadCheckpointContext: () =>
+          Effect.succeed(
+            Option.some({
+              threadId,
+              projectId: ProjectId.make("project-1"),
+              workspaceRoot: "/workspace",
+              worktreePath: "/workspace/worktree",
+              checkpoints: [
+                {
+                  turnId: TurnId.make("turn-1"),
+                  checkpointTurnCount: 1,
+                  checkpointRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:00:00.000Z",
+                },
+              ],
+            }),
+          ),
+      }),
+      Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint, captureCheckpoint }),
+      Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: refreshEntries }),
+      Layer.mock(WorkspacePaths.WorkspacePaths)({
+        resolveRelativePathWithinRoot: ({ workspaceRoot, relativePath }) =>
+          Effect.succeed({
+            absolutePath: `${workspaceRoot}/${relativePath}`,
+            relativePath,
+          }),
+      }),
+      Layer.mock(VcsStatusBroadcaster.VcsStatusBroadcaster)({ refreshLocalStatus }),
+    );
+    const result = yield* CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint({
+      threadId,
+      turnCount: 1,
+      filePaths: ["README.md"],
+    }).pipe(Effect.provide(dependencies));
+
+    assert.deepStrictEqual(result, { restored: true });
+    assert.deepStrictEqual(restoreCheckpoint.mock.calls[0]?.[0], {
+      cwd: "/workspace/worktree",
+      checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+      fallbackToHead: true,
+      filePaths: ["README.md"],
+    });
+    assert.deepStrictEqual(captureCheckpoint.mock.calls[0]?.[0], {
+      cwd: "/workspace/worktree",
+      checkpointRef,
+    });
+    assert.deepStrictEqual(refreshEntries.mock.calls[0]?.[0], "/workspace/worktree");
+    assert.deepStrictEqual(refreshLocalStatus.mock.calls[0]?.[0], "/workspace/worktree");
+  }),
+);
+
+it.effect("rejects restores for non-latest turns", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread-1");
+    const olderRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1");
+    const latestRef = CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/2");
+    const restoreCheckpoint = vi.fn((_input: CheckpointStore.RestoreCheckpointInput) =>
+      Effect.succeed(true),
+    );
+
+    const dependencies = Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+        getThreadCheckpointContext: () =>
+          Effect.succeed(
+            Option.some({
+              threadId,
+              projectId: ProjectId.make("project-1"),
+              workspaceRoot: "/workspace",
+              worktreePath: "/workspace/worktree",
+              checkpoints: [
+                {
+                  turnId: TurnId.make("turn-1"),
+                  checkpointTurnCount: 1,
+                  checkpointRef: olderRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:00:00.000Z",
+                },
+                {
+                  turnId: TurnId.make("turn-2"),
+                  checkpointTurnCount: 2,
+                  checkpointRef: latestRef,
+                  status: "ready",
+                  files: [],
+                  assistantMessageId: null,
+                  completedAt: "2026-07-17T00:01:00.000Z",
+                },
+              ],
+            }),
+          ),
+      }),
+      Layer.mock(CheckpointStore.CheckpointStore)({ restoreCheckpoint }),
+      Layer.mock(WorkspaceEntries.WorkspaceEntries)({ refresh: () => Effect.void }),
+      Layer.mock(WorkspacePaths.WorkspacePaths)({
+        resolveRelativePathWithinRoot: ({ workspaceRoot, relativePath }) =>
+          Effect.succeed({
+            absolutePath: `${workspaceRoot}/${relativePath}`,
+            relativePath,
+          }),
+      }),
+      Layer.mock(VcsStatusBroadcaster.VcsStatusBroadcaster)({
+        refreshLocalStatus: () =>
+          Effect.succeed({
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: true,
+            refName: "main",
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+          }),
+      }),
+    );
+
+    const error = yield* CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint({
+      threadId,
+      turnCount: 1,
+    }).pipe(Effect.provide(dependencies), Effect.flip);
+
+    assert.strictEqual(error._tag, "CheckpointWorkspaceRestoreFailedError");
+    if (error._tag === "CheckpointWorkspaceRestoreFailedError") {
+      assert.strictEqual(error.detail, "Only the latest workspace checkpoint can be rewound.");
+    }
+    assert.strictEqual(restoreCheckpoint.mock.calls.length, 0);
+  }),
+);

--- a/apps/server/src/checkpointing/CheckpointWorkspaceRestore.ts
+++ b/apps/server/src/checkpointing/CheckpointWorkspaceRestore.ts
@@ -1,0 +1,158 @@
+import {
+  NonNegativeInt,
+  ThreadId,
+  type OrchestrationRestoreWorkspaceCheckpointInput,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+
+import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as VcsStatusBroadcaster from "../vcs/VcsStatusBroadcaster.ts";
+import * as WorkspaceEntries from "../workspace/WorkspaceEntries.ts";
+import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import * as CheckpointStore from "./CheckpointStore.ts";
+import { checkpointRefForThreadTurn } from "./Utils.ts";
+
+export class CheckpointWorkspaceRestoreFailedError extends Schema.TaggedErrorClass<CheckpointWorkspaceRestoreFailedError>()(
+  "CheckpointWorkspaceRestoreFailedError",
+  {
+    threadId: ThreadId,
+    turnCount: NonNegativeInt,
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+// ponytail: per-cwd mutex; SynchronizedRef service if lock lifecycle needs cleanup
+const restoreLocks = new Map<string, Semaphore.Semaphore>();
+
+const withWorkspaceRestoreLock = <A, E, R>(
+  cwd: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => {
+  let lock = restoreLocks.get(cwd);
+  if (!lock) {
+    lock = Semaphore.makeUnsafe(1);
+    restoreLocks.set(cwd, lock);
+  }
+  return lock.withPermit(effect);
+};
+
+export const restoreWorkspaceCheckpoint = Effect.fn("CheckpointWorkspaceRestore.restore")(
+  function* (input: OrchestrationRestoreWorkspaceCheckpointInput) {
+    const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+    const checkpointStore = yield* CheckpointStore.CheckpointStore;
+    const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+    const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
+    const vcsStatusBroadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+
+    const context = yield* projectionSnapshotQuery.getThreadCheckpointContext(input.threadId);
+    if (Option.isNone(context)) {
+      return yield* new CheckpointWorkspaceRestoreFailedError({
+        threadId: input.threadId,
+        turnCount: input.turnCount,
+        detail: `Thread '${input.threadId}' was not found.`,
+      });
+    }
+
+    const cwd = context.value.worktreePath ?? context.value.workspaceRoot;
+    if (!cwd) {
+      return yield* new CheckpointWorkspaceRestoreFailedError({
+        threadId: input.threadId,
+        turnCount: input.turnCount,
+        detail: `Thread '${input.threadId}' has no workspace path.`,
+      });
+    }
+
+    const latestTurnCount = Math.max(
+      0,
+      ...context.value.checkpoints.map((checkpoint) => checkpoint.checkpointTurnCount),
+    );
+    if (input.turnCount !== latestTurnCount) {
+      return yield* new CheckpointWorkspaceRestoreFailedError({
+        threadId: input.threadId,
+        turnCount: input.turnCount,
+        detail: "Only the latest workspace checkpoint can be rewound.",
+      });
+    }
+
+    const restoreTurnCount = input.turnCount - 1;
+    const checkpointRef =
+      restoreTurnCount === 0
+        ? checkpointRefForThreadTurn(input.threadId, 0)
+        : context.value.checkpoints.find(
+            (checkpoint) => checkpoint.checkpointTurnCount === restoreTurnCount,
+          )?.checkpointRef;
+    const updatedCheckpointRef = context.value.checkpoints.find(
+      (checkpoint) => checkpoint.checkpointTurnCount === input.turnCount,
+    )?.checkpointRef;
+    if (!checkpointRef || !updatedCheckpointRef) {
+      return yield* new CheckpointWorkspaceRestoreFailedError({
+        threadId: input.threadId,
+        turnCount: input.turnCount,
+        detail: `Checkpoint for thread '${input.threadId}' turn ${input.turnCount} cannot be rewound.`,
+      });
+    }
+
+    let filePaths: ReadonlyArray<string> | undefined;
+    if (input.filePaths !== undefined) {
+      if (input.filePaths.length === 0) {
+        return yield* new CheckpointWorkspaceRestoreFailedError({
+          threadId: input.threadId,
+          turnCount: input.turnCount,
+          detail: "At least one file path is required for a scoped restore.",
+        });
+      }
+      const resolvedPaths = yield* Effect.forEach(input.filePaths, (relativePath) =>
+        workspacePaths
+          .resolveRelativePathWithinRoot({
+            workspaceRoot: cwd,
+            relativePath,
+          })
+          .pipe(
+            Effect.map((resolved) => resolved.relativePath),
+            Effect.mapError(
+              () =>
+                new CheckpointWorkspaceRestoreFailedError({
+                  threadId: input.threadId,
+                  turnCount: input.turnCount,
+                  detail: `File path '${relativePath}' is outside the workspace.`,
+                }),
+            ),
+          ),
+      );
+      filePaths = [...new Set(resolvedPaths)];
+    }
+
+    return yield* withWorkspaceRestoreLock(
+      cwd,
+      Effect.gen(function* () {
+        const restored = yield* checkpointStore.restoreCheckpoint({
+          cwd,
+          checkpointRef,
+          fallbackToHead: restoreTurnCount === 0,
+          ...(filePaths ? { filePaths } : {}),
+        });
+        if (!restored) {
+          return yield* new CheckpointWorkspaceRestoreFailedError({
+            threadId: input.threadId,
+            turnCount: input.turnCount,
+            detail: `Filesystem checkpoint for turn ${restoreTurnCount} is unavailable.`,
+          });
+        }
+
+        // Keep the latest-turn diff aligned with the restored workspace.
+        yield* checkpointStore.captureCheckpoint({ cwd, checkpointRef: updatedCheckpointRef });
+        yield* workspaceEntries.refresh(cwd);
+        // ponytail: status refresh is best-effort; restore already succeeded
+        yield* vcsStatusBroadcaster.refreshLocalStatus(cwd).pipe(Effect.ignoreCause({ log: true }));
+        return { restored: true as const };
+      }),
+    );
+  },
+);

--- a/apps/server/src/checkpointing/CheckpointWorkspaceRestore.ts
+++ b/apps/server/src/checkpointing/CheckpointWorkspaceRestore.ts
@@ -6,13 +6,13 @@ import {
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
-import * as Semaphore from "effect/Semaphore";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as VcsStatusBroadcaster from "../vcs/VcsStatusBroadcaster.ts";
 import * as WorkspaceEntries from "../workspace/WorkspaceEntries.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
+import { withWorkspaceCheckpointLock } from "./CheckpointWorkspaceLock.ts";
 import { checkpointRefForThreadTurn } from "./Utils.ts";
 
 export class CheckpointWorkspaceRestoreFailedError extends Schema.TaggedErrorClass<CheckpointWorkspaceRestoreFailedError>()(
@@ -28,21 +28,6 @@ export class CheckpointWorkspaceRestoreFailedError extends Schema.TaggedErrorCla
   }
 }
 
-// ponytail: per-cwd mutex; SynchronizedRef service if lock lifecycle needs cleanup
-const restoreLocks = new Map<string, Semaphore.Semaphore>();
-
-const withWorkspaceRestoreLock = <A, E, R>(
-  cwd: string,
-  effect: Effect.Effect<A, E, R>,
-): Effect.Effect<A, E, R> => {
-  let lock = restoreLocks.get(cwd);
-  if (!lock) {
-    lock = Semaphore.makeUnsafe(1);
-    restoreLocks.set(cwd, lock);
-  }
-  return lock.withPermit(effect);
-};
-
 export const restoreWorkspaceCheckpoint = Effect.fn("CheckpointWorkspaceRestore.restore")(
   function* (input: OrchestrationRestoreWorkspaceCheckpointInput) {
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
@@ -51,8 +36,10 @@ export const restoreWorkspaceCheckpoint = Effect.fn("CheckpointWorkspaceRestore.
     const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
     const vcsStatusBroadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
 
-    const context = yield* projectionSnapshotQuery.getThreadCheckpointContext(input.threadId);
-    if (Option.isNone(context)) {
+    const initialContext = yield* projectionSnapshotQuery.getThreadCheckpointContext(
+      input.threadId,
+    );
+    if (Option.isNone(initialContext)) {
       return yield* new CheckpointWorkspaceRestoreFailedError({
         threadId: input.threadId,
         turnCount: input.turnCount,
@@ -60,42 +47,12 @@ export const restoreWorkspaceCheckpoint = Effect.fn("CheckpointWorkspaceRestore.
       });
     }
 
-    const cwd = context.value.worktreePath ?? context.value.workspaceRoot;
+    const cwd = initialContext.value.worktreePath ?? initialContext.value.workspaceRoot;
     if (!cwd) {
       return yield* new CheckpointWorkspaceRestoreFailedError({
         threadId: input.threadId,
         turnCount: input.turnCount,
         detail: `Thread '${input.threadId}' has no workspace path.`,
-      });
-    }
-
-    const latestTurnCount = Math.max(
-      0,
-      ...context.value.checkpoints.map((checkpoint) => checkpoint.checkpointTurnCount),
-    );
-    if (input.turnCount !== latestTurnCount) {
-      return yield* new CheckpointWorkspaceRestoreFailedError({
-        threadId: input.threadId,
-        turnCount: input.turnCount,
-        detail: "Only the latest workspace checkpoint can be rewound.",
-      });
-    }
-
-    const restoreTurnCount = input.turnCount - 1;
-    const checkpointRef =
-      restoreTurnCount === 0
-        ? checkpointRefForThreadTurn(input.threadId, 0)
-        : context.value.checkpoints.find(
-            (checkpoint) => checkpoint.checkpointTurnCount === restoreTurnCount,
-          )?.checkpointRef;
-    const updatedCheckpointRef = context.value.checkpoints.find(
-      (checkpoint) => checkpoint.checkpointTurnCount === input.turnCount,
-    )?.checkpointRef;
-    if (!checkpointRef || !updatedCheckpointRef) {
-      return yield* new CheckpointWorkspaceRestoreFailedError({
-        threadId: input.threadId,
-        turnCount: input.turnCount,
-        detail: `Checkpoint for thread '${input.threadId}' turn ${input.turnCount} cannot be rewound.`,
       });
     }
 
@@ -129,9 +86,60 @@ export const restoreWorkspaceCheckpoint = Effect.fn("CheckpointWorkspaceRestore.
       filePaths = [...new Set(resolvedPaths)];
     }
 
-    return yield* withWorkspaceRestoreLock(
+    return yield* withWorkspaceCheckpointLock(
       cwd,
       Effect.gen(function* () {
+        // Re-read under the lock so latest-turn checks and checkpoint refs cannot
+        // race a concurrent capture that lands after the pre-lock cwd lookup.
+        const context = yield* projectionSnapshotQuery.getThreadCheckpointContext(input.threadId);
+        if (Option.isNone(context)) {
+          return yield* new CheckpointWorkspaceRestoreFailedError({
+            threadId: input.threadId,
+            turnCount: input.turnCount,
+            detail: `Thread '${input.threadId}' was not found.`,
+          });
+        }
+
+        const threadShell = yield* projectionSnapshotQuery.getThreadShellById(input.threadId);
+        const session = Option.isSome(threadShell) ? threadShell.value.session : null;
+        if (session?.activeTurnId != null || session?.status === "running") {
+          return yield* new CheckpointWorkspaceRestoreFailedError({
+            threadId: input.threadId,
+            turnCount: input.turnCount,
+            detail: "Interrupt the current turn before rewinding workspace changes.",
+          });
+        }
+
+        const latestTurnCount = Math.max(
+          0,
+          ...context.value.checkpoints.map((checkpoint) => checkpoint.checkpointTurnCount),
+        );
+        if (input.turnCount !== latestTurnCount) {
+          return yield* new CheckpointWorkspaceRestoreFailedError({
+            threadId: input.threadId,
+            turnCount: input.turnCount,
+            detail: "Only the latest workspace checkpoint can be rewound.",
+          });
+        }
+
+        const restoreTurnCount = input.turnCount - 1;
+        const checkpointRef =
+          restoreTurnCount === 0
+            ? checkpointRefForThreadTurn(input.threadId, 0)
+            : context.value.checkpoints.find(
+                (checkpoint) => checkpoint.checkpointTurnCount === restoreTurnCount,
+              )?.checkpointRef;
+        const updatedCheckpointRef = context.value.checkpoints.find(
+          (checkpoint) => checkpoint.checkpointTurnCount === input.turnCount,
+        )?.checkpointRef;
+        if (!checkpointRef || !updatedCheckpointRef) {
+          return yield* new CheckpointWorkspaceRestoreFailedError({
+            threadId: input.threadId,
+            turnCount: input.turnCount,
+            detail: `Checkpoint for thread '${input.threadId}' turn ${input.turnCount} cannot be rewound.`,
+          });
+        }
+
         const restored = yield* checkpointStore.restoreCheckpoint({
           cwd,
           checkpointRef,
@@ -147,9 +155,12 @@ export const restoreWorkspaceCheckpoint = Effect.fn("CheckpointWorkspaceRestore.
         }
 
         // Keep the latest-turn diff aligned with the restored workspace.
-        yield* checkpointStore.captureCheckpoint({ cwd, checkpointRef: updatedCheckpointRef });
-        yield* workspaceEntries.refresh(cwd);
-        // ponytail: status refresh is best-effort; restore already succeeded
+        // Capture/refresh are best-effort: restore already mutated the tree, so
+        // failing the RPC here would leave clients with a stale Diff tab.
+        yield* checkpointStore
+          .captureCheckpoint({ cwd, checkpointRef: updatedCheckpointRef })
+          .pipe(Effect.ignoreCause({ log: true }));
+        yield* workspaceEntries.refresh(cwd).pipe(Effect.ignoreCause({ log: true }));
         yield* vcsStatusBroadcaster.refreshLocalStatus(cwd).pipe(Effect.ignoreCause({ log: true }));
         return { restored: true as const };
       }),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -25,6 +25,7 @@ import {
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import * as CheckpointStore from "../../checkpointing/CheckpointStore.ts";
+import { withWorkspaceCheckpointLock } from "../../checkpointing/CheckpointWorkspaceLock.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { CheckpointReactor, type CheckpointReactorShape } from "../Services/CheckpointReactor.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
@@ -231,121 +232,128 @@ const make = Effect.gen(function* () {
     readonly assistantMessageId: MessageId | undefined;
     readonly createdAt: string;
   }) {
-    const fromTurnCount = Math.max(0, input.turnCount - 1);
-    const fromCheckpointRef = checkpointRefForThreadTurn(input.threadId, fromTurnCount);
-    const targetCheckpointRef = checkpointRefForThreadTurn(input.threadId, input.turnCount);
+    // Share the per-cwd lock with workspace restore so a restore cannot validate
+    // and apply against a stale latest turn while this capture is in flight.
+    return yield* withWorkspaceCheckpointLock(
+      input.cwd,
+      Effect.gen(function* () {
+        const fromTurnCount = Math.max(0, input.turnCount - 1);
+        const fromCheckpointRef = checkpointRefForThreadTurn(input.threadId, fromTurnCount);
+        const targetCheckpointRef = checkpointRefForThreadTurn(input.threadId, input.turnCount);
 
-    const fromCheckpointExists = yield* checkpointStore.hasCheckpointRef({
-      cwd: input.cwd,
-      checkpointRef: fromCheckpointRef,
-    });
-    if (!fromCheckpointExists) {
-      yield* Effect.logWarning("checkpoint capture missing pre-turn baseline", {
-        threadId: input.threadId,
-        turnId: input.turnId,
-        fromTurnCount,
-      });
-    }
-
-    yield* checkpointStore.captureCheckpoint({
-      cwd: input.cwd,
-      checkpointRef: targetCheckpointRef,
-    });
-
-    // Refresh the workspace entry index so the @-mention file picker
-    // reflects files created or deleted during this turn.
-    yield* workspaceEntries.refresh(input.cwd);
-
-    const files = yield* checkpointStore
-      .diffCheckpoints({
-        cwd: input.cwd,
-        fromCheckpointRef,
-        toCheckpointRef: targetCheckpointRef,
-        fallbackFromToHead: false,
-        ignoreWhitespace: false,
-      })
-      .pipe(
-        Effect.map((diff) =>
-          parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
-            path: file.path,
-            kind: "modified" as const,
-            additions: file.additions,
-            deletions: file.deletions,
-          })),
-        ),
-        Effect.tapError((error) =>
-          appendCaptureFailureActivity({
+        const fromCheckpointExists = yield* checkpointStore.hasCheckpointRef({
+          cwd: input.cwd,
+          checkpointRef: fromCheckpointRef,
+        });
+        if (!fromCheckpointExists) {
+          yield* Effect.logWarning("checkpoint capture missing pre-turn baseline", {
             threadId: input.threadId,
             turnId: input.turnId,
-            detail: `Checkpoint captured, but turn diff summary is unavailable: ${error.message}`,
-            createdAt: input.createdAt,
-          }),
-        ),
-        Effect.catch((error) =>
-          Effect.logWarning("failed to derive checkpoint file summary", {
-            threadId: input.threadId,
-            turnId: input.turnId,
-            turnCount: input.turnCount,
-            detail: error.message,
-          }).pipe(Effect.as([])),
-        ),
-      );
+            fromTurnCount,
+          });
+        }
 
-    const assistantMessageId =
-      input.assistantMessageId ??
-      input.thread.messages
-        .toReversed()
-        .find((entry) => entry.role === "assistant" && entry.turnId === input.turnId)?.id ??
-      MessageId.make(`assistant:${input.turnId}`);
+        yield* checkpointStore.captureCheckpoint({
+          cwd: input.cwd,
+          checkpointRef: targetCheckpointRef,
+        });
 
-    yield* orchestrationEngine.dispatch({
-      type: "thread.turn.diff.complete",
-      commandId: yield* serverCommandId("checkpoint-turn-diff-complete"),
-      threadId: input.threadId,
-      turnId: input.turnId,
-      completedAt: input.createdAt,
-      checkpointRef: targetCheckpointRef,
-      status: input.status,
-      files,
-      assistantMessageId,
-      checkpointTurnCount: input.turnCount,
-      createdAt: input.createdAt,
-    });
-    yield* receiptBus.publish({
-      type: "checkpoint.diff.finalized",
-      threadId: input.threadId,
-      turnId: input.turnId,
-      checkpointTurnCount: input.turnCount,
-      checkpointRef: targetCheckpointRef,
-      status: input.status,
-      createdAt: input.createdAt,
-    });
-    yield* receiptBus.publish({
-      type: "turn.processing.quiesced",
-      threadId: input.threadId,
-      turnId: input.turnId,
-      checkpointTurnCount: input.turnCount,
-      createdAt: input.createdAt,
-    });
+        // Refresh the workspace entry index so the @-mention file picker
+        // reflects files created or deleted during this turn.
+        yield* workspaceEntries.refresh(input.cwd);
 
-    yield* orchestrationEngine.dispatch({
-      type: "thread.activity.append",
-      commandId: yield* serverCommandId("checkpoint-captured-activity"),
-      threadId: input.threadId,
-      activity: {
-        id: EventId.make(yield* randomUUID),
-        tone: "info",
-        kind: "checkpoint.captured",
-        summary: "Checkpoint captured",
-        payload: {
-          turnCount: input.turnCount,
+        const files = yield* checkpointStore
+          .diffCheckpoints({
+            cwd: input.cwd,
+            fromCheckpointRef,
+            toCheckpointRef: targetCheckpointRef,
+            fallbackFromToHead: false,
+            ignoreWhitespace: false,
+          })
+          .pipe(
+            Effect.map((diff) =>
+              parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
+                path: file.path,
+                kind: "modified" as const,
+                additions: file.additions,
+                deletions: file.deletions,
+              })),
+            ),
+            Effect.tapError((error) =>
+              appendCaptureFailureActivity({
+                threadId: input.threadId,
+                turnId: input.turnId,
+                detail: `Checkpoint captured, but turn diff summary is unavailable: ${error.message}`,
+                createdAt: input.createdAt,
+              }),
+            ),
+            Effect.catch((error) =>
+              Effect.logWarning("failed to derive checkpoint file summary", {
+                threadId: input.threadId,
+                turnId: input.turnId,
+                turnCount: input.turnCount,
+                detail: error.message,
+              }).pipe(Effect.as([])),
+            ),
+          );
+
+        const assistantMessageId =
+          input.assistantMessageId ??
+          input.thread.messages
+            .toReversed()
+            .find((entry) => entry.role === "assistant" && entry.turnId === input.turnId)?.id ??
+          MessageId.make(`assistant:${input.turnId}`);
+
+        yield* orchestrationEngine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: yield* serverCommandId("checkpoint-turn-diff-complete"),
+          threadId: input.threadId,
+          turnId: input.turnId,
+          completedAt: input.createdAt,
+          checkpointRef: targetCheckpointRef,
           status: input.status,
-        },
-        turnId: input.turnId,
-        createdAt: input.createdAt,
-      },
-      createdAt: input.createdAt,
-    });
+          files,
+          assistantMessageId,
+          checkpointTurnCount: input.turnCount,
+          createdAt: input.createdAt,
+        });
+        yield* receiptBus.publish({
+          type: "checkpoint.diff.finalized",
+          threadId: input.threadId,
+          turnId: input.turnId,
+          checkpointTurnCount: input.turnCount,
+          checkpointRef: targetCheckpointRef,
+          status: input.status,
+          createdAt: input.createdAt,
+        });
+        yield* receiptBus.publish({
+          type: "turn.processing.quiesced",
+          threadId: input.threadId,
+          turnId: input.turnId,
+          checkpointTurnCount: input.turnCount,
+          createdAt: input.createdAt,
+        });
+
+        yield* orchestrationEngine.dispatch({
+          type: "thread.activity.append",
+          commandId: yield* serverCommandId("checkpoint-captured-activity"),
+          threadId: input.threadId,
+          activity: {
+            id: EventId.make(yield* randomUUID),
+            tone: "info",
+            kind: "checkpoint.captured",
+            summary: "Checkpoint captured",
+            payload: {
+              turnCount: input.turnCount,
+              status: input.status,
+            },
+            turnId: input.turnId,
+            createdAt: input.createdAt,
+          },
+          createdAt: input.createdAt,
+        });
+      }),
+    );
   });
 
   // Captures a real git checkpoint when a turn completes via a runtime event.

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -73,6 +73,7 @@ const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 import * as ServerConfig from "./config.ts";
 import { makeRoutesLayer } from "./server.ts";
 import * as CheckpointDiffQuery from "./checkpointing/CheckpointDiffQuery.ts";
+import * as CheckpointStore from "./checkpointing/CheckpointStore.ts";
 import * as GitManager from "./git/GitManager.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -711,23 +712,26 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(CheckpointDiffQuery.CheckpointDiffQuery)({
-          getTurnDiff: () =>
-            Effect.succeed({
-              threadId: defaultThreadId,
-              fromTurnCount: 0,
-              toTurnCount: 0,
-              diff: "",
-            }),
-          getFullThreadDiff: () =>
-            Effect.succeed({
-              threadId: defaultThreadId,
-              fromTurnCount: 0,
-              toTurnCount: 0,
-              diff: "",
-            }),
-          ...options?.layers?.checkpointDiffQuery,
-        }),
+        Layer.mergeAll(
+          Layer.mock(CheckpointDiffQuery.CheckpointDiffQuery)({
+            getTurnDiff: () =>
+              Effect.succeed({
+                threadId: defaultThreadId,
+                fromTurnCount: 0,
+                toTurnCount: 0,
+                diff: "",
+              }),
+            getFullThreadDiff: () =>
+              Effect.succeed({
+                threadId: defaultThreadId,
+                fromTurnCount: 0,
+                toTurnCount: 0,
+                diff: "",
+              }),
+            ...options?.layers?.checkpointDiffQuery,
+          }),
+          Layer.mock(CheckpointStore.CheckpointStore)({}),
+        ),
       ),
     );
 

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -747,23 +747,65 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         return false;
       }
 
-      yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
-      });
-      yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: ["clean", "-fd", "--", "."],
-      });
-
-      const headExists = yield* hasHeadCommit(input.cwd);
-      if (headExists) {
+      if (input.filePaths === undefined) {
         yield* execute({
           operation,
           cwd: input.cwd,
-          args: ["reset", "--quiet", "--", "."],
+          args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
+        });
+        yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["clean", "-fd", "--", "."],
+        });
+
+        const headExists = yield* hasHeadCommit(input.cwd);
+        if (headExists) {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["reset", "--quiet", "--", "."],
+          });
+        }
+        return true;
+      }
+
+      // Path-scoped: restore each path individually so a missing source path
+      // cannot abort restore of the others (git restore fails the whole batch).
+      for (const filePath of input.filePaths) {
+        const pathspec = `:(literal)${filePath}`;
+        const inSource = yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["cat-file", "-e", `${commitOid}:${filePath}`],
+          allowNonZeroExit: true,
+        }).pipe(Effect.map((result) => result.exitCode === 0));
+
+        if (inSource) {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", pathspec],
+          });
+        } else {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["rm", "-f", "--ignore-unmatch", "--", pathspec],
+          });
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["clean", "-fd", "--", pathspec],
+          });
+        }
+      }
+
+      if (yield* hasHeadCommit(input.cwd)) {
+        yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["reset", "--quiet", "--", ...input.filePaths.map((path) => `:(literal)${path}`)],
         });
       }
 

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -770,6 +770,16 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         return true;
       }
 
+      if (input.filePaths.length === 0) {
+        return yield* new VcsProcessExitError({
+          operation,
+          command: "git reset",
+          cwd: input.cwd,
+          exitCode: 1,
+          detail: "At least one file path is required for a scoped restore.",
+        });
+      }
+
       // Path-scoped: restore each path individually so a missing source path
       // cannot abort restore of the others (git restore fails the whole batch).
       for (const filePath of input.filePaths) {

--- a/apps/server/src/vcs/VcsDriver.ts
+++ b/apps/server/src/vcs/VcsDriver.ts
@@ -23,6 +23,7 @@ export interface VcsRestoreCheckpointInput {
   readonly cwd: string;
   readonly checkpointRef: CheckpointRef;
   readonly fallbackToHead?: boolean;
+  readonly filePaths?: ReadonlyArray<string>;
 }
 
 export interface VcsDiffCheckpointsInput {

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -35,6 +35,7 @@ import {
   OrchestrationGetFullThreadDiffError,
   OrchestrationGetSnapshotError,
   OrchestrationGetTurnDiffError,
+  OrchestrationRestoreWorkspaceCheckpointError,
   ORCHESTRATION_WS_METHODS,
   type ProjectEntriesFailure,
   type ProjectFileFailure,
@@ -64,6 +65,7 @@ import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/uns
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
 import * as CheckpointDiffQuery from "./checkpointing/CheckpointDiffQuery.ts";
+import * as CheckpointWorkspaceRestore from "./checkpointing/CheckpointWorkspaceRestore.ts";
 import * as ServerConfig from "./config.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -280,6 +282,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [ORCHESTRATION_WS_METHODS.dispatchCommand, AuthOrchestrationOperateScope],
   [ORCHESTRATION_WS_METHODS.getTurnDiff, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.getFullThreadDiff, AuthOrchestrationReadScope],
+  [ORCHESTRATION_WS_METHODS.restoreWorkspaceCheckpoint, AuthOrchestrationOperateScope],
   [ORCHESTRATION_WS_METHODS.replayEvents, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.subscribeShell, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.getArchivedShellSnapshot, AuthOrchestrationReadScope],
@@ -1032,6 +1035,23 @@ const makeWsRpcLayer = (
                 (cause) =>
                   new OrchestrationGetFullThreadDiffError({
                     message: "Failed to load full thread diff",
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "orchestration" },
+          ),
+        [ORCHESTRATION_WS_METHODS.restoreWorkspaceCheckpoint]: (input) =>
+          observeRpcEffect(
+            ORCHESTRATION_WS_METHODS.restoreWorkspaceCheckpoint,
+            CheckpointWorkspaceRestore.restoreWorkspaceCheckpoint(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new OrchestrationRestoreWorkspaceCheckpointError({
+                    message:
+                      "message" in cause && typeof cause.message === "string"
+                        ? cause.message
+                        : "Failed to restore workspace checkpoint",
                     cause,
                   }),
               ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -240,6 +240,7 @@ import { useComposerHandleContext } from "../composerHandleContext";
 import { sanitizeThreadErrorMessage } from "~/rpc/transportError";
 import { RightPanelSheet } from "./RightPanelSheet";
 import { previewEnvironment } from "../state/preview";
+import { orchestrationEnvironment } from "../state/orchestration";
 import { useAtomCommand } from "../state/use-atom-command";
 import { Button } from "./ui/button";
 import {
@@ -1024,6 +1025,10 @@ function ChatViewContent(props: ChatViewProps) {
   const revertThreadCheckpoint = useAtomCommand(threadEnvironment.revertCheckpoint, {
     reportFailure: false,
   });
+  const restoreWorkspaceCheckpoint = useAtomCommand(
+    orchestrationEnvironment.restoreWorkspaceCheckpoint,
+    { reportFailure: false },
+  );
   const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
   const closePreview = useAtomCommand(previewEnvironment.close, "preview close");
   const { environments } = useEnvironments();
@@ -1110,6 +1115,7 @@ function ChatViewContent(props: ChatViewProps) {
   >({});
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [checkpointDiffRefreshEpoch, setCheckpointDiffRefreshEpoch] = useState(0);
   const [maximizedRightPanelThreadKey, setMaximizedRightPanelThreadKey] = useState<string | null>(
     null,
   );
@@ -2065,6 +2071,21 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
+  const latestCheckpoint = [...turnDiffSummaries].toSorted((left, right) => {
+    const leftCount =
+      left.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[left.turnId] ?? 0;
+    const rightCount =
+      right.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[right.turnId] ?? 0;
+    if (leftCount !== rightCount) return rightCount - leftCount;
+    return right.completedAt.localeCompare(left.completedAt);
+  })[0];
+  const latestCheckpointTurnCount = (() => {
+    if (latestCheckpoint?.status !== "ready") return null;
+    const count =
+      latestCheckpoint.checkpointTurnCount ??
+      inferredCheckpointTurnCountByTurnId[latestCheckpoint.turnId];
+    return typeof count === "number" && count >= 1 ? count : null;
+  })();
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
     const byMessageId = new Map<MessageId, TurnDiffSummary>();
     for (const summary of turnDiffSummaries) {
@@ -4908,6 +4929,85 @@ function ChatViewContent(props: ChatViewProps) {
     }
     void onRevertToTurnCountRef.current(targetTurnCount);
   }, []);
+  const onRewindLatestTurn = useCallback(
+    async (filePaths?: ReadonlyArray<string>) => {
+      const localApi = readLocalApi();
+      if (
+        !localApi ||
+        !activeThread ||
+        !activeThreadRef ||
+        typeof latestCheckpointTurnCount !== "number" ||
+        isRevertingCheckpoint
+      ) {
+        return;
+      }
+      if (activeEnvironmentUnavailable && activeEnvironmentUnavailableLabel) {
+        setThreadError(
+          activeThread.id,
+          `Reconnect ${activeEnvironmentUnavailableLabel} before rewinding workspace changes.`,
+        );
+        return;
+      }
+      if (phase === "running" || isSendBusy || isConnecting) {
+        setThreadError(
+          activeThread.id,
+          "Interrupt the current turn before rewinding workspace changes.",
+        );
+        return;
+      }
+
+      const isFileRewind = filePaths !== undefined;
+      const confirmed = await localApi.dialogs.confirm(
+        [
+          isFileRewind
+            ? `Rewind ${filePaths.length === 1 ? filePaths[0] : "this file change"}?`
+            : "Rewind all workspace changes from the latest turn?",
+          "This restores files to the previous checkpoint without removing conversation history.",
+          isFileRewind
+            ? "Changes to other files will be kept."
+            : "Uncommitted changes made after that checkpoint will be discarded.",
+        ].join("\n"),
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      setIsRevertingCheckpoint(true);
+      setThreadError(activeThread.id, null);
+      const result = await restoreWorkspaceCheckpoint({
+        environmentId,
+        input: {
+          threadId: activeThread.id,
+          turnCount: latestCheckpointTurnCount,
+          ...(filePaths ? { filePaths } : {}),
+        },
+      });
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        setThreadError(
+          activeThread.id,
+          error instanceof Error ? error.message : "Failed to rewind workspace changes.",
+        );
+      } else if (result._tag === "Success") {
+        setCheckpointDiffRefreshEpoch((epoch) => epoch + 1);
+      }
+      setIsRevertingCheckpoint(false);
+    },
+    [
+      activeEnvironmentUnavailable,
+      activeEnvironmentUnavailableLabel,
+      activeThread,
+      activeThreadRef,
+      environmentId,
+      isConnecting,
+      isRevertingCheckpoint,
+      isSendBusy,
+      latestCheckpointTurnCount,
+      phase,
+      restoreWorkspaceCheckpoint,
+      setThreadError,
+    ],
+  );
 
   // Empty state: no active thread
   if (!activeThread) {
@@ -4968,7 +5068,15 @@ function ChatViewContent(props: ChatViewProps) {
       />
     ) : activeRightPanelSurface?.kind === "diff" ? (
       <Suspense fallback={null}>
-        <DiffPanel mode="embedded" composerDraftTarget={composerDraftTarget} />
+        <DiffPanel
+          mode="embedded"
+          composerDraftTarget={composerDraftTarget}
+          canRewindLatestTurn={latestCheckpointTurnCount !== null}
+          isRewinding={isWorking}
+          onRewindLatestTurn={onRewindLatestTurn}
+          onRewindFile={onRewindLatestTurn}
+          checkpointDiffRefreshEpoch={checkpointDiffRefreshEpoch}
+        />
       </Suspense>
     ) : activeRightPanelSurface?.kind === "plan" ? (
       <PlanSidebar

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -22,7 +22,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOpenInPreferredEditor } from "../editorPreferences";
 import { type DraftId } from "../composerDraftStore";
 import { openDiffFilePrimaryAction } from "../diffFileActions";
-import { useCheckpointDiff } from "~/lib/checkpointDiffState";
+import { refreshCheckpointDiff, useCheckpointDiff } from "~/lib/checkpointDiffState";
 import { cn } from "~/lib/utils";
 import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
 import { useTheme } from "../hooks/useTheme";
@@ -286,6 +286,9 @@ export default function DiffPanel({
     selectedTurn &&
     (selectedTurn.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[selectedTurn.turnId]);
   const latestTurn = orderedTurnDiffSummaries[0];
+  const latestCheckpointTurnCount =
+    latestTurn &&
+    (latestTurn.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[latestTurn.turnId]);
   const canRewindSelectedFile =
     canRewindLatestTurn &&
     selectedTurn !== undefined &&
@@ -462,8 +465,17 @@ export default function DiffPanel({
     if (checkpointDiffRefreshEpoch <= 0) return;
     if (selectedTurnId === null) {
       branchDiffPreview.refresh();
-    } else {
-      activeCheckpointDiff.refresh();
+    }
+    // Rewind re-captures the latest turn's checkpoint. Refresh that cache even
+    // when an older turn (or git scope) is selected, so switching back is fresh.
+    if (typeof latestCheckpointTurnCount === "number") {
+      refreshCheckpointDiff({
+        environmentId: activeThread?.environmentId ?? null,
+        threadId: activeThreadId,
+        fromTurnCount: Math.max(0, latestCheckpointTurnCount - 1),
+        toTurnCount: latestCheckpointTurnCount,
+        ignoreWhitespace: diffIgnoreWhitespace,
+      });
     }
     // ponytail: refresh only after a restore, not when the query view object changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -16,6 +16,7 @@ import {
   Rows3Icon,
   SearchIcon,
   TextWrapIcon,
+  Undo2Icon,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOpenInPreferredEditor } from "../editorPreferences";
@@ -31,6 +32,7 @@ import {
   getRenderablePatch,
   resolveDiffThemeName,
   resolveFileDiffPath,
+  resolveFileDiffRewindPaths,
 } from "../lib/diffRendering";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { useProject, useThread } from "../state/entities";
@@ -39,6 +41,7 @@ import { useClientSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
 import { AnnotatableCodeView, type AnnotatableCodeViewHandle } from "./diffs/AnnotatableCodeView";
+import { Button } from "./ui/button";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 import { Switch } from "./ui/switch";
 import {
@@ -178,11 +181,24 @@ const DIFF_PANEL_UNSAFE_CSS = `
 interface DiffPanelProps {
   mode?: DiffPanelMode;
   composerDraftTarget: ScopedThreadRef | DraftId;
+  canRewindLatestTurn?: boolean;
+  isRewinding?: boolean;
+  onRewindLatestTurn?: () => void;
+  onRewindFile?: (filePaths: ReadonlyArray<string>) => void;
+  checkpointDiffRefreshEpoch?: number;
 }
 
 export { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 
-export default function DiffPanel({ mode = "inline", composerDraftTarget }: DiffPanelProps) {
+export default function DiffPanel({
+  mode = "inline",
+  composerDraftTarget,
+  canRewindLatestTurn = false,
+  isRewinding = false,
+  onRewindLatestTurn,
+  onRewindFile,
+  checkpointDiffRefreshEpoch = 0,
+}: DiffPanelProps) {
   const { resolvedTheme } = useTheme();
   const settings = useClientSettings();
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
@@ -270,6 +286,11 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     selectedTurn &&
     (selectedTurn.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[selectedTurn.turnId]);
   const latestTurn = orderedTurnDiffSummaries[0];
+  const canRewindSelectedFile =
+    canRewindLatestTurn &&
+    selectedTurn !== undefined &&
+    selectedTurn.turnId === latestTurn?.turnId &&
+    onRewindFile !== undefined;
   const selectedScopeLabel =
     selectedTurnId === null
       ? selectedGitScope === "unstaged"
@@ -404,7 +425,6 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     : branchDiffPreview.isPending;
   const selectedPatchError = selectedTurn ? activeCheckpointDiff.error : branchDiffPreview.error;
   const hasResolvedPatch = typeof selectedPatch === "string";
-  const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
   const renderablePatch = useMemo(
     () =>
       getRenderablePatch(selectedPatch, `diff-panel:${resolvedTheme}`, {
@@ -436,6 +456,18 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
       }),
     [collapsedDiffFileKeys, renderableFiles],
   );
+  const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
+
+  useEffect(() => {
+    if (checkpointDiffRefreshEpoch <= 0) return;
+    if (selectedTurnId === null) {
+      branchDiffPreview.refresh();
+    } else {
+      activeCheckpointDiff.refresh();
+    }
+    // ponytail: refresh only after a restore, not when the query view object changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkpointDiffRefreshEpoch]);
 
   useEffect(() => {
     if (!selectedFilePath) return;
@@ -673,6 +705,23 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="outline"
+                disabled={!canRewindLatestTurn || isRewinding || !onRewindLatestTurn}
+                onClick={() => onRewindLatestTurn?.()}
+                aria-label="Rewind latest turn"
+              />
+            }
+          >
+            <Undo2Icon className="size-3" />
+          </TooltipTrigger>
+          <TooltipPopup side="top">Rewind latest turn</TooltipPopup>
+        </Tooltip>
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -837,6 +886,38 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
                         <TooltipPopup side="top">
                           {collapsed ? "Expand diff" : "Collapse diff"}
                         </TooltipPopup>
+                      </Tooltip>
+                    );
+                  }}
+                  renderHeaderMetadata={(fileDiff) => {
+                    if (!canRewindSelectedFile) {
+                      return null;
+                    }
+                    const filePath = resolveFileDiffPath(fileDiff);
+                    const rewindPaths = resolveFileDiffRewindPaths(fileDiff);
+                    if (rewindPaths.length === 0) {
+                      return null;
+                    }
+                    return (
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              type="button"
+                              size="icon-xs"
+                              variant="ghost"
+                              disabled={isRewinding}
+                              aria-label={`Rewind ${filePath}`}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onRewindFile?.(rewindPaths);
+                              }}
+                            />
+                          }
+                        >
+                          <Undo2Icon className="size-3" />
+                        </TooltipTrigger>
+                        <TooltipPopup side="top">Rewind this file</TooltipPopup>
                       </Tooltip>
                     );
                   }}

--- a/apps/web/src/components/diffs/AnnotatableCodeView.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.tsx
@@ -88,6 +88,11 @@ interface AnnotatableCodeViewProps {
     fileKey: string,
     collapsed: boolean,
   ) => ReactNode;
+  renderHeaderMetadata?: (
+    fileDiff: FileDiffMetadata,
+    fileKey: string,
+    collapsed: boolean,
+  ) => ReactNode;
 }
 
 interface DiffSelectionContext {
@@ -103,6 +108,7 @@ export function AnnotatableCodeView({
   viewerRef,
   className,
   renderHeaderPrefix,
+  renderHeaderMetadata,
 }: AnnotatableCodeViewProps) {
   const addReviewComment = useComposerDraftStore((store) => store.addReviewComment);
   const removeReviewComment = useComposerDraftStore((store) => store.removeReviewComment);
@@ -248,6 +254,14 @@ export function AnnotatableCodeView({
           ? renderHeaderPrefix(item.fileDiff, item.id, item.collapsed === true)
           : null
       }
+      {...(renderHeaderMetadata
+        ? {
+            renderHeaderMetadata: (item: CodeViewItem<DiffCommentAnnotationGroup>) =>
+              item.type === "diff"
+                ? renderHeaderMetadata(item.fileDiff, item.id, item.collapsed === true)
+                : null,
+          }
+        : {})}
       renderAnnotation={(annotation) => (
         <div className="py-1">
           {annotation.metadata.entries.map((entry) => (

--- a/apps/web/src/lib/checkpointDiffState.ts
+++ b/apps/web/src/lib/checkpointDiffState.ts
@@ -8,11 +8,12 @@ import { useCheckpointDiff as useCheckpointDiffQuery } from "../state/queries";
 export function useCheckpointDiff(
   target: CheckpointDiffTarget,
   options?: { readonly enabled?: boolean },
-): CheckpointDiffState {
+): CheckpointDiffState & { readonly refresh: () => void } {
   const state = useCheckpointDiffQuery(target, options);
   return {
     data: state.data,
     error: state.error,
     isPending: state.isPending,
+    refresh: state.refresh,
   };
 }

--- a/apps/web/src/lib/checkpointDiffState.ts
+++ b/apps/web/src/lib/checkpointDiffState.ts
@@ -3,6 +3,8 @@ import {
   type CheckpointDiffTarget,
 } from "@t3tools/client-runtime/state/threads";
 
+import { appAtomRegistry } from "../rpc/atomRegistry";
+import { orchestrationEnvironment } from "../state/orchestration";
 import { useCheckpointDiff as useCheckpointDiffQuery } from "../state/queries";
 
 export function useCheckpointDiff(
@@ -16,4 +18,42 @@ export function useCheckpointDiff(
     isPending: state.isPending,
     refresh: state.refresh,
   };
+}
+
+/** Refresh a checkpoint diff query even when it is not the currently selected scope. */
+export function refreshCheckpointDiff(target: CheckpointDiffTarget): void {
+  if (
+    target.environmentId === null ||
+    target.threadId === null ||
+    target.fromTurnCount === null ||
+    target.toTurnCount === null
+  ) {
+    return;
+  }
+
+  if (target.fromTurnCount === 0) {
+    appAtomRegistry.refresh(
+      orchestrationEnvironment.fullThreadDiff({
+        environmentId: target.environmentId,
+        input: {
+          threadId: target.threadId,
+          toTurnCount: target.toTurnCount,
+          ignoreWhitespace: target.ignoreWhitespace,
+        },
+      }),
+    );
+    return;
+  }
+
+  appAtomRegistry.refresh(
+    orchestrationEnvironment.turnDiff({
+      environmentId: target.environmentId,
+      input: {
+        threadId: target.threadId,
+        fromTurnCount: target.fromTurnCount,
+        toTurnCount: target.toTurnCount,
+        ignoreWhitespace: target.ignoreWhitespace,
+      },
+    }),
+  );
 }

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import { buildPatchCacheKey, getRenderablePatch } from "./diffRendering";
+import {
+  buildPatchCacheKey,
+  getRenderablePatch,
+  resolveFileDiffRewindPaths,
+} from "./diffRendering";
 
 describe("buildPatchCacheKey", () => {
   it("returns a stable cache key for identical content", () => {
@@ -80,5 +84,54 @@ describe("getRenderablePatch", () => {
     expect(parsed?.kind).toBe("files");
     if (parsed?.kind !== "files") return;
     expect(parsed.files[0]?.hunks[0]?.unifiedLineStart).toBe(47);
+  });
+});
+
+describe("resolveFileDiffRewindPaths", () => {
+  it("returns both sides of a rename", () => {
+    const parsed = getRenderablePatch(
+      [
+        "diff --git a/old.ts b/new.ts",
+        "similarity index 100%",
+        "rename from old.ts",
+        "rename to new.ts",
+      ].join("\n"),
+    );
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files" || !parsed.files[0]) return;
+
+    expect(resolveFileDiffRewindPaths(parsed.files[0])).toEqual(["old.ts", "new.ts"]);
+  });
+
+  it("returns one normalized path for a modified file", () => {
+    const parsed = getRenderablePatch(
+      [
+        "diff --git a/src/file.ts b/src/file.ts",
+        "--- a/src/file.ts",
+        "+++ b/src/file.ts",
+        "@@ -1 +1 @@",
+        "-before",
+        "+after",
+      ].join("\n"),
+    );
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files" || !parsed.files[0]) return;
+
+    expect(resolveFileDiffRewindPaths(parsed.files[0])).toEqual(["src/file.ts"]);
+  });
+
+  it("preserves repository paths that start with a/ or b/", () => {
+    const parsed = getRenderablePatch(
+      [
+        "diff --git a/a/old.ts b/b/new.ts",
+        "similarity index 100%",
+        "rename from a/old.ts",
+        "rename to b/new.ts",
+      ].join("\n"),
+    );
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files" || !parsed.files[0]) return;
+
+    expect(resolveFileDiffRewindPaths(parsed.files[0])).toEqual(["a/old.ts", "b/new.ts"]);
   });
 });

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -132,6 +132,17 @@ export function resolveFileDiffPath(fileDiff: FileDiffMetadata): string {
   return raw;
 }
 
+export function resolveFileDiffRewindPaths(fileDiff: FileDiffMetadata): string[] {
+  // ponytail: Pierre already strips git a/b prefixes; keep paths as-is so dirs named a/b survive
+  return [
+    ...new Set(
+      [fileDiff.prevName, fileDiff.name].filter(
+        (path): path is string => Boolean(path) && path !== "/dev/null",
+      ),
+    ),
+  ];
+}
+
 export function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
   return fileDiff.cacheKey ?? `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
 }

--- a/packages/client-runtime/src/state/orchestration.ts
+++ b/packages/client-runtime/src/state/orchestration.ts
@@ -1,12 +1,18 @@
 import { ORCHESTRATION_WS_METHODS } from "@t3tools/contracts";
 import { Atom } from "effect/unstable/reactivity";
 
-import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+import {
+  createAtomCommandScheduler,
+  createEnvironmentRpcCommand,
+  createEnvironmentRpcQueryAtomFamily,
+} from "./runtime.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 
 export function createOrchestrationEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
 ) {
+  const workspaceRestoreScheduler = createAtomCommandScheduler();
+
   return {
     turnDiff: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:orchestration:turn-diff",
@@ -15,6 +21,15 @@ export function createOrchestrationEnvironmentAtoms<R, E>(
     fullThreadDiff: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:orchestration:full-thread-diff",
       tag: ORCHESTRATION_WS_METHODS.getFullThreadDiff,
+    }),
+    restoreWorkspaceCheckpoint: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:orchestration:restore-workspace-checkpoint",
+      tag: ORCHESTRATION_WS_METHODS.restoreWorkspaceCheckpoint,
+      scheduler: workspaceRestoreScheduler,
+      concurrency: {
+        mode: "singleFlight",
+        key: ({ environmentId, input }) => JSON.stringify([environmentId, input.threadId]),
+      },
     }),
     archivedShellSnapshot: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:orchestration:archived-shell-snapshot",

--- a/packages/client-runtime/src/state/orchestration.ts
+++ b/packages/client-runtime/src/state/orchestration.ts
@@ -28,7 +28,9 @@ export function createOrchestrationEnvironmentAtoms<R, E>(
       scheduler: workspaceRestoreScheduler,
       concurrency: {
         mode: "singleFlight",
-        key: ({ environmentId, input }) => JSON.stringify([environmentId, input.threadId]),
+        // Include full input so file-scoped restores are not coalesced with each
+        // other (or with a full-thread restore) for the same environment/thread.
+        key: ({ environmentId, input }) => JSON.stringify([environmentId, input]),
       },
     }),
     archivedShellSnapshot: createEnvironmentRpcQueryAtomFamily(runtime, {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -92,6 +92,8 @@ import type {
   OrchestrationGetFullThreadDiffResult,
   OrchestrationGetTurnDiffInput,
   OrchestrationGetTurnDiffResult,
+  OrchestrationRestoreWorkspaceCheckpointInput,
+  OrchestrationRestoreWorkspaceCheckpointResult,
   OrchestrationShellSnapshot,
   OrchestrationShellStreamItem,
   OrchestrationSubscribeThreadInput,
@@ -1209,6 +1211,9 @@ export interface EnvironmentApi {
     getFullThreadDiff: (
       input: OrchestrationGetFullThreadDiffInput,
     ) => Promise<OrchestrationGetFullThreadDiffResult>;
+    restoreWorkspaceCheckpoint: (
+      input: OrchestrationRestoreWorkspaceCheckpointInput,
+    ) => Promise<OrchestrationRestoreWorkspaceCheckpointResult>;
     getArchivedShellSnapshot: () => Promise<OrchestrationShellSnapshot>;
     subscribeShell: (
       callback: (event: OrchestrationShellStreamItem) => void,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -14,6 +14,7 @@ import {
   IsoDateTime,
   MessageId,
   NonNegativeInt,
+  PositiveInt,
   ProjectId,
   ProviderItemId,
   ThreadId,
@@ -26,6 +27,7 @@ export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
   getTurnDiff: "orchestration.getTurnDiff",
   getFullThreadDiff: "orchestration.getFullThreadDiff",
+  restoreWorkspaceCheckpoint: "orchestration.restoreWorkspaceCheckpoint",
   replayEvents: "orchestration.replayEvents",
   getArchivedShellSnapshot: "orchestration.getArchivedShellSnapshot",
   subscribeShell: "orchestration.subscribeShell",
@@ -1232,6 +1234,20 @@ export type OrchestrationGetFullThreadDiffInput = typeof OrchestrationGetFullThr
 export const OrchestrationGetFullThreadDiffResult = ThreadTurnDiff;
 export type OrchestrationGetFullThreadDiffResult = typeof OrchestrationGetFullThreadDiffResult.Type;
 
+export const OrchestrationRestoreWorkspaceCheckpointInput = Schema.Struct({
+  threadId: ThreadId,
+  turnCount: PositiveInt,
+  filePaths: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+export type OrchestrationRestoreWorkspaceCheckpointInput =
+  typeof OrchestrationRestoreWorkspaceCheckpointInput.Type;
+
+export const OrchestrationRestoreWorkspaceCheckpointResult = Schema.Struct({
+  restored: Schema.Boolean,
+});
+export type OrchestrationRestoreWorkspaceCheckpointResult =
+  typeof OrchestrationRestoreWorkspaceCheckpointResult.Type;
+
 export const OrchestrationReplayEventsInput = Schema.Struct({
   fromSequenceExclusive: NonNegativeInt,
 });
@@ -1252,6 +1268,10 @@ export const OrchestrationRpcSchemas = {
   getFullThreadDiff: {
     input: OrchestrationGetFullThreadDiffInput,
     output: OrchestrationGetFullThreadDiffResult,
+  },
+  restoreWorkspaceCheckpoint: {
+    input: OrchestrationRestoreWorkspaceCheckpointInput,
+    output: OrchestrationRestoreWorkspaceCheckpointResult,
   },
   replayEvents: {
     input: OrchestrationReplayEventsInput,
@@ -1297,6 +1317,14 @@ export class OrchestrationGetTurnDiffError extends Schema.TaggedErrorClass<Orche
 
 export class OrchestrationGetFullThreadDiffError extends Schema.TaggedErrorClass<OrchestrationGetFullThreadDiffError>()(
   "OrchestrationGetFullThreadDiffError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class OrchestrationRestoreWorkspaceCheckpointError extends Schema.TaggedErrorClass<OrchestrationRestoreWorkspaceCheckpointError>()(
+  "OrchestrationRestoreWorkspaceCheckpointError",
   {
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -54,6 +54,8 @@ import {
   OrchestrationGetSnapshotError,
   OrchestrationGetTurnDiffError,
   OrchestrationGetTurnDiffInput,
+  OrchestrationRestoreWorkspaceCheckpointError,
+  OrchestrationRestoreWorkspaceCheckpointInput,
   OrchestrationReplayEventsError,
   OrchestrationReplayEventsInput,
   OrchestrationRpcSchemas,
@@ -614,6 +616,18 @@ export const WsOrchestrationGetFullThreadDiffRpc = Rpc.make(
   },
 );
 
+export const WsOrchestrationRestoreWorkspaceCheckpointRpc = Rpc.make(
+  ORCHESTRATION_WS_METHODS.restoreWorkspaceCheckpoint,
+  {
+    payload: OrchestrationRestoreWorkspaceCheckpointInput,
+    success: OrchestrationRpcSchemas.restoreWorkspaceCheckpoint.output,
+    error: Schema.Union([
+      OrchestrationRestoreWorkspaceCheckpointError,
+      EnvironmentAuthorizationError,
+    ]),
+  },
+);
+
 export const WsOrchestrationReplayEventsRpc = Rpc.make(ORCHESTRATION_WS_METHODS.replayEvents, {
   payload: OrchestrationReplayEventsInput,
   success: OrchestrationRpcSchemas.replayEvents.output,
@@ -746,6 +760,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsOrchestrationDispatchCommandRpc,
   WsOrchestrationGetTurnDiffRpc,
   WsOrchestrationGetFullThreadDiffRpc,
+  WsOrchestrationRestoreWorkspaceCheckpointRpc,
   WsOrchestrationReplayEventsRpc,
   WsOrchestrationGetArchivedShellSnapshotRpc,
   WsOrchestrationSubscribeShellRpc,


### PR DESCRIPTION
## What Changed

* Added an **Undo/Rewind** action to the Diff tab.
* The action reverts the most recent edit without requiring the user to leave the current review workflow.
* The displayed diff refreshes after the undo so it immediately reflects the restored state.

Closes #4070.

## Why

While reviewing changes in the Diff tab, users may realize that the latest edit is incorrect or unwanted.

Previously, reverting that edit required leaving the Diff tab or manually restoring the previous content. This interrupted the review flow and added unnecessary steps.

This change keeps the operation inside the Diff tab and intentionally limits the scope to undoing the latest edit. Multi-level undo history and redo support are not included.

## UI Changes

### Before

<img width="903" height="553" alt="image" src="https://github.com/user-attachments/assets/da67d7c4-96bc-43ba-b4f2-71cb6bbcc460" />

### After

<img width="828" height="525" alt="image" src="https://github.com/user-attachments/assets/026bd0b8-7985-48de-9255-0346debbd9d2" />

### Interaction

https://github.com/user-attachments/assets/3e4d2bdf-8f3b-4710-9ba0-1fce02159af6

## Checklist

* [x] This PR is small and focused
* [x] I explained what changed and why
* [x] I included before/after screenshots for the UI changes
* [x] I included a video for the interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Mutates the git working tree and index under concurrency with turn completion; mistakes could discard uncommitted work or desync diffs if guards or scoped restore behave incorrectly.
> 
> **Overview**
> Adds **workspace rewind** from the Diff tab: users can undo the **latest turn’s** file changes while **keeping conversation history**, either for the whole turn or selected paths.
> 
> **Backend:** New `restoreWorkspaceCheckpoint` orchestration RPC wires through `CheckpointWorkspaceRestore`, which restores the worktree to the **previous** checkpoint for the requested latest `turnCount`, optionally via `filePaths`. Guards block non-latest turns, active/running turns, paths outside the workspace, and races where a newer checkpoint appears before a per-`cwd` lock is taken (`CheckpointWorkspaceLock`, also used when `CheckpointReactor` captures). After a successful restore, the latest turn’s checkpoint is **re-captured** and workspace/VCS refresh run best-effort so the Diff tab can update without failing the RPC.
> 
> **Git layer:** `restoreCheckpoint` / `GitVcsDriver` gain optional `filePaths` for path-scoped `git restore` / remove / clean (full restore behavior unchanged when omitted).
> 
> **UI:** Diff panel toolbar **Rewind latest turn** and per-file rewind actions (rename-aware paths via `resolveFileDiffRewindPaths`), confirmation in `ChatView`, and diff cache refresh via `checkpointDiffRefreshEpoch` / `refreshCheckpointDiff`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af7d5b75620db6e5f29c0e4481dee6d374118487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add workspace checkpoint rewind to the diff tab
> - Adds a "Rewind latest turn" button to `DiffPanel` and per-file "Rewind this file" buttons for files in the latest turn, allowing users to restore workspace state to the previous checkpoint.
> - Introduces `CheckpointWorkspaceRestore.restore` on the server, which validates that no turn is running, enforces the requested turn is the latest, acquires a per-cwd lock (`withWorkspaceCheckpointLock`), invokes `CheckpointStore.restoreCheckpoint`, and best-effort recaptures the restored state.
> - Exposes a new `restoreWorkspaceCheckpoint` WebSocket RPC (in `orchestration.ts` and `rpc.ts`) with structured input/output schemas and a tagged error type, wired through the WS layer in `ws.ts`.
> - Extends `GitVcsDriver.restoreCheckpoint` to support path-scoped restores: restores or removes each specified file individually and performs a path-scoped index reset.
> - Checkpoint capture in `CheckpointReactor` is now serialized under the per-cwd lock to prevent races with concurrent restores.
> - Risk: full-turn and file-scoped restores use `singleFlight` keyed by `[environmentId, input]`, so concurrent restores with different inputs will not coalesce.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af7d5b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->