### PR TITLE
Preserve T3 Code identity in macOS development launcher

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -20,7 +20,7 @@ export const APP_BUNDLE_ID = isDevelopment
   ? `com.t3tools.t3code.dev.${devBundleIdSuffix || "local"}`
   : "com.t3tools.t3code";
 const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3code"];
-const LAUNCHER_VERSION = 12;
+const LAUNCHER_VERSION = 14;
 const defaultIconPath = NodePath.join(desktopDir, "resources", "icon.icns");
 const developmentMacIconPngPath = NodePath.join(
   repoRoot,
@@ -220,11 +220,12 @@ function ensureDevelopmentIconIcns(runtimeDir) {
   }
 }
 
-function patchMainBundleInfoPlist(appBundlePath, iconPath) {
+function patchMainBundleInfoPlist(appBundlePath, iconPath, executableName) {
   const infoPlistPath = NodePath.join(appBundlePath, "Contents", "Info.plist");
   setPlistString(infoPlistPath, "CFBundleDisplayName", APP_DISPLAY_NAME);
   setPlistString(infoPlistPath, "CFBundleName", APP_DISPLAY_NAME);
   setPlistString(infoPlistPath, "CFBundleIdentifier", APP_BUNDLE_ID);
+  setPlistString(infoPlistPath, "CFBundleExecutable", executableName);
   setPlistString(infoPlistPath, "CFBundleIconFile", "icon.icns");
   setPlistJson(infoPlistPath, "CFBundleURLTypes", [
     {
@@ -277,11 +278,25 @@ function readJson(path) {
   }
 }
 
+export function resolveMacLauncherPaths(appBundlePath, displayName = APP_DISPLAY_NAME) {
+  const executableDir = NodePath.join(appBundlePath, "Contents", "MacOS");
+  const launcherExecutableName = `${displayName} Launcher`;
+  return {
+    launcherExecutableName,
+    launcherBinaryPath: NodePath.join(executableDir, launcherExecutableName),
+    runtimeElectronBinaryPath: NodePath.join(executableDir, "Electron"),
+  };
+}
+
 function buildMacLauncher(electronBinaryPath) {
   const sourceAppBundlePath = NodePath.resolve(NodePath.dirname(electronBinaryPath), "../..");
   const runtimeDir = NodePath.join(desktopDir, ".electron-runtime");
   const targetAppBundlePath = NodePath.join(runtimeDir, `${APP_DISPLAY_NAME}.app`);
-  const targetBinaryPath = NodePath.join(targetAppBundlePath, "Contents", "MacOS", "Electron");
+  const developmentPaths = resolveMacLauncherPaths(targetAppBundlePath);
+  const runtimeElectronBinaryPath = developmentPaths.runtimeElectronBinaryPath;
+  const launcherBinaryPath = isDevelopment
+    ? developmentPaths.launcherBinaryPath
+    : runtimeElectronBinaryPath;
   const iconPath = isDevelopment ? ensureDevelopmentIconIcns(runtimeDir) : defaultIconPath;
   const metadataPath = NodePath.join(runtimeDir, "metadata.json");
 
@@ -298,7 +313,8 @@ function buildMacLauncher(electronBinaryPath) {
 
   const currentMetadata = readJson(metadataPath);
   if (
-    NodeFS.existsSync(targetBinaryPath) &&
+    NodeFS.existsSync(launcherBinaryPath) &&
+    (!isDevelopment || NodeFS.existsSync(runtimeElectronBinaryPath)) &&
     currentMetadata &&
     JSON.stringify(currentMetadata) === JSON.stringify(expectedMetadata)
   ) {
@@ -306,10 +322,10 @@ function buildMacLauncher(electronBinaryPath) {
       // The launcher also handles protocol activations outside the dev runner,
       // so refresh its fallback environment on every launch. Never let a value
       // captured by an older parent app override the live dev-runner environment.
-      writeDevelopmentLauncherScript(targetBinaryPath, electronBinaryPath);
+      writeDevelopmentLauncherScript(launcherBinaryPath, runtimeElectronBinaryPath);
     }
     registerMacLauncherBundle(targetAppBundlePath);
-    return targetBinaryPath;
+    return launcherBinaryPath;
   }
 
   NodeFS.rmSync(targetAppBundlePath, { recursive: true, force: true });
@@ -321,15 +337,24 @@ function buildMacLauncher(electronBinaryPath) {
     recursive: true,
     verbatimSymlinks: true,
   });
-  patchMainBundleInfoPlist(targetAppBundlePath, iconPath);
+  patchMainBundleInfoPlist(
+    targetAppBundlePath,
+    iconPath,
+    isDevelopment ? developmentPaths.launcherExecutableName : "Electron",
+  );
   patchHelperBundleInfoPlists(targetAppBundlePath);
   if (isDevelopment) {
-    writeDevelopmentLauncherScript(targetBinaryPath, electronBinaryPath);
+    // Keep Electron's native executable inside the branded bundle. Launching the
+    // node_modules copy makes macOS associate the process (and Dock label) with
+    // Electron.app even though this bundle's Info.plist has the T3 Code name.
+    // Its conventional executable name also keeps Electron's default-app runtime
+    // in development mode instead of making app.isPackaged report true.
+    writeDevelopmentLauncherScript(launcherBinaryPath, runtimeElectronBinaryPath);
   }
   NodeFS.writeFileSync(metadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`);
   registerMacLauncherBundle(targetAppBundlePath);
 
-  return targetBinaryPath;
+  return launcherBinaryPath;
 }
 
 function isLinuxSetuidSandboxConfigured(electronBinaryPath) {

--- a/apps/desktop/scripts/electron-launcher.test.mjs
+++ b/apps/desktop/scripts/electron-launcher.test.mjs
@@ -1,6 +1,10 @@
 import { assert, describe, it } from "vite-plus/test";
 
-import { makeDevelopmentLauncherScript, resolveElectronBinaryPath } from "./electron-launcher.mjs";
+import {
+  makeDevelopmentLauncherScript,
+  resolveElectronBinaryPath,
+  resolveMacLauncherPaths,
+} from "./electron-launcher.mjs";
 
 describe("electron development launcher", () => {
   it("uses captured values only as fallbacks for a live runner environment", () => {
@@ -44,5 +48,34 @@ describe("electron development launcher", () => {
       "/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
     );
     assert.deepEqual(calls, ["ensure", "require:electron"]);
+  });
+
+  it("keeps the native Electron executable name inside the branded macOS bundle", () => {
+    const paths = resolveMacLauncherPaths(
+      "/repo/apps/desktop/.electron-runtime/T3 Code (Dev).app",
+      "T3 Code (Dev)",
+    );
+
+    assert.equal(paths.launcherExecutableName, "T3 Code (Dev) Launcher");
+    assert.equal(
+      paths.launcherBinaryPath,
+      "/repo/apps/desktop/.electron-runtime/T3 Code (Dev).app/Contents/MacOS/T3 Code (Dev) Launcher",
+    );
+    assert.equal(
+      paths.runtimeElectronBinaryPath,
+      "/repo/apps/desktop/.electron-runtime/T3 Code (Dev).app/Contents/MacOS/Electron",
+    );
+
+    const script = makeDevelopmentLauncherScript({
+      electronBinaryPath: paths.runtimeElectronBinaryPath,
+      mainEntryPath: "/repo/apps/desktop/dist-electron/main.cjs",
+      desktopRoot: "/repo/apps/desktop",
+      environment: {},
+    });
+    assert.include(
+      script,
+      "exec '/repo/apps/desktop/.electron-runtime/T3 Code (Dev).app/Contents/MacOS/Electron'",
+    );
+    assert.notInclude(script, "node_modules/electron");
   });
 });


### PR DESCRIPTION
## Summary
- Keep the native Electron executable inside the branded T3 Code development bundle.
- Preserve macOS bundle identity, Dock labeling, and development runtime behavior.
- Add coverage for launcher path resolution and generated launch scripts.

## Testing
- Not run (PR description generated from the provided diff).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only macOS launcher packaging and plist changes; production path still uses the Electron executable with no auth or data impact.
> 
> **Overview**
> **macOS development** now launches through a separate **`{displayName} Launcher`** entry in the branded `.electron-runtime` bundle instead of reusing the `Electron` binary as the bundle executable.
> 
> The launcher shell script **`exec`s the in-bundle `Contents/MacOS/Electron`**, not the `node_modules` copy, so Dock/process identity stays on T3 Code and **`app.isPackaged`** stays in dev-like behavior. **`CFBundleExecutable`** is patched accordingly (launcher name in dev, `Electron` otherwise), and **`LAUNCHER_VERSION`** is bumped so cached bundles rebuild.
> 
> Adds **`resolveMacLauncherPaths`** and tests that path resolution and generated scripts target the bundled Electron binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8dc0521c3b5bd04e6d46934d8e04f7d6db7b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve T3 Code identity in the macOS development launcher bundle
> - In development, the macOS app bundle now keeps the native Electron binary at `Contents/MacOS/Electron` and uses a separate launcher executable as `CFBundleExecutable`, so the Electron binary is no longer overwritten.
> - `patchMainBundleInfoPlist` now accepts an `executableName` parameter and writes `CFBundleExecutable` explicitly to `Info.plist`.
> - A new `resolveMacLauncherPaths` function centralizes path resolution for the launcher binary, runtime Electron binary, and executable name.
> - `LAUNCHER_VERSION` is bumped from 12 to 14, invalidating cached launcher metadata from previous builds.
> - Risk: callers of `buildMacLauncher` now receive the launcher executable path instead of the Electron binary path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe8dc05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->