### PR TITLE
[codex] keep scoped package references as text

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.test.ts
+++ b/apps/web/src/components/ComposerPromptEditor.test.ts
@@ -70,4 +70,83 @@ describe("registerComposerInlineTokenPaste", () => {
       "<mention:.changeset/improve-deploy-error-logging.md> ",
     );
   });
+
+  it.each([
+    "yarn expo install @expo/ui",
+    "npm install @jane/foo.js",
+    "import '@scope/pkg/sub/path'",
+  ])("leaves scoped package command %s to the plain-text paste fallback", (command) => {
+    vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
+    const editor = createEditor();
+    const plainTextFallback = vi.fn((event: ClipboardEvent) => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return false;
+      selection.insertText(event.clipboardData?.getData("text/plain") ?? "");
+      return true;
+    });
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().append(paragraph);
+        paragraph.selectEnd();
+      },
+      { discrete: true },
+    );
+    registerComposerInlineTokenPaste(editor, {
+      createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
+      getExpandedAbsoluteOffsetForPoint: () => 0,
+    });
+    editor.registerCommand(PASTE_COMMAND, plainTextFallback, COMMAND_PRIORITY_EDITOR);
+
+    const event = new TestClipboardEvent(command);
+    let handled = false;
+    editor.update(
+      () => {
+        handled = editor.dispatchCommand(PASTE_COMMAND, event as ClipboardEvent);
+      },
+      { discrete: true },
+    );
+
+    expect(handled).toBe(true);
+    expect(plainTextFallback).toHaveBeenCalledOnce();
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(command);
+  });
+
+  it("pastes a canonical scoped folder link as a mention", () => {
+    vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
+    const editor = createEditor();
+    const mention = "[sub](@scope/pkg/sub)";
+    const plainTextFallback = vi.fn(() => true);
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().append(paragraph);
+        paragraph.selectEnd();
+      },
+      { discrete: true },
+    );
+    registerComposerInlineTokenPaste(editor, {
+      createMentionNode: (path) => $createTextNode(`<mention:${path}>`),
+      getExpandedAbsoluteOffsetForPoint: () => 0,
+    });
+    editor.registerCommand(PASTE_COMMAND, plainTextFallback, COMMAND_PRIORITY_EDITOR);
+
+    const event = new TestClipboardEvent(mention);
+    let handled = false;
+    editor.update(
+      () => {
+        handled = editor.dispatchCommand(PASTE_COMMAND, event as ClipboardEvent);
+      },
+      { discrete: true },
+    );
+
+    expect(handled).toBe(true);
+    expect(plainTextFallback).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe(
+      "<mention:@scope/pkg/sub> ",
+    );
+  });
 });

--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -22,9 +22,9 @@ describe("splitPromptIntoComposerSegments", () => {
   });
 
   it("keeps newlines around mention tokens", () => {
-    expect(splitPromptIntoComposerSegments("one\n@src/index.ts \ntwo")).toEqual([
+    expect(splitPromptIntoComposerSegments("one\n@AGENTS.md \ntwo")).toEqual([
       { type: "text", text: "one\n" },
-      { type: "mention", path: "src/index.ts", source: "@src/index.ts" },
+      { type: "mention", path: "AGENTS.md", source: "@AGENTS.md" },
       { type: "text", text: " \ntwo" },
     ]);
   });
@@ -69,6 +69,31 @@ describe("splitPromptIntoComposerSegments", () => {
     expect(
       splitPromptIntoComposerSegments("Read [the docs](https://example.com/docs) first"),
     ).toEqual([{ type: "text", text: "Read [the docs](https://example.com/docs) first" }]);
+  });
+
+  it.each(["@expo/ui", "@jane/foo.js", "@scope/pkg/sub/path"])(
+    "does not turn scoped package reference %s into file mention segments",
+    (reference) => {
+      const prompt = `Install ${reference} next`;
+      expect(splitPromptIntoComposerSegments(prompt)).toEqual([{ type: "text", text: prompt }]);
+    },
+  );
+
+  it("keeps IME-composed text containing a scoped package reference as text", () => {
+    const prompt = "入力 @expo/ui　を追加";
+    expect(splitPromptIntoComposerSegments(prompt)).toEqual([{ type: "text", text: prompt }]);
+  });
+
+  it("turns canonical scoped folder links into file mention segments", () => {
+    expect(splitPromptIntoComposerSegments("Inspect [sub](@scope/pkg/sub) next")).toEqual([
+      { type: "text", text: "Inspect " },
+      {
+        type: "mention",
+        path: "@scope/pkg/sub",
+        source: "[sub](@scope/pkg/sub)",
+      },
+      { type: "text", text: " next" },
+    ]);
   });
 
   it("decodes reserved path characters from generated links", () => {

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -246,12 +246,21 @@ describe("collapseExpandedComposerCursor", () => {
     );
   });
 
-  it("keeps replacement cursors aligned when another mention already exists earlier", () => {
+  it("keeps package-like text expanded when another mention already exists earlier", () => {
     const text = "open @AGENTS.md then @src/index.ts ";
     const expandedCursor = text.length;
     const collapsedCursor = collapseExpandedComposerCursor(text, expandedCursor);
 
-    expect(collapsedCursor).toBe("open ".length + 1 + " then ".length + 2);
+    expect(collapsedCursor).toBe("open ".length + 1 + " then @src/index.ts ".length);
+    expect(expandCollapsedComposerCursor(text, collapsedCursor)).toBe(expandedCursor);
+  });
+
+  it("collapses only genuine mentions when package-like text exists earlier", () => {
+    const text = "install @scope/pkg then @README.md ";
+    const expandedCursor = text.length;
+    const collapsedCursor = collapseExpandedComposerCursor(text, expandedCursor);
+
+    expect(collapsedCursor).toBe("install @scope/pkg then ".length + 1 + " ".length);
     expect(expandCollapsedComposerCursor(text, collapsedCursor)).toBe(expandedCursor);
   });
 

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -81,4 +81,52 @@ describe("collectComposerInlineTokens", () => {
   it("ignores normal web links", () => {
     expect(collectComposerInlineTokens("Read [docs](https://example.com) first")).toEqual([]);
   });
+
+  it.each(["@expo/ui", "@jane/foo.js", "@scope/pkg/sub/path"])(
+    "keeps scoped package reference %s as plain text",
+    (reference) => {
+      expect(collectComposerInlineTokens(`Install ${reference} next`)).toEqual([]);
+    },
+  );
+
+  it("keeps scoped package references plain across incomplete input and IME whitespace", () => {
+    expect(collectComposerInlineTokens("Install @expo/ui")).toEqual([]);
+    expect(collectComposerInlineTokens("入力 @expo/ui　を追加")).toEqual([]);
+  });
+
+  it("keeps bare non-scoped file paths as mentions", () => {
+    expect(collectComposerInlineTokens("Inspect @README.md next")).toEqual([
+      {
+        type: "mention",
+        value: "README.md",
+        source: "@README.md",
+        start: 8,
+        end: 18,
+      },
+    ]);
+  });
+
+  it("keeps canonical file links for scoped paths as mentions", () => {
+    expect(collectComposerInlineTokens("Inspect [sub](@scope/pkg/sub) next")).toEqual([
+      {
+        type: "mention",
+        value: "@scope/pkg/sub",
+        source: "[sub](@scope/pkg/sub)",
+        start: 8,
+        end: 29,
+      },
+    ]);
+  });
+
+  it("allows ambiguous scoped paths through explicit quoted mentions", () => {
+    expect(collectComposerInlineTokens('Inspect @"expo/ui" next')).toEqual([
+      {
+        type: "mention",
+        value: "expo/ui",
+        source: '@"expo/ui"',
+        start: 8,
+        end: 18,
+      },
+    ]);
+  });
 });

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -23,6 +23,9 @@ const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 const FILE_LINK_TOKEN_REGEX = /(^|\s)\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)(?=\s)/g;
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+// Autocomplete emits canonical file links, so ambiguous bare @scope/package text stays a package.
+const SCOPED_PACKAGE_REFERENCE_REGEX =
+  /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*(?:\/[^\s@"]+)*$/;
 
 function collectMentionTokens(text: string): ComposerInlineToken[] {
   const matches: ComposerInlineToken[] = [];
@@ -60,7 +63,7 @@ function collectMentionTokens(text: string): ComposerInlineToken[] {
     const prefix = match[1] ?? "";
     const quotedPath = match[2];
     const path = quotedPath !== undefined ? quotedPath.replace(/\\(.)/g, "$1") : (match[3] ?? "");
-    if (!path) {
+    if (!path || (quotedPath === undefined && SCOPED_PACKAGE_REFERENCE_REGEX.test(path))) {
       continue;
     }
     const start = (match.index ?? 0) + prefix.length;


### PR DESCRIPTION
Fixes #4142.

## What changed

- keep common unquoted `@scope/package` references as plain composer text instead of file-mention pills
- preserve canonical autocomplete-generated file links, including paths under `@scope/`
- preserve explicit quoted path mentions for ambiguous paths
- add regression coverage at the shared tokenizer, web segmentation, and Lexical paste-command boundaries

## Why

The shared inline-token grammar treated every whitespace-delimited `@value` as a file mention. The paste handler appends a virtual delimiter before parsing, so pasting a command such as `yarn expo install @expo/ui` immediately converted the package reference into a folder pill.

Scoped package syntax is ambiguous with a bare relative path. Current file autocomplete already serializes selected paths as canonical Markdown file links, so leaving the ambiguous bare form as package text fixes the paste behavior without weakening selected file mentions. The shared tokenizer is used by web and native mobile composers.

## Verification

- `vp check` (passes with 10 existing warnings outside this diff)
- `vp run typecheck`
- focused tokenizer, segmentation, and paste tests: 32 passed
- `vp test`: 608 files and 4,829 tests passed; 2 files and 7 tests skipped by the existing suite
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip scoped package references as mention tokens in composer inline parsing
> - Adds `SCOPED_PACKAGE_REFERENCE_REGEX` in [`composerInlineTokens.ts`](https://github.com/pingdotgg/t3code/pull/4167/files#diff-5cffe3270b732b403f881278a2c54291483129bca7ee5cdb8c14f1cc6aac666c) to detect paths like `@scope/pkg` or `@scope/pkg/sub/path`.
> - Unquoted `@` mentions matching the scoped package pattern are now skipped by `collectMentionTokens`; quoted mentions (e.g. `@"expo/ui"`) and canonical markdown file links (e.g. `[sub](@scope/pkg/sub)`) are still collected.
> - Paste handling in the composer editor also falls back to plain text for scoped package strings, preventing accidental mention creation from pasted install commands or import statements.
> - Behavioral Change: text like `@expo/ui` or `@jane/foo.js` that previously may have been treated as mentions will now remain plain text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef9d15a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer mention parsing only, with broad test coverage and no auth or data-path changes; intentional behavior change for ambiguous `@scope/pkg` bare text.
> 
> **Overview**
> Stops unquoted `@scope/package` text (e.g. in `yarn expo install @expo/ui`) from becoming file-mention pills by skipping those paths in the shared **`collectComposerInlineTokens`** grammar via **`SCOPED_PACKAGE_REFERENCE_REGEX`**.
> 
> **Canonical** markdown file links like `[sub](@scope/pkg/sub)` and **quoted** mentions like `@"expo/ui"` still resolve as mentions; bare `@README.md`-style paths are unchanged. Regression tests cover the shared tokenizer, web prompt segmentation, Lexical paste handling, and expanded/collapsed cursor mapping when package-like text sits next to real mentions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9d15a4226555bdd92e4cbddec7be5e7d28453d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->