### PR TITLE
fix(web): preserve composer focus during browser automation

### DIFF
--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -37,6 +37,7 @@ import {
 import { resolveBrowserRecordingStopTarget } from "~/browser/browserRecordingScope";
 import { useBrowserSurfaceStore } from "~/browser/browserSurfaceStore";
 import { isElectron } from "~/env";
+import { runPreservingDocumentFocus } from "~/lib/documentFocus";
 import { useEnvironments } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
@@ -471,9 +472,11 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           }
           case "press": {
             const ready = await requireReadyTab();
-            return await ready.bridge.automation.press(
-              ready.tabId,
-              request.input as Parameters<typeof ready.bridge.automation.press>[1],
+            return await runPreservingDocumentFocus(() =>
+              ready.bridge.automation.press(
+                ready.tabId,
+                request.input as Parameters<typeof ready.bridge.automation.press>[1],
+              ),
             );
           }
           case "scroll": {

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -10,6 +10,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useComposerDraftStore } from "~/composerDraftStore";
+import { captureDocumentFocus, restoreDocumentFocus } from "~/lib/documentFocus";
 import { previewAnnotationScreenshotFile } from "~/lib/previewAnnotation";
 import { ensureLocalApi } from "~/localApi";
 import {
@@ -468,8 +469,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
     // focus into the guest webContents. We restore it when the pick
     // resolves so the user's typing context isn't lost — otherwise after
     // every pick they'd have to click back into the textarea.
-    const previouslyFocused =
-      typeof document !== "undefined" ? (document.activeElement as HTMLElement | null) : null;
+    const previouslyFocused = captureDocumentFocus();
     pickActiveRef.current = true;
     setPickActive(true);
     void (async () => {
@@ -499,17 +499,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         // Best-effort: restore focus to whatever the user had before the
         // pick stole it into the guest webContents. Skip if the previously-
         // focused element was unmounted or is no longer focusable.
-        if (
-          previouslyFocused &&
-          previouslyFocused.isConnected &&
-          typeof previouslyFocused.focus === "function"
-        ) {
-          try {
-            previouslyFocused.focus({ preventScroll: true });
-          } catch {
-            // Some elements throw on .focus() (detached iframes, etc.).
-          }
-        }
+        restoreDocumentFocus(previouslyFocused);
       }
     })();
   }, [addImage, addPreviewAnnotation, tabId, threadRef]);

--- a/apps/web/src/lib/documentFocus.test.ts
+++ b/apps/web/src/lib/documentFocus.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { runPreservingDocumentFocus } from "./documentFocus";
+
+class MockHTMLElement {
+  isConnected = true;
+  readonly focus = vi.fn();
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const setActiveElement = (activeElement: unknown): void => {
+  vi.stubGlobal("HTMLElement", MockHTMLElement);
+  vi.stubGlobal("document", { activeElement });
+};
+
+describe("document focus", () => {
+  it("restores the active element without scrolling after success", async () => {
+    const element = new MockHTMLElement();
+    setActiveElement(element);
+
+    await expect(runPreservingDocumentFocus(async () => "result")).resolves.toBe("result");
+    expect(element.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("restores the active element after failure", async () => {
+    const element = new MockHTMLElement();
+    const cause = new Error("automation failed");
+    setActiveElement(element);
+
+    await expect(
+      runPreservingDocumentFocus(async () => {
+        throw cause;
+      }),
+    ).rejects.toBe(cause);
+    expect(element.focus).toHaveBeenCalledOnce();
+  });
+
+  it("does not restore a focused element that was detached during the operation", async () => {
+    const element = new MockHTMLElement();
+    setActiveElement(element);
+
+    await runPreservingDocumentFocus(async () => {
+      element.isConnected = false;
+    });
+
+    expect(element.focus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/documentFocus.ts
+++ b/apps/web/src/lib/documentFocus.ts
@@ -1,0 +1,22 @@
+export function captureDocumentFocus(): HTMLElement | null {
+  const activeElement = document.activeElement;
+  return activeElement instanceof HTMLElement && activeElement.isConnected ? activeElement : null;
+}
+
+export function restoreDocumentFocus(element: HTMLElement | null): void {
+  if (!element?.isConnected) return;
+  try {
+    element.focus({ preventScroll: true });
+  } catch {
+    // Focus restoration is best-effort when the element becomes unavailable.
+  }
+}
+
+export async function runPreservingDocumentFocus<T>(operation: () => Promise<T>): Promise<T> {
+  const previouslyFocused = captureDocumentFocus();
+  try {
+    return await operation();
+  } finally {
+    restoreDocumentFocus(previouslyFocused);
+  }
+}


### PR DESCRIPTION
## What Changed

- Preserve the renderer DOM focus around agent browser `press` operations.
- Restore the previously focused element in a `finally` block, including when automation fails.
- Reuse the same best-effort focus helper in the existing element-picker flow.
- Add coverage for success, failure, and detached-element cleanup.

## Why

Native browser key dispatch temporarily focuses Electron’s guest `WebContents`. The main process restores the outer renderer afterward, but not its active DOM element, so the composer stays blurred and interrupts users typing queued follow-ups while the agent works. This restores the prompt editor without changing the guest-focus behavior required by browser automation.

## UI Changes

Behavior-only fix; there are no visual changes. Before this change, an agent browser key press leaves the composer unfocused. Afterward, the same editor regains focus without scrolling.

## Validation

- `vp check` (0 errors; 10 pre-existing warnings)
- `vp run typecheck`
- Web unit suite: 152 files / 1,321 tests passed
- Focus regression test: 3 tests passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there is no visual change
- [ ] Interaction video not included

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized renderer UX fix with best-effort focus restoration and no changes to auth, data, or automation semantics beyond wrapping `press`.
> 
> **Overview**
> Adds shared **`documentFocus`** helpers that snapshot the renderer’s active element and restore it with `focus({ preventScroll: true })` in a `finally` block, skipping detached or invalid targets.
> 
> **Agent browser `press`** in `PreviewAutomationHosts` now runs inside `runPreservingDocumentFocus` so guest `WebContents` key dispatch no longer leaves the chat composer blurred while the user types follow-ups.
> 
> The **element-picker** flow in `PreviewView` uses the same capture/restore helpers instead of inline focus logic. Unit tests cover success, failure, and detached-element cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae438257b847299da768747a09b3c2f2a39e8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve composer focus during browser automation press actions
> - Extracts focus capture/restore logic into a new `documentFocus` utility module ([documentFocus.ts](https://github.com/pingdotgg/t3code/pull/4118/files#diff-a0d6ede48531933fa1ab6dcae26cee94c43ce1a60a534ae81a27a9fdd5796f02)) with `captureDocumentFocus`, `restoreDocumentFocus`, and `runPreservingDocumentFocus` helpers.
> - Wraps the `press` automation action in [PreviewAutomationHosts.tsx](https://github.com/pingdotgg/t3code/pull/4118/files#diff-8244d1ca34cc1e3ae2b642df57ee711f79d00c5a2af9b56bd852e3f093fed097) with `runPreservingDocumentFocus` so the previously focused element is restored after the operation completes or fails.
> - Replaces manual focus snapshot/restore in [PreviewView.tsx](https://github.com/pingdotgg/t3code/pull/4118/files#diff-c02d770e873143915b2b12f22b2539bd0111c82465ae9e385583be2391fbcad5) with the new shared helpers.
> - Adds a unit test suite in [documentFocus.test.ts](https://github.com/pingdotgg/t3code/pull/4118/files#diff-ba24e0da191d612ffe154edae4358b0725a5f426d5406ead612922b33dc799a0) covering success, failure, and detached-element cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ae4382.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->