### PR TITLE
fix(server): absorb unknown Claude SDK messages instead of work-log warnings

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -931,6 +931,103 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "absorbs unknown SDK message types and system subtypes without work-log warnings",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        const turn = yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "hello",
+          attachments: [],
+        });
+
+        // Top-level SDK message type this build does not model (emitted by
+        // Claude CLI >= ~2.1.2xx). Must be absorbed silently.
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: "d5375ed5-741a-4371-83c4-ed59ad75ced3",
+          state: "running",
+          session_id: "sdk-session-1",
+          uuid: "lifecycle-1",
+        } as unknown as SDKMessage);
+
+        // System message subtypes this build does not model. Same posture.
+        harness.query.emit({
+          type: "system",
+          subtype: "background_tasks_changed",
+          session_id: "sdk-session-1",
+          uuid: "system-unknown-1",
+        } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "system",
+          subtype: "commands_changed",
+          session_id: "sdk-session-1",
+          uuid: "system-unknown-2",
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-1",
+          uuid: "assistant-1",
+          parent_tool_use_id: null,
+          message: {
+            id: "assistant-message-1",
+            content: [{ type: "text", text: "Hi" }],
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-1",
+          uuid: "result-1",
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        // The unknown messages contribute no events at all — in particular no
+        // "runtime.warning" work-log rows — and the turn still completes.
+        assert.deepEqual(
+          runtimeEvents.map((event) => event.type),
+          [
+            "session.started",
+            "session.configured",
+            "session.state.changed",
+            "turn.started",
+            "thread.started",
+            "content.delta",
+            "item.completed",
+            "turn.completed",
+          ],
+        );
+        const turnCompleted = runtimeEvents[runtimeEvents.length - 1];
+        assert.equal(turnCompleted?.type, "turn.completed");
+        if (turnCompleted?.type === "turn.completed") {
+          assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+          assert.equal(turnCompleted.payload.state, "completed");
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("steers a running turn instead of opening a new one on mid-turn sendTurn", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1263,52 +1263,6 @@ function sdkNativeMethod(message: SDKMessage): string {
   return `claude/${message.type}`;
 }
 
-// Discriminator/identity keys carry no human-readable content; everything else
-// on an unmodeled SDK message is potentially worth surfacing in the work log.
-const SDK_MESSAGE_NOISE_KEYS = new Set([
-  "type",
-  "subtype",
-  "uuid",
-  "parent_uuid",
-  "session_id",
-  "parent_tool_use_id",
-  "request_id",
-]);
-
-// Pull the salient scalar content out of a message the adapter doesn't model
-// yet, so the work-log row shows what actually arrived (e.g. a notification's
-// text) instead of an opaque "unhandled subtype" placeholder. Nested structures
-// are left to the full payload retained in the event's `detail`.
-function previewUnknownSdkContent(message: unknown): string | undefined {
-  if (!message || typeof message !== "object") {
-    return undefined;
-  }
-  const parts: string[] = [];
-  for (const [key, value] of Object.entries(message as Record<string, unknown>)) {
-    if (SDK_MESSAGE_NOISE_KEYS.has(key)) {
-      continue;
-    }
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (trimmed.length > 0) {
-        parts.push(`${key}: ${trimmed}`);
-      }
-    } else if (typeof value === "number" || typeof value === "boolean") {
-      parts.push(`${key}: ${String(value)}`);
-    }
-  }
-  if (parts.length === 0) {
-    return undefined;
-  }
-  const joined = parts.join(" · ");
-  return joined.length > 280 ? `${joined.slice(0, 279)}…` : joined;
-}
-
-function describeUnknownSdkMessage(kind: string, message: unknown): string {
-  const preview = previewUnknownSdkContent(message);
-  return preview ? `${kind} — ${preview}` : `${kind} (no displayable text content)`;
-}
-
 function sdkNativeItemId(message: SDKMessage): string | undefined {
   if (message.type === "assistant") {
     const maybeId = (message.message as { id?: unknown }).id;
@@ -1702,28 +1656,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         message,
         class: "provider_error",
         ...(cause !== undefined ? { detail: cause } : {}),
-      },
-      providerRefs: nativeProviderRefs(context),
-    });
-  });
-
-  const emitRuntimeWarning = Effect.fn("emitRuntimeWarning")(function* (
-    context: ClaudeSessionContext,
-    message: string,
-    detail?: unknown,
-  ) {
-    const turnState = context.turnState;
-    const stamp = yield* makeEventStamp();
-    yield* offerRuntimeEvent({
-      type: "runtime.warning",
-      eventId: stamp.eventId,
-      provider: PROVIDER,
-      createdAt: stamp.createdAt,
-      threadId: context.session.threadId,
-      ...(turnState ? { turnId: asCanonicalTurnId(turnState.turnId) } : {}),
-      payload: {
-        message,
-        ...(detail !== undefined ? { detail } : {}),
       },
       providerRefs: nativeProviderRefs(context),
     });
@@ -2761,11 +2693,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         );
         return;
       default:
-        yield* emitRuntimeWarning(
-          context,
-          describeUnknownSdkMessage(`Claude system message '${message.subtype}'`, message),
-          message,
-        );
+        // Newer Claude CLI releases emit system subtypes this build does not
+        // know (97 distinct subtypes in CLI 2.1.211 vs the handful handled
+        // above). Unknown members degrade gracefully: no user-visible work-log
+        // row, just a debug log for diagnostics.
+        yield* Effect.logDebug("claude.sdk.system.unknown", {
+          subtype: message.subtype,
+          threadId: context.session.threadId,
+        });
         return;
     }
   });
@@ -2875,11 +2810,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         yield* handleSdkTelemetryMessage(context, message);
         return;
       default:
-        yield* emitRuntimeWarning(
-          context,
-          describeUnknownSdkMessage(`Claude SDK message '${message.type}'`, message),
-          message,
-        );
+        // Same forward-compat posture as unknown system subtypes: newer CLIs
+        // add top-level message types (command_lifecycle, audit_event, ...);
+        // absorb them silently instead of alarming the work log.
+        yield* Effect.logDebug("claude.sdk.message.unknown", {
+          messageType: (message as { type: string }).type,
+          threadId: context.session.threadId,
+        });
         return;
     }
   });


### PR DESCRIPTION
## Problem

Recent Claude Code CLI releases (≥ ~2.1.2xx) emit Claude Agent SDK message types and system subtypes that `ClaudeAdapter` doesn't model — e.g. top-level `command_lifecycle` and system subtypes `background_tasks_changed` / `commands_changed`. Each unknown message renders a red ✗ `runtime.warning` row in the thread Work Log:

> ✗ Claude SDK message 'command_lifecycle' — command_uuid: … · state: …
> ✗ Claude system message 'background_tasks_changed' (no displayable text content)

These fire on essentially every turn with a current CLI, and they read as failures even though the turn completes normally. The set of unmodeled events keeps growing: CLI 2.1.211 ships **97 distinct system subtypes** (vs 13 handled by the adapter), so enumerating cases is a losing game.

## Fix

Treat unknown message types/subtypes the way the contracts layer already treats unknown drivers (see `providerInstance.ts` forward-compat notes): degrade gracefully. The two unknown-message default branches now emit `Effect.logDebug` (`claude.sdk.message.unknown` / `claude.sdk.system.unknown`) instead of a user-visible `runtime.warning`. The `emitRuntimeWarning` helper and the unknown-message preview utilities had no other consumers and are removed.

Genuinely important events (`permission_denied`, `mirror_error`, `result` errors, …) remain explicitly handled and visible.

## Testing

- New adapter regression test: emits `command_lifecycle` + `background_tasks_changed` + `commands_changed` mid-turn and asserts the exact runtime-event sequence contains no `runtime.warning` and the turn completes.
- `apps/server` suite: 1408 passed / 160 files; typecheck/lint/fmt clean; no existing assertions modified.
- Manual: live dev-app turn on CLI 2.1.211 — Work Log shows only real tool rows, no red unknown-message rows (previously reproduced on every turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX/observability change in Claude adapter forward-compat paths; explicitly handled errors remain visible and behavior is covered by a new regression test.
> 
> **Overview**
> **Stops treating unmodeled Claude Agent SDK traffic as user-visible failures** in the thread Work Log.
> 
> `ClaudeAdapter` no longer emits `runtime.warning` for unknown top-level message types (e.g. `command_lifecycle`) or unknown `system` subtypes (e.g. `background_tasks_changed`). Those paths now **log at debug** (`claude.sdk.message.unknown` / `claude.sdk.system.unknown`) and are ignored for runtime events. The `emitRuntimeWarning` helper and unknown-message preview/describe utilities are removed as unused.
> 
> Explicit handling for real errors and important system events is unchanged. A new adapter test asserts mid-turn unknown messages produce **no** `runtime.warning` and the turn still completes normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8c067af1f702b6bdbf76537d95669ac7765c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Absorb unknown Claude SDK message types silently instead of emitting work-log warnings
> Unknown top-level SDK message types and unrecognized `system` subtypes previously emitted `runtime.warning` events to the runtime event queue. They now log a debug entry (`claude.sdk.message.unknown` or `claude.sdk.system.unknown`) and are otherwise absorbed silently. The warning-related helpers (`emitRuntimeWarning`, `describeUnknownSdkMessage`, `previewUnknownSdkContent`, `SDK_MESSAGE_NOISE_KEYS`) are removed from [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/4119/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc). Behavioral Change: consumers that relied on `runtime.warning` events to detect unmodeled SDK messages will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c8c067.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->