### PR TITLE
fix(web): improve dev sidebar backdrop contrast & remove version pills

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2762,12 +2762,12 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
           backdropVariant && "hover:bg-white/15 [&_svg]:text-white/85! [&_svg]:hover:text-white!",
         )}
       />
-      <SidebarBrand onBackdrop={backdropVariant !== null} stageLabel={stageLabel} />
+      <SidebarBrand onBackdrop={backdropVariant !== null} />
     </SidebarHeader>
   );
 });
 
-function SidebarBrand({ stageLabel, onBackdrop }: { stageLabel: string; onBackdrop: boolean }) {
+function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
   return (
     <Link
       aria-label="Go to threads"
@@ -2785,16 +2785,6 @@ function SidebarBrand({ stageLabel, onBackdrop }: { stageLabel: string; onBackdr
         )}
       >
         Code
-      </span>
-      <span
-        className={cn(
-          "sidebar-brand-stage shrink-0 items-center whitespace-nowrap rounded-full px-1.5 py-0.5 text-[8px] font-medium uppercase tracking-[0.18em]",
-          onBackdrop
-            ? "bg-white/15 text-white/80 backdrop-blur-sm"
-            : "bg-muted/50 text-muted-foreground/60",
-        )}
-      >
-        {stageLabel}
       </span>
     </Link>
   );

--- a/apps/web/src/components/SidebarStageBackdrop.tsx
+++ b/apps/web/src/components/SidebarStageBackdrop.tsx
@@ -201,9 +201,9 @@ function DevBlueprintArt() {
           gradientUnits="userSpaceOnUse"
           spreadMethod="reflect"
         >
-          <stop style={{ stopColor: "var(--stage-bp-top)" }} />
+          <stop style={{ stopColor: "var(--stage-bp-bottom)" }} />
           <stop offset="0.5" style={{ stopColor: "var(--stage-bp-mid)" }} />
-          <stop offset="1" style={{ stopColor: "var(--stage-bp-bottom)" }} />
+          <stop offset="1" style={{ stopColor: "var(--stage-bp-top)" }} />
         </linearGradient>
         <radialGradient
           id="stage-bp-glow"


### PR DESCRIPTION
## What Changed

  - Removed the Dev/Nightly stage pill from the sidebar brand.
  - Reversed the dev blueprint’s background gradient so the darker blue appears beneath the sidebar toggle.
  - Preserved the blueprint grid, ruler, lines, and annotations in their original orientation.
  - Kept each channel’s artwork assignment unchanged: Dev uses the blueprint, Nightly uses the sky, and Latest has no stage artwork.

## Why

 The stage pill added visual clutter to a header that already communicates the active channel through its artwork. Removing it gives the brand more room and keeps the header cleaner.

The light sidebar toggle was also difficult to distinguish against the bright portion of the dev backdrop. Moving the darker blue beneath the control improves contrast without changing the artwork’s geometry.

  ## UI Changes

  ### Before
  
<img width="596" height="144" alt="image" src="https://github.com/user-attachments/assets/5c4ac84b-4706-4e7e-9b87-2ca3f972dbcc" />


  ### After

<img width="714" height="194" alt="image" src="https://github.com/user-attachments/assets/b00c27da-9b00-4792-b338-ff56319b4261" />
<img width="551" height="198" alt="image" src="https://github.com/user-attachments/assets/a88bb268-be13-4c08-a8f9-751cebc02176" />



  ## Checklist

  - [x] This PR is small and focused
  - [x] I explained what changed and why
  - [ ] I included before/after screenshots for any UI changes
  - [x] A video is not applicable because this change does not involve animation or interaction

  The fork branch already contains both commits, so no additional push was needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized sidebar UI tweaks with no auth, data, or API impact.
> 
> **Overview**
> Cleans up the sidebar header by **removing the Dev/Nightly stage pill** next to the T3 Code brand; channel is still shown via stage backdrop art, not duplicate text.
> 
> For the **dev blueprint** header backdrop, the paper gradient stops are **swapped** so darker blue sits under the mobile sidebar toggle, improving contrast for the light icon without changing grid, ruler, or annotation artwork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837de11e5b095c04d6663a06f4addabecc37be08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove version pills and invert backdrop gradient in dev sidebar
> - Removes the stage label chip/badge from `SidebarBrand` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4166/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), which previously appeared next to the wordmark in the dev sidebar.
> - Inverts the blueprint paper gradient in [SidebarStageBackdrop.tsx](https://github.com/pingdotgg/t3code/pull/4166/files#diff-f1658d989a2aabf053c89389e90879e844dfeb4779e8b3ac54fed2f3810743d9) by swapping the top and bottom color stops, improving backdrop contrast.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 837de11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->