### PR TITLE
Expose reasoning effort for custom Claude models

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -30,6 +30,7 @@ import { ProviderDriverError } from "../Errors.ts";
 import { makeClaudeAdapter } from "../Layers/ClaudeAdapter.ts";
 import {
   checkClaudeProviderStatus,
+  getClaudeModelCapabilities,
   makePendingClaudeProvider,
   probeClaudeCapabilities,
 } from "../Layers/ClaudeProvider.ts";
@@ -141,14 +142,6 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         continuationGroupKey,
       });
 
-      const adapterOptions = {
-        instanceId,
-        environment: processEnv,
-        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
-      };
-      const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
-      const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
-
       // Per-instance capabilities cache: keyed on binary + resolved HOME so
       // account-specific probes never share auth metadata across instances.
       const capabilitiesProbeCache = yield* Cache.make({
@@ -160,6 +153,23 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
           ),
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
+      const resolveModelCapabilities = (model: string | null | undefined) =>
+        Cache.get(capabilitiesProbeCache, capabilitiesCacheKey).pipe(
+          Effect.map((capabilities) => getClaudeModelCapabilities(model, capabilities?.models)),
+        );
+
+      const adapterOptions = {
+        instanceId,
+        environment: processEnv,
+        resolveModelCapabilities,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+      };
+      const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
+      const textGeneration = yield* makeClaudeTextGeneration(
+        effectiveConfig,
+        processEnv,
+        resolveModelCapabilities,
+      );
 
       const checkProvider = checkClaudeProviderStatus(
         effectiveConfig,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -14,6 +14,7 @@ import type {
 import {
   ApprovalRequestId,
   ClaudeSettings,
+  type ModelCapabilities,
   ProviderDriverKind,
   ProviderItemId,
   ProviderRuntimeEvent,
@@ -21,7 +22,7 @@ import {
   ThreadId,
   ProviderInstanceId,
 } from "@t3tools/contracts";
-import { createModelSelection } from "@t3tools/shared/model";
+import { createModelCapabilities, createModelSelection } from "@t3tools/shared/model";
 import { assert, describe, it } from "@effect/vitest";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -156,6 +157,7 @@ function makeHarness(config?: {
   readonly baseDir?: string;
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
+  readonly resolveModelCapabilities?: ClaudeAdapterLiveOptions["resolveModelCapabilities"];
 }) {
   const query = new FakeClaudeQuery();
   let createInput:
@@ -171,6 +173,9 @@ function makeHarness(config?: {
       createInput = input;
       return query;
     },
+    ...(config?.resolveModelCapabilities
+      ? { resolveModelCapabilities: config.resolveModelCapabilities }
+      : {}),
     ...(config?.nativeEventLogger
       ? {
           nativeEventLogger: config.nativeEventLogger,
@@ -203,6 +208,19 @@ function makeHarness(config?: {
     query,
     getLastCreateQueryInput: () => createInput,
   };
+}
+
+function customEffortCapabilities(...efforts: ReadonlyArray<string>): ModelCapabilities {
+  return createModelCapabilities({
+    optionDescriptors: [
+      {
+        id: "effort",
+        label: "Reasoning",
+        type: "select",
+        options: efforts.map((effort) => ({ id: effort, label: effort })),
+      },
+    ],
+  });
 }
 
 function makeDeterministicRandomService(seed = 0x1234_5678): {
@@ -439,7 +457,9 @@ describe("ClaudeAdapterLive", () => {
   });
 
   it.effect("preserves xhigh effort for custom Claude models", () => {
-    const harness = makeHarness();
+    const harness = makeHarness({
+      resolveModelCapabilities: () => Effect.succeed(customEffortCapabilities("xhigh")),
+    });
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
       yield* adapter.startSession({
@@ -455,6 +475,31 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.effort, "xhigh");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("ignores custom Claude effort levels not advertised by the SDK", () => {
+    const harness = makeHarness({
+      resolveModelCapabilities: () => Effect.succeed(customEffortCapabilities("low")),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "gpt-5.6-sol",
+          [{ id: "effort", value: "xhigh" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, undefined);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -350,6 +350,7 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+      assert.equal(createInput?.options.effort, undefined);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -412,6 +413,29 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.effort, "max");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("preserves xhigh effort for custom Claude models", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "gpt-5.6-sol",
+          [{ id: "effort", value: "xhigh" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, "xhigh");
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -419,6 +419,25 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("does not default effort for custom Claude models", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(ProviderInstanceId.make("claudeAgent"), "gpt-5.6-sol"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("preserves xhigh effort for custom Claude models", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -27,6 +27,7 @@ import {
   type CanonicalRequestType,
   type ClaudeSettings,
   EventId,
+  type ModelCapabilities,
   type ProviderApprovalDecision,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -221,6 +222,9 @@ export interface ClaudeAdapterLiveOptions {
   }) => ClaudeQueryRuntime;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly resolveModelCapabilities?: (
+    model: string | null | undefined,
+  ) => Effect.Effect<ModelCapabilities>;
 }
 
 function isUuid(value: string): boolean {
@@ -1359,6 +1363,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           stream: "native",
         })
       : undefined);
+  const resolveModelCapabilities =
+    options?.resolveModelCapabilities ??
+    ((model: string | null | undefined) => Effect.succeed(getClaudeModelCapabilities(model)));
 
   const createQuery =
     options?.createQuery ??
@@ -3414,7 +3421,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const extraArgs = parseCliArgs(claudeSettings.launchArgs).flags;
       const modelSelection =
         input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
-      const caps = getClaudeModelCapabilities(modelSelection?.model);
+      const caps = yield* resolveModelCapabilities(modelSelection?.model);
       const descriptors = getProviderOptionDescriptors({ caps });
       const apiModelId = modelSelection ? resolveClaudeApiModelId(modelSelection) : undefined;
       const initialContextWindow = selectedClaudeContextWindow(modelSelection);

--- a/apps/server/src/provider/Layers/ClaudeProvider.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.test.ts
@@ -1,0 +1,98 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import { ClaudeSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
+import { beforeEach, vi } from "vite-plus/test";
+
+import { probeClaudeCapabilities } from "./ClaudeProvider.ts";
+
+type ClaudeQuery = typeof import("@anthropic-ai/claude-agent-sdk").query;
+type ClaudeInitialization = Awaited<ReturnType<ReturnType<ClaudeQuery>["initializationResult"]>>;
+
+const claudeQueryMock = vi.hoisted(() => vi.fn());
+const decodeClaudeSettings = Schema.decodeEffect(ClaudeSettings);
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: claudeQueryMock,
+}));
+
+beforeEach(() => {
+  claudeQueryMock.mockReset();
+});
+
+it.layer(NodeServices.layer)("probeClaudeCapabilities", (it) => {
+  it.effect("keeps completed probes when another custom model times out", () =>
+    Effect.gen(function* () {
+      let activeProbes = 0;
+      let peakActiveProbes = 0;
+      const closedModels: Array<string> = [];
+
+      claudeQueryMock.mockImplementation((input: Parameters<ClaudeQuery>[0]) => {
+        assert.ok(input.options);
+        assert.ok(input.options.abortController);
+        const model = input.options.model ?? "default";
+        const abort = input.options.abortController;
+        activeProbes += 1;
+        peakActiveProbes = Math.max(peakActiveProbes, activeProbes);
+        let closed = false;
+        const close = () => {
+          if (!closed) {
+            closed = true;
+            activeProbes -= 1;
+            closedModels.push(model);
+          }
+        };
+
+        const initializationResult = () => {
+          if (model === "slow") {
+            return new Promise<ClaudeInitialization>((_resolve, reject) => {
+              abort.signal.addEventListener("abort", () => reject(new Error("aborted")), {
+                once: true,
+              });
+            });
+          }
+          return Promise.resolve({
+            account: { email: `${model}@example.com` },
+            commands: [],
+            models: [
+              {
+                value: model,
+                displayName: model,
+                description: "Custom model",
+                supportsEffort: true,
+                supportedEffortLevels: ["low", "high"],
+              },
+            ],
+          } as unknown as ClaudeInitialization);
+        };
+
+        return { close, initializationResult } as ReturnType<ClaudeQuery>;
+      });
+
+      const settings = yield* decodeClaudeSettings({
+        customModels: ["slow", "fast", "later"],
+      });
+      const probe = yield* probeClaudeCapabilities(settings).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+
+      while (claudeQueryMock.mock.calls.length < 3) {
+        yield* Effect.yieldNow;
+      }
+      yield* TestClock.adjust("25 seconds");
+
+      const result = yield* Fiber.join(probe);
+      assert.deepStrictEqual(result?.models.map((model) => model.value).toSorted(), [
+        "fast",
+        "later",
+      ]);
+      assert.strictEqual(result?.email, "fast@example.com");
+      assert.strictEqual(peakActiveProbes, 2);
+      assert.strictEqual(activeProbes, 0);
+      assert.deepStrictEqual(closedModels.toSorted(), ["fast", "later", "slow"]);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -21,6 +21,7 @@ import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { compareSemverVersions } from "@t3tools/shared/semver";
 import {
   query as claudeQuery,
+  type ModelInfo as ClaudeModelInfo,
   type SlashCommand as ClaudeSlashCommand,
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -43,7 +44,7 @@ const EMPTY_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabiliti
   optionDescriptors: [],
 });
 
-const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+const CUSTOM_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [
     buildSelectOptionDescriptor({
       id: "effort",
@@ -51,7 +52,7 @@ const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabili
       options: [
         { value: "low", label: "Low" },
         { value: "medium", label: "Medium" },
-        { value: "high", label: "High", isDefault: true },
+        { value: "high", label: "High" },
         { value: "xhigh", label: "Extra High" },
         { value: "max", label: "Max" },
       ],
@@ -311,6 +312,63 @@ function getBuiltInClaudeModelsForVersion(
   });
 }
 
+function claudeEffortLabel(effort: string): string {
+  switch (effort) {
+    case "low":
+      return "Low";
+    case "medium":
+      return "Medium";
+    case "high":
+      return "High";
+    case "xhigh":
+      return "Extra High";
+    case "max":
+      return "Max";
+    default:
+      return effort;
+  }
+}
+
+function customClaudeModelCapabilities(model: ClaudeModelInfo | undefined): ModelCapabilities {
+  const effortLevels = model?.supportedEffortLevels ?? [];
+  if (effortLevels.length === 0) {
+    return EMPTY_CLAUDE_MODEL_CAPABILITIES;
+  }
+
+  return createModelCapabilities({
+    optionDescriptors: [
+      buildSelectOptionDescriptor({
+        id: "effort",
+        label: "Reasoning",
+        options: effortLevels.map((effort) => ({
+          value: effort,
+          label: claudeEffortLabel(effort),
+        })),
+      }),
+    ],
+  });
+}
+
+function claudeModelsFromSettings(
+  builtInModels: ReadonlyArray<ServerProviderModel>,
+  customModels: ReadonlyArray<string>,
+  availableModels: ReadonlyArray<ClaudeModelInfo> = [],
+): ReadonlyArray<ServerProviderModel> {
+  const availableModelsBySlug = new Map(availableModels.map((model) => [model.value, model]));
+  return providerModelsFromSettings(
+    builtInModels,
+    customModels,
+    EMPTY_CLAUDE_MODEL_CAPABILITIES,
+  ).map((model) =>
+    model.isCustom
+      ? {
+          ...model,
+          capabilities: customClaudeModelCapabilities(availableModelsBySlug.get(model.slug)),
+        }
+      : model,
+  );
+}
+
 function formatClaudeFable5UpgradeMessage(version: string | null): string {
   const versionLabel = version ? `v${version}` : "the installed version";
   return `Claude Code ${versionLabel} is too old for Claude Fable 5. Upgrade to v${MINIMUM_CLAUDE_FABLE_5_VERSION} or newer to access it.`;
@@ -333,7 +391,7 @@ export function getClaudeModelCapabilities(model: string | null | undefined): Mo
   }
   return (
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
-    DEFAULT_CLAUDE_MODEL_CAPABILITIES
+    CUSTOM_CLAUDE_MODEL_CAPABILITIES
   );
 }
 
@@ -528,6 +586,7 @@ type ClaudeCapabilitiesProbe = {
    */
   readonly apiProvider: string | undefined;
   readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly models: ReadonlyArray<ClaudeModelInfo>;
 };
 
 function parseClaudeInitializationCommands(
@@ -609,8 +668,10 @@ function waitForAbortSignal(signal: AbortSignal): Promise<void> {
  * We pass a never-yielding AsyncIterable as the prompt so that no user
  * message is ever written to the subprocess stdin. This means the Claude
  * Code subprocess completes its local initialization IPC (returning
- * account info and slash commands) but never starts an API request to
- * Anthropic. We read the init data and then abort the subprocess.
+ * account info, slash commands, and model metadata) but never starts an API
+ * request to Anthropic. Custom models are initialized individually because
+ * Claude only advertises their supported effort levels when selected. We read
+ * the init data and then abort every subprocess.
  *
  * This is used as a fallback when `claude auth status` does not include
  * subscription type information.
@@ -620,7 +681,7 @@ const probeClaudeCapabilities = (
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
 ) => {
-  const abort = new AbortController();
+  const abortControllers: AbortController[] = [];
   return Effect.gen(function* () {
     const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
     const executablePath = yield* resolveClaudeSdkExecutablePath(
@@ -628,25 +689,49 @@ const probeClaudeCapabilities = (
       claudeEnvironment,
     );
     return yield* Effect.tryPromise(async () => {
-      const q = claudeQuery({
-        // Never yield — we only need initialization data, not a conversation.
-        // This prevents any prompt from reaching the Anthropic API.
-        // oxlint-disable-next-line require-yield
-        prompt: (async function* (): AsyncGenerator<SDKUserMessage> {
-          await waitForAbortSignal(abort.signal);
-        })(),
-        options: {
-          persistSession: false,
-          pathToClaudeCodeExecutable: executablePath,
-          abortController: abort,
-          settingSources: ["user", "project", "local"],
-          allowedTools: [],
-          env: claudeEnvironment,
-          ...(cwd ? { cwd } : {}),
-          stderr: () => {},
-        },
-      });
-      const init = await q.initializationResult();
+      const initialize = (model?: string) => {
+        const abort = new AbortController();
+        abortControllers.push(abort);
+        const q = claudeQuery({
+          // Never yield — we only need initialization data, not a conversation.
+          // This prevents any prompt from reaching the Anthropic API.
+          // oxlint-disable-next-line require-yield
+          prompt: (async function* (): AsyncGenerator<SDKUserMessage> {
+            await waitForAbortSignal(abort.signal);
+          })(),
+          options: {
+            persistSession: false,
+            pathToClaudeCodeExecutable: executablePath,
+            abortController: abort,
+            settingSources: ["user", "project", "local"],
+            allowedTools: [],
+            env: claudeEnvironment,
+            ...(model ? { model } : {}),
+            ...(cwd ? { cwd } : {}),
+            stderr: () => {},
+          },
+        });
+        return q.initializationResult();
+      };
+      const customModels = [
+        ...new Set(claudeSettings.customModels.map((model) => model.trim())),
+      ].filter((model) => model.length > 0);
+      const results = await Promise.allSettled(
+        (customModels.length > 0 ? customModels : [undefined]).map((model) => initialize(model)),
+      );
+      const initializations = results.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      if (initializations.length === 0 && customModels.length > 0) {
+        initializations.push(await initialize());
+      }
+      const init = initializations[0]!;
+      const modelsByValue = new Map<string, ClaudeModelInfo>();
+      for (const initialization of initializations) {
+        for (const model of initialization.models) {
+          modelsByValue.set(model.value, model);
+        }
+      }
       const account = init.account as
         | {
             readonly email?: string;
@@ -661,12 +746,15 @@ const probeClaudeCapabilities = (
         tokenSource: account?.tokenSource,
         apiProvider: account?.apiProvider,
         slashCommands: parseClaudeInitializationCommands(init.commands),
+        models: [...modelsByValue.values()],
       } satisfies ClaudeCapabilitiesProbe;
     });
   }).pipe(
     Effect.ensuring(
       Effect.sync(() => {
-        if (!abort.signal.aborted) abort.abort();
+        for (const abort of abortControllers) {
+          if (!abort.signal.aborted) abort.abort();
+        }
       }),
     ),
     Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),
@@ -707,11 +795,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
 > {
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
-  const allModels = providerModelsFromSettings(
-    BUILT_IN_MODELS,
-    claudeSettings.customModels,
-    DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-  );
+  const allModels = claudeModelsFromSettings(BUILT_IN_MODELS, claudeSettings.customModels);
 
   if (!claudeSettings.enabled) {
     return buildServerProvider({
@@ -797,11 +881,6 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     });
   }
 
-  const models = providerModelsFromSettings(
-    getBuiltInClaudeModelsForVersion(parsedVersion),
-    claudeSettings.customModels,
-    DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-  );
   const versionUpgradeMessage = supportsClaudeFable5(parsedVersion)
     ? undefined
     : supportsClaudeOpus48(parsedVersion)
@@ -813,6 +892,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
+  const models = claudeModelsFromSettings(
+    getBuiltInClaudeModelsForVersion(parsedVersion),
+    claudeSettings.customModels,
+    capabilities?.models,
+  );
   const slashCommands = capabilities?.slashCommands ?? [];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
@@ -865,11 +949,7 @@ export const makePendingClaudeProvider = (
 ): Effect.Effect<ServerProviderDraft> =>
   Effect.gen(function* () {
     const checkedAt = yield* nowIso;
-    const models = providerModelsFromSettings(
-      BUILT_IN_MODELS,
-      claudeSettings.customModels,
-      DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-    );
+    const models = claudeModelsFromSettings(BUILT_IN_MODELS, claudeSettings.customModels);
 
     if (!claudeSettings.enabled) {
       return buildServerProvider({

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -349,12 +349,27 @@ function customClaudeModelCapabilities(model: ClaudeModelInfo | undefined): Mode
   });
 }
 
+function indexClaudeModels(models: Iterable<ClaudeModelInfo>): Map<string, ClaudeModelInfo> {
+  const modelsBySlug = new Map<string, ClaudeModelInfo>();
+  for (const model of models) {
+    const existing = modelsBySlug.get(model.value);
+    if (
+      (existing?.supportedEffortLevels?.length ?? 0) > 0 &&
+      (model.supportedEffortLevels?.length ?? 0) === 0
+    ) {
+      continue;
+    }
+    modelsBySlug.set(model.value, model);
+  }
+  return modelsBySlug;
+}
+
 function claudeModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
   availableModels: ReadonlyArray<ClaudeModelInfo> = [],
 ): ReadonlyArray<ServerProviderModel> {
-  const availableModelsBySlug = new Map(availableModels.map((model) => [model.value, model]));
+  const availableModelsBySlug = indexClaudeModels(availableModels);
   return providerModelsFromSettings(
     builtInModels,
     customModels,
@@ -726,12 +741,9 @@ const probeClaudeCapabilities = (
         initializations.push(await initialize());
       }
       const init = initializations[0]!;
-      const modelsByValue = new Map<string, ClaudeModelInfo>();
-      for (const initialization of initializations) {
-        for (const model of initialization.models) {
-          modelsByValue.set(model.value, model);
-        }
-      }
+      const modelsByValue = indexClaudeModels(
+        initializations.flatMap((initialization) => initialization.models),
+      );
       const account = init.account as
         | {
             readonly email?: string;

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -39,8 +39,24 @@ import {
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 
-const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+const EMPTY_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
+});
+
+const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [
+    buildSelectOptionDescriptor({
+      id: "effort",
+      label: "Reasoning",
+      options: [
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "xhigh", label: "Extra High" },
+        { value: "max", label: "Max" },
+      ],
+    }),
+  ],
 });
 
 const CLAUDE_PRESENTATION = {
@@ -312,6 +328,9 @@ function formatClaudeOpus47UpgradeMessage(version: string | null): string {
 
 export function getClaudeModelCapabilities(model: string | null | undefined): ModelCapabilities {
   const slug = model?.trim();
+  if (!slug) {
+    return EMPTY_CLAUDE_MODEL_CAPABILITIES;
+  }
   return (
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
@@ -353,6 +372,7 @@ export function normalizeClaudeCliEffort(
   }
   if (
     effort === "xhigh" &&
+    BUILT_IN_MODELS.some((candidate) => candidate.slug === model) &&
     model !== "claude-fable-5" &&
     model !== "claude-opus-4-8" &&
     model !== "claude-sonnet-5"

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -571,6 +571,7 @@ function apiProviderAuthMetadata(
 // account info. The previous 8s budget expired mid-init, so the probe returned
 // `undefined` and left the provider unverified and unselectable in the picker.
 const CAPABILITIES_PROBE_TIMEOUT_MS = 25_000;
+const CAPABILITIES_PROBE_CONCURRENCY = 2;
 
 function nonEmptyProbeString(value: string): string | undefined {
   const candidate = value.trim();
@@ -683,18 +684,17 @@ const probeClaudeCapabilities = (
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
 ) => {
-  const abortControllers: AbortController[] = [];
   return Effect.gen(function* () {
     const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
     const executablePath = yield* resolveClaudeSdkExecutablePath(
       claudeSettings.binaryPath,
       claudeEnvironment,
     );
-    return yield* Effect.tryPromise(async () => {
-      const initialize = (model?: string) => {
-        const abort = new AbortController();
-        abortControllers.push(abort);
-        const q = claudeQuery({
+    const initialize = (model?: string) => {
+      const abort = new AbortController();
+      let query: ReturnType<typeof claudeQuery> | undefined;
+      return Effect.tryPromise(() => {
+        query = claudeQuery({
           // Never yield — we only need initialization data, not a conversation.
           // This prevents any prompt from reaching the Anthropic API.
           // oxlint-disable-next-line require-yield
@@ -713,56 +713,60 @@ const probeClaudeCapabilities = (
             stderr: () => {},
           },
         });
-        return q.initializationResult();
-      };
-      const customModels = [
-        ...new Set(claudeSettings.customModels.map((model) => model.trim())),
-      ].filter((model) => model.length > 0);
-      const initializations = [];
-      for (const model of customModels.length > 0 ? customModels : [undefined]) {
-        try {
-          initializations.push(await initialize(model));
-        } catch {
-          // One invalid custom model must not prevent the remaining probes.
-        }
-      }
-      if (initializations.length === 0 && customModels.length > 0) {
-        initializations.push(await initialize());
-      }
-      const init = initializations[0]!;
-      const modelsByValue = indexClaudeModels(
-        initializations.flatMap((initialization) => initialization.models),
+        return query.initializationResult();
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (!abort.signal.aborted) abort.abort();
+            query?.close();
+          }),
+        ),
+        Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),
+        Effect.result,
+        Effect.map((result) =>
+          Result.isFailure(result) ? undefined : Option.getOrUndefined(result.success),
+        ),
       );
-      const account = init.account as
-        | {
-            readonly email?: string;
-            readonly subscriptionType?: string;
-            readonly tokenSource?: string;
-            readonly apiProvider?: string;
-          }
-        | undefined;
-      return {
-        email: account?.email,
-        subscriptionType: account?.subscriptionType,
-        tokenSource: account?.tokenSource,
-        apiProvider: account?.apiProvider,
-        slashCommands: parseClaudeInitializationCommands(init.commands),
-        models: [...modelsByValue.values()],
-      } satisfies ClaudeCapabilitiesProbe;
-    });
-  }).pipe(
-    Effect.ensuring(
-      Effect.sync(() => {
-        for (const abort of abortControllers) {
-          if (!abort.signal.aborted) abort.abort();
+    };
+    const customModels = [
+      ...new Set(claudeSettings.customModels.map((model) => model.trim())),
+    ].filter((model) => model.length > 0);
+    const initializations = (yield* Effect.forEach(
+      customModels.length > 0 ? customModels : [undefined],
+      initialize,
+      { concurrency: CAPABILITIES_PROBE_CONCURRENCY },
+    )).filter((initialization) => initialization !== undefined);
+    if (initializations.length === 0 && customModels.length > 0) {
+      const fallback = yield* initialize();
+      if (fallback) initializations.push(fallback);
+    }
+    const init = initializations[0];
+    if (!init) return undefined;
+
+    const modelsByValue = indexClaudeModels(
+      initializations.flatMap((initialization) => initialization.models),
+    );
+    const account = init.account as
+      | {
+          readonly email?: string;
+          readonly subscriptionType?: string;
+          readonly tokenSource?: string;
+          readonly apiProvider?: string;
         }
-      }),
-    ),
-    Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),
+      | undefined;
+    return {
+      email: account?.email,
+      subscriptionType: account?.subscriptionType,
+      tokenSource: account?.tokenSource,
+      apiProvider: account?.apiProvider,
+      slashCommands: parseClaudeInitializationCommands(init.commands),
+      models: [...modelsByValue.values()],
+    } satisfies ClaudeCapabilitiesProbe;
+  }).pipe(
     Effect.result,
     Effect.map((result) => {
       if (Result.isFailure(result)) return undefined;
-      return Option.isSome(result.success) ? result.success.value : undefined;
+      return result.success;
     }),
   );
 };

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -44,22 +44,6 @@ const EMPTY_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabiliti
   optionDescriptors: [],
 });
 
-const CUSTOM_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
-  optionDescriptors: [
-    buildSelectOptionDescriptor({
-      id: "effort",
-      label: "Reasoning",
-      options: [
-        { value: "low", label: "Low" },
-        { value: "medium", label: "Medium" },
-        { value: "high", label: "High" },
-        { value: "xhigh", label: "Extra High" },
-        { value: "max", label: "Max" },
-      ],
-    }),
-  ],
-});
-
 const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
@@ -399,14 +383,17 @@ function formatClaudeOpus47UpgradeMessage(version: string | null): string {
   return `Claude Code ${versionLabel} is too old for Claude Opus 4.7. Upgrade to v${MINIMUM_CLAUDE_OPUS_4_7_VERSION} or newer to access it.`;
 }
 
-export function getClaudeModelCapabilities(model: string | null | undefined): ModelCapabilities {
+export function getClaudeModelCapabilities(
+  model: string | null | undefined,
+  availableModels: ReadonlyArray<ClaudeModelInfo> = [],
+): ModelCapabilities {
   const slug = model?.trim();
   if (!slug) {
     return EMPTY_CLAUDE_MODEL_CAPABILITIES;
   }
   return (
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
-    CUSTOM_CLAUDE_MODEL_CAPABILITIES
+    customClaudeModelCapabilities(indexClaudeModels(availableModels).get(slug))
   );
 }
 
@@ -731,12 +718,14 @@ const probeClaudeCapabilities = (
       const customModels = [
         ...new Set(claudeSettings.customModels.map((model) => model.trim())),
       ].filter((model) => model.length > 0);
-      const results = await Promise.allSettled(
-        (customModels.length > 0 ? customModels : [undefined]).map((model) => initialize(model)),
-      );
-      const initializations = results.flatMap((result) =>
-        result.status === "fulfilled" ? [result.value] : [],
-      );
+      const initializations = [];
+      for (const model of customModels.length > 0 ? customModels : [undefined]) {
+        try {
+          initializations.push(await initialize(model));
+        } catch {
+          // One invalid custom model must not prevent the remaining probes.
+        }
+      }
       if (initializations.length === 0 && customModels.length > 0) {
         initializations.push(await initialize());
       }

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1510,6 +1510,45 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect("adds reasoning effort options to custom Claude models", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            {
+              ...defaultClaudeSettings,
+              customModels: ["gpt-5.6-sol"],
+            },
+            claudeCapabilities(),
+          );
+          const customModel = status.models.find((model) => model.slug === "gpt-5.6-sol");
+          const effortDescriptor = customModel?.capabilities?.optionDescriptors?.find(
+            (descriptor) => descriptor.type === "select" && descriptor.id === "effort",
+          );
+
+          assert.strictEqual(customModel?.isCustom, true);
+          assert.deepStrictEqual(effortDescriptor, {
+            id: "effort",
+            label: "Reasoning",
+            type: "select",
+            options: [
+              { id: "low", label: "Low" },
+              { id: "medium", label: "Medium" },
+              { id: "high", label: "High", isDefault: true },
+              { id: "xhigh", label: "Extra High" },
+              { id: "max", label: "Max" },
+            ],
+            currentValue: "high",
+          });
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.215\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("returns ready and labels Bedrock-backed Claude as authenticated", () =>
         Effect.gen(function* () {
           // Bedrock authenticates via external AWS credentials, so the SDK init

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -12,6 +12,7 @@ import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import * as CodexErrors from "effect-codex-app-server/errors";
+import type { ModelInfo as ClaudeModelInfo } from "@anthropic-ai/claude-agent-sdk";
 import {
   ClaudeSettings,
   CodexSettings,
@@ -103,6 +104,7 @@ type TestClaudeCapabilities = {
   readonly tokenSource: string | undefined;
   readonly apiProvider: string | undefined;
   readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly models: ReadonlyArray<ClaudeModelInfo>;
 };
 
 function claudeCapabilities(overrides: Partial<TestClaudeCapabilities> = {}) {
@@ -113,6 +115,7 @@ function claudeCapabilities(overrides: Partial<TestClaudeCapabilities> = {}) {
       tokenSource: undefined,
       apiProvider: undefined,
       slashCommands: [],
+      models: [],
       ...overrides,
     });
 }
@@ -1510,14 +1513,24 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
-      it.effect("adds reasoning effort options to custom Claude models", () =>
+      it.effect("uses advertised reasoning effort options for custom Claude models", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(
             {
               ...defaultClaudeSettings,
               customModels: ["gpt-5.6-sol"],
             },
-            claudeCapabilities(),
+            claudeCapabilities({
+              models: [
+                {
+                  value: "gpt-5.6-sol",
+                  displayName: "GPT 5.6 Sol",
+                  description: "Custom model",
+                  supportsEffort: true,
+                  supportedEffortLevels: ["low", "high", "xhigh"],
+                },
+              ],
+            }),
           );
           const customModel = status.models.find((model) => model.slug === "gpt-5.6-sol");
           const effortDescriptor = customModel?.capabilities?.optionDescriptors?.find(
@@ -1531,13 +1544,43 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             type: "select",
             options: [
               { id: "low", label: "Low" },
-              { id: "medium", label: "Medium" },
-              { id: "high", label: "High", isDefault: true },
+              { id: "high", label: "High" },
               { id: "xhigh", label: "Extra High" },
-              { id: "max", label: "Max" },
             ],
-            currentValue: "high",
           });
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.215\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("does not guess reasoning effort options for custom Claude models", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            {
+              ...defaultClaudeSettings,
+              customModels: ["custom-without-effort"],
+            },
+            claudeCapabilities({
+              models: [
+                {
+                  value: "custom-without-effort",
+                  displayName: "Custom Without Effort",
+                  description: "Custom model",
+                  supportsEffort: false,
+                },
+              ],
+            }),
+          );
+          const customModel = status.models.find((model) => model.slug === "custom-without-effort");
+
+          assert.strictEqual(customModel?.isCustom, true);
+          assert.deepStrictEqual(customModel?.capabilities?.optionDescriptors, []);
         }).pipe(
           Effect.provide(
             mockSpawnerLayer((args) => {

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1592,6 +1592,48 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect("preserves advertised effort levels across custom model probes", () =>
+        Effect.gen(function* () {
+          const advertisedModel: ClaudeModelInfo = {
+            value: "gpt-5.6-sol",
+            displayName: "GPT 5.6 Sol",
+            description: "Custom model",
+            supportsEffort: true,
+            supportedEffortLevels: ["low", "xhigh"],
+          };
+          const status = yield* checkClaudeProviderStatus(
+            {
+              ...defaultClaudeSettings,
+              customModels: [advertisedModel.value],
+            },
+            claudeCapabilities({
+              models: [advertisedModel, { ...advertisedModel, supportedEffortLevels: [] }],
+            }),
+          );
+          const effortDescriptor = status.models
+            .find((model) => model.slug === advertisedModel.value)
+            ?.capabilities?.optionDescriptors?.find((descriptor) => descriptor.id === "effort");
+
+          assert.deepStrictEqual(effortDescriptor, {
+            id: "effort",
+            label: "Reasoning",
+            type: "select",
+            options: [
+              { id: "low", label: "Low" },
+              { id: "xhigh", label: "Extra High" },
+            ],
+          });
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.215\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("returns ready and labels Bedrock-backed Claude as authenticated", () =>
         Effect.gen(function* () {
           // Bedrock authenticates via external AWS credentials, so the SDK init

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -255,6 +255,33 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     ),
   );
 
+  it.effect("preserves xhigh effort for custom Claude models", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: {
+            title: "Use custom reasoning effort",
+          },
+        }),
+        argsMustContain: "--model gpt-5.6-sol --effort xhigh",
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateThreadTitle({
+            cwd: process.cwd(),
+            message: "Name this thread.",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("claudeAgent"),
+              "gpt-5.6-sol",
+              [{ id: "effort", value: "xhigh" }],
+            ),
+          });
+
+          expect(generated.title).toBe("Use custom reasoning effort");
+        }),
+    ),
+  );
+
   it.effect("generates thread titles through the Claude provider", () =>
     withFakeClaudeEnv(
       {

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -282,6 +282,33 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     ),
   );
 
+  it.effect("does not default effort for custom Claude models", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: {
+            title: "Use provider reasoning default",
+          },
+        }),
+        argsMustContain: "--model gpt-5.6-sol",
+        argsMustNotContain: "--effort",
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateThreadTitle({
+            cwd: process.cwd(),
+            message: "Name this thread.",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("claudeAgent"),
+              "gpt-5.6-sol",
+            ),
+          });
+
+          expect(generated.title).toBe("Use provider reasoning default");
+        }),
+    ),
+  );
+
   it.effect("generates thread titles through the Claude provider", () =>
     withFakeClaudeEnv(
       {

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -1,4 +1,4 @@
-import { ClaudeSettings, ProviderInstanceId } from "@t3tools/contracts";
+import { ClaudeSettings, type ModelCapabilities, ProviderInstanceId } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -6,7 +6,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import { createModelSelection } from "@t3tools/shared/model";
+import { createModelCapabilities, createModelSelection } from "@t3tools/shared/model";
 import { expect } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
@@ -78,6 +78,7 @@ function withFakeClaudeEnv<A, E, R>(
     stdinMustContain?: string;
     configDirMustBe?: string;
     claudeConfig?: Partial<ClaudeSettings>;
+    modelCapabilities?: ModelCapabilities;
   },
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
 ) {
@@ -184,7 +185,12 @@ function withFakeClaudeEnv<A, E, R>(
     );
 
     const config = decodeClaudeSettings(input.claudeConfig ?? {});
-    const textGeneration = yield* makeClaudeTextGeneration(config);
+    const modelCapabilities = input.modelCapabilities;
+    const textGeneration = yield* makeClaudeTextGeneration(
+      config,
+      undefined,
+      modelCapabilities ? () => Effect.succeed(modelCapabilities) : undefined,
+    );
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
 }
@@ -264,6 +270,16 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
           },
         }),
         argsMustContain: "--model gpt-5.6-sol --effort xhigh",
+        modelCapabilities: createModelCapabilities({
+          optionDescriptors: [
+            {
+              id: "effort",
+              label: "Reasoning",
+              type: "select",
+              options: [{ id: "xhigh", label: "Extra High" }],
+            },
+          ],
+        }),
       },
       (textGeneration) =>
         Effect.gen(function* () {
@@ -278,6 +294,44 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
           });
 
           expect(generated.title).toBe("Use custom reasoning effort");
+        }),
+    ),
+  );
+
+  it.effect("ignores custom Claude effort levels not advertised by the SDK", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: {
+            title: "Use advertised custom reasoning",
+          },
+        }),
+        argsMustContain: "--model gpt-5.6-sol",
+        argsMustNotContain: "--effort",
+        modelCapabilities: createModelCapabilities({
+          optionDescriptors: [
+            {
+              id: "effort",
+              label: "Reasoning",
+              type: "select",
+              options: [{ id: "low", label: "Low" }],
+            },
+          ],
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateThreadTitle({
+            cwd: process.cwd(),
+            message: "Name this thread.",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("claudeAgent"),
+              "gpt-5.6-sol",
+              [{ id: "effort", value: "xhigh" }],
+            ),
+          });
+
+          expect(generated.title).toBe("Use advertised custom reasoning");
         }),
     ),
   );

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -13,7 +13,11 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
-import { type ClaudeSettings, type ModelSelection } from "@t3tools/contracts";
+import {
+  type ClaudeSettings,
+  type ModelCapabilities,
+  type ModelSelection,
+} from "@t3tools/contracts";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 
@@ -61,6 +65,10 @@ const decodeClaudeOutputEnvelope = Schema.decodeEffect(Schema.fromJsonString(Cla
 export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(function* (
   claudeSettings: ClaudeSettings,
   environment?: NodeJS.ProcessEnv,
+  resolveModelCapabilities: (
+    model: string | null | undefined,
+  ) => Effect.Effect<ModelCapabilities> = (model) =>
+    Effect.succeed(getClaudeModelCapabilities(model)),
 ) {
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
@@ -126,7 +134,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       toJsonSchemaObject(outputSchemaJson),
       "Failed to encode structured output schema.",
     );
-    const caps = getClaudeModelCapabilities(modelSelection.model);
+    const caps = yield* resolveModelCapabilities(modelSelection.model);
     const descriptors = getProviderOptionDescriptors({
       caps,
       selections: modelSelection.options,


### PR DESCRIPTION
## Summary

- discover reasoning capabilities dynamically for each custom Claude model ID through the Claude Agent SDK
- build the T3 reasoning selector only from the `supportedEffortLevels` announced for that selected model
- avoid assigning `high` or any other effort by default, and hide the control when no levels are advertised
- preserve explicit selections such as `xhigh` end-to-end for Claude-compatible custom models

## Why

Claude-compatible gateways can expose Codex/OpenAI models through Claude Code using custom model IDs. Claude Code only announces `supportedEffortLevels` for a custom model when that model is selected during initialization, so static capabilities would either hide valid reasoning levels or advertise options the model does not support. T3 should respect the model's dynamically discovered reasoning capabilities instead of assuming a fixed capability set.

The custom model IDs are therefore initialized individually through the Claude Agent SDK. The resulting `initializationResult().models` metadata drives the provider capabilities while preserving the existing generic provider-option UI. The adapter and CLI text generation now reuse the provider’s cached capabilities for runtime validation, so they stay aligned with the levels actually announced by each model. Custom-model probes run sequentially to preserve failure isolation without unbounded subprocess fan-out.

Closes #4192.

## Before / After

| Before | After |
| --- | --- |
| Custom Claude models did not expose their model-specific reasoning capabilities. | Each custom Claude model exposes only the reasoning levels announced by Claude Code; models with none do not show a reasoning control, and no effort is selected by default. |
| ![Before: no reasoning control](https://raw.githubusercontent.com/IsraelAraujo70/t3code/fcc0b1302931dd3d7583bccc1ac72b6e4652af01/.github/pr-assets/4192/before.png) | ![After: reasoning effort menu](https://raw.githubusercontent.com/IsraelAraujo70/t3code/fcc0b1302931dd3d7583bccc1ac72b6e4652af01/.github/pr-assets/4192/after.png) |

## Testing

- `vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts apps/server/src/textGeneration/ClaudeTextGeneration.test.ts` (111 tests)
- `vp run --filter t3 typecheck`
- targeted `vp lint` on the four changed files
- integrated web verification with custom `gpt-5.6-sol` Claude model: the Claude SDK advertised `Low`, `Medium`, `High`, `Extra High`, and `Max`, the selector initially had no selection, and an explicit `Extra High` selection worked end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases probe subprocess work and changes effort handling for custom models; behavior is localized to Claude provider paths and covered by new tests, but mis-probes could hide or mislabel reasoning options.
> 
> **Overview**
> Custom Claude model IDs now get **reasoning effort** from Claude Code’s per-model SDK metadata instead of static or built-in assumptions.
> 
> The capabilities probe runs a lightweight init for **each configured custom model** (concurrency 2, 25s timeout per probe), merges `supportedEffortLevels` into provider model capabilities, and feeds that through a cached `resolveModelCapabilities` hook shared by the adapter, CLI text generation, and provider status. Custom models show a reasoning selector only when levels are advertised; nothing is defaulted when they are not. Explicit selections like `xhigh` pass through when advertised, and built-in-only mappings (e.g. coercing `xhigh` to `max`) no longer apply to custom slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec95dc64cb6a48db802cca2c7f5cbe5ca9a2c5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose reasoning effort options for custom Claude models based on SDK capability probes
> - `probeClaudeCapabilities` in [`ClaudeProvider.ts`](https://github.com/pingdotgg/t3code/pull/4194/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) now concurrently initializes the SDK for each custom model, collects advertised `supportedEffortLevels`, and returns them. Individual probes time out without discarding completed results.
> - `getClaudeModelCapabilities` and `normalizeClaudeCliEffort` are extended to use SDK-advertised effort levels for custom models, and `xhigh` is no longer coerced to `max` for custom models.
> - `makeClaudeAdapter` and `makeClaudeTextGeneration` accept an async `resolveModelCapabilities` resolver so capability lookups use the per-instance probe cache at runtime.
> - Provider status now surfaces custom models with effort-level selectors in the model selection UI when the SDK advertises them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec95dc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


