### PR TITLE
fix(mobile): keep new thread composer above keyboard

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -2,7 +2,11 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
-import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
+import {
+  KeyboardAvoidingView,
+  KeyboardStickyView,
+  useKeyboardState,
+} from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
@@ -1050,9 +1054,15 @@ export function NewTaskDraftScreen(props: {
         <NativeStackScreenOptions options={{ headerShown: false }} />
         <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
 
-        <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
-          <View className="flex-1" />
+        <View className="flex-1" />
 
+        {/* Match the existing-thread composer: Android's IME animation drives
+            the whole composer above the keyboard instead of padding an empty
+            flex layout beneath it. */}
+        <KeyboardStickyView
+          style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
+          offset={{ closed: 0, opened: 0 }}
+        >
           <View
             className="px-4 pt-2"
             style={{
@@ -1116,7 +1126,7 @@ export function NewTaskDraftScreen(props: {
               </ComposerToolbarRow>
             ) : null}
           </View>
-        </KeyboardAvoidingView>
+        </KeyboardStickyView>
       </View>
     );
   }


### PR DESCRIPTION
## Summary

Fix the new-thread composer being partially covered by the keyboard on Android.

The new-thread screen was using a padding-based `KeyboardAvoidingView` around an empty flex layout. This switches it to the existing-thread composer's `KeyboardStickyView` pattern, so the input, model picker, configuration control, and send button move together with the IME.

## Validation

- Tested on a physical Android device: opened a new thread and verified the full composer remains visible and usable with the keyboard open.
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

## Visual evidence

### Before

<img src="https://raw.githubusercontent.com/anirudh-makuluri/t3code/pr-4114-evidence/.github/pr-evidence/4114/before.png" alt="Before: new-thread controls obscured by keyboard" width="280" />

### After

<img src="https://raw.githubusercontent.com/anirudh-makuluri/t3code/pr-4114-evidence/.github/pr-evidence/4114/after.png" alt="After: full composer remains visible above keyboard" width="280" />

[Short Android device recording (MP4)](https://raw.githubusercontent.com/anirudh-makuluri/t3code/pr-4114-evidence/.github/pr-evidence/4114/android-keyboard-fix.mp4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Android layout change in NewTaskDraftScreen with no auth, data, or API impact.
> 
> **Overview**
> On **Android**, the new-thread screen no longer wraps the layout in a padding-based `KeyboardAvoidingView` over an empty `flex-1` area. The composer chrome is now in an absolutely positioned **`KeyboardStickyView`** at the bottom, aligned with existing-thread **`ThreadComposer`** behavior so the IME animation lifts the input, toolbar, and send control together.
> 
> **iOS** still uses `KeyboardAvoidingView` with the editor in the main column; only the Android branch changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fd803fbc064fa1c20d79a6dfbe5b8bfb046e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix new thread composer position above keyboard on Android
> Replaces `KeyboardAvoidingView` with `KeyboardStickyView` in [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/4114/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) so the composer follows the IME animation directly via absolute positioning rather than padding adjustments. Behavioral Change: the composer now moves in sync with the keyboard open/close animation instead of jumping with padding changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6fd803.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->