### PR TITLE
Make test-t3-app skill discoverable by Claude Code

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary
- `test-t3-app` was authored via Codex and only lives under `.agents/skills/`, the path Codex's app-server scans (`skills/list` RPC, relayed in `apps/server/src/provider/Layers/CodexProvider.ts`)
- Claude Code (and T3's `ClaudeAdapter`, which runs sessions with `settingSources: ["user","project","local"]`) only discovers project skills under `.claude/skills/*/SKILL.md`, so it never saw this skill
- Adds `.claude/skills -> ../.agents/skills` symlink, mirroring the existing `CLAUDE.md -> AGENTS.md` convention, so a single `SKILL.md` serves both providers
- No per-provider metadata file (e.g. `agents/claude.yaml`) is needed — Claude Code only reads the `name`/`description` frontmatter in `SKILL.md`; the `agents/openai.yaml` `interface` block is Codex/T3-UI-only presentation metadata

## Test plan
- [x] Ran the real `claude` CLI in this repo before/after the symlink: skill list did not include `test-t3-app` before, includes it after, with description matching `SKILL.md` frontmatter verbatim
- [x] `git show` confirms `.claude/skills` was committed as a symlink (mode 120000), not a copy

Note: T3 Code's own in-product provider-skill picker UI still won't list `$test-t3-app` for Claude-backed sessions, since `apps/server/src/provider/Layers/ClaudeProvider.ts` always reports `skills: []` (unlike `CodexProvider.ts`). That's a separate, larger feature gap left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/discovery-only symlink with no runtime or security impact.
> 
> **Overview**
> Project skills such as `test-t3-app` live under `.agents/skills/` for Codex, but Claude Code only loads skills from `.claude/skills/*/SKILL.md`. This PR adds **`.claude/skills` → `../.agents/skills`**, following the same pattern as `CLAUDE.md` → `AGENTS.md`, so one `SKILL.md` tree is visible to both toolchains.
> 
> No application code changes; T3’s in-app Claude skill picker still reports an empty list until `ClaudeProvider` implements skill listing separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e04f361bfbeef6a9d41673e1e4c50b9ca0de20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.claude/skills` symlink to make `test-t3-app` skill discoverable by Claude Code
> Adds [.claude/skills](.claude/skills) as a symlink pointing to `../.agents/skills` so Claude Code can discover the existing skill definitions for this project.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95e04f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->