### PR TITLE
fix(web): default provider selection for users without Codex

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -152,6 +152,7 @@ import {
 } from "~/projectScripts";
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
+import { NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
 import { useEnvironmentSettings } from "../hooks/useSettings";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
@@ -1361,10 +1362,7 @@ function ChatViewContent(props: ChatViewProps) {
         ? buildLocalDraftThread(
             threadId,
             draftThread,
-            fallbackDraftProject?.defaultModelSelection ?? {
-              instanceId: ProviderInstanceId.make("codex"),
-              model: DEFAULT_MODEL,
-            },
+            fallbackDraftProject?.defaultModelSelection ?? NO_PROVIDER_MODEL_SELECTION,
           )
         : undefined,
     [draftThread, fallbackDraftProject?.defaultModelSelection, threadId],
@@ -1856,7 +1854,7 @@ function ChatViewContent(props: ChatViewProps) {
   const providerStatuses = serverConfig?.providers ?? EMPTY_PROVIDERS;
   const unlockedSelectedProvider = resolveSelectableProvider(
     providerStatuses,
-    selectedProviderByThreadId ?? threadProvider ?? ProviderDriverKind.make("codex"),
+    selectedProviderByThreadId ?? threadProvider,
   );
   const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
   const phase = derivePhase(activeThread?.session ?? null);
@@ -4038,7 +4036,7 @@ function ChatViewContent(props: ChatViewProps) {
       return;
     }
     const sendCtx = composerRef.current?.getSendContext();
-    if (!sendCtx) return;
+    if (!sendCtx?.providerAvailable) return;
     const {
       images: composerImages,
       terminalContexts: composerTerminalContexts,
@@ -4614,7 +4612,7 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       const sendCtx = composerRef.current?.getSendContext();
-      if (!sendCtx) {
+      if (!sendCtx?.providerAvailable) {
         return;
       }
       const {
@@ -4773,7 +4771,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     const sendCtx = composerRef.current?.getSendContext();
-    if (!sendCtx) {
+    if (!sendCtx?.providerAvailable) {
       return;
     }
     const {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -111,7 +111,9 @@ import { CommandPaletteResults } from "./CommandPaletteResults";
 import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
+import { resolveSelectableProviderInstance } from "../providerInstances";
+import { getDefaultServerModel } from "../providerModels";
 import { resolveShortcutCommand } from "../keybindings";
 import {
   Command,
@@ -476,6 +478,7 @@ function OpenCommandPaletteDialog(props: {
   const projects = useProjects();
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const providers = useAtomValue(primaryServerProvidersAtom);
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
   const [browseGeneration, setBrowseGeneration] = useState(0);
@@ -1149,6 +1152,11 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const projectId = newProjectId();
+      const defaultInstanceId =
+        resolveSelectableProviderInstance(providers, undefined) ?? ProviderInstanceId.make("codex");
+      const defaultDriver = providers.find(
+        (snapshot) => snapshot.instanceId === defaultInstanceId,
+      )?.driver;
       const createResult = await createProject({
         environmentId: input.environmentId,
         input: {
@@ -1157,8 +1165,8 @@ function OpenCommandPaletteDialog(props: {
           workspaceRoot: cwd,
           createWorkspaceRootIfMissing: true,
           defaultModelSelection: {
-            instanceId: ProviderInstanceId.make("codex"),
-            model: DEFAULT_MODEL,
+            instanceId: defaultInstanceId,
+            model: defaultDriver ? getDefaultServerModel(providers, defaultDriver) : DEFAULT_MODEL,
           },
         },
       });
@@ -1197,6 +1205,7 @@ function OpenCommandPaletteDialog(props: {
       createProject,
       navigate,
       projects,
+      providers,
       setOpen,
       clientSettings.sidebarThreadSortOrder,
       threads,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -7,12 +7,10 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import {
-  DEFAULT_MODEL,
   type DesktopWslState,
   type EnvironmentId,
   type FilesystemBrowseResult,
   type ProjectId,
-  ProviderInstanceId,
   type SourceControlDiscoveryResult,
   type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
@@ -112,10 +110,7 @@ import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons"
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
-import {
-  getDefaultProviderInstanceModel,
-  resolveSelectableProviderInstance,
-} from "../providerInstances";
+import { resolveDefaultProviderModelSelection } from "../providerInstances";
 import { resolveShortcutCommand } from "../keybindings";
 import {
   Command,
@@ -1154,8 +1149,10 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const projectId = newProjectId();
-      const defaultInstanceId =
-        resolveSelectableProviderInstance(providers, undefined) ?? ProviderInstanceId.make("codex");
+      const targetEnvironmentProviders =
+        environments.find((environment) => environment.environmentId === input.environmentId)
+          ?.serverConfig?.providers ??
+        (input.environmentId === primaryEnvironmentId ? providers : []);
       const createResult = await createProject({
         environmentId: input.environmentId,
         input: {
@@ -1163,10 +1160,10 @@ function OpenCommandPaletteDialog(props: {
           title: inferProjectTitleFromPath(cwd),
           workspaceRoot: cwd,
           createWorkspaceRootIfMissing: true,
-          defaultModelSelection: {
-            instanceId: defaultInstanceId,
-            model: getDefaultProviderInstanceModel(providers, defaultInstanceId) ?? DEFAULT_MODEL,
-          },
+          defaultModelSelection: resolveDefaultProviderModelSelection(
+            targetEnvironmentProviders,
+            null,
+          ),
         },
       });
       if (createResult._tag === "Failure") {
@@ -1202,7 +1199,9 @@ function OpenCommandPaletteDialog(props: {
     [
       handleNewThread,
       createProject,
+      environments,
       navigate,
+      primaryEnvironmentId,
       projects,
       providers,
       setOpen,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -112,8 +112,10 @@ import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons"
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
-import { resolveSelectableProviderInstance } from "../providerInstances";
-import { getDefaultServerModel } from "../providerModels";
+import {
+  getDefaultProviderInstanceModel,
+  resolveSelectableProviderInstance,
+} from "../providerInstances";
 import { resolveShortcutCommand } from "../keybindings";
 import {
   Command,
@@ -1154,9 +1156,6 @@ function OpenCommandPaletteDialog(props: {
       const projectId = newProjectId();
       const defaultInstanceId =
         resolveSelectableProviderInstance(providers, undefined) ?? ProviderInstanceId.make("codex");
-      const defaultDriver = providers.find(
-        (snapshot) => snapshot.instanceId === defaultInstanceId,
-      )?.driver;
       const createResult = await createProject({
         environmentId: input.environmentId,
         input: {
@@ -1166,7 +1165,7 @@ function OpenCommandPaletteDialog(props: {
           createWorkspaceRootIfMissing: true,
           defaultModelSelection: {
             instanceId: defaultInstanceId,
-            model: defaultDriver ? getDefaultServerModel(providers, defaultDriver) : DEFAULT_MODEL,
+            model: getDefaultProviderInstanceModel(providers, defaultInstanceId) ?? DEFAULT_MODEL,
           },
         },
       });

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -114,7 +114,9 @@ import { getProviderDisplayName, getProviderInteractionModeToggle } from "../../
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
+  NO_PROVIDER_MODEL_SELECTION,
   resolveProviderDriverKindForInstanceSelection,
+  resolveSelectableProviderInstanceEntry,
   sortProviderInstanceEntries,
   type ProviderInstanceEntry,
 } from "../../providerInstances";
@@ -433,6 +435,7 @@ export interface ChatComposerHandle {
     selectedPromptEffort: string | null;
     selectedModelOptionsForDispatch: unknown;
     selectedModelSelection: ModelSelection;
+    providerAvailable: boolean;
     selectedProvider: ProviderDriverKind;
     selectedModel: string;
     selectedProviderModels: ReadonlyArray<ServerProvider["models"][number]>;
@@ -696,7 +699,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       providerInstanceEntries,
       providerStatuses,
       explicitSelectedInstanceId,
-    ) ?? ProviderDriverKind.make("codex");
+    ) ??
+    providerInstanceEntries[0]?.driverKind ??
+    ProviderDriverKind.make("unconfigured");
   const requestedDriverKind: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
   const lockedContinuationGroupKey = useMemo((): string | null => {
     if (!lockedProvider || !activeThread) return null;
@@ -734,7 +739,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     for (const candidate of candidates) {
       if (!candidate) continue;
       const match = providerInstanceEntries.find(
-        (entry) => entry.instanceId === candidate && entry.enabled,
+        (entry) => entry.instanceId === candidate && entry.enabled && entry.isAvailable,
       );
       if (match) {
         // When locked to a specific driver kind, ignore persisted instance
@@ -749,50 +754,24 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return match.instanceId;
       }
     }
-    if (explicitSelectedInstanceId) {
-      // An id missing from the entries list may be a custom instance whose
-      // snapshot has not arrived yet, so it is trusted as-is. A known-but-
-      // disabled id is abandoned only when an enabled instance satisfies
-      // the thread's driver/continuation lock; otherwise it is kept so the
-      // send fails with the server error naming the disabled provider
-      // rather than a driver switch the thread cannot make.
-      const isKnownDisabled = providerInstanceEntries.some(
-        (entry) => entry.instanceId === explicitSelectedInstanceId && !entry.enabled,
-      );
-      const replacement = isKnownDisabled
-        ? providerInstanceEntries.find(
-            (entry) =>
-              entry.enabled &&
-              (!lockedProvider || entry.driverKind === lockedProvider) &&
-              (!lockedContinuationGroupKey ||
-                entry.continuationGroupKey === lockedContinuationGroupKey),
-          )
-        : undefined;
-      if (!isKnownDisabled || replacement === undefined) {
-        return ProviderInstanceId.make(explicitSelectedInstanceId);
-      }
-    }
-    const byKind = providerInstanceEntries.find(
+    const compatibleEntries = providerInstanceEntries.filter(
       (entry) =>
-        entry.enabled &&
-        entry.driverKind === requestedDriverKind &&
+        (!lockedProvider || entry.driverKind === lockedProvider) &&
         (!lockedContinuationGroupKey || entry.continuationGroupKey === lockedContinuationGroupKey),
     );
-    if (byKind) return byKind.instanceId;
-    const anyEnabled = providerInstanceEntries.find((entry) => entry.enabled);
+    const requestedDriverEntries = compatibleEntries.filter(
+      (entry) => entry.driverKind === requestedDriverKind,
+    );
     return (
-      anyEnabled?.instanceId ??
-      providerInstanceEntries[0]?.instanceId ??
-      activeThreadModelSelection?.instanceId ??
-      activeProjectDefaultModelSelection?.instanceId ??
-      ProviderInstanceId.make("codex")
+      resolveSelectableProviderInstanceEntry(requestedDriverEntries, undefined)?.instanceId ??
+      resolveSelectableProviderInstanceEntry(compatibleEntries, undefined)?.instanceId ??
+      NO_PROVIDER_MODEL_SELECTION.instanceId
     );
   }, [
     activeProjectDefaultModelSelection?.instanceId,
     activeThread?.session?.providerInstanceId,
     activeThreadModelSelection?.instanceId,
     composerDraft.activeProvider,
-    explicitSelectedInstanceId,
     lockedContinuationGroupKey,
     lockedProvider,
     providerInstanceEntries,
@@ -806,6 +785,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => providerInstanceEntries.find((entry) => entry.instanceId === selectedInstanceId),
     [providerInstanceEntries, selectedInstanceId],
   );
+  const noProviderAvailable = selectedProviderEntry === undefined;
   // The driver kind follows the instance that will actually run the turn,
   // which can differ from the persisted selection when that selection is
   // disabled.
@@ -1183,6 +1163,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     phase === "running" ||
     isSendBusy ||
     isConnecting ||
+    noProviderAvailable ||
     projectSelectionRequired ||
     environmentUnavailable !== null ||
     !composerSendState.hasSendableContent;
@@ -1723,7 +1704,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   const shouldBlurMobileComposerOnSubmit = useCallback(() => {
     if (!isMobileViewport) return false;
-    if (isSendBusy || isConnecting || environmentUnavailable !== null || phase === "running") {
+    if (
+      isSendBusy ||
+      isConnecting ||
+      noProviderAvailable ||
+      environmentUnavailable !== null ||
+      phase === "running"
+    ) {
       return false;
     }
     if (activePendingProgress) {
@@ -1738,18 +1725,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isConnecting,
     isMobileViewport,
     isSendBusy,
+    noProviderAvailable,
     phase,
     showPlanFollowUpPrompt,
   ]);
 
   const submitComposer = useCallback(
     (event?: { preventDefault: () => void }) => {
+      if (noProviderAvailable) {
+        event?.preventDefault();
+        return;
+      }
       onSend(event);
       if (shouldBlurMobileComposerOnSubmit()) {
         blurMobileComposerAfterSend();
       }
     },
-    [blurMobileComposerAfterSend, onSend, shouldBlurMobileComposerOnSubmit],
+    [blurMobileComposerAfterSend, noProviderAvailable, onSend, shouldBlurMobileComposerOnSubmit],
   );
   const expandMobileComposer = useCallback(() => {
     if (composerBlurFrameRef.current !== null) {
@@ -2108,6 +2100,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         selectedPromptEffort,
         selectedModelOptionsForDispatch,
         selectedModelSelection,
+        providerAvailable: !noProviderAvailable,
         selectedProvider,
         selectedModel,
         selectedProviderModels,
@@ -2135,6 +2128,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       selectedModel,
       selectedModelOptionsForDispatch,
       selectedModelSelection,
+      noProviderAvailable,
       selectedPromptEffort,
       selectedProvider,
       selectedProviderModels,
@@ -2285,7 +2279,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       isSendBusy={isSendBusy}
                       isConnecting={isConnecting}
                       isEnvironmentUnavailable={
-                        environmentUnavailable !== null || projectSelectionRequired
+                        environmentUnavailable !== null ||
+                        noProviderAvailable ||
+                        projectSelectionRequired
                       }
                       isPreparingWorktree={false}
                       hasSendableContent={false}
@@ -2317,7 +2313,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 {activePendingProgress
                   ? activePendingProgress.customAnswer ||
                     "Type your own answer, or leave this blank to use the selected option"
-                  : prompt.trim() || "Ask anything..."}
+                  : prompt.trim() ||
+                    (noProviderAvailable ? "Enable a provider in Settings" : "Ask anything...")}
               </button>
               <button
                 type="button"
@@ -2526,9 +2523,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                             ? `${environmentUnavailable.label}: ${connectionStatusText(
                                 environmentUnavailable.connection,
                               )}`
-                            : phase === "disconnected"
-                              ? "Ask for follow-up changes or attach images"
-                              : "Ask anything, @tag files/folders, $use skills, or / for commands"
+                            : noProviderAvailable
+                              ? "Enable a provider in Settings to send a message"
+                              : phase === "disconnected"
+                                ? "Ask for follow-up changes or attach images"
+                                : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}
               />
@@ -2546,7 +2545,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     isSendBusy={isSendBusy}
                     isConnecting={isConnecting}
                     isEnvironmentUnavailable={
-                      environmentUnavailable !== null || projectSelectionRequired
+                      environmentUnavailable !== null ||
+                      noProviderAvailable ||
+                      projectSelectionRequired
                     }
                     isPreparingWorktree={false}
                     hasSendableContent={false}
@@ -2581,28 +2582,43 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               )}
             >
               <div className="-m-1 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                <ProviderModelPicker
-                  compact={isComposerFooterCompact}
-                  activeInstanceId={selectedInstanceId}
-                  model={selectedModelForPickerWithCustomFallback}
-                  lockedProvider={lockedProvider}
-                  lockedContinuationGroupKey={lockedContinuationGroupKey}
-                  instanceEntries={providerInstanceEntries}
-                  keybindings={keybindings}
-                  modelOptionsByInstance={modelOptionsByInstance}
-                  terminalOpen={terminalOpen}
-                  open={isComposerModelPickerOpen}
-                  {...(composerProviderState.modelPickerIconClassName
-                    ? {
-                        activeProviderIconClassName: composerProviderState.modelPickerIconClassName,
-                      }
-                    : {})}
-                  onOpenChange={(open) => {
-                    setIsComposerModelPickerOpen(open);
-                  }}
-                  getModelDisabledReason={getModelDisabledReason}
-                  onInstanceModelChange={onProviderModelSelect}
-                />
+                {noProviderAvailable ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled
+                    data-chat-provider-unavailable="true"
+                    className="shrink-0 gap-2 px-2 text-muted-foreground/70 sm:px-3"
+                  >
+                    <CircleAlertIcon className="size-4" />
+                    No provider available
+                  </Button>
+                ) : (
+                  <ProviderModelPicker
+                    compact={isComposerFooterCompact}
+                    activeInstanceId={selectedInstanceId}
+                    model={selectedModelForPickerWithCustomFallback}
+                    lockedProvider={lockedProvider}
+                    lockedContinuationGroupKey={lockedContinuationGroupKey}
+                    instanceEntries={providerInstanceEntries}
+                    keybindings={keybindings}
+                    modelOptionsByInstance={modelOptionsByInstance}
+                    terminalOpen={terminalOpen}
+                    open={isComposerModelPickerOpen}
+                    {...(composerProviderState.modelPickerIconClassName
+                      ? {
+                          activeProviderIconClassName:
+                            composerProviderState.modelPickerIconClassName,
+                        }
+                      : {})}
+                    onOpenChange={(open) => {
+                      setIsComposerModelPickerOpen(open);
+                    }}
+                    getModelDisabledReason={getModelDisabledReason}
+                    onInstanceModelChange={onProviderModelSelect}
+                  />
+                )}
 
                 {isComposerFooterCompact ? (
                   <CompactComposerControlsMenu
@@ -2659,7 +2675,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   isSendBusy={isSendBusy}
                   isConnecting={isConnecting}
                   isEnvironmentUnavailable={
-                    environmentUnavailable !== null || projectSelectionRequired
+                    environmentUnavailable !== null ||
+                    noProviderAvailable ||
+                    projectSelectionRequired
                   }
                   isPreparingWorktree={isPreparingWorktree}
                   hasSendableContent={composerSendState.hasSendableContent}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -697,7 +697,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       providerStatuses,
       explicitSelectedInstanceId,
     ) ?? ProviderDriverKind.make("codex");
-  const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
+  const requestedDriverKind: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
   const lockedContinuationGroupKey = useMemo((): string | null => {
     if (!lockedProvider || !activeThread) return null;
     const lockedInstanceId =
@@ -750,20 +750,32 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
     }
     if (explicitSelectedInstanceId) {
-      // Return the raw id only for unknown instances (e.g. a custom instance
-      // not yet hydrated into providerInstanceEntries). If the id IS known
-      // but disabled, fall through so anyEnabled/byKind picks a valid one.
+      // An id missing from the entries list may be a custom instance whose
+      // snapshot has not arrived yet, so it is trusted as-is. A known-but-
+      // disabled id is abandoned only when an enabled instance satisfies
+      // the thread's driver/continuation lock; otherwise it is kept so the
+      // send fails with the server error naming the disabled provider
+      // rather than a driver switch the thread cannot make.
       const isKnownDisabled = providerInstanceEntries.some(
         (entry) => entry.instanceId === explicitSelectedInstanceId && !entry.enabled,
       );
-      if (!isKnownDisabled) {
+      const replacement = isKnownDisabled
+        ? providerInstanceEntries.find(
+            (entry) =>
+              entry.enabled &&
+              (!lockedProvider || entry.driverKind === lockedProvider) &&
+              (!lockedContinuationGroupKey ||
+                entry.continuationGroupKey === lockedContinuationGroupKey),
+          )
+        : undefined;
+      if (!isKnownDisabled || replacement === undefined) {
         return ProviderInstanceId.make(explicitSelectedInstanceId);
       }
     }
     const byKind = providerInstanceEntries.find(
       (entry) =>
         entry.enabled &&
-        entry.driverKind === selectedProvider &&
+        entry.driverKind === requestedDriverKind &&
         (!lockedContinuationGroupKey || entry.continuationGroupKey === lockedContinuationGroupKey),
     );
     if (byKind) return byKind.instanceId;
@@ -784,8 +796,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     lockedContinuationGroupKey,
     lockedProvider,
     providerInstanceEntries,
-    selectedProvider,
+    requestedDriverKind,
   ]);
+
+  // Resolve the active instance's snapshot by `instanceId` so a custom
+  // instance gets its own slash commands, skills, and model list — not
+  // the first snapshot for the same driver kind.
+  const selectedProviderEntry = useMemo(
+    () => providerInstanceEntries.find((entry) => entry.instanceId === selectedInstanceId),
+    [providerInstanceEntries, selectedInstanceId],
+  );
+  // The driver kind follows the instance that will actually run the turn,
+  // which can differ from the persisted selection when that selection is
+  // disabled.
+  const selectedProvider: ProviderDriverKind =
+    selectedProviderEntry?.driverKind ?? requestedDriverKind;
 
   const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
     threadRef: composerDraftTarget,
@@ -796,14 +821,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     projectModelSelection: activeProjectDefaultModelSelection,
     settings,
   });
-
-  // Resolve the active instance's snapshot by `instanceId` so a custom
-  // instance gets its own slash commands, skills, and model list — not
-  // the first snapshot for the same driver kind.
-  const selectedProviderEntry = useMemo(
-    () => providerInstanceEntries.find((entry) => entry.instanceId === selectedInstanceId),
-    [providerInstanceEntries, selectedInstanceId],
-  );
   const selectedProviderStatus = useMemo(
     () => selectedProviderEntry?.snapshot ?? null,
     [selectedProviderEntry],

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -750,7 +750,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
     }
     if (explicitSelectedInstanceId) {
-      return ProviderInstanceId.make(explicitSelectedInstanceId);
+      // Return the raw id only for unknown instances (e.g. a custom instance
+      // not yet hydrated into providerInstanceEntries). If the id IS known
+      // but disabled, fall through so anyEnabled/byKind picks a valid one.
+      const isKnownDisabled = providerInstanceEntries.some(
+        (entry) => entry.instanceId === explicitSelectedInstanceId && !entry.enabled,
+      );
+      if (!isKnownDisabled) {
+        return ProviderInstanceId.make(explicitSelectedInstanceId);
+      }
     }
     const byKind = providerInstanceEntries.find(
       (entry) =>

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
+  getDefaultProviderInstanceModel,
   isProviderInstancePickerReady,
   isProviderInstancePickerVisible,
   resolveSelectableProviderInstance,
@@ -16,6 +17,7 @@ function provider(input: {
   availability?: ServerProvider["availability"];
   displayName?: string;
   status?: ServerProvider["status"];
+  models?: ServerProvider["models"];
 }): ServerProvider {
   return {
     instanceId: ProviderInstanceId.make(input.instanceId),
@@ -28,7 +30,7 @@ function provider(input: {
     ...(input.availability ? { availability: input.availability } : {}),
     auth: { status: "authenticated" },
     checkedAt: "2026-01-01T00:00:00.000Z",
-    models: [],
+    models: input.models ?? [],
     slashCommands: [],
     skills: [],
   };
@@ -162,6 +164,39 @@ describe("resolveSelectableProviderInstance", () => {
     expect(resolveSelectableProviderInstance(providers, undefined)).toBe(ready);
   });
 
+  it("prefers an unprobed (warning) instance over one whose probe errored", () => {
+    const notInstalled = ProviderInstanceId.make("codex");
+    const unprobed = ProviderInstanceId.make("claudeAgent");
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: notInstalled,
+        status: "error",
+      }),
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: unprobed,
+        status: "warning",
+      }),
+    ];
+
+    expect(resolveSelectableProviderInstance(providers, undefined)).toBe(unprobed);
+  });
+
+  it("keeps a requested instance even when its probe errored", () => {
+    const requested = ProviderInstanceId.make("codex");
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: requested,
+        status: "error",
+      }),
+      provider({ provider: ProviderDriverKind.make("claudeAgent"), instanceId: "claudeAgent" }),
+    ];
+
+    expect(resolveSelectableProviderInstance(providers, requested)).toBe(requested);
+  });
+
   it("still falls back to an enabled instance when nothing is ready", () => {
     const notInstalled = ProviderInstanceId.make("codex");
     const providers = [
@@ -232,6 +267,53 @@ describe("resolveProviderDriverKindForInstanceSelection", () => {
         providers,
         ProviderInstanceId.make("removed_instance"),
       ),
+    ).toBeUndefined();
+  });
+});
+
+describe("getDefaultProviderInstanceModel", () => {
+  const model = (slug: string, isCustom = false) => ({
+    slug,
+    name: slug,
+    isCustom,
+    capabilities: {},
+  });
+
+  it("uses the instance's own models, not the default instance of the kind", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: "claude_openrouter",
+        models: [model("openai/gpt-5.5", true), model("claude-opus-4-8")],
+      }),
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: "claudeAgent",
+        models: [model("claude-sonnet-5")],
+      }),
+    ];
+
+    expect(
+      getDefaultProviderInstanceModel(providers, ProviderInstanceId.make("claude_openrouter")),
+    ).toBe("claude-opus-4-8");
+  });
+
+  it("falls back to the driver default when the instance reports no models", () => {
+    const providers = [
+      provider({ provider: ProviderDriverKind.make("claudeAgent"), instanceId: "claudeAgent" }),
+    ];
+
+    const resolved = getDefaultProviderInstanceModel(
+      providers,
+      ProviderInstanceId.make("claudeAgent"),
+    );
+    expect(typeof resolved).toBe("string");
+    expect(resolved?.length).toBeGreaterThan(0);
+  });
+
+  it("returns undefined for an unknown instance", () => {
+    expect(
+      getDefaultProviderInstanceModel([], ProviderInstanceId.make("removed_instance")),
     ).toBeUndefined();
   });
 });

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -15,6 +15,7 @@ function provider(input: {
   enabled?: boolean;
   availability?: ServerProvider["availability"];
   displayName?: string;
+  status?: ServerProvider["status"];
 }): ServerProvider {
   return {
     instanceId: ProviderInstanceId.make(input.instanceId),
@@ -23,7 +24,7 @@ function provider(input: {
     enabled: input.enabled ?? true,
     installed: true,
     version: null,
-    status: "ready",
+    status: input.status ?? "ready",
     ...(input.availability ? { availability: input.availability } : {}),
     auth: { status: "authenticated" },
     checkedAt: "2026-01-01T00:00:00.000Z",
@@ -144,6 +145,34 @@ describe("resolveSelectableProviderInstance", () => {
     ];
 
     expect(resolveSelectableProviderInstance(providers, disabled)).toBe(fallback);
+  });
+
+  it("prefers a ready instance over an enabled one whose driver cannot start", () => {
+    const notInstalled = ProviderInstanceId.make("codex");
+    const ready = ProviderInstanceId.make("claudeAgent");
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: notInstalled,
+        status: "error",
+      }),
+      provider({ provider: ProviderDriverKind.make("claudeAgent"), instanceId: ready }),
+    ];
+
+    expect(resolveSelectableProviderInstance(providers, undefined)).toBe(ready);
+  });
+
+  it("still falls back to an enabled instance when nothing is ready", () => {
+    const notInstalled = ProviderInstanceId.make("codex");
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: notInstalled,
+        status: "error",
+      }),
+    ];
+
+    expect(resolveSelectableProviderInstance(providers, undefined)).toBe(notInstalled);
   });
 
   it("does not return disabled, unavailable, or unknown instances when none are sendable", () => {

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -6,6 +6,7 @@ import {
   getDefaultProviderInstanceModel,
   isProviderInstancePickerReady,
   isProviderInstancePickerVisible,
+  resolveDefaultProviderModelSelection,
   resolveSelectableProviderInstance,
   resolveProviderDriverKindForInstanceSelection,
 } from "./providerInstances";
@@ -35,6 +36,14 @@ function provider(input: {
     skills: [],
   };
 }
+
+const model = (slug: string, isCustom = false, isDefault = false) => ({
+  slug,
+  name: slug,
+  isCustom,
+  ...(isDefault ? { isDefault: true } : {}),
+  capabilities: {},
+});
 
 describe("isProviderInstancePickerReady", () => {
   it("rejects a disabled instance even while its last probe status is ready", () => {
@@ -197,7 +206,7 @@ describe("resolveSelectableProviderInstance", () => {
     expect(resolveSelectableProviderInstance(providers, requested)).toBe(requested);
   });
 
-  it("still falls back to an enabled instance when nothing is ready", () => {
+  it("does not invent an errored instance as a new-user default", () => {
     const notInstalled = ProviderInstanceId.make("codex");
     const providers = [
       provider({
@@ -207,7 +216,7 @@ describe("resolveSelectableProviderInstance", () => {
       }),
     ];
 
-    expect(resolveSelectableProviderInstance(providers, undefined)).toBe(notInstalled);
+    expect(resolveSelectableProviderInstance(providers, undefined)).toBeUndefined();
   });
 
   it("does not return disabled, unavailable, or unknown instances when none are sendable", () => {
@@ -272,13 +281,6 @@ describe("resolveProviderDriverKindForInstanceSelection", () => {
 });
 
 describe("getDefaultProviderInstanceModel", () => {
-  const model = (slug: string, isCustom = false) => ({
-    slug,
-    name: slug,
-    isCustom,
-    capabilities: {},
-  });
-
   it("uses the instance's own models, not the default instance of the kind", () => {
     const providers = [
       provider({
@@ -311,9 +313,150 @@ describe("getDefaultProviderInstanceModel", () => {
     expect(resolved?.length).toBeGreaterThan(0);
   });
 
+  it("honors the instance's declared default before model-list order", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: "claudeAgent",
+        models: [model("claude-sonnet-5"), model("claude-opus-4-8", false, true)],
+      }),
+    ];
+
+    expect(getDefaultProviderInstanceModel(providers, ProviderInstanceId.make("claudeAgent"))).toBe(
+      "claude-opus-4-8",
+    );
+  });
+
   it("returns undefined for an unknown instance", () => {
     expect(
       getDefaultProviderInstanceModel([], ProviderInstanceId.make("removed_instance")),
     ).toBeUndefined();
+  });
+});
+
+describe("resolveDefaultProviderModelSelection", () => {
+  it.each([
+    ["codex", "codex", "gpt-5.6"],
+    ["claudeAgent", "claudeAgent", "claude-fable-5"],
+    ["cursor", "cursor", "composer-2"],
+  ])("uses the only available %s instance", (driver, instanceId, modelSlug) => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make(driver),
+        instanceId,
+        models: [model(modelSlug, false, true)],
+      }),
+    ];
+
+    expect(resolveDefaultProviderModelSelection(providers, null)).toEqual({
+      instanceId,
+      model: modelSlug,
+    });
+  });
+
+  it("preserves a valid stored selection including its options", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: "claudeAgent",
+        models: [model("claude-opus-4-8")],
+      }),
+    ];
+    const stored = {
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      model: "custom-model",
+      options: [{ id: "effort", value: "high" }],
+    };
+
+    expect(resolveDefaultProviderModelSelection(providers, stored)).toBe(stored);
+  });
+
+  it("replaces a stale stored instance with the first ready instance and its model", () => {
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("codex"),
+        instanceId: "codex",
+        status: "warning",
+        models: [model("gpt-5.6")],
+      }),
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: "claudeAgent",
+        models: [model("claude-opus-4-8", false, true)],
+      }),
+    ];
+
+    expect(
+      resolveDefaultProviderModelSelection(providers, {
+        instanceId: ProviderInstanceId.make("removed-provider"),
+        model: "stale-model",
+      }),
+    ).toEqual({ instanceId: "claudeAgent", model: "claude-opus-4-8" });
+  });
+
+  it.each([{ enabled: false }, { availability: "unavailable" as const }])(
+    "replaces an unavailable stored instance deterministically",
+    (requestedState) => {
+      const providers = [
+        provider({
+          provider: ProviderDriverKind.make("codex"),
+          instanceId: "codex",
+          models: [model("gpt-5.6")],
+          ...requestedState,
+        }),
+        provider({
+          provider: ProviderDriverKind.make("claudeAgent"),
+          instanceId: "claudeAgent",
+          models: [model("claude-opus-4-8", false, true)],
+        }),
+      ];
+
+      expect(
+        resolveDefaultProviderModelSelection(providers, {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5.6",
+        }),
+      ).toEqual({ instanceId: "claudeAgent", model: "claude-opus-4-8" });
+    },
+  );
+
+  it("returns no selection for empty, disabled, unavailable, or error-only profiles", () => {
+    expect(resolveDefaultProviderModelSelection([], null)).toBeNull();
+    expect(
+      resolveDefaultProviderModelSelection(
+        [
+          provider({
+            provider: ProviderDriverKind.make("codex"),
+            instanceId: "codex",
+            enabled: false,
+          }),
+        ],
+        null,
+      ),
+    ).toBeNull();
+    expect(
+      resolveDefaultProviderModelSelection(
+        [
+          provider({
+            provider: ProviderDriverKind.make("codex"),
+            instanceId: "codex",
+            availability: "unavailable",
+          }),
+        ],
+        null,
+      ),
+    ).toBeNull();
+    expect(
+      resolveDefaultProviderModelSelection(
+        [
+          provider({
+            provider: ProviderDriverKind.make("codex"),
+            instanceId: "codex",
+            status: "error",
+          }),
+        ],
+        null,
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -13,6 +13,7 @@
  * @module providerInstances
  */
 import {
+  DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
   PROVIDER_DISPLAY_NAMES,
   type ProviderDriverKind,
@@ -254,6 +255,26 @@ export function getProviderInstanceModels(
 }
 
 /**
+ * Default model slug for a specific instance: its first built-in model,
+ * then any model it reports, then the driver-level default. Custom
+ * instances can serve a different model list than the default instance of
+ * the same driver kind, so the lookup must be instance-scoped rather than
+ * kind-scoped.
+ */
+export function getDefaultProviderInstanceModel(
+  providers: ReadonlyArray<ServerProvider>,
+  instanceId: ProviderInstanceId,
+): string | undefined {
+  const entry = getProviderInstanceEntry(providers, instanceId);
+  if (!entry) return undefined;
+  return (
+    entry.models.find((model) => !model.isCustom)?.slug ??
+    entry.models[0]?.slug ??
+    DEFAULT_MODEL_BY_PROVIDER[entry.driverKind]
+  );
+}
+
+/**
  * Resolve the routing key for a selection that may reference an instance
  * id that no longer exists (e.g. a persisted thread selection after the
  * user deleted the custom instance). Returns the first enabled instance
@@ -270,13 +291,16 @@ export function resolveSelectableProviderInstance(
       return instanceId;
     }
   }
-  // Prefer an instance that can actually start a session. An enabled entry
-  // whose driver binary is missing (e.g. the default codex instance on a
-  // machine without the Codex CLI) is "selectable" but every turn on it
-  // fails, so it only wins when nothing is ready.
+  // "ready" instances can start a session right now. "warning" instances
+  // (not probed yet this session, or probed with a degraded result) may
+  // still work. "error" (e.g. the driver CLI is not installed) almost
+  // never starts, so a broken instance is chosen only when nothing else
+  // is configured.
+  const selectable = (entry: ProviderInstanceEntry) => entry.enabled && entry.isAvailable;
   return (
     entries.find(isProviderInstancePickerReady)?.instanceId ??
-    entries.find((entry) => entry.enabled && entry.isAvailable)?.instanceId
+    entries.find((entry) => selectable(entry) && entry.status !== "error")?.instanceId ??
+    entries.find(selectable)?.instanceId
   );
 }
 

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -16,8 +16,9 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
   PROVIDER_DISPLAY_NAMES,
+  type ModelSelection,
   type ProviderDriverKind,
-  type ProviderInstanceId,
+  ProviderInstanceId,
   type ServerProvider,
   type ServerProviderModel,
   type ServerSettings,
@@ -25,6 +26,16 @@ import {
 } from "@t3tools/contracts";
 
 import { formatProviderDriverKindLabel } from "./providerModels";
+
+/**
+ * Local-only placeholder used while a draft has no provider it can safely
+ * target. It must never be persisted or dispatched; the composer disables
+ * send until a live provider replaces it.
+ */
+export const NO_PROVIDER_MODEL_SELECTION: ModelSelection = {
+  instanceId: ProviderInstanceId.make("t3code_no_provider"),
+  model: "",
+};
 
 /**
  * UI-facing projection of one configured provider instance. Carries the
@@ -255,8 +266,8 @@ export function getProviderInstanceModels(
 }
 
 /**
- * Default model slug for a specific instance: its first built-in model,
- * then any model it reports, then the driver-level default. Custom
+ * Default model slug for a specific instance: its declared built-in default,
+ * then its first built-in model, then any model it reports, then the driver-level default. Custom
  * instances can serve a different model list than the default instance of
  * the same driver kind, so the lookup must be instance-scoped rather than
  * kind-scoped.
@@ -268,40 +279,68 @@ export function getDefaultProviderInstanceModel(
   const entry = getProviderInstanceEntry(providers, instanceId);
   if (!entry) return undefined;
   return (
+    entry.models.find((model) => model.isDefault && !model.isCustom)?.slug ??
     entry.models.find((model) => !model.isCustom)?.slug ??
     entry.models[0]?.slug ??
     DEFAULT_MODEL_BY_PROVIDER[entry.driverKind]
   );
 }
 
+const isSelectableProviderInstanceEntry = (entry: ProviderInstanceEntry): boolean =>
+  entry.enabled && entry.isAvailable;
+
+/**
+ * Resolve an exact stored instance when it remains enabled and available.
+ * Otherwise choose a deterministic fallback that can plausibly start now:
+ * ready first, then a non-error probe result. An errored provider is retained
+ * only when it was explicitly requested; it is never invented as a new-user
+ * default.
+ */
+export function resolveSelectableProviderInstanceEntry(
+  entries: ReadonlyArray<ProviderInstanceEntry>,
+  instanceId: ProviderInstanceId | undefined,
+): ProviderInstanceEntry | undefined {
+  if (instanceId !== undefined) {
+    const requested = entries.find((entry) => entry.instanceId === instanceId);
+    if (requested && isSelectableProviderInstanceEntry(requested)) {
+      return requested;
+    }
+  }
+  return (
+    entries.find(isProviderInstancePickerReady) ??
+    entries.find((entry) => isSelectableProviderInstanceEntry(entry) && entry.status !== "error")
+  );
+}
+
 /**
  * Resolve the routing key for a selection that may reference an instance
  * id that no longer exists (e.g. a persisted thread selection after the
- * user deleted the custom instance). Returns the first enabled instance
- * as a fallback so downstream code can still send a turn.
+ * user deleted the custom instance). Returns a ready or non-error fallback,
+ * or `undefined` when no provider can safely become a new selection.
  */
 export function resolveSelectableProviderInstance(
   providers: ReadonlyArray<ServerProvider>,
   instanceId: ProviderInstanceId | undefined,
 ): ProviderInstanceId | undefined {
   const entries = deriveProviderInstanceEntries(providers);
-  if (instanceId !== undefined) {
-    const requested = entries.find((entry) => entry.instanceId === instanceId);
-    if (requested && requested.enabled && requested.isAvailable) {
-      return instanceId;
-    }
-  }
-  // "ready" instances can start a session right now. "warning" instances
-  // (not probed yet this session, or probed with a degraded result) may
-  // still work. "error" (e.g. the driver CLI is not installed) almost
-  // never starts, so a broken instance is chosen only when nothing else
-  // is configured.
-  const selectable = (entry: ProviderInstanceEntry) => entry.enabled && entry.isAvailable;
-  return (
-    entries.find(isProviderInstancePickerReady)?.instanceId ??
-    entries.find((entry) => selectable(entry) && entry.status !== "error")?.instanceId ??
-    entries.find(selectable)?.instanceId
-  );
+  return resolveSelectableProviderInstanceEntry(entries, instanceId)?.instanceId;
+}
+
+/**
+ * Resolve the model selection persisted for a project or new thread. A valid
+ * stored selection is preserved byte-for-byte. Falling back to another
+ * instance also resets the model to that instance's own default, avoiding
+ * cross-provider instance/model pairs.
+ */
+export function resolveDefaultProviderModelSelection(
+  providers: ReadonlyArray<ServerProvider>,
+  selection: ModelSelection | null | undefined,
+): ModelSelection | null {
+  const instanceId = resolveSelectableProviderInstance(providers, selection?.instanceId);
+  if (instanceId === undefined) return null;
+  if (selection?.instanceId === instanceId) return selection;
+  const model = getDefaultProviderInstanceModel(providers, instanceId);
+  return model ? { instanceId, model } : null;
 }
 
 /**

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -263,17 +263,21 @@ export function resolveSelectableProviderInstance(
   providers: ReadonlyArray<ServerProvider>,
   instanceId: ProviderInstanceId | undefined,
 ): ProviderInstanceId | undefined {
-  if (instanceId === undefined) {
-    return deriveProviderInstanceEntries(providers).find(
-      (entry) => entry.enabled && entry.isAvailable,
-    )?.instanceId;
-  }
   const entries = deriveProviderInstanceEntries(providers);
-  const requested = entries.find((entry) => entry.instanceId === instanceId);
-  if (requested && requested.enabled && requested.isAvailable) {
-    return instanceId;
+  if (instanceId !== undefined) {
+    const requested = entries.find((entry) => entry.instanceId === instanceId);
+    if (requested && requested.enabled && requested.isAvailable) {
+      return instanceId;
+    }
   }
-  return entries.find((entry) => entry.enabled && entry.isAvailable)?.instanceId;
+  // Prefer an instance that can actually start a session. An enabled entry
+  // whose driver binary is missing (e.g. the default codex instance on a
+  // machine without the Codex CLI) is "selectable" but every turn on it
+  // fails, so it only wins when nothing is ready.
+  return (
+    entries.find(isProviderInstancePickerReady)?.instanceId ??
+    entries.find((entry) => entry.enabled && entry.isAvailable)?.instanceId
+  );
 }
 
 /**

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
-  DEFAULT_MODEL,
   EnvironmentId,
   ProjectId,
   CommandId,
@@ -138,10 +137,7 @@ describe("add project shared logic", () => {
       title: "repo",
       workspaceRoot: "/work/repo",
       createWorkspaceRootIfMissing: true,
-      defaultModelSelection: {
-        instanceId: "codex",
-        model: DEFAULT_MODEL,
-      },
+      defaultModelSelection: null,
     });
   });
 });

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -7,7 +7,6 @@ import type {
   SourceControlProviderKind,
   SourceControlRepositoryInfo,
 } from "@t3tools/contracts";
-import { DEFAULT_MODEL, ProviderInstanceId } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
@@ -215,10 +214,7 @@ export function buildProjectCreateCommand(input: {
     title: inferProjectTitleFromPath(input.workspaceRoot),
     workspaceRoot: input.workspaceRoot,
     createWorkspaceRootIfMissing: true,
-    defaultModelSelection: {
-      instanceId: ProviderInstanceId.make("codex"),
-      model: DEFAULT_MODEL,
-    },
+    defaultModelSelection: null,
     createdAt: input.createdAt,
   };
 }


### PR DESCRIPTION
## What Changed

- Command palette project creation no longer hard-codes `codex` as the new project's `defaultModelSelection`. It resolves the first usable provider instance (ready → non-error → enabled, then the codex literal), stamps that instance's own default model, and adds the missing `providers` entry to the callback dependencies so the handler does not act on the at-mount provider snapshot.
- The composer's instance resolution falls through to an enabled instance when the persisted instance id is known-but-disabled — but only when an enabled instance satisfies the thread's driver/continuation lock; otherwise the id is kept so the accurate "provider disabled" server error surfaces. Unknown ids (e.g. a custom instance not yet hydrated) are still returned as before. The composer's driver kind now follows the resolved instance, so options and send context stay consistent with the instance that actually runs.
- `resolveSelectableProviderInstance` tiers its fallback by probe status and `getDefaultProviderInstanceModel` provides an instance-scoped default model. Unit tests cover the tiering, requested-instance retention, and the model helper.

## Why

Fixes #4116. New users without Codex get their first palette-created project defaulted to codex, so the first thread fails (`Failed to spawn Codex App Server process` on fresh settings, or `Provider instance 'codex' is disabled in T3 Code settings.` when codex is disabled) and the thread stays permanently pinned to codex. The composer change also lets existing broken threads recover: on the next send they fall through to a working provider.

## UI Changes

Before (thread pinned to codex, turn fails, composer shows the OpenAI icon with a claude model):

![before](https://raw.githubusercontent.com/mfazekas/t3code/issue-4116-assets/repro-desktop-error.png)

After (same flow defaults to the ready Claude instance and the send succeeds):

![after](https://raw.githubusercontent.com/mfazekas/t3code/issue-4116-assets/repro-dev-build-claude-ok.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix default provider selection for users without Codex access
> - Removes hardcoded `codex` as the default provider/model across project creation, the chat composer, and the command palette; new projects now start with `null` for `defaultModelSelection`.
> - Adds `NO_PROVIDER_MODEL_SELECTION` as a sentinel value in [providerInstances.ts](https://github.com/pingdotgg/t3code/pull/4117/files#diff-366ee4ff966b3b9fefcc872cdc0d10484ac52c174b5ed0e8ed59e84e97f58d5b) and new helpers (`resolveDefaultProviderModelSelection`, `resolveSelectableProviderInstanceEntry`, `getDefaultProviderInstanceModel`) that prefer ready/non-error instances and return `null` when no viable provider exists.
> - The chat composer disables send actions and replaces the model picker with a disabled "No provider available" notice when no provider instance is selectable.
> - Behavioral Change: `resolveSelectableProviderInstance` may now return `undefined` instead of always falling back to the first enabled instance, and stored `defaultModelSelection` on new projects is `null` instead of a codex default.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 44b14f4. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default model selection and composer send gating across project creation and chat, but behavior is covered by expanded unit tests and narrows failure modes for misconfigured providers.
> 
> **Overview**
> Stops assuming **Codex** as the default provider when none is configured or available. New projects from the command palette and the low-level `project.create` path now get `defaultModelSelection` from **`resolveDefaultProviderModelSelection`** (first ready instance, then non-error, with that instance’s default model) or **`null`** when nothing is sendable. Draft threads without a project default use a local **`NO_PROVIDER_MODEL_SELECTION`** placeholder instead of inventing Codex.
> 
> **`providerInstances`** gains instance-scoped **`getDefaultProviderInstanceModel`**, tiered **`resolveSelectableProviderInstanceEntry`**, and shared default-resolution logic; errored instances are not auto-picked for new users but can stay selected when explicitly requested.
> 
> The **composer** resolves the active instance via the new helpers (respecting locks), drives UI/send off whether a real provider exists (`providerAvailable`), and blocks send with “Enable a provider in Settings” / “No provider available” when none is available. **`ChatView`** send paths honor `providerAvailable` and drop the Codex fallback in provider resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b14f43d2b8f0123799fa32c44bd8d597b07031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->