### PR TITLE
Keep draft hero headline visible above expanded banners

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5343,22 +5343,26 @@ function ChatViewContent(props: ChatViewProps) {
                 <div className="pointer-events-auto relative z-10 isolate">
                   {isDraftHeroState ? (
                     <div className="absolute inset-x-0 bottom-full z-0">
-                      <div
-                        className="pb-8"
-                        style={
-                          forceExpandedMobileComposer
-                            ? {
-                                viewTransitionName: MOBILE_DRAFT_HEADLINE_VIEW_TRANSITION_NAME,
-                              }
-                            : undefined
+                      <ComposerBannerStack
+                        className="relative z-0"
+                        header={
+                          <div
+                            style={
+                              forceExpandedMobileComposer
+                                ? {
+                                    viewTransitionName: MOBILE_DRAFT_HEADLINE_VIEW_TRANSITION_NAME,
+                                  }
+                                : undefined
+                            }
+                          >
+                            <DraftHeroHeadline
+                              activeProjectRef={activeProjectRef}
+                              activeProjectTitle={activeProject?.title ?? null}
+                            />
+                          </div>
                         }
-                      >
-                        <DraftHeroHeadline
-                          activeProjectRef={activeProjectRef}
-                          activeProjectTitle={activeProject?.title ?? null}
-                        />
-                      </div>
-                      <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
+                        items={composerBannerItems}
+                      />
                     </div>
                   ) : (
                     <ComposerBannerStack className="relative z-0" items={composerBannerItems} />

--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -32,6 +32,7 @@ describe("ComposerBannerStack", () => {
 
     expect(markup).toContain("grid-rows-[0fr]");
     expect(markup).toContain("group-hover/banner-stack:grid-rows-[1fr]");
+    expect(markup).not.toContain("invisible");
     expect(markup.indexOf("Hero headline")).toBeLessThan(markup.indexOf("Stacked banner"));
     expect(markup.indexOf("Stacked banner")).toBeLessThan(markup.indexOf("Front banner"));
   });

--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ComposerBannerStack, type ComposerBannerStackItem } from "./ComposerBannerStack";
+
+function banner(id: string, title: string): ComposerBannerStackItem {
+  return {
+    id,
+    variant: "warning",
+    icon: <span aria-hidden="true">!</span>,
+    title,
+  };
+}
+
+describe("ComposerBannerStack", () => {
+  it("keeps the hero header visible when there are no banners", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerBannerStack header={<h1>Hero headline</h1>} items={[]} />,
+    );
+
+    expect(markup).toContain("Hero headline");
+    expect(markup).toContain("pb-8");
+  });
+
+  it("places expanded banners in flow between the header and front banner", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerBannerStack
+        header={<h1>Hero headline</h1>}
+        items={[banner("front", "Front banner"), banner("stacked", "Stacked banner")]}
+      />,
+    );
+
+    expect(markup).toContain("grid-rows-[0fr]");
+    expect(markup).toContain("group-hover/banner-stack:grid-rows-[1fr]");
+    expect(markup.indexOf("Hero headline")).toBeLessThan(markup.indexOf("Stacked banner"));
+    expect(markup.indexOf("Stacked banner")).toBeLessThan(markup.indexOf("Front banner"));
+  });
+});

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -105,10 +105,10 @@ export function ComposerBannerStack({ className, header, items }: ComposerBanner
             <div className="min-h-0 overflow-hidden">
               <div
                 className={cn(
-                  "invisible pointer-events-none space-y-2 pb-2 opacity-0",
-                  "translate-y-1 transform-gpu transition-[opacity,transform,visibility] duration-150 ease-out will-change-[opacity,transform]",
-                  "group-hover/banner-stack:visible group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
-                  "group-focus-within/banner-stack:visible group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
+                  "pointer-events-none space-y-2 pb-2 opacity-0",
+                  "translate-y-1 transform-gpu transition-[opacity,transform] duration-150 ease-out will-change-[opacity,transform]",
+                  "group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
+                  "group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
                 )}
               >
                 {stackedItems.map((item) => (

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -36,10 +36,11 @@ export interface ComposerBannerStackItem {
 
 interface ComposerBannerStackProps {
   readonly className?: string;
+  readonly header?: ReactNode;
   readonly items: ReadonlyArray<ComposerBannerStackItem>;
 }
 
-export function ComposerBannerStack({ className, items }: ComposerBannerStackProps) {
+export function ComposerBannerStack({ className, header, items }: ComposerBannerStackProps) {
   const [requestedExitingItemId, setExitingItemId] = useState<string | null>(null);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const exitingItemId =
@@ -56,7 +57,11 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
   }, []);
 
   if (items.length === 0) {
-    return null;
+    return header ? (
+      <div className={cn("mx-auto w-full", className)}>
+        <div className="pb-8">{header}</div>
+      </div>
+    ) : null;
   }
 
   const frontItem = items[0];
@@ -82,13 +87,50 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
   };
 
   return (
-    <div className={cn("group/banner-stack mx-auto mb-2 max-w-3xl", className)}>
+    <div className={cn("mx-auto mb-2 w-full", className)}>
+      {header ? <div className="pb-8">{header}</div> : null}
       <div
         className={cn(
-          "relative",
+          "group/banner-stack relative mx-auto max-w-3xl",
           hasStack ? "group-hover/banner-stack:z-50 group-focus-within/banner-stack:z-50" : null,
         )}
       >
+        {hasStack ? (
+          <div
+            className={cn(
+              "grid grid-rows-[0fr] transition-[grid-template-rows] duration-150 ease-out",
+              "group-hover/banner-stack:grid-rows-[1fr] group-focus-within/banner-stack:grid-rows-[1fr]",
+            )}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div
+                className={cn(
+                  "invisible pointer-events-none space-y-2 pb-2 opacity-0",
+                  "translate-y-1 transform-gpu transition-[opacity,transform,visibility] duration-150 ease-out will-change-[opacity,transform]",
+                  "group-hover/banner-stack:visible group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
+                  "group-focus-within/banner-stack:visible group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
+                )}
+              >
+                {stackedItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className={cn(exitingItemId === item.id ? "pointer-events-none" : null)}
+                    style={{
+                      ...exitTransitionStyle,
+                      ...(exitingItemId === item.id ? stackedExitStyle : restingStyle),
+                    }}
+                  >
+                    <ComposerBannerStackAlert
+                      item={item}
+                      exiting={exitingItemId === item.id}
+                      onDismissRequest={() => requestDismiss(item)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : null}
         {showCollapsedStackCap ? (
           <div
             className={cn(
@@ -117,34 +159,6 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
             onDismissRequest={() => requestDismiss(frontItem)}
           />
         </div>
-        {hasStack ? (
-          <div
-            className={cn(
-              "pointer-events-none absolute inset-x-0 bottom-[calc(100%+0.5rem)] z-20 space-y-2 opacity-0",
-              "transition-[opacity,transform] duration-150 ease-out",
-              "translate-y-1 transform-gpu will-change-[opacity,transform]",
-              "group-hover/banner-stack:pointer-events-auto group-hover/banner-stack:translate-y-0 group-hover/banner-stack:opacity-100",
-              "group-focus-within/banner-stack:pointer-events-auto group-focus-within/banner-stack:translate-y-0 group-focus-within/banner-stack:opacity-100",
-            )}
-          >
-            {stackedItems.map((item) => (
-              <div
-                key={item.id}
-                className={cn(exitingItemId === item.id ? "pointer-events-none" : null)}
-                style={{
-                  ...exitTransitionStyle,
-                  ...(exitingItemId === item.id ? stackedExitStyle : restingStyle),
-                }}
-              >
-                <ComposerBannerStackAlert
-                  item={item}
-                  exiting={exitingItemId === item.id}
-                  onDismissRequest={() => requestDismiss(item)}
-                />
-              </div>
-            ))}
-          </div>
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## What Changed

- Render the draft hero headline as part of the composer banner stack layout.
- Expand additional banners in a grid track that occupies real layout space, keeping hover and keyboard-focus behavior intact.
- Preserve the headline when no banners are present and add focused regression coverage for headline visibility and banner ordering.

## Why

Expanded banners were absolutely positioned above the front banner. Because they were removed from document flow, the draft hero headline did not move when the stack opened and the warning content painted directly over it. Keeping the headline and expanding banners in the same flow lets the stack push the headline upward by the actual banner height.

## UI Changes

| Before | After |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/sonner-banner-stack/010fe1b11867-before-image.png" alt="Expanded banners overlapping the draft hero headline" width="480"> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/sonner-banner-stack/3564af5ea09e-after-1_5.png" alt="Expanded banners pushing the draft hero headline upward" width="480"> |

[Watch the interaction recording (MP4)](https://codex-file-host.shawnadedeji.workers.dev/files/sonner-banner-stack/feed9f75b7cd-after-video.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep draft hero headline visible above expanded banners in `ComposerBannerStack`
> - Adds an optional `header` prop to [`ComposerBannerStack`](https://github.com/pingdotgg/t3code/pull/4170/files#diff-70e682f5637e29152782d8d01713cd41d0ced0860f99ad7cefbdc07da06e364b); when no banner items are present but a header is supplied, the component renders the header with `pb-8` spacing instead of returning null.
> - In [`ChatView`](https://github.com/pingdotgg/t3code/pull/4170/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), the `DraftHeroHeadline` is now passed as the `header` prop rather than being wrapped in a separate sibling div above the stack.
> - Stacked (expanded) banners now render in normal document flow between the header and the front banner using a CSS grid collapse (`grid-rows-[0fr]` → `grid-rows-[1fr]` on hover/focus), replacing the previous absolutely positioned overlay approach.
> - Behavioral Change: stacked banners no longer overlay content above them; they push content down when expanded.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1a6c01c. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the composer banner layout to support an optional header alongside stacked banners.
  * Headers now remain visible even when no banners are present.

* **Bug Fixes**
  * Improved banner stacking, positioning, transitions, and visual ordering across responsive layouts.

* **Tests**
  * Added coverage for header rendering, empty banner states, and stacked banner ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->