### PR TITLE
Add portable mobile app testing guidance

### DIFF
--- a/.agents/skills/ios-debugger-agent/LICENSE
+++ b/.agents/skills/ios-debugger-agent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) OpenAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/ios-debugger-agent/SKILL.md
+++ b/.agents/skills/ios-debugger-agent/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: ios-debugger-agent
+description: Build, launch, inspect, and drive iOS apps with the repository-configured XcodeBuildMCP server. Use on macOS for iOS Simulator builds, focused native test runs, semantic UI automation, screenshots, logs, or debugging, including T3 Code Mobile verification.
+---
+
+# iOS Debugger Agent
+
+Use the repository-configured `xcodebuildmcp` tools instead of requiring a globally installed Codex plugin. Prefer MCP tools over raw `xcodebuild`, `xcrun`, or `simctl` when the client exposes them.
+
+## Confirm availability
+
+This workflow requires macOS 14.5 or newer, Xcode 16 or newer, and Node.js 18 or newer. The repository pins XcodeBuildMCP in both `.mcp.json` for Claude Code and `.codex/config.toml` for Codex. Project MCP servers may require one-time trust or approval followed by a new session.
+
+If the tools are missing:
+
+1. Confirm the repository is trusted and its project MCP server was approved.
+2. Restart or recreate the agent session after approving configuration.
+3. Run `npx --yes xcodebuildmcp@2.6.2 doctor` when the server starts but simulator or UI-automation tools are unavailable. Follow its actionable Xcode or AXe setup guidance.
+4. Fall back to the pinned XcodeBuildMCP CLI or native Apple CLIs only when the current agent client cannot expose project MCP tools.
+
+Do not ask contributors to install the OpenAI `build-ios-apps` plugin globally.
+
+## Establish one simulator context
+
+1. Call `session_show_defaults` before discovery, build, launch, or UI work.
+2. Call `list_sims` and select one explicit simulator UDID. Prefer a simulator that is already booted; boot an installed simulator when verification requires it, but do not create or download runtimes without user authorization.
+3. Call `session_set_defaults` with the project or workspace, scheme, Debug configuration, simulator ID, and bundle identifier when known.
+4. Keep every subsequent build, launch, screenshot, log capture, and UI action pinned to that same UDID.
+
+Avoid generic Mac window automation for switching among Simulator windows. Explicit device identity is more reliable.
+
+## Choose build or launch
+
+- Use `build_run_sim` when native source, native dependencies, entitlements, or project configuration changed.
+- Use `test_sim` for the smallest relevant native test target or test cases; do not run an entire workspace test matrix routinely.
+- Use `launch_app_sim` when a compatible app is already installed and no native rebuild is needed.
+- To reuse an existing build artifact, use `get_sim_app_path` or `get_app_bundle_id`, install it with `install_app_sim` when necessary, and then launch it.
+- Do not run a build-only action immediately before `build_run_sim` unless the task requires both artifacts.
+
+After launch, call `snapshot_ui` or `screenshot` before interacting. An open Simulator window alone is not evidence that the intended app launched.
+
+## Drive the UI semantically
+
+1. Call `snapshot_ui` to obtain the current accessibility hierarchy and element references.
+2. Use only current `elementRef` values whose snapshot entries list the intended action. XcodeBuildMCP `2.6.2` does not accept coordinates for `tap`; when the app exposes no actionable reference, prefer a registered deep link or another app-supported route and otherwise report the accessibility blocker.
+3. Refresh with `snapshot_ui` after navigation or layout changes. Element references are snapshot-specific.
+4. Use `wait_for_ui` for asynchronous transitions when available rather than fixed sleeps.
+5. Capture a final `screenshot` for the state that proves the affected flow.
+
+Use `gesture` or scoped swipe actions when needed. If a gesture is unreliable, return to a known route or relaunch rather than switching to generic desktop automation.
+
+## Capture logs and debug
+
+- Use `start_sim_log_cap` and `stop_sim_log_cap` with the exact bundle identifier for focused runtime logs.
+- Use debugger tools only when the task requires runtime diagnosis; attach to the selected simulator and app rather than an ambiguous process.
+- Summarize relevant errors instead of returning unbounded logs.
+
+## Clean up
+
+Stop only log captures, debugger sessions, apps, or simulators started for the current test. Leave pre-existing simulators and unrelated sessions alone.
+
+## Upstream
+
+Adapted from OpenAI's [`build-ios-apps`](https://github.com/openai/plugins/tree/main/plugins/build-ios-apps) plugin version `0.1.2` (`ios-debugger-agent`, MIT) and aligned with XcodeBuildMCP `2.6.2` tool names.

--- a/.agents/skills/ios-debugger-agent/agents/openai.yaml
+++ b/.agents/skills/ios-debugger-agent/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: "iOS Debugger Agent"
+  short_description: "Build and drive iOS Simulator apps"
+  default_prompt: "Use $ios-debugger-agent to build, launch, and inspect the current iOS app on Simulator."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "xcodebuildmcp"
+      description: "Repository-configured Xcode build, simulator, logging, debugging, and semantic UI tools"

--- a/.agents/skills/ios-simulator-browser/LICENSE
+++ b/.agents/skills/ios-simulator-browser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) OpenAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/ios-simulator-browser/SKILL.md
+++ b/.agents/skills/ios-simulator-browser/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ios-simulator-browser
+description: Stream an explicit iOS Simulator through pinned serve-sim into the T3 Code in-app browser or another agent browser. Use on Apple Silicon macOS when the user should watch simulator verification live or when browser-visible simulator evidence is needed.
+---
+
+# iOS Simulator Browser
+
+Use serve-sim as the shared visual feed for an iOS Simulator. Use `ios-debugger-agent` and XcodeBuildMCP semantic UI tools to drive the app; do not treat browser-canvas coordinates as a substitute for missing app accessibility.
+
+## Confirm availability
+
+serve-sim `0.1.45` requires Apple Silicon macOS, Xcode command-line tools, and Node.js 20 or newer. If the host is unsupported, continue with XcodeBuildMCP screenshots and report that live streaming was unavailable.
+
+When running inside T3 Code, use its product-native browser MCP to open the stream. Other agent hosts may use their own browser or preview surface.
+
+Keep serve-sim on its default `127.0.0.1` binding. Do not expose its preview to a LAN or tunnel unless the user explicitly requests that access and the network is trusted; the preview includes a token-gated shell-execution route.
+
+## Start one owned stream
+
+1. Obtain the exact simulator UDID from the iOS build or launch workflow.
+2. Check whether an existing serve-sim stream for that UDID belongs to another task. Reuse it only when explicitly shared; never kill another task's stream.
+3. Otherwise, clear only a stale stream for that UDID and start the pinned version with scoped cleanup:
+
+   ```bash
+   SIMULATOR_ID=<simulator-udid>
+   cleanup_serve_sim() {
+     npx --yes serve-sim@0.1.45 --kill "$SIMULATOR_ID" >/dev/null 2>&1 || true
+   }
+   trap cleanup_serve_sim EXIT INT TERM HUP
+   cleanup_serve_sim
+   npx --yes serve-sim@0.1.45 "$SIMULATOR_ID"
+   ```
+
+4. Keep the terminal alive and open the exact local URL printed by serve-sim in the agent's browser.
+5. Verify that a live simulator frame renders. A loaded wrapper page is not sufficient evidence.
+
+## Observe while driving semantically
+
+- Let the user watch the serve-sim stream while XcodeBuildMCP performs `snapshot_ui`, semantic taps, typing, gestures, and screenshots.
+- Keep the browser and Xcode tooling pinned to the same simulator UDID.
+- Do not switch to generic desktop automation or browser-canvas clicking merely because the stream is visible.
+
+If the in-app browser explicitly reports that previews are unavailable, do not install unrelated browser automation. Continue through XcodeBuildMCP, capture a simulator screenshot, report the unavailable live stream, and clean up the owned serve-sim process.
+
+## Finish
+
+Stop the long-running terminal and wait for its cleanup trap to finish. If it disappeared without cleanup, run `npx --yes serve-sim@0.1.45 --kill <simulator-udid>` for that exact simulator. Never run an unscoped `--kill`.
+
+## Upstream
+
+Adapted from OpenAI's [`build-ios-apps`](https://github.com/openai/plugins/tree/main/plugins/build-ios-apps) plugin version `0.1.2` (`ios-simulator-browser`, MIT). It invokes serve-sim `0.1.45` under its Apache-2.0 license without vendoring the package.

--- a/.agents/skills/ios-simulator-browser/agents/openai.yaml
+++ b/.agents/skills/ios-simulator-browser/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "iOS Simulator Browser"
+  short_description: "Stream iOS Simulator in the browser"
+  default_prompt: "Use $ios-simulator-browser to stream the selected iOS Simulator into the T3 Code in-app browser."

--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -5,6 +5,8 @@ description: Launch and test the T3 Code web app in isolated development environ
 
 # Test T3 App
 
+Use this skill for the web client. For iOS Simulator, Android Emulator, or physical-device testing against an isolated T3 backend, use the sibling [`test-t3-mobile`](../test-t3-mobile/SKILL.md) skill.
+
 ## Start an isolated web environment
 
 1. Run commands from the repository root.

--- a/.agents/skills/test-t3-mobile/SKILL.md
+++ b/.agents/skills/test-t3-mobile/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: test-t3-mobile
+description: Launch and test T3 Code Mobile on an iOS Simulator or Android Emulator against disposable local T3 environments, including Metro and dev-client reuse, native rebuild decisions, per-client pairing, seeded projects, semantic UI control, screenshots, and iOS serve-sim streaming. Use after mobile UI or native changes, when reproducing phone or tablet behavior, pairing an emulator to isolated state, or verifying mobile behavior on macOS, Linux, or Windows.
+---
+
+# Test T3 Mobile
+
+Run one focused, end-to-end mobile verification pass against disposable T3 state. Use the sibling [`test-t3-app`](../test-t3-app/SKILL.md) skill as the detailed reference for pairing-token semantics and SQLite fixtures.
+
+Command examples use POSIX shell syntax. On Windows, use PowerShell equivalents: set variables with `$env:NAME = "value"`, use an explicit temporary directory from `[System.IO.Path]::GetTempPath()`, and run multiline examples on one line or with PowerShell backticks. Use `$env:ANDROID_HOME\platform-tools\adb.exe` when `adb` is not already on `PATH`.
+
+## Select a viable platform
+
+Inspect the host and the affected code before launching processes:
+
+- On macOS with Xcode, prefer one representative iOS Simulator when the change is cross-platform so the user can watch through serve-sim. Load and follow [`ios-debugger-agent`](../ios-debugger-agent/SKILL.md), and load [`ios-simulator-browser`](../ios-simulator-browser/SKILL.md) when live streaming is available.
+- On macOS, Linux, or Windows with the Android SDK, use one Android Emulator when Android is the affected surface or iOS tooling is unavailable.
+- When the change is platform-specific, test that platform. When neither platform is viable, report the missing SDK, emulator, or dev-client prerequisite rather than claiming verification.
+
+Do not treat unavailable iOS tooling as a blocker when Android is a valid representative target.
+
+## Choose the lightest valid launch path
+
+- For JavaScript, TypeScript, or asset-only changes, reuse a compatible installed development client and start Metro. Do not rebuild native code merely to load a new bundle.
+- For native source, native dependencies, entitlements, config plugins, or generated project changes, rebuild the affected platform.
+- Use `vp run ios:dev` or `vp run android:dev` only when an Expo clean prebuild is actually required; both commands regenerate the native project.
+- If the user requested no native rebuild and no compatible app is installed, reuse an existing compatible `.app` or `.apk` artifact when available. Otherwise report the missing dev client instead of silently rebuilding.
+
+The development identity on both platforms is:
+
+- App: `T3 Code Dev`
+- Bundle/package identifier: `com.t3tools.t3code.dev`
+- URL scheme: `t3code-dev`
+
+Bundle or package presence proves the correct variant, not native compatibility. Reuse it only when the current changes did not alter its Expo SDK, native dependencies, config plugins, entitlements, generated project, or native source.
+
+## Start one disposable T3 environment
+
+Run backend commands from the repository root. Use the ignored, worktree-local `.t3` directory or create a fresh directory with the host OS's temporary-directory mechanism. An explicit base directory stores state in `<base-dir>/userdata`; never point testing at shared `~/.t3` state.
+
+Seed a small number of meaningful Git projects before starting the backend:
+
+```bash
+node apps/server/src/bin.ts project add <git-workspace> \
+  --base-dir <base-dir> \
+  --title <project-title>
+```
+
+Running `project add` before the backend starts gives it exclusive offline database access. If a backend is already running, wait until it is ready so the CLI dispatches through the live server; never run offline mutations concurrently with the server.
+
+Use direct SQLite mutation only for disposable projection fixtures. Follow `test-t3-app` and stop the backend before writing.
+
+Start a headless backend after seeding:
+
+```bash
+node apps/server/src/bin.ts serve \
+  --host 127.0.0.1 \
+  --port <server-port> \
+  --base-dir <base-dir> \
+  --no-browser
+```
+
+Use these client origins:
+
+- iOS Simulator: `http://127.0.0.1:<server-port>`
+- Android Emulator: `http://10.0.2.2:<server-port>`
+- Physical device: bind the backend to `0.0.0.0` and use the host's reachable LAN origin
+
+Always enter the complete `http://` origin; the mobile host field otherwise assumes HTTPS. When testing web and mobile together, run `vp run dev --home-dir <base-dir> --host 127.0.0.1` instead and do not launch a second backend over the same base directory.
+
+## Start or reuse Metro safely
+
+Run Metro from `apps/mobile`.
+
+1. Inspect any process on the intended Metro port and its `/status` response. Reuse it only when it is healthy, belongs to this worktree, and matches `APP_VARIANT=development`, `--dev-client`, and scheme `t3code-dev`.
+2. Never kill another worktree's Metro. Use a free explicit port when necessary.
+3. Run `vp run dev:client` on the standard port. For another port, retain the complete development identity:
+
+   ```bash
+   APP_VARIANT=development vp exec expo start \
+     --dev-client \
+     --scheme t3code-dev \
+     --clear \
+     --lan \
+     --port <metro-port>
+   ```
+
+   In PowerShell, set `$env:APP_VARIANT = "development"` first and then run the `vp exec expo start ...` command without the leading assignment.
+
+4. Open the exact development-client URL for the selected device and confirm the loaded bundle belongs to this worktree and Metro port.
+
+### iOS launch
+
+Use `ios-debugger-agent` to select one UDID and set these XcodeBuildMCP session defaults:
+
+- Workspace: `<repo>/apps/mobile/ios/T3CodeDev.xcworkspace`
+- Scheme: `T3CodeDev`
+- Configuration: `Debug`
+- Simulator ID: the selected UDID
+- Bundle ID: `com.t3tools.t3code.dev`
+
+Check the installed client with:
+
+```bash
+xcrun simctl get_app_container <simulator-udid> com.t3tools.t3code.dev app
+xcrun simctl openurl <simulator-udid> <printed-dev-client-url>
+```
+
+Accept the iOS confirmation prompt and dismiss the developer menu when it obscures the app.
+
+### Android launch
+
+Select one running emulator serial from `adb devices` and check the installed client:
+
+```bash
+adb -s <emulator-serial> shell pm path com.t3tools.t3code.dev
+adb -s <emulator-serial> reverse tcp:<metro-port> tcp:<metro-port>
+adb -s <emulator-serial> shell am start -W \
+  -a android.intent.action.VIEW \
+  -d '<printed-dev-client-url>' \
+  com.t3tools.t3code.dev
+```
+
+Do not start, stop, erase, or reconfigure an emulator owned by another task. Track and later stop only processes owned by this test.
+
+## Pair each client once
+
+Issue a fresh credential against the running backend's exact base directory:
+
+```bash
+T3CODE_PORT=<server-port> node apps/server/src/bin.ts auth pairing create \
+  --base-dir <base-dir> \
+  --base-url <mobile-origin> \
+  --ttl 15m \
+  --label agent-mobile-<short-device-id>
+```
+
+In PowerShell, set `$env:T3CODE_PORT = "<server-port>"` first and run the `node ... auth pairing create` command without the leading assignment.
+
+If the visible Add Environment action is not exposed as a semantic target, open the app's registered route instead of guessing coordinates:
+
+```bash
+xcrun simctl openurl <simulator-udid> 't3code-dev://connections/new'
+adb -s <emulator-serial> shell am start -W \
+  -a android.intent.action.VIEW \
+  -d 't3code-dev://connections/new' \
+  com.t3tools.t3code.dev
+```
+
+Run only the command for the selected platform.
+
+In T3 Code Dev, open Add Environment and enter the complete `<mobile-origin>` and newly printed `Token`. Verify the expected seeded projects appear before exercising the affected flow.
+
+Pairing credentials are secret, short-lived, and single-use. Create a different credential for every simulator, emulator, physical device, or browser. If an attempt fails, issue a new credential rather than retrying the old one. Do not expose tokens in screenshots, commits, or final responses.
+
+## Drive and observe the affected flow
+
+### iOS
+
+Use `snapshot_ui` and current element references from XcodeBuildMCP for taps and typing. Stream the same UDID through `ios-simulator-browser` so the user can watch in T3 Code when the host supports it. Use the stream as a visual feed rather than a reason to switch to fragile browser coordinates.
+
+### Android
+
+Prefer semantic Android automation exposed by the current agent host. Otherwise inspect the current hierarchy with `adb shell uiautomator dump`, target stable resource IDs, content descriptions, text, or bounds, and use scoped `adb shell input` actions. Refresh the hierarchy after navigation. Capture the final state with `adb exec-out screencap -p`.
+
+Android does not use serve-sim. Use a browser-compatible Android mirror when the host already provides one; otherwise return focused emulator screenshots as evidence rather than installing unrelated streaming infrastructure during verification.
+
+## Verify and clean up
+
+Exercise only the affected flow on one representative device unless the change specifically concerns platform, OS version, or screen size. Before finishing:
+
+1. Confirm the app connected to the intended disposable environment instead of merely rendering an empty disconnected state.
+2. Capture the relevant final state.
+3. Remove the disposable environment from T3 Code Dev.
+4. Remove any `adb reverse` rule created for this test with `adb -s <emulator-serial> reverse --remove tcp:<metro-port>`.
+5. Stop only the serve-sim, Metro, backend, emulator, and log processes started by this test.
+6. Remove only base directories and temporary Git repositories deliberately created for this test. Preserve them when they contain useful reproduction evidence.
+
+Keep local verification focused. Do not turn this workflow into a full repository test run.
+
+## Troubleshoot predictable failures
+
+- **Old UI or an old error appears:** verify Metro's worktree, variant, URL, and port before diagnosing the app.
+- **The environment remains empty:** verify the platform-specific HTTP origin, use a fresh token, and confirm project seeding used the identical base directory.
+- **A second client cannot pair:** pairing tokens are single-use; issue another token.
+- **iOS semantic actions fail:** set explicit XcodeBuildMCP defaults and refresh with `snapshot_ui`.
+- **Android cannot reach Metro:** verify `adb reverse` for the exact Metro port and relaunch the development-client URL.
+- **Android cannot reach the backend:** use `10.0.2.2`, not `127.0.0.1`, for the Android Emulator.

--- a/.agents/skills/test-t3-mobile/agents/openai.yaml
+++ b/.agents/skills/test-t3-mobile/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test T3 Mobile"
+  short_description: "Test T3 Code on iOS or Android"
+  default_prompt: "Use $test-t3-mobile to launch T3 Code against an isolated backend and verify the affected flow on an available simulator or emulator."

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+[mcp_servers.xcodebuildmcp]
+enabled = true
+required = false
+command = "npx"
+args = ["--yes", "xcodebuildmcp@2.6.2", "mcp"]
+startup_timeout_sec = 20.0
+
+[mcp_servers.xcodebuildmcp.env]
+XCODEBUILDMCP_ENABLED_WORKFLOWS = "simulator,ui-automation,debugging,logging"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "xcodebuildmcp": {
+      "command": "npx",
+      "args": ["--yes", "xcodebuildmcp@2.6.2", "mcp"],
+      "env": {
+        "XCODEBUILDMCP_ENABLED_WORKFLOWS": "simulator,ui-automation,debugging,logging"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@
   - Backend changes must include and run focused tests for the changed behavior.
   - Run targeted formatting, lint, and type checks for the affected scope when available.
 - Do not run repo-wide `vp check`, `vp run typecheck`, `vp run test`, or equivalent full-suite commands locally unless the user explicitly requests them. CI is responsible for the full verification suite.
-- After frontend feature development or any user-visible frontend behavior change, the primary agent must use the `test-t3-app` skill once after integrating the work. Launch one isolated environment, authenticate through the printed pairing URL, and verify the affected flow in the controlled browser.
-  - Subagents must not independently launch dev servers or repeat integrated browser verification unless their delegated task explicitly requires it.
+- After frontend feature development or any user-visible frontend behavior change, the primary agent must run one integrated verification pass for each affected client surface after integrating the work:
+  - Web: use the `test-t3-app` skill. Launch one isolated environment, authenticate through the printed pairing URL, and verify the affected flow in the controlled browser.
+  - Mobile: use the `test-t3-mobile` skill. Connect one representative iOS Simulator or Android Emulator available on the host to one isolated environment and verify the affected flow. On compatible macOS hosts, prefer iOS for cross-platform changes and stream it through serve-sim in the T3 Code in-app browser or another available agent browser; use Android when it is the affected or viable platform.
+  - Subagents must not independently launch dev servers or repeat integrated client verification unless their delegated task explicitly requires it.
   - Stop dev servers, watchers, and other long-running verification processes when the focused verification is complete.
 
 ## Package Roles

--- a/apps/mobile/src/features/connection/ConnectionSheetButton.tsx
+++ b/apps/mobile/src/features/connection/ConnectionSheetButton.tsx
@@ -58,6 +58,9 @@ export function ConnectionSheetButton(props: {
 
   return (
     <Pressable
+      accessibilityLabel={props.label}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: props.disabled ?? false }}
       className={cn(
         props.compact
           ? "min-h-[42px] flex-row items-center justify-center gap-1.5 rounded-[14px] px-3.5 py-2.5"


### PR DESCRIPTION
## Summary
- Add repository-owned skills for isolated T3 Code Mobile verification on iOS and Android
- Configure pinned XcodeBuildMCP integration for Codex and Claude Code, plus pinned serve-sim guidance
- Update agent instructions to run one focused integrated pass for each affected client surface
- Expose connection-sheet actions as semantic mobile buttons so simulator automation can complete pairing

## Validation
- Validated all four repository testing skills
- Parsed the JSON, TOML, and agent YAML configuration
- Passed focused formatting, mobile lint, and `@t3tools/mobile` typecheck
- React Doctor: 100/100 for the branch diff
- Fresh context-free iOS agent pass paired to isolated state and found the seeded project through XcodeBuildMCP

Full repository tests were not run, in accordance with the focused local-verification policy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mobile app testing guidance and iOS simulator tooling configuration
> - Adds skill documentation and agent configs for `ios-debugger-agent`, `ios-simulator-browser`, and `test-t3-mobile` to guide agents through building, launching, and testing iOS/Android apps against a disposable T3 backend.
> - Configures the `xcodebuildmcp` MCP server in [`.mcp.json`](.mcp.json) and [`.codex/config.toml`](.codex/config.toml) with simulator, UI automation, debugging, and logging workflows enabled.
> - Updates [`AGENTS.md`](AGENTS.md) to require one integrated verification pass per affected client surface (web and mobile) and prefer iOS with `serve-sim` on compatible macOS hosts.
> - Adds accessibility props (`accessibilityLabel`, `accessibilityRole`, `accessibilityState`) to [`ConnectionSheetButton`](https://github.com/pingdotgg/t3code/pull/4165/files#diff-cc626dd01668180f61bfed57b06f49559ab948a99ce59c230627d75b40b1444b) to support semantic UI automation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9435fb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->