### PR TITLE
Share MCP OAuth locks across Codex shadow homes

### DIFF
--- a/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
@@ -114,6 +114,9 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
 
         const sessionsTarget = yield* fileSystem.readLink(path.join(shadowHome, "sessions"));
         const configTarget = yield* fileSystem.readLink(path.join(shadowHome, "config.toml"));
+        const mcpOauthLocksTarget = yield* fileSystem.readLink(
+          path.join(shadowHome, "mcp-oauth-locks"),
+        );
         const modelsCacheExists = yield* fileSystem.exists(
           path.join(shadowHome, "models_cache.json"),
         );
@@ -124,9 +127,42 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
 
         expect(sessionsTarget).toBe(path.join(sharedHome, "sessions"));
         expect(configTarget).toBe(path.join(sharedHome, "config.toml"));
+        expect(mcpOauthLocksTarget).toBe(path.join(sharedHome, "mcp-oauth-locks"));
         expect(modelsCacheExists).toBe(false);
         expect(authLinkResult._tag).toBe("Failure");
         expect(authContents).toContain("shadow");
+      }),
+    );
+
+    it.effect("replaces Codex-created local MCP OAuth locks with the shared lock directory", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const sharedHome = yield* makeTempDir("t3code-codex-shared-");
+        const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
+        const shadowHome = path.join(shadowRoot, "shadow");
+        const sharedLocks = path.join(sharedHome, "mcp-oauth-locks");
+        const shadowLocks = path.join(shadowHome, "mcp-oauth-locks");
+
+        yield* writeTextFile(path.join(sharedLocks, "file-store.lock"), "");
+        yield* writeTextFile(path.join(shadowLocks, "file-store.lock"), "");
+
+        const layout = yield* resolveCodexHomeLayout(
+          decodeCodexSettings({
+            homePath: sharedHome,
+            shadowHomePath: shadowHome,
+          }),
+        );
+
+        yield* materializeCodexShadowHome(layout);
+
+        const locksTarget = yield* fileSystem.readLink(shadowLocks);
+        const sharedLockExists = yield* fileSystem.exists(
+          path.join(sharedLocks, "file-store.lock"),
+        );
+
+        expect(locksTarget).toBe(sharedLocks);
+        expect(sharedLockExists).toBe(true);
       }),
     );
 

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.ts
@@ -26,10 +26,12 @@ const KNOWN_SHARED_DIRECTORIES = [
   "plugins",
   "cache",
   "logs",
+  "mcp-oauth-locks",
 ] as const;
 
 const PRIVATE_ENTRY_NAMES = new Set(["auth.json", "models_cache.json"]);
 const SHADOW_LOCAL_ENTRY_NAMES = new Set(["log", "memories", "tmp"]);
+const REPLACEABLE_SHARED_RUNTIME_DIRECTORIES = new Set(["mcp-oauth-locks"]);
 
 function resolveHomePath(path: Path.Path, value: string | undefined): string {
   const expanded =
@@ -225,16 +227,6 @@ const ensureSymlink = Effect.fn("CodexHomeLayout.ensureSymlink")(function* (inpu
     linkPath: link,
   });
 
-  if (state._tag === "NotSymlink") {
-    return yield* new CodexShadowHomeEntryConflictError({
-      sharedHomePath: input.sharedHomePath,
-      effectiveHomePath: input.effectiveHomePath,
-      entryName: input.entryName,
-      linkPath: link,
-      targetPath: target,
-    });
-  }
-
   const createLink = input.fileSystem.symlink(target, link).pipe(
     Effect.catchTags({
       PlatformError: (cause) =>
@@ -249,6 +241,33 @@ const ensureSymlink = Effect.fn("CodexHomeLayout.ensureSymlink")(function* (inpu
         }),
     }),
   );
+
+  if (state._tag === "NotSymlink") {
+    if (!REPLACEABLE_SHARED_RUNTIME_DIRECTORIES.has(input.entryName)) {
+      return yield* new CodexShadowHomeEntryConflictError({
+        sharedHomePath: input.sharedHomePath,
+        effectiveHomePath: input.effectiveHomePath,
+        entryName: input.entryName,
+        linkPath: link,
+        targetPath: target,
+      });
+    }
+
+    yield* input.fileSystem.remove(link, { recursive: true }).pipe(
+      Effect.catchTags({
+        PlatformError: (cause) =>
+          new CodexShadowHomeFileSystemError({
+            sharedHomePath: input.sharedHomePath,
+            effectiveHomePath: input.effectiveHomePath,
+            operation: "remove",
+            path: link,
+            entryName: input.entryName,
+            cause,
+          }),
+      }),
+    );
+    return yield* createLink;
+  }
 
   if (state._tag === "Missing") {
     return yield* createLink;


### PR DESCRIPTION
## Summary

- Add `mcp-oauth-locks` to the shared Codex home directories.
- Replace Codex-created local MCP OAuth lock directories with symlinks to the shared directory.
- Add coverage for shared lock linking and replacement behavior.

## Testing

- Added `CodexHomeLayout` tests for MCP OAuth lock directory sharing and replacement.
- Not run: full lint and test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP OAuth lock paths on disk during shadow-home materialization; scope is limited to Codex layout and one replaceable directory, but incorrect removal/linking could affect concurrent OAuth lock behavior.
> 
> **Overview**
> Codex **auth-overlay** shadow homes now treat **`mcp-oauth-locks`** like other shared state: the directory is created under the shared home and linked from the shadow home so MCP OAuth file locks stay consistent across instances.
> 
> **`ensureSymlink`** no longer fails when Codex has already created a **real** `mcp-oauth-locks` folder in the shadow home. For that entry only, materialization **recursively removes** the local directory and replaces it with a symlink to the shared lock path; other non-symlink conflicts still raise **`CodexShadowHomeEntryConflictError`**.
> 
> Tests assert the symlink in the main materialization case and add a dedicated case for replacing a Codex-created local lock directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11eca5965243e4a024f84995d9a1c46ba96018c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share MCP OAuth locks across Codex shadow homes via symlink
> - Adds `mcp-oauth-locks` to `KNOWN_SHARED_DIRECTORIES` in [CodexHomeLayout.ts](https://github.com/pingdotgg/t3code/pull/4104/files#diff-17973143128131a5e3f30fc3e32012a3a86aee719917b08d60615a47558fb8d5) so it is symlinked to the shared home when materializing a shadow home.
> - Introduces `REPLACEABLE_SHARED_RUNTIME_DIRECTORIES` to handle the case where a shadow home already has a local `mcp-oauth-locks` directory: instead of raising a conflict error, the existing directory is removed and replaced with a symlink to the shared path.
> - Behavioral Change: a pre-existing non-symlink `mcp-oauth-locks` in a shadow home is now silently deleted and replaced; previously this would have thrown a `CodexShadowHomeEntryConflictError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11eca59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->