### PR TITLE
[codex] show complete approval details

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.approval.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.approval.test.ts
@@ -1,0 +1,33 @@
+import {
+  EventId,
+  ProviderDriverKind,
+  RuntimeRequestId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { runtimeEventToActivities } from "./ProviderRuntimeIngestion.ts";
+
+describe("runtimeEventToActivities approval details", () => {
+  it("preserves complete multiline command details", () => {
+    const detail = `bun run release -- ${"long-argument ".repeat(20)}\nsecond line`;
+    const event = {
+      type: "request.opened",
+      eventId: EventId.make("evt-request-opened"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-07-18T00:00:00.000Z",
+      threadId: ThreadId.make("thread-1"),
+      requestId: RuntimeRequestId.make("approval-1"),
+      payload: {
+        requestType: "command_execution_approval",
+        detail,
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const [activity] = runtimeEventToActivities(event);
+
+    expect(activity?.kind).toBe("approval.requested");
+    expect((activity?.payload as Record<string, unknown> | undefined)?.detail).toBe(detail);
+  });
+});

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -262,7 +262,7 @@ function requestKindFromCanonicalRequestType(
   }
 }
 
-function runtimeEventToActivities(
+export function runtimeEventToActivities(
   event: ProviderRuntimeEvent,
 ): ReadonlyArray<OrchestrationThreadActivity> {
   const maybeSequence = (() => {
@@ -295,7 +295,7 @@ function runtimeEventToActivities(
             requestId: toApprovalRequestId(event.requestId),
             ...(requestKind ? { requestKind } : {}),
             requestType: event.payload.requestType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail ? { detail: event.payload.detail } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.test.tsx
@@ -1,0 +1,28 @@
+import { ApprovalRequestId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ComposerPendingApprovalPanel } from "./ComposerPendingApprovalPanel";
+
+describe("ComposerPendingApprovalPanel", () => {
+  it("renders complete multiline command details without hover or truncation", () => {
+    const detail = `bun run release -- ${"long-argument ".repeat(20)}\nsecond line`;
+    const markup = renderToStaticMarkup(
+      <ComposerPendingApprovalPanel
+        approval={{
+          requestId: ApprovalRequestId.make("approval-1"),
+          requestKind: "command",
+          createdAt: "2026-07-18T00:00:00.000Z",
+          detail,
+        }}
+        pendingCount={1}
+      />,
+    );
+
+    expect(markup).toContain('data-approval-detail="complete"');
+    expect(markup).toContain('aria-label="Command"');
+    expect(markup).toContain(detail);
+    expect(markup).not.toContain("truncate");
+    expect(markup).not.toContain("line-clamp");
+  });
+});

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
@@ -16,6 +16,12 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
       : approval.requestKind === "file-read"
         ? "File-read approval requested"
         : "File-change approval requested";
+  const detailLabel =
+    approval.requestKind === "command"
+      ? "Command"
+      : approval.requestKind === "file-read"
+        ? "File to read"
+        : "File change";
 
   return (
     <div className="px-4 py-3.5 sm:px-5 sm:py-4">
@@ -26,6 +32,18 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
           <span className="text-xs text-muted-foreground">1/{pendingCount}</span>
         ) : null}
       </div>
+      {approval.detail ? (
+        <div className="mt-3 rounded-lg border border-border/65 bg-background/70 p-3">
+          <p className="text-xs font-medium text-muted-foreground">{detailLabel}</p>
+          <pre
+            aria-label={detailLabel}
+            className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground"
+            data-approval-detail="complete"
+          >
+            {approval.detail}
+          </pre>
+        </div>
+      ) : null}
     </div>
   );
 });


### PR DESCRIPTION
## What changed

- Preserve complete approval details when canonical runtime requests become persisted approval activities.
- Show the full command or file detail directly in the approval panel as wrapped, scrollable preformatted text.
- Add server and UI regression tests using multiline content longer than the previous 180-character limit.

## Why

Fixes #4051.

Approval details were truncated to 180 characters during server ingestion, then only surfaced through the disabled composer placeholder. For long commands, the user could not inspect the exact operation before approving it.

The panel now exposes the complete value without requiring hover, while a bounded scroll area keeps large commands usable at narrow widths.

## Verification

- `vp check` (passes with 10 existing warnings outside this diff)
- `vp run typecheck`
- Focused server and UI tests: 2 passed
- Full suite: 601 files and 4,756 tests passed; 2 files and 7 tests skipped by the existing suite
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Added regression coverage at the persistence and rendering boundaries
- [x] No migration required


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show complete approval details in the pending approval panel without truncation
> - Replaces `truncateDetail` with the raw `event.payload.detail` in [`ProviderRuntimeIngestion.ts`](https://github.com/pingdotgg/t3code/pull/4111/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) so the full detail string is preserved in `approval.requested` activity payloads.
> - Updates [`ComposerPendingApprovalPanel.tsx`](https://github.com/pingdotgg/t3code/pull/4111/files#diff-3f6a92c07f981fc2fdf01ac0c1c53a1de7da9b08d204cfaf962dc9ddf7d0304f) to render a scrollable `<pre>` block for `approval.detail` with no truncation or line-clamp, labeled by request kind (Command/File to read/File change).
> - Exports `runtimeEventToActivities` to support new test coverage added in [`ProviderRuntimeIngestion.approval.test.ts`](https://github.com/pingdotgg/t3code/pull/4111/files#diff-5738fd4f91a80957b6a6adf9e5ff39bfd36e996f572fb43cd7e73d2dd3339ea7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 266dba0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted approval UX and persistence change with regression tests; no auth or migration impact, though activity payloads may grow for very long commands.
> 
> **Overview**
> Fixes approval inspection for long or multiline commands by **stopping 180-character truncation** when `request.opened` events become `approval.requested` activities—`detail` is now stored verbatim in `ProviderRuntimeIngestion`.
> 
> The **pending approval panel** now renders that full `approval.detail` in a labeled, scrollable `<pre>` (wrapped text, no hover or line-clamp), so users can review the exact command or file path before approving.
> 
> **`runtimeEventToActivities`** is exported for a server regression test; a matching UI test asserts complete multiline output and `data-approval-detail="complete"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266dba0f87327b2e286e8e73864fa0d9da302e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->