### PR TITLE
fix: increase OpenCode server startup timeout from 5s to 30s

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -37,7 +37,7 @@ const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJ
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
-const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 5_000;
+const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 10_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 export interface OpenCodeServerProcess {
   readonly url: string;

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -37,7 +37,7 @@ const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJ
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
-const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 15_000;
+const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 30_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 export interface OpenCodeServerProcess {
   readonly url: string;

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -37,7 +37,7 @@ const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJ
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
-const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 10_000;
+const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 15_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 export interface OpenCodeServerProcess {
   readonly url: string;


### PR DESCRIPTION
## What Changed

Bumped OpenCode server startup timeout from 5s to 30s (DEFAULT_OPENCODE_SERVER_TIMEOUT_MS in opencodeRuntime.ts).

## Why

OpenCode server startup time is highly variable under system load. Raw child_process.spawn benchmarks on a Windows machine showed:

| Run | Time to opencode server listening |
|-----|-------------------------------------|
| 1   | 19.6s                               |
| 2   | 16.9s                               |

Under normal conditions opencode serve starts in ~5-7s, but during T3 Code startup, when git operations, port discovery, provider refresh, and diagnostics queries all compete for resources, startup routinely exceeds 15s. The previous 15s timeout still caused Timed out waiting for OpenCode server start errors.

30s provides sufficient headroom for worst-case startup without meaningfully delaying failure detection (the process will exit with an error long before 30s if something is truly broken).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default constant change for startup polling only; no auth, data, or API behavior changes.
> 
> **Overview**
> Raises the default wait for the OpenCode **serve** process to print `opencode server listening` from **5s to 30s** via `DEFAULT_OPENCODE_SERVER_TIMEOUT_MS` in `opencodeRuntime.ts`. Callers can still override with `timeoutMs` on `startOpenCodeServerProcess` / `connectToOpenCodeServer`.
> 
> This targets false **Timed out waiting for OpenCode server start** failures when startup is slowed by concurrent T3 Code work (git, port discovery, provider refresh, etc.), where cold starts can exceed the old limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4afa23f01385c4064fdde98e85cbeaa61bb6d403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase OpenCode server startup timeout from 5s to 30s
> Raises `DEFAULT_OPENCODE_SERVER_TIMEOUT_MS` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/4132/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) from 5,000ms to 30,000ms to reduce false timeout failures when waiting for the OpenCode server to begin listening.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4afa23f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->