### PR TITLE
[codex] canonicalize client timestamps

### DIFF
--- a/apps/server/src/orchestration/Normalizer.test.ts
+++ b/apps/server/src/orchestration/Normalizer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  CommandId,
+  type ClientOrchestrationCommand,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+
+import { canonicalizeClientCommandTimestamps } from "./Normalizer.ts";
+
+const clientCreatedAt = "2031-01-01T00:00:00.000Z";
+const serverReceivedAt = "2026-07-18T00:00:00.000Z";
+
+describe("canonicalizeClientCommandTimestamps", () => {
+  it("replaces a client command timestamp with the server receipt timestamp", () => {
+    const command: ClientOrchestrationCommand = {
+      type: "project.create",
+      commandId: CommandId.make("command-1"),
+      projectId: ProjectId.make("project-1"),
+      title: "Clock-safe project",
+      workspaceRoot: "/tmp/clock-safe-project",
+      createdAt: clientCreatedAt,
+    };
+
+    expect(canonicalizeClientCommandTimestamps(command, serverReceivedAt)).toEqual({
+      ...command,
+      createdAt: serverReceivedAt,
+    });
+  });
+
+  it("replaces both timestamps when the first turn bootstraps a thread", () => {
+    const command: ClientOrchestrationCommand = {
+      type: "thread.turn.start",
+      commandId: CommandId.make("command-2"),
+      threadId: ThreadId.make("thread-1"),
+      message: {
+        messageId: MessageId.make("message-1"),
+        role: "user",
+        text: "Start a thread",
+        attachments: [],
+      },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      bootstrap: {
+        createThread: {
+          projectId: ProjectId.make("project-1"),
+          title: "Clock-safe thread",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5.4",
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: clientCreatedAt,
+        },
+      },
+      createdAt: clientCreatedAt,
+    };
+
+    const result = canonicalizeClientCommandTimestamps(command, serverReceivedAt);
+
+    expect(result.type).toBe("thread.turn.start");
+    if (result.type !== "thread.turn.start") {
+      throw new Error("Expected a thread.turn.start command");
+    }
+    expect(result.createdAt).toBe(serverReceivedAt);
+    expect(result.bootstrap?.createThread?.createdAt).toBe(serverReceivedAt);
+  });
+});

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -1,8 +1,10 @@
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import {
   type ClientOrchestrationCommand,
+  type IsoDateTime,
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
@@ -13,8 +15,38 @@ import { ServerConfig } from "../config.ts";
 import { parseBase64DataUrl } from "../imageMime.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
+export const canonicalizeClientCommandTimestamps = (
+  command: ClientOrchestrationCommand,
+  receivedAt: IsoDateTime,
+): ClientOrchestrationCommand => {
+  const canonicalCommand =
+    "createdAt" in command
+      ? {
+          ...command,
+          createdAt: receivedAt,
+        }
+      : command;
+
+  if (canonicalCommand.type !== "thread.turn.start" || !canonicalCommand.bootstrap?.createThread) {
+    return canonicalCommand;
+  }
+
+  return {
+    ...canonicalCommand,
+    bootstrap: {
+      ...canonicalCommand.bootstrap,
+      createThread: {
+        ...canonicalCommand.bootstrap.createThread,
+        createdAt: receivedAt,
+      },
+    },
+  };
+};
+
 export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
   Effect.gen(function* () {
+    const receivedAt = DateTime.formatIso(yield* DateTime.now);
+    const canonicalCommand = canonicalizeClientCommandTimestamps(command, receivedAt);
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const serverConfig = yield* ServerConfig;
@@ -47,30 +79,33 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
           ),
         );
 
-    if (command.type === "project.create") {
+    if (canonicalCommand.type === "project.create") {
       return {
-        ...command,
+        ...canonicalCommand,
         workspaceRoot: yield* normalizeProjectWorkspaceRootForCreate(
-          command.workspaceRoot,
-          command.createWorkspaceRootIfMissing,
+          canonicalCommand.workspaceRoot,
+          canonicalCommand.createWorkspaceRootIfMissing,
         ),
-        createWorkspaceRootIfMissing: command.createWorkspaceRootIfMissing === true,
+        createWorkspaceRootIfMissing: canonicalCommand.createWorkspaceRootIfMissing === true,
       } satisfies OrchestrationCommand;
     }
 
-    if (command.type === "project.meta.update" && command.workspaceRoot !== undefined) {
+    if (
+      canonicalCommand.type === "project.meta.update" &&
+      canonicalCommand.workspaceRoot !== undefined
+    ) {
       return {
-        ...command,
-        workspaceRoot: yield* normalizeProjectWorkspaceRoot(command.workspaceRoot),
+        ...canonicalCommand,
+        workspaceRoot: yield* normalizeProjectWorkspaceRoot(canonicalCommand.workspaceRoot),
       } satisfies OrchestrationCommand;
     }
 
-    if (command.type !== "thread.turn.start") {
-      return command as OrchestrationCommand;
+    if (canonicalCommand.type !== "thread.turn.start") {
+      return canonicalCommand as OrchestrationCommand;
     }
 
     const normalizedAttachments = yield* Effect.forEach(
-      command.message.attachments,
+      canonicalCommand.message.attachments,
       (attachment) =>
         Effect.gen(function* () {
           const parsed = parseBase64DataUrl(attachment.dataUrl);
@@ -87,7 +122,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
             });
           }
 
-          const attachmentId = createAttachmentId(command.threadId);
+          const attachmentId = createAttachmentId(canonicalCommand.threadId);
           if (!attachmentId) {
             return yield* new OrchestrationDispatchCommandError({
               message: "Failed to create a safe attachment id.",
@@ -135,9 +170,9 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
     );
 
     return {
-      ...command,
+      ...canonicalCommand,
       message: {
-        ...command.message,
+        ...canonicalCommand.message,
         attachments: normalizedAttachments,
       },
     } satisfies OrchestrationCommand;


### PR DESCRIPTION
Fixes #3983.

## What changed

- assign canonical timestamps to client orchestration commands when the server receives them
- apply the same receipt timestamp to nested thread creation metadata when a first turn bootstraps a thread
- cover both ordinary timestamped commands and bootstrap turns with regression tests

## Why

Clients currently generate `createdAt` from their local clocks. If a client clock is ahead, that future timestamp reaches persisted events and projections, so an older user message can sort after its assistant response and after genuinely newer prompts.

Canonicalizing at the server boundary keeps persisted chronology consistent across web and desktop clients while leaving internal server-generated command timestamps unchanged.

This is forward-only: it prevents new skewed records but does not migrate timestamps that are already persisted.

## Verification

- `vp check` (passes with 10 pre-existing warnings in unrelated web files)
- `vp run typecheck`
- `vp test` (4,756 passed, 7 skipped)
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Canonicalize client timestamps in `normalizeDispatchCommand` with server receipt time
> - Adds `canonicalizeClientCommandTimestamps` in [Normalizer.ts](https://github.com/pingdotgg/t3code/pull/4112/files#diff-751e99c6b2a5986d684c4717507023bfb24d6250386e071d6b48dd195e10c5ea) that replaces client-supplied `createdAt` with the server's receipt timestamp.
> - For `thread.turn.start` commands that include `bootstrap.createThread`, the bootstrap's `createdAt` is also overwritten.
> - `normalizeDispatchCommand` now calls this before any other normalization logic.
> - Behavioral Change: client-provided `createdAt` values on all dispatched commands are now silently overwritten with the server receipt time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3337346.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Silently overwrites client timestamps on every dispatched command, which changes persisted event ordering for all clients but is scoped to the normalization boundary and covered by tests.
> 
> **Overview**
> Client orchestration commands no longer persist client-supplied `createdAt` values. **`normalizeDispatchCommand`** now stamps commands with the server’s receipt time via new **`canonicalizeClientCommandTimestamps`**, applied before workspace and attachment normalization on both HTTP and WebSocket dispatch paths.
> 
> For **`thread.turn.start`** commands that bootstrap a new thread, the nested **`bootstrap.createThread.createdAt`** is overwritten with the same receipt timestamp so thread creation and the first turn stay in order when client clocks are skewed. Regression tests cover a plain timestamped command and a bootstrap turn.
> 
> This is **forward-only**: existing persisted timestamps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3337346f7a369e4930a7000276ba8ee80d9c559a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->