### PR TITLE
feat(web): add tooltip for branch selector

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -611,7 +611,9 @@ export function BranchToolbarBranchSelector({
         onClick={() => selectBranch(refName)}
       >
         <div className="flex w-full min-w-0 items-center justify-between gap-2">
-          <span className="min-w-0 flex-1 truncate">{itemValue}</span>
+          <span className="min-w-0 flex-1 truncate" title={itemValue}>
+            {itemValue}
+          </span>
           {badge && <span className="shrink-0 text-[10px] text-muted-foreground/45">{badge}</span>}
         </div>
       </ComboboxItem>
@@ -659,15 +661,22 @@ export function BranchToolbarBranchSelector({
             <TooltipPopup side="top">{branchPrTooltip}</TooltipPopup>
           </Tooltip>
         ) : null}
-        <ComboboxTrigger
-          render={<Button variant="ghost" size="xs" />}
-          className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
-          disabled={isInitialBranchesLoadPending || isBranchActionPending}
-        >
-          <GitBranchIcon className="size-3 shrink-0 opacity-70" />
-          <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
-          <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
-        </ComboboxTrigger>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <ComboboxTrigger
+                render={<Button variant="ghost" size="xs" />}
+                className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
+                disabled={isInitialBranchesLoadPending || isBranchActionPending}
+              />
+            }
+          >
+            <GitBranchIcon className="size-3 shrink-0 opacity-70" />
+            <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
+            <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
+          </TooltipTrigger>
+          <TooltipPopup side="top">{triggerLabel}</TooltipPopup>
+        </Tooltip>
       </div>
       <ComboboxPopup align="end" side="top" className="flex w-80 flex-col">
         <div className="shrink-0 px-3 pt-2.5">


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added tooltip to the branch selector and `title` attribute for combobox items.

## Why
Longer branch names are truncated, and it's hard to tell which branch is which when they have the same prefix.


## UI Changes

<img width="343" height="94" alt="featunify-deploy-server-native-runtime-config" src="https://github.com/user-attachments/assets/05202798-aa46-4bf8-a350-13bba9d90626" />
<img width="354" height="142" alt="Q Search refs" src="https://github.com/user-attachments/assets/84220fb9-68ce-4f93-9208-7f626689ed97" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UX in the branch toolbar; no behavior, API, or data-path changes.
> 
> **Overview**
> Truncated branch names in the toolbar and ref picker are now easier to read at a glance.
> 
> The branch selector trigger is wrapped in a **tooltip** that shows the full `triggerLabel` on hover, matching the pattern already used for the adjacent PR pill. Each ref row in the combobox list gets a native **`title`** attribute with the full ref name so truncated entries in the dropdown expose the complete string without opening anything else.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08417c143209a80b4824b5ff7b43f1ac56a8c811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tooltip to branch selector trigger in toolbar
> Wraps the branch selector trigger in [BranchToolbarBranchSelector.tsx](https://github.com/pingdotgg/t3code/pull/4202/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734) with a `Tooltip` that displays the full current branch name on hover. Also adds a native `title` attribute to each combobox item label so truncated branch names are readable without opening the dropdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08417c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->