### PR TITLE
Fix draft banner stack overlap

### DIFF
--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ComposerBannerStack, type ComposerBannerStackItem } from "./ComposerBannerStack";
+
+const banner = (id: string): ComposerBannerStackItem => ({
+  id,
+  variant: "warning",
+  icon: <span aria-hidden="true">!</span>,
+  title: `${id} warning`,
+});
+
+describe("ComposerBannerStack", () => {
+  it("keeps expanded banners in layout flow so surrounding content moves out of their way", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerBannerStack items={[banner("front"), banner("stacked")]} />,
+    );
+
+    const expandedItems = markup.match(
+      /<div data-composer-banner-stack-expanded-items="true" class="([^"]+)">/,
+    );
+
+    expect(expandedItems?.[1]).toContain("grid-rows-[0fr]");
+    expect(expandedItems?.[1]).toContain("group-hover/banner-stack:grid-rows-[1fr]");
+    expect(expandedItems?.[1]).not.toContain("absolute");
+    expect(markup.indexOf("stacked warning")).toBeLessThan(markup.indexOf("front warning"));
+  });
+
+  it("does not render an expandable region for a single banner", () => {
+    const markup = renderToStaticMarkup(<ComposerBannerStack items={[banner("front")]} />);
+
+    expect(markup).not.toContain("data-composer-banner-stack-expanded-items");
+  });
+});

--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -22,8 +22,11 @@ describe("ComposerBannerStack", () => {
 
     expect(expandedItems?.[1]).toContain("grid-rows-[0fr]");
     expect(expandedItems?.[1]).toContain("group-hover/banner-stack:grid-rows-[1fr]");
+    expect(expandedItems?.[1]).toContain("z-20");
     expect(expandedItems?.[1]).not.toContain("absolute");
-    expect(markup.indexOf("stacked warning")).toBeLessThan(markup.indexOf("front warning"));
+    expect(markup.indexOf("front warning")).toBeLessThan(markup.indexOf("stacked warning"));
+    expect(markup).toContain("invisible pointer-events-none");
+    expect(markup).toContain("group-focus-within/banner-stack:visible");
   });
 
   it("does not render an expandable region for a single banner", () => {

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -101,6 +101,43 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
             aria-hidden="true"
           />
         ) : null}
+        {hasStack ? (
+          <div
+            data-composer-banner-stack-expanded-items="true"
+            className={cn(
+              "grid grid-rows-[0fr] transition-[grid-template-rows] duration-150 ease-out",
+              "group-hover/banner-stack:grid-rows-[1fr] group-focus-within/banner-stack:grid-rows-[1fr]",
+            )}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div
+                className={cn(
+                  "pointer-events-none space-y-2 pb-2 opacity-0",
+                  "translate-y-1 transform-gpu transition-[opacity,transform] duration-150 ease-out will-change-[opacity,transform]",
+                  "group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
+                  "group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
+                )}
+              >
+                {stackedItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className={cn(exitingItemId === item.id ? "pointer-events-none" : null)}
+                    style={{
+                      ...exitTransitionStyle,
+                      ...(exitingItemId === item.id ? stackedExitStyle : restingStyle),
+                    }}
+                  >
+                    <ComposerBannerStackAlert
+                      item={item}
+                      exiting={exitingItemId === item.id}
+                      onDismissRequest={() => requestDismiss(item)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : null}
         <div
           className={cn(
             "relative z-10",
@@ -117,34 +154,6 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
             onDismissRequest={() => requestDismiss(frontItem)}
           />
         </div>
-        {hasStack ? (
-          <div
-            className={cn(
-              "pointer-events-none absolute inset-x-0 bottom-[calc(100%+0.5rem)] z-20 space-y-2 opacity-0",
-              "transition-[opacity,transform] duration-150 ease-out",
-              "translate-y-1 transform-gpu will-change-[opacity,transform]",
-              "group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
-              "group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
-            )}
-          >
-            {stackedItems.map((item) => (
-              <div
-                key={item.id}
-                className={cn(exitingItemId === item.id ? "pointer-events-none" : null)}
-                style={{
-                  ...exitTransitionStyle,
-                  ...(exitingItemId === item.id ? stackedExitStyle : restingStyle),
-                }}
-              >
-                <ComposerBannerStackAlert
-                  item={item}
-                  exiting={exitingItemId === item.id}
-                  onDismissRequest={() => requestDismiss(item)}
-                />
-              </div>
-            ))}
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -85,7 +85,7 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
     <div className={cn("group/banner-stack mx-auto mb-2 max-w-3xl", className)}>
       <div
         className={cn(
-          "relative",
+          "relative flex flex-col-reverse",
           hasStack ? "group-hover/banner-stack:z-50 group-focus-within/banner-stack:z-50" : null,
         )}
       >
@@ -101,21 +101,37 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
             aria-hidden="true"
           />
         ) : null}
+        <div
+          className={cn(
+            "relative z-10",
+            exitingItemId === frontItem.id ? "pointer-events-none" : null,
+          )}
+          style={{
+            ...exitTransitionStyle,
+            ...(exitingItemId === frontItem.id ? frontExitStyle : restingStyle),
+          }}
+        >
+          <ComposerBannerStackAlert
+            item={frontItem}
+            exiting={exitingItemId === frontItem.id}
+            onDismissRequest={() => requestDismiss(frontItem)}
+          />
+        </div>
         {hasStack ? (
           <div
             data-composer-banner-stack-expanded-items="true"
             className={cn(
-              "grid grid-rows-[0fr] transition-[grid-template-rows] duration-150 ease-out",
+              "relative z-20 grid grid-rows-[0fr] transition-[grid-template-rows] duration-150 ease-out",
               "group-hover/banner-stack:grid-rows-[1fr] group-focus-within/banner-stack:grid-rows-[1fr]",
             )}
           >
             <div className="min-h-0 overflow-hidden">
               <div
                 className={cn(
-                  "pointer-events-none space-y-2 pb-2 opacity-0",
+                  "invisible pointer-events-none space-y-2 pb-2 opacity-0",
                   "translate-y-1 transform-gpu transition-[opacity,transform] duration-150 ease-out will-change-[opacity,transform]",
-                  "group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
-                  "group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
+                  "group-hover/banner-stack:visible group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
+                  "group-focus-within/banner-stack:visible group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
                 )}
               >
                 {stackedItems.map((item) => (
@@ -138,22 +154,6 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
             </div>
           </div>
         ) : null}
-        <div
-          className={cn(
-            "relative z-10",
-            exitingItemId === frontItem.id ? "pointer-events-none" : null,
-          )}
-          style={{
-            ...exitTransitionStyle,
-            ...(exitingItemId === frontItem.id ? frontExitStyle : restingStyle),
-          }}
-        >
-          <ComposerBannerStackAlert
-            item={frontItem}
-            exiting={exitingItemId === frontItem.id}
-            onDismissRequest={() => requestDismiss(frontItem)}
-          />
-        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -101,7 +101,7 @@ export function DraftHeroHeadline({
   );
 
   return (
-    <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-3xl text-foreground tracking-tight sm:text-5xl">
+    <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-2xl text-foreground tracking-tight sm:text-3xl">
       {hasResolvedProject ? (
         <>What should we build in {projectSelector}?</>
       ) : canChooseProject ? (


### PR DESCRIPTION
## Summary

- expand additional composer banners in normal layout flow instead of absolutely positioning them over nearby content
- preserve the collapsed stack treatment and hover/focus transition while allowing the draft hero to move out of the way
- add regression coverage for multi-banner and single-banner rendering

## Root cause

Additional banners were absolutely positioned above the front banner, so their expanded height was not included in layout. In the empty-draft hero, those cards painted over the draft CTA headline on hover or keyboard focus.

## Impact

Expanded warning and connection banners no longer obscure the draft CTA. The same flow-based sizing also lets docked composer inset measurement account for expanded stacks.

## Validation

- `vp test run apps/web/src/components/chat/ComposerBannerStack.test.tsx`
- `vp lint apps/web/src/components/chat/ComposerBannerStack.tsx apps/web/src/components/chat/ComposerBannerStack.test.tsx`
- `vp fmt --check apps/web/src/components/chat/ComposerBannerStack.tsx apps/web/src/components/chat/ComposerBannerStack.test.tsx`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/web build`
- React Doctor diff scan (no findings in the changed component; existing findings remain elsewhere)
- launched an isolated T3 development environment; collaborative preview automation could not attach because its stored session signature was rejected, so visual browser capture was unavailable

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix draft banner stack overlap by replacing absolute positioning with collapsible grid layout
> - Reworks `ComposerBannerStack` to render stacked banners in normal document flow using a `grid-rows` collapse/expand animation, so expanding banners push surrounding content instead of overlapping it.
> - The expanded items container transitions from `grid-rows-[0fr]` to `grid-rows-[1fr]` on group hover/focus-within; inner content toggles visibility and pointer-events accordingly.
> - Reduces `DraftHeroHeadline` font sizes (`text-3xl sm:text-5xl` → `text-2xl sm:text-3xl`) to address overlap at smaller viewports.
> - Adds tests in [`ComposerBannerStack.test.tsx`](https://github.com/pingdotgg/t3code/pull/4164/files#diff-42a843f261677966877e088af03bb146717f2e6ca66172f4763d8449d994a5f0) verifying layout class names, DOM ordering, and single-item rendering.
> - Behavioral Change: stacked banners now occupy layout space when expanded rather than floating above content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0507e3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and typography changes in chat composer/draft hero with regression tests; no auth, data, or API impact.
> 
> **Overview**
> Fixes draft hero overlap when multiple composer banners expand on hover or focus by **reworking `ComposerBannerStack`** so extra banners live in normal layout flow instead of floating above the headline.
> 
> Stacked items use a **collapsible `grid-rows-[0fr]` → `grid-rows-[1fr]`** animation on group hover/focus-within (with visibility/pointer-events on the inner content), **`flex-col-reverse`** so the front banner stays visually on top, and **no absolute positioning** on the expanded region—so the draft CTA and inset measurement can shift when the stack opens. **Single-banner** stacks skip the expandable region.
> 
> **`DraftHeroHeadline`** headline sizes are reduced (`text-3xl sm:text-5xl` → `text-2xl sm:text-3xl`) for tighter viewports.
> 
> Adds **`ComposerBannerStack.test.tsx`** regression tests for multi-banner layout classes/DOM order and single-banner behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0507e3ca7e2327b9ca30113a4517077f70b50409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->