### PR TITLE
feat(packaging): maintain AUR packages in-repo

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,65 @@
+name: Publish AUR package
+
+# See packaging/aur/README.md.
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      pkgrel:
+        required: false
+        default: "1"
+        type: string
+    secrets:
+      AUR_SSH_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish"
+        required: true
+        type: string
+      pkgrel:
+        description: "Arch package release override"
+        required: false
+        default: "1"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-aur
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Validate and publish
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
+    container:
+      image: archlinux:base-devel
+
+    steps:
+      - name: Install Arch packaging tools
+        run: pacman -Syu --noconfirm --needed git github-cli jq namcap openssh sudo
+
+      - name: Checkout packaging sources
+        uses: actions/checkout@v6
+
+      - name: Create unprivileged build user
+        run: |
+          useradd --create-home builder
+          install -Dm0440 /dev/stdin /etc/sudoers.d/builder <<'EOF'
+          builder ALL=(root) NOPASSWD: /usr/bin/pacman
+          EOF
+
+      - name: Validate and publish package sources
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          PKGREL: ${{ inputs.pkgrel || '1' }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: packaging/aur/scripts/release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -856,6 +856,16 @@ jobs:
           fail_on_unmatched_files: true
           token: ${{ github.token }}
 
+  publish_aur:
+    name: Publish AUR package
+    needs: [preflight, release]
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.release.result == 'success' }}
+    uses: ./.github/workflows/publish-aur.yml
+    with:
+      release_tag: ${{ needs.preflight.outputs.tag }}
+    secrets:
+      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+
   deploy_web:
     name: Deploy hosted web app
     needs: [preflight, relay_public_config, release]

--- a/README.md
+++ b/README.md
@@ -51,9 +51,19 @@ brew install --cask t3-code
 
 #### Arch Linux (AUR)
 
+Stable:
+
 ```bash
 yay -S t3code-bin
 ```
+
+Nightly:
+
+```bash
+yay -S t3code-nightly-bin
+```
+
+The AUR packaging is maintained in this repository under [`packaging/aur`](./packaging/aur).
 
 ## Some notes
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -37,8 +37,16 @@ brew install --cask t3-code
 
 Arch Linux:
 
+Stable:
+
 ```bash
 yay -S t3code-bin
+```
+
+Nightly:
+
+```bash
+yay -S t3code-nightly-bin
 ```
 
 ## Providers

--- a/packaging/aur/.gitignore
+++ b/packaging/aur/.gitignore
@@ -1,0 +1,9 @@
+src/
+pkg/
+*.AppImage
+*.pkg.tar.zst
+.SRCINFO
+t3code-bin-*.png
+t3code-bin-*-LICENSE
+t3code-nightly-bin-*.png
+t3code-nightly-bin-*-LICENSE

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,20 @@
+# AUR packaging
+
+This directory maintains the [`t3code-bin`](https://aur.archlinux.org/packages/t3code-bin) and
+[`t3code-nightly-bin`](https://aur.archlinux.org/packages/t3code-nightly-bin) packages. Both
+repackage the official x86_64 AppImage from GitHub Releases.
+
+## Publishing
+
+The release workflow calls `.github/workflows/publish-aur.yml` after publishing a GitHub release;
+the workflow can also be run manually for a specific tag. It selects the stable or nightly
+package, then updates its version and checksums, builds it, regenerates `.SRCINFO`, and pushes it
+to the AUR.
+
+To validate a release on Arch Linux:
+
+```bash
+sudo pacman -Syu --needed base-devel github-cli jq namcap
+GH_TOKEN=$(gh auth token) RELEASE_TAG=v0.0.33 \
+  packaging/aur/scripts/release.sh
+```

--- a/packaging/aur/scripts/release.sh
+++ b/packaging/aur/scripts/release.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+repo='pingdotgg/t3code'
+tag="${RELEASE_TAG:?RELEASE_TAG is required}"
+pkgrel="${PKGREL:-1}"
+
+if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  pkgname='t3code-bin'
+  icon_path='assets/prod/black-universal-1024.png'
+elif [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}\.[0-9]+$ ]]; then
+  pkgname='t3code-nightly-bin'
+  icon_path='assets/nightly/nightly-universal-1024.png'
+else
+  echo "Release $tag does not publish an AUR package."
+  exit 0
+fi
+
+version="${tag#v}"
+pkgver="${version//-/_}"
+asset_name="T3-Code-${version}-x86_64.AppImage"
+release_json="$(gh api "repos/$repo/releases/tags/$tag")"
+asset_digest="$(jq -r --arg name "$asset_name" \
+  '.assets[] | select(.name == $name) | .digest' <<<"$release_json")"
+appimage_sha256="${asset_digest#sha256:}"
+
+if [[ ! "$appimage_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Release $tag is missing $asset_name or its SHA-256 digest." >&2
+  exit 1
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf -- "$work_dir"' EXIT
+gh api -H 'Accept: application/vnd.github.raw' \
+  "repos/$repo/contents/$icon_path?ref=$tag" > "$work_dir/icon.png"
+gh api -H 'Accept: application/vnd.github.raw' \
+  "repos/$repo/contents/LICENSE?ref=$tag" > "$work_dir/LICENSE"
+icon_sha256="$(sha256sum "$work_dir/icon.png" | awk '{print $1}')"
+license_sha256="$(sha256sum "$work_dir/LICENSE" | awk '{print $1}')"
+
+package_dir="$repo_root/packaging/aur/$pkgname"
+cd "$package_dir"
+sed -Ei \
+  -e "s/^pkgver=.*/pkgver=$pkgver/" \
+  -e "s/^pkgrel=.*/pkgrel=$pkgrel/" \
+  -e "/# AppImage$/s/'[0-9a-f]{64}'/'$appimage_sha256'/" \
+  -e "/# icon$/s/'[0-9a-f]{64}'/'$icon_sha256'/" \
+  -e "/# upstream license$/s/'[0-9a-f]{64}'/'$license_sha256'/" \
+  PKGBUILD
+
+run_as_builder() {
+  if [[ "$(id -u)" == 0 ]]; then
+    runuser -u builder -- "$@"
+  else
+    "$@"
+  fi
+}
+
+if [[ "$(id -u)" == 0 ]]; then
+  chown -R builder:builder "$package_dir"
+fi
+run_as_builder namcap PKGBUILD
+run_as_builder makepkg --printsrcinfo > .SRCINFO
+run_as_builder makepkg --syncdeps --cleanbuild --clean --noconfirm
+run_as_builder namcap "$(run_as_builder makepkg --packagelist)"
+
+if [[ -z "${AUR_SSH_PRIVATE_KEY:-}" ]]; then
+  echo 'AUR_SSH_PRIVATE_KEY is not set; build complete, skipping publish.'
+  exit 0
+fi
+
+key_file="$work_dir/id_ed25519"
+known_hosts_file="$work_dir/known_hosts"
+aur_dir="$work_dir/$pkgname"
+printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$key_file"
+chmod 600 "$key_file"
+printf '%s\n' \
+  'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN' \
+  > "$known_hosts_file"
+export GIT_SSH_COMMAND="ssh -i $key_file -o IdentitiesOnly=yes -o UserKnownHostsFile=$known_hosts_file -o StrictHostKeyChecking=yes"
+
+git clone "ssh://aur@aur.archlinux.org/$pkgname.git" "$aur_dir"
+cp PKGBUILD .SRCINFO "$aur_dir/"
+cd "$aur_dir"
+git rm --ignore-unmatch LICENSE .upstream-commit t3code-icon.png
+git config user.name 't3code-ci'
+git config user.email 't3code-ci@users.noreply.github.com'
+git add -A
+
+if git diff --cached --quiet; then
+  echo 'AUR package is already up to date.'
+  exit 0
+fi
+
+git commit -m "$pkgname: update to $pkgver-$pkgrel"
+git push origin HEAD:master

--- a/packaging/aur/t3code-bin/PKGBUILD
+++ b/packaging/aur/t3code-bin/PKGBUILD
@@ -1,0 +1,101 @@
+# Maintainer: maria-rcks <maria at kuuro dot net>
+
+pkgname=t3code-bin
+pkgver=0.0.33
+pkgrel=1
+pkgdesc='Desktop control surface for local coding agents'
+arch=('x86_64')
+url='https://github.com/pingdotgg/t3code'
+license=('MIT')
+depends=(
+  'alsa-lib'
+  'at-spi2-core'
+  'cairo'
+  'dbus'
+  'expat'
+  'gdk-pixbuf2'
+  'glib2'
+  'glibc'
+  'gtk3'
+  'hicolor-icon-theme'
+  'libcups'
+  'libdrm'
+  'libgcc'
+  'libstdc++'
+  'libx11'
+  'libxcb'
+  'libxcomposite'
+  'libxdamage'
+  'libxext'
+  'libxfixes'
+  'libxkbcommon'
+  'libxrandr'
+  'mesa'
+  'nspr'
+  'nss'
+  'pango'
+  'systemd-libs'
+  'xdg-utils'
+  'zlib'
+)
+optdepends=('openai-codex: use the system-installed Codex CLI')
+provides=("t3code=$pkgver")
+conflicts=('t3code')
+options=('!debug' '!strip')
+
+_appimage="T3-Code-${pkgver}-x86_64.AppImage"
+source=(
+  "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${pkgver}/$_appimage"
+  "${pkgname}-${pkgver}.png::https://raw.githubusercontent.com/pingdotgg/t3code/v${pkgver}/assets/prod/black-universal-1024.png"
+  "${pkgname}-${pkgver}-LICENSE::https://raw.githubusercontent.com/pingdotgg/t3code/v${pkgver}/LICENSE"
+)
+sha256sums=(
+  '415c8648f43c3d22d572f27f2c50fdc8c310ea7fcde9537b903e1e2f1c8775a1' # AppImage
+  '403e874556ffbecee8d1b2b5d612a874303fac791212a261bb3bd1b71d83e78d' # icon
+  '935d8f2af0c703f9c39517ee57cc4930b19d02d533be930b63f0e82f93614b43' # upstream license
+)
+
+prepare() {
+  chmod +x "$srcdir/$_appimage"
+  rm -rf "$srcdir/squashfs-root"
+  "$srcdir/$_appimage" --appimage-extract >/dev/null
+
+  if [[ ! -x "$srcdir/squashfs-root/AppRun" ||
+        ! -f "$srcdir/squashfs-root/chrome-sandbox" ]]; then
+    echo 'The AppImage payload is missing its launcher or Chromium sandbox.' >&2
+    return 1
+  fi
+}
+
+package() {
+  install -d "$pkgdir/opt/$pkgname"
+  cp -a --no-preserve=ownership "$srcdir/squashfs-root/." "$pkgdir/opt/$pkgname/"
+  chmod -R u=rwX,go=rX "$pkgdir/opt/$pkgname"
+  chmod 4755 "$pkgdir/opt/$pkgname/chrome-sandbox"
+
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/t3code" <<'EOF'
+#!/bin/sh
+exec /opt/t3code-bin/AppRun "$@"
+EOF
+  ln -s t3code "$pkgdir/usr/bin/t3-code-desktop"
+
+  install -Dm644 "$srcdir/${pkgname}-${pkgver}.png" \
+    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3code.png"
+
+  install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/t3code.desktop" <<'EOF'
+[Desktop Entry]
+Name=T3 Code
+Comment=Desktop control surface for local coding agents
+Exec=t3code %U
+TryExec=t3code
+Terminal=false
+Type=Application
+Icon=t3code
+StartupWMClass=t3code
+Categories=Development;
+MimeType=x-scheme-handler/t3code;
+EOF
+
+  install -Dm644 "$srcdir/${pkgname}-${pkgver}-LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/t3code-nightly-bin/PKGBUILD
+++ b/packaging/aur/t3code-nightly-bin/PKGBUILD
@@ -1,0 +1,102 @@
+# Maintainer: maria-rcks <maria at kuuro dot net>
+
+pkgname=t3code-nightly-bin
+pkgver=0.0.34_nightly.20260814.1095
+pkgrel=1
+pkgdesc='Nightly desktop control surface for local coding agents'
+arch=('x86_64')
+url='https://github.com/pingdotgg/t3code'
+license=('MIT')
+depends=(
+  'alsa-lib'
+  'at-spi2-core'
+  'cairo'
+  'dbus'
+  'expat'
+  'gdk-pixbuf2'
+  'glib2'
+  'glibc'
+  'gtk3'
+  'hicolor-icon-theme'
+  'libcups'
+  'libdrm'
+  'libgcc'
+  'libstdc++'
+  'libx11'
+  'libxcb'
+  'libxcomposite'
+  'libxdamage'
+  'libxext'
+  'libxfixes'
+  'libxkbcommon'
+  'libxrandr'
+  'mesa'
+  'nspr'
+  'nss'
+  'pango'
+  'systemd-libs'
+  'xdg-utils'
+  'zlib'
+)
+optdepends=('openai-codex: use the system-installed Codex CLI')
+provides=("t3code-nightly=$pkgver")
+conflicts=('t3code-nightly' 't3code')
+options=('!debug' '!strip')
+
+_upstream_version="${pkgver/_nightly./-nightly.}"
+_appimage="T3-Code-${_upstream_version}-x86_64.AppImage"
+source=(
+  "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${_upstream_version}/$_appimage"
+  "${pkgname}-${pkgver}.png::https://raw.githubusercontent.com/pingdotgg/t3code/v${_upstream_version}/assets/nightly/nightly-universal-1024.png"
+  "${pkgname}-${pkgver}-LICENSE::https://raw.githubusercontent.com/pingdotgg/t3code/v${_upstream_version}/LICENSE"
+)
+sha256sums=(
+  'c4dea5bba9ed0b51b2f60f2d4a4867e61d62b57c50ea66f2792a73112e054566' # AppImage
+  '7e59b6394016ef83ed1e946847769e01bf36d4062c5c5af2577fd3e228285fd9' # icon
+  '935d8f2af0c703f9c39517ee57cc4930b19d02d533be930b63f0e82f93614b43' # upstream license
+)
+
+prepare() {
+  chmod +x "$srcdir/$_appimage"
+  rm -rf "$srcdir/squashfs-root"
+  "$srcdir/$_appimage" --appimage-extract >/dev/null
+
+  if [[ ! -x "$srcdir/squashfs-root/AppRun" ||
+        ! -f "$srcdir/squashfs-root/chrome-sandbox" ]]; then
+    echo 'The AppImage payload is missing its launcher or Chromium sandbox.' >&2
+    return 1
+  fi
+}
+
+package() {
+  install -d "$pkgdir/opt/$pkgname"
+  cp -a --no-preserve=ownership "$srcdir/squashfs-root/." "$pkgdir/opt/$pkgname/"
+  chmod -R u=rwX,go=rX "$pkgdir/opt/$pkgname"
+  chmod 4755 "$pkgdir/opt/$pkgname/chrome-sandbox"
+
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/t3code-nightly" <<'EOF'
+#!/bin/sh
+exec /opt/t3code-nightly-bin/AppRun "$@"
+EOF
+  ln -s t3code-nightly "$pkgdir/usr/bin/t3-code-nightly-desktop"
+
+  install -Dm644 "$srcdir/${pkgname}-${pkgver}.png" \
+    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3code-nightly.png"
+
+  install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/t3code.desktop" <<'EOF'
+[Desktop Entry]
+Name=T3 Code Nightly
+Comment=Nightly desktop control surface for local coding agents
+Exec=t3code-nightly %U
+TryExec=t3code-nightly
+Terminal=false
+Type=Application
+Icon=t3code-nightly
+StartupWMClass=t3code
+Categories=Development;
+MimeType=x-scheme-handler/t3code;
+EOF
+
+  install -Dm644 "$srcdir/${pkgname}-${pkgver}-LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
## Summary

- add upstream-maintained AUR recipes for `t3code-bin` and `t3code-nightly-bin`
- call the reusable AUR publisher from the existing Release workflow after each stable or nightly release
- support manual publishing for a specific release tag and `pkgrel`
- validate release assets, build with `makepkg`, regenerate `.SRCINFO`, and push to the AUR
- document stable and nightly installation commands

This keeps the existing AUR packages synchronized with T3 Code releases without a separate packaging repository.

## Validation

- `actionlint`
- `shellcheck packaging/aur/scripts/release.sh`
- Bash syntax and PKGBUILD metadata checks
- stable and nightly release checksums verified against GitHub
- repository CI: Check, Test, Mobile Native Static Analysis, and Release Smoke

Implemented with GPT-5.6 Sol in T3 Code using the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add AUR package definitions and release workflow for t3code-bin and t3code-nightly-bin
> - Adds `PKGBUILD` files for `t3code-bin` and `t3code-nightly-bin` under [`packaging/aur/`](https://github.com/pingdotgg/t3code/pull/4128/files#diff-976515658bf20a7943085a2e20cd941959ce61b23415460d75038739a93d8f9c), packaging the x86_64 AppImage with a CLI wrapper, desktop entry, icon, and suid chrome-sandbox.
> - Adds [`packaging/aur/scripts/release.sh`](https://github.com/pingdotgg/t3code/pull/4128/files#diff-95dd0840eed48d9bf92e26e60c9ef91b786639bcce7784b829c13ee36f66d4b3) to fetch the release AppImage, update `PKGBUILD` checksums/versions, validate with `namcap`, build with `makepkg`, and push to the AUR Git repo when `AUR_SSH_PRIVATE_KEY` is set.
> - Adds a reusable GitHub Actions workflow [`publish-aur.yml`](https://github.com/pingdotgg/t3code/pull/4128/files#diff-a358425bd1f9c45824a666a9bec55cf63682a3d3f661596ef90355e8d07f4018) and wires it into the release pipeline via a new `publish_aur` job that runs after a successful release.
> - Updates `README.md` and `docs/user/install.md` with `yay`-based install instructions for both stable and nightly AUR packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c715fb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release automation uses SSH credentials to push to the AUR and installs packages with setuid chrome-sandbox; mistakes could publish bad checksums or break Arch installs.
> 
> **Overview**
> Moves **stable** (`t3code-bin`) and **nightly** (`t3code-nightly-bin`) AUR packaging into `packaging/aur`, with PKGBUILDs that repackage the official x86_64 AppImage (launcher, desktop entry, setuid `chrome-sandbox`).
> 
> Adds `packaging/aur/scripts/release.sh` to pick the package from the release tag, refresh `pkgver`/`pkgrel` and checksums from GitHub, run `namcap`/`makepkg`, and push `PKGBUILD` + `.SRCINFO` to the AUR when `AUR_SSH_PRIVATE_KEY` is set.
> 
> Wires a reusable **`publish-aur.yml`** workflow (Arch `base-devel` container, unprivileged builder) into **`release.yml`** after the GitHub release step, with manual `workflow_dispatch` support for tag and `pkgrel`. README and install docs now document separate stable and nightly `yay` commands and point at `packaging/aur`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c715fb33c0de97ffa58d745d6649cdd2ee2a1ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->