### PR TITLE
fix: restore missing revert actions and chat layout after resize

### DIFF
--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -162,10 +162,14 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
           0,
         );
         const createdPath = NodePath.join(tmp, "created.txt");
+        const postCheckpointIgnorePath = NodePath.join(tmp, ".gitignore");
+        const ignoredCreatedPath = NodePath.join(tmp, "state.cache");
 
         yield* git(tmp, ["init"]);
         yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baselineRef });
         yield* writeTextFile(createdPath, "created after baseline\n");
+        yield* writeTextFile(postCheckpointIgnorePath, "*.cache\n");
+        yield* writeTextFile(ignoredCreatedPath, "ignored after baseline\n");
 
         expect(
           yield* checkpointStore.restoreCheckpoint({
@@ -174,6 +178,36 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
           }),
         ).toBe(true);
         expect(yield* fileSystem.exists(createdPath)).toBe(false);
+        expect(yield* fileSystem.exists(postCheckpointIgnorePath)).toBe(false);
+        expect(yield* fileSystem.exists(ignoredCreatedPath)).toBe(false);
+      }),
+    );
+
+    it.effect("preserves files ignored by the restored checkpoint", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-unborn-ignored-test-");
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const baselineRef = checkpointRefForThreadTurn(
+          ThreadId.make("thread-unborn-ignored-checkpoint-store"),
+          0,
+        );
+        const ignorePath = NodePath.join(tmp, ".gitignore");
+        const ignoredPath = NodePath.join(tmp, "local.cache");
+
+        yield* git(tmp, ["init"]);
+        yield* writeTextFile(ignorePath, "*.cache\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baselineRef });
+        yield* writeTextFile(ignoredPath, "local-only data\n");
+
+        expect(
+          yield* checkpointStore.restoreCheckpoint({
+            cwd: tmp,
+            checkpointRef: baselineRef,
+          }),
+        ).toBe(true);
+        expect(yield* fileSystem.readFileString(ignorePath)).toBe("*.cache\n");
+        expect(yield* fileSystem.readFileString(ignoredPath)).toBe("local-only data\n");
       }),
     );
 

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -301,7 +301,7 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
       }),
     );
 
-    it.effect("surfaces corrupt shadow refs on lookup and repairs them during recapture", () =>
+    it.effect("surfaces corrupted shadow checkpoint refs instead of treating them as missing", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir("checkpoint-store-shadow-corrupt-ref-test-");
         const checkpointStore = yield* CheckpointStore.CheckpointStore;
@@ -329,14 +329,13 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(error._tag).toBe("VcsProcessExitError");
         expect(error.message).toContain("git for-each-ref");
 
-        const sourcePath = NodePath.join(tmp, "source.txt");
-        yield* writeTextFile(sourcePath, "recaptured\n");
-        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
-        expect(yield* checkpointStore.hasCheckpointRef({ cwd: tmp, checkpointRef })).toBe(true);
-
-        yield* writeTextFile(sourcePath, "changed again\n");
-        expect(yield* checkpointStore.restoreCheckpoint({ cwd: tmp, checkpointRef })).toBe(true);
-        expect(yield* fileSystem.readFileString(sourcePath)).toBe("recaptured\n");
+        const captureError = yield* Effect.flip(
+          checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef }),
+        );
+        expect(captureError._tag).toBe("VcsProcessExitError");
+        expect(
+          yield* Effect.flip(checkpointStore.hasCheckpointRef({ cwd: tmp, checkpointRef })),
+        ).toMatchObject({ _tag: "VcsProcessExitError" });
       }),
     );
 

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics nodeBuiltinImport:off
+import * as NodeCrypto from "node:crypto";
 import * as NodePath from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -297,6 +298,36 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
 
         expect(error._tag).toBe("VcsProcessExitError");
         expect(error.message).toContain("git diff");
+      }),
+    );
+
+    it.effect("surfaces corrupted shadow checkpoint refs instead of treating them as missing", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-shadow-corrupt-ref-test-");
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const config = yield* ServerConfig.ServerConfig;
+        const checkpointRef = checkpointRefForThreadTurn(
+          ThreadId.make("thread-shadow-corrupt-ref-checkpoint-store"),
+          0,
+        );
+
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+        const shadowRepositoryPath = NodePath.join(
+          config.stateDir,
+          "checkpoints",
+          NodeCrypto.createHash("sha256").update(NodePath.resolve(tmp)).digest("hex"),
+        );
+        yield* fileSystem.writeFileString(
+          NodePath.join(shadowRepositoryPath, checkpointRef),
+          "not-a-commit\n",
+        );
+
+        const error = yield* Effect.flip(
+          checkpointStore.hasCheckpointRef({ cwd: tmp, checkpointRef }),
+        );
+        expect(error._tag).toBe("VcsProcessExitError");
+        expect(error.message).toContain("git rev-parse");
       }),
     );
 

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -152,6 +152,31 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
       }),
     );
 
+    it.effect("restores an empty checkpoint in a repository before its first commit", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-unborn-empty-test-");
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const baselineRef = checkpointRefForThreadTurn(
+          ThreadId.make("thread-unborn-empty-checkpoint-store"),
+          0,
+        );
+        const createdPath = NodePath.join(tmp, "created.txt");
+
+        yield* git(tmp, ["init"]);
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baselineRef });
+        yield* writeTextFile(createdPath, "created after baseline\n");
+
+        expect(
+          yield* checkpointStore.restoreCheckpoint({
+            cwd: tmp,
+            checkpointRef: baselineRef,
+          }),
+        ).toBe(true);
+        expect(yield* fileSystem.exists(createdPath)).toBe(false);
+      }),
+    );
+
     it.effect("uses shadow checkpoints for a project nested under an unrelated repository", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir("checkpoint-store-nested-project-test-");
@@ -215,6 +240,29 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(yield* fileSystem.readFileString(sourcePath)).toBe("before\n");
         expect(yield* fileSystem.exists(createdPath)).toBe(false);
         expect(yield* checkpointStore.isGitRepository(tmp)).toBe(false);
+      }),
+    );
+
+    it.effect("fails shadow checkpoint diffs when a ref is unavailable", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-shadow-invalid-ref-test-");
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("thread-shadow-invalid-ref-checkpoint-store");
+        const baselineRef = checkpointRefForThreadTurn(threadId, 0);
+        const missingRef = checkpointRefForThreadTurn(threadId, 1);
+
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baselineRef });
+        const error = yield* Effect.flip(
+          checkpointStore.diffCheckpoints({
+            cwd: tmp,
+            fromCheckpointRef: baselineRef,
+            toCheckpointRef: missingRef,
+            ignoreWhitespace: false,
+          }),
+        );
+
+        expect(error._tag).toBe("VcsProcessExitError");
+        expect(error.message).toContain("git diff");
       }),
     );
 

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -301,7 +301,7 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
       }),
     );
 
-    it.effect("surfaces corrupted shadow checkpoint refs instead of treating them as missing", () =>
+    it.effect("surfaces corrupt shadow refs on lookup and repairs them during recapture", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir("checkpoint-store-shadow-corrupt-ref-test-");
         const checkpointStore = yield* CheckpointStore.CheckpointStore;
@@ -327,7 +327,16 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
           checkpointStore.hasCheckpointRef({ cwd: tmp, checkpointRef }),
         );
         expect(error._tag).toBe("VcsProcessExitError");
-        expect(error.message).toContain("git rev-parse");
+        expect(error.message).toContain("git for-each-ref");
+
+        const sourcePath = NodePath.join(tmp, "source.txt");
+        yield* writeTextFile(sourcePath, "recaptured\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+        expect(yield* checkpointStore.hasCheckpointRef({ cwd: tmp, checkpointRef })).toBe(true);
+
+        yield* writeTextFile(sourcePath, "changed again\n");
+        expect(yield* checkpointStore.restoreCheckpoint({ cwd: tmp, checkpointRef })).toBe(true);
+        expect(yield* fileSystem.readFileString(sourcePath)).toBe("recaptured\n");
       }),
     );
 

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -114,6 +114,21 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
       }),
     );
 
+    it.effect("recognizes an owned Git repository through a symbolic path alias", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const fileSystem = yield* FileSystem.FileSystem;
+        const repositoryPath = NodePath.join(tmp, "repository");
+        const aliasPath = NodePath.join(tmp, "repository-alias");
+        yield* fileSystem.makeDirectory(repositoryPath);
+        yield* initRepoWithCommit(repositoryPath);
+        yield* fileSystem.symlink(repositoryPath, aliasPath);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        expect(yield* checkpointStore.isGitRepository(aliasPath)).toBe(true);
+      }),
+    );
+
     it.effect("treats a standalone project nested under another repository as non-Git", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -112,9 +112,112 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(yield* checkpointStore.isGitRepository(tmp)).toBe(true);
       }),
     );
+
+    it.effect("treats a standalone project nested under another repository as non-Git", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const project = NodePath.join(tmp, "project");
+        yield* git(tmp, ["init"]);
+        yield* fileSystem.makeDirectory(project);
+
+        expect(yield* checkpointStore.isGitRepository(project)).toBe(false);
+      }),
+    );
   });
 
   describe("diffCheckpoints", () => {
+    it.effect("captures and restores an initialized repository before its first commit", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-unborn-git-test-");
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("thread-unborn-git-checkpoint-store");
+        const baselineRef = checkpointRefForThreadTurn(threadId, 0);
+        const sourcePath = NodePath.join(tmp, "source.txt");
+
+        yield* git(tmp, ["init"]);
+        yield* writeTextFile(sourcePath, "before\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baselineRef });
+        yield* writeTextFile(sourcePath, "after\n");
+
+        expect(
+          yield* checkpointStore.restoreCheckpoint({
+            cwd: tmp,
+            checkpointRef: baselineRef,
+          }),
+        ).toBe(true);
+        const fileSystem = yield* FileSystem.FileSystem;
+        expect(yield* fileSystem.readFileString(sourcePath)).toBe("before\n");
+      }),
+    );
+
+    it.effect("uses shadow checkpoints for a project nested under an unrelated repository", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-nested-project-test-");
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const project = NodePath.join(tmp, "project");
+        const threadId = ThreadId.make("thread-nested-project-checkpoint-store");
+        const baselineRef = checkpointRefForThreadTurn(threadId, 0);
+        const changedRef = checkpointRefForThreadTurn(threadId, 1);
+        const createdPath = NodePath.join(project, "created.txt");
+
+        yield* git(tmp, ["init"]);
+        yield* fileSystem.makeDirectory(project);
+        yield* checkpointStore.captureCheckpoint({ cwd: project, checkpointRef: baselineRef });
+        yield* writeTextFile(createdPath, "created\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: project, checkpointRef: changedRef });
+
+        expect(
+          yield* checkpointStore.restoreCheckpoint({
+            cwd: project,
+            checkpointRef: baselineRef,
+          }),
+        ).toBe(true);
+        expect(yield* fileSystem.exists(createdPath)).toBe(false);
+        expect(yield* checkpointStore.isGitRepository(project)).toBe(false);
+      }),
+    );
+
+    it.effect("captures and restores files without initializing Git in the workspace", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir("checkpoint-store-shadow-test-");
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        const threadId = ThreadId.make("thread-shadow-checkpoint-store");
+        const baselineRef = checkpointRefForThreadTurn(threadId, 0);
+        const changedRef = checkpointRefForThreadTurn(threadId, 1);
+        const sourcePath = NodePath.join(tmp, "source.txt");
+        const createdPath = NodePath.join(tmp, "created.txt");
+
+        yield* writeTextFile(sourcePath, "before\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: baselineRef });
+        yield* writeTextFile(sourcePath, "after\n");
+        yield* writeTextFile(createdPath, "new\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef: changedRef });
+
+        const diff = yield* checkpointStore.diffCheckpoints({
+          cwd: tmp,
+          fromCheckpointRef: baselineRef,
+          toCheckpointRef: changedRef,
+          ignoreWhitespace: false,
+        });
+        expect(diff).toContain("+after");
+        expect(diff).toContain("created.txt");
+
+        expect(
+          yield* checkpointStore.restoreCheckpoint({
+            cwd: tmp,
+            checkpointRef: baselineRef,
+          }),
+        ).toBe(true);
+        const fileSystem = yield* FileSystem.FileSystem;
+        expect(yield* fileSystem.readFileString(sourcePath)).toBe("before\n");
+        expect(yield* fileSystem.exists(createdPath)).toBe(false);
+        expect(yield* checkpointStore.isGitRepository(tmp)).toBe(false);
+      }),
+    );
+
     it.effect("returns full oversized checkpoint diffs without truncation", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -152,11 +152,21 @@ export const make = Effect.gen(function* () {
       args: ["rev-parse", "--verify", "--quiet", `${input.checkpointRef}^{commit}`],
       allowNonZeroExit: true,
     });
-    if (result.exitCode !== 0) {
+    const stdout = result.stdout.trim();
+    const stderr = result.stderr.trim();
+    if (result.exitCode === 1 && stdout.length === 0 && stderr.length === 0) {
       return null;
     }
-    const commit = result.stdout.trim();
-    return commit.length > 0 ? commit : null;
+    if (result.exitCode !== 0) {
+      return yield* new VcsProcessExitError({
+        operation: "CheckpointStore.shadow.resolveCheckpointCommit",
+        command: "git rev-parse",
+        cwd: input.cwd,
+        exitCode: result.exitCode,
+        detail: stderr || "Failed to resolve shadow checkpoint commit.",
+      });
+    }
+    return stdout.length > 0 ? stdout : null;
   });
 
   const shadowCheckpoints: VcsCheckpointOps = {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -24,7 +24,6 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 
 import type { CheckpointStoreError } from "./Errors.ts";
-import { CHECKPOINT_REFS_PREFIX } from "./Utils.ts";
 import type { VcsCheckpointOps } from "../vcs/VcsDriver.ts";
 import { ServerConfig } from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -155,7 +154,7 @@ export const make = Effect.gen(function* () {
     });
     const refStdout = refResult.stdout.trim();
     const refStderr = refResult.stderr.trim();
-    if (refResult.exitCode !== 0 || refStderr.length > 0) {
+    if (refResult.exitCode !== 0 || (refStdout.length === 0 && refStderr.length > 0)) {
       return yield* new VcsProcessExitError({
         operation: "CheckpointStore.shadow.resolveCheckpointRef",
         command: "git for-each-ref",
@@ -188,72 +187,9 @@ export const make = Effect.gen(function* () {
     return stdout.length > 0 ? stdout : null;
   });
 
-  const repairBrokenLooseShadowRef = Effect.fn("CheckpointStore.repairBrokenLooseShadowRef")(
-    function* (input: {
-      readonly cwd: string;
-      readonly checkpointRef: CheckpointRef;
-      readonly error: VcsProcessExitError;
-    }) {
-      const checkpointRef = String(input.checkpointRef);
-      const segments = checkpointRef.split("/");
-      const isManagedCheckpointRef =
-        checkpointRef.startsWith(`${CHECKPOINT_REFS_PREFIX}/`) &&
-        segments.every(
-          (segment) =>
-            segment.length > 0 && segment !== "." && segment !== ".." && !segment.includes("\\"),
-        );
-      const isBrokenRefError =
-        /(?:ignoring broken ref|bad ref|reference broken|bad object|does not resolve to a commit)/iu.test(
-          input.error.detail,
-        ) && input.error.detail.includes(checkpointRef);
-      if (!isManagedCheckpointRef || !isBrokenRefError) {
-        return yield* input.error;
-      }
-
-      const looseRefPath = NodePath.join(shadowRepositoryPath(input.cwd), ...segments);
-      const looseRefExists = yield* fileSystem.exists(looseRefPath).pipe(
-        Effect.mapError(
-          (error) =>
-            new VcsProcessExitError({
-              operation: "CheckpointStore.shadow.repairBrokenLooseRef.exists",
-              command: "filesystem exists",
-              cwd: input.cwd,
-              exitCode: -1,
-              detail: error.message,
-            }),
-        ),
-      );
-      if (!looseRefExists) {
-        return yield* input.error;
-      }
-      yield* fileSystem.remove(looseRefPath, { force: true }).pipe(
-        Effect.mapError(
-          (error) =>
-            new VcsProcessExitError({
-              operation: "CheckpointStore.shadow.repairBrokenLooseRef.remove",
-              command: "filesystem remove",
-              cwd: input.cwd,
-              exitCode: -1,
-              detail: error.message,
-            }),
-        ),
-      );
-      yield* Effect.logWarning("removed corrupt loose shadow checkpoint ref before recapture", {
-        checkpointRef: input.checkpointRef,
-        cwd: input.cwd,
-      });
-    },
-  );
-
   const shadowCheckpoints: VcsCheckpointOps = {
     captureCheckpoint: Effect.fn("CheckpointStore.shadow.captureCheckpoint")(function* (input) {
       const gitDir = shadowRepositoryPath(input.cwd);
-      yield* resolveShadowCommit(input).pipe(
-        Effect.asVoid,
-        Effect.catchTag("VcsProcessExitError", (error) =>
-          repairBrokenLooseShadowRef({ ...input, error }),
-        ),
-      );
       const tempIndexPath = NodePath.join(gitDir, `t3-checkpoint-index-${NodeCrypto.randomUUID()}`);
       const env: NodeJS.ProcessEnv = {
         ...process.env,

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -17,7 +17,7 @@
 import * as NodeCrypto from "node:crypto";
 import * as NodePath from "node:path";
 
-import { type CheckpointRef } from "@t3tools/contracts";
+import { type CheckpointRef, VcsProcessExitError } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -265,6 +265,15 @@ export const make = Effect.gen(function* () {
         allowNonZeroExit: true,
         maxOutputBytes: 50 * 1024 * 1024,
       });
+      if (result.exitCode !== 0) {
+        return yield* new VcsProcessExitError({
+          operation: "CheckpointStore.shadow.diffCheckpoints",
+          command: "git diff",
+          cwd: input.cwd,
+          exitCode: result.exitCode,
+          detail: result.stderr.trim() || "Checkpoint ref is unavailable for diff operation.",
+        });
+      }
       return result.stdout;
     }),
 

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -115,6 +115,8 @@ export const make = Effect.gen(function* () {
       "checkpoints",
       NodeCrypto.createHash("sha256").update(NodePath.resolve(cwd)).digest("hex"),
     );
+  const canonicalizeWorkspacePath = (value: string) =>
+    fileSystem.realPath(value).pipe(Effect.orElseSucceed(() => NodePath.resolve(value)));
 
   const runShadowGit = Effect.fn("CheckpointStore.runShadowGit")(function* (input: {
     readonly operation: string;
@@ -337,22 +339,24 @@ export const make = Effect.gen(function* () {
   ) {
     const handle = yield* vcsRegistry.detect({ cwd });
     const workspaceOwnsRepository =
-      handle !== null && NodePath.resolve(handle.repository.rootPath) === NodePath.resolve(cwd);
+      handle !== null &&
+      (yield* canonicalizeWorkspacePath(handle.repository.rootPath)) ===
+        (yield* canonicalizeWorkspacePath(cwd));
     return workspaceOwnsRepository
       ? (handle.driver.checkpoints ?? shadowCheckpoints)
       : shadowCheckpoints;
   });
 
-  const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
-    vcsRegistry
-      .detect({ cwd, requestedKind: "git" })
-      .pipe(
-        Effect.map(
-          (repository) =>
-            repository !== null &&
-            NodePath.resolve(repository.repository.rootPath) === NodePath.resolve(cwd),
-        ),
-      );
+  const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = Effect.fn(
+    "CheckpointStore.isGitRepository",
+  )(function* (cwd) {
+    const repository = yield* vcsRegistry.detect({ cwd, requestedKind: "git" });
+    return (
+      repository !== null &&
+      (yield* canonicalizeWorkspacePath(repository.repository.rootPath)) ===
+        (yield* canonicalizeWorkspacePath(cwd))
+    );
+  });
 
   const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
     "captureCheckpoint",

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -160,7 +160,9 @@ export const make = Effect.gen(function* () {
         command: "git for-each-ref",
         cwd: input.cwd,
         exitCode: refResult.exitCode === 0 ? 1 : refResult.exitCode,
-        detail: refStderr || "Failed to resolve shadow checkpoint ref.",
+        detail: "Failed to resolve shadow checkpoint ref.",
+        stderrLength: refStderr.length,
+        stderrTruncated: refResult.stderrTruncated,
       });
     }
     if (refStdout.length === 0) {
@@ -181,7 +183,9 @@ export const make = Effect.gen(function* () {
         command: "git rev-parse",
         cwd: input.cwd,
         exitCode: result.exitCode,
-        detail: stderr || `Checkpoint ref ${input.checkpointRef} does not resolve to a commit.`,
+        detail: `Checkpoint ref ${input.checkpointRef} does not resolve to a commit.`,
+        stderrLength: stderr.length,
+        stderrTruncated: result.stderrTruncated,
       });
     }
     return stdout.length > 0 ? stdout : null;
@@ -302,7 +306,9 @@ export const make = Effect.gen(function* () {
           command: "git diff",
           cwd: input.cwd,
           exitCode: result.exitCode,
-          detail: result.stderr.trim() || "Checkpoint ref is unavailable for diff operation.",
+          detail: "Checkpoint ref is unavailable for diff operation.",
+          stderrLength: result.stderr.trim().length,
+          stderrTruncated: result.stderrTruncated,
         });
       }
       return result.stdout;

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -1,9 +1,9 @@
 /**
  * CheckpointStore - Repository interface for filesystem-backed workspace checkpoints.
  *
- * Owns hidden Git-ref checkpoint capture/restore and diff computation for a
- * workspace thread timeline. It does not store user-facing checkpoint metadata
- * and does not coordinate provider conversation rollback.
+ * Owns hidden checkpoint capture/restore and diff computation for a workspace
+ * thread timeline. Git workspaces use their repository's hidden refs; other
+ * workspaces use a T3-managed shadow Git store outside the project directory.
  *
  * The live adapter resolves the active VCS driver once per checkpoint operation
  * and delegates to the driver's optional checkpoint capability.
@@ -13,14 +13,21 @@
  *
  * @module CheckpointStore
  */
-import { VcsUnsupportedOperationError, type CheckpointRef } from "@t3tools/contracts";
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeCrypto from "node:crypto";
+import * as NodePath from "node:path";
+
+import { type CheckpointRef } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 
 import type { CheckpointStoreError } from "./Errors.ts";
 import type { VcsCheckpointOps } from "../vcs/VcsDriver.ts";
+import { ServerConfig } from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
 
 export interface CaptureCheckpointInput {
   readonly cwd: string;
@@ -50,7 +57,7 @@ export interface DeleteCheckpointRefsInput {
 export class CheckpointStore extends Context.Service<
   CheckpointStore,
   {
-    /** Check whether cwd is inside a Git worktree. */
+    /** Check whether cwd is inside a user-managed Git worktree. */
     readonly isGitRepository: (cwd: string) => Effect.Effect<boolean, CheckpointStoreError>;
 
     /**
@@ -98,26 +105,208 @@ export class CheckpointStore extends Context.Service<
 
 export const make = Effect.gen(function* () {
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
+  const vcsProcess = yield* VcsProcess.VcsProcess;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const config = yield* ServerConfig;
+
+  const shadowRepositoryPath = (cwd: string) =>
+    NodePath.join(
+      config.stateDir,
+      "checkpoints",
+      NodeCrypto.createHash("sha256").update(NodePath.resolve(cwd)).digest("hex"),
+    );
+
+  const runShadowGit = Effect.fn("CheckpointStore.runShadowGit")(function* (input: {
+    readonly operation: string;
+    readonly cwd: string;
+    readonly args: ReadonlyArray<string>;
+    readonly env?: NodeJS.ProcessEnv;
+    readonly allowNonZeroExit?: boolean;
+    readonly maxOutputBytes?: number;
+  }) {
+    const gitDir = shadowRepositoryPath(input.cwd);
+    yield* vcsProcess.run({
+      operation: `${input.operation}.init`,
+      command: "git",
+      cwd: input.cwd,
+      args: ["init", "--bare", "--quiet", gitDir],
+    });
+    return yield* vcsProcess.run({
+      operation: input.operation,
+      command: "git",
+      cwd: input.cwd,
+      args: [`--git-dir=${gitDir}`, `--work-tree=${NodePath.resolve(input.cwd)}`, ...input.args],
+      ...(input.env ? { env: input.env } : {}),
+      ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
+      ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+    });
+  });
+
+  const resolveShadowCommit = Effect.fn("CheckpointStore.resolveShadowCommit")(function* (input: {
+    readonly cwd: string;
+    readonly checkpointRef: CheckpointRef;
+  }) {
+    const result = yield* runShadowGit({
+      operation: "CheckpointStore.shadow.resolveCheckpointCommit",
+      cwd: input.cwd,
+      args: ["rev-parse", "--verify", "--quiet", `${input.checkpointRef}^{commit}`],
+      allowNonZeroExit: true,
+    });
+    if (result.exitCode !== 0) {
+      return null;
+    }
+    const commit = result.stdout.trim();
+    return commit.length > 0 ? commit : null;
+  });
+
+  const shadowCheckpoints: VcsCheckpointOps = {
+    captureCheckpoint: Effect.fn("CheckpointStore.shadow.captureCheckpoint")(function* (input) {
+      const gitDir = shadowRepositoryPath(input.cwd);
+      const tempIndexPath = NodePath.join(gitDir, `t3-checkpoint-index-${NodeCrypto.randomUUID()}`);
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        GIT_INDEX_FILE: tempIndexPath,
+        GIT_AUTHOR_NAME: "T3 Code",
+        GIT_AUTHOR_EMAIL: "t3code@users.noreply.github.com",
+        GIT_COMMITTER_NAME: "T3 Code",
+        GIT_COMMITTER_EMAIL: "t3code@users.noreply.github.com",
+      };
+      const cleanup = fileSystem.remove(tempIndexPath, { force: true }).pipe(Effect.ignore);
+
+      yield* Effect.gen(function* () {
+        yield* runShadowGit({
+          operation: "CheckpointStore.shadow.captureCheckpoint.readTree",
+          cwd: input.cwd,
+          args: ["read-tree", "--empty"],
+          env,
+        });
+        yield* runShadowGit({
+          operation: "CheckpointStore.shadow.captureCheckpoint.add",
+          cwd: input.cwd,
+          args: ["add", "-A", "--", "."],
+          env,
+        });
+        const tree = yield* runShadowGit({
+          operation: "CheckpointStore.shadow.captureCheckpoint.writeTree",
+          cwd: input.cwd,
+          args: ["write-tree"],
+          env,
+        });
+        const commit = yield* runShadowGit({
+          operation: "CheckpointStore.shadow.captureCheckpoint.commitTree",
+          cwd: input.cwd,
+          args: [
+            "commit-tree",
+            tree.stdout.trim(),
+            "-m",
+            `t3 checkpoint ref=${input.checkpointRef}`,
+          ],
+          env,
+        });
+        yield* runShadowGit({
+          operation: "CheckpointStore.shadow.captureCheckpoint.updateRef",
+          cwd: input.cwd,
+          args: ["update-ref", input.checkpointRef, commit.stdout.trim()],
+        });
+      }).pipe(Effect.ensuring(cleanup));
+    }),
+
+    hasCheckpointRef: (input) =>
+      resolveShadowCommit(input).pipe(Effect.map((commit) => commit !== null)),
+
+    restoreCheckpoint: Effect.fn("CheckpointStore.shadow.restoreCheckpoint")(function* (input) {
+      const commit = yield* resolveShadowCommit(input);
+      if (!commit) {
+        return false;
+      }
+      const tempIndexPath = NodePath.join(
+        shadowRepositoryPath(input.cwd),
+        `t3-checkpoint-index-${NodeCrypto.randomUUID()}`,
+      );
+      const env: NodeJS.ProcessEnv = { ...process.env, GIT_INDEX_FILE: tempIndexPath };
+      const cleanup = fileSystem.remove(tempIndexPath, { force: true }).pipe(Effect.ignore);
+      yield* Effect.gen(function* () {
+        yield* runShadowGit({
+          operation: "CheckpointStore.shadow.restoreCheckpoint.readTree",
+          cwd: input.cwd,
+          args: ["read-tree", commit],
+          env,
+        });
+        yield* runShadowGit({
+          operation: "CheckpointStore.shadow.restoreCheckpoint.checkout",
+          cwd: input.cwd,
+          args: ["checkout-index", "--all", "--force"],
+          env,
+        });
+        yield* runShadowGit({
+          operation: "CheckpointStore.shadow.restoreCheckpoint.clean",
+          cwd: input.cwd,
+          args: ["clean", "-fd", "--", "."],
+          env,
+        });
+      }).pipe(Effect.ensuring(cleanup));
+      return true;
+    }),
+
+    diffCheckpoints: Effect.fn("CheckpointStore.shadow.diffCheckpoints")(function* (input) {
+      const result = yield* runShadowGit({
+        operation: "CheckpointStore.shadow.diffCheckpoints",
+        cwd: input.cwd,
+        args: [
+          "diff",
+          "--patch",
+          "--no-color",
+          "--no-ext-diff",
+          "--no-textconv",
+          ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
+          `${input.fromCheckpointRef}^{commit}`,
+          `${input.toCheckpointRef}^{commit}`,
+        ],
+        allowNonZeroExit: true,
+        maxOutputBytes: 50 * 1024 * 1024,
+      });
+      return result.stdout;
+    }),
+
+    deleteCheckpointRefs: Effect.fn("CheckpointStore.shadow.deleteCheckpointRefs")(
+      function* (input) {
+        yield* Effect.forEach(
+          input.checkpointRefs,
+          (checkpointRef) =>
+            runShadowGit({
+              operation: "CheckpointStore.shadow.deleteCheckpointRefs",
+              cwd: input.cwd,
+              args: ["update-ref", "-d", checkpointRef],
+              allowNonZeroExit: true,
+            }),
+          { concurrency: 1, discard: true },
+        );
+      },
+    ),
+  };
 
   const resolveCheckpoints = Effect.fn("CheckpointStore.resolveCheckpoints")(function* (
-    operation: string,
+    _operation: string,
     cwd: string,
   ) {
-    const handle = yield* vcsRegistry.resolve({ cwd });
-    if (!handle.driver.checkpoints) {
-      return yield* new VcsUnsupportedOperationError({
-        operation,
-        kind: handle.kind,
-        detail: `${handle.kind} driver does not implement checkpoint operations.`,
-      });
-    }
-    return handle.driver.checkpoints satisfies VcsCheckpointOps;
+    const handle = yield* vcsRegistry.detect({ cwd });
+    const workspaceOwnsRepository =
+      handle !== null && NodePath.resolve(handle.repository.rootPath) === NodePath.resolve(cwd);
+    return workspaceOwnsRepository
+      ? (handle.driver.checkpoints ?? shadowCheckpoints)
+      : shadowCheckpoints;
   });
 
   const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
     vcsRegistry
       .detect({ cwd, requestedKind: "git" })
-      .pipe(Effect.map((repository) => repository !== null));
+      .pipe(
+        Effect.map(
+          (repository) =>
+            repository !== null &&
+            NodePath.resolve(repository.repository.rootPath) === NodePath.resolve(cwd),
+        ),
+      );
 
   const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
     "captureCheckpoint",

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -24,6 +24,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 
 import type { CheckpointStoreError } from "./Errors.ts";
+import { CHECKPOINT_REFS_PREFIX } from "./Utils.ts";
 import type { VcsCheckpointOps } from "../vcs/VcsDriver.ts";
 import { ServerConfig } from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -146,6 +147,27 @@ export const make = Effect.gen(function* () {
     readonly cwd: string;
     readonly checkpointRef: CheckpointRef;
   }) {
+    const refResult = yield* runShadowGit({
+      operation: "CheckpointStore.shadow.resolveCheckpointRef",
+      cwd: input.cwd,
+      args: ["for-each-ref", "--format=%(objectname)", "--", input.checkpointRef],
+      allowNonZeroExit: true,
+    });
+    const refStdout = refResult.stdout.trim();
+    const refStderr = refResult.stderr.trim();
+    if (refResult.exitCode !== 0 || refStderr.length > 0) {
+      return yield* new VcsProcessExitError({
+        operation: "CheckpointStore.shadow.resolveCheckpointRef",
+        command: "git for-each-ref",
+        cwd: input.cwd,
+        exitCode: refResult.exitCode === 0 ? 1 : refResult.exitCode,
+        detail: refStderr || "Failed to resolve shadow checkpoint ref.",
+      });
+    }
+    if (refStdout.length === 0) {
+      return null;
+    }
+
     const result = yield* runShadowGit({
       operation: "CheckpointStore.shadow.resolveCheckpointCommit",
       cwd: input.cwd,
@@ -154,24 +176,84 @@ export const make = Effect.gen(function* () {
     });
     const stdout = result.stdout.trim();
     const stderr = result.stderr.trim();
-    if (result.exitCode === 1 && stdout.length === 0 && stderr.length === 0) {
-      return null;
-    }
     if (result.exitCode !== 0) {
       return yield* new VcsProcessExitError({
         operation: "CheckpointStore.shadow.resolveCheckpointCommit",
         command: "git rev-parse",
         cwd: input.cwd,
         exitCode: result.exitCode,
-        detail: stderr || "Failed to resolve shadow checkpoint commit.",
+        detail: stderr || `Checkpoint ref ${input.checkpointRef} does not resolve to a commit.`,
       });
     }
     return stdout.length > 0 ? stdout : null;
   });
 
+  const repairBrokenLooseShadowRef = Effect.fn("CheckpointStore.repairBrokenLooseShadowRef")(
+    function* (input: {
+      readonly cwd: string;
+      readonly checkpointRef: CheckpointRef;
+      readonly error: VcsProcessExitError;
+    }) {
+      const checkpointRef = String(input.checkpointRef);
+      const segments = checkpointRef.split("/");
+      const isManagedCheckpointRef =
+        checkpointRef.startsWith(`${CHECKPOINT_REFS_PREFIX}/`) &&
+        segments.every(
+          (segment) =>
+            segment.length > 0 && segment !== "." && segment !== ".." && !segment.includes("\\"),
+        );
+      const isBrokenRefError =
+        /(?:ignoring broken ref|bad ref|reference broken|bad object|does not resolve to a commit)/iu.test(
+          input.error.detail,
+        ) && input.error.detail.includes(checkpointRef);
+      if (!isManagedCheckpointRef || !isBrokenRefError) {
+        return yield* input.error;
+      }
+
+      const looseRefPath = NodePath.join(shadowRepositoryPath(input.cwd), ...segments);
+      const looseRefExists = yield* fileSystem.exists(looseRefPath).pipe(
+        Effect.mapError(
+          (error) =>
+            new VcsProcessExitError({
+              operation: "CheckpointStore.shadow.repairBrokenLooseRef.exists",
+              command: "filesystem exists",
+              cwd: input.cwd,
+              exitCode: -1,
+              detail: error.message,
+            }),
+        ),
+      );
+      if (!looseRefExists) {
+        return yield* input.error;
+      }
+      yield* fileSystem.remove(looseRefPath, { force: true }).pipe(
+        Effect.mapError(
+          (error) =>
+            new VcsProcessExitError({
+              operation: "CheckpointStore.shadow.repairBrokenLooseRef.remove",
+              command: "filesystem remove",
+              cwd: input.cwd,
+              exitCode: -1,
+              detail: error.message,
+            }),
+        ),
+      );
+      yield* Effect.logWarning("removed corrupt loose shadow checkpoint ref before recapture", {
+        checkpointRef: input.checkpointRef,
+        cwd: input.cwd,
+      });
+    },
+  );
+
   const shadowCheckpoints: VcsCheckpointOps = {
     captureCheckpoint: Effect.fn("CheckpointStore.shadow.captureCheckpoint")(function* (input) {
       const gitDir = shadowRepositoryPath(input.cwd);
+      yield* resolveShadowCommit(input).pipe(
+        Effect.asVoid,
+        Effect.catchTag("VcsProcessExitError", (error) =>
+          repairBrokenLooseShadowRef({ ...input, error }),
+        ),
+      );
       const tempIndexPath = NodePath.join(gitDir, `t3-checkpoint-index-${NodeCrypto.randomUUID()}`);
       const env: NodeJS.ProcessEnv = {
         ...process.env,

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -217,6 +217,9 @@ export const make = Effect.gen(function* () {
     restoreCheckpoint: Effect.fn("CheckpointStore.shadow.restoreCheckpoint")(function* (input) {
       const commit = yield* resolveShadowCommit(input);
       if (!commit) {
+        // Shadow repositories intentionally have no HEAD: every restorable
+        // state must be addressed by its explicit checkpoint ref. Fail closed
+        // so callers never roll conversation history back without matching files.
         return false;
       }
       const tempIndexPath = NodePath.join(

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -886,7 +886,7 @@ describe("CheckpointReactor", () => {
     expect(thread.checkpoints).toHaveLength(1);
     expect(
       thread.activities.some((activity) => activity.kind === "checkpoint.capture.failed"),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("executes provider revert and emits thread.reverted for checkpoint revert requests", async () => {
@@ -970,7 +970,7 @@ describe("CheckpointReactor", () => {
     ).toBe(false);
   });
 
-  it("reverts legacy conversation turns that predate filesystem checkpoints", async () => {
+  it("reverts legacy predecessor turns in mixed checkpoint history", async () => {
     const harness = await createHarness();
     const threadId = ThreadId.make("thread-1");
     const createdAt = "2026-01-01T00:00:00.000Z";
@@ -993,7 +993,7 @@ describe("CheckpointReactor", () => {
       }),
     );
 
-    for (const turnNumber of [1, 2]) {
+    for (const turnNumber of [1, 2, 3]) {
       const turnId = asTurnId(`legacy-turn-${turnNumber}`);
       await harness.runPromise(
         harness.engine.dispatch({
@@ -1036,10 +1036,25 @@ describe("CheckpointReactor", () => {
 
     await harness.runPromise(
       harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-mixed-checkpoint"),
+        threadId,
+        turnId: asTurnId("legacy-turn-3"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      }),
+    );
+
+    await harness.runPromise(
+      harness.engine.dispatch({
         type: "thread.checkpoint.revert",
         commandId: CommandId.make("cmd-legacy-revert-request"),
         threadId,
-        turnCount: 1,
+        turnCount: 2,
         createdAt,
       }),
     );

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1066,6 +1066,88 @@ describe("CheckpointReactor", () => {
     });
   });
 
+  it("rewinds legacy conversation history when no filesystem checkpoints exist", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const createdAt = "2026-01-01T00:00:00.000Z";
+
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-legacy-only-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    for (const turnNumber of [1, 2]) {
+      const turnId = asTurnId(`legacy-only-turn-${turnNumber}`);
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`cmd-legacy-only-user-${turnNumber}`),
+          threadId,
+          message: {
+            messageId: MessageId.make(`legacy-only-user-${turnNumber}`),
+            role: "user",
+            text: `User ${turnNumber}`,
+            attachments: [],
+          },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt,
+        }),
+      );
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.delta",
+          commandId: CommandId.make(`cmd-legacy-only-assistant-delta-${turnNumber}`),
+          threadId,
+          messageId: MessageId.make(`legacy-only-assistant-${turnNumber}`),
+          delta: `Assistant ${turnNumber}`,
+          turnId,
+          createdAt,
+        }),
+      );
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.complete",
+          commandId: CommandId.make(`cmd-legacy-only-assistant-complete-${turnNumber}`),
+          threadId,
+          messageId: MessageId.make(`legacy-only-assistant-${turnNumber}`),
+          turnId,
+          createdAt,
+        }),
+      );
+    }
+
+    runGit(harness.cwd, ["update-ref", "-d", checkpointRefForThreadTurn(threadId, 1)]);
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-legacy-only-revert"),
+        threadId,
+        turnCount: 1,
+        createdAt,
+      }),
+    );
+
+    await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+      threadId,
+      numTurns: 1,
+    });
+  });
+
   it("does not rewind conversation when a shadow filesystem checkpoint is missing", async () => {
     const workspace = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-shadow-revert-"));
     tempDirs.push(workspace);

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -35,7 +35,7 @@ import * as VcsDriverRegistry from "../../vcs/VcsDriverRegistry.ts";
 import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
-import { CheckpointReactorLive } from "./CheckpointReactor.ts";
+import { CheckpointReactorLive, conversationTurnCountForTurn } from "./CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
@@ -228,6 +228,24 @@ function gitRefExists(cwd: string, ref: string): boolean {
 function gitShowFileAtRef(cwd: string, ref: string, filePath: string): string {
   return runGit(cwd, ["show", `${ref}:${filePath}`]);
 }
+
+describe("conversationTurnCountForTurn", () => {
+  it("counts steering prompts through the last assistant message for the same turn", () => {
+    const steeredTurnId = asTurnId("steered-turn");
+    const laterTurnId = asTurnId("later-turn");
+    const messages = [
+      { role: "user", turnId: null },
+      { role: "assistant", turnId: steeredTurnId },
+      { role: "user", turnId: null },
+      { role: "assistant", turnId: steeredTurnId },
+      { role: "user", turnId: null },
+      { role: "assistant", turnId: laterTurnId },
+    ];
+
+    expect(conversationTurnCountForTurn(messages, steeredTurnId)).toBe(2);
+    expect(conversationTurnCountForTurn(messages, laterTurnId)).toBe(3);
+  });
+});
 
 async function waitForGitRefExists(cwd: string, ref: string, timeoutMs = 15_000) {
   const deadline = (await Effect.runPromise(Clock.currentTimeMillis)) + timeoutMs;

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -413,6 +413,7 @@ describe("CheckpointReactor", () => {
 
     return {
       engine,
+      runPromise: <A, E>(effect: Effect.Effect<A, E>) => runtime!.runPromise(effect),
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
       cwd,
@@ -424,7 +425,7 @@ describe("CheckpointReactor", () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
+    await harness.runPromise(
       harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-capture"),
@@ -828,7 +829,7 @@ describe("CheckpointReactor", () => {
     );
   });
 
-  it("continues processing runtime events after a single checkpoint runtime failure", async () => {
+  it("captures completed turns in a non-Git workspace and continues processing", async () => {
     const nonRepositorySessionCwd = NodeFS.mkdtempSync(
       NodePath.join(NodeOS.tmpdir(), "t3-checkpoint-runtime-non-repo-"),
     );
@@ -879,13 +880,13 @@ describe("CheckpointReactor", () => {
       turnId: asTurnId("turn-after-runtime-failure"),
     });
 
-    await waitForGitRefExists(
-      harness.cwd,
-      checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.checkpoints.some((checkpoint) => checkpoint.checkpointTurnCount === 1),
     );
+    expect(thread.checkpoints).toHaveLength(1);
     expect(
-      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0)),
-    ).toBe(true);
+      thread.activities.some((activity) => activity.kind === "checkpoint.capture.failed"),
+    ).toBe(false);
   });
 
   it("executes provider revert and emits thread.reverted for checkpoint revert requests", async () => {
@@ -967,6 +968,87 @@ describe("CheckpointReactor", () => {
     expect(
       gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)),
     ).toBe(false);
+  });
+
+  it("reverts legacy conversation turns that predate filesystem checkpoints", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.make("thread-1");
+    const createdAt = "2026-01-01T00:00:00.000Z";
+
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-legacy-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    for (const turnNumber of [1, 2]) {
+      const turnId = asTurnId(`legacy-turn-${turnNumber}`);
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`cmd-legacy-user-${turnNumber}`),
+          threadId,
+          message: {
+            messageId: MessageId.make(`legacy-user-${turnNumber}`),
+            role: "user",
+            text: `User ${turnNumber}`,
+            attachments: [],
+          },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt,
+        }),
+      );
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.delta",
+          commandId: CommandId.make(`cmd-legacy-assistant-delta-${turnNumber}`),
+          threadId,
+          messageId: MessageId.make(`legacy-assistant-${turnNumber}`),
+          delta: `Assistant ${turnNumber}`,
+          turnId,
+          createdAt,
+        }),
+      );
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.complete",
+          commandId: CommandId.make(`cmd-legacy-assistant-complete-${turnNumber}`),
+          threadId,
+          messageId: MessageId.make(`legacy-assistant-${turnNumber}`),
+          turnId,
+          createdAt,
+        }),
+      );
+    }
+
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-legacy-revert-request"),
+        threadId,
+        turnCount: 1,
+        createdAt,
+      }),
+    );
+
+    await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+      threadId,
+      numTurns: 1,
+    });
   });
 
   it("executes provider revert and emits thread.reverted for claude sessions", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -787,6 +787,81 @@ describe("CheckpointReactor", () => {
     ).toBe("v2\n");
   });
 
+  it("keeps the authoritative turn count when a placeholder is processed late", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const threadId = ThreadId.make("thread-1");
+    const createdAt = "2026-01-01T00:00:00.000Z";
+
+    for (const turnNumber of [1, 2]) {
+      const turnId = asTurnId(`late-placeholder-turn-${turnNumber}`);
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`cmd-late-placeholder-user-${turnNumber}`),
+          threadId,
+          message: {
+            messageId: MessageId.make(`late-placeholder-user-${turnNumber}`),
+            role: "user",
+            text: `User ${turnNumber}`,
+            attachments: [],
+          },
+          runtimeMode: "approval-required",
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          createdAt,
+        }),
+      );
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.delta",
+          commandId: CommandId.make(`cmd-late-placeholder-assistant-delta-${turnNumber}`),
+          threadId,
+          messageId: MessageId.make(`late-placeholder-assistant-${turnNumber}`),
+          delta: `Assistant ${turnNumber}`,
+          turnId,
+          createdAt,
+        }),
+      );
+      await harness.runPromise(
+        harness.engine.dispatch({
+          type: "thread.message.assistant.complete",
+          commandId: CommandId.make(`cmd-late-placeholder-assistant-complete-${turnNumber}`),
+          threadId,
+          messageId: MessageId.make(`late-placeholder-assistant-${turnNumber}`),
+          turnId,
+          createdAt,
+        }),
+      );
+    }
+
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-late-placeholder-diff"),
+        threadId,
+        turnId: asTurnId("late-placeholder-turn-1"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      }),
+    );
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.checkpoints.some((checkpoint) => checkpoint.checkpointTurnCount === 1) &&
+        entry.activities.some((activity) => activity.kind === "checkpoint.captured"),
+    );
+    expect(thread.checkpoints.some((checkpoint) => checkpoint.checkpointTurnCount === 1)).toBe(
+      true,
+    );
+    expect(thread.checkpoints.some((checkpoint) => checkpoint.checkpointTurnCount === 2)).toBe(
+      false,
+    );
+  });
+
   it("ignores non-v2 checkpoint.captured runtime events", async () => {
     const harness = await createHarness();
     const createdAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1066,6 +1066,69 @@ describe("CheckpointReactor", () => {
     });
   });
 
+  it("does not rewind conversation when a shadow filesystem checkpoint is missing", async () => {
+    const workspace = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-shadow-revert-"));
+    tempDirs.push(workspace);
+    NodeFS.writeFileSync(NodePath.join(workspace, "keep.txt"), "unchanged\n", "utf8");
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      projectWorkspaceRoot: workspace,
+      threadWorktreePath: workspace,
+      providerSessionCwd: workspace,
+    });
+    const threadId = ThreadId.make("thread-1");
+    const createdAt = "2026-01-01T00:00:00.000Z";
+
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-shadow-missing-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-shadow-missing-checkpoint-summary"),
+        threadId,
+        turnId: asTurnId("shadow-missing-turn"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      }),
+    );
+
+    await harness.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-shadow-missing-revert"),
+        threadId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some((activity) => activity.kind === "checkpoint.revert.failed"),
+    );
+    expect(thread.checkpoints).toHaveLength(1);
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
+    expect(NodeFS.readFileSync(NodePath.join(workspace, "keep.txt"), "utf8")).toBe("unchanged\n");
+  });
+
   it("executes provider revert and emits thread.reverted for claude sessions", async () => {
     const harness = await createHarness({ providerName: ProviderDriverKind.make("claudeAgent") });
     const createdAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -219,21 +219,6 @@ const make = Effect.gen(function* () {
     return cwd;
   });
 
-  const hasCheckpointRefForCapture = Effect.fn("hasCheckpointRefForCapture")(function* (input: {
-    readonly cwd: string;
-    readonly checkpointRef: CheckpointRef;
-  }) {
-    return yield* checkpointStore.hasCheckpointRef(input).pipe(
-      Effect.catchTag("VcsProcessExitError", (error) =>
-        Effect.logWarning("checkpoint ref probe failed; attempting recapture", {
-          checkpointRef: input.checkpointRef,
-          cwd: input.cwd,
-          detail: error.message,
-        }).pipe(Effect.as(false)),
-      ),
-    );
-  });
-
   // Shared tail for both capture paths: creates the git checkpoint ref, diffs
   // it against the previous turn, then dispatches the domain events to update
   // the orchestration read model.
@@ -257,10 +242,21 @@ const make = Effect.gen(function* () {
     const fromCheckpointRef = checkpointRefForThreadTurn(input.threadId, fromTurnCount);
     const targetCheckpointRef = checkpointRefForThreadTurn(input.threadId, input.turnCount);
 
-    const fromCheckpointExists = yield* hasCheckpointRefForCapture({
-      cwd: input.cwd,
-      checkpointRef: fromCheckpointRef,
-    });
+    const fromCheckpointExists = yield* checkpointStore
+      .hasCheckpointRef({
+        cwd: input.cwd,
+        checkpointRef: fromCheckpointRef,
+      })
+      .pipe(
+        Effect.catchTags({
+          VcsProcessExitError: (error) =>
+            Effect.logWarning("previous checkpoint ref probe failed", {
+              checkpointRef: fromCheckpointRef,
+              cwd: input.cwd,
+              detail: error.message,
+            }).pipe(Effect.as(false)),
+        }),
+      );
     if (!fromCheckpointExists) {
       yield* Effect.logWarning("checkpoint capture missing pre-turn baseline", {
         threadId: input.threadId,
@@ -524,7 +520,7 @@ const make = Effect.gen(function* () {
         Math.max(0, countConversationTurns(thread.messages) - 1),
       );
       const baselineCheckpointRef = checkpointRefForThreadTurn(thread.id, currentTurnCount);
-      const baselineExists = yield* hasCheckpointRefForCapture({
+      const baselineExists = yield* checkpointStore.hasCheckpointRef({
         cwd: checkpointCwd,
         checkpointRef: baselineCheckpointRef,
       });
@@ -610,7 +606,7 @@ const make = Effect.gen(function* () {
         : projectedConversationTurnCount,
     );
     const baselineCheckpointRef = checkpointRefForThreadTurn(threadId, currentTurnCount);
-    const baselineExists = yield* hasCheckpointRefForCapture({
+    const baselineExists = yield* checkpointStore.hasCheckpointRef({
       cwd: checkpointCwd,
       checkpointRef: baselineCheckpointRef,
     });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -655,30 +655,36 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const summarizedCheckpoint = thread.checkpoints.find(
-      (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
-    );
-    const targetCheckpointRef =
-      summarizedCheckpoint?.checkpointRef ??
-      checkpointRefForThreadTurn(event.payload.threadId, event.payload.turnCount);
-    const restored = yield* checkpointStore.restoreCheckpoint({
-      cwd: sessionRuntime.value.cwd,
-      checkpointRef: targetCheckpointRef,
-      fallbackToHead: event.payload.turnCount === 0,
-    });
-    if (!restored) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}. Conversation history was not changed.`,
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
+    // Legacy/imported threads can predate filesystem checkpoints entirely. They
+    // still support conversation-only rewind. Once a thread has checkpoint
+    // summaries, however, fail closed if the matching filesystem state cannot
+    // be restored so conversation and workspace never diverge silently.
+    if (checkpointTurnCount > 0) {
+      const summarizedCheckpoint = thread.checkpoints.find(
+        (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
+      );
+      const targetCheckpointRef =
+        summarizedCheckpoint?.checkpointRef ??
+        checkpointRefForThreadTurn(event.payload.threadId, event.payload.turnCount);
+      const restored = yield* checkpointStore.restoreCheckpoint({
+        cwd: sessionRuntime.value.cwd,
+        checkpointRef: targetCheckpointRef,
+        fallbackToHead: event.payload.turnCount === 0,
+      });
+      if (!restored) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}. Conversation history was not changed.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
 
-    // Refresh the workspace entry index so the @-mention file picker reflects
-    // the reverted filesystem state before conversation history is rewound.
-    yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
+      // Refresh the workspace entry index so the @-mention file picker reflects
+      // the reverted filesystem state before conversation history is rewound.
+      yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
+    }
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
     if (rolledBackTurns > 0) {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -62,7 +62,7 @@ export function countConversationTurns(messages: ReadonlyArray<{ readonly role: 
   return messages.reduce((count, message) => count + (message.role === "user" ? 1 : 0), 0);
 }
 
-function conversationTurnCountForTurn(
+export function conversationTurnCountForTurn(
   messages: ReadonlyArray<{
     readonly role: string;
     readonly turnId: TurnId | null;
@@ -70,15 +70,16 @@ function conversationTurnCountForTurn(
   turnId: TurnId,
 ): number | undefined {
   let turnCount = 0;
+  let matchedTurnCount: number | undefined;
   for (const message of messages) {
     if (message.role === "user") {
       turnCount += 1;
     }
     if (message.role === "assistant" && sameId(message.turnId, turnId)) {
-      return turnCount > 0 ? turnCount : undefined;
+      matchedTurnCount = turnCount > 0 ? turnCount : undefined;
     }
   }
-  return undefined;
+  return matchedTurnCount;
 }
 
 function maxCheckpointTurnCount(

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -62,6 +62,15 @@ export function countConversationTurns(messages: ReadonlyArray<{ readonly role: 
   return messages.reduce((count, message) => count + (message.role === "user" ? 1 : 0), 0);
 }
 
+function maxCheckpointTurnCount(
+  checkpoints: ReadonlyArray<{ readonly checkpointTurnCount: number }>,
+): number {
+  return checkpoints.reduce(
+    (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
+    0,
+  );
+}
+
 function checkpointStatusFromRuntime(status: string | undefined): "ready" | "missing" | "error" {
   switch (status) {
     case "failed":
@@ -391,13 +400,11 @@ const make = Effect.gen(function* () {
       const existingPlaceholder = thread.checkpoints.find(
         (checkpoint) => checkpoint.turnId === turnId && checkpoint.status === "missing",
       );
-      const currentTurnCount = thread.checkpoints.reduce(
-        (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-        0,
-      );
+      const currentTurnCount = maxCheckpointTurnCount(thread.checkpoints);
+      const conversationTurnCount = countConversationTurns(thread.messages);
       const nextTurnCount = existingPlaceholder
-        ? existingPlaceholder.checkpointTurnCount
-        : currentTurnCount + 1;
+        ? Math.max(existingPlaceholder.checkpointTurnCount, conversationTurnCount)
+        : Math.max(currentTurnCount + 1, conversationTurnCount);
 
       yield* captureAndDispatchCheckpoint({
         threadId: thread.id,
@@ -467,7 +474,7 @@ const make = Effect.gen(function* () {
       turnId,
       thread,
       cwd: checkpointCwd,
-      turnCount: checkpointTurnCount,
+      turnCount: Math.max(checkpointTurnCount, countConversationTurns(thread.messages)),
       status: "ready",
       assistantMessageId: event.payload.assistantMessageId ?? undefined,
       createdAt: event.payload.completedAt,
@@ -497,9 +504,9 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      const currentTurnCount = thread.checkpoints.reduce(
-        (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-        0,
+      const currentTurnCount = Math.max(
+        maxCheckpointTurnCount(thread.checkpoints),
+        Math.max(0, countConversationTurns(thread.messages) - 1),
       );
       const baselineCheckpointRef = checkpointRefForThreadTurn(thread.id, currentTurnCount);
       const baselineExists = yield* checkpointStore.hasCheckpointRef({
@@ -579,9 +586,13 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const currentTurnCount = thread.checkpoints.reduce(
-      (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-      0,
+    const projectedConversationTurnCount = countConversationTurns(thread.messages);
+    const currentTurnCount = Math.max(
+      maxCheckpointTurnCount(thread.checkpoints),
+      event.type === "thread.message-sent" &&
+        thread.messages.some((message) => message.id === event.payload.messageId)
+        ? Math.max(0, projectedConversationTurnCount - 1)
+        : projectedConversationTurnCount,
     );
     const baselineCheckpointRef = checkpointRefForThreadTurn(threadId, currentTurnCount);
     const baselineExists = yield* checkpointStore.hasCheckpointRef({
@@ -631,12 +642,8 @@ const make = Effect.gen(function* () {
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
-    const checkpointTurnCount = thread.checkpoints.reduce(
-      (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-      0,
-    );
-    const currentTurnCount =
-      checkpointTurnCount > 0 ? checkpointTurnCount : countConversationTurns(thread.messages);
+    const checkpointTurnCount = maxCheckpointTurnCount(thread.checkpoints);
+    const currentTurnCount = Math.max(checkpointTurnCount, countConversationTurns(thread.messages));
 
     if (event.payload.turnCount > currentTurnCount) {
       yield* appendRevertFailureActivity({
@@ -649,29 +656,18 @@ const make = Effect.gen(function* () {
     }
 
     if (checkpointTurnCount > 0) {
+      const summarizedCheckpoint = thread.checkpoints.find(
+        (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
+      );
       const targetCheckpointRef =
-        event.payload.turnCount === 0
-          ? checkpointRefForThreadTurn(event.payload.threadId, 0)
-          : thread.checkpoints.find(
-              (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
-            )?.checkpointRef;
-
-      if (!targetCheckpointRef) {
-        yield* appendRevertFailureActivity({
-          threadId: event.payload.threadId,
-          turnCount: event.payload.turnCount,
-          detail: `Checkpoint ref for turn ${event.payload.turnCount} is unavailable in read model.`,
-          createdAt: now,
-        }).pipe(Effect.catch(() => Effect.void));
-        return;
-      }
-
+        summarizedCheckpoint?.checkpointRef ??
+        checkpointRefForThreadTurn(event.payload.threadId, event.payload.turnCount);
       const restored = yield* checkpointStore.restoreCheckpoint({
         cwd: sessionRuntime.value.cwd,
         checkpointRef: targetCheckpointRef,
         fallbackToHead: event.payload.turnCount === 0,
       });
-      if (!restored) {
+      if (!restored && summarizedCheckpoint) {
         yield* appendRevertFailureActivity({
           threadId: event.payload.threadId,
           turnCount: event.payload.turnCount,
@@ -681,9 +677,11 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      // Refresh the workspace entry index so the @-mention file picker
-      // reflects the reverted filesystem state.
-      yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
+      if (restored) {
+        // Refresh the workspace entry index so the @-mention file picker
+        // reflects the reverted filesystem state.
+        yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
+      }
     }
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -62,6 +62,25 @@ export function countConversationTurns(messages: ReadonlyArray<{ readonly role: 
   return messages.reduce((count, message) => count + (message.role === "user" ? 1 : 0), 0);
 }
 
+function conversationTurnCountForTurn(
+  messages: ReadonlyArray<{
+    readonly role: string;
+    readonly turnId: TurnId | null;
+  }>,
+  turnId: TurnId,
+): number | undefined {
+  let turnCount = 0;
+  for (const message of messages) {
+    if (message.role === "user") {
+      turnCount += 1;
+    }
+    if (message.role === "assistant" && sameId(message.turnId, turnId)) {
+      return turnCount > 0 ? turnCount : undefined;
+    }
+  }
+  return undefined;
+}
+
 function maxCheckpointTurnCount(
   checkpoints: ReadonlyArray<{ readonly checkpointTurnCount: number }>,
 ): number {
@@ -412,10 +431,9 @@ const make = Effect.gen(function* () {
         (checkpoint) => checkpoint.turnId === turnId && checkpoint.status === "missing",
       );
       const currentTurnCount = maxCheckpointTurnCount(thread.checkpoints);
-      const conversationTurnCount = countConversationTurns(thread.messages);
       const nextTurnCount = existingPlaceholder
-        ? Math.max(existingPlaceholder.checkpointTurnCount, conversationTurnCount)
-        : Math.max(currentTurnCount + 1, conversationTurnCount);
+        ? existingPlaceholder.checkpointTurnCount
+        : (conversationTurnCountForTurn(thread.messages, turnId) ?? currentTurnCount + 1);
 
       yield* captureAndDispatchCheckpoint({
         threadId: thread.id,
@@ -485,7 +503,7 @@ const make = Effect.gen(function* () {
       turnId,
       thread,
       cwd: checkpointCwd,
-      turnCount: Math.max(checkpointTurnCount, countConversationTurns(thread.messages)),
+      turnCount: checkpointTurnCount,
       status: "ready",
       assistantMessageId: event.payload.assistantMessageId ?? undefined,
       createdAt: event.payload.completedAt,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -219,6 +219,21 @@ const make = Effect.gen(function* () {
     return cwd;
   });
 
+  const hasCheckpointRefForCapture = Effect.fn("hasCheckpointRefForCapture")(function* (input: {
+    readonly cwd: string;
+    readonly checkpointRef: CheckpointRef;
+  }) {
+    return yield* checkpointStore.hasCheckpointRef(input).pipe(
+      Effect.catchTag("VcsProcessExitError", (error) =>
+        Effect.logWarning("checkpoint ref probe failed; attempting recapture", {
+          checkpointRef: input.checkpointRef,
+          cwd: input.cwd,
+          detail: error.message,
+        }).pipe(Effect.as(false)),
+      ),
+    );
+  });
+
   // Shared tail for both capture paths: creates the git checkpoint ref, diffs
   // it against the previous turn, then dispatches the domain events to update
   // the orchestration read model.
@@ -242,7 +257,7 @@ const make = Effect.gen(function* () {
     const fromCheckpointRef = checkpointRefForThreadTurn(input.threadId, fromTurnCount);
     const targetCheckpointRef = checkpointRefForThreadTurn(input.threadId, input.turnCount);
 
-    const fromCheckpointExists = yield* checkpointStore.hasCheckpointRef({
+    const fromCheckpointExists = yield* hasCheckpointRefForCapture({
       cwd: input.cwd,
       checkpointRef: fromCheckpointRef,
     });
@@ -509,7 +524,7 @@ const make = Effect.gen(function* () {
         Math.max(0, countConversationTurns(thread.messages) - 1),
       );
       const baselineCheckpointRef = checkpointRefForThreadTurn(thread.id, currentTurnCount);
-      const baselineExists = yield* checkpointStore.hasCheckpointRef({
+      const baselineExists = yield* hasCheckpointRefForCapture({
         cwd: checkpointCwd,
         checkpointRef: baselineCheckpointRef,
       });
@@ -595,7 +610,7 @@ const make = Effect.gen(function* () {
         : projectedConversationTurnCount,
     );
     const baselineCheckpointRef = checkpointRefForThreadTurn(threadId, currentTurnCount);
-    const baselineExists = yield* checkpointStore.hasCheckpointRef({
+    const baselineExists = yield* hasCheckpointRefForCapture({
       cwd: checkpointCwd,
       checkpointRef: baselineCheckpointRef,
     });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -655,34 +655,30 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    if (checkpointTurnCount > 0) {
-      const summarizedCheckpoint = thread.checkpoints.find(
-        (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
-      );
-      const targetCheckpointRef =
-        summarizedCheckpoint?.checkpointRef ??
-        checkpointRefForThreadTurn(event.payload.threadId, event.payload.turnCount);
-      const restored = yield* checkpointStore.restoreCheckpoint({
-        cwd: sessionRuntime.value.cwd,
-        checkpointRef: targetCheckpointRef,
-        fallbackToHead: event.payload.turnCount === 0,
-      });
-      if (!restored && summarizedCheckpoint) {
-        yield* appendRevertFailureActivity({
-          threadId: event.payload.threadId,
-          turnCount: event.payload.turnCount,
-          detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
-          createdAt: now,
-        }).pipe(Effect.catch(() => Effect.void));
-        return;
-      }
-
-      if (restored) {
-        // Refresh the workspace entry index so the @-mention file picker
-        // reflects the reverted filesystem state.
-        yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
-      }
+    const summarizedCheckpoint = thread.checkpoints.find(
+      (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
+    );
+    const targetCheckpointRef =
+      summarizedCheckpoint?.checkpointRef ??
+      checkpointRefForThreadTurn(event.payload.threadId, event.payload.turnCount);
+    const restored = yield* checkpointStore.restoreCheckpoint({
+      cwd: sessionRuntime.value.cwd,
+      checkpointRef: targetCheckpointRef,
+      fallbackToHead: event.payload.turnCount === 0,
+    });
+    if (!restored) {
+      yield* appendRevertFailureActivity({
+        threadId: event.payload.threadId,
+        turnCount: event.payload.turnCount,
+        detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}. Conversation history was not changed.`,
+        createdAt: now,
+      }).pipe(Effect.catch(() => Effect.void));
+      return;
     }
+
+    // Refresh the workspace entry index so the @-mention file picker reflects
+    // the reverted filesystem state before conversation history is rewound.
+    yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
     if (rolledBackTurns > 0) {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -32,7 +32,6 @@ import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts"
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import type { OrchestrationDispatchError } from "../Errors.ts";
-import { isGitRepository } from "../../git/Utils.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
 
@@ -57,6 +56,10 @@ function sameId(left: string | null | undefined, right: string | null | undefine
     return false;
   }
   return left === right;
+}
+
+export function countConversationTurns(messages: ReadonlyArray<{ readonly role: string }>): number {
+  return messages.reduce((count, message) => count + (message.role === "user" ? 1 : 0), 0);
 }
 
 function checkpointStatusFromRuntime(status: string | undefined): "ready" | "missing" | "error" {
@@ -174,12 +177,10 @@ const make = Effect.gen(function* () {
     return project ? [project] : [];
   });
 
-  const isGitWorkspace = (cwd: string) => isGitRepository(cwd);
-
   // Resolves the workspace CWD for checkpoint operations, preferring the
   // active provider session CWD and falling back to the thread/project config.
-  // Returns undefined when no CWD can be determined or the workspace is not
-  // a git repository.
+  // CheckpointStore supports both user Git repositories and T3-managed shadow
+  // repositories, so a project does not need to initialize Git first.
   const resolveCheckpointCwd = Effect.fn("resolveCheckpointCwd")(function* (input: {
     readonly threadId: ThreadId;
     readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
@@ -204,9 +205,6 @@ const make = Effect.gen(function* () {
         }));
 
     if (!cwd) {
-      return undefined;
-    }
-    if (!isGitWorkspace(cwd)) {
       return undefined;
     }
     return cwd;
@@ -633,20 +631,12 @@ const make = Effect.gen(function* () {
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
-    if (!isGitWorkspace(sessionRuntime.value.cwd)) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: "Checkpoints are unavailable because this project is not a git repository.",
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-
-    const currentTurnCount = thread.checkpoints.reduce(
+    const checkpointTurnCount = thread.checkpoints.reduce(
       (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
       0,
     );
+    const currentTurnCount =
+      checkpointTurnCount > 0 ? checkpointTurnCount : countConversationTurns(thread.messages);
 
     if (event.payload.turnCount > currentTurnCount) {
       yield* appendRevertFailureActivity({
@@ -658,41 +648,43 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const targetCheckpointRef =
-      event.payload.turnCount === 0
-        ? checkpointRefForThreadTurn(event.payload.threadId, 0)
-        : thread.checkpoints.find(
-            (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
-          )?.checkpointRef;
+    if (checkpointTurnCount > 0) {
+      const targetCheckpointRef =
+        event.payload.turnCount === 0
+          ? checkpointRefForThreadTurn(event.payload.threadId, 0)
+          : thread.checkpoints.find(
+              (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
+            )?.checkpointRef;
 
-    if (!targetCheckpointRef) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: `Checkpoint ref for turn ${event.payload.turnCount} is unavailable in read model.`,
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
+      if (!targetCheckpointRef) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Checkpoint ref for turn ${event.payload.turnCount} is unavailable in read model.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      const restored = yield* checkpointStore.restoreCheckpoint({
+        cwd: sessionRuntime.value.cwd,
+        checkpointRef: targetCheckpointRef,
+        fallbackToHead: event.payload.turnCount === 0,
+      });
+      if (!restored) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      // Refresh the workspace entry index so the @-mention file picker
+      // reflects the reverted filesystem state.
+      yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
     }
-
-    const restored = yield* checkpointStore.restoreCheckpoint({
-      cwd: sessionRuntime.value.cwd,
-      checkpointRef: targetCheckpointRef,
-      fallbackToHead: event.payload.turnCount === 0,
-    });
-    if (!restored) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-
-    // Refresh the workspace entry index so the @-mention file picker
-    // reflects the reverted filesystem state.
-    yield* workspaceEntries.refresh(sessionRuntime.value.cwd);
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
     if (rolledBackTurns > 0) {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -789,6 +789,28 @@ it.layer(
       });
 
       yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-revert-files-user-keep"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-01-01T00:00:00.100Z",
+        commandId: CommandId.make("cmd-revert-files-user-keep"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-files-user-keep"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("message-user-keep"),
+          role: "user",
+          text: "Keep this turn",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-01-01T00:00:00.100Z",
+          updatedAt: "2026-01-01T00:00:00.100Z",
+        },
+      });
+
+      yield* appendAndProject({
         type: "thread.turn-diff-completed",
         eventId: EventId.make("evt-revert-files-3"),
         aggregateKind: "thread",
@@ -836,8 +858,8 @@ it.layer(
           ],
           turnId: TurnId.make("turn-keep"),
           streaming: false,
-          createdAt: now,
-          updatedAt: now,
+          createdAt: "2026-01-01T00:00:00.200Z",
+          updatedAt: "2026-01-01T00:00:00.200Z",
         },
       });
 
@@ -860,6 +882,28 @@ it.layer(
           files: [],
           assistantMessageId: MessageId.make("message-remove"),
           completedAt: now,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-revert-files-user-remove"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-01-01T00:00:00.300Z",
+        commandId: CommandId.make("cmd-revert-files-user-remove"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-files-user-remove"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("message-user-remove"),
+          role: "user",
+          text: "Revert here",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-01-01T00:00:00.300Z",
+          updatedAt: "2026-01-01T00:00:00.300Z",
         },
       });
 
@@ -889,8 +933,8 @@ it.layer(
           ],
           turnId: TurnId.make("turn-remove"),
           streaming: false,
-          createdAt: now,
-          updatedAt: now,
+          createdAt: "2026-01-01T00:00:00.400Z",
+          updatedAt: "2026-01-01T00:00:00.400Z",
         },
       });
 
@@ -2252,6 +2296,28 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
 
       yield* appendAndProject({
         type: "thread.message-sent",
+        eventId: EventId.make("evt-revert-user-keep"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert"),
+        occurredAt: "2026-02-26T12:00:02.050Z",
+        commandId: CommandId.make("cmd-revert-user-keep"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-user-keep"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert"),
+          messageId: MessageId.make("user-keep"),
+          role: "user",
+          text: "start",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-02-26T12:00:02.050Z",
+          updatedAt: "2026-02-26T12:00:02.050Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
         eventId: EventId.make("evt-revert-4"),
         aggregateKind: "thread",
         aggregateId: ThreadId.make("thread-revert"),
@@ -2289,7 +2355,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert/turn/2"),
           status: "ready",
           files: [],
-          assistantMessageId: MessageId.make("assistant-remove"),
+          assistantMessageId: null,
           completedAt: "2026-02-26T12:00:03.000Z",
         },
       });
@@ -2309,7 +2375,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           messageId: MessageId.make("user-remove"),
           role: "user",
           text: "removed",
-          turnId: TurnId.make("turn-2"),
+          turnId: null,
           streaming: false,
           createdAt: "2026-02-26T12:00:03.050Z",
           updatedAt: "2026-02-26T12:00:03.050Z",
@@ -2331,7 +2397,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           messageId: MessageId.make("assistant-remove"),
           role: "assistant",
           text: "removed",
-          turnId: TurnId.make("turn-2"),
+          turnId: TurnId.make("turn-1"),
           streaming: false,
           createdAt: "2026-02-26T12:00:03.100Z",
           updatedAt: "2026-02-26T12:00:03.100Z",
@@ -2369,13 +2435,18 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       `;
       assert.deepEqual(messageRows, [
         {
+          messageId: "user-keep",
+          turnId: null,
+          role: "user",
+        },
+        {
           messageId: "assistant-keep",
           turnId: "turn-1",
           role: "assistant",
         },
         {
           messageId: "user-remove",
-          turnId: "turn-2",
+          turnId: null,
           role: "user",
         },
       ]);

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2351,12 +2351,60 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         payload: {
           threadId: ThreadId.make("thread-revert"),
           turnId: TurnId.make("turn-2"),
-          checkpointTurnCount: 2,
+          checkpointTurnCount: 1,
           checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert/turn/2"),
           status: "ready",
           files: [],
           assistantMessageId: null,
           completedAt: "2026-02-26T12:00:03.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-revert-checkpoint-activity"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert"),
+        occurredAt: "2026-02-26T12:00:03.010Z",
+        commandId: CommandId.make("cmd-revert-checkpoint-activity"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-checkpoint-activity"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert"),
+          activity: {
+            id: EventId.make("checkpoint-only-activity"),
+            tone: "tool",
+            kind: "command",
+            summary: "Retained checkpoint activity",
+            payload: {},
+            turnId: TurnId.make("turn-2"),
+            createdAt: "2026-02-26T12:00:03.010Z",
+          },
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.proposed-plan-upserted",
+        eventId: EventId.make("evt-revert-checkpoint-plan"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-revert"),
+        occurredAt: "2026-02-26T12:00:03.020Z",
+        commandId: CommandId.make("cmd-revert-checkpoint-plan"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-revert-checkpoint-plan"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-revert"),
+          proposedPlan: {
+            id: "checkpoint-only-plan",
+            turnId: TurnId.make("turn-2"),
+            planMarkdown: "## Retained checkpoint plan",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt: "2026-02-26T12:00:03.020Z",
+            updatedAt: "2026-02-26T12:00:03.020Z",
+          },
         },
       });
 
@@ -2457,7 +2505,21 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         WHERE thread_id = 'thread-revert'
         ORDER BY requested_at ASC, turn_id ASC
       `;
-      assert.deepEqual(turnRows, [{ turnId: "turn-1" }]);
+      assert.deepEqual(turnRows, [{ turnId: "turn-1" }, { turnId: "turn-2" }]);
+
+      const activityRows = yield* sql<{ readonly activityId: string }>`
+        SELECT activity_id AS "activityId"
+        FROM projection_thread_activities
+        WHERE thread_id = 'thread-revert'
+      `;
+      assert.deepEqual(activityRows, [{ activityId: "checkpoint-only-activity" }]);
+
+      const planRows = yield* sql<{ readonly planId: string }>`
+        SELECT plan_id AS "planId"
+        FROM projection_thread_proposed_plans
+        WHERE thread_id = 'thread-revert'
+      `;
+      assert.deepEqual(planRows, [{ planId: "checkpoint-only-plan" }]);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2193,7 +2193,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
-  it.effect("does not fallback-retain messages whose turnId is removed by revert", () =>
+  it.effect("preserves an uncheckpointed predecessor when reverting mixed history", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;
       const eventStore = yield* OrchestrationEventStore;
@@ -2247,28 +2247,6 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           worktreePath: null,
           createdAt: "2026-02-26T12:00:01.000Z",
           updatedAt: "2026-02-26T12:00:01.000Z",
-        },
-      });
-
-      yield* appendAndProject({
-        type: "thread.turn-diff-completed",
-        eventId: EventId.make("evt-revert-3"),
-        aggregateKind: "thread",
-        aggregateId: ThreadId.make("thread-revert"),
-        occurredAt: "2026-02-26T12:00:02.000Z",
-        commandId: CommandId.make("cmd-revert-3"),
-        causationEventId: null,
-        correlationId: CorrelationId.make("cmd-revert-3"),
-        metadata: {},
-        payload: {
-          threadId: ThreadId.make("thread-revert"),
-          turnId: TurnId.make("turn-1"),
-          checkpointTurnCount: 1,
-          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-revert/turn/1"),
-          status: "ready",
-          files: [],
-          assistantMessageId: MessageId.make("assistant-keep"),
-          completedAt: "2026-02-26T12:00:02.000Z",
         },
       });
 
@@ -2401,6 +2379,14 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           role: "user",
         },
       ]);
+
+      const turnRows = yield* sql<{ readonly turnId: string }>`
+        SELECT turn_id AS "turnId"
+        FROM projection_turns
+        WHERE thread_id = 'thread-revert'
+        ORDER BY requested_at ASC, turn_id ASC
+      `;
+      assert.deepEqual(turnRows, [{ turnId: "turn-1" }]);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2395,6 +2395,11 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
           turnId: "turn-1",
           role: "assistant",
         },
+        {
+          messageId: "user-remove",
+          turnId: "turn-2",
+          role: "user",
+        },
       ]);
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -207,41 +207,21 @@ function retainProjectionMessagesAfterRevert(
   messages: ReadonlyArray<ProjectionThreadMessage>,
   turnCount: number,
 ): ReadonlyArray<ProjectionThreadMessage> {
-  const compareMessages = (left: ProjectionThreadMessage, right: ProjectionThreadMessage): number =>
-    left.createdAt.localeCompare(right.createdAt) || left.messageId.localeCompare(right.messageId);
-  const retainedMessageIds = new Set(
-    messages
-      .filter((message) => message.role === "user")
-      .toSorted(compareMessages)
-      .slice(0, turnCount + 1)
-      .map((message) => message.messageId),
-  );
-  const assistantTurnIndexes = new Map<string, number>();
-  let nextAssistantTurnIndex = 0;
-  for (const message of messages
-    .filter((entry) => entry.role === "assistant")
-    .toSorted(compareMessages)) {
-    if (message.turnId === null) {
-      if (nextAssistantTurnIndex < turnCount) {
-        retainedMessageIds.add(message.messageId);
-      }
-      nextAssistantTurnIndex += 1;
-      continue;
+  let userMessageIndex = 0;
+  let reachedTargetUser = false;
+  return messages.filter((message) => {
+    if (message.role === "system") {
+      return true;
     }
-    let assistantTurnIndex = assistantTurnIndexes.get(message.turnId);
-    if (assistantTurnIndex === undefined) {
-      assistantTurnIndex = nextAssistantTurnIndex;
-      assistantTurnIndexes.set(message.turnId, assistantTurnIndex);
-      nextAssistantTurnIndex += 1;
+    if (reachedTargetUser) {
+      return false;
     }
-    if (assistantTurnIndex < turnCount) {
-      retainedMessageIds.add(message.messageId);
+    if (message.role === "user") {
+      reachedTargetUser = userMessageIndex === turnCount;
+      userMessageIndex += 1;
     }
-  }
-
-  return messages.filter(
-    (message) => message.role === "system" || retainedMessageIds.has(message.messageId),
-  );
+    return true;
+  });
 }
 
 function retainProjectionTurnsAfterRevert(

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -205,94 +205,49 @@ function deriveHasActionableProposedPlan(input: {
 
 function retainProjectionMessagesAfterRevert(
   messages: ReadonlyArray<ProjectionThreadMessage>,
-  turns: ReadonlyArray<ProjectionTurn>,
   turnCount: number,
 ): ReadonlyArray<ProjectionThreadMessage> {
-  const retainedMessageIds = new Set<string>();
-  const retainedTurnIds = new Set<string>();
-  const keptTurns = retainProjectionTurnsAfterRevert(turns, turnCount);
-  for (const turn of keptTurns) {
-    if (turn.turnId !== null) {
-      retainedTurnIds.add(turn.turnId);
-    }
-    if (turn.pendingMessageId !== null) {
-      retainedMessageIds.add(turn.pendingMessageId);
-    }
-    if (turn.assistantMessageId !== null) {
-      retainedMessageIds.add(turn.assistantMessageId);
-    }
-  }
-
-  for (const message of messages) {
-    if (message.role === "system") {
-      retainedMessageIds.add(message.messageId);
+  const compareMessages = (left: ProjectionThreadMessage, right: ProjectionThreadMessage): number =>
+    left.createdAt.localeCompare(right.createdAt) || left.messageId.localeCompare(right.messageId);
+  const retainedMessageIds = new Set(
+    messages
+      .filter((message) => message.role === "user")
+      .toSorted(compareMessages)
+      .slice(0, turnCount + 1)
+      .map((message) => message.messageId),
+  );
+  const assistantTurnIndexes = new Map<string, number>();
+  let nextAssistantTurnIndex = 0;
+  for (const message of messages
+    .filter((entry) => entry.role === "assistant")
+    .toSorted(compareMessages)) {
+    if (message.turnId === null) {
+      if (nextAssistantTurnIndex < turnCount) {
+        retainedMessageIds.add(message.messageId);
+      }
+      nextAssistantTurnIndex += 1;
       continue;
     }
-    if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
+    let assistantTurnIndex = assistantTurnIndexes.get(message.turnId);
+    if (assistantTurnIndex === undefined) {
+      assistantTurnIndex = nextAssistantTurnIndex;
+      assistantTurnIndexes.set(message.turnId, assistantTurnIndex);
+      nextAssistantTurnIndex += 1;
+    }
+    if (assistantTurnIndex < turnCount) {
       retainedMessageIds.add(message.messageId);
     }
   }
 
-  const retainedUserCount = messages.filter(
-    (message) => message.role === "user" && retainedMessageIds.has(message.messageId),
-  ).length;
-  // Keep the selected user prompt (the message immediately after the retained turns),
-  // while pruning its response and every message that follows it.
-  const missingUserCount = Math.max(0, turnCount + 1 - retainedUserCount);
-  if (missingUserCount > 0) {
-    const fallbackUserMessages = messages
-      .filter((message) => message.role === "user" && !retainedMessageIds.has(message.messageId))
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) ||
-          left.messageId.localeCompare(right.messageId),
-      )
-      .slice(0, missingUserCount);
-    for (const message of fallbackUserMessages) {
-      retainedMessageIds.add(message.messageId);
-    }
-  }
-
-  const retainedAssistantCount = messages.filter(
-    (message) => message.role === "assistant" && retainedMessageIds.has(message.messageId),
-  ).length;
-  const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
-  if (missingAssistantCount > 0) {
-    const fallbackAssistantMessages = messages
-      .filter(
-        (message) =>
-          message.role === "assistant" &&
-          !retainedMessageIds.has(message.messageId) &&
-          (message.turnId === null || retainedTurnIds.has(message.turnId)),
-      )
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) ||
-          left.messageId.localeCompare(right.messageId),
-      )
-      .slice(0, missingAssistantCount);
-    for (const message of fallbackAssistantMessages) {
-      retainedMessageIds.add(message.messageId);
-    }
-  }
-
-  return messages.filter((message) => retainedMessageIds.has(message.messageId));
+  return messages.filter(
+    (message) => message.role === "system" || retainedMessageIds.has(message.messageId),
+  );
 }
 
 function retainProjectionTurnsAfterRevert(
   turns: ReadonlyArray<ProjectionTurn>,
   turnCount: number,
 ): ReadonlyArray<ProjectionTurn> {
-  const checkpointedTurns = turns.filter(
-    (turn) =>
-      turn.turnId !== null &&
-      turn.checkpointTurnCount !== null &&
-      turn.checkpointTurnCount <= turnCount,
-  );
-  if (turns.some((turn) => turn.checkpointTurnCount !== null)) {
-    return checkpointedTurns;
-  }
-
   return turns
     .filter((turn) => turn.turnId !== null)
     .toSorted(
@@ -865,12 +820,8 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             return;
           }
 
-          const existingTurns = yield* projectionTurnRepository.listByThreadId({
-            threadId: event.payload.threadId,
-          });
           const keptRows = retainProjectionMessagesAfterRevert(
             existingRows,
-            existingTurns,
             event.payload.turnCount,
           );
           if (keptRows.length === existingRows.length) {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -228,14 +228,24 @@ function retainProjectionTurnsAfterRevert(
   turns: ReadonlyArray<ProjectionTurn>,
   turnCount: number,
 ): ReadonlyArray<ProjectionTurn> {
-  return turns
+  const sortedTurns = turns
     .filter((turn) => turn.turnId !== null)
     .toSorted(
       (left, right) =>
         left.requestedAt.localeCompare(right.requestedAt) ||
         (left.turnId ?? "").localeCompare(right.turnId ?? ""),
-    )
-    .slice(0, turnCount);
+    );
+  const retainedTurnIds = new Set(
+    sortedTurns
+      .slice(0, turnCount)
+      .concat(
+        sortedTurns.filter(
+          (turn) => turn.checkpointTurnCount !== null && turn.checkpointTurnCount <= turnCount,
+        ),
+      )
+      .flatMap((turn) => (turn.turnId === null ? [] : [turn.turnId])),
+  );
+  return sortedTurns.filter((turn) => turn.turnId !== null && retainedTurnIds.has(turn.turnId));
 }
 
 function retainProjectionActivitiesAfterRevert(

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -210,12 +210,7 @@ function retainProjectionMessagesAfterRevert(
 ): ReadonlyArray<ProjectionThreadMessage> {
   const retainedMessageIds = new Set<string>();
   const retainedTurnIds = new Set<string>();
-  const keptTurns = turns.filter(
-    (turn) =>
-      turn.turnId !== null &&
-      turn.checkpointTurnCount !== null &&
-      turn.checkpointTurnCount <= turnCount,
-  );
+  const keptTurns = retainProjectionTurnsAfterRevert(turns, turnCount);
   for (const turn of keptTurns) {
     if (turn.turnId !== null) {
       retainedTurnIds.add(turn.turnId);
@@ -241,15 +236,12 @@ function retainProjectionMessagesAfterRevert(
   const retainedUserCount = messages.filter(
     (message) => message.role === "user" && retainedMessageIds.has(message.messageId),
   ).length;
-  const missingUserCount = Math.max(0, turnCount - retainedUserCount);
+  // Keep the selected user prompt (the message immediately after the retained turns),
+  // while pruning its response and every message that follows it.
+  const missingUserCount = Math.max(0, turnCount + 1 - retainedUserCount);
   if (missingUserCount > 0) {
     const fallbackUserMessages = messages
-      .filter(
-        (message) =>
-          message.role === "user" &&
-          !retainedMessageIds.has(message.messageId) &&
-          (message.turnId === null || retainedTurnIds.has(message.turnId)),
-      )
+      .filter((message) => message.role === "user" && !retainedMessageIds.has(message.messageId))
       .toSorted(
         (left, right) =>
           left.createdAt.localeCompare(right.createdAt) ||
@@ -287,20 +279,39 @@ function retainProjectionMessagesAfterRevert(
   return messages.filter((message) => retainedMessageIds.has(message.messageId));
 }
 
+function retainProjectionTurnsAfterRevert(
+  turns: ReadonlyArray<ProjectionTurn>,
+  turnCount: number,
+): ReadonlyArray<ProjectionTurn> {
+  const checkpointedTurns = turns.filter(
+    (turn) =>
+      turn.turnId !== null &&
+      turn.checkpointTurnCount !== null &&
+      turn.checkpointTurnCount <= turnCount,
+  );
+  if (turns.some((turn) => turn.checkpointTurnCount !== null)) {
+    return checkpointedTurns;
+  }
+
+  return turns
+    .filter((turn) => turn.turnId !== null)
+    .toSorted(
+      (left, right) =>
+        left.requestedAt.localeCompare(right.requestedAt) ||
+        (left.turnId ?? "").localeCompare(right.turnId ?? ""),
+    )
+    .slice(0, turnCount);
+}
+
 function retainProjectionActivitiesAfterRevert(
   activities: ReadonlyArray<ProjectionThreadActivity>,
   turns: ReadonlyArray<ProjectionTurn>,
   turnCount: number,
 ): ReadonlyArray<ProjectionThreadActivity> {
   const retainedTurnIds = new Set<string>(
-    turns
-      .filter(
-        (turn) =>
-          turn.turnId !== null &&
-          turn.checkpointTurnCount !== null &&
-          turn.checkpointTurnCount <= turnCount,
-      )
-      .flatMap((turn) => (turn.turnId === null ? [] : [turn.turnId])),
+    retainProjectionTurnsAfterRevert(turns, turnCount).flatMap((turn) =>
+      turn.turnId === null ? [] : [turn.turnId],
+    ),
   );
   return activities.filter(
     (activity) => activity.turnId === null || retainedTurnIds.has(activity.turnId),
@@ -313,14 +324,9 @@ function retainProjectionProposedPlansAfterRevert(
   turnCount: number,
 ): ReadonlyArray<ProjectionThreadProposedPlan> {
   const retainedTurnIds = new Set<string>(
-    turns
-      .filter(
-        (turn) =>
-          turn.turnId !== null &&
-          turn.checkpointTurnCount !== null &&
-          turn.checkpointTurnCount <= turnCount,
-      )
-      .flatMap((turn) => (turn.turnId === null ? [] : [turn.turnId])),
+    retainProjectionTurnsAfterRevert(turns, turnCount).flatMap((turn) =>
+      turn.turnId === null ? [] : [turn.turnId],
+    ),
   );
   return proposedPlans.filter(
     (proposedPlan) => proposedPlan.turnId === null || retainedTurnIds.has(proposedPlan.turnId),
@@ -772,19 +778,22 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             return;
           }
 
-          const retainedTurns = yield* projectionTurnRepository.listByThreadId({
+          const existingTurns = yield* projectionTurnRepository.listByThreadId({
             threadId: event.payload.threadId,
           });
+          const retainedTurns = retainProjectionTurnsAfterRevert(
+            existingTurns,
+            event.payload.turnCount,
+          );
           let latestTurnId: ProjectionTurn["turnId"] = null;
           let latestCheckpointTurnCount = -1;
           for (let index = 0; index < retainedTurns.length; index += 1) {
             const turn = retainedTurns[index];
-            if (
-              !turn ||
-              turn.turnId === null ||
-              turn.checkpointTurnCount === null ||
-              turn.checkpointTurnCount > event.payload.turnCount
-            ) {
+            if (!turn || turn.turnId === null) {
+              continue;
+            }
+            if (turn.checkpointTurnCount === null) {
+              latestTurnId = turn.turnId;
               continue;
             }
             if (turn.checkpointTurnCount > latestCheckpointTurnCount) {
@@ -1305,11 +1314,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           const existingTurns = yield* projectionTurnRepository.listByThreadId({
             threadId: event.payload.threadId,
           });
-          const keptTurns = existingTurns.filter(
-            (turn) =>
-              turn.turnId !== null &&
-              turn.checkpointTurnCount !== null &&
-              turn.checkpointTurnCount <= event.payload.turnCount,
+          const keptTurns = retainProjectionTurnsAfterRevert(
+            existingTurns,
+            event.payload.turnCount,
           );
           yield* projectionTurnRepository.deleteByThreadId({
             threadId: event.payload.threadId,

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -682,7 +682,7 @@ describe("orchestration projector", () => {
     expect(thread?.latestTurn).toBeNull();
   });
 
-  it("retains the selected user prompt even when it is tied to the reverted turn", async () => {
+  it("removes assistant output produced after the selected steering message", async () => {
     const createdAt = "2026-02-26T12:00:00.000Z";
     const model = createEmptyReadModel(createdAt);
 
@@ -717,6 +717,24 @@ describe("orchestration projector", () => {
     const events: ReadonlyArray<OrchestrationEvent> = [
       makeEvent({
         sequence: 2,
+        type: "thread.message-sent",
+        aggregateKind: "thread",
+        aggregateId: "thread-revert",
+        occurredAt: "2026-02-26T12:00:00.500Z",
+        commandId: "cmd-user-keep",
+        payload: {
+          threadId: "thread-revert",
+          messageId: "user-keep",
+          role: "user",
+          text: "start",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-02-26T12:00:00.500Z",
+          updatedAt: "2026-02-26T12:00:00.500Z",
+        },
+      }),
+      makeEvent({
+        sequence: 3,
         type: "thread.turn-diff-completed",
         aggregateKind: "thread",
         aggregateId: "thread-revert",
@@ -724,17 +742,17 @@ describe("orchestration projector", () => {
         commandId: "cmd-turn-1",
         payload: {
           threadId: "thread-revert",
-          turnId: "turn-1",
+          turnId: "checkpoint-only-turn",
           checkpointTurnCount: 1,
           checkpointRef: "refs/t3/checkpoints/thread-revert/turn/1",
           status: "ready",
           files: [],
-          assistantMessageId: "assistant-keep",
+          assistantMessageId: null,
           completedAt: "2026-02-26T12:00:01.000Z",
         },
       }),
       makeEvent({
-        sequence: 3,
+        sequence: 4,
         type: "thread.message-sent",
         aggregateKind: "thread",
         aggregateId: "thread-revert",
@@ -752,7 +770,47 @@ describe("orchestration projector", () => {
         },
       }),
       makeEvent({
-        sequence: 4,
+        sequence: 5,
+        type: "thread.activity-appended",
+        aggregateKind: "thread",
+        aggregateId: "thread-revert",
+        occurredAt: "2026-02-26T12:00:01.200Z",
+        commandId: "cmd-checkpoint-only-activity",
+        payload: {
+          threadId: "thread-revert",
+          activity: {
+            id: "checkpoint-only-activity",
+            tone: "tool",
+            kind: "command",
+            summary: "Retained activity",
+            payload: {},
+            turnId: "checkpoint-only-turn",
+            createdAt: "2026-02-26T12:00:01.200Z",
+          },
+        },
+      }),
+      makeEvent({
+        sequence: 6,
+        type: "thread.proposed-plan-upserted",
+        aggregateKind: "thread",
+        aggregateId: "thread-revert",
+        occurredAt: "2026-02-26T12:00:01.300Z",
+        commandId: "cmd-checkpoint-only-plan",
+        payload: {
+          threadId: "thread-revert",
+          proposedPlan: {
+            id: "checkpoint-only-plan",
+            turnId: "checkpoint-only-turn",
+            planMarkdown: "## Retained plan",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt: "2026-02-26T12:00:01.300Z",
+            updatedAt: "2026-02-26T12:00:01.300Z",
+          },
+        },
+      }),
+      makeEvent({
+        sequence: 7,
         type: "thread.turn-diff-completed",
         aggregateKind: "thread",
         aggregateId: "thread-revert",
@@ -765,12 +823,12 @@ describe("orchestration projector", () => {
           checkpointRef: "refs/t3/checkpoints/thread-revert/turn/2",
           status: "ready",
           files: [],
-          assistantMessageId: "assistant-remove",
+          assistantMessageId: null,
           completedAt: "2026-02-26T12:00:02.000Z",
         },
       }),
       makeEvent({
-        sequence: 5,
+        sequence: 8,
         type: "thread.message-sent",
         aggregateKind: "thread",
         aggregateId: "thread-revert",
@@ -781,14 +839,14 @@ describe("orchestration projector", () => {
           messageId: "user-remove",
           role: "user",
           text: "removed",
-          turnId: "turn-2",
+          turnId: null,
           streaming: false,
           createdAt: "2026-02-26T12:00:02.050Z",
           updatedAt: "2026-02-26T12:00:02.050Z",
         },
       }),
       makeEvent({
-        sequence: 6,
+        sequence: 9,
         type: "thread.message-sent",
         aggregateKind: "thread",
         aggregateId: "thread-revert",
@@ -799,14 +857,14 @@ describe("orchestration projector", () => {
           messageId: "assistant-remove",
           role: "assistant",
           text: "removed",
-          turnId: "turn-2",
+          turnId: "turn-1",
           streaming: false,
           createdAt: "2026-02-26T12:00:02.100Z",
           updatedAt: "2026-02-26T12:00:02.100Z",
         },
       }),
       makeEvent({
-        sequence: 7,
+        sequence: 10,
         type: "thread.reverted",
         aggregateKind: "thread",
         aggregateId: "thread-revert",
@@ -833,9 +891,12 @@ describe("orchestration projector", () => {
         turnId: message.turnId,
       })),
     ).toEqual([
+      { id: "user-keep", role: "user", turnId: null },
       { id: "assistant-keep", role: "assistant", turnId: "turn-1" },
-      { id: "user-remove", role: "user", turnId: "turn-2" },
+      { id: "user-remove", role: "user", turnId: null },
     ]);
+    expect(thread?.activities.map((activity) => activity.id)).toEqual(["checkpoint-only-activity"]);
+    expect(thread?.proposedPlans.map((plan) => plan.id)).toEqual(["checkpoint-only-plan"]);
   });
 
   it("caps message and checkpoint retention for long-lived threads", async () => {

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -484,7 +484,7 @@ describe("orchestration projector", () => {
     expect(message?.updatedAt).toBe(completeAt);
   });
 
-  it("prunes reverted turn messages from in-memory thread snapshot", async () => {
+  it("preserves an uncheckpointed predecessor when reverting mixed history", async () => {
     const createdAt = "2026-02-23T10:00:00.000Z";
     const model = createEmptyReadModel(createdAt);
 
@@ -555,24 +555,6 @@ describe("orchestration projector", () => {
       }),
       makeEvent({
         sequence: 4,
-        type: "thread.turn-diff-completed",
-        aggregateKind: "thread",
-        aggregateId: "thread-1",
-        occurredAt: "2026-02-23T10:00:02.500Z",
-        commandId: "cmd-turn-1-complete",
-        payload: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          checkpointTurnCount: 1,
-          checkpointRef: "refs/t3/checkpoints/thread-1/turn/1",
-          status: "ready",
-          files: [],
-          assistantMessageId: "assistant-msg-1",
-          completedAt: "2026-02-23T10:00:02.500Z",
-        },
-      }),
-      makeEvent({
-        sequence: 5,
         type: "thread.activity-appended",
         aggregateKind: "thread",
         aggregateId: "thread-1",
@@ -592,7 +574,7 @@ describe("orchestration projector", () => {
         },
       }),
       makeEvent({
-        sequence: 6,
+        sequence: 5,
         type: "thread.message-sent",
         aggregateKind: "thread",
         aggregateId: "thread-1",
@@ -610,7 +592,7 @@ describe("orchestration projector", () => {
         },
       }),
       makeEvent({
-        sequence: 7,
+        sequence: 6,
         type: "thread.message-sent",
         aggregateKind: "thread",
         aggregateId: "thread-1",
@@ -628,7 +610,7 @@ describe("orchestration projector", () => {
         },
       }),
       makeEvent({
-        sequence: 8,
+        sequence: 7,
         type: "thread.turn-diff-completed",
         aggregateKind: "thread",
         aggregateId: "thread-1",
@@ -646,7 +628,7 @@ describe("orchestration projector", () => {
         },
       }),
       makeEvent({
-        sequence: 9,
+        sequence: 8,
         type: "thread.activity-appended",
         aggregateKind: "thread",
         aggregateId: "thread-1",
@@ -666,7 +648,7 @@ describe("orchestration projector", () => {
         },
       }),
       makeEvent({
-        sequence: 10,
+        sequence: 9,
         type: "thread.reverted",
         aggregateKind: "thread",
         aggregateId: "thread-1",
@@ -696,8 +678,8 @@ describe("orchestration projector", () => {
     expect(
       thread?.activities.map((activity) => ({ id: activity.id, turnId: activity.turnId })),
     ).toEqual([{ id: "activity-1", turnId: "turn-1" }]);
-    expect(thread?.checkpoints.map((checkpoint) => checkpoint.checkpointTurnCount)).toEqual([1]);
-    expect(thread?.latestTurn?.turnId).toBe("turn-1");
+    expect(thread?.checkpoints).toEqual([]);
+    expect(thread?.latestTurn).toBeNull();
   });
 
   it("retains the selected user prompt even when it is tied to the reverted turn", async () => {

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -690,6 +690,7 @@ describe("orchestration projector", () => {
       [
         { role: "user", text: "First edit" },
         { role: "assistant", text: "Updated README to v2.\n" },
+        { role: "user", text: "Second edit" },
       ],
     );
     expect(
@@ -699,7 +700,7 @@ describe("orchestration projector", () => {
     expect(thread?.latestTurn?.turnId).toBe("turn-1");
   });
 
-  it("does not fallback-retain messages tied to removed turn IDs", async () => {
+  it("retains the selected user prompt even when it is tied to the reverted turn", async () => {
     const createdAt = "2026-02-26T12:00:00.000Z";
     const model = createEmptyReadModel(createdAt);
 
@@ -849,7 +850,10 @@ describe("orchestration projector", () => {
         role: message.role,
         turnId: message.turnId,
       })),
-    ).toEqual([{ id: "assistant-keep", role: "assistant", turnId: "turn-1" }]);
+    ).toEqual([
+      { id: "assistant-keep", role: "assistant", turnId: "turn-1" },
+      { id: "user-remove", role: "user", turnId: "turn-2" },
+    ]);
   });
 
   it("caps message and checkpoint retention for long-lived threads", async () => {

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -84,41 +84,21 @@ function retainThreadMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   turnCount: number,
 ): ReadonlyArray<OrchestrationMessage> {
-  const compareMessages = (left: OrchestrationMessage, right: OrchestrationMessage): number =>
-    left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
-  const retainedMessageIds = new Set(
-    messages
-      .filter((message) => message.role === "user")
-      .toSorted(compareMessages)
-      .slice(0, turnCount + 1)
-      .map((message) => message.id),
-  );
-  const assistantTurnIndexes = new Map<string, number>();
-  let nextAssistantTurnIndex = 0;
-  for (const message of messages
-    .filter((entry) => entry.role === "assistant")
-    .toSorted(compareMessages)) {
-    if (message.turnId === null) {
-      if (nextAssistantTurnIndex < turnCount) {
-        retainedMessageIds.add(message.id);
-      }
-      nextAssistantTurnIndex += 1;
-      continue;
+  let userMessageIndex = 0;
+  let reachedTargetUser = false;
+  return messages.filter((message) => {
+    if (message.role === "system") {
+      return true;
     }
-    let assistantTurnIndex = assistantTurnIndexes.get(message.turnId);
-    if (assistantTurnIndex === undefined) {
-      assistantTurnIndex = nextAssistantTurnIndex;
-      assistantTurnIndexes.set(message.turnId, assistantTurnIndex);
-      nextAssistantTurnIndex += 1;
+    if (reachedTargetUser) {
+      return false;
     }
-    if (assistantTurnIndex < turnCount) {
-      retainedMessageIds.add(message.id);
+    if (message.role === "user") {
+      reachedTargetUser = userMessageIndex === turnCount;
+      userMessageIndex += 1;
     }
-  }
-
-  return messages.filter(
-    (message) => message.role === "system" || retainedMessageIds.has(message.id),
-  );
+    return true;
+  });
 }
 
 function retainThreadActivitiesAfterRevert(
@@ -605,9 +585,10 @@ export function projectEvent(
             thread.messages,
             payload.turnCount,
           ).slice(-MAX_THREAD_MESSAGES);
-          const retainedTurnIds = new Set(
-            messages.flatMap((message) => (message.turnId === null ? [] : [message.turnId])),
-          );
+          const retainedTurnIds = new Set([
+            ...checkpoints.map((checkpoint) => checkpoint.turnId),
+            ...messages.flatMap((message) => (message.turnId === null ? [] : [message.turnId])),
+          ]);
           const proposedPlans = retainThreadProposedPlansAfterRevert(
             thread.proposedPlans,
             retainedTurnIds,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -82,64 +82,43 @@ function decodeForEvent<A>(
 
 function retainThreadMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
-  retainedTurnIds: ReadonlySet<string>,
   turnCount: number,
 ): ReadonlyArray<OrchestrationMessage> {
-  const retainedMessageIds = new Set<string>();
-  for (const message of messages) {
-    if (message.role === "system") {
-      retainedMessageIds.add(message.id);
+  const compareMessages = (left: OrchestrationMessage, right: OrchestrationMessage): number =>
+    left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+  const retainedMessageIds = new Set(
+    messages
+      .filter((message) => message.role === "user")
+      .toSorted(compareMessages)
+      .slice(0, turnCount + 1)
+      .map((message) => message.id),
+  );
+  const assistantTurnIndexes = new Map<string, number>();
+  let nextAssistantTurnIndex = 0;
+  for (const message of messages
+    .filter((entry) => entry.role === "assistant")
+    .toSorted(compareMessages)) {
+    if (message.turnId === null) {
+      if (nextAssistantTurnIndex < turnCount) {
+        retainedMessageIds.add(message.id);
+      }
+      nextAssistantTurnIndex += 1;
       continue;
     }
-    if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
+    let assistantTurnIndex = assistantTurnIndexes.get(message.turnId);
+    if (assistantTurnIndex === undefined) {
+      assistantTurnIndex = nextAssistantTurnIndex;
+      assistantTurnIndexes.set(message.turnId, assistantTurnIndex);
+      nextAssistantTurnIndex += 1;
+    }
+    if (assistantTurnIndex < turnCount) {
       retainedMessageIds.add(message.id);
     }
   }
 
-  const retainedUserCount = messages.filter(
-    (message) => message.role === "user" && retainedMessageIds.has(message.id),
-  ).length;
-  // Reverting "to" a user message keeps that selected prompt visible. The
-  // payload count represents completed turns before it, so retain one extra user message.
-  const missingUserCount = Math.max(0, turnCount + 1 - retainedUserCount);
-  if (missingUserCount > 0) {
-    const fallbackUserMessages = messages
-      .filter((message) => message.role === "user" && !retainedMessageIds.has(message.id))
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-      )
-      .slice(0, missingUserCount);
-    for (const message of fallbackUserMessages) {
-      retainedMessageIds.add(message.id);
-    }
-  }
-
-  const retainedAssistantCount = messages.filter(
-    (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
-  ).length;
-  const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
-  if (missingAssistantCount > 0) {
-    const fallbackAssistantMessages = messages
-      .filter(
-        (message) =>
-          message.role === "assistant" &&
-          !retainedMessageIds.has(message.id) &&
-          (retainedTurnIds.size === 0 ||
-            message.turnId === null ||
-            retainedTurnIds.has(message.turnId)),
-      )
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-      )
-      .slice(0, missingAssistantCount);
-    for (const message of fallbackAssistantMessages) {
-      retainedMessageIds.add(message.id);
-    }
-  }
-
-  return messages.filter((message) => retainedMessageIds.has(message.id));
+  return messages.filter(
+    (message) => message.role === "system" || retainedMessageIds.has(message.id),
+  );
 }
 
 function retainThreadActivitiesAfterRevert(
@@ -622,12 +601,13 @@ export function projectEvent(
             .filter((entry) => entry.checkpointTurnCount <= payload.turnCount)
             .toSorted((left, right) => left.checkpointTurnCount - right.checkpointTurnCount)
             .slice(-MAX_THREAD_CHECKPOINTS);
-          const retainedTurnIds = new Set(checkpoints.map((checkpoint) => checkpoint.turnId));
           const messages = retainThreadMessagesAfterRevert(
             thread.messages,
-            retainedTurnIds,
             payload.turnCount,
           ).slice(-MAX_THREAD_MESSAGES);
+          const retainedTurnIds = new Set(
+            messages.flatMap((message) => (message.turnId === null ? [] : [message.turnId])),
+          );
           const proposedPlans = retainThreadProposedPlansAfterRevert(
             thread.proposedPlans,
             retainedTurnIds,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -99,15 +99,12 @@ function retainThreadMessagesAfterRevert(
   const retainedUserCount = messages.filter(
     (message) => message.role === "user" && retainedMessageIds.has(message.id),
   ).length;
-  const missingUserCount = Math.max(0, turnCount - retainedUserCount);
+  // Reverting "to" a user message keeps that selected prompt visible. The
+  // payload count represents completed turns before it, so retain one extra user message.
+  const missingUserCount = Math.max(0, turnCount + 1 - retainedUserCount);
   if (missingUserCount > 0) {
     const fallbackUserMessages = messages
-      .filter(
-        (message) =>
-          message.role === "user" &&
-          !retainedMessageIds.has(message.id) &&
-          (message.turnId === null || retainedTurnIds.has(message.turnId)),
-      )
+      .filter((message) => message.role === "user" && !retainedMessageIds.has(message.id))
       .toSorted(
         (left, right) =>
           left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
@@ -128,7 +125,9 @@ function retainThreadMessagesAfterRevert(
         (message) =>
           message.role === "assistant" &&
           !retainedMessageIds.has(message.id) &&
-          (message.turnId === null || retainedTurnIds.has(message.turnId)),
+          (retainedTurnIds.size === 0 ||
+            message.turnId === null ||
+            retainedTurnIds.has(message.turnId)),
       )
       .toSorted(
         (left, right) =>

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -748,50 +748,76 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       }
 
       const headExists = yield* hasHeadCommit(input.cwd);
-      let snapshotHasEntries = true;
       if (!headExists) {
-        // In an unborn repository every restored path is still untracked from
-        // Git's perspective. Clean first so we remove post-checkpoint files
-        // without immediately deleting the files restored from the snapshot.
-        yield* execute({
-          operation,
-          cwd: input.cwd,
-          args: ["clean", "-fd", "--", "."],
-        });
-        const snapshotEntries = yield* execute({
-          operation,
-          cwd: input.cwd,
-          args: ["ls-tree", "-r", "--name-only", commitOid],
-        });
-        snapshotHasEntries = snapshotEntries.stdout.trim().length > 0;
+        const gitCommonDir = yield* resolveGitCommonDir(input.cwd);
+        const tempIndexPath = path.join(
+          gitCommonDir,
+          `t3-checkpoint-restore-index-${NodeCrypto.randomUUID()}`,
+        );
+        const restoreEnv: NodeJS.ProcessEnv = {
+          ...process.env,
+          GIT_INDEX_FILE: tempIndexPath,
+        };
+        const cleanupTempIndex = fileSystem
+          .remove(tempIndexPath, { force: true })
+          .pipe(Effect.ignore);
+
+        yield* Effect.gen(function* () {
+          // The real index is empty in an unborn repository. Clean before
+          // restoring so untracked paths cannot block the checkout.
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["clean", "-fd", "--", "."],
+          });
+          const snapshotEntries = yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["ls-tree", "-r", "--name-only", commitOid],
+          });
+          if (snapshotEntries.stdout.trim().length > 0) {
+            yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: ["restore", "--source", commitOid, "--worktree", "--", "."],
+            });
+          }
+
+          // Load the checkpoint tree into a temporary index before the final
+          // clean. Snapshot files are then protected as tracked, while paths
+          // ignored only by post-checkpoint rules are removed safely without -x.
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["read-tree", commitOid],
+            env: restoreEnv,
+          });
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["clean", "-fd", "--", "."],
+            env: restoreEnv,
+          });
+        }).pipe(Effect.ensuring(cleanupTempIndex));
+
+        return true;
       }
-      if (headExists || snapshotHasEntries) {
-        yield* execute({
-          operation,
-          cwd: input.cwd,
-          args: [
-            "restore",
-            "--source",
-            commitOid,
-            "--worktree",
-            ...(headExists ? ["--staged"] : []),
-            "--",
-            ".",
-          ],
-        });
-      }
-      if (headExists) {
-        yield* execute({
-          operation,
-          cwd: input.cwd,
-          args: ["clean", "-fd", "--", "."],
-        });
-        yield* execute({
-          operation,
-          cwd: input.cwd,
-          args: ["reset", "--quiet", "--", "."],
-        });
-      }
+
+      yield* execute({
+        operation,
+        cwd: input.cwd,
+        args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
+      });
+      yield* execute({
+        operation,
+        cwd: input.cwd,
+        args: ["clean", "-fd", "--", "."],
+      });
+      yield* execute({
+        operation,
+        cwd: input.cwd,
+        args: ["reset", "--quiet", "--", "."],
+      });
 
       return true;
     }),

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -748,6 +748,7 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       }
 
       const headExists = yield* hasHeadCommit(input.cwd);
+      let snapshotHasEntries = true;
       if (!headExists) {
         // In an unborn repository every restored path is still untracked from
         // Git's perspective. Clean first so we remove post-checkpoint files
@@ -757,20 +758,28 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
           cwd: input.cwd,
           args: ["clean", "-fd", "--", "."],
         });
+        const snapshotEntries = yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["ls-tree", "-r", "--name-only", commitOid],
+        });
+        snapshotHasEntries = snapshotEntries.stdout.trim().length > 0;
       }
-      yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: [
-          "restore",
-          "--source",
-          commitOid,
-          "--worktree",
-          ...(headExists ? ["--staged"] : []),
-          "--",
-          ".",
-        ],
-      });
+      if (headExists || snapshotHasEntries) {
+        yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: [
+            "restore",
+            "--source",
+            commitOid,
+            "--worktree",
+            ...(headExists ? ["--staged"] : []),
+            "--",
+            ".",
+          ],
+        });
+      }
       if (headExists) {
         yield* execute({
           operation,

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -747,19 +747,36 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         return false;
       }
 
-      yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
-      });
-      yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: ["clean", "-fd", "--", "."],
-      });
-
       const headExists = yield* hasHeadCommit(input.cwd);
+      if (!headExists) {
+        // In an unborn repository every restored path is still untracked from
+        // Git's perspective. Clean first so we remove post-checkpoint files
+        // without immediately deleting the files restored from the snapshot.
+        yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["clean", "-fd", "--", "."],
+        });
+      }
+      yield* execute({
+        operation,
+        cwd: input.cwd,
+        args: [
+          "restore",
+          "--source",
+          commitOid,
+          "--worktree",
+          ...(headExists ? ["--staged"] : []),
+          "--",
+          ".",
+        ],
+      });
       if (headExists) {
+        yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["clean", "-fd", "--", "."],
+        });
         yield* execute({
           operation,
           cwd: input.cwd,

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -92,6 +92,33 @@ describe("deriveRevertTurnCountByUserMessageId", () => {
     expect(result.get(user.message.id)).toBe(0);
     expect(result.get(secondUser.message.id)).toBe(1);
   });
+
+  it("uses conversation order for unmatched legacy turns in mixed checkpoint histories", () => {
+    const secondUser = timelineMessage("user-2", "user", null, "2026-03-29T00:00:02.000Z");
+    const secondAssistant = timelineMessage(
+      "assistant-2",
+      "assistant",
+      TurnId.make("turn-2"),
+      "2026-03-29T00:00:03.000Z",
+    );
+    const result = deriveRevertTurnCountByUserMessageId({
+      timelineEntries: [user, assistant, secondUser, secondAssistant],
+      checkpoints: [
+        {
+          turnId: TurnId.make("turn-2"),
+          checkpointTurnCount: 2,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/2"),
+          status: "ready",
+          files: [],
+          assistantMessageId: secondAssistant.message.id,
+          completedAt: secondAssistant.createdAt,
+        },
+      ],
+    });
+
+    expect(result.get(user.message.id)).toBe(0);
+    expect(result.get(secondUser.message.id)).toBe(1);
+  });
 });
 
 const environmentId = EnvironmentId.make("environment-local");

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,4 +1,5 @@
 import {
+  CheckpointRef,
   EnvironmentId,
   MessageId,
   ProjectId,
@@ -16,6 +17,7 @@ import {
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  deriveRevertTurnCountByUserMessageId,
   getStartedThreadModelChangeBlockReason,
   hasServerAcknowledgedLocalDispatch,
   reconcileMountedTerminalThreadIds,
@@ -23,6 +25,74 @@ import {
   resolveSendEnvMode,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
+
+function timelineMessage(
+  id: string,
+  role: "user" | "assistant",
+  turnId: TurnId | null,
+  createdAt: string,
+) {
+  return {
+    id: `entry-${id}`,
+    kind: "message" as const,
+    createdAt,
+    message: {
+      id: MessageId.make(id),
+      role,
+      text: id,
+      turnId,
+      createdAt,
+      updatedAt: createdAt,
+      streaming: false,
+    },
+  };
+}
+
+describe("deriveRevertTurnCountByUserMessageId", () => {
+  const user = timelineMessage("user-1", "user", null, "2026-03-29T00:00:00.000Z");
+  const assistant = timelineMessage(
+    "assistant-1",
+    "assistant",
+    TurnId.make("turn-1"),
+    "2026-03-29T00:00:01.000Z",
+  );
+
+  it("falls back to the stable turn id when the assistant message id is absent", () => {
+    const result = deriveRevertTurnCountByUserMessageId({
+      timelineEntries: [user, assistant],
+      checkpoints: [
+        {
+          turnId: TurnId.make("turn-1"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-1/turn/1"),
+          status: "ready",
+          files: [],
+          assistantMessageId: null,
+          completedAt: assistant.createdAt,
+        },
+      ],
+    });
+
+    expect(result.get(user.message.id)).toBe(0);
+  });
+
+  it("uses conversation order for completed legacy turns without checkpoints", () => {
+    const secondUser = timelineMessage("user-2", "user", null, "2026-03-29T00:00:02.000Z");
+    const secondAssistant = timelineMessage(
+      "assistant-2",
+      "assistant",
+      TurnId.make("turn-2"),
+      "2026-03-29T00:00:03.000Z",
+    );
+    const result = deriveRevertTurnCountByUserMessageId({
+      timelineEntries: [user, assistant, secondUser, secondAssistant],
+      checkpoints: [],
+    });
+
+    expect(result.get(user.message.id)).toBe(0);
+    expect(result.get(secondUser.message.id)).toBe(1);
+  });
+});
 
 const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -43,7 +43,6 @@ export function deriveRevertTurnCountByUserMessageId(input: {
   const checkpointByTurnId = new Map(
     input.checkpoints.map((checkpoint) => [checkpoint.turnId, checkpoint] as const),
   );
-  const useConversationOrderFallback = input.checkpoints.length === 0;
   let userTurnIndex = 0;
 
   for (let index = 0; index < input.timelineEntries.length; index += 1) {
@@ -70,10 +69,10 @@ export function deriveRevertTurnCountByUserMessageId(input: {
           ? undefined
           : checkpointByTurnId.get(nextEntry.message.turnId));
       if (checkpoint) {
-        result.set(entry.message.id, Math.max(0, checkpoint.checkpointTurnCount - 1));
+        result.set(entry.message.id, userTurnIndex);
         break;
       }
-      if (useConversationOrderFallback && !nextEntry.message.streaming) {
+      if (!nextEntry.message.streaming) {
         result.set(entry.message.id, userTurnIndex);
         break;
       }

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -9,7 +9,8 @@ import {
   type ThreadId,
   type TurnId,
 } from "@t3tools/contracts";
-import { type ChatMessage, type SessionPhase, type Thread } from "../types";
+import { type ChatMessage, type SessionPhase, type Thread, type TurnDiffSummary } from "../types";
+import type { TimelineEntry } from "../session-logic";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
 import { appAtomRegistry } from "../rpc/atomRegistry";
@@ -26,6 +27,63 @@ export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
+
+export function deriveRevertTurnCountByUserMessageId(input: {
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  checkpoints: ReadonlyArray<TurnDiffSummary>;
+}): Map<ChatMessage["id"], number> {
+  const result = new Map<ChatMessage["id"], number>();
+  const checkpointByAssistantMessageId = new Map(
+    input.checkpoints.flatMap((checkpoint) =>
+      checkpoint.assistantMessageId === null
+        ? []
+        : ([[checkpoint.assistantMessageId, checkpoint]] as const),
+    ),
+  );
+  const checkpointByTurnId = new Map(
+    input.checkpoints.map((checkpoint) => [checkpoint.turnId, checkpoint] as const),
+  );
+  const useConversationOrderFallback = input.checkpoints.length === 0;
+  let userTurnIndex = 0;
+
+  for (let index = 0; index < input.timelineEntries.length; index += 1) {
+    const entry = input.timelineEntries[index];
+    if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
+      continue;
+    }
+
+    for (let nextIndex = index + 1; nextIndex < input.timelineEntries.length; nextIndex += 1) {
+      const nextEntry = input.timelineEntries[nextIndex];
+      if (!nextEntry || nextEntry.kind !== "message") {
+        continue;
+      }
+      if (nextEntry.message.role === "user") {
+        break;
+      }
+      if (nextEntry.message.role !== "assistant") {
+        continue;
+      }
+
+      const checkpoint =
+        checkpointByAssistantMessageId.get(nextEntry.message.id) ??
+        (nextEntry.message.turnId === null
+          ? undefined
+          : checkpointByTurnId.get(nextEntry.message.turnId));
+      if (checkpoint) {
+        result.set(entry.message.id, Math.max(0, checkpoint.checkpointTurnCount - 1));
+        break;
+      }
+      if (useConversationOrderFallback && !nextEntry.message.streaming) {
+        result.set(entry.message.id, userTurnIndex);
+        break;
+      }
+    }
+
+    userTurnIndex += 1;
+  }
+
+  return result;
+}
 
 export function buildLocalDraftThread(
   threadId: ThreadId,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -231,6 +231,7 @@ import {
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  deriveRevertTurnCountByUserMessageId,
   hasServerAcknowledgedLocalDispatch,
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
@@ -2208,8 +2209,7 @@ function ChatViewContent(props: ChatViewProps) {
     attachDraftHeroComposerAnchorRef,
     captureDraftHeroComposerRect,
   ] = useDraftHeroLayoutTransition(isDraftHeroState);
-  const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
-    useTurnDiffSummaries(activeThread);
+  const { turnDiffSummaries } = useTurnDiffSummaries(activeThread);
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
     const byMessageId = new Map<MessageId, TurnDiffSummary>();
     for (const summary of turnDiffSummaries) {
@@ -2219,37 +2219,11 @@ function ChatViewContent(props: ChatViewProps) {
     return byMessageId;
   }, [turnDiffSummaries]);
   const revertTurnCountByUserMessageId = useMemo(() => {
-    const byUserMessageId = new Map<MessageId, number>();
-    for (let index = 0; index < timelineEntries.length; index += 1) {
-      const entry = timelineEntries[index];
-      if (!entry || entry.kind !== "message" || entry.message.role !== "user") {
-        continue;
-      }
-
-      for (let nextIndex = index + 1; nextIndex < timelineEntries.length; nextIndex += 1) {
-        const nextEntry = timelineEntries[nextIndex];
-        if (!nextEntry || nextEntry.kind !== "message") {
-          continue;
-        }
-        if (nextEntry.message.role === "user") {
-          break;
-        }
-        const summary = turnDiffSummaryByAssistantMessageId.get(nextEntry.message.id);
-        if (!summary) {
-          continue;
-        }
-        const turnCount =
-          summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId];
-        if (typeof turnCount !== "number") {
-          break;
-        }
-        byUserMessageId.set(entry.message.id, Math.max(0, turnCount - 1));
-        break;
-      }
-    }
-
-    return byUserMessageId;
-  }, [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByAssistantMessageId]);
+    return deriveRevertTurnCountByUserMessageId({
+      timelineEntries,
+      checkpoints: turnDiffSummaries,
+    });
+  }, [timelineEntries, turnDiffSummaries]);
 
   const gitCwd = activeProject
     ? projectScriptCwd({
@@ -3972,18 +3946,21 @@ function ChatViewContent(props: ChatViewProps) {
       if (activeEnvironmentUnavailable && activeEnvironmentUnavailableLabel) {
         setThreadError(
           activeThread.id,
-          `Reconnect ${activeEnvironmentUnavailableLabel} before reverting checkpoints.`,
+          `Reconnect ${activeEnvironmentUnavailableLabel} before reverting this conversation.`,
         );
         return;
       }
       if (phase === "running" || isSendBusy || isConnecting) {
-        setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
+        setThreadError(
+          activeThread.id,
+          "Interrupt the current turn before reverting this conversation.",
+        );
         return;
       }
       const confirmed = await localApi.dialogs.confirm(
         [
-          `Revert this thread to checkpoint ${turnCount}?`,
-          "This will discard newer messages and turn diffs in this thread.",
+          "Revert this conversation to this message?",
+          "This will discard newer messages and restore workspace files when a snapshot is available.",
           "This action cannot be undone.",
         ].join("\n"),
       );

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -271,6 +271,21 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("1 changed file");
   });
 
+  it("renders a disabled revert action while a user turn has no checkpoint yet", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        isWorking
+        activeTurnInProgress
+        timelineEntries={[buildUserTimelineEntry("Current prompt.")]}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Revert to this message"');
+    expect(markup).toContain("disabled");
+  });
+
   it("uses LegendList isNearEnd when deciding whether the live edge is visible", async () => {
     const {
       resolveTimelineIsAtEnd,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -328,6 +328,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
   );
+  const timelineViewportWidthRef = useRef<number | null>(null);
+  const [timelineLayoutGeneration, setTimelineLayoutGeneration] = useState(0);
   const [minimapHasPersistentGutter, setMinimapHasPersistentGutter] = useState(false);
   const [minimapHitStripWidth, setMinimapHitStripWidth] = useState(0);
   const handleAnchorReady = useCallback(
@@ -395,25 +397,62 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       return;
     }
 
-    const measure = () => {
-      const viewportWidth = timelineViewportElement.getBoundingClientRect().width;
+    let layoutRefreshTimeout: number | undefined;
+
+    const measure = (forceLayoutRefresh = false) => {
+      const viewportWidth = Math.round(timelineViewportElement.getBoundingClientRect().width);
       const nextHasPersistentGutter = resolveTimelineMinimapHasPersistentGutter(viewportWidth);
       setMinimapHasPersistentGutter((current) =>
         current === nextHasPersistentGutter ? current : nextHasPersistentGutter,
       );
       setMinimapHitStripWidth(resolveTimelineMinimapHitStripWidth(viewportWidth));
+
+      if (viewportWidth <= 0) {
+        return;
+      }
+      if (timelineViewportWidthRef.current === null) {
+        timelineViewportWidthRef.current =
+          viewportWidth > 0 ? viewportWidth : timelineViewportWidthRef.current;
+        return;
+      }
+      if (!forceLayoutRefresh && viewportWidth === timelineViewportWidthRef.current) {
+        return;
+      }
+
+      timelineViewportWidthRef.current = viewportWidth;
+      if (layoutRefreshTimeout !== undefined) {
+        window.clearTimeout(layoutRefreshTimeout);
+      }
+      layoutRefreshTimeout = window.setTimeout(() => {
+        // LegendList caches both row measurements and recycled container widths. A desktop
+        // window resize can briefly make the chat only a few pixels wide. Clearing sizes alone
+        // leaves some recycled rows one-character-wide, so remount the list after resize settles.
+        flushSync(() => {
+          setTimelineLayoutGeneration((generation) => generation + 1);
+        });
+      }, 120);
     };
+    const handleViewportResize = () => measure(true);
 
-    const frame = requestAnimationFrame(measure);
+    const frame = requestAnimationFrame(() => measure());
 
-    const observer = new ResizeObserver(measure);
+    const observer = new ResizeObserver(() => measure());
     observer.observe(timelineViewportElement);
+    window.addEventListener("resize", handleViewportResize);
+    window.visualViewport?.addEventListener("resize", handleViewportResize);
+    const pollId = window.setInterval(() => measure(), 250);
 
     return () => {
       cancelAnimationFrame(frame);
+      if (layoutRefreshTimeout !== undefined) {
+        window.clearTimeout(layoutRefreshTimeout);
+      }
       observer.disconnect();
+      window.removeEventListener("resize", handleViewportResize);
+      window.visualViewport?.removeEventListener("resize", handleViewportResize);
+      window.clearInterval(pollId);
     };
-  }, [timelineViewportElement, rows.length]);
+  }, [timelineViewportElement]);
 
   const sharedState = useMemo<TimelineRowSharedState>(
     () => ({
@@ -482,8 +521,13 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   return (
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
-        <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
+        <div
+          ref={setTimelineViewportElement}
+          className="relative h-full min-h-0"
+          data-timeline-layout-generation={timelineLayoutGeneration}
+        >
           <LegendList<MessagesTimelineRow>
+            key={timelineLayoutGeneration}
             ref={listRef}
             data={rows}
             keyExtractor={keyExtractor}
@@ -955,7 +999,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
             </TooltipPopup>
           </Tooltip>
           <div className="flex items-center gap-0.5">
-            {canRevertAgentWork && <RevertUserMessageButton messageId={row.message.id} />}
+            <RevertUserMessageButton messageId={row.message.id} canRevert={canRevertAgentWork} />
             {displayedUserMessage.copyText && (
               <MessageCopyButton text={displayedUserMessage.copyText} variant="ghost" />
             )}
@@ -966,27 +1010,37 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
   );
 }
 
-function RevertUserMessageButton({ messageId }: { messageId: MessageId }) {
+function RevertUserMessageButton({
+  messageId,
+  canRevert,
+}: {
+  messageId: MessageId;
+  canRevert: boolean;
+}) {
   const ctx = use(TimelineRowCtx);
   const activity = use(TimelineRowActivityCtx);
+  const disabled = activity.isRevertingCheckpoint || activity.isWorking || !canRevert;
+  const tooltip = activity.isWorking
+    ? "Stop the current turn before reverting"
+    : canRevert
+      ? "Revert to this message"
+      : "Revert is unavailable until this turn finishes";
 
   return (
     <Tooltip>
-      <TooltipTrigger
-        render={
-          <Button
-            type="button"
-            size="xs"
-            variant="ghost"
-            disabled={activity.isRevertingCheckpoint || activity.isWorking}
-            onClick={() => ctx.onRevertUserMessage(messageId)}
-            aria-label="Revert to this message"
-          />
-        }
-      >
-        <Undo2Icon className="size-3" />
+      <TooltipTrigger render={<span className="inline-flex" />}>
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          disabled={disabled}
+          onClick={() => ctx.onRevertUserMessage(messageId)}
+          aria-label="Revert to this message"
+        >
+          <Undo2Icon className="size-3" />
+        </Button>
       </TooltipTrigger>
-      <TooltipPopup side="top">Revert to this message</TooltipPopup>
+      <TooltipPopup side="top">{tooltip}</TooltipPopup>
     </Tooltip>
   );
 }

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -763,6 +763,72 @@ describe("applyThreadDetailEvent", () => {
       }
     });
 
+    it("removes assistant output produced after the selected steering message", () => {
+      const steeringThread: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("steering-user-initial"),
+            role: "user",
+            text: "Start the task",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+          {
+            id: MessageId.make("steering-assistant-before"),
+            role: "assistant",
+            text: "Working on it",
+            turnId: TurnId.make("steering-turn"),
+            streaming: false,
+            createdAt: "2026-04-01T02:00:00.000Z",
+            updatedAt: "2026-04-01T02:00:00.000Z",
+          },
+          {
+            id: MessageId.make("steering-user-target"),
+            role: "user",
+            text: "Actually, change direction",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T03:00:00.000Z",
+            updatedAt: "2026-04-01T03:00:00.000Z",
+          },
+          {
+            id: MessageId.make("steering-assistant-after"),
+            role: "assistant",
+            text: "Changed direction",
+            turnId: TurnId.make("steering-turn"),
+            streaming: false,
+            createdAt: "2026-04-01T04:00:00.000Z",
+            updatedAt: "2026-04-01T04:00:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(steeringThread, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T05:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 1,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([
+          MessageId.make("steering-user-initial"),
+          MessageId.make("steering-assistant-before"),
+          MessageId.make("steering-user-target"),
+        ]);
+      }
+    });
+
     it("removes every message after the selected user prompt when checkpoints exist", () => {
       const threadWithData: OrchestrationThread = {
         ...baseThread,
@@ -871,6 +937,15 @@ describe("applyThreadDetailEvent", () => {
           },
           {
             id: MessageId.make("msg-3"),
+            role: "user",
+            text: "Second",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T02:30:00.000Z",
+            updatedAt: "2026-04-01T02:30:00.000Z",
+          },
+          {
+            id: MessageId.make("msg-4"),
             role: "assistant",
             text: "Response 2",
             turnId: TurnId.make("turn-2"),
@@ -895,7 +970,7 @@ describe("applyThreadDetailEvent", () => {
             checkpointRef: CheckpointRef.make("ref-2"),
             status: "ready",
             files: [],
-            assistantMessageId: MessageId.make("msg-3"),
+            assistantMessageId: MessageId.make("msg-4"),
             completedAt: "2026-04-01T03:00:00.000Z",
           },
         ],
@@ -919,9 +994,92 @@ describe("applyThreadDetailEvent", () => {
         // turn-2 checkpoint is filtered out (turnCount 2 > revert target 1)
         expect(result.thread.checkpoints).toHaveLength(1);
         expect(result.thread.checkpoints[0]?.turnId).toBe("turn-1");
-        // msg-3 (turn-2) is filtered, msg-1 (no turn) and msg-2 (turn-1) remain
-        expect(result.thread.messages).toHaveLength(2);
+        // The selected second user prompt remains, but its turn-2 response is removed.
+        expect(result.thread.messages).toHaveLength(3);
         expect(result.thread.latestTurn?.turnId).toBe("turn-1");
+      }
+    });
+
+    it("retains checkpoint turn entities when no assistant message exists", () => {
+      const retainedTurnId = TurnId.make("checkpoint-only-turn");
+      const checkpointOnlyThread: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("checkpoint-only-user"),
+            role: "user",
+            text: "Start",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+          {
+            id: MessageId.make("checkpoint-only-next-user"),
+            role: "user",
+            text: "Try again",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T02:00:00.000Z",
+            updatedAt: "2026-04-01T02:00:00.000Z",
+          },
+        ],
+        checkpoints: [
+          {
+            turnId: retainedTurnId,
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("checkpoint-only-ref"),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: "2026-04-01T01:30:00.000Z",
+          },
+        ],
+        proposedPlans: [
+          {
+            id: "checkpoint-only-plan",
+            turnId: retainedTurnId,
+            planMarkdown: "## Retained plan",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt: "2026-04-01T01:10:00.000Z",
+            updatedAt: "2026-04-01T01:10:00.000Z",
+          },
+        ],
+        activities: [
+          {
+            id: EventId.make("checkpoint-only-activity"),
+            tone: "tool",
+            kind: "command",
+            summary: "Retained activity",
+            payload: {},
+            turnId: retainedTurnId,
+            createdAt: "2026-04-01T01:20:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(checkpointOnlyThread, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T03:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 1,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.proposedPlans.map((plan) => plan.id)).toEqual([
+          "checkpoint-only-plan",
+        ]);
+        expect(result.thread.activities.map((activity) => activity.id)).toEqual([
+          EventId.make("checkpoint-only-activity"),
+        ]);
       }
     });
   });

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -666,6 +666,103 @@ describe("applyThreadDetailEvent", () => {
       }
     });
 
+    it("retains uncheckpointed predecessor responses in mixed histories", () => {
+      const mixedThread: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("mixed-user-1"),
+            role: "user",
+            text: "First",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+          {
+            id: MessageId.make("mixed-assistant-1"),
+            role: "assistant",
+            text: "Response 1",
+            turnId: TurnId.make("mixed-turn-1"),
+            streaming: false,
+            createdAt: "2026-04-01T02:00:00.000Z",
+            updatedAt: "2026-04-01T02:00:00.000Z",
+          },
+          {
+            id: MessageId.make("mixed-user-2"),
+            role: "user",
+            text: "Second",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T03:00:00.000Z",
+            updatedAt: "2026-04-01T03:00:00.000Z",
+          },
+          {
+            id: MessageId.make("mixed-assistant-2"),
+            role: "assistant",
+            text: "Response 2",
+            turnId: TurnId.make("mixed-turn-2"),
+            streaming: false,
+            createdAt: "2026-04-01T04:00:00.000Z",
+            updatedAt: "2026-04-01T04:00:00.000Z",
+          },
+          {
+            id: MessageId.make("mixed-user-3"),
+            role: "user",
+            text: "Third",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T05:00:00.000Z",
+            updatedAt: "2026-04-01T05:00:00.000Z",
+          },
+          {
+            id: MessageId.make("mixed-assistant-3"),
+            role: "assistant",
+            text: "Response 3",
+            turnId: TurnId.make("mixed-turn-3"),
+            streaming: false,
+            createdAt: "2026-04-01T06:00:00.000Z",
+            updatedAt: "2026-04-01T06:00:00.000Z",
+          },
+        ],
+        checkpoints: [
+          {
+            turnId: TurnId.make("mixed-turn-2"),
+            checkpointTurnCount: 2,
+            checkpointRef: CheckpointRef.make("mixed-ref-2"),
+            status: "ready",
+            files: [],
+            assistantMessageId: MessageId.make("mixed-assistant-2"),
+            completedAt: "2026-04-01T04:00:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(mixedThread, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T07:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 2,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([
+          MessageId.make("mixed-user-1"),
+          MessageId.make("mixed-assistant-1"),
+          MessageId.make("mixed-user-2"),
+          MessageId.make("mixed-assistant-2"),
+          MessageId.make("mixed-user-3"),
+        ]);
+      }
+    });
+
     it("removes every message after the selected user prompt when checkpoints exist", () => {
       const threadWithData: OrchestrationThread = {
         ...baseThread,

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -599,6 +599,157 @@ describe("applyThreadDetailEvent", () => {
   });
 
   describe("thread.reverted", () => {
+    it("retains earlier turns and the selected legacy user prompt", () => {
+      const legacyThread: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("legacy-user-1"),
+            role: "user",
+            text: "First",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+          {
+            id: MessageId.make("legacy-assistant-1"),
+            role: "assistant",
+            text: "Response 1",
+            turnId: TurnId.make("legacy-turn-1"),
+            streaming: false,
+            createdAt: "2026-04-01T02:00:00.000Z",
+            updatedAt: "2026-04-01T02:00:00.000Z",
+          },
+          {
+            id: MessageId.make("legacy-user-2"),
+            role: "user",
+            text: "Second",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T03:00:00.000Z",
+            updatedAt: "2026-04-01T03:00:00.000Z",
+          },
+          {
+            id: MessageId.make("legacy-assistant-2"),
+            role: "assistant",
+            text: "Response 2",
+            turnId: TurnId.make("legacy-turn-2"),
+            streaming: false,
+            createdAt: "2026-04-01T04:00:00.000Z",
+            updatedAt: "2026-04-01T04:00:00.000Z",
+          },
+        ],
+        checkpoints: [],
+      };
+
+      const result = applyThreadDetailEvent(legacyThread, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T05:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 1,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([
+          MessageId.make("legacy-user-1"),
+          MessageId.make("legacy-assistant-1"),
+          MessageId.make("legacy-user-2"),
+        ]);
+      }
+    });
+
+    it("removes every message after the selected user prompt when checkpoints exist", () => {
+      const threadWithData: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("user-hello"),
+            role: "user",
+            text: "hello",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+          {
+            id: MessageId.make("assistant-hello"),
+            role: "assistant",
+            text: "Hello!",
+            turnId: TurnId.make("turn-1"),
+            streaming: false,
+            createdAt: "2026-04-01T02:00:00.000Z",
+            updatedAt: "2026-04-01T02:00:00.000Z",
+          },
+          {
+            id: MessageId.make("user-create-file"),
+            role: "user",
+            text: "create a file",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T03:00:00.000Z",
+            updatedAt: "2026-04-01T03:00:00.000Z",
+          },
+          {
+            id: MessageId.make("assistant-create-file"),
+            role: "assistant",
+            text: "Created it.",
+            turnId: TurnId.make("turn-2"),
+            streaming: false,
+            createdAt: "2026-04-01T04:00:00.000Z",
+            updatedAt: "2026-04-01T04:00:00.000Z",
+          },
+        ],
+        checkpoints: [
+          {
+            turnId: TurnId.make("turn-1"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            status: "ready",
+            files: [],
+            assistantMessageId: MessageId.make("assistant-hello"),
+            completedAt: "2026-04-01T02:00:00.000Z",
+          },
+          {
+            turnId: TurnId.make("turn-2"),
+            checkpointTurnCount: 2,
+            checkpointRef: CheckpointRef.make("ref-2"),
+            status: "ready",
+            files: [],
+            assistantMessageId: MessageId.make("assistant-create-file"),
+            completedAt: "2026-04-01T04:00:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(threadWithData, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T05:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([
+          MessageId.make("user-hello"),
+        ]);
+      }
+    });
+
     it("filters entities to retained turns", () => {
       const threadWithData: OrchestrationThread = {
         ...baseThread,

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -418,9 +418,10 @@ export function applyThreadDetailEvent(
       );
 
       const messages = retainMessagesAfterRevert(thread.messages, event.payload.turnCount);
-      const retainedTurnIds = new Set(
-        messages.flatMap((message) => (message.turnId === null ? [] : [message.turnId])),
-      );
+      const retainedTurnIds = new Set([
+        ...Arr.map(checkpoints, (checkpoint) => checkpoint.turnId),
+        ...messages.flatMap((message) => (message.turnId === null ? [] : [message.turnId])),
+      ]);
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -535,40 +536,19 @@ function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   turnCount: number,
 ): OrchestrationMessage[] {
-  const compareMessages = (left: OrchestrationMessage, right: OrchestrationMessage): number =>
-    left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
-  const retainedMessageIds = new Set(
-    messages
-      .filter((message) => message.role === "user")
-      .toSorted(compareMessages)
-      .slice(0, turnCount + 1)
-      .map((message) => message.id),
-  );
-  const assistantTurnIndexes = new Map<string, number>();
-  let nextAssistantTurnIndex = 0;
-  for (const message of messages
-    .filter((entry) => entry.role === "assistant")
-    .toSorted(compareMessages)) {
-    if (message.turnId === null) {
-      if (nextAssistantTurnIndex < turnCount) {
-        retainedMessageIds.add(message.id);
-      }
-      nextAssistantTurnIndex += 1;
-      continue;
+  let userMessageIndex = 0;
+  let reachedTargetUser = false;
+  return Arr.filter(messages, (message) => {
+    if (message.role === "system") {
+      return true;
     }
-    let assistantTurnIndex = assistantTurnIndexes.get(message.turnId);
-    if (assistantTurnIndex === undefined) {
-      assistantTurnIndex = nextAssistantTurnIndex;
-      assistantTurnIndexes.set(message.turnId, assistantTurnIndex);
-      nextAssistantTurnIndex += 1;
+    if (reachedTargetUser) {
+      return false;
     }
-    if (assistantTurnIndex < turnCount) {
-      retainedMessageIds.add(message.id);
+    if (message.role === "user") {
+      reachedTargetUser = userMessageIndex === turnCount;
+      userMessageIndex += 1;
     }
-  }
-
-  return Arr.filter(
-    messages,
-    (message) => message.role === "system" || retainedMessageIds.has(message.id),
-  );
+    return true;
+  });
 }

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -417,11 +417,9 @@ export function applyThreadDetailEvent(
         Arr.sort(checkpointOrder),
       );
 
-      const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(
-        thread.messages,
-        retainedTurnIds,
-        event.payload.turnCount,
+      const messages = retainMessagesAfterRevert(thread.messages, event.payload.turnCount);
+      const retainedTurnIds = new Set(
+        messages.flatMap((message) => (message.turnId === null ? [] : [message.turnId])),
       );
       const proposedPlans = pipe(
         thread.proposedPlans,
@@ -535,63 +533,42 @@ function rebindCheckpointAssistantMessage(
 
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
-  retainedTurnIds: ReadonlySet<string>,
   turnCount: number,
 ): OrchestrationMessage[] {
-  const retainedMessageIds = new Set<string>();
-  for (const message of messages) {
-    if (message.role === "system") {
-      retainedMessageIds.add(message.id);
+  const compareMessages = (left: OrchestrationMessage, right: OrchestrationMessage): number =>
+    left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+  const retainedMessageIds = new Set(
+    messages
+      .filter((message) => message.role === "user")
+      .toSorted(compareMessages)
+      .slice(0, turnCount + 1)
+      .map((message) => message.id),
+  );
+  const assistantTurnIndexes = new Map<string, number>();
+  let nextAssistantTurnIndex = 0;
+  for (const message of messages
+    .filter((entry) => entry.role === "assistant")
+    .toSorted(compareMessages)) {
+    if (message.turnId === null) {
+      if (nextAssistantTurnIndex < turnCount) {
+        retainedMessageIds.add(message.id);
+      }
+      nextAssistantTurnIndex += 1;
       continue;
     }
-    if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
+    let assistantTurnIndex = assistantTurnIndexes.get(message.turnId);
+    if (assistantTurnIndex === undefined) {
+      assistantTurnIndex = nextAssistantTurnIndex;
+      assistantTurnIndexes.set(message.turnId, assistantTurnIndex);
+      nextAssistantTurnIndex += 1;
+    }
+    if (assistantTurnIndex < turnCount) {
       retainedMessageIds.add(message.id);
     }
   }
 
-  // The revert target is the next user prompt after the retained completed turns.
-  // Keep that selected prompt visible, but discard its response and every later message.
-  const targetUserCount = turnCount + 1;
-  const retainedUserCount = messages.filter(
-    (message) => message.role === "user" && retainedMessageIds.has(message.id),
-  ).length;
-  const missingUserCount = Math.max(0, targetUserCount - retainedUserCount);
-  if (missingUserCount > 0) {
-    const fallbackUserMessages = messages
-      .filter((message) => message.role === "user" && !retainedMessageIds.has(message.id))
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-      )
-      .slice(0, missingUserCount);
-    for (const message of fallbackUserMessages) {
-      retainedMessageIds.add(message.id);
-    }
-  }
-
-  const retainedAssistantCount = messages.filter(
-    (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
-  ).length;
-  const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
-  if (missingAssistantCount > 0) {
-    const fallbackAssistantMessages = messages
-      .filter(
-        (message) =>
-          message.role === "assistant" &&
-          !retainedMessageIds.has(message.id) &&
-          (retainedTurnIds.size === 0 ||
-            message.turnId === null ||
-            retainedTurnIds.has(message.turnId)),
-      )
-      .toSorted(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-      )
-      .slice(0, missingAssistantCount);
-    for (const message of fallbackAssistantMessages) {
-      retainedMessageIds.add(message.id);
-    }
-  }
-
-  return Arr.filter(messages, (message) => retainedMessageIds.has(message.id));
+  return Arr.filter(
+    messages,
+    (message) => message.role === "system" || retainedMessageIds.has(message.id),
+  );
 }

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -418,7 +418,11 @@ export function applyThreadDetailEvent(
       );
 
       const retainedTurnIds = new Set(Arr.map(checkpoints, (entry) => entry.turnId));
-      const messages = retainMessagesAfterRevert(thread.messages, retainedTurnIds);
+      const messages = retainMessagesAfterRevert(
+        thread.messages,
+        retainedTurnIds,
+        event.payload.turnCount,
+      );
       const proposedPlans = pipe(
         thread.proposedPlans,
         Arr.filter((plan) => plan.turnId === null || retainedTurnIds.has(plan.turnId)),
@@ -532,16 +536,62 @@ function rebindCheckpointAssistantMessage(
 function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
+  turnCount: number,
 ): OrchestrationMessage[] {
-  // Keep messages that belong to a retained turn, plus system messages and
-  // messages without a turn binding (pre-turn-0 user messages).
-  return Arr.filter(messages, (message) => {
+  const retainedMessageIds = new Set<string>();
+  for (const message of messages) {
     if (message.role === "system") {
-      return true;
+      retainedMessageIds.add(message.id);
+      continue;
     }
-    if (message.turnId === null) {
-      return true;
+    if (message.turnId !== null && retainedTurnIds.has(message.turnId)) {
+      retainedMessageIds.add(message.id);
     }
-    return retainedTurnIds.has(message.turnId);
-  });
+  }
+
+  // The revert target is the next user prompt after the retained completed turns.
+  // Keep that selected prompt visible, but discard its response and every later message.
+  const targetUserCount = turnCount + 1;
+  const retainedUserCount = messages.filter(
+    (message) => message.role === "user" && retainedMessageIds.has(message.id),
+  ).length;
+  const missingUserCount = Math.max(0, targetUserCount - retainedUserCount);
+  if (missingUserCount > 0) {
+    const fallbackUserMessages = messages
+      .filter((message) => message.role === "user" && !retainedMessageIds.has(message.id))
+      .toSorted(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .slice(0, missingUserCount);
+    for (const message of fallbackUserMessages) {
+      retainedMessageIds.add(message.id);
+    }
+  }
+
+  const retainedAssistantCount = messages.filter(
+    (message) => message.role === "assistant" && retainedMessageIds.has(message.id),
+  ).length;
+  const missingAssistantCount = Math.max(0, turnCount - retainedAssistantCount);
+  if (missingAssistantCount > 0) {
+    const fallbackAssistantMessages = messages
+      .filter(
+        (message) =>
+          message.role === "assistant" &&
+          !retainedMessageIds.has(message.id) &&
+          (retainedTurnIds.size === 0 ||
+            message.turnId === null ||
+            retainedTurnIds.has(message.turnId)),
+      )
+      .toSorted(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .slice(0, missingAssistantCount);
+    for (const message of fallbackAssistantMessages) {
+      retainedMessageIds.add(message.id);
+    }
+  }
+
+  return Arr.filter(messages, (message) => retainedMessageIds.has(message.id));
 }


### PR DESCRIPTION
## Summary

This fixes two user-facing issues:

1. The revert feature was unavailable in most conversation threads, even when hovering over a user message.
2. When another desktop window temporarily made T3 Code narrower, the conversation became squished and stayed that way after the window was closed.

## Revert was unavailable in most threads

The revert icon would appear in some conversations but be completely absent in many others. This made the feature feel inconsistent and often impossible to use.

![Revert action missing from a user message](https://raw.githubusercontent.com/1-minute-to-midnight/t3code/b736ee17bff4e439352624abf30efa8dca2706d2/pr-assets/missing-revert-control.png)

The fix keeps the revert action available on user messages and makes checkpoint matching work across current, resumed, imported, and older threads. While a turn is still running, the action remains visible but disabled with an explanation.

Reverting to a message now restores the conversation to that point and restores the corresponding workspace files. This also works in folders that are not Git repositories: T3 stores its own snapshots outside the workspace and does not create a `.git` directory in the user's project.

Implementation details:

- fall back from an exact assistant-message checkpoint match to stable turn IDs and conversation order when needed
- use a T3-managed shadow repository under the application state directory for non-Git workspace snapshots
- align the server and client projections so the selected user message remains while its response and every later message are removed
- prevent a non-Git revert from incorrectly reaching `GitVcsDriver` and failing with exit code 128

<details>
<summary>Additional revert failure screenshots</summary>

![A non-Git revert incorrectly failing in GitVcsDriver](https://raw.githubusercontent.com/1-minute-to-midnight/t3code/b736ee17bff4e439352624abf30efa8dca2706d2/pr-assets/nongit-revert-git-driver-failure.png)

![A later user message remaining after reverting to hello](https://raw.githubusercontent.com/1-minute-to-midnight/t3code/b736ee17bff4e439352624abf30efa8dca2706d2/pr-assets/revert-preserved-later-message.png)

</details>

## Resizing the window could permanently squish the conversation

Opening an external desktop window, such as KDE Konsole beside T3 Code, temporarily narrowed the app as expected. After closing that window, the T3 layout expanded again but the conversation rows remained collapsed into one-character-wide strips. Switching to another thread and back was previously required to reset them.

![Conversation rows remaining squished after the window expands](https://raw.githubusercontent.com/1-minute-to-midnight/t3code/b736ee17bff4e439352624abf30efa8dca2706d2/pr-assets/stale-timeline-after-resize.png)

The virtualized message list was retaining cached row measurements from the narrow layout. The fix refreshes the list after resizing settles, covering element resize notifications, desktop window and visual viewport changes, and compositor transitions that do not reliably emit the same event sequence.

## Validation

- 112 focused tests passed across seven affected test files
- targeted formatting and lint checks passed
- targeted type checks passed for `t3`, `@t3tools/web`, and `@t3tools/client-runtime`
- isolated browser verification confirmed that reverting to `hello` removes a file created by the next turn and removes every subsequent message
- isolated narrow/restore verification confirmed that conversation rows recover their correct width
- rebuilt AppImage reached `backend ready` and `main window created` in an isolated smoke test
- the reporter manually confirmed both fixes in the packaged AppImage

## Development note

**ChatGPT 5.6 Sol** was used to debug these issues, implement the fixes, and run the focused verification. The packaged result was then manually tested and confirmed by the reporter.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore missing revert actions and fix chat layout after viewport resize
> - Rewrites message retention on `thread.reverted` to truncate at the Nth user message boundary (by index) rather than by checkpoint-derived turn IDs, preserving uncheckpointed predecessor messages and always retaining system messages across the server projector, client reducer, and orchestration pipeline.
> - Adds `deriveRevertTurnCountByUserMessageId` in [`ChatView.logic.ts`](https://github.com/pingdotgg/t3code/pull/4157/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to map user messages to revert indices by matching checkpoints via `assistantMessageId` or `turnId` fallback, including non-streaming assistant messages.
> - Makes the revert button always visible in [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/pull/4157/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) with context-aware disabled state and tooltip, instead of being hidden when unavailable.
> - Fixes [`MessagesTimeline`](https://github.com/pingdotgg/t3code/pull/4157/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) remounting `LegendList` after viewport width changes settle (debounced 120ms) to reset cached measurements and correct layout after resize.
> - Extends [`CheckpointStore`](https://github.com/pingdotgg/t3code/pull/4157/files#diff-81ee8314218d1cb6f56ad7eece6b007318c109b5fbcb1f3a83ef99c8eb581c9d) to support non-Git workspaces via a per-workspace shadow bare Git repository, and fixes checkpoint restore in unborn repositories in [`GitVcsDriver`](https://github.com/pingdotgg/t3code/pull/4157/files#diff-51125f02a750f476d151ebf951da622dc9738e642dc72b99dc8bfccf689a1483).
> - Risk: revert now fails closed for threads where a summarized filesystem checkpoint cannot be restored — conversation history is not rewound and a `checkpoint.revert.failed` activity is recorded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bafb7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes checkpoint capture/restore, revert semantics, and Git detection across server and client; incorrect behavior could corrupt workspace files or desync conversation from disk state.
> 
> **Overview**
> Restores **revert-to-message** across more thread types and fixes a **chat layout** bug after the window narrows and widens again.
> 
> **Checkpoints and revert:** `CheckpointStore` now uses a T3-managed **shadow Git repo** under app state when the workspace does not own a Git root (non-Git folders, nested projects). `isGitRepository` only returns true for the canonical repo root. `CheckpointReactor` no longer skips checkpoint work for non-Git cwd; revert **fails closed** on missing filesystem snapshots when checkpoint summaries exist, but still allows **conversation-only** rollback for legacy threads. Revert retention on `thread.reverted` is rewritten to cut at the **Nth user message** (conversation index), not checkpoint turn IDs—server projector, projection pipeline, and client `threadReducer` stay aligned.
> 
> **UI:** `deriveRevertTurnCountByUserMessageId` centralizes revert targets (checkpoints, turn IDs, conversation order). Revert stays visible on user messages (disabled until the turn can revert). `MessagesTimeline` remounts the virtualized list after viewport width changes so rows do not stay one-character wide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bafb7b938e9f2bf2ab5b94054c0e6093d5322c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->