### PR TITLE
fix(grok): surface ACP slash commands and ignore skills-reload ids

### DIFF
--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -89,6 +89,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
+      const { cwd } = yield* ServerConfig;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
@@ -113,7 +114,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       });
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -107,4 +107,36 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
       expect(snapshot.message).toContain("ACP startup failed");
     }),
   );
+
+  it.effect("accepts an explicit workspace cwd for ACP discovery without hanging probes", () =>
+    Effect.gen(function* () {
+      // Regression: probe must accept ServerConfig.cwd (not only process.cwd()).
+      // Discovery still fails with a version-only binary; the important part is
+      // the third argument is plumbed and check completes.
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-workspace-cwd-" });
+          const workspaceCwd = path.join(dir, "workspace");
+          yield* fs.makeDirectory(workspaceCwd, { recursive: true });
+          const grokPath = path.join(dir, "grok");
+          yield* fs.writeFileString(
+            grokPath,
+            ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
+          );
+          yield* fs.chmod(grokPath, 0o755);
+
+          return yield* checkGrokProviderStatus(
+            decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            process.env,
+            workspaceCwd,
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toContain("ACP startup failed");
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -161,6 +161,11 @@ const waitForGrokSlashCommands = (
 const discoverGrokModelsViaAcp = (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  /**
+   * Workspace root for `session/new`. Must match live Grok threads so project-local
+   * skills (`.agents/skills`, `.grok/skills`, etc.) match the composer menu.
+   */
+  cwd: string = process.cwd(),
 ) =>
   Effect.gen(function* () {
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -168,7 +173,7 @@ const discoverGrokModelsViaAcp = (
       grokSettings,
       environment,
       childProcessSpawner,
-      cwd: process.cwd(),
+      cwd,
       clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
     });
 
@@ -217,6 +222,11 @@ const runGrokVersionCommand = (
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  /**
+   * Server workspace cwd from `ServerConfig` (not `process.cwd()`). Used for ACP
+   * skill/command discovery so the slash menu matches live Grok threads.
+   */
+  cwd: string = process.cwd(),
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -307,7 +317,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
-  const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
+  const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment, cwd).pipe(
     Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
     Effect.exit,
   );

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -4,14 +4,17 @@ import {
   ProviderDriverKind,
   type ServerProvider,
   type ServerProviderModel,
+  type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -31,6 +34,7 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import { parseAcpAvailableCommands } from "../acp/parseAcpAvailableCommands.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -45,6 +49,14 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+/** Grok emits `available_commands_update` shortly after `session/new` returns. */
+const GROK_ACP_SLASH_COMMAND_WAIT_MS = 2_000;
+const GROK_ACP_SLASH_COMMAND_POLL_MS = 50;
+
+interface GrokAcpDiscoveryResult {
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+}
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
@@ -130,6 +142,22 @@ function buildGrokDiscoveredModelsFromSessionModelState(
     .filter((model): model is ServerProviderModel => model !== undefined);
 }
 
+const waitForGrokSlashCommands = (
+  slashCommandsRef: Ref.Ref<ReadonlyArray<ServerProviderSlashCommand>>,
+) =>
+  Effect.gen(function* () {
+    while (true) {
+      const commands = yield* Ref.get(slashCommandsRef);
+      if (commands.length > 0) {
+        return commands;
+      }
+      yield* Effect.sleep(Duration.millis(GROK_ACP_SLASH_COMMAND_POLL_MS));
+    }
+  }).pipe(
+    Effect.timeoutOption(GROK_ACP_SLASH_COMMAND_WAIT_MS),
+    Effect.map((result) => (Option.isSome(result) ? result.value : [])),
+  );
+
 const discoverGrokModelsViaAcp = (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
@@ -143,8 +171,29 @@ const discoverGrokModelsViaAcp = (
       cwd: process.cwd(),
       clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
     });
+
+    // Collect ACP available_commands_update (skills + builtins) for the composer.
+    // Register before start so we do not miss the post-session/new notification.
+    const slashCommandsRef = yield* Ref.make<ReadonlyArray<ServerProviderSlashCommand>>([]);
+    yield* acp.handleSessionUpdate((notification) => {
+      const update = notification.update;
+      if (update.sessionUpdate !== "available_commands_update") {
+        return Effect.void;
+      }
+      return Ref.set(slashCommandsRef, parseAcpAvailableCommands(update.availableCommands));
+    });
+
     const started = yield* acp.start();
-    return buildGrokDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
+    const models = buildGrokDiscoveredModelsFromSessionModelState(
+      started.sessionSetupResult.models,
+    );
+    // Commands usually arrive after the session/new response; wait briefly.
+    let slashCommands = yield* Ref.get(slashCommandsRef);
+    if (slashCommands.length === 0) {
+      slashCommands = yield* waitForGrokSlashCommands(slashCommandsRef);
+    }
+
+    return { models, slashCommands } satisfies GrokAcpDiscoveryResult;
   }).pipe(Effect.scoped);
 
 const runGrokVersionCommand = (
@@ -298,10 +347,10 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       },
     });
   }
-  const discoveredModels = discoveryExit.value.value;
+  const discovery = discoveryExit.value.value;
   const models =
-    discoveredModels.length > 0
-      ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
+    discovery.models.length > 0
+      ? grokModelsFromSettings(grokSettings.customModels, discovery.models)
       : fallbackModels;
 
   return buildServerProvider({
@@ -309,6 +358,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     enabled: grokSettings.enabled,
     checkedAt,
     models,
+    slashCommands: discovery.slashCommands,
     probe: {
       installed: true,
       version,

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -8,6 +8,7 @@ import {
 } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
@@ -49,8 +50,14 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
-/** Grok emits `available_commands_update` shortly after `session/new` returns. */
+/** Max wait for first/non-empty available_commands_update after session/new. */
 const GROK_ACP_SLASH_COMMAND_WAIT_MS = 2_000;
+/**
+ * After an empty update, briefly watch for a follow-up non-empty "changed"
+ * update without burning the full wait budget (avoids pushing the 15s discovery
+ * timeout when model setup already took most of the window).
+ */
+const GROK_ACP_SLASH_EMPTY_SETTLE_MS = 250;
 const GROK_ACP_SLASH_COMMAND_POLL_MS = 50;
 
 interface GrokAcpDiscoveryResult {
@@ -145,34 +152,40 @@ function buildGrokDiscoveredModelsFromSessionModelState(
 /**
  * Wait for ACP `available_commands_update` during the probe window.
  *
- * - Option.none = no notification yet
- * - Option.some([]) = empty update seen (may be intermediate; ACP can send "changed" later)
- * - Option.some(nonEmpty) = ready to use
- *
- * Returns immediately on a non-empty list. On timeout, returns the latest seen
- * list (including empty) or [] if nothing arrived.
+ * - Option.none = no notification yet → wait up to GROK_ACP_SLASH_COMMAND_WAIT_MS
+ * - Option.some([]) = empty update → wait only GROK_ACP_SLASH_EMPTY_SETTLE_MS more
+ *   for a possible non-empty "changed" update, then accept empty
+ * - Option.some(nonEmpty) = return immediately
  */
 const waitForGrokSlashCommands = (
   slashCommandsRef: Ref.Ref<Option.Option<ReadonlyArray<ServerProviderSlashCommand>>>,
 ) =>
   Effect.gen(function* () {
+    const startedAt = yield* Clock.currentTimeMillis;
+    let emptySeenAt: number | undefined;
+
     while (true) {
+      const now = yield* Clock.currentTimeMillis;
       const commandsOpt = yield* Ref.get(slashCommandsRef);
+
       if (Option.isSome(commandsOpt) && commandsOpt.value.length > 0) {
         return commandsOpt.value;
       }
+
+      if (Option.isSome(commandsOpt) && commandsOpt.value.length === 0) {
+        emptySeenAt ??= now;
+        if (now - emptySeenAt >= GROK_ACP_SLASH_EMPTY_SETTLE_MS) {
+          return commandsOpt.value;
+        }
+      }
+
+      if (now - startedAt >= GROK_ACP_SLASH_COMMAND_WAIT_MS) {
+        return Option.isSome(commandsOpt) ? commandsOpt.value : [];
+      }
+
       yield* Effect.sleep(Duration.millis(GROK_ACP_SLASH_COMMAND_POLL_MS));
     }
-  }).pipe(
-    Effect.timeoutOption(GROK_ACP_SLASH_COMMAND_WAIT_MS),
-    Effect.flatMap((result) =>
-      Option.isSome(result)
-        ? Effect.succeed(result.value)
-        : Ref.get(slashCommandsRef).pipe(
-            Effect.map((commandsOpt) => (Option.isSome(commandsOpt) ? commandsOpt.value : [])),
-          ),
-    ),
-  );
+  });
 
 const discoverGrokModelsViaAcp = (
   grokSettings: GrokSettings,
@@ -214,8 +227,7 @@ const discoverGrokModelsViaAcp = (
     const models = buildGrokDiscoveredModelsFromSessionModelState(
       started.sessionSetupResult.models,
     );
-    // Prefer an already-populated list; otherwise wait the probe window (empty
-    // updates keep waiting so a later non-empty "changed" update can land).
+    // Prefer an already-populated list; otherwise wait (short settle if empty).
     const slashCommandsOpt = yield* Ref.get(slashCommandsRef);
     const slashCommands =
       Option.isSome(slashCommandsOpt) && slashCommandsOpt.value.length > 0

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -143,24 +143,35 @@ function buildGrokDiscoveredModelsFromSessionModelState(
 }
 
 /**
- * Wait until Grok emits `available_commands_update` (including an empty list).
- * Option.none = no notification yet; Option.some([]) = explicit empty command set.
- * Times out to [] when the agent never sends the update.
+ * Wait for ACP `available_commands_update` during the probe window.
+ *
+ * - Option.none = no notification yet
+ * - Option.some([]) = empty update seen (may be intermediate; ACP can send "changed" later)
+ * - Option.some(nonEmpty) = ready to use
+ *
+ * Returns immediately on a non-empty list. On timeout, returns the latest seen
+ * list (including empty) or [] if nothing arrived.
  */
 const waitForGrokSlashCommands = (
   slashCommandsRef: Ref.Ref<Option.Option<ReadonlyArray<ServerProviderSlashCommand>>>,
 ) =>
   Effect.gen(function* () {
     while (true) {
-      const commands = yield* Ref.get(slashCommandsRef);
-      if (Option.isSome(commands)) {
-        return commands.value;
+      const commandsOpt = yield* Ref.get(slashCommandsRef);
+      if (Option.isSome(commandsOpt) && commandsOpt.value.length > 0) {
+        return commandsOpt.value;
       }
       yield* Effect.sleep(Duration.millis(GROK_ACP_SLASH_COMMAND_POLL_MS));
     }
   }).pipe(
     Effect.timeoutOption(GROK_ACP_SLASH_COMMAND_WAIT_MS),
-    Effect.map((result) => (Option.isSome(result) ? result.value : [])),
+    Effect.flatMap((result) =>
+      Option.isSome(result)
+        ? Effect.succeed(result.value)
+        : Ref.get(slashCommandsRef).pipe(
+            Effect.map((commandsOpt) => (Option.isSome(commandsOpt) ? commandsOpt.value : [])),
+          ),
+    ),
   );
 
 const discoverGrokModelsViaAcp = (
@@ -185,9 +196,9 @@ const discoverGrokModelsViaAcp = (
     // Collect ACP available_commands_update (skills + builtins) for the composer.
     // Register before start so we do not miss the post-session/new notification.
     // Option.none = not yet received; Option.some(list) = notification seen (list may be empty).
-    const slashCommandsRef = yield* Ref.make<
-      Option.Option<ReadonlyArray<ServerProviderSlashCommand>>
-    >(Option.none());
+    const slashCommandsRef = yield* Ref.make(
+      Option.none<ReadonlyArray<ServerProviderSlashCommand>>(),
+    );
     yield* acp.handleSessionUpdate((notification) => {
       const update = notification.update;
       if (update.sessionUpdate !== "available_commands_update") {
@@ -203,11 +214,13 @@ const discoverGrokModelsViaAcp = (
     const models = buildGrokDiscoveredModelsFromSessionModelState(
       started.sessionSetupResult.models,
     );
-    // Commands usually arrive after the session/new response; wait briefly if still pending.
-    const pendingOrReady = yield* Ref.get(slashCommandsRef);
-    const slashCommands = Option.isSome(pendingOrReady)
-      ? pendingOrReady.value
-      : yield* waitForGrokSlashCommands(slashCommandsRef);
+    // Prefer an already-populated list; otherwise wait the probe window (empty
+    // updates keep waiting so a later non-empty "changed" update can land).
+    const slashCommandsOpt = yield* Ref.get(slashCommandsRef);
+    const slashCommands =
+      Option.isSome(slashCommandsOpt) && slashCommandsOpt.value.length > 0
+        ? slashCommandsOpt.value
+        : yield* waitForGrokSlashCommands(slashCommandsRef);
 
     return { models, slashCommands } satisfies GrokAcpDiscoveryResult;
   }).pipe(Effect.scoped);

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -50,12 +50,16 @@ const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
-/** Max wait for first/non-empty available_commands_update after session/new. */
+/**
+ * Headroom so slash-command wait + returning from discovery finishes before the
+ * outer Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS) fires.
+ */
+const GROK_ACP_DISCOVERY_TIMEOUT_RESERVE_MS = 200;
+/** Ideal max wait for available_commands_update after session/new (may be capped). */
 const GROK_ACP_SLASH_COMMAND_WAIT_MS = 2_000;
 /**
  * After an empty update, briefly watch for a follow-up non-empty "changed"
- * update without burning the full wait budget (avoids pushing the 15s discovery
- * timeout when model setup already took most of the window).
+ * update without burning the full wait budget.
  */
 const GROK_ACP_SLASH_EMPTY_SETTLE_MS = 250;
 const GROK_ACP_SLASH_COMMAND_POLL_MS = 50;
@@ -150,22 +154,33 @@ function buildGrokDiscoveredModelsFromSessionModelState(
 }
 
 /**
- * Wait for ACP `available_commands_update` during the probe window.
+ * Wait for ACP `available_commands_update` within `maxWaitMs` (remaining discovery budget).
  *
- * - Option.none = no notification yet → wait up to GROK_ACP_SLASH_COMMAND_WAIT_MS
- * - Option.some([]) = empty update → wait only GROK_ACP_SLASH_EMPTY_SETTLE_MS more
- *   for a possible non-empty "changed" update, then accept empty
+ * - Option.none = no notification yet → wait up to maxWaitMs
+ * - Option.some([]) = empty → wait min(empty settle, maxWaitMs) for a non-empty follow-up
  * - Option.some(nonEmpty) = return immediately
+ * - maxWaitMs <= 0 = return whatever is already on the ref (slash wait is non-fatal)
  */
 const waitForGrokSlashCommands = (
   slashCommandsRef: Ref.Ref<Option.Option<ReadonlyArray<ServerProviderSlashCommand>>>,
+  maxWaitMs: number,
 ) =>
   Effect.gen(function* () {
+    const readCommands = Effect.map(Ref.get(slashCommandsRef), (commandsOpt) =>
+      Option.isSome(commandsOpt) ? commandsOpt.value : [],
+    );
+
+    if (maxWaitMs <= 0) {
+      return yield* readCommands;
+    }
+
     const startedAt = yield* Clock.currentTimeMillis;
+    const emptySettleMs = Math.min(GROK_ACP_SLASH_EMPTY_SETTLE_MS, maxWaitMs);
     let emptySeenAt: number | undefined;
 
     while (true) {
       const now = yield* Clock.currentTimeMillis;
+      const elapsed = now - startedAt;
       const commandsOpt = yield* Ref.get(slashCommandsRef);
 
       if (Option.isSome(commandsOpt) && commandsOpt.value.length > 0) {
@@ -174,16 +189,17 @@ const waitForGrokSlashCommands = (
 
       if (Option.isSome(commandsOpt) && commandsOpt.value.length === 0) {
         emptySeenAt ??= now;
-        if (now - emptySeenAt >= GROK_ACP_SLASH_EMPTY_SETTLE_MS) {
+        if (now - emptySeenAt >= emptySettleMs) {
           return commandsOpt.value;
         }
       }
 
-      if (now - startedAt >= GROK_ACP_SLASH_COMMAND_WAIT_MS) {
+      const remaining = maxWaitMs - elapsed;
+      if (remaining <= 0) {
         return Option.isSome(commandsOpt) ? commandsOpt.value : [];
       }
 
-      yield* Effect.sleep(Duration.millis(GROK_ACP_SLASH_COMMAND_POLL_MS));
+      yield* Effect.sleep(Duration.millis(Math.min(GROK_ACP_SLASH_COMMAND_POLL_MS, remaining)));
     }
   });
 
@@ -197,6 +213,9 @@ const discoverGrokModelsViaAcp = (
   cwd: string = process.cwd(),
 ) =>
   Effect.gen(function* () {
+    // Wall clock for the whole discovery effect so slash wait cannot overrun the
+    // outer GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS and discard already-found models.
+    const discoveryStartedAt = yield* Clock.currentTimeMillis;
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const acp = yield* makeGrokAcpRuntime({
       grokSettings,
@@ -227,12 +246,23 @@ const discoverGrokModelsViaAcp = (
     const models = buildGrokDiscoveredModelsFromSessionModelState(
       started.sessionSetupResult.models,
     );
-    // Prefer an already-populated list; otherwise wait (short settle if empty).
+
+    // Slash discovery is best-effort: cap wait by remaining outer budget so a slow
+    // acp.start() never turns a successful model discovery into a timeout failure.
+    const now = yield* Clock.currentTimeMillis;
+    const remainingDiscoveryMs = Math.max(
+      0,
+      GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS -
+        (now - discoveryStartedAt) -
+        GROK_ACP_DISCOVERY_TIMEOUT_RESERVE_MS,
+    );
+    const slashWaitMs = Math.min(GROK_ACP_SLASH_COMMAND_WAIT_MS, remainingDiscoveryMs);
+
     const slashCommandsOpt = yield* Ref.get(slashCommandsRef);
     const slashCommands =
       Option.isSome(slashCommandsOpt) && slashCommandsOpt.value.length > 0
         ? slashCommandsOpt.value
-        : yield* waitForGrokSlashCommands(slashCommandsRef);
+        : yield* waitForGrokSlashCommands(slashCommandsRef, slashWaitMs);
 
     return { models, slashCommands } satisfies GrokAcpDiscoveryResult;
   }).pipe(Effect.scoped);

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -142,14 +142,19 @@ function buildGrokDiscoveredModelsFromSessionModelState(
     .filter((model): model is ServerProviderModel => model !== undefined);
 }
 
+/**
+ * Wait until Grok emits `available_commands_update` (including an empty list).
+ * Option.none = no notification yet; Option.some([]) = explicit empty command set.
+ * Times out to [] when the agent never sends the update.
+ */
 const waitForGrokSlashCommands = (
-  slashCommandsRef: Ref.Ref<ReadonlyArray<ServerProviderSlashCommand>>,
+  slashCommandsRef: Ref.Ref<Option.Option<ReadonlyArray<ServerProviderSlashCommand>>>,
 ) =>
   Effect.gen(function* () {
     while (true) {
       const commands = yield* Ref.get(slashCommandsRef);
-      if (commands.length > 0) {
-        return commands;
+      if (Option.isSome(commands)) {
+        return commands.value;
       }
       yield* Effect.sleep(Duration.millis(GROK_ACP_SLASH_COMMAND_POLL_MS));
     }
@@ -179,24 +184,30 @@ const discoverGrokModelsViaAcp = (
 
     // Collect ACP available_commands_update (skills + builtins) for the composer.
     // Register before start so we do not miss the post-session/new notification.
-    const slashCommandsRef = yield* Ref.make<ReadonlyArray<ServerProviderSlashCommand>>([]);
+    // Option.none = not yet received; Option.some(list) = notification seen (list may be empty).
+    const slashCommandsRef = yield* Ref.make<
+      Option.Option<ReadonlyArray<ServerProviderSlashCommand>>
+    >(Option.none());
     yield* acp.handleSessionUpdate((notification) => {
       const update = notification.update;
       if (update.sessionUpdate !== "available_commands_update") {
         return Effect.void;
       }
-      return Ref.set(slashCommandsRef, parseAcpAvailableCommands(update.availableCommands));
+      return Ref.set(
+        slashCommandsRef,
+        Option.some(parseAcpAvailableCommands(update.availableCommands)),
+      );
     });
 
     const started = yield* acp.start();
     const models = buildGrokDiscoveredModelsFromSessionModelState(
       started.sessionSetupResult.models,
     );
-    // Commands usually arrive after the session/new response; wait briefly.
-    let slashCommands = yield* Ref.get(slashCommandsRef);
-    if (slashCommands.length === 0) {
-      slashCommands = yield* waitForGrokSlashCommands(slashCommandsRef);
-    }
+    // Commands usually arrive after the session/new response; wait briefly if still pending.
+    const pendingOrReady = yield* Ref.get(slashCommandsRef);
+    const slashCommands = Option.isSome(pendingOrReady)
+      ? pendingOrReady.value
+      : yield* waitForGrokSlashCommands(slashCommandsRef);
 
     return { models, slashCommands } satisfies GrokAcpDiscoveryResult;
   }).pipe(Effect.scoped);

--- a/apps/server/src/provider/acp/parseAcpAvailableCommands.test.ts
+++ b/apps/server/src/provider/acp/parseAcpAvailableCommands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { parseAcpAvailableCommands } from "./parseAcpAvailableCommands.ts";
+
+describe("parseAcpAvailableCommands", () => {
+  it("maps ACP available commands into provider slash commands", () => {
+    expect(
+      parseAcpAvailableCommands([
+        {
+          name: "factory-planner",
+          description: "Plan factory tickets",
+          input: { hint: "ticket intent" },
+        },
+        {
+          name: "context",
+          description: "Show context usage",
+        },
+      ]),
+    ).toEqual([
+      {
+        name: "factory-planner",
+        description: "Plan factory tickets",
+        input: { hint: "ticket intent" },
+      },
+      {
+        name: "context",
+        description: "Show context usage",
+      },
+    ]);
+  });
+
+  it("dedupes by case-insensitive name and keeps the first description/hint", () => {
+    expect(
+      parseAcpAvailableCommands([
+        { name: "Trade-Research", description: "first", input: { hint: "ticker" } },
+        { name: "trade-research", description: "second", input: { hint: "other" } },
+        { name: "  ", description: "ignored" },
+      ]),
+    ).toEqual([
+      {
+        name: "Trade-Research",
+        description: "first",
+        input: { hint: "ticker" },
+      },
+    ]);
+  });
+
+  it("returns an empty list for nullish input", () => {
+    expect(parseAcpAvailableCommands(undefined)).toEqual([]);
+    expect(parseAcpAvailableCommands(null)).toEqual([]);
+    expect(parseAcpAvailableCommands([])).toEqual([]);
+  });
+});

--- a/apps/server/src/provider/acp/parseAcpAvailableCommands.ts
+++ b/apps/server/src/provider/acp/parseAcpAvailableCommands.ts
@@ -1,0 +1,46 @@
+import type { ServerProviderSlashCommand } from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { nonEmptyTrimmed } from "../providerSnapshot.ts";
+
+/**
+ * Map ACP `available_commands_update` entries into the provider slash-command
+ * shape used by the T3 composer (same contract Claude fills from SDK init).
+ */
+export function parseAcpAvailableCommands(
+  commands: ReadonlyArray<EffectAcpSchema.AvailableCommand> | null | undefined,
+): ReadonlyArray<ServerProviderSlashCommand> {
+  const byName = new Map<string, ServerProviderSlashCommand>();
+
+  for (const command of commands ?? []) {
+    const name = nonEmptyTrimmed(command.name);
+    if (!name) {
+      continue;
+    }
+
+    const description = nonEmptyTrimmed(command.description);
+    const hint =
+      command.input && typeof command.input === "object" && "hint" in command.input
+        ? nonEmptyTrimmed(command.input.hint)
+        : undefined;
+
+    const key = name.toLowerCase();
+    const existing = byName.get(key);
+    if (!existing) {
+      byName.set(key, {
+        name,
+        ...(description ? { description } : {}),
+        ...(hint ? { input: { hint } } : {}),
+      });
+      continue;
+    }
+
+    byName.set(key, {
+      ...existing,
+      ...(existing.description ? {} : description ? { description } : {}),
+      ...(existing.input?.hint ? {} : hint ? { input: { hint } } : {}),
+    });
+  }
+
+  return [...byName.values()];
+}

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -3,6 +3,7 @@ import * as AcpError from "./errors.ts";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
 import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -246,6 +247,67 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
         },
       });
       assert.notInclude(encodeUnknownJsonString(event), secret);
+    }),
+  );
+
+  it.effect("drops non-numeric response ids so Effect RpcClient does not BigInt-crash", () =>
+    Effect.gen(function* () {
+      // Grok emits internal JSON-RPC ids like "skills-reload". Effect's RpcClient
+      // does BigInt(requestId); without dropping, that throws and tears the stream.
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const termination = yield* Deferred.make<AcpError.AcpError>();
+      const transport = yield* AcpProtocol.makeAcpPatchedProtocol({
+        stdio,
+        serverRequestMethods: new Set(),
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+
+      const notifications =
+        yield* Deferred.make<ReadonlyArray<AcpProtocol.AcpIncomingNotification>>();
+      yield* transport.incoming.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.flatMap((chunk) => Deferred.succeed(notifications, chunk)),
+        Effect.forkScoped,
+      );
+
+      yield* Queue.offer(
+        input,
+        encoder.encode(
+          `${encodeUnknownJsonString({
+            jsonrpc: "2.0",
+            id: "skills-reload",
+            result: {},
+          })}\n`,
+        ),
+      );
+
+      yield* Queue.offer(
+        input,
+        yield* encodeJsonl(SessionUpdateNotification, {
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: "session-1",
+            update: {
+              sessionUpdate: "plan",
+              entries: [
+                {
+                  content: "Still healthy after skills-reload id",
+                  priority: "medium",
+                  status: "completed",
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+      const [update] = yield* Deferred.await(notifications);
+      assert.equal(update?._tag, "SessionUpdate");
+
+      const terminatedEarly = yield* Deferred.poll(termination);
+      assert.isTrue(Option.isNone(terminatedEarly));
     }),
   );
 

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -337,12 +337,33 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
     return Queue.offer(serverQueue, message).pipe(Effect.asVoid);
   };
 
+  /**
+   * Effect RPC brands request ids as bigint. Agents may emit non-numeric JSON-RPC
+   * ids (e.g. Grok's internal "skills-reload"). Forwarding those to RpcClient
+   * throws `Cannot convert … to a BigInt` and tears down the stream.
+   */
+  const isEffectRpcRequestId = (requestId: string): boolean => {
+    try {
+      BigInt(requestId);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const offerClientMessageIfNumericRequestId = (
+    message: RpcMessage.ResponseExitEncoded | RpcMessage.ResponseChunkEncoded,
+  ) =>
+    isEffectRpcRequestId(message.requestId)
+      ? Queue.offer(clientQueue, message).pipe(Effect.asVoid)
+      : Effect.void;
+
   const handleExitEncoded = (message: RpcMessage.ResponseExitEncoded) =>
     Ref.get(extPending).pipe(
       Effect.flatMap((pending) => {
         const pendingRequest = pending.get(message.requestId);
         if (!pendingRequest) {
-          return Queue.offer(clientQueue, message).pipe(Effect.asVoid);
+          return offerClientMessageIfNumericRequestId(message);
         }
         if (message.exit._tag === "Success") {
           return completeExtPendingSuccess(message.requestId, message.exit.value);
@@ -389,7 +410,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
                     message.requestId,
                   ),
                 )
-              : Queue.offer(clientQueue, message).pipe(Effect.asVoid);
+              : offerClientMessageIfNumericRequestId(message);
           }),
         );
       case "Defect":


### PR DESCRIPTION
## Summary

- **Grok slash/skills empty in T3 UI:** Grok already advertises commands over ACP (`session/update` → `available_commands_update`, including user skills). The Grok provider probe only discovered models and never filled `ServerProvider.slashCommands`, so the composer menu stayed empty (Claude works because it maps SDK init commands).
- **ACP crash on `skills-reload`:** Grok emits non-numeric JSON-RPC ids such as `skills-reload`. Effect `RpcClient` does `BigInt(requestId)` and throws `Cannot convert skills-reload to a BigInt`, which showed up during `checkGrokProviderStatus` / `startSession`.

## Changes

1. **`packages/effect-acp`**: Drop `Exit`/`Chunk` messages whose `requestId` is not a valid Effect RPC bigint **and** not extension-pending, so RpcClient never BigInt-crashes on agent-internal string ids.
2. **`GrokProvider`**: During ACP model discovery, listen for `available_commands_update`, map via `parseAcpAvailableCommands`, and publish as `slashCommands` on the ready snapshot (with a short wait after `session/new`, since Grok sends commands after the create response).
3. **Tests** for the mapper and the non-numeric id path.

## Test plan

- [x] `vp run --filter effect-acp test` (31 passed)
- [x] `vp run --filter t3 test` (includes new parse tests + GrokProvider; 1425 passed)
- [x] `vp run --filter effect-acp --filter t3 typecheck`
- [ ] Manual: install Grok CLI with skills under `~/.grok/skills/`, open T3 → Grok → confirm `/` menu lists skills (e.g. `factory-planner` if present)
- [ ] Manual: no `Cannot convert skills-reload to a BigInt` in server logs on Grok session start
- [ ] Manual: Claude slash commands still populate

## Notes

- Live mid-session command refresh is still not wired (`parseSessionUpdateEvent` still ignores `available_commands_update` for the thread event stream). Provider snapshot fill is enough for the composer menu, matching how Claude exposes commands.
- Small reliability/interop fix; happy to adjust if you prefer a different collection point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ACP wire handling and Grok status probing; incorrect filtering could hide legitimate RPC responses, but changes are scoped to non-numeric ids and provider snapshot enrichment.
> 
> **Overview**
> Fixes an empty Grok `/` composer menu and ACP stream crashes during Grok provider checks.
> 
> **Grok provider discovery** now uses **`ServerConfig.cwd`** (not `process.cwd()`) for ACP `session/new`, listens for **`available_commands_update`**, maps entries via **`parseAcpAvailableCommands`**, and publishes **`slashCommands`** on the ready provider snapshot. Slash collection is **best-effort** with a short bounded wait so it does not blow the existing model-discovery timeout.
> 
> **`effect-acp` protocol** drops JSON-RPC **responses** whose `requestId` is not a valid bigint when they are not extension-pending (e.g. Grok’s **`skills-reload`**), avoiding **`BigInt(requestId)`** crashes that tear down the stream.
> 
> Adds unit tests for the mapper, the protocol path, and explicit workspace **`cwd`** on **`checkGrokProviderStatus`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fde55dc01db784084d4eae58de56c6f659db703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface ACP slash commands in Grok provider and drop non-numeric JSON-RPC response ids
> - ACP discovery in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/4110/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) now registers a session update handler before `acp.start()` to capture `available_commands_update` notifications, polls briefly for slash commands, and returns them alongside models in the provider status.
> - Adds [parseAcpAvailableCommands.ts](https://github.com/pingdotgg/t3code/pull/4110/files#diff-aab0086d9a075f86e1db2936fdb36d99bdb07115ee26c232ca18c85a66f92858) to normalize and deduplicate ACP commands into `ServerProviderSlashCommand` objects before surfacing them.
> - [protocol.ts](https://github.com/pingdotgg/t3code/pull/4110/files#diff-c41432f9e7fbaf0a7a40c325bf318ea40df32aed6b771c8b6fa5c935e37006d2) now drops incoming JSON-RPC responses with non-numeric ids that don't correspond to a tracked pending request, preventing BigInt conversion crashes in the Effect RpcClient.
> - `checkGrokProviderStatus` and `discoverGrokModelsViaAcp` now accept an explicit `cwd` parameter passed from `ServerConfig`, replacing implicit reliance on `process.cwd()`.
> - Behavioral Change: slash command discovery introduces bounded polling (capped by the overall ACP discovery timeout) that may delay provider status responses slightly when commands arrive shortly after session start.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fde55d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Grok provider discovery now includes available models and ACP slash commands.
  - Slash commands include descriptions and input hints, with duplicate commands handled cleanly.
  - Grok discovery now respects the active workspace directory.

- **Bug Fixes**
  - Improved ACP protocol stability by ignoring unsupported response identifiers, preventing connection failures during session updates.
  - Fixed Grok status checks that could fail or hang when ACP startup or discovery encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->