### PR TITLE
Animate project name completion in new threads

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,12 +1,17 @@
 import type { ScopedProjectRef } from "@t3tools/contracts";
 import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { FolderPlusIcon } from "lucide-react";
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { useOpenAddProjectCommandPalette } from "~/commandPaletteContext";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
 import { useProjects, useThreadShells } from "~/state/entities";
 import { sortScopedProjectsForSidebar } from "../Sidebar.logic";
+import {
+  getIncrementalTextCompletionStart,
+  INCREMENTAL_TEXT_COMPLETION_INTERVAL_MS,
+  splitTextForIncrementalCompletion,
+} from "./incrementalTextCompletion";
 import {
   Menu,
   MenuItem,
@@ -20,6 +25,65 @@ import {
 interface DraftHeroHeadlineProps {
   readonly activeProjectRef: ScopedProjectRef | null;
   readonly activeProjectTitle: string | null;
+}
+
+function useIncrementalProjectTitle(
+  projectKey: string,
+  projectTitle: string | null,
+): string | null {
+  const [completedTitle, setCompletedTitle] = useState(projectTitle);
+  const completedTitleRef = useRef(projectTitle);
+  const previousProjectKeyRef = useRef(projectKey);
+
+  useLayoutEffect(() => {
+    const projectChanged = previousProjectKeyRef.current !== projectKey;
+    previousProjectKeyRef.current = projectKey;
+
+    if (!projectChanged || projectTitle === null) {
+      completedTitleRef.current = projectTitle;
+      setCompletedTitle(projectTitle);
+      return;
+    }
+
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false);
+    if (prefersReducedMotion) {
+      completedTitleRef.current = projectTitle;
+      setCompletedTitle(projectTitle);
+      return;
+    }
+
+    const characters = splitTextForIncrementalCompletion(projectTitle);
+    let completedCharacterCount = getIncrementalTextCompletionStart(
+      completedTitleRef.current ?? "",
+      projectTitle,
+    );
+    const updateCompletedTitle = () => {
+      const nextTitle = characters.slice(0, completedCharacterCount).join("");
+      completedTitleRef.current = nextTitle;
+      setCompletedTitle(nextTitle);
+    };
+
+    updateCompletedTitle();
+    if (completedCharacterCount >= characters.length) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      completedCharacterCount += 1;
+      updateCompletedTitle();
+      if (completedCharacterCount >= characters.length) {
+        window.clearInterval(intervalId);
+      }
+    }, INCREMENTAL_TEXT_COMPLETION_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [projectKey, projectTitle]);
+
+  return completedTitle;
 }
 
 export function DraftHeroHeadline({
@@ -49,6 +113,7 @@ export function DraftHeroHeadline({
     [orderedProjects],
   );
   const activeProjectKey = activeProjectRef === null ? "" : scopedProjectKey(activeProjectRef);
+  const completedProjectTitle = useIncrementalProjectTitle(activeProjectKey, activeProjectTitle);
   const hasResolvedProject = activeProjectTitle !== null;
   const canChooseProject = orderedProjects.length > 0;
   const shouldShowProjectMenu = canChooseProject;
@@ -59,7 +124,16 @@ export function DraftHeroHeadline({
         aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
         className="pointer-events-auto inline cursor-pointer border-current border-b border-dotted text-foreground underline-offset-8 transition-opacity hover:opacity-75 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
       >
-        {activeProjectTitle ?? "Choose a project"}
+        {activeProjectTitle ? (
+          <span className="inline-grid">
+            <span aria-hidden className="invisible col-start-1 row-start-1">
+              {activeProjectTitle}
+            </span>
+            <span className="col-start-1 row-start-1">{completedProjectTitle}</span>
+          </span>
+        ) : (
+          "Choose a project"
+        )}
       </MenuTrigger>
       <MenuPopup align="center" className="max-h-80 w-64 overflow-y-auto">
         <MenuRadioGroup

--- a/apps/web/src/components/chat/incrementalTextCompletion.test.ts
+++ b/apps/web/src/components/chat/incrementalTextCompletion.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getIncrementalTextCompletionStart,
+  splitTextForIncrementalCompletion,
+} from "./incrementalTextCompletion";
+
+describe("incremental text completion", () => {
+  it("keeps the shared prefix when the selected project changes", () => {
+    expect(getIncrementalTextCompletionStart("t3code-web", "t3code-mobile")).toBe(7);
+  });
+
+  it("starts over when project names do not share a prefix", () => {
+    expect(getIncrementalTextCompletionStart("frontend", "backend")).toBe(0);
+  });
+
+  it("advances through unicode text by code point instead of UTF-16 code unit", () => {
+    expect(splitTextForIncrementalCompletion("T3 🚀")).toEqual(["T", "3", " ", "🚀"]);
+  });
+});

--- a/apps/web/src/components/chat/incrementalTextCompletion.ts
+++ b/apps/web/src/components/chat/incrementalTextCompletion.ts
@@ -1,0 +1,21 @@
+export const INCREMENTAL_TEXT_COMPLETION_INTERVAL_MS = 24;
+
+export function splitTextForIncrementalCompletion(text: string): string[] {
+  return Array.from(text);
+}
+
+export function getIncrementalTextCompletionStart(currentText: string, nextText: string): number {
+  const currentCharacters = splitTextForIncrementalCompletion(currentText);
+  const nextCharacters = splitTextForIncrementalCompletion(nextText);
+  const maxSharedLength = Math.min(currentCharacters.length, nextCharacters.length);
+
+  let sharedLength = 0;
+  while (
+    sharedLength < maxSharedLength &&
+    currentCharacters[sharedLength] === nextCharacters[sharedLength]
+  ) {
+    sharedLength += 1;
+  }
+
+  return sharedLength;
+}


### PR DESCRIPTION
## What changed

- incrementally reveal the newly selected project name in the new-thread hero
- preserve the shared prefix between project names and reserve the final label width to avoid layout shift
- skip the animation for users who prefer reduced motion
- cover shared-prefix and Unicode behavior with focused tests

## Why

Selecting a different project in the new-thread experience replaced the project label in a single frame. Incremental completion makes the context change easier to follow while keeping the surrounding headline and composer stable.

## Validation

- `vp test` (web unit suite: 161 files, 1,376 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI in the new-thread headline; no auth, data, or API changes.
> 
> **Overview**
> The new-thread hero **incrementally reveals** the selected project name when you switch projects, instead of swapping the label in one frame.
> 
> A new `useIncrementalProjectTitle` hook drives a character-by-character reveal (24ms steps) from a **shared prefix** between the old and new names. **`prefers-reduced-motion`** skips the animation and shows the full title immediately. The menu trigger uses an **invisible full-title layer** plus a visible animated layer in an `inline-grid` so the headline width stays fixed while the text animates.
> 
> Shared-prefix and Unicode splitting logic lives in `incrementalTextCompletion.ts`, with focused unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c86b329b8705b4f36342806a4a14a13d3d699c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Animate project name completion character-by-character in new thread hero headline
> - Adds a `useIncrementalProjectTitle` hook in [`DraftHeroHeadline.tsx`](https://github.com/pingdotgg/t3code/pull/4214/files#diff-59395eb8416aacb935e49426b6445ebb8ce3ab54f9d16bd99ed27d0e85a60ec7) that progressively reveals the project title from the shared prefix when the active project changes.
> - Uses a fixed-interval timer to append one Unicode code point at a time; skips animation when `prefers-reduced-motion` is set.
> - Renders two stacked layers in the `MenuTrigger`: an invisible full-title layer for stable layout sizing and a visible animated layer.
> - New [`incrementalTextCompletion.ts`](https://github.com/pingdotgg/t3code/pull/4214/files#diff-91578d73e35dd250df7dfac0cdd19daf03a8ba0840a8fc3a82c6a3a06dbcd6d6) utilities handle Unicode-aware code point splitting and shared prefix detection, covered by unit tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c86b32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->