### PR TITLE
fix(client): use lightweight connection probe

### DIFF
--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -67,6 +67,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
 
       expect(first.environmentId).toBe(second.environmentId);
       expect(second.capabilities.repositoryIdentity).toBe(true);
+      expect(second.capabilities.connectionProbe).toBe(true);
     }),
   );
 

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -135,6 +135,7 @@ export const make = Effect.gen(function* () {
     serverVersion: packageJson.version,
     capabilities: {
       repositoryIdentity: true,
+      connectionProbe: true,
     },
   };
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -284,6 +284,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [ORCHESTRATION_WS_METHODS.subscribeShell, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.getArchivedShellSnapshot, AuthOrchestrationReadScope],
   [ORCHESTRATION_WS_METHODS.subscribeThread, AuthOrchestrationReadScope],
+  [WS_METHODS.serverProbe, AuthOrchestrationReadScope],
   [WS_METHODS.serverGetConfig, AuthOrchestrationReadScope],
   [WS_METHODS.serverRefreshProviders, AuthOrchestrationOperateScope],
   [WS_METHODS.serverUpdateProvider, AuthOrchestrationOperateScope],
@@ -1238,6 +1239,10 @@ const makeWsRpcLayer = (
             }),
             { "rpc.aggregate": "orchestration" },
           ),
+        [WS_METHODS.serverProbe]: (_input) =>
+          observeRpcEffect(WS_METHODS.serverProbe, Effect.succeed({}), {
+            "rpc.aggregate": "server",
+          }),
         [WS_METHODS.serverGetConfig]: (_input) =>
           observeRpcEffect(WS_METHODS.serverGetConfig, loadServerConfig, {
             "rpc.aggregate": "server",

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -652,7 +652,7 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("keeps a healthy session when the application becomes active", () =>
+  it.effect("probes the active session without reconnecting on application activation", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);
       const probeCalled = yield* Deferred.make<void>();

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -109,6 +109,7 @@ const SERVER_CONFIG: ServerConfigType = {
     serverVersion: "0.0.0-test",
     capabilities: {
       repositoryIdentity: true,
+      connectionProbe: true,
     },
   },
   auth: {
@@ -141,6 +142,16 @@ const decodeJson = Schema.decodeUnknownSync(Schema.UnknownFromJsonString);
 const decodeRpcRequest = Schema.decodeUnknownSync(RpcRequest);
 const encodeJson = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
 const encodeServerConfig = Schema.encodeSync(ServerConfig);
+const ENCODED_SERVER_CONFIG = encodeServerConfig(SERVER_CONFIG);
+const LEGACY_SERVER_CONFIG = {
+  ...ENCODED_SERVER_CONFIG,
+  environment: {
+    ...ENCODED_SERVER_CONFIG.environment,
+    capabilities: {
+      repositoryIdentity: true,
+    },
+  },
+};
 
 const makeFactory = Effect.fn("TestRpcSessionFactory.make")(function* () {
   const sockets: TestWebSocket[] = [];
@@ -183,6 +194,7 @@ const awaitRequest = Effect.fn("TestRpcSessionFactory.awaitRequest")(function* (
 
 const completeInitialConfig = Effect.fn("TestRpcSessionFactory.completeInitialConfig")(function* (
   socket: TestWebSocket,
+  config: unknown = ENCODED_SERVER_CONFIG,
 ) {
   const request = yield* awaitRequest(socket);
   expect(request).toMatchObject({
@@ -196,7 +208,7 @@ const completeInitialConfig = Effect.fn("TestRpcSessionFactory.completeInitialCo
       requestId: request.id,
       exit: {
         _tag: "Success",
-        value: encodeServerConfig(SERVER_CONFIG),
+        value: config,
       },
     }),
   );
@@ -273,6 +285,45 @@ describe("RpcSessionFactory", () => {
 
       expect(sockets[0]?.readyState).toBe(TestWebSocket.CLOSED);
     }),
+  );
+
+  it.effect("uses the legacy config RPC for probes when the server lacks the capability", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { factory, sockets } = yield* makeFactory();
+        const session = yield* factory.connect(PREPARED);
+        const readyFiber = yield* Effect.forkChild(session.ready);
+        const socket = yield* awaitSocket(sockets);
+
+        socket.open();
+        yield* completeInitialConfig(socket, LEGACY_SERVER_CONFIG);
+        yield* Fiber.join(readyFiber);
+
+        const probeFiber = yield* Effect.forkChild(session.probe);
+        const probeRequest = yield* awaitRequest(socket, 1);
+        expect(probeRequest).toMatchObject({
+          _tag: "Request",
+          tag: WS_METHODS.serverGetConfig,
+          payload: {},
+        });
+        socket.serverMessage(
+          encodeJson({
+            _tag: "Exit",
+            requestId: probeRequest.id,
+            exit: {
+              _tag: "Success",
+              value: LEGACY_SERVER_CONFIG,
+            },
+          }),
+        );
+        yield* Fiber.join(probeFiber);
+
+        expect(socket.sent.map((request) => decodeRpcRequest(decodeJson(request)).tag)).toEqual([
+          WS_METHODS.serverGetConfig,
+          WS_METHODS.serverGetConfig,
+        ]);
+      }),
+    ),
   );
 
   it.effect("fails readiness when the websocket never opens", () =>

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -169,9 +169,10 @@ const awaitSocket = Effect.fn("TestRpcSessionFactory.awaitSocket")(function* (
 
 const awaitRequest = Effect.fn("TestRpcSessionFactory.awaitRequest")(function* (
   socket: TestWebSocket,
+  index = 0,
 ) {
   for (let attempt = 0; attempt < 100; attempt += 1) {
-    const request = socket.sent[0];
+    const request = socket.sent[index];
     if (request) {
       return decodeRpcRequest(decodeJson(request));
     }
@@ -217,6 +218,30 @@ describe("RpcSessionFactory", () => {
       const config = yield* session.initialConfig;
       expect(config).toEqual(SERVER_CONFIG);
       expect(socket.sent).toHaveLength(1);
+
+      const probeFiber = yield* Effect.forkChild(session.probe);
+      const probeRequest = yield* awaitRequest(socket, 1);
+      expect(probeRequest).toMatchObject({
+        _tag: "Request",
+        tag: WS_METHODS.serverProbe,
+        payload: {},
+      });
+      socket.serverMessage(
+        encodeJson({
+          _tag: "Exit",
+          requestId: probeRequest.id,
+          exit: {
+            _tag: "Success",
+            value: {},
+          },
+        }),
+      );
+      yield* Fiber.join(probeFiber);
+
+      expect(socket.sent.map((request) => decodeRpcRequest(decodeJson(request)).tag)).toEqual([
+        WS_METHODS.serverGetConfig,
+        WS_METHODS.serverProbe,
+      ]);
 
       socket.close(1012, "service restart");
       const error = yield* Effect.flip(session.closed);

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -42,8 +42,9 @@ export class RpcSessionFactory extends Context.Service<
 type InitialConfigError = Effect.Error<
   ReturnType<WsRpcProtocolClient[typeof WS_METHODS.serverGetConfig]>
 >;
+type ProbeError = Effect.Error<ReturnType<WsRpcProtocolClient[typeof WS_METHODS.serverProbe]>>;
 
-function mapInitialConfigError(error: InitialConfigError): ConnectionAttemptError {
+function mapSessionRpcError(error: InitialConfigError | ProbeError): ConnectionAttemptError {
   switch (error._tag) {
     case "EnvironmentAuthorizationError":
       return new ConnectionBlockedError({
@@ -115,12 +116,12 @@ export const make = Effect.gen(function* () {
     const client = yield* makeWsRpcProtocolClient.pipe(Effect.provide(protocolContext));
     const initialConfig = yield* Effect.cached(
       client[WS_METHODS.serverGetConfig]({}).pipe(
-        Effect.mapError(mapInitialConfigError),
+        Effect.mapError(mapSessionRpcError),
         Effect.withSpan("environment.initialSync"),
       ),
     );
-    const probe = client[WS_METHODS.serverGetConfig]({}).pipe(
-      Effect.mapError(mapInitialConfigError),
+    const probe = client[WS_METHODS.serverProbe]({}).pipe(
+      Effect.mapError(mapSessionRpcError),
       Effect.asVoid,
       Effect.withSpan("clientRuntime.connection.rpcSession.probe"),
     );

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -120,8 +120,13 @@ export const make = Effect.gen(function* () {
         Effect.withSpan("environment.initialSync"),
       ),
     );
-    const probe = client[WS_METHODS.serverProbe]({}).pipe(
-      Effect.mapError(mapSessionRpcError),
+    const probe = initialConfig.pipe(
+      Effect.flatMap((config) =>
+        (config.environment.capabilities.connectionProbe === true
+          ? client[WS_METHODS.serverProbe]({})
+          : client[WS_METHODS.serverGetConfig]({})
+        ).pipe(Effect.mapError(mapSessionRpcError)),
+      ),
       Effect.asVoid,
       Effect.withSpan("clientRuntime.connection.rpcSession.probe"),
     );

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -22,6 +22,7 @@ export type ExecutionEnvironmentPlatform = typeof ExecutionEnvironmentPlatform.T
 
 export const ExecutionEnvironmentCapabilities = Schema.Struct({
   repositoryIdentity: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  connectionProbe: Schema.optionalKey(Schema.Boolean),
 });
 export type ExecutionEnvironmentCapabilities = typeof ExecutionEnvironmentCapabilities.Type;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -201,6 +201,7 @@ export const WS_METHODS = {
   previewAutomationFocusHost: "previewAutomation.focusHost",
 
   // Server meta
+  serverProbe: "server.probe",
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
   serverUpdateProvider: "server.updateProvider",
@@ -244,6 +245,12 @@ export const WsServerRemoveKeybindingRpc = Rpc.make(WS_METHODS.serverRemoveKeybi
   payload: ServerRemoveKeybindingInput,
   success: ServerRemoveKeybindingResult,
   error: Schema.Union([KeybindingsConfigError, EnvironmentAuthorizationError]),
+});
+
+export const WsServerProbeRpc = Rpc.make(WS_METHODS.serverProbe, {
+  payload: Schema.Struct({}),
+  success: Schema.Struct({}),
+  error: EnvironmentAuthorizationError,
 });
 
 export const WsServerGetConfigRpc = Rpc.make(WS_METHODS.serverGetConfig, {
@@ -682,6 +689,7 @@ export const WsSubscribeAuthAccessRpc = Rpc.make(WS_METHODS.subscribeAuthAccess,
 });
 
 export const WsRpcGroup = RpcGroup.make(
+  WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
   WsServerUpdateProviderRpc,


### PR DESCRIPTION
Fixes #3553.

Related to #3911, which addresses initial `server.getConfig` latency. This PR is narrower: foreground connection health checks no longer invoke configuration hydration at all.

## What Changed

- Add a dedicated `server.probe` RPC that returns immediately and uses the existing orchestration-read authorization scope.
- Use that endpoint for client-runtime connection health checks instead of `server.getConfig`.
- Keep `server.getConfig` for initial session configuration hydration.
- Add focused coverage verifying that initialization loads configuration while subsequent probes use the lightweight endpoint.

## Why

When the application becomes active, the connection supervisor currently probes the session through `server.getConfig`.

That RPC performs configuration and provider discovery work, which can become slow on busy or resource-constrained Windows systems. If it exceeds the 15-second foreground probe timeout, the client treats an otherwise live WebSocket as unavailable, enters reconnecting state, and temporarily disables the composer.

A dedicated no-work RPC separates connection liveness from configuration hydration. This reduces false reconnects without changing initial configuration loading, authorization requirements, or the existing timeout and reconnect policy.

## Testing

- `vp test packages/client-runtime/src/rpc/session.test.ts packages/client-runtime/src/connection/supervisor.test.ts` — 28 tests passed
- `vp check` — passed with 10 unrelated existing web lint warnings
- `vp run typecheck` — passed
- `git diff --check` — passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable because there is no UI change
- [x] An interaction video is not applicable because there is no motion or interaction change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to probe RPC selection; initial config loading and auth scopes stay the same, with backward compatibility for servers missing the new capability.
> 
> **Overview**
> Introduces **`server.probe`**, a no-op RPC for liveness checks, and advertises it via the optional **`connectionProbe`** capability on the execution environment descriptor.
> 
> **Client-runtime** still hydrates the session with **`server.getConfig`** on connect, but **`RpcSession.probe`** now calls **`server.probe`** when the capability is present; older servers without it keep using **`server.getConfig`** for probes. The WebSocket server wires the handler with the same orchestration-read scope as other read RPCs.
> 
> Tests cover probe vs initial config traffic, legacy fallback, and supervisor behavior on application activation (probe without reconnect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da511a97bb5af75f51c272932826ce776de8e2cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lightweight `server.probe` RPC for connection health checks
> - Adds a new `server.probe` RPC contract (`WsServerProbeRpc`) with an empty payload and empty success response, authorized under `AuthOrchestrationReadScope`.
> - `RpcSession.probe` now calls `server.probe` when the server reports `capabilities.connectionProbe: true`, falling back to `server.getConfig` for legacy servers.
> - The server advertises `connectionProbe: true` in the `ExecutionEnvironmentDescriptor.capabilities` returned by `ServerEnvironment.make`.
> - Behavioral Change: connection probes on capable servers now send a lightweight `server.probe` request instead of the heavier `server.getConfig` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da511a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->