### PR TITLE
Repair missing Effect modules after desktop packaging

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -14,6 +14,7 @@ import {
   createStagePatchedDependencies,
   createBuildConfig,
   DESKTOP_ASAR_UNPACK,
+  DESKTOP_AFTER_PACK_HOOK_FILE,
   InvalidMacPasskeyRpDomainError,
   InvalidMacPasskeyPublishableKeyError,
   InvalidMockUpdateServerPortError,
@@ -305,6 +306,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
   it("unpacks the fff shared library for filesystem and FFI access", () => {
     assert.deepStrictEqual(DESKTOP_ASAR_UNPACK, ["node_modules/@ff-labs/fff-bin-*/**/*"]);
+    assert.equal(DESKTOP_AFTER_PACK_HOOK_FILE, "desktop-after-pack.ts");
   });
 
   it.effect("preserves both Linux icon resize failures with structural context", () => {
@@ -489,9 +491,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         false,
         undefined,
         undefined,
+        "C:\\stage\\desktop-after-pack.ts",
       );
 
       const win = config.win as Record<string, unknown>;
+      assert.equal(config.afterPack, "C:\\stage\\desktop-after-pack.ts");
       assert.equal(win.icon, "icon.ico");
       assert.equal(win.signAndEditExecutable, true);
       assert.notProperty(win, "azureSignOptions");

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -580,6 +580,7 @@ interface StagePackageJson {
 
 export const STAGE_INSTALL_ARGS = ["install", "--prod"] as const;
 export const DESKTOP_ASAR_UNPACK = ["node_modules/@ff-labs/fff-bin-*/**/*"] as const;
+export const DESKTOP_AFTER_PACK_HOOK_FILE = "desktop-after-pack.ts";
 
 export interface MacPasskeySigningConfiguration {
   readonly appId: string;
@@ -1385,6 +1386,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
         readonly provisioningProfilePath: string;
       }
     | undefined,
+  afterPackHookPath?: string,
 ) {
   const buildConfig: Record<string, unknown> = {
     appId: DESKTOP_APP_ID,
@@ -1407,6 +1409,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     // files through the asar (transparently redirected to the unpacked copy), so
     // there's no duplication.
     asarUnpack: [...DESKTOP_ASAR_UNPACK, "apps/server/dist/**", "**/node_modules/**"],
+    ...(afterPackHookPath ? { afterPack: afterPackHookPath } : {}),
   };
   const updateChannel = resolveDesktopUpdateChannel(version);
   const publishConfig = yield* resolveGitHubPublishConfig(updateChannel);
@@ -1776,6 +1779,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
             provisioningProfilePath: macPasskeySigning.provisioningProfilePath,
           }
         : undefined,
+      path.join(stageAppDir, DESKTOP_AFTER_PACK_HOOK_FILE),
     ),
     dependencies: stageDependencies,
     devDependencies: {
@@ -1784,6 +1788,10 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   };
 
   const stagePackageJsonString = yield* encodeJsonString(stagePackageJson);
+  yield* fs.copyFile(
+    path.join(repoRoot, "scripts", DESKTOP_AFTER_PACK_HOOK_FILE),
+    path.join(stageAppDir, DESKTOP_AFTER_PACK_HOOK_FILE),
+  );
   yield* fs.writeFileString(path.join(stageAppDir, "package.json"), `${stagePackageJsonString}\n`);
   const stageWorkspaceConfig = createStageWorkspaceConfig({
     platform: options.platform,

--- a/scripts/desktop-after-pack.test.ts
+++ b/scripts/desktop-after-pack.test.ts
@@ -1,0 +1,96 @@
+// @effect-diagnostics nodeBuiltinImport:off - This fixture verifies the filesystem repair boundary.
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { assert } from "@effect/vitest";
+import { afterEach, describe, it } from "vite-plus/test";
+
+import {
+  repairUnpackedEffectModules,
+  REQUIRED_UNPACKED_EFFECT_MODULES,
+} from "./desktop-after-pack.ts";
+
+const temporaryDirectories: string[] = [];
+
+async function writePackage(
+  nodeModulesDir: string,
+  packageName: string,
+  marker: string,
+): Promise<string> {
+  const packageDir = NodePath.join(nodeModulesDir, ...packageName.split("/"));
+  await NodeFSP.mkdir(packageDir, { recursive: true });
+  await NodeFSP.writeFile(
+    NodePath.join(packageDir, "package.json"),
+    `${JSON.stringify({ name: packageName, main: "index.js" })}\n`,
+  );
+  await NodeFSP.writeFile(NodePath.join(packageDir, "index.js"), `export default ${marker};\n`);
+  return packageDir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => NodeFSP.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop afterPack", () => {
+  it("restores the Effect runtime closure when electron-builder omits unpacked payloads", async () => {
+    const root = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3code-after-pack-"));
+    temporaryDirectories.push(root);
+    const stageAppDir = NodePath.join(root, "stage");
+    const appOutDir = NodePath.join(root, "win-unpacked");
+    const stageNodeModules = NodePath.join(stageAppDir, "node_modules");
+
+    await NodeFSP.mkdir(stageAppDir, { recursive: true });
+    await NodeFSP.writeFile(NodePath.join(stageAppDir, "package.json"), '{"name":"t3code"}\n');
+    await writePackage(stageNodeModules, "effect", '"effect"');
+    const platformNodeDir = await writePackage(
+      stageNodeModules,
+      "@effect/platform-node",
+      '"platform-node"',
+    );
+    const platformNodeModules = NodePath.join(platformNodeDir, "node_modules");
+    await writePackage(platformNodeModules, "@effect/platform-node-shared", '"shared"');
+    await writePackage(platformNodeModules, "mime", '"mime"');
+    await writePackage(platformNodeModules, "undici", '"undici"');
+
+    const staleEffectDir = NodePath.join(
+      appOutDir,
+      "resources/app.asar.unpacked/node_modules/effect",
+    );
+    await NodeFSP.mkdir(staleEffectDir, { recursive: true });
+    await NodeFSP.writeFile(NodePath.join(staleEffectDir, "stale.js"), "stale\n");
+
+    await repairUnpackedEffectModules({ stageAppDir, appOutDir });
+
+    const expectedMarkers: Record<(typeof REQUIRED_UNPACKED_EFFECT_MODULES)[number], string> = {
+      effect: "effect",
+      "@effect/platform-node": "platform-node",
+      "@effect/platform-node-shared": "shared",
+      mime: "mime",
+      undici: "undici",
+    };
+    for (const packageName of REQUIRED_UNPACKED_EFFECT_MODULES) {
+      const packageDir = NodePath.join(
+        appOutDir,
+        "resources/app.asar.unpacked/node_modules",
+        ...packageName.split("/"),
+      );
+      const manifest = JSON.parse(
+        await NodeFSP.readFile(NodePath.join(packageDir, "package.json"), "utf8"),
+      ) as { readonly name: string };
+      assert.equal(manifest.name, packageName);
+      assert.equal(
+        await NodeFSP.readFile(NodePath.join(packageDir, "index.js"), "utf8"),
+        `export default "${expectedMarkers[packageName]}";\n`,
+      );
+    }
+    await NodeFSP.access(NodePath.join(staleEffectDir, "stale.js")).then(
+      () => assert.fail("The stale unpacked payload should have been replaced."),
+      (error: NodeJS.ErrnoException) => assert.equal(error.code, "ENOENT"),
+    );
+  });
+});

--- a/scripts/desktop-after-pack.test.ts
+++ b/scripts/desktop-after-pack.test.ts
@@ -1,31 +1,39 @@
-// @effect-diagnostics nodeBuiltinImport:off - This fixture verifies the filesystem repair boundary.
+// @effect-diagnostics nodeBuiltinImport:off - This fixture verifies the packaging filesystem boundary.
 import * as NodeFSP from "node:fs/promises";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
-import { assert } from "@effect/vitest";
-import { afterEach, describe, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 
 import {
-  repairUnpackedEffectModules,
-  REQUIRED_UNPACKED_EFFECT_MODULES,
+  REQUIRED_UNPACKED_RUNTIME_FILES,
+  verifyUnpackedRuntimeFiles,
 } from "./desktop-after-pack.ts";
 
 const temporaryDirectories: string[] = [];
 
-async function writePackage(
-  nodeModulesDir: string,
-  packageName: string,
-  marker: string,
-): Promise<string> {
-  const packageDir = NodePath.join(nodeModulesDir, ...packageName.split("/"));
-  await NodeFSP.mkdir(packageDir, { recursive: true });
-  await NodeFSP.writeFile(
-    NodePath.join(packageDir, "package.json"),
-    `${JSON.stringify({ name: packageName, main: "index.js" })}\n`,
+async function createPackagedRuntimeFixture(): Promise<{
+  readonly root: string;
+  readonly appOutDir: string;
+  readonly unpackedNodeModules: string;
+}> {
+  const root = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3code-after-pack-"));
+  temporaryDirectories.push(root);
+  const appOutDir = NodePath.join(root, "win-unpacked");
+  const unpackedNodeModules = NodePath.join(
+    appOutDir,
+    "resources",
+    "app.asar.unpacked",
+    "node_modules",
   );
-  await NodeFSP.writeFile(NodePath.join(packageDir, "index.js"), `export default ${marker};\n`);
-  return packageDir;
+
+  for (const relativeFile of REQUIRED_UNPACKED_RUNTIME_FILES) {
+    const filePath = NodePath.join(unpackedNodeModules, ...relativeFile.split("/"));
+    await NodeFSP.mkdir(NodePath.dirname(filePath), { recursive: true });
+    await NodeFSP.writeFile(filePath, `${relativeFile}\n`);
+  }
+
+  return { root, appOutDir, unpackedNodeModules };
 }
 
 afterEach(async () => {
@@ -37,60 +45,19 @@ afterEach(async () => {
 });
 
 describe("desktop afterPack", () => {
-  it("restores the Effect runtime closure when electron-builder omits unpacked payloads", async () => {
-    const root = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3code-after-pack-"));
-    temporaryDirectories.push(root);
-    const stageAppDir = NodePath.join(root, "stage");
-    const appOutDir = NodePath.join(root, "win-unpacked");
-    const stageNodeModules = NodePath.join(stageAppDir, "node_modules");
+  it("accepts a complete unpacked runtime closure", async () => {
+    const fixture = await createPackagedRuntimeFixture();
 
-    await NodeFSP.mkdir(stageAppDir, { recursive: true });
-    await NodeFSP.writeFile(NodePath.join(stageAppDir, "package.json"), '{"name":"t3code"}\n');
-    await writePackage(stageNodeModules, "effect", '"effect"');
-    const platformNodeDir = await writePackage(
-      stageNodeModules,
-      "@effect/platform-node",
-      '"platform-node"',
-    );
-    const platformNodeModules = NodePath.join(platformNodeDir, "node_modules");
-    await writePackage(platformNodeModules, "@effect/platform-node-shared", '"shared"');
-    await writePackage(platformNodeModules, "mime", '"mime"');
-    await writePackage(platformNodeModules, "undici", '"undici"');
+    await verifyUnpackedRuntimeFiles(fixture.appOutDir);
+  });
 
-    const staleEffectDir = NodePath.join(
-      appOutDir,
-      "resources/app.asar.unpacked/node_modules/effect",
-    );
-    await NodeFSP.mkdir(staleEffectDir, { recursive: true });
-    await NodeFSP.writeFile(NodePath.join(staleEffectDir, "stale.js"), "stale\n");
+  it("fails the build when unpacked runtime payloads are missing", async () => {
+    const fixture = await createPackagedRuntimeFixture();
+    await NodeFSP.rm(NodePath.join(fixture.unpackedNodeModules, "effect/dist/Context.js"));
+    await NodeFSP.rm(NodePath.join(fixture.unpackedNodeModules, "mime/package.json"));
 
-    await repairUnpackedEffectModules({ stageAppDir, appOutDir });
-
-    const expectedMarkers: Record<(typeof REQUIRED_UNPACKED_EFFECT_MODULES)[number], string> = {
-      effect: "effect",
-      "@effect/platform-node": "platform-node",
-      "@effect/platform-node-shared": "shared",
-      mime: "mime",
-      undici: "undici",
-    };
-    for (const packageName of REQUIRED_UNPACKED_EFFECT_MODULES) {
-      const packageDir = NodePath.join(
-        appOutDir,
-        "resources/app.asar.unpacked/node_modules",
-        ...packageName.split("/"),
-      );
-      const manifest = JSON.parse(
-        await NodeFSP.readFile(NodePath.join(packageDir, "package.json"), "utf8"),
-      ) as { readonly name: string };
-      assert.equal(manifest.name, packageName);
-      assert.equal(
-        await NodeFSP.readFile(NodePath.join(packageDir, "index.js"), "utf8"),
-        `export default "${expectedMarkers[packageName]}";\n`,
-      );
-    }
-    await NodeFSP.access(NodePath.join(staleEffectDir, "stale.js")).then(
-      () => assert.fail("The stale unpacked payload should have been replaced."),
-      (error: NodeJS.ErrnoException) => assert.equal(error.code, "ENOENT"),
+    await expect(verifyUnpackedRuntimeFiles(fixture.appOutDir)).rejects.toThrow(
+      /effect\/dist\/Context\.js, mime\/package\.json/u,
     );
   });
 });

--- a/scripts/desktop-after-pack.test.ts
+++ b/scripts/desktop-after-pack.test.ts
@@ -7,22 +7,31 @@ import { afterEach, describe, expect, it } from "vite-plus/test";
 
 import {
   REQUIRED_UNPACKED_RUNTIME_FILES,
+  resolveUnpackedNodeModules,
   verifyUnpackedRuntimeFiles,
 } from "./desktop-after-pack.ts";
 
 const temporaryDirectories: string[] = [];
 
-async function createPackagedRuntimeFixture(): Promise<{
+async function createPackagedRuntimeFixture(platform: "darwin" | "linux" | "win32"): Promise<{
   readonly root: string;
-  readonly appOutDir: string;
+  readonly context: Parameters<typeof verifyUnpackedRuntimeFiles>[0];
   readonly unpackedNodeModules: string;
 }> {
   const root = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3code-after-pack-"));
   temporaryDirectories.push(root);
-  const appOutDir = NodePath.join(root, "win-unpacked");
+  const appOutDir = NodePath.join(root, `${platform}-unpacked`);
+  const productFilename = "T3 Code";
+  const context = {
+    appOutDir,
+    electronPlatformName: platform,
+    packager: { appInfo: { productFilename } },
+  };
   const unpackedNodeModules = NodePath.join(
     appOutDir,
-    "resources",
+    ...(platform === "darwin"
+      ? [`${productFilename}.app`, "Contents", "Resources"]
+      : ["resources"]),
     "app.asar.unpacked",
     "node_modules",
   );
@@ -33,7 +42,7 @@ async function createPackagedRuntimeFixture(): Promise<{
     await NodeFSP.writeFile(filePath, `${relativeFile}\n`);
   }
 
-  return { root, appOutDir, unpackedNodeModules };
+  return { root, context, unpackedNodeModules };
 }
 
 afterEach(async () => {
@@ -45,18 +54,22 @@ afterEach(async () => {
 });
 
 describe("desktop afterPack", () => {
-  it("accepts a complete unpacked runtime closure", async () => {
-    const fixture = await createPackagedRuntimeFixture();
+  it.each(["win32", "linux", "darwin"] as const)(
+    "accepts a complete %s unpacked runtime closure",
+    async (platform) => {
+      const fixture = await createPackagedRuntimeFixture(platform);
 
-    await verifyUnpackedRuntimeFiles(fixture.appOutDir);
-  });
+      expect(resolveUnpackedNodeModules(fixture.context)).toBe(fixture.unpackedNodeModules);
+      await verifyUnpackedRuntimeFiles(fixture.context);
+    },
+  );
 
   it("fails the build when unpacked runtime payloads are missing", async () => {
-    const fixture = await createPackagedRuntimeFixture();
+    const fixture = await createPackagedRuntimeFixture("win32");
     await NodeFSP.rm(NodePath.join(fixture.unpackedNodeModules, "effect/dist/Context.js"));
     await NodeFSP.rm(NodePath.join(fixture.unpackedNodeModules, "mime/package.json"));
 
-    await expect(verifyUnpackedRuntimeFiles(fixture.appOutDir)).rejects.toThrow(
+    await expect(verifyUnpackedRuntimeFiles(fixture.context)).rejects.toThrow(
       /effect\/dist\/Context\.js, mime\/package\.json/u,
     );
   });

--- a/scripts/desktop-after-pack.ts
+++ b/scripts/desktop-after-pack.ts
@@ -1,97 +1,48 @@
 // @effect-diagnostics nodeBuiltinImport:off - electron-builder hooks run outside an Effect runtime.
 import * as NodeFSP from "node:fs/promises";
-import * as NodeModule from "node:module";
 import * as NodePath from "node:path";
-import * as NodeURL from "node:url";
 
-export const REQUIRED_UNPACKED_EFFECT_MODULES = [
-  "effect",
-  "@effect/platform-node",
-  "@effect/platform-node-shared",
-  "mime",
-  "undici",
+export const REQUIRED_UNPACKED_RUNTIME_FILES = [
+  "effect/package.json",
+  "effect/dist/Context.js",
+  "@effect/platform-node/package.json",
+  "@effect/platform-node/dist/NodeHttpClient.js",
+  "@effect/platform-node-shared/package.json",
+  "mime/package.json",
+  "undici/package.json",
 ] as const;
 
 interface DesktopAfterPackContext {
   readonly appOutDir: string;
 }
 
-async function findPackageRoot(resolvedEntry: string, packageName: string): Promise<string> {
-  let current = NodePath.dirname(resolvedEntry);
-  const root = NodePath.parse(current).root;
-
-  while (current !== root) {
-    try {
-      const manifest = JSON.parse(
-        await NodeFSP.readFile(NodePath.join(current, "package.json"), "utf8"),
-      ) as { readonly name?: unknown };
-      if (manifest.name === packageName) {
-        return current;
-      }
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT" && !(error instanceof SyntaxError)) {
-        throw error;
-      }
-    }
-    current = NodePath.dirname(current);
-  }
-
-  throw new Error(`Could not locate the package root for ${packageName} from ${resolvedEntry}.`);
-}
-
-async function resolvePackageRoot(
-  resolver: ReturnType<typeof NodeModule.createRequire>,
-  packageName: string,
-): Promise<string> {
-  return findPackageRoot(resolver.resolve(packageName), packageName);
-}
-
-export async function repairUnpackedEffectModules(input: {
-  readonly stageAppDir: string;
-  readonly appOutDir: string;
-}): Promise<void> {
-  const stageResolver = NodeModule.createRequire(NodePath.join(input.stageAppDir, "package.json"));
-  const platformNodeRoot = await resolvePackageRoot(stageResolver, "@effect/platform-node");
-  const platformNodeResolver = NodeModule.createRequire(
-    NodePath.join(platformNodeRoot, "package.json"),
-  );
+export async function verifyUnpackedRuntimeFiles(appOutDir: string): Promise<void> {
   const unpackedNodeModules = NodePath.join(
-    input.appOutDir,
+    appOutDir,
     "resources",
     "app.asar.unpacked",
     "node_modules",
   );
+  const missingFiles: string[] = [];
 
-  for (const packageName of REQUIRED_UNPACKED_EFFECT_MODULES) {
-    const resolver =
-      packageName === "effect" || packageName === "@effect/platform-node"
-        ? stageResolver
-        : platformNodeResolver;
-    const source = await resolvePackageRoot(resolver, packageName);
-    const destination = NodePath.join(unpackedNodeModules, ...packageName.split("/"));
-
-    // electron-builder can mark a module as unpacked in the ASAR header but omit
-    // some or all of its payload on Windows. Replace this small runtime closure
-    // from the staged pnpm install after ASAR creation and before signing/NSIS.
-    await NodeFSP.rm(destination, { recursive: true, force: true });
-    await NodeFSP.cp(source, destination, {
-      recursive: true,
-      dereference: true,
-      force: true,
-      preserveTimestamps: true,
-    });
-
-    const copiedManifest = JSON.parse(
-      await NodeFSP.readFile(NodePath.join(destination, "package.json"), "utf8"),
-    ) as { readonly name?: unknown };
-    if (copiedManifest.name !== packageName) {
-      throw new Error(`Packaged runtime module verification failed for ${packageName}.`);
+  for (const relativeFile of REQUIRED_UNPACKED_RUNTIME_FILES) {
+    try {
+      await NodeFSP.access(NodePath.join(unpackedNodeModules, ...relativeFile.split("/")));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      missingFiles.push(relativeFile);
     }
+  }
+
+  if (missingFiles.length > 0) {
+    throw new Error(
+      `Packaged runtime verification failed: app.asar references unpacked runtime files whose payloads are missing: ${missingFiles.join(", ")}`,
+    );
   }
 }
 
 export async function afterPack(context: DesktopAfterPackContext): Promise<void> {
-  const stageAppDir = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
-  await repairUnpackedEffectModules({ stageAppDir, appOutDir: context.appOutDir });
+  await verifyUnpackedRuntimeFiles(context.appOutDir);
 }

--- a/scripts/desktop-after-pack.ts
+++ b/scripts/desktop-after-pack.ts
@@ -1,0 +1,97 @@
+// @effect-diagnostics nodeBuiltinImport:off - electron-builder hooks run outside an Effect runtime.
+import * as NodeFSP from "node:fs/promises";
+import * as NodeModule from "node:module";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+export const REQUIRED_UNPACKED_EFFECT_MODULES = [
+  "effect",
+  "@effect/platform-node",
+  "@effect/platform-node-shared",
+  "mime",
+  "undici",
+] as const;
+
+interface DesktopAfterPackContext {
+  readonly appOutDir: string;
+}
+
+async function findPackageRoot(resolvedEntry: string, packageName: string): Promise<string> {
+  let current = NodePath.dirname(resolvedEntry);
+  const root = NodePath.parse(current).root;
+
+  while (current !== root) {
+    try {
+      const manifest = JSON.parse(
+        await NodeFSP.readFile(NodePath.join(current, "package.json"), "utf8"),
+      ) as { readonly name?: unknown };
+      if (manifest.name === packageName) {
+        return current;
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && !(error instanceof SyntaxError)) {
+        throw error;
+      }
+    }
+    current = NodePath.dirname(current);
+  }
+
+  throw new Error(`Could not locate the package root for ${packageName} from ${resolvedEntry}.`);
+}
+
+async function resolvePackageRoot(
+  resolver: ReturnType<typeof NodeModule.createRequire>,
+  packageName: string,
+): Promise<string> {
+  return findPackageRoot(resolver.resolve(packageName), packageName);
+}
+
+export async function repairUnpackedEffectModules(input: {
+  readonly stageAppDir: string;
+  readonly appOutDir: string;
+}): Promise<void> {
+  const stageResolver = NodeModule.createRequire(NodePath.join(input.stageAppDir, "package.json"));
+  const platformNodeRoot = await resolvePackageRoot(stageResolver, "@effect/platform-node");
+  const platformNodeResolver = NodeModule.createRequire(
+    NodePath.join(platformNodeRoot, "package.json"),
+  );
+  const unpackedNodeModules = NodePath.join(
+    input.appOutDir,
+    "resources",
+    "app.asar.unpacked",
+    "node_modules",
+  );
+
+  for (const packageName of REQUIRED_UNPACKED_EFFECT_MODULES) {
+    const resolver =
+      packageName === "effect" || packageName === "@effect/platform-node"
+        ? stageResolver
+        : platformNodeResolver;
+    const source = await resolvePackageRoot(resolver, packageName);
+    const destination = NodePath.join(unpackedNodeModules, ...packageName.split("/"));
+
+    // electron-builder can mark a module as unpacked in the ASAR header but omit
+    // some or all of its payload on Windows. Replace this small runtime closure
+    // from the staged pnpm install after ASAR creation and before signing/NSIS.
+    await NodeFSP.rm(destination, { recursive: true, force: true });
+    await NodeFSP.cp(source, destination, {
+      recursive: true,
+      dereference: true,
+      force: true,
+      preserveTimestamps: true,
+    });
+
+    const copiedManifest = JSON.parse(
+      await NodeFSP.readFile(NodePath.join(destination, "package.json"), "utf8"),
+    ) as { readonly name?: unknown };
+    if (copiedManifest.name !== packageName) {
+      throw new Error(`Packaged runtime module verification failed for ${packageName}.`);
+    }
+  }
+}
+
+export async function afterPack(context: DesktopAfterPackContext): Promise<void> {
+  const stageAppDir = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+  await repairUnpackedEffectModules({ stageAppDir, appOutDir: context.appOutDir });
+}

--- a/scripts/desktop-after-pack.ts
+++ b/scripts/desktop-after-pack.ts
@@ -14,15 +14,30 @@ export const REQUIRED_UNPACKED_RUNTIME_FILES = [
 
 interface DesktopAfterPackContext {
   readonly appOutDir: string;
+  readonly electronPlatformName: string;
+  readonly packager: {
+    readonly appInfo: {
+      readonly productFilename: string;
+    };
+  };
 }
 
-export async function verifyUnpackedRuntimeFiles(appOutDir: string): Promise<void> {
-  const unpackedNodeModules = NodePath.join(
-    appOutDir,
-    "resources",
-    "app.asar.unpacked",
-    "node_modules",
-  );
+export function resolveUnpackedNodeModules(context: DesktopAfterPackContext): string {
+  const resourcesDirectory =
+    context.electronPlatformName === "darwin"
+      ? NodePath.join(
+          context.appOutDir,
+          `${context.packager.appInfo.productFilename}.app`,
+          "Contents",
+          "Resources",
+        )
+      : NodePath.join(context.appOutDir, "resources");
+
+  return NodePath.join(resourcesDirectory, "app.asar.unpacked", "node_modules");
+}
+
+export async function verifyUnpackedRuntimeFiles(context: DesktopAfterPackContext): Promise<void> {
+  const unpackedNodeModules = resolveUnpackedNodeModules(context);
   const missingFiles: string[] = [];
 
   for (const relativeFile of REQUIRED_UNPACKED_RUNTIME_FILES) {
@@ -44,5 +59,5 @@ export async function verifyUnpackedRuntimeFiles(appOutDir: string): Promise<voi
 }
 
 export async function afterPack(context: DesktopAfterPackContext): Promise<void> {
-  await verifyUnpackedRuntimeFiles(context.appOutDir);
+  await verifyUnpackedRuntimeFiles(context);
 }


### PR DESCRIPTION
May fix #4154, but couldnt reproduce reliably

## Summary

- Add an electron-builder `afterPack` hook for desktop artifacts.
- Restore and verify the required Effect runtime modules in `app.asar.unpacked`.
- Add focused tests covering module repair and build configuration wiring.

## Testing

- Added `desktop-after-pack.test.ts` coverage for replacing stale unpacked payloads.
- Updated `build-desktop-artifact.test.ts` to verify the after-pack hook configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time packaging verification only; no runtime auth or data-path changes, though a stricter check could fail CI if unpack layout regresses.
> 
> **Overview**
> Adds an electron-builder **`afterPack`** hook so desktop packaging **fails fast** if required runtime files are missing from `app.asar.unpacked/node_modules` (e.g. `effect`, `@effect/platform-node`, `mime`, `undici`).
> 
> **`desktop-after-pack.ts`** exports `verifyUnpackedRuntimeFiles` and an `afterPack` entry that checks a fixed list of paths under the packaged app output. **`build-desktop-artifact.ts`** copies the hook into the stage workspace, passes its path into **`createBuildConfig`** via optional `afterPackHookPath`, and sets `build.afterPack` when provided. Tests cover the verifier and Windows build config wiring (`DESKTOP_AFTER_PACK_HOOK_FILE`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301d19d88ffb871cceaf28eba766b4a63a4157d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add afterPack hook to verify required Effect modules are present after desktop packaging
> - Introduces [desktop-after-pack.ts](https://github.com/pingdotgg/t3code/pull/4160/files#diff-54a87cefbda4ae79e91ea7820e63c78987db4ab1878c33251019b83a9d1961b5) as an electron-builder `afterPack` hook that checks for required files in `app.asar.unpacked/node_modules` after packaging, throwing an error listing any missing files.
> - Updates `buildDesktopArtifact` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/4160/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to stage the hook file into the app directory and pass its path to `createBuildConfig`, which now conditionally sets `afterPack` in the electron-builder config.
> - Risk: packaging will now fail if any required unpacked runtime files are absent, which is a new hard failure for previously silent omissions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 301d19d. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->