### PR TITLE
Repair legacy shell summary migrations

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -45,6 +45,7 @@ import Migration0029 from "./Migrations/029_ProjectionThreadDetailOrderingIndexe
 import Migration0030 from "./Migrations/030_ProjectionThreadShellArchiveIndexes.ts";
 import Migration0031 from "./Migrations/031_AuthAuthorizationScopes.ts";
 import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
+import Migration0034 from "./Migrations/034_RepairProjectionThreadShellSummary.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -89,6 +90,8 @@ export const migrationEntries = [
   [30, "ProjectionThreadShellArchiveIndexes", Migration0030],
   [31, "AuthAuthorizationScopes", Migration0031],
   [32, "AuthPairingProofKeyThumbprint", Migration0032],
+  // 33_ProjectionThreadsSettled shipped in a nightly before it was reverted.
+  [34, "RepairProjectionThreadShellSummary", Migration0034],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/025_CleanupInvalidProjectionPendingApprovals.ts
+++ b/apps/server/src/persistence/Migrations/025_CleanupInvalidProjectionPendingApprovals.ts
@@ -15,6 +15,13 @@ export default Effect.gen(function* () {
     )
   `;
 
+  const projectionThreadColumns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_threads)
+  `;
+  if (!projectionThreadColumns.some((column) => column.name === "pending_approval_count")) {
+    return;
+  }
+
   yield* sql`
     UPDATE projection_threads
     SET pending_approval_count = COALESCE((

--- a/apps/server/src/persistence/Migrations/034_RepairProjectionThreadShellSummary.test.ts
+++ b/apps/server/src/persistence/Migrations/034_RepairProjectionThreadShellSummary.test.ts
@@ -1,0 +1,189 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("034_RepairProjectionThreadShellSummary", (it) => {
+  it.effect("repairs legacy databases whose migration ids 23 and 24 were already used", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 22 });
+      yield* sql`
+        INSERT INTO effect_sql_migrations (migration_id, name)
+        VALUES
+          (23, 'ProjectionThreadsAssociatedWorktreeRef'),
+          (24, 'ProjectionThreadsArchivedAt')
+      `;
+
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          latest_turn_id,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'thread-legacy',
+          'project-1',
+          'Legacy thread',
+          'turn-1',
+          '2026-07-19T00:00:00.000Z',
+          '2026-07-19T00:00:00.000Z'
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_thread_messages (
+          message_id,
+          thread_id,
+          turn_id,
+          role,
+          text,
+          is_streaming,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'message-1',
+          'thread-legacy',
+          'turn-1',
+          'user',
+          'Please repair this database',
+          0,
+          '2026-07-19T00:01:00.000Z',
+          '2026-07-19T00:01:00.000Z'
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id,
+          thread_id,
+          turn_id,
+          tone,
+          kind,
+          summary,
+          payload_json,
+          created_at
+        )
+        VALUES (
+          'activity-approval-requested',
+          'thread-legacy',
+          'turn-1',
+          'approval',
+          'approval.requested',
+          'Command approval requested',
+          '{"requestId":"approval-1","requestKind":"command"}',
+          '2026-07-19T00:02:00.000Z'
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_pending_approvals (
+          request_id,
+          thread_id,
+          turn_id,
+          status,
+          decision,
+          created_at,
+          resolved_at
+        )
+        VALUES (
+          'approval-1',
+          'thread-legacy',
+          'turn-1',
+          'pending',
+          NULL,
+          '2026-07-19T00:02:00.000Z',
+          NULL
+        )
+      `;
+
+      const executedMigrations = yield* runMigrations();
+      assert.deepStrictEqual(
+        executedMigrations.map(([id, name]) => `${id}_${name}`),
+        [
+          "25_CleanupInvalidProjectionPendingApprovals",
+          "26_CanonicalizeModelSelectionOptions",
+          "27_ProviderSessionRuntimeInstanceId",
+          "28_ProjectionThreadSessionInstanceId",
+          "29_ProjectionThreadDetailOrderingIndexes",
+          "30_ProjectionThreadShellArchiveIndexes",
+          "31_AuthAuthorizationScopes",
+          "32_AuthPairingProofKeyThumbprint",
+          "34_RepairProjectionThreadShellSummary",
+        ],
+      );
+
+      const projectionThreadColumns = yield* sql<{ readonly name: string }>`
+        PRAGMA table_info(projection_threads)
+      `;
+      for (const expectedColumn of [
+        "latest_user_message_at",
+        "pending_approval_count",
+        "pending_user_input_count",
+        "has_actionable_proposed_plan",
+      ]) {
+        assert.isTrue(
+          projectionThreadColumns.some((column) => column.name === expectedColumn),
+          `expected projection_threads.${expectedColumn}`,
+        );
+      }
+
+      const threadRows = yield* sql<{
+        readonly latestUserMessageAt: string | null;
+        readonly pendingApprovalCount: number;
+        readonly pendingUserInputCount: number;
+        readonly hasActionableProposedPlan: number;
+      }>`
+        SELECT
+          latest_user_message_at AS "latestUserMessageAt",
+          pending_approval_count AS "pendingApprovalCount",
+          pending_user_input_count AS "pendingUserInputCount",
+          has_actionable_proposed_plan AS "hasActionableProposedPlan"
+        FROM projection_threads
+        WHERE thread_id = 'thread-legacy'
+      `;
+      assert.deepStrictEqual(threadRows, [
+        {
+          latestUserMessageAt: "2026-07-19T00:01:00.000Z",
+          pendingApprovalCount: 1,
+          pendingUserInputCount: 0,
+          hasActionableProposedPlan: 0,
+        },
+      ]);
+
+      const migrationRows = yield* sql<{
+        readonly migrationId: number;
+        readonly name: string;
+      }>`
+        SELECT migration_id AS "migrationId", name
+        FROM effect_sql_migrations
+        WHERE migration_id IN (23, 24, 34)
+        ORDER BY migration_id
+      `;
+      assert.deepStrictEqual(migrationRows, [
+        {
+          migrationId: 23,
+          name: "ProjectionThreadsAssociatedWorktreeRef",
+        },
+        {
+          migrationId: 24,
+          name: "ProjectionThreadsArchivedAt",
+        },
+        {
+          migrationId: 34,
+          name: "RepairProjectionThreadShellSummary",
+        },
+      ]);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/034_RepairProjectionThreadShellSummary.ts
+++ b/apps/server/src/persistence/Migrations/034_RepairProjectionThreadShellSummary.ts
@@ -1,0 +1,11 @@
+import * as Effect from "effect/Effect";
+
+import Migration0023 from "./023_ProjectionThreadShellSummary.ts";
+import Migration0024 from "./024_BackfillProjectionThreadShellSummary.ts";
+import Migration0025 from "./025_CleanupInvalidProjectionPendingApprovals.ts";
+
+export default Effect.gen(function* () {
+  yield* Migration0023;
+  yield* Migration0024;
+  yield* Migration0025;
+});


### PR DESCRIPTION
## What changed

- Make migration 25 tolerate databases where `pending_approval_count` is not present yet.
- Add migration 34 to re-run the idempotent shell-summary schema, backfill, and cleanup migrations.
- Leave migration ID 33 retired because `ProjectionThreadsSettled` shipped in a nightly before it was reverted.
- Add regression coverage for databases where legacy migrations already occupy IDs 23 and 24.

## Why

Older nightly databases can record IDs 23 and 24 as `ProjectionThreadsAssociatedWorktreeRef` and `ProjectionThreadsArchivedAt`. The current migration registry reuses those IDs for the projection thread shell-summary migrations, so the migrator skips them and then migration 25 fails with `no such column: pending_approval_count`.

That backend failure causes the desktop process to continuously restart its child server without ever creating the main window. I reproduced this on macOS 27.0 arm64 with the current nightly.

## Impact

Affected existing installations self-repair on their next startup without resetting user data. Fresh databases remain unchanged apart from recording migration 34.

## Validation

- Focused migration regression tests pass.
- `vp check` passes with zero errors (only existing unrelated warnings).
- `vp run typecheck` passes for all 15 packages.
- `vp run --filter t3 build` succeeds.
- A copy of the affected 126 MB database successfully ran migrations 25-32 and 34 with the rebuilt server.
- The desktop app then opened on macOS 27.0 arm64 and rendered the existing projects and threads from that migrated database.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repair legacy shell summary migrations by adding migration 34
> - Adds [034_RepairProjectionThreadShellSummary.ts](https://github.com/pingdotgg/t3code/pull/4143/files#diff-0887ae3cf70ec8db63b74f703414dc75ed1a94f7b3096dd52dfde87dc3ce5906) (migration id 34) that re-executes the logic from migrations 23, 24, and 25 under a new id, repairing `projection_threads` summary fields for databases that missed those migrations.
> - Registers migration 34 in [Migrations.ts](https://github.com/pingdotgg/t3code/pull/4143/files#diff-87557f6881a7a3dd24fa7e31f895b009cc6ede9a3571779088a10c5093110707), skipping id 33 which was shipped and reverted.
> - Guards [025_CleanupInvalidProjectionPendingApprovals.ts](https://github.com/pingdotgg/t3code/pull/4143/files#diff-553b6c1031b5ca14f35533ec7a6fe621673a9449cce6a7cdbc50f4cf6add67e6) with a column existence check so it skips the `pending_approval_count` update if the column is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a659fb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->