### PR TITLE
Keep draft hero headline at 30px

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -101,7 +101,7 @@ export function DraftHeroHeadline({
   );
 
   return (
-    <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-3xl text-foreground tracking-tight sm:text-5xl">
+    <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-3xl text-foreground tracking-tight">
       {hasResolvedProject ? (
         <>What should we build in {projectSelector}?</>
       ) : canChooseProject ? (


### PR DESCRIPTION
## What Changed

- Keep the draft hero headline at `text-3xl` across viewport sizes.
- Remove the desktop breakpoint that enlarged the headline to `text-5xl`.

## Why

The draft hero headline grew from 30px to 48px on larger screens, making it visually overpower the composer. A consistent 30px size preserves the hierarchy shown at smaller widths and keeps the prompt visually balanced with the composer.

## UI Changes

| Before | After |
| --- | --- |
| <img src="https://codex-file-host.shawnadedeji.workers.dev/files/headline-30px/98c87836f110-before.png" alt="Draft hero headline at 48px on desktop" width="480"> | <img src="https://codex-file-host.shawnadedeji.workers.dev/files/headline-30px/ad8806806fed-after.png" alt="Draft hero headline at 30px on desktop" width="480"> |

## Verification

- `vp fmt --check apps/web/src/components/chat/DraftHeroHeadline.tsx`
- `vp lint apps/web/src/components/chat/DraftHeroHeadline.tsx`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`
- Launched and authenticated an isolated development environment; the collaborative preview reached the app, but its snapshot/evaluation automation timed out after navigation. The supplied after screenshot confirms the 30px desktop result.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] A video is not applicable because this change does not involve animation or interaction


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `DraftHeroHeadline` font size to 30px across all breakpoints
> Removes the `sm:text-5xl` Tailwind class from [DraftHeroHeadline.tsx](https://github.com/pingdotgg/t3code/pull/4171/files#diff-59395eb8416aacb935e49426b6445ebb8ce3ab54f9d16bd99ed27d0e85a60ec7), so the headline stays at `text-3xl` (30px) on all screen sizes instead of scaling up at the `sm` breakpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00bdc92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a presentational headline with no logic, data, or auth impact.
> 
> **Overview**
> **Keeps the draft chat hero headline at 30px on large screens** by dropping the `sm:text-5xl` responsive class from the `DraftHeroHeadline` `<h1>`, so it no longer jumps to 48px at the `sm` breakpoint.
> 
> This aligns the headline size with the composer on desktop and preserves the visual hierarchy used on smaller viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00bdc922dbcc868c780b0755e7cef6ddfbd6b25f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the Draft Hero headline to use a consistent text size across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->