### PR TITLE
fix(shared): delete unused agentAwareness phase predicates

### DIFF
--- a/packages/shared/src/agentAwareness.ts
+++ b/packages/shared/src/agentAwareness.ts
@@ -50,14 +50,6 @@ export function buildAgentAwarenessDeepLink(input: {
   return `/threads/${encodeURIComponent(input.environmentId)}/${encodeURIComponent(input.threadId)}`;
 }
 
-export function isTerminalAgentAwarenessPhase(phase: AgentAwarenessPhase): boolean {
-  return phase === "completed" || phase === "failed";
-}
-
-export function isInterruptiveAgentAwarenessPhase(phase: AgentAwarenessPhase): boolean {
-  return phase === "waiting_for_approval" || phase === "waiting_for_input" || phase === "failed";
-}
-
 export function projectThreadAwareness(
   input: ProjectThreadAwarenessInput,
 ): AgentAwarenessState | null {


### PR DESCRIPTION
Removed isTerminalAgentAwarenessPhase and isInterruptiveAgentAwarenessPhase from agentAwareness.ts.

They had zero importers across the repo. Removing only the export left private-unused dead code that failed lint, so the functions are deleted entirely.

vp lint passes clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure removal of unused exports with no call sites; no behavior or API surface used elsewhere is affected.
> 
> **Overview**
> Removes **`isTerminalAgentAwarenessPhase`** and **`isInterruptiveAgentAwarenessPhase`** from `packages/shared/src/agentAwareness.ts`. Neither helper had any importers in the repo, so this is dead-code cleanup only; **`projectThreadAwareness`** and phase resolution logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7344d0740b4668c5e885a90043579f1d41bb0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `isTerminalAgentAwarenessPhase` and `isInterruptiveAgentAwarenessPhase` exports
> Deletes two unused predicate functions from [agentAwareness.ts](https://github.com/pingdotgg/t3code/pull/4134/files#diff-66ebc456b9d6bb60d305947cf2a19b69f907be064ca64602383a12f8a02b3425). No callers reference these exports, so removal has no runtime impact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f7344d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->