### PR TITLE
feat(web): composer attach button and view-wide image drag-and-drop

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1197,6 +1197,11 @@ function ChatViewContent(props: ChatViewProps) {
   const composerRef = useComposerHandleContext() ?? localComposerRef;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [isDraggingFilesOverView, setIsDraggingFilesOverView] = useState(false);
+  const viewDragDepthRef = useRef(0);
+  const resetViewDragState = useCallback(() => {
+    viewDragDepthRef.current = 0;
+    setIsDraggingFilesOverView(false);
+  }, []);
 
   // A cancelled drag (Escape) can end without a dragleave on the hovered
   // target, which would leave the drop overlay stuck. dragend always fires
@@ -1204,12 +1209,9 @@ function ChatViewContent(props: ChatViewProps) {
   // last resort while the overlay is up.
   useEffect(() => {
     if (!isDraggingFilesOverView) return;
-    const onWindowDragEnd = () => {
-      setIsDraggingFilesOverView(false);
-    };
-    window.addEventListener("dragend", onWindowDragEnd);
-    return () => window.removeEventListener("dragend", onWindowDragEnd);
-  }, [isDraggingFilesOverView]);
+    window.addEventListener("dragend", resetViewDragState);
+    return () => window.removeEventListener("dragend", resetViewDragState);
+  }, [isDraggingFilesOverView, resetViewDragState]);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
   const optimisticUserMessagesRef = useRef(optimisticUserMessages);
@@ -5204,9 +5206,18 @@ function ChatViewContent(props: ChatViewProps) {
   const canDropImagesOnView =
     activeEnvironmentUnavailableState === null && !(isLocalDraftThread && activeProject === null);
 
+  // If attaching becomes unavailable mid-drag, retract the overlay so it
+  // does not keep inviting a drop that would be discarded.
+  useEffect(() => {
+    if (!canDropImagesOnView) {
+      resetViewDragState();
+    }
+  }, [canDropImagesOnView, resetViewDragState]);
+
   const onViewDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
     if (!canDropImagesOnView || !event.dataTransfer.types.includes("Files")) return;
     event.preventDefault();
+    viewDragDepthRef.current += 1;
     setIsDraggingFilesOverView(true);
   };
 
@@ -5217,18 +5228,23 @@ function ChatViewContent(props: ChatViewProps) {
     setIsDraggingFilesOverView(true);
   };
 
+  // dragenter/dragleave bubble in balanced pairs from descendants, so a
+  // plain depth counter tracks whether the pointer is still inside the
+  // view without inspecting relatedTarget (which nested targets and some
+  // browsers report as null).
   const onViewDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
     if (!event.dataTransfer.types.includes("Files")) return;
     event.preventDefault();
-    const nextTarget = event.relatedTarget;
-    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-    setIsDraggingFilesOverView(false);
+    viewDragDepthRef.current = Math.max(0, viewDragDepthRef.current - 1);
+    if (viewDragDepthRef.current === 0) {
+      setIsDraggingFilesOverView(false);
+    }
   };
 
   const onViewDrop = (event: React.DragEvent<HTMLDivElement>) => {
     if (!event.dataTransfer.types.includes("Files")) return;
     event.preventDefault();
-    setIsDraggingFilesOverView(false);
+    resetViewDragState();
     if (!canDropImagesOnView) return;
     composerRef.current?.addImages(Array.from(event.dataTransfer.files));
   };

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5100,6 +5100,17 @@ function ChatViewContent(props: ChatViewProps) {
     void onRevertToTurnCountRef.current(targetTurnCount);
   }, []);
 
+  const canDropImagesOnView =
+    activeEnvironmentUnavailableState === null && !(isLocalDraftThread && activeProject === null);
+
+  // If attaching becomes unavailable mid-drag, retract the overlay so it
+  // does not keep inviting a drop that would be discarded.
+  useEffect(() => {
+    if (!canDropImagesOnView) {
+      resetViewDragState();
+    }
+  }, [canDropImagesOnView, resetViewDragState]);
+
   // Empty state: no active thread
   if (!activeThread) {
     return <NoActiveThreadState />;
@@ -5202,17 +5213,6 @@ function ChatViewContent(props: ChatViewProps) {
       </Suspense>
     ) : null
   ) : null;
-
-  const canDropImagesOnView =
-    activeEnvironmentUnavailableState === null && !(isLocalDraftThread && activeProject === null);
-
-  // If attaching becomes unavailable mid-drag, retract the overlay so it
-  // does not keep inviting a drop that would be discarded.
-  useEffect(() => {
-    if (!canDropImagesOnView) {
-      resetViewDragState();
-    }
-  }, [canDropImagesOnView, resetViewDragState]);
 
   const onViewDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
     if (!canDropImagesOnView || !event.dataTransfer.types.includes("Files")) return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -138,7 +138,7 @@ import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
-import { ChevronDownIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
+import { ChevronDownIcon, ImageUpIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
@@ -1196,6 +1196,8 @@ function ChatViewContent(props: ChatViewProps) {
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
   const composerRef = useComposerHandleContext() ?? localComposerRef;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [isDraggingFilesOverView, setIsDraggingFilesOverView] = useState(false);
+  const viewDragDepthRef = useRef(0);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
   const optimisticUserMessagesRef = useRef(optimisticUserMessages);
@@ -5187,8 +5189,55 @@ function ChatViewContent(props: ChatViewProps) {
     ) : null
   ) : null;
 
+  const onViewDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    viewDragDepthRef.current += 1;
+    setIsDraggingFilesOverView(true);
+  };
+
+  const onViewDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setIsDraggingFilesOverView(true);
+  };
+
+  const onViewDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    viewDragDepthRef.current = Math.max(0, viewDragDepthRef.current - 1);
+    if (viewDragDepthRef.current === 0) {
+      setIsDraggingFilesOverView(false);
+    }
+  };
+
+  const onViewDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    viewDragDepthRef.current = 0;
+    setIsDraggingFilesOverView(false);
+    composerRef.current?.addImages(Array.from(event.dataTransfer.files));
+  };
+
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+    <div
+      className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
+      onDragEnter={onViewDragEnter}
+      onDragOver={onViewDragOver}
+      onDragLeave={onViewDragLeave}
+      onDrop={onViewDrop}
+    >
+      {isDraggingFilesOverView ? (
+        <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-background/70 p-6 backdrop-blur-sm">
+          <div className="flex items-center gap-2.5 rounded-2xl border-2 border-dashed border-primary/60 bg-card/90 px-6 py-4 font-medium text-foreground text-sm shadow-lg">
+            <ImageUpIcon className="size-5 text-primary" />
+            Drop images to attach
+          </div>
+        </div>
+      ) : null}
       {rightPanelOpen && !shouldUsePlanSidebarSheet ? panelLayoutControls : null}
       <div
         className={cn(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1197,7 +1197,19 @@ function ChatViewContent(props: ChatViewProps) {
   const composerRef = useComposerHandleContext() ?? localComposerRef;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [isDraggingFilesOverView, setIsDraggingFilesOverView] = useState(false);
-  const viewDragDepthRef = useRef(0);
+
+  // A cancelled drag (Escape) can end without a dragleave on the hovered
+  // target, which would leave the drop overlay stuck. dragend always fires
+  // on the in-page drag source and bubbles to window, so it is the reset of
+  // last resort while the overlay is up.
+  useEffect(() => {
+    if (!isDraggingFilesOverView) return;
+    const onWindowDragEnd = () => {
+      setIsDraggingFilesOverView(false);
+    };
+    window.addEventListener("dragend", onWindowDragEnd);
+    return () => window.removeEventListener("dragend", onWindowDragEnd);
+  }, [isDraggingFilesOverView]);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
   const optimisticUserMessagesRef = useRef(optimisticUserMessages);
@@ -5189,15 +5201,17 @@ function ChatViewContent(props: ChatViewProps) {
     ) : null
   ) : null;
 
+  const canDropImagesOnView =
+    activeEnvironmentUnavailableState === null && !(isLocalDraftThread && activeProject === null);
+
   const onViewDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
+    if (!canDropImagesOnView || !event.dataTransfer.types.includes("Files")) return;
     event.preventDefault();
-    viewDragDepthRef.current += 1;
     setIsDraggingFilesOverView(true);
   };
 
   const onViewDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
+    if (!canDropImagesOnView || !event.dataTransfer.types.includes("Files")) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = "copy";
     setIsDraggingFilesOverView(true);
@@ -5208,17 +5222,14 @@ function ChatViewContent(props: ChatViewProps) {
     event.preventDefault();
     const nextTarget = event.relatedTarget;
     if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-    viewDragDepthRef.current = Math.max(0, viewDragDepthRef.current - 1);
-    if (viewDragDepthRef.current === 0) {
-      setIsDraggingFilesOverView(false);
-    }
+    setIsDraggingFilesOverView(false);
   };
 
   const onViewDrop = (event: React.DragEvent<HTMLDivElement>) => {
     if (!event.dataTransfer.types.includes("Files")) return;
     event.preventDefault();
-    viewDragDepthRef.current = 0;
     setIsDraggingFilesOverView(false);
+    if (!canDropImagesOnView) return;
     composerRef.current?.addImages(Array.from(event.dataTransfer.files));
   };
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2018,8 +2018,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         );
       },
       addImages: (files: File[]) => {
+        if (environmentUnavailable !== null || projectSelectionRequired) return;
         addComposerImages(files);
-        focusComposer();
+        if (isComposerCollapsedMobile) {
+          expandMobileComposer();
+        } else {
+          focusComposer();
+        }
       },
       addTerminalContext: (selection: TerminalContextSelection) => {
         if (!activeThread) return;
@@ -2090,6 +2095,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       environmentUnavailable,
       activePendingProgress,
       applyPromptReplacement,
+      isComposerCollapsedMobile,
+      expandMobileComposer,
       isComposerModelPickerOpen,
       readComposerSnapshot,
       selectedModel,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -107,6 +107,7 @@ import {
   LockIcon,
   LockOpenIcon,
   PenLineIcon,
+  PlusIcon,
   XIcon,
 } from "lucide-react";
 import { proposedPlanTitle } from "../../proposedPlan";
@@ -422,6 +423,8 @@ export interface ChatComposerHandle {
   }) => void;
   /** Insert a terminal context from the terminal drawer. */
   addTerminalContext: (selection: TerminalContextSelection) => void;
+  /** Attach image files (e.g. from a view-level drop zone). */
+  addImages: (files: File[]) => void;
   /** Get the current prompt/effort/model state for use in send. */
   getSendContext: () => {
     prompt: string;
@@ -919,6 +922,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const mobileComposerExpandReleaseFrameRef = useRef<number | null>(null);
   const mobileComposerExpandInFlightRef = useRef(false);
   const dragDepthRef = useRef(0);
+  const attachFileInputRef = useRef<HTMLInputElement | null>(null);
 
   // ------------------------------------------------------------------
   // Derived: composer send state
@@ -1836,8 +1840,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     removeComposerImageFromDraft(imageId);
   };
 
+  const openAttachFilePicker = () => {
+    attachFileInputRef.current?.click();
+  };
+
+  const onAttachFileInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    if (files.length === 0) return;
+    addComposerImages(files);
+    focusComposer();
+  };
+
   // ------------------------------------------------------------------
-  // Callbacks: paste / drag
+  // Callbacks: paste
   // ------------------------------------------------------------------
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
@@ -1846,41 +1862,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (imageFiles.length === 0) return;
     event.preventDefault();
     addComposerImages(imageFiles);
-  };
-
-  const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    dragDepthRef.current += 1;
-    setIsDragOverComposer(true);
-  };
-
-  const onComposerDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
-    setIsDragOverComposer(true);
-  };
-
-  const onComposerDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    const nextTarget = event.relatedTarget;
-    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) {
-      setIsDragOverComposer(false);
-    }
-  };
-
-  const onComposerDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    dragDepthRef.current = 0;
-    setIsDragOverComposer(false);
-    const files = Array.from(event.dataTransfer.files);
-    addComposerImages(files);
-    focusComposer();
   };
 
   const insertComposerTextAtEnd = (
@@ -1943,6 +1924,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     window.addEventListener("dragend", onWindowDragEnd);
     return () => window.removeEventListener("dragend", onWindowDragEnd);
   }, [isDragOverComposer]);
+
   const handleInterruptPrimaryAction = useCallback(() => {
     void onInterrupt();
   }, [onInterrupt]);
@@ -2034,6 +2016,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               )
             : null,
         );
+      },
+      addImages: (files: File[]) => {
+        addComposerImages(files);
+        focusComposer();
       },
       addTerminalContext: (selection: TerminalContextSelection) => {
         if (!activeThread) return;
@@ -2129,10 +2115,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           "group rounded-[22px] p-px transition-colors duration-200",
           composerProviderState.composerFrameClassName,
         )}
-        onDragEnter={onComposerDragEnter}
-        onDragOver={onComposerDragOver}
-        onDragLeave={onComposerDragLeave}
-        onDrop={onComposerDrop}
         onDragEnterCapture={composerMentionDragHandlers.onDragEnter}
         onDragOverCapture={composerMentionDragHandlers.onDragOver}
         onDragLeaveCapture={onComposerMentionDragLeaveCapture}
@@ -2558,6 +2540,32 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               )}
             >
               <div className="-m-1 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <input
+                  ref={attachFileInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  className="hidden"
+                  onChange={onAttachFileInputChange}
+                />
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        type="button"
+                        className="shrink-0 text-muted-foreground/70 hover:text-foreground/80"
+                        disabled={environmentUnavailable !== null || projectSelectionRequired}
+                        onClick={openAttachFilePicker}
+                        aria-label="Attach images"
+                      />
+                    }
+                  >
+                    <PlusIcon />
+                  </TooltipTrigger>
+                  <TooltipPopup side="top">Attach images</TooltipPopup>
+                </Tooltip>
                 <ProviderModelPicker
                   compact={isComposerFooterCompact}
                   activeInstanceId={selectedInstanceId}


### PR DESCRIPTION
## What Changed
 
- Added a `+` attach button on the left of the composer footer that opens an image file picker, reusing the existing `addComposerImages` validation (image-only, size and count limits).
- Image drag-and-drop is now accepted anywhere on the chat view instead of only over the input box: the drag handlers moved from `ChatComposer` to the `ChatView` root, which shows a full-view "Drop images to attach" overlay while dragging and appends dropped images to the composer draft via a new `addImages(files)` method on `ChatComposerHandle`.
 
## Why
 
Attaching images was only discoverable via paste or by dropping precisely on the input box. The `+` button makes uploads discoverable, and the view-wide drop zone with an explicit overlay makes drag-and-drop forgiving and clearly communicated.
 
## UI Changes
 
`+` attach button (light / dark):
 
<img width="735" height="255" alt="image" src="https://github.com/user-attachments/assets/2a1fdf4d-6423-4c3a-afe6-f745806efcea" />
<img width="654" height="262" alt="image" src="https://github.com/user-attachments/assets/3b90e303-610b-4123-ab7c-ce2773105e7a" />

Drop-anywhere overlay while dragging files over the chat view (light / dark):
 
<img width="1568" height="993" alt="image" src="https://github.com/user-attachments/assets/143c267a-292d-4860-b771-4a9a027da55b" />
<img width="1568" height="993" alt="image" src="https://github.com/user-attachments/assets/20d060c1-b543-42da-992e-fc576d5f1309" />
 
Attachment added after dropping on the header area, far from the composer:
 
<img width="698" height="271" alt="image" src="https://github.com/user-attachments/assets/140a44a5-f4fc-47a0-a3ce-5c5cda324f23" />
 
## Checklist
 
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat composer UX around image attachments; reuses existing validation and draft mutation with no auth or server contract changes.
> 
> **Overview**
> Makes **image attachments** easier to discover by adding a **`+` attach control** in the composer footer and moving **file drag-and-drop** from the composer box to the whole chat view.
> 
> The footer button opens a hidden **`image/*`** file picker and feeds files through the existing **`addComposerImages`** path (same limits as paste). **`ChatComposerHandle`** gains **`addImages(files)`** so **`ChatView`** can attach drops from anywhere in the thread UI.
> 
> While dragging files over the view, a full-screen **“Drop images to attach”** overlay appears. Drops are gated when the environment is unavailable or a draft has no project; drag state resets on **`dragend`** and when attaching becomes disabled mid-drag. Composer-level drop handlers and the composer drop highlight are removed in favor of this view-level zone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0504ff4c5d0807ad61f3ab81292961018d81c33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add composer attach button and view-wide image drag-and-drop to chat
> - Adds a `PlusIcon` button in the [ChatComposer](https://github.com/pingdotgg/t3code/pull/4201/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) footer that opens a hidden file input to attach images, and exposes an `addImages(files)` method on the composer handle for external callers.
> - Adds view-level drag-and-drop in [ChatView](https://github.com/pingdotgg/t3code/pull/4201/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) that shows a drop overlay with `ImageUpIcon` when image files are dragged over the chat view, forwarding dropped files to the composer via `addImages`.
> - Removes the previous in-composer drag-and-drop handlers; image drops are now handled at the view level.
> - Behavioral Change: the drop target for images shifts from the composer frame to the full chat view container.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0504ff4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->