### PR TITLE
Refresh turn checkpoints at completion

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -420,6 +420,44 @@ describe("CheckpointReactor", () => {
     };
   }
 
+  async function createEarlyCheckpointHarness() {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const turnId = asTurnId("turn-1");
+    const checkpointRef = checkpointRefForThreadTurn(threadId, 1);
+    const capturedAt = "2026-01-01T00:01:00.000Z";
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-early-checkpoint"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId,
+      turnId,
+    });
+    await waitForGitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0));
+
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-placeholder-early-checkpoint"),
+        threadId,
+        turnId,
+        completedAt: capturedAt,
+        checkpointRef,
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt: capturedAt,
+      }),
+    );
+    await harness.drain();
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v2\n");
+
+    return { harness, threadId, turnId, checkpointRef, capturedAt };
+  }
+
   it("captures pre-turn baseline on turn.started and post-turn checkpoint on turn.completed", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = "2026-01-01T00:00:00.000Z";
@@ -497,38 +535,7 @@ describe("CheckpointReactor", () => {
   });
 
   it("refreshes an early checkpoint when the turn completes", async () => {
-    const harness = await createHarness({ seedFilesystemCheckpoints: false });
-    const threadId = ThreadId.make("thread-1");
-    const turnId = asTurnId("turn-1");
-    const checkpointRef = checkpointRefForThreadTurn(threadId, 1);
-
-    harness.provider.emit({
-      type: "turn.started",
-      eventId: EventId.make("evt-turn-started-refresh"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: "2026-01-01T00:00:00.000Z",
-      threadId,
-      turnId,
-    });
-    await waitForGitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0));
-
-    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-placeholder-refresh"),
-        threadId,
-        turnId,
-        completedAt: "2026-01-01T00:01:00.000Z",
-        checkpointRef,
-        status: "missing",
-        files: [],
-        checkpointTurnCount: 1,
-        createdAt: "2026-01-01T00:01:00.000Z",
-      }),
-    );
-    await harness.drain();
-    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v2\n");
+    const { harness, threadId, turnId, checkpointRef } = await createEarlyCheckpointHarness();
 
     NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v3\n", "utf8");
     const completedAt = "2026-01-01T00:02:00.000Z";
@@ -564,6 +571,38 @@ describe("CheckpointReactor", () => {
 
     expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v3\n");
   });
+
+  it.each(["cancelled", "interrupted"] as const)(
+    "preserves an early ready checkpoint when completion is %s",
+    async (state) => {
+      const { harness, threadId, turnId, checkpointRef, capturedAt } =
+        await createEarlyCheckpointHarness();
+      const snapshotBefore = await harness.readModel();
+      const checkpointBefore = snapshotBefore.threads
+        .find((entry) => entry.id === threadId)
+        ?.checkpoints.find((checkpoint) => checkpoint.turnId === turnId);
+
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v3\n", "utf8");
+      harness.provider.emit({
+        type: "turn.completed",
+        eventId: EventId.make(`evt-turn-completed-${state}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:02:00.000Z",
+        threadId,
+        turnId,
+        payload: { state },
+      });
+      await harness.drain();
+
+      expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v2\n");
+      const snapshotAfter = await harness.readModel();
+      const checkpointAfter = snapshotAfter.threads
+        .find((entry) => entry.id === threadId)
+        ?.checkpoints.find((checkpoint) => checkpoint.turnId === turnId);
+      expect(checkpointBefore?.completedAt).toBe(capturedAt);
+      expect(checkpointAfter).toEqual(checkpointBefore);
+    },
+  );
 
   it("refreshes local git status state on turn completion using the session cwd", async () => {
     const gitStatusRefreshCalls: string[] = [];

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -280,6 +280,7 @@ describe("CheckpointReactor", () => {
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderDriverKind;
     readonly gitStatusRefreshCalls?: Array<string>;
+    readonly startReactor?: boolean;
   }) {
     const cwd = createGitRepository();
     tempDirs.push(cwd);
@@ -350,8 +351,12 @@ describe("CheckpointReactor", () => {
     const checkpointStore = await runtime.runPromise(
       Effect.service(CheckpointStore.CheckpointStore),
     );
-    scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
+    const reactorScope = await Effect.runPromise(Scope.make("sequential"));
+    scope = reactorScope;
+    const start = () => Effect.runPromise(reactor.start().pipe(Scope.provide(reactorScope)));
+    if (options?.startReactor ?? true) {
+      await start();
+    }
     const drain = () => Effect.runPromise(reactor.drain);
 
     const createdAt = "2026-01-01T00:00:00.000Z";
@@ -416,6 +421,7 @@ describe("CheckpointReactor", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
       cwd,
+      start,
       drain,
     };
   }
@@ -570,6 +576,65 @@ describe("CheckpointReactor", () => {
     await harness.drain();
 
     expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v3\n");
+  });
+
+  it("preserves a newer placeholder when an older completion arrives", async () => {
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      startReactor: false,
+    });
+    const threadId = ThreadId.make("thread-1");
+    const turnId = asTurnId("turn-stale-completion");
+    const checkpointRef = checkpointRefForThreadTurn(threadId, 1);
+    const placeholderAt = "2026-01-01T00:02:00.000Z";
+    const dispatchPlaceholder = (commandId: string) =>
+      Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make(commandId),
+          threadId,
+          turnId,
+          completedAt: placeholderAt,
+          checkpointRef,
+          status: "missing",
+          files: [],
+          checkpointTurnCount: 1,
+          createdAt: placeholderAt,
+        }),
+      );
+
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    await dispatchPlaceholder("cmd-placeholder-before-reactor-start");
+    await harness.start();
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-stale"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:01:00.000Z",
+      threadId,
+      turnId,
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    const snapshotBeforeCapture = await harness.readModel();
+    const placeholder = snapshotBeforeCapture.threads
+      .find((entry) => entry.id === threadId)
+      ?.checkpoints.find((checkpoint) => checkpoint.turnId === turnId);
+    expect(placeholder?.status).toBe("missing");
+    expect(placeholder?.completedAt).toBe(placeholderAt);
+    expect(gitRefExists(harness.cwd, checkpointRef)).toBe(false);
+
+    await dispatchPlaceholder("cmd-placeholder-after-stale-completion");
+    await harness.drain();
+
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v2\n");
+    const snapshotAfterCapture = await harness.readModel();
+    const checkpoint = snapshotAfterCapture.threads
+      .find((entry) => entry.id === threadId)
+      ?.checkpoints.find((entry) => entry.turnId === turnId);
+    expect(checkpoint?.status).toBe("ready");
+    expect(checkpoint?.completedAt).toBe(placeholderAt);
   });
 
   it.each(["cancelled", "interrupted"] as const)(

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -496,6 +496,75 @@ describe("CheckpointReactor", () => {
     ).toBe("v2\n");
   });
 
+  it("refreshes an early checkpoint when the turn completes", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const turnId = asTurnId("turn-1");
+    const checkpointRef = checkpointRefForThreadTurn(threadId, 1);
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.make("evt-turn-started-refresh"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId,
+      turnId,
+    });
+    await waitForGitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 0));
+
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-placeholder-refresh"),
+        threadId,
+        turnId,
+        completedAt: "2026-01-01T00:01:00.000Z",
+        checkpointRef,
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt: "2026-01-01T00:01:00.000Z",
+      }),
+    );
+    await harness.drain();
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v2\n");
+
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v3\n", "utf8");
+    const completedAt = "2026-01-01T00:02:00.000Z";
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-refresh"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId,
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v3\n");
+    const snapshot = await harness.readModel();
+    const thread = snapshot.threads.find((entry) => entry.id === threadId);
+    expect(thread?.checkpoints).toHaveLength(1);
+    expect(thread?.checkpoints[0]?.checkpointTurnCount).toBe(1);
+    expect(thread?.checkpoints[0]?.completedAt).toBe(completedAt);
+
+    NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v4\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.make("evt-turn-completed-refresh-duplicate"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: completedAt,
+      threadId,
+      turnId,
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    expect(gitShowFileAtRef(harness.cwd, checkpointRef, "README.md")).toBe("v3\n");
+  });
+
   it("refreshes local git status state on turn completion using the session cwd", async () => {
     const gitStatusRefreshCalls: string[] = [];
     const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -369,12 +369,14 @@ const make = Effect.gen(function* () {
       const existingCheckpoint = thread.checkpoints.find(
         (checkpoint) => checkpoint.turnId === turnId,
       );
+      const checkpointStatus = checkpointStatusFromRuntime(event.payload.state);
       // A diff update can capture a ready checkpoint while the turn is still running.
-      // Refresh older captures at completion and keep repeated completion events idempotent.
+      // Refresh older final captures while preserving ready refs for interrupted turns.
       if (
         existingCheckpoint &&
         existingCheckpoint.status !== "missing" &&
-        existingCheckpoint.completedAt.localeCompare(event.createdAt) >= 0
+        (checkpointStatus === "missing" ||
+          existingCheckpoint.completedAt.localeCompare(event.createdAt) >= 0)
       ) {
         return;
       }
@@ -404,7 +406,7 @@ const make = Effect.gen(function* () {
         thread,
         cwd: checkpointCwd,
         turnCount: nextTurnCount,
-        status: checkpointStatusFromRuntime(event.payload.state),
+        status: checkpointStatus,
         assistantMessageId: undefined,
         createdAt: event.createdAt,
       });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -366,13 +366,15 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      // Only skip if a real (non-placeholder) checkpoint already exists for this turn.
-      // ProviderRuntimeIngestion may insert placeholder entries with status "missing"
-      // before this reactor runs; those must not prevent real git capture.
+      const existingCheckpoint = thread.checkpoints.find(
+        (checkpoint) => checkpoint.turnId === turnId,
+      );
+      // A diff update can capture a ready checkpoint while the turn is still running.
+      // Refresh older captures at completion and keep repeated completion events idempotent.
       if (
-        thread.checkpoints.some(
-          (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
-        )
+        existingCheckpoint &&
+        existingCheckpoint.status !== "missing" &&
+        existingCheckpoint.completedAt.localeCompare(event.createdAt) >= 0
       ) {
         return;
       }
@@ -388,17 +390,12 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      // If a placeholder checkpoint exists for this turn, reuse its turn count
-      // instead of incrementing past it.
-      const existingPlaceholder = thread.checkpoints.find(
-        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status === "missing",
-      );
       const currentTurnCount = thread.checkpoints.reduce(
         (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
         0,
       );
-      const nextTurnCount = existingPlaceholder
-        ? existingPlaceholder.checkpointTurnCount
+      const nextTurnCount = existingCheckpoint
+        ? existingCheckpoint.checkpointTurnCount
         : currentTurnCount + 1;
 
       yield* captureAndDispatchCheckpoint({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -371,12 +371,12 @@ const make = Effect.gen(function* () {
       );
       const checkpointStatus = checkpointStatusFromRuntime(event.payload.state);
       // A diff update can capture a ready checkpoint while the turn is still running.
-      // Refresh older final captures while preserving ready refs for interrupted turns.
+      // Refresh older final captures, preserve newer placeholders, and keep real refs
+      // synchronized when interrupted completions map to a missing checkpoint.
       if (
         existingCheckpoint &&
-        existingCheckpoint.status !== "missing" &&
-        (checkpointStatus === "missing" ||
-          existingCheckpoint.completedAt.localeCompare(event.createdAt) >= 0)
+        (existingCheckpoint.completedAt.localeCompare(event.createdAt) >= 0 ||
+          (existingCheckpoint.status !== "missing" && checkpointStatus === "missing"))
       ) {
         return;
       }


### PR DESCRIPTION
## Issue

Changed-files checkpoints can be captured from a `turn.diff.updated` event while the provider turn is still running. Edits made after that capture are absent from the turn's checkpoint and can first appear in the next turn's diff.

## Root cause

`ProviderRuntimeIngestion` emits a placeholder checkpoint for the diff update, and `CheckpointReactor` replaces it with a real Git checkpoint immediately. When the final `turn.completed` event arrives, the reactor exits as soon as it finds that real checkpoint, leaving the early filesystem state attached to the turn.

## Fix

Successful or failed turn completion now refreshes an older checkpoint for the same turn while preserving its turn count and Git ref. A real or placeholder checkpoint with the same or newer completion timestamp remains unchanged, keeping repeated, delayed, and stale completion events idempotent. Cancelled and interrupted completions preserve an existing real checkpoint so its projected metadata stays synchronized with the Git ref.

The regression covers an early diff checkpoint, additional filesystem edits before completion, final checkpoint refresh, stable turn count, duplicate completion handling, cancelled or interrupted completion events, and an older completion arriving before a newer placeholder is captured.

## Validation

- `pnpm exec vp test apps/server/src/orchestration/Layers/CheckpointReactor.test.ts` — 17 tests
- `pnpm exec vp run typecheck`
- `pnpm exec vp check --no-lint apps/server/src/orchestration/Layers/CheckpointReactor.ts apps/server/src/orchestration/Layers/CheckpointReactor.test.ts`
- `git diff --check`
- `pnpm exec vp check` currently reports existing formatting drift in `apps/web/src/index.css` on current `main`; scoped lint also reports the existing manual Effect runtime call later in `CheckpointReactor.test.ts`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots for UI changes *(N/A — server only)*
- [x] Video for animation/interaction changes *(N/A — server only)*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh turn checkpoints on completion while preserving newer or non-missing checkpoints
> - The `turn.completed` handler in [CheckpointReactor.ts](https://github.com/pingdotgg/t3code/pull/4129/files#diff-79dc41615f79575ae1404bd102df915797fb24ba34989557f80e229d305521fb) now skips capture if an existing checkpoint has a `completedAt` timestamp equal to or newer than the incoming event, preventing redundant overwrites of early ready checkpoints.
> - If a non-missing checkpoint already exists for the turn and the incoming completion resolves to `missing` (e.g. cancelled or interrupted), the existing checkpoint is preserved.
> - When capturing, the handler reuses the existing checkpoint's `checkpointTurnCount` rather than always incrementing from the max.
> - Tests cover: refreshing an early diff checkpoint on completion, preserving a newer placeholder when an older completion arrives, and preserving a ready checkpoint when completion is cancelled or interrupted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 250f3e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->