### PR TITLE
Use short names for grouped projects

### DIFF
--- a/packages/client-runtime/src/state/projectGrouping.ts
+++ b/packages/client-runtime/src/state/projectGrouping.ts
@@ -165,18 +165,19 @@ export function deriveProjectGroupLabel(input: {
   readonly representative: Pick<EnvironmentProject, "title" | "repositoryIdentity">;
   readonly members: ReadonlyArray<Pick<EnvironmentProject, "title" | "repositoryIdentity">>;
 }): string {
-  const sharedDisplayNames = uniqueNonEmptyValues(
-    input.members.map((member) => member.repositoryIdentity?.displayName),
-  );
-  if (sharedDisplayNames.length === 1) {
-    return sharedDisplayNames[0]!;
-  }
-
+  // Prefer the short repository name before falling back to the qualified owner/repository label.
   const sharedRepositoryNames = uniqueNonEmptyValues(
     input.members.map((member) => member.repositoryIdentity?.name),
   );
   if (sharedRepositoryNames.length === 1) {
     return sharedRepositoryNames[0]!;
+  }
+
+  const sharedDisplayNames = uniqueNonEmptyValues(
+    input.members.map((member) => member.repositoryIdentity?.displayName),
+  );
+  if (sharedDisplayNames.length === 1) {
+    return sharedDisplayNames[0]!;
   }
 
   return input.representative.title;


### PR DESCRIPTION
## What Changed

- Keep matching repositories grouped across devices and environments.
- Prefer the shared repository name for grouped sidebar labels, while preserving the owner-qualified display name and project title as fallbacks.

## Why

Repository grouping correctly uses a canonical remote identity, but the group label preferred `displayName`, which can include a repository owner. The repository identity already exposes the short `name`, so checking it first keeps cross-device grouping intact without showing the owner.

## UI Changes

### Before

![Grouped project labels include the repository owner](https://raw.githubusercontent.com/unknown6003/t3code/pr-assets-4138/before.jpg)

### After

![Grouped project labels use only the repository name](https://raw.githubusercontent.com/unknown6003/t3code/pr-assets-4138/after.jpg)

## Checks

- `vp test apps/web/src/environmentGrouping.test.ts apps/mobile/src/features/home/homeThreadList.test.ts` (18 passed)
- `vp check`
- `vp run typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation or interaction change requires a video
