### PR TITLE
Update marketing GitHub star count

### DIFF
--- a/apps/marketing/src/lib/site.ts
+++ b/apps/marketing/src/lib/site.ts
@@ -1,6 +1,6 @@
 export const GITHUB_REPOSITORY_URL = "https://github.com/pingdotgg/t3code";
 
 export const MARKETING_STATS = {
-  githubStars: "12k+",
+  githubStars: "14k+",
   users: "100,000",
 } as const;


### PR DESCRIPTION
## What Changed

Updated the shared marketing GitHub star count from `12k+` to `14k+`. This refreshes the count in the navigation badge, its accessible label, and the open-source section.

## Why

The repository currently has 14,091 GitHub stars, so the displayed `12k+` count is stale. `14k+` preserves the existing compact format while reflecting the current milestone.

## UI Changes

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/AmoonPod/t3code/pr-media-update-marketing-star-count/pr-media/update-marketing-star-count/before.png" alt="Marketing page showing 12k+ GitHub stars" width="420"> | <img src="https://raw.githubusercontent.com/AmoonPod/t3code/pr-media-update-marketing-star-count/pr-media/update-marketing-star-count/after.png" alt="Marketing page showing 14k+ GitHub stars" width="420"> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable; no motion or interaction changes)

## Validation

- `vp check` (passes with 10 existing warnings outside this change)
- `vp run typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update GitHub star count to 14k+ in marketing site stats
> Updates the `githubStars` field in the `MARKETING_STATS` constant in [site.ts](https://github.com/pingdotgg/t3code/pull/4088/files#diff-248474d7225337d6d1604123700c6b123b4c6935e65af658c7429d0cf1061510) from `"12k+"` to `"14k+"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8992c1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a marketing stat string with no logic, auth, or data handling impact.
> 
> **Overview**
> Updates **`MARKETING_STATS.githubStars`** in `site.ts` from **`12k+`** to **`14k+`**, so the marketing site shows the current milestone everywhere that constant is used (nav GitHub stars link and open-source section).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8992c1a8e73ebb88edbbeb9579b9ae5d853044cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->