### PR TITLE
Close the active thread when it is deleted from another client

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5665,6 +5665,58 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
+  it.effect("delivers thread.deleted to thread detail subscribers", () =>
+    Effect.gen(function* () {
+      const thread = makeDefaultOrchestrationReadModel().threads[0]!;
+      const liveEvents = yield* PubSub.unbounded<OrchestrationEvent>();
+      const deletedEvent = {
+        sequence: 2,
+        eventId: EventId.make("event-deleted"),
+        aggregateKind: "thread",
+        aggregateId: defaultThreadId,
+        occurredAt: "2026-01-01T00:00:01.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.deleted",
+        payload: {
+          threadId: defaultThreadId,
+          deletedAt: "2026-01-01T00:00:01.000Z",
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.deleted" }>;
+
+      yield* buildAppUnderTest({
+        layers: {
+          orchestrationEngine: {
+            streamDomainEvents: Stream.fromPubSub(liveEvents),
+          },
+          projectionSnapshotQuery: {
+            getThreadDetailSnapshot: () =>
+              Effect.gen(function* () {
+                yield* Effect.sleep("25 millis");
+                yield* PubSub.publish(liveEvents, deletedEvent);
+                return Option.some({ snapshotSequence: 1, thread });
+              }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const items = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.subscribeThread]({
+            threadId: defaultThreadId,
+          }).pipe(Stream.take(2), Stream.runCollect),
+        ),
+      ).pipe(Effect.timeout("2 seconds"));
+
+      assert.equal(items[0]?.kind, "snapshot");
+      assert.equal(items[1]?.kind, "event");
+      assert.equal(items[1]?.kind === "event" ? items[1].event.type : null, "thread.deleted");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
   it.effect("enriches replayed project events with repository identity metadata", () =>
     Effect.gen(function* () {
       const repositoryIdentity = {

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -261,7 +261,8 @@ function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
       | "thread.activity-appended"
       | "thread.turn-diff-completed"
       | "thread.reverted"
-      | "thread.session-set";
+      | "thread.session-set"
+      | "thread.deleted";
   }
 > {
   return (
@@ -270,7 +271,8 @@ function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
     event.type === "thread.activity-appended" ||
     event.type === "thread.turn-diff-completed" ||
     event.type === "thread.reverted" ||
-    event.type === "thread.session-set"
+    event.type === "thread.session-set" ||
+    event.type === "thread.deleted"
   );
 }
 

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -6,7 +6,7 @@ import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
 import { resolveThreadRouteRef } from "../threadRoutes";
 import { SidebarInset } from "~/components/ui/sidebar";
-import { useEnvironmentThreadRefs, useThreadDetail, useThreadShell } from "../state/entities";
+import { useThreadDetail, useThreadShell } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
 import { environmentShell } from "../state/shell";
 
@@ -20,35 +20,26 @@ function ChatThreadRouteView() {
   );
   const serverThreadShell = useThreadShell(threadRef);
   const serverThreadDetail = useThreadDetail(threadRef);
-  const environmentThreadRefs = useEnvironmentThreadRefs(threadRef?.environmentId ?? null);
   const bootstrapComplete = shell.data?.snapshot._tag === "Some";
   const threadExists = serverThreadShell !== null || serverThreadDetail !== null;
-  const environmentHasServerThreads = environmentThreadRefs.length > 0;
   const draftThreadExists = useComposerDraftStore((store) =>
     threadRef ? store.getDraftThreadByRef(threadRef) !== null : false,
   );
   const draftThread = useComposerDraftStore((store) =>
     threadRef ? store.getDraftThreadByRef(threadRef) : null,
   );
-  const environmentHasDraftThreads = useComposerDraftStore((store) => {
-    if (!threadRef) {
-      return false;
-    }
-    return store.hasDraftThreadsInEnvironment(threadRef.environmentId);
-  });
   const routeThreadExists = threadExists || draftThreadExists;
   const serverThreadStarted = threadHasStarted(serverThreadDetail);
-  const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {
       return;
     }
 
-    if (!routeThreadExists && environmentHasAnyThreads) {
+    if (!routeThreadExists) {
       void navigate({ to: "/", replace: true });
     }
-  }, [bootstrapComplete, environmentHasAnyThreads, navigate, routeThreadExists, threadRef]);
+  }, [bootstrapComplete, navigate, routeThreadExists, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !serverThreadStarted || !draftThread) {


### PR DESCRIPTION
## Problem

When a thread is deleted while another client has it open, that client keeps rendering the deleted thread indefinitely: title, messages and composer all stay visible, and the composer still accepts input. The sidebar correctly drops the thread, so the two panes disagree. A manual reload is the only way out.

This affects any setup with more than one client on the same environment: two windows/tabs, desktop plus web, or two devices.

*Client A viewing the thread, before deletion:*
<img width="3600" height="1974" alt="1-before-delete" src="https://github.com/user-attachments/assets/74814136-92f0-42e9-950a-8557cf99da61" />

*After deleting it from client B — sidebar is empty ("No threads yet"), but the thread is still fully rendered:*
<img width="3600" height="1974" alt="2-bug-thread-still-rendered" src="https://github.com/user-attachments/assets/3aef9675-872e-497b-bb10-05bdeef3a74b" />

*Same bug with two threads (deleting the viewed one leaves the other in the sidebar) — this is not specific to deleting the last thread:*
<img width="3600" height="1974" alt="3-bug-control-two-threads" src="https://github.com/user-attachments/assets/f59324ba-d434-421f-b852-2a1940ea255e" />

## Root cause

`isThreadDetailEvent` in `apps/server/src/ws.ts` is an allowlist of the event types forwarded to `subscribeThread` subscribers. `thread.deleted` was missing from it, so the server never told detail subscribers the thread was gone.

The client has always been ready for this event: `threadReducer.ts` already has a `case "thread.deleted"` returning `{ kind: "deleted" }`, and `threads.ts` already calls `setDeleted()` on it. That branch was simply unreachable in practice.

The consequence cascades into the route. `_chat.$environmentId.$threadId.tsx` derives:

```ts
const threadExists = serverThreadShell !== null || serverThreadDetail !== null;
```

The shell clears (hence the sidebar updating), but the detail atom stays populated, so `threadExists` remains `true` via the `||`, `routeThreadExists` never flips to `false`, and `ChatView` keeps rendering a thread that no longer exists.

Deleting from the *same* client always worked, which is why this went unnoticed: `useThreadActions.deleteThread` navigates on its own once the RPC resolves, without depending on the event stream.

## Changes

**`apps/server/src/ws.ts`** — add `thread.deleted` to `isThreadDetailEvent`, so detail subscribers learn the thread is gone and their state clears.

**`apps/web/src/routes/_chat.$environmentId.$threadId.tsx`** — drop the `environmentHasAnyThreads` condition from the redirect guard:

```diff
-if (!routeThreadExists && environmentHasAnyThreads) {
+if (!routeThreadExists) {
   void navigate({ to: "/", replace: true });
 }
```

This is a latent bug that the server fix would otherwise expose. The guard only redirected when other threads remained, so deleting the *last* thread of an environment would leave the component on `return null` (a blank pane) instead of the empty state. `_chat.draft.$draftId.tsx` already redirects unconditionally in the same situation, so this also removes an inconsistency between the two routes. `environmentThreadRefs`, `environmentHasServerThreads` and `environmentHasDraftThreads` become unused and are removed with it.

## Testing

Added `"delivers thread.deleted to thread detail subscribers"` to `apps/server/src/server.test.ts`, modelled on the neighbouring `"buffers thread events published while the initial snapshot loads"` test. **Verified it fails without the server fix** (times out waiting for an event that never arrives) and passes with it.

Manually verified with two clients on one environment, in both directions:

| Scenario | Before | After |
|---|---|---|
| Delete viewed thread from another client, others remain | Deleted thread stays fully rendered | Closes, returns to empty state |
| Delete viewed thread from another client, it was the last one | Deleted thread stays fully rendered | Closes, returns to empty state |
| Delete from the same client (regression check) | Works | Works |
| Create a thread (regression check for the route change) | Works | Works |

*After the fix — client A returns to the empty state on its own:*
<img width="3600" height="1974" alt="4-after-fix-empty-state" src="https://github.com/user-attachments/assets/e0853db1-6774-4d04-b740-89f10378d966" />

The creation check matters: the route now redirects as soon as `routeThreadExists` is false, and I confirmed `bootstrapComplete` and `draftThreadExists` cover the window during thread creation.

Full suites pass: 1403 server tests, 1303 web tests, typecheck and lint clean.

## Notes

The route change has no automated test. `apps/web` currently has no component testing setup (no jsdom, no testing-library, no `.tsx` tests), so the route is not testable as-is. It is covered only by the manual two-client verification above. Happy to add coverage if you'd like that infrastructure introduced here.

Mobile has a related but separate gap: `useThreadListActions` has no notion of an active thread and `ThreadRouteScreen` shows "Thread unavailable" in place rather than navigating back. Left out of scope.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close the active thread view when the thread is deleted from another client
> - Adds `'thread.deleted'` to the `isThreadDetailEvent` type guard in [ws.ts](https://github.com/pingdotgg/t3code/pull/4091/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) so deletion events are forwarded to thread detail subscribers over WebSocket.
> - Simplifies the redirect logic in [ChatThreadRouteView](https://github.com/pingdotgg/t3code/pull/4091/files#diff-5873401c664d8c70d7bd404a83ecb5f76631a08bc699d6e4841186b329a2cf63): when a thread no longer exists after bootstrap, the route now always navigates to `'/'`, removing the previous check for whether the environment has any other threads.
> - Adds a server router test covering delivery of `thread.deleted` events to thread detail subscribers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47b4ed3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted WebSocket allowlist and route redirect tweak; no auth or data-model changes, with a focused server test.
> 
> **Overview**
> Fixes multi-client behavior when a thread is deleted elsewhere: the open chat view now clears instead of staying on a ghost thread.
> 
> **Server:** `thread.deleted` is included in `isThreadDetailEvent`, so `subscribeThread` WebSocket clients receive deletion events (client reducers already handled this type but never saw it).
> 
> **Web route:** When bootstrap finishes and the routed thread no longer exists, navigation to `/` runs unconditionally—removing the old guard that only redirected if the environment still had other threads (which left a blank pane when the last thread was deleted).
> 
> **Tests:** New server effect test asserts the second item on a thread subscription is a `thread.deleted` event after snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b4ed3e07ce31d3aad0a569182452f869446486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->