### PR TITLE
Avoid packaged Windows console pipe crashes

### DIFF
--- a/apps/desktop/src/app/DesktopObservability.test.ts
+++ b/apps/desktop/src/app/DesktopObservability.test.ts
@@ -1,6 +1,7 @@
 import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -36,40 +37,64 @@ const TraceRecordLine = Schema.Struct({
 
 const decodeTraceRecordLine = Schema.decodeUnknownSync(Schema.fromJsonString(TraceRecordLine));
 
-const environmentInput = (baseDir: string) =>
+const environmentInput = (
+  baseDir: string,
+  options: { readonly development?: boolean; readonly platform?: NodeJS.Platform } = {},
+) =>
   ({
     dirname: "/repo/apps/desktop/dist-electron",
     homeDirectory: baseDir,
-    platform: "darwin",
+    platform: options.platform ?? "darwin",
     processArch: "arm64",
     appVersion: "1.2.3",
     appPath: "/repo",
-    isPackaged: false,
+    isPackaged: options.development === false,
     resourcesPath: "/repo/resources",
     runningUnderArm64Translation: false,
   }) satisfies DesktopEnvironment.MakeDesktopEnvironmentInput;
 
-const makeEnvironmentLayer = (baseDir: string) =>
-  DesktopEnvironment.layer(environmentInput(baseDir)).pipe(
+const makeEnvironmentLayer = (
+  baseDir: string,
+  options: { readonly development?: boolean; readonly platform?: NodeJS.Platform } = {},
+) =>
+  DesktopEnvironment.layer(environmentInput(baseDir, options)).pipe(
     Layer.provide(
       Layer.mergeAll(
         NodeServices.layer,
         DesktopConfig.layerTest({
           T3CODE_HOME: baseDir,
-          VITE_DEV_SERVER_URL: "http://127.0.0.1:5733",
+          ...(options.development === false
+            ? {}
+            : { VITE_DEV_SERVER_URL: "http://127.0.0.1:5733" }),
         }),
       ),
     ),
   );
 
 describe("DesktopObservability", () => {
-  it.effect("persists desktop Effect logs as span events in desktop.trace.ndjson", () =>
+  it.effect("avoids console writes while persisting packaged Windows logs", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const baseDir = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "t3-desktop-observability-test-",
       });
-      const environmentLayer = makeEnvironmentLayer(baseDir);
+      const environmentLayer = makeEnvironmentLayer(baseDir, {
+        development: false,
+        platform: "win32",
+      });
+      let consoleLogCalls = 0;
+      const throwingConsole = new Proxy(globalThis.console, {
+        get(target, property, receiver) {
+          if (property === "log") {
+            return () => {
+              consoleLogCalls += 1;
+              throw Object.assign(new Error("EPIPE: broken pipe, write"), { code: "EPIPE" });
+            };
+          }
+          const value = Reflect.get(target, property, receiver) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }) as Console.Console;
       const tracePath = yield* Effect.gen(function* () {
         const environment = yield* DesktopEnvironment.DesktopEnvironment;
         return environment.path.join(environment.logDir, "desktop.trace.ndjson");
@@ -86,8 +111,11 @@ describe("DesktopObservability", () => {
         }).pipe(
           Effect.withSpan("desktop-observability-test"),
           Effect.provide(DesktopObservability.layer.pipe(Layer.provideMerge(environmentLayer))),
+          Effect.provideService(Console.Console, throwingConsole),
         ),
       );
+
+      assert.equal(consoleLogCalls, 0);
 
       const records = (yield* fileSystem.readFileString(tracePath))
         .trim()

--- a/apps/desktop/src/app/DesktopObservability.test.ts
+++ b/apps/desktop/src/app/DesktopObservability.test.ts
@@ -1,8 +1,10 @@
 import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
@@ -36,6 +38,15 @@ const TraceRecordLine = Schema.Struct({
 });
 
 const decodeTraceRecordLine = Schema.decodeUnknownSync(Schema.fromJsonString(TraceRecordLine));
+
+const consoleWithLog = (log: Console.Console["log"]): Console.Console =>
+  new Proxy(globalThis.console, {
+    get(target, property, receiver) {
+      if (property === "log") return log;
+      const value = Reflect.get(target, property, receiver) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as Console.Console;
 
 const environmentInput = (
   baseDir: string,
@@ -72,7 +83,7 @@ const makeEnvironmentLayer = (
   );
 
 describe("DesktopObservability", () => {
-  it.effect("avoids console writes while persisting packaged Windows logs", () =>
+  it.effect("keeps the packaged Windows console logger and tolerates a broken pipe", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const baseDir = yield* fileSystem.makeTempDirectoryScoped({
@@ -83,18 +94,10 @@ describe("DesktopObservability", () => {
         platform: "win32",
       });
       let consoleLogCalls = 0;
-      const throwingConsole = new Proxy(globalThis.console, {
-        get(target, property, receiver) {
-          if (property === "log") {
-            return () => {
-              consoleLogCalls += 1;
-              throw Object.assign(new Error("EPIPE: broken pipe, write"), { code: "EPIPE" });
-            };
-          }
-          const value = Reflect.get(target, property, receiver) as unknown;
-          return typeof value === "function" ? value.bind(target) : value;
-        },
-      }) as Console.Console;
+      const throwingConsole = consoleWithLog(() => {
+        consoleLogCalls += 1;
+        throw Object.assign(new Error("EPIPE: broken pipe, write"), { code: "EPIPE" });
+      });
       const tracePath = yield* Effect.gen(function* () {
         const environment = yield* DesktopEnvironment.DesktopEnvironment;
         return environment.path.join(environment.logDir, "desktop.trace.ndjson");
@@ -115,7 +118,7 @@ describe("DesktopObservability", () => {
         ),
       );
 
-      assert.equal(consoleLogCalls, 0);
+      assert.equal(consoleLogCalls, 1);
 
       const records = (yield* fileSystem.readFileString(tracePath))
         .trim()
@@ -134,6 +137,40 @@ describe("DesktopObservability", () => {
         true,
       );
       assert.isFalse(yield* fileSystem.exists(logPath));
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Layer.mergeAll(NodeServices.layer, NodeHttpClient.layerUndici)),
+    ),
+  );
+
+  it.effect("does not hide unrelated packaged Windows console failures", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-observability-console-error-test-",
+      });
+      const environmentLayer = makeEnvironmentLayer(baseDir, {
+        development: false,
+        platform: "win32",
+      });
+      const unexpectedError = Object.assign(new Error("unexpected console failure"), {
+        code: "EINVAL",
+      });
+      const throwingConsole = consoleWithLog(() => {
+        throw unexpectedError;
+      });
+
+      const exit = yield* Effect.exit(
+        Effect.scoped(
+          Effect.logInfo("desktop console failure").pipe(
+            Effect.provide(DesktopObservability.layer.pipe(Layer.provideMerge(environmentLayer))),
+            Effect.provideService(Console.Console, throwingConsole),
+          ),
+        ),
+      );
+
+      assert(Exit.isFailure(exit));
+      assert.equal(Cause.squash(exit.cause), unexpectedError);
     }).pipe(
       Effect.scoped,
       Effect.provide(Layer.mergeAll(NodeServices.layer, NodeHttpClient.layerUndici)),

--- a/apps/desktop/src/app/DesktopObservability.ts
+++ b/apps/desktop/src/app/DesktopObservability.ts
@@ -438,9 +438,21 @@ const backendOutputLogFactoryLayer = Layer.effect(
   }),
 );
 
-const desktopLoggerLayer = Layer.mergeAll(
-  Logger.layer([Logger.consolePretty(), Logger.tracerLogger], { mergeWithExisting: false }),
-  Layer.succeed(References.MinimumLogLevel, "Info"),
+const desktopLoggerLayer = Layer.unwrap(
+  Effect.gen(function* () {
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    // Packaged Windows launches can inherit a short-lived stdout pipe whose closed reader makes
+    // synchronous console writes throw EPIPE. The tracer still persists these logs locally.
+    const loggers =
+      environment.platform === "win32" && !environment.isDevelopment
+        ? [Logger.tracerLogger]
+        : [Logger.consolePretty(), Logger.tracerLogger];
+
+    return Layer.mergeAll(
+      Logger.layer(loggers, { mergeWithExisting: false }),
+      Layer.succeed(References.MinimumLogLevel, "Info"),
+    );
+  }),
 );
 
 const tracerLayer = Layer.unwrap(

--- a/apps/desktop/src/app/DesktopObservability.ts
+++ b/apps/desktop/src/app/DesktopObservability.ts
@@ -438,18 +438,37 @@ const backendOutputLogFactoryLayer = Layer.effect(
   }),
 );
 
+const isBrokenPipeError = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "EPIPE";
+
+const makeBrokenPipeSafeConsoleLogger = (): Logger.Logger<unknown, void> => {
+  const delegate = Logger.consolePretty();
+  let pipeBroken = false;
+
+  return Logger.make((options) => {
+    if (pipeBroken) return;
+
+    try {
+      delegate.log(options);
+    } catch (error) {
+      if (!isBrokenPipeError(error)) throw error;
+      pipeBroken = true;
+    }
+  });
+};
+
 const desktopLoggerLayer = Layer.unwrap(
   Effect.gen(function* () {
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
-    // Packaged Windows launches can inherit a short-lived stdout pipe whose closed reader makes
-    // synchronous console writes throw EPIPE. The tracer still persists these logs locally.
-    const loggers =
+    // Packaged Windows launches can inherit a short-lived stdout pipe. Keep console logging active
+    // until that pipe closes, then disable only the unavailable sink while tracing continues.
+    const consoleLogger =
       environment.platform === "win32" && !environment.isDevelopment
-        ? [Logger.tracerLogger]
-        : [Logger.consolePretty(), Logger.tracerLogger];
+        ? makeBrokenPipeSafeConsoleLogger()
+        : Logger.consolePretty();
 
     return Layer.mergeAll(
-      Logger.layer(loggers, { mergeWithExisting: false }),
+      Logger.layer([consoleLogger, Logger.tracerLogger], { mergeWithExisting: false }),
       Layer.succeed(References.MinimumLogLevel, "Info"),
     );
   }),


### PR DESCRIPTION
## What Changed

- Keep Effect's pretty console logger active in packaged-style Windows desktop runs.
- Guard that logger against `EPIPE`; after the inherited pipe breaks, only the unavailable console sink is disabled while the tracer continues writing `desktop.trace.ndjson`.
- Add regression coverage for both the expected `EPIPE` case and unrelated console failures that must still surface.

## Why

The packaged Electron main process installs Effect's `consolePretty` logger. On Windows, a launch path that gives the app piped stdout or stderr can leave it with a broken pipe after the reader exits. The next Effect log calls `console.log` synchronously and escapes as an uncaught `EPIPE`, producing Electron's "A JavaScript error occurred in the main process" dialog.

This was reproduced with `0.0.29-nightly.20260720.853` by launching T3 Code Nightly with piped output, closing the parent-side reader after startup, and allowing the desktop updater to emit another main-process Effect log.

The guarded logger preserves normal console output for Windows launches with a usable pipe. It catches only errors whose code is `EPIPE`, stops retrying that dead sink after the first failure, and rethrows every other console error.

## UI Changes

No product UI changes. These artifacts show the existing Windows failure:

- [Watch the verified live Windows EPIPE repro (6 seconds)](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-4206/windows-epipe-live-error-repro.mp4)

![Windows EPIPE main-process error](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-4206/df31fbe57afc-windows-epipe-main-process-error.png)

## Verification

- `vp exec vitest run apps/desktop/src/app/DesktopObservability.test.ts`
- `vp run --filter @t3tools/desktop typecheck`
- `vp fmt --check apps/desktop/src/app/DesktopObservability.ts apps/desktop/src/app/DesktopObservability.test.ts`
- `vp lint apps/desktop/src/app/DesktopObservability.ts apps/desktop/src/app/DesktopObservability.test.ts`
- Rebuilt the Electron main bundle with the repository-local `vp pack`.
- Launched the rebuilt desktop app on Windows with an isolated state directory, closed its parent pipe, and observed the healthy `T3 Code (Alpha)` window while `desktop.trace.ndjson` continued receiving events for another 17 seconds without an Electron error dialog.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because this PR does not change the UI; the attached image documents the existing failure
- [x] Animation or interaction video is not applicable; the attached video is reproduction evidence
