### PR TITLE
Pass CLI OAuth config to hosted web deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -788,6 +788,7 @@ jobs:
     env:
       T3CODE_CLERK_PUBLISHABLE_KEY: ${{ needs.relay_public_config.outputs.clerk_publishable_key }}
       T3CODE_CLERK_JWT_TEMPLATE: ${{ needs.relay_public_config.outputs.clerk_jwt_template }}
+      T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: ${{ needs.relay_public_config.outputs.clerk_cli_oauth_client_id }}
       T3CODE_RELAY_URL: ${{ needs.relay_public_config.outputs.relay_url }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -871,6 +872,7 @@ jobs:
               --build-env "APP_VERSION=${{ needs.preflight.outputs.version }}" \
               --build-env "T3CODE_CLERK_PUBLISHABLE_KEY=${T3CODE_CLERK_PUBLISHABLE_KEY:-}" \
               --build-env "T3CODE_CLERK_JWT_TEMPLATE=${T3CODE_CLERK_JWT_TEMPLATE:-}" \
+              --build-env "T3CODE_CLERK_CLI_OAUTH_CLIENT_ID=${T3CODE_CLERK_CLI_OAUTH_CLIENT_ID:-}" \
               --build-env "T3CODE_RELAY_URL=${T3CODE_RELAY_URL:-}" \
               --build-env "T3CODE_RELAY_CLIENT_OTLP_TRACES_URL=${T3CODE_RELAY_CLIENT_OTLP_TRACES_URL:-}" \
               --build-env "T3CODE_RELAY_CLIENT_OTLP_TRACES_DATASET=${T3CODE_RELAY_CLIENT_OTLP_TRACES_DATASET:-}" \


### PR DESCRIPTION
## Summary

Pass `T3CODE_CLERK_CLI_OAUTH_CLIENT_ID` from the resolved production relay configuration into the hosted web deployment job and forward it to Vercel as a build environment variable.

## Why

The `/connect` route requires the CLI OAuth client ID at build time. The release workflow resolved and validated that value, but the hosted web deployment did not receive it. As a result, `connectCliAuthRoutesEnabled()` returned false in deployed bundles and redirected `/connect` to `/`.

## Impact

The next hosted web release will include the CLI OAuth client ID, allowing the `/connect` and `/connect/callback` routes to stay enabled.

## Validation

- formatted `.github/workflows/release.yml` with `vp fmt`
- ran targeted `vp lint` (workflow YAML is outside the configured lint inputs)
- verified the patch with `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass CLI OAuth client ID to hosted web deploy via Vercel build environment
> Adds `T3CODE_CLERK_CLI_OAUTH_CLIENT_ID` to the `deploy_web` job in [release.yml](.github/workflows/release.yml), sourcing it from the `relay_public_config` job outputs and forwarding it to Vercel as a `--build-env` flag during deployment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8a6d68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release workflow-only change that passes an already-required public OAuth client ID into the existing Vercel build; no application logic or secrets handling changes.
> 
> **Overview**
> **Aligns hosted web deployment with desktop/CLI release jobs** by wiring `T3CODE_CLERK_CLI_OAUTH_CLIENT_ID` from `relay_public_config` into the `deploy_web` job and forwarding it to Vercel as a `--build-env` value.
> 
> Without this, the hosted bundle was built without the Clerk CLI OAuth client ID even though production config already resolves and validates it, so `connectCliAuthRoutesEnabled()` stayed false and `/connect` (and callback) redirected to `/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a6d688c2e629a9f1a2da50e016dafe50613bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->