### PR TITLE
Honor configured protocol for automatic repository clones

### DIFF
--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -210,18 +210,20 @@ describe("GitHubCli.layer", () => {
 
   it.effect("reads repository clone URLs", () =>
     Effect.gen(function* () {
-      mockRun.mockReturnValueOnce(
-        Effect.succeed(
-          processOutput(
-            // @effect-diagnostics-next-line preferSchemaOverJson:off
-            JSON.stringify({
-              nameWithOwner: "octocat/codething-mvp",
-              url: "https://github.com/octocat/codething-mvp",
-              sshUrl: "git@github.com:octocat/codething-mvp.git",
-            }),
+      mockRun
+        .mockReturnValueOnce(
+          Effect.succeed(
+            processOutput(
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify({
+                nameWithOwner: "octocat/codething-mvp",
+                url: "https://github.com/octocat/codething-mvp",
+                sshUrl: "git@github.com:octocat/codething-mvp.git",
+              }),
+            ),
           ),
-        ),
-      );
+        )
+        .mockReturnValueOnce(Effect.succeed(processOutput("https\n")));
 
       const gh = yield* GitHubCli.GitHubCli;
       const result = yield* gh.getRepositoryCloneUrls({
@@ -233,6 +235,14 @@ describe("GitHubCli.layer", () => {
         nameWithOwner: "octocat/codething-mvp",
         url: "https://github.com/octocat/codething-mvp",
         sshUrl: "git@github.com:octocat/codething-mvp.git",
+        preferredProtocol: "https",
+      });
+      expect(mockRun).toHaveBeenNthCalledWith(2, {
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: ["config", "get", "git_protocol", "--host", "github.com"],
+        cwd: "/repo",
+        timeoutMs: 30_000,
       });
     }).pipe(Effect.provide(layer)),
   );

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -194,6 +194,7 @@ export interface GitHubRepositoryCloneUrls {
   readonly nameWithOwner: string;
   readonly url: string;
   readonly sshUrl: string;
+  readonly preferredProtocol?: "ssh" | "https";
 }
 
 export class GitHubCli extends Context.Service<
@@ -264,6 +265,22 @@ function normalizeRepositoryCloneUrls(
     url: raw.url,
     sshUrl: raw.sshUrl,
   };
+}
+
+function repositoryHost(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "github.com";
+  }
+}
+
+function parseConfiguredGitProtocol(stdout: string): "ssh" | "https" | undefined {
+  const protocol = stdout.trim().toLowerCase();
+  if (protocol === "ssh" || protocol === "https") {
+    return protocol;
+  }
+  return undefined;
 }
 
 /**
@@ -409,6 +426,20 @@ export const make = Effect.gen(function* () {
           ),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
+        Effect.flatMap((urls) =>
+          execute({
+            cwd: input.cwd,
+            args: ["config", "get", "git_protocol", "--host", repositoryHost(urls.url)],
+          }).pipe(
+            Effect.map((result) => parseConfiguredGitProtocol(result.stdout)),
+            Effect.map((preferredProtocol) =>
+              preferredProtocol === undefined ? urls : { ...urls, preferredProtocol },
+            ),
+            // Repository lookup should still work when older `gh` versions or
+            // incomplete host configuration cannot report a preference.
+            Effect.orElseSucceed(() => urls),
+          ),
+        ),
       ),
     createRepository: (input) =>
       execute({

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -150,7 +150,7 @@ it.effect("preserves provider failures without deriving the repository message f
   }).pipe(Effect.provide(makeLayer({ provider })));
 });
 
-it.effect("clones a looked-up repository into the requested destination", () =>
+it.effect("clones a looked-up repository over HTTPS by default", () =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const parent = yield* fs.makeTempDirectoryScoped({
@@ -165,7 +165,6 @@ it.effect("clones a looked-up repository into the requested destination", () =>
         provider: "github",
         repository: "octocat/t3code",
         destinationPath,
-        protocol: "https",
       });
 
       assert.deepStrictEqual(result, {

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -150,7 +150,60 @@ it.effect("preserves provider failures without deriving the repository message f
   }).pipe(Effect.provide(makeLayer({ provider })));
 });
 
-it.effect("clones a looked-up repository over HTTPS by default", () =>
+it.effect("clones a looked-up repository using the provider's HTTPS preference", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const parent = yield* fs.makeTempDirectoryScoped({
+      prefix: "t3-source-control-clone-parent-",
+    });
+    const destinationPath = `${parent}/t3code`;
+    const cloneCalls: Array<{ cwd: string; args: ReadonlyArray<string> }> = [];
+    const provider = makeProvider({
+      getRepositoryCloneUrls: () =>
+        Effect.succeed({ ...CLONE_URLS, preferredProtocol: "https" as const }),
+    });
+
+    yield* Effect.gen(function* () {
+      const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      const result = yield* service.cloneRepository({
+        provider: "github",
+        repository: "octocat/t3code",
+        destinationPath,
+      });
+
+      assert.deepStrictEqual(result, {
+        cwd: destinationPath,
+        remoteUrl: CLONE_URLS.url,
+        repository: {
+          provider: "github",
+          ...CLONE_URLS,
+          preferredProtocol: "https",
+        },
+      });
+      assert.deepStrictEqual(cloneCalls, [
+        {
+          cwd: parent,
+          args: ["clone", CLONE_URLS.url, "t3code"],
+        },
+      ]);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          provider,
+          git: {
+            execute: (input) =>
+              Effect.sync(() => {
+                cloneCalls.push({ cwd: input.cwd, args: input.args });
+                return processOutput();
+              }),
+          },
+        }),
+      ),
+    );
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("keeps SSH as the automatic fallback without a provider preference", () =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const parent = yield* fs.makeTempDirectoryScoped({
@@ -167,15 +220,11 @@ it.effect("clones a looked-up repository over HTTPS by default", () =>
         destinationPath,
       });
 
-      assert.deepStrictEqual(result, {
-        cwd: destinationPath,
-        remoteUrl: CLONE_URLS.url,
-        repository: { provider: "github", ...CLONE_URLS },
-      });
+      assert.strictEqual(result.remoteUrl, CLONE_URLS.sshUrl);
       assert.deepStrictEqual(cloneCalls, [
         {
           cwd: parent,
-          args: ["clone", CLONE_URLS.url, "t3code"],
+          args: ["clone", CLONE_URLS.sshUrl, "t3code"],
         },
       ]);
     }).pipe(

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -203,7 +203,7 @@ it.effect("clones a looked-up repository using the provider's HTTPS preference",
   }).pipe(Effect.provide(NodeServices.layer)),
 );
 
-it.effect("keeps SSH as the automatic fallback without a provider preference", () =>
+it.effect("uses HTTPS as the automatic fallback without a provider preference", () =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const parent = yield* fs.makeTempDirectoryScoped({
@@ -220,11 +220,11 @@ it.effect("keeps SSH as the automatic fallback without a provider preference", (
         destinationPath,
       });
 
-      assert.strictEqual(result.remoteUrl, CLONE_URLS.sshUrl);
+      assert.strictEqual(result.remoteUrl, CLONE_URLS.url);
       assert.deepStrictEqual(cloneCalls, [
         {
           cwd: parent,
-          args: ["clone", CLONE_URLS.sshUrl, "t3code"],
+          args: ["clone", CLONE_URLS.url, "t3code"],
         },
       ]);
     }).pipe(

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -71,8 +71,9 @@ function selectRemoteUrl(
   switch (protocol ?? "auto") {
     case "https":
       return urls.url;
-    case "ssh":
     case "auto":
+      return urls.url;
+    case "ssh":
       return urls.sshUrl;
   }
 }

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -73,7 +73,7 @@ function selectRemoteUrl(
     case "https":
       return urls.url;
     case "auto":
-      return urls.preferredProtocol === "https" ? urls.url : urls.sshUrl;
+      return urls.preferredProtocol === "ssh" ? urls.sshUrl : urls.url;
     case "ssh":
       return urls.sshUrl;
   }

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -61,6 +61,7 @@ function toRepositoryInfo(
     nameWithOwner: urls.nameWithOwner,
     url: urls.url,
     sshUrl: urls.sshUrl,
+    ...(urls.preferredProtocol ? { preferredProtocol: urls.preferredProtocol } : {}),
   };
 }
 
@@ -72,7 +73,7 @@ function selectRemoteUrl(
     case "https":
       return urls.url;
     case "auto":
-      return urls.url;
+      return urls.preferredProtocol === "https" ? urls.url : urls.sshUrl;
     case "ssh":
       return urls.sshUrl;
   }

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,6 +4,7 @@ import type { Thread } from "../types";
 import {
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  getDefaultCloneRemoteUrl,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -34,6 +35,14 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     ...overrides,
   };
 }
+
+it("uses HTTPS for automatic repository clones", () => {
+  expect(
+    getDefaultCloneRemoteUrl({
+      url: "https://github.com/octocat/t3code",
+    }),
+  ).toBe("https://github.com/octocat/t3code");
+});
 
 describe("buildThreadActionItems", () => {
   it("orders threads by most recent activity and formats timestamps from updatedAt", () => {

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,7 +4,7 @@ import type { Thread } from "../types";
 import {
   buildThreadActionItems,
   filterCommandPaletteGroups,
-  getDefaultCloneRemoteUrl,
+  getCloneSourceInput,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -36,12 +36,24 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
   };
 }
 
-it("uses HTTPS for automatic repository clones", () => {
+it("uses provider-based automatic selection for looked-up repositories", () => {
   expect(
-    getDefaultCloneRemoteUrl({
-      url: "https://github.com/octocat/t3code",
+    getCloneSourceInput({
+      repository: {
+        provider: "github",
+        nameWithOwner: "octocat/t3code",
+        url: "https://github.com/octocat/t3code",
+        sshUrl: "git@github.com:octocat/t3code.git",
+      },
+      remoteUrl: "https://github.com/octocat/t3code",
     }),
-  ).toBe("https://github.com/octocat/t3code");
+  ).toEqual({ provider: "github", repository: "octocat/t3code", protocol: "auto" });
+});
+
+it("passes explicit clone URLs through unchanged", () => {
+  expect(
+    getCloneSourceInput({ repository: null, remoteUrl: "git@example.com:org/repo.git" }),
+  ).toEqual({ remoteUrl: "git@example.com:org/repo.git" });
 });
 
 describe("buildThreadActionItems", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,6 +1,7 @@
 import {
   type FilesystemBrowseEntry,
   type KeybindingCommand,
+  type SourceControlCloneRepositoryInput,
   type SourceControlRepositoryInfo,
 } from "@t3tools/contracts";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
@@ -58,10 +59,19 @@ export interface CommandPaletteView {
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
-export function getDefaultCloneRemoteUrl(
-  repository: Pick<SourceControlRepositoryInfo, "url">,
-): string {
-  return repository.url;
+export function getCloneSourceInput(input: {
+  repository: SourceControlRepositoryInfo | null;
+  remoteUrl: string;
+}): Pick<SourceControlCloneRepositoryInput, "provider" | "repository" | "remoteUrl" | "protocol"> {
+  if (input.repository) {
+    return {
+      provider: input.repository.provider,
+      repository: input.repository.nameWithOwner,
+      protocol: "auto",
+    };
+  }
+
+  return { remoteUrl: input.remoteUrl };
 }
 
 export function filterBrowseEntries(input: {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,4 +1,8 @@
-import { type KeybindingCommand, type FilesystemBrowseEntry } from "@t3tools/contracts";
+import {
+  type FilesystemBrowseEntry,
+  type KeybindingCommand,
+  type SourceControlRepositoryInfo,
+} from "@t3tools/contracts";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
@@ -53,6 +57,12 @@ export interface CommandPaletteView {
 }
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
+
+export function getDefaultCloneRemoteUrl(
+  repository: Pick<SourceControlRepositoryInfo, "url">,
+): string {
+  return repository.url;
+}
 
 export function filterBrowseEntries(input: {
   browseEntries: ReadonlyArray<FilesystemBrowseEntry>;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -102,7 +102,7 @@ import {
   filterBrowseEntries,
   filterCommandPaletteGroups,
   getCommandPaletteInputPlaceholder,
-  getDefaultCloneRemoteUrl,
+  getCloneSourceInput,
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
@@ -1283,7 +1283,7 @@ function OpenCommandPaletteDialog(props: {
         source: addProjectCloneFlow.source,
         repositoryInput: rawRepository,
         repository,
-        remoteUrl: getDefaultCloneRemoteUrl(repository),
+        remoteUrl: repository.url,
       });
       setHighlightedItemValue(null);
       setQuery(destinationPath);
@@ -1330,7 +1330,7 @@ function OpenCommandPaletteDialog(props: {
     const cloneResult = await cloneRepository({
       environmentId: addProjectCloneFlow.environmentId,
       input: {
-        remoteUrl: addProjectCloneFlow.remoteUrl,
+        ...getCloneSourceInput(addProjectCloneFlow),
         destinationPath,
       },
     });

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -102,6 +102,7 @@ import {
   filterBrowseEntries,
   filterCommandPaletteGroups,
   getCommandPaletteInputPlaceholder,
+  getDefaultCloneRemoteUrl,
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
@@ -1282,7 +1283,7 @@ function OpenCommandPaletteDialog(props: {
         source: addProjectCloneFlow.source,
         repositoryInput: rawRepository,
         repository,
-        remoteUrl: repository.sshUrl,
+        remoteUrl: getDefaultCloneRemoteUrl(repository),
       });
       setHighlightedItemValue(null);
       setQuery(destinationPath);

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -40,6 +40,7 @@ export const SourceControlRepositoryCloneUrls = Schema.Struct({
   nameWithOwner: TrimmedNonEmptyString,
   url: TrimmedNonEmptyString,
   sshUrl: TrimmedNonEmptyString,
+  preferredProtocol: Schema.optional(Schema.Literals(["ssh", "https"])),
 });
 export type SourceControlRepositoryCloneUrls = typeof SourceControlRepositoryCloneUrls.Type;
 
@@ -54,6 +55,7 @@ export const SourceControlRepositoryInfo = Schema.Struct({
   nameWithOwner: TrimmedNonEmptyString,
   url: TrimmedNonEmptyString,
   sshUrl: TrimmedNonEmptyString,
+  preferredProtocol: Schema.optional(Schema.Literals(["ssh", "https"])),
 });
 export type SourceControlRepositoryInfo = typeof SourceControlRepositoryInfo.Type;
 


### PR DESCRIPTION
## Summary

- keep the default Create & Clone flow protocol-aware instead of hardcoding a concrete clone URL
- honor GitHub CLI's per-host `git_protocol` setting for automatic clones
- preserve explicit HTTPS and SSH behavior, using HTTPS as the safe fallback when a provider cannot report a preference
- add focused web, GitHub CLI, and repository-service regression coverage

## Why

The Create & Clone UI passed `repository.sshUrl` directly to the clone operation, bypassing the existing `auto` protocol path. Remote servers authenticated with `gh` over HTTPS but without a GitHub SSH key therefore failed to clone private repositories even though HTTPS access was valid.

The UI now submits the provider and repository identity with `protocol: "auto"`. For GitHub, repository lookup reads `gh config get git_protocol --host <host>` and carries that preference into clone selection. A reported SSH preference still uses SSH, a reported HTTPS preference uses HTTPS, and an unavailable preference falls back to HTTPS instead of recreating the original authentication failure.

Explicit URL clones remain unchanged.

Fixes #4203.

## Testing

- `vp test run apps/server/src/sourceControl/GitHubCli.test.ts apps/server/src/sourceControl/SourceControlRepositoryService.test.ts apps/web/src/components/CommandPalette.logic.test.ts` (22 tests passed)
- `pnpm --filter @t3tools/contracts typecheck`
- `pnpm --filter t3 typecheck`
- `pnpm --filter @t3tools/web typecheck`

An isolated UI smoke-test startup was attempted, but this nightly checkout's Vite+ dev server is independently blocked by `Tsconfig not found @tsconfig/node24/tsconfig.json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes clone URL selection for provider-based clones, which can affect how private repos authenticate (HTTPS vs SSH). Explicit protocol and URL clones stay the same.
> 
> **Overview**
> Create & Clone no longer hardcodes SSH. Looked-up repos now clone with `protocol: "auto"` so GitHub’s per-host `gh config git_protocol` can choose HTTPS vs SSH.
> 
> GitHub lookup reads `gh config get git_protocol --host <host>` and attaches optional `preferredProtocol`. Auto clones use SSH only when that preference is `ssh`; otherwise they use HTTPS (including when config is missing). Explicit HTTPS/SSH and raw clone URLs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a164a7cc79e00b9ee968df98608f1db36b55364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor configured `git_protocol` for automatic repository clones
> - `GitHubCli.Service.getRepositoryCloneUrls` now runs an extra `gh config get git_protocol --host <host>` lookup and attaches `preferredProtocol` ("ssh" | "https") to the returned clone URLs. Errors during this step are tolerated.
> - `selectRemoteUrl` changes automatic protocol selection: SSH is only chosen when `preferredProtocol` is explicitly "ssh"; otherwise HTTPS is used. Explicit "ssh"/"https" branches are unchanged.
> - The Command Palette UI defaults looked-up repositories to the HTTPS URL and routes cloning through the new `getCloneSourceInput` helper with `protocol: "auto"`.
> - Contracts in [sourceControl.ts](https://github.com/pingdotgg/t3code/pull/4205/files#diff-87aa564a9bfc2a49955a6cb89163c947800a5dea9614ee4458d9bdd23c9753eb) add an optional `preferredProtocol` field to `SourceControlRepositoryCloneUrls` and `SourceControlRepositoryInfo`.
> - Behavioral Change: automatic cloning now prefers HTTPS instead of SSH unless the provider's `gh` config explicitly sets `git_protocol` to SSH for the host. Review `selectRemoteUrl` in [SourceControlRepositoryService.ts](https://github.com/pingdotgg/t3code/pull/4205/files#diff-ee6247891e4a01ae6615258135b417c8454fe770eae597f3591b677b32c7aa0b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a164a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->