### PR TITLE
Local dev for retaining my changes in parrallel.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -55,6 +55,11 @@ jobs:
           cache: true
           run-install: true
 
+      - name: Install minimum supported Jujutsu
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2
+        with:
+          tool: jj-cli@0.42.0
+
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
 
@@ -63,7 +68,7 @@ jobs:
 
   mobile_native_static_analysis:
     name: Mobile Native Static Analysis
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: macos-26
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -84,7 +89,7 @@ jobs:
 
   release_smoke:
     name: Release Smoke
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/jj-phase-zero.yml
+++ b/.github/workflows/jj-phase-zero.yml
@@ -23,6 +23,9 @@ on:
       - "scripts/jj-phase-zero-smoke.ts"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   contract:
     name: ${{ matrix.os }} / ${{ matrix.jj_tool }}
@@ -41,10 +44,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: package.json
 
@@ -55,7 +60,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts --filter @t3tools/scripts...
 
       - name: Install Jujutsu
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2
         with:
           tool: ${{ matrix.jj_tool }}
 

--- a/.github/workflows/jj-phase-zero.yml
+++ b/.github/workflows/jj-phase-zero.yml
@@ -1,0 +1,63 @@
+name: jj Phase 0 Contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/jj-phase-zero.yml"
+      - "apps/server/src/sourceControl/SourceControlDiscovery.ts"
+      - "apps/server/src/vcs/VcsProcess.ts"
+      - "packages/contracts/src/sourceControl.ts"
+      - "packages/contracts/src/vcs.ts"
+      - "packages/shared/src/jjCli.ts"
+      - "scripts/jj-phase-zero-smoke.ts"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/jj-phase-zero.yml"
+      - "apps/server/src/sourceControl/SourceControlDiscovery.ts"
+      - "apps/server/src/vcs/VcsProcess.ts"
+      - "packages/contracts/src/sourceControl.ts"
+      - "packages/contracts/src/vcs.ts"
+      - "packages/shared/src/jjCli.ts"
+      - "scripts/jj-phase-zero-smoke.ts"
+  workflow_dispatch:
+
+jobs:
+  contract:
+    name: ${{ matrix.os }} / ${{ matrix.jj_tool }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+          - windows-2022
+        jj_tool:
+          - jj-cli@0.42.0
+          - jj-cli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install smoke-test dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts --filter @t3tools/scripts...
+
+      - name: Install Jujutsu
+        uses: taiki-e/install-action@v2
+        with:
+          tool: ${{ matrix.jj_tool }}
+
+      - name: Verify jj command contract
+        run: node scripts/jj-phase-zero-smoke.ts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "repos/alchemy-effect/vendor/alchemy"]
+	path = .repos/alchemy-effect/.vendor/alchemy
+	url = git@github.com:alchemy-run/alchemy.git

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -1,6 +1,6 @@
 # jj Equivalent Workflows Plan
 
-Status: Phases 0-3 implemented locally; Phase 4 next
+Status: Phases 0-4 implemented locally; Phase 5 next
 
 Scope: server, shared contracts, web, mobile, provider integrations, tests, and documentation
 
@@ -198,6 +198,11 @@ Exit criteria:
 - equivalent Git and jj fixtures produce equivalent review file lists.
 
 ### Phase 4: thread workspaces
+
+Implementation status: implemented locally. Thread bootstrap and generic workspace RPCs now route
+through `VcsWorkspaceService`; JJ workspaces use deterministic thread names, persisted revision/base
+identity, stale repair, idempotent recreation, and forget-before-delete cleanup. Git worktrees retain
+their existing behavior through the same service.
 
 Replace worktree assumptions with a generic isolated-workspace workflow.
 

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -1,6 +1,6 @@
 # jj Equivalent Workflows Plan
 
-Status: proposed
+Status: Phases 0-3 implemented locally; Phase 4 next
 
 Scope: server, shared contracts, web, mobile, provider integrations, tests, and documentation
 
@@ -121,6 +121,8 @@ Exit criteria:
 
 ### Phase 1: make workflow contracts VCS-neutral
 
+Implementation status: implemented locally. Generic contracts, legacy Git RPC aliases, persisted-thread compatibility fields/tests, and provider Git compatibility boundary are in place.
+
 Replace Git-shaped shared models before implementing jj behavior.
 
 Tasks:
@@ -141,6 +143,8 @@ Exit criteria:
 - old persisted Git threads still open.
 
 ### Phase 2: implement the jj process and repository driver
+
+Implementation status: implemented locally. `JjProcess`, `JjVcsDriver`, registry preference, init UI, and real Git/jj driver contract tests are in place.
 
 Add `JjProcess` and `JjVcsDriver` using the same timeout, cancellation, redaction, output-limit, and error-mapping standards as Git.
 
@@ -163,6 +167,8 @@ Exit criteria:
 - command cancellation cannot leave an unobserved child process.
 
 ### Phase 3: status, refs, revisions, and diffs
+
+Implementation status: implemented locally.
 
 Model jj state directly.
 

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -1,0 +1,477 @@
+# jj Equivalent Workflows Plan
+
+Status: proposed
+
+Scope: server, shared contracts, web, mobile, provider integrations, tests, and documentation
+
+Target: Git-backed, colocated Jujutsu repositories first
+
+## Goal
+
+Give a repository selected as `jj` the same product outcomes currently available for Git:
+
+- initialize, clone, publish, and discover a repository;
+- show source-control status and diffs;
+- create an isolated thread workspace;
+- start, describe, and finalize a change;
+- push a named ref and create a pull request;
+- fetch remote updates safely;
+- check out a pull request into the current workspace or a new one;
+- capture, preview, and restore T3 Code checkpoints;
+- recover predictably from interrupted commands, stale workspaces, and conflicts.
+
+Equivalence means equivalent user outcomes, not translating every Git command literally. jj has no staging index or current bookmark, its working copy is a commit, and conflicts can persist in commits. The product model must expose those semantics instead of pretending jj is Git.
+
+## Initial support boundary
+
+The first release supports Git-backed jj repositories in colocated mode.
+
+This boundary preserves:
+
+- GitHub, GitLab, and Bitbucket remote compatibility;
+- provider CLI behavior that expects a `.git` directory;
+- existing agents and tools that may still invoke Git;
+- a low-risk migration path for existing repositories.
+
+Pure jj repositories and non-colocated Git-backed repositories are later work. Commands must still go through the jj driver; direct Git calls are allowed only inside explicitly documented provider compatibility adapters.
+
+Repository selection rules:
+
+1. An explicit `.t3code/vcs.json` selection wins.
+2. In automatic mode, `.jj` wins over `.git` so a colocated repository is treated as jj.
+3. A repository with only `.git` remains Git.
+4. An explicit unsupported selection returns a useful configuration error; it must not silently mutate the repository with another VCS.
+
+## Semantic mapping
+
+| Product concept | Git implementation | jj implementation |
+| --- | --- | --- |
+| Repository | Git working tree | jj workspace backed by Git |
+| Thread isolation | Git worktree | `jj workspace` |
+| Named publish ref | Branch | Bookmark |
+| Current location | Checked-out branch and `HEAD` | Workspace commit `@`; optional publish bookmark is separate |
+| Uncommitted work | Working tree and index | Mutable working-copy commit |
+| Commit action | Create a commit from staged or selected files | Describe/finalize the current change, then create a new working-copy change |
+| Select files | Git index/pathspec commit | jj fileset arguments to `jj commit` |
+| Switch base | Checkout/switch branch | Create a new change on a revision, or explicitly edit an existing change |
+| Pull | Fetch plus fast-forward | Fetch tracked bookmarks; advance/rebase only when safe |
+| Push | Push branch | Move and push one explicit bookmark |
+| Remote branch | Remote-tracking branch | Remote bookmark such as `main@origin` |
+| Recovery snapshot | Hidden Git checkpoint refs | jj operation and working-copy revision metadata, restored locally |
+| Merge conflict | Transient index/worktree state | First-class conflicted revision or bookmark |
+
+Two product concepts must remain separate:
+
+- `workspaceRevision`: the change currently edited by a workspace;
+- `publishRef`: the bookmark deliberately moved and pushed for a change request.
+
+There is no “current bookmark” in jj. UI and server code must never infer a publish bookmark merely because it points at `@`.
+
+## Architecture direction
+
+Do not add jj branches throughout `GitManager`. Extract workflow-level VCS services, then implement Git and jj adapters behind them.
+
+Keep `packages/contracts` schema-only. Put process execution and semantic mapping in server packages.
+
+Proposed server boundaries:
+
+- `VcsRepositoryService`: detection, initialization, clone, remotes, files, ignored paths;
+- `VcsStatusService`: status, revisions, refs, divergence, conflicts, diffs;
+- `VcsWorkspaceService`: create, reuse, list, repair, and forget isolated workspaces;
+- `VcsChangeService`: describe, finalize all or selected files, generate message context;
+- `VcsSyncService`: fetch, advance/rebase safely, move a publish ref, and push;
+- `VcsCheckpointService`: capture, diff, restore, and expire checkpoints.
+
+Each service resolves a driver through `VcsDriverRegistry`. Provider services depend on these workflow interfaces, not on `GitVcsDriver`.
+
+Avoid one oversized driver interface. Capabilities should describe real semantic support, including:
+
+- `supportsWorkspaces`;
+- `supportsNamedPublishRefs`;
+- `supportsSelectedFileFinalize`;
+- `supportsAtomicSnapshot`;
+- `supportsThreadLocalRestore`;
+- `supportsDefaultRemotePush`;
+- `supportsGitProviderCompatibility`.
+
+## Delivery phases
+
+### Phase 0: command and data contract spike
+
+Implementation status: implemented locally; cross-platform verification runs in CI. See `docs/architecture/jj-command-contract.md` and `scripts/jj-phase-zero-smoke.ts`.
+
+Build a disposable fixture matrix before changing production behavior.
+
+Tasks:
+
+- choose and document a minimum supported jj version;
+- test the command surface against that version and the current stable version;
+- prove `jj git init --colocate` and `jj git clone --colocate` on macOS, Linux, and Windows;
+- define machine-readable templates for status, log, bookmarks, workspaces, and operation IDs;
+- use explicit templates and safe delimiters; never parse colored or human-formatted output;
+- test paths, bookmark names, and descriptions containing spaces, Unicode, tabs, and newlines;
+- classify exit codes and stderr for missing binary, non-repository, stale workspace, unresolved revision, bookmark conflict, content conflict, authentication, and rejected push;
+- prove a durable, thread-local checkpoint restore strategy without restoring the entire repository operation state.
+
+Exit criteria:
+
+- a checked-in command mapping document or test fixture records every command used later;
+- the checkpoint experiment survives process restart and jj garbage collection within the promised retention window;
+- unsupported jj versions fail during discovery with an actionable message.
+
+### Phase 1: make workflow contracts VCS-neutral
+
+Replace Git-shaped shared models before implementing jj behavior.
+
+Tasks:
+
+- introduce generic status models with `workspaceRevision`, optional `publishRef`, default ref, tracked remote state, conflicts, and divergence;
+- replace branch-only identity with a named-ref type carrying `kind: "branch" | "bookmark"`;
+- replace worktree-only identity with workspace identity while retaining a migration reader for stored Git threads;
+- add generic change, workspace, sync, and checkpoint errors to `packages/contracts`;
+- introduce `vcs.*` RPC methods for generic workflows;
+- retain `git.*` RPC aliases temporarily so old clients can reconnect during rollout;
+- move progress phases and messages to VCS-neutral events, with driver-specific user labels supplied separately;
+- update persistence schemas with forward and backward migration tests.
+
+Exit criteria:
+
+- Git behavior is unchanged through the new interfaces;
+- no provider, review, or source-control service needs to import `GitVcsDriver` directly;
+- old persisted Git threads still open.
+
+### Phase 2: implement the jj process and repository driver
+
+Add `JjProcess` and `JjVcsDriver` using the same timeout, cancellation, redaction, output-limit, and error-mapping standards as Git.
+
+Tasks:
+
+- discover the binary and supported version;
+- detect `.jj`, resolve repository/workspace roots, and detect colocation;
+- implement file listing and ignored-path filtering;
+- implement remote list/add/remove and default-remote selection;
+- initialize an existing directory with `jj git init --colocate`;
+- clone with `jj git clone --colocate`;
+- register the driver and mark jj discovery as implemented;
+- add the jj driver to all server layer graphs;
+- ensure automatic detection prefers jj in a colocated repository.
+
+Exit criteria:
+
+- the shared driver contract suite runs against temporary Git and jj repositories;
+- initialization and clone never choose jj unless configuration or detection says jj;
+- command cancellation cannot leave an unobserved child process.
+
+### Phase 3: status, refs, revisions, and diffs
+
+Model jj state directly.
+
+Tasks:
+
+- snapshot before status-sensitive reads so filesystem changes are represented;
+- report the workspace commit ID, change ID, description, parents, emptiness, and content conflicts;
+- list local and remote bookmarks, tracking state, divergence, and bookmark conflicts;
+- identify a default remote bookmark without treating it as a current bookmark;
+- calculate changed files and patch data from the working-copy revision;
+- support working-copy, base-to-publish-ref, turn, and arbitrary checkpoint diffs;
+- preserve rename, binary-file, mode, and deletion metadata expected by review UI;
+- cap and stream large patches consistently with Git;
+- keep line comments keyed to stable diff identity rather than a branch name.
+
+Suggested command shapes, validated in Phase 0:
+
+- status metadata: `jj log` and `jj bookmark list` with explicit templates;
+- working-copy patch: `jj diff --git -r @`;
+- range patch: `jj diff --git --from <base> --to <target>`;
+- explicit snapshot: `jj util snapshot` when a read path otherwise would not snapshot.
+
+Exit criteria:
+
+- the web and mobile clients render jj status without a fictional active branch;
+- conflicted changes and conflicted bookmarks are distinct states;
+- equivalent Git and jj fixtures produce equivalent review file lists.
+
+### Phase 4: thread workspaces
+
+Replace worktree assumptions with a generic isolated-workspace workflow.
+
+Tasks:
+
+- create a deterministic jj workspace name from the T3 Code thread ID;
+- create the directory with `jj workspace add` at the requested base revision;
+- start a new empty change on that base rather than editing a published revision;
+- store workspace name, root path, current change ID, base revision, and optional publish bookmark in thread metadata;
+- reuse an existing valid workspace on reconnect;
+- detect and repair stale workspaces with `jj workspace update-stale` only after showing the intended recovery action in logs;
+- forget workspace metadata before deleting a workspace directory;
+- handle missing directories, duplicate names, interrupted creation, and external workspace rewrites idempotently;
+- preserve Git worktree behavior through the same interface.
+
+Exit criteria:
+
+- two threads can edit separate jj workspaces concurrently;
+- restarting the server reconnects each thread to the correct workspace/change;
+- deleting one thread cannot change or forget another workspace.
+
+### Phase 5: change finalization and AI messages
+
+Implement the current commit workflows with jj-native behavior.
+
+Tasks:
+
+- generate AI message context from the patch for `@`;
+- describe and finalize all files with `jj commit -m <message>`;
+- finalize selected files using validated jj fileset arguments;
+- leave non-selected changes in the new working-copy change;
+- return the finalized revision and the newly created workspace revision explicitly;
+- create or move a publish bookmark to the finalized revision only when the workflow requests publishing;
+- implement “create feature ref” as creating a bookmark, not as changing workspace attachment;
+- reject an empty message and distinguish an empty finalized change from a successful finalize;
+- preserve streamed progress and cancellation.
+
+The product should label this action contextually:
+
+- Git: “Commit”;
+- jj: “Finalize change” or “Commit change”.
+
+Do not emulate the Git index. Do not silently run Git commit hooks: their index semantics do not match jj selected-file finalization. If project validation is required, expose it as a separate, VCS-neutral validation step with visible output.
+
+Exit criteria:
+
+- custom, AI-generated, all-file, and selected-file workflows work in both drivers;
+- selected-file finalization preserves excluded changes;
+- no finalized revision is pushed until an explicit publish action.
+
+### Phase 6: fetch, publish, and change requests
+
+Make remote mutation explicit and conservative.
+
+Tasks:
+
+- implement fetch as `jj git fetch --remote <remote>`;
+- refresh tracked bookmarks and return bookmark conflicts as structured state;
+- after fetch, automatically advance an empty workspace change only when the old base is safely superseded;
+- if the workspace change is non-empty, divergent, or conflicted, leave it untouched and return `needsRebase` or `needsResolution`;
+- move one explicit publish bookmark to the selected finalized revision;
+- push only that bookmark with `jj git push --remote <remote> --bookmark <name>`;
+- never use an implicit “push all bookmarks” operation;
+- use the publish bookmark as the provider pull-request head;
+- derive provider identity from normalized remotes through the generic repository service;
+- keep provider CLI compatibility isolated to colocated repositories;
+- create/publish a new hosted repository by creating the provider repository, adding the jj Git remote, and pushing the explicit bookmark;
+- map authentication and push-safety failures to actionable errors without automatic force.
+
+Stacked action mapping:
+
+1. Snapshot and validate the working-copy change.
+2. Finalize it with a message.
+3. Create or move the publish bookmark to the finalized revision.
+4. Push exactly that bookmark.
+5. Create or update the provider pull request.
+6. Leave the workspace on a new empty change above the finalized revision.
+
+Exit criteria:
+
+- commit-only, commit-and-push, and commit-push-PR modes reach the same user-visible outcomes as Git;
+- a rejected or conflicted push never overwrites remote work;
+- fetch never rewrites a non-empty workspace change automatically.
+
+### Phase 7: pull-request checkout
+
+Implement review checkout without editing published history accidentally.
+
+Tasks:
+
+- fetch the provider PR head into a deterministic local bookmark;
+- support checkout into the current workspace by creating a new empty change on the PR head;
+- support checkout into a new thread by creating a jj workspace on the PR head;
+- add cross-fork remotes through the generic remote service;
+- make repeated checkout idempotent;
+- preserve the PR bookmark separately from any future publish bookmark for review edits;
+- clean up temporary PR bookmarks/remotes only when no thread references them.
+
+Exit criteria:
+
+- GitHub, GitLab, and Bitbucket checkout fixtures work for same-repository and fork pull requests;
+- opening a PR for review does not mutate its published revision;
+- current-workspace and isolated-workspace modes behave consistently.
+
+### Phase 8: checkpoints and rollback
+
+Use jj’s snapshot and operation model, but keep rollback thread-local.
+
+Tasks:
+
+- run an explicit snapshot and record operation ID, workspace name, commit ID, change ID, parents, and description;
+- compute checkpoint previews between recorded revisions;
+- restore file contents and description into the selected workspace revision;
+- never use repository-wide `jj op restore` for a thread rollback;
+- define checkpoint retention and prove recorded revisions remain addressable for that duration;
+- expire checkpoint metadata and any retention anchors together;
+- detect when a checkpoint belongs to another repository/workspace and refuse restore;
+- serialize restore against other mutations in the same workspace while allowing independent workspaces to proceed;
+- retain the Git hidden-ref implementation behind the same contract.
+
+If jj cannot provide durable revision retention without exporting unwanted refs to Git, checkpoint parity blocks jj general availability. Do not hide this limitation behind `supportsAtomicSnapshot`.
+
+Exit criteria:
+
+- checkpoint capture, preview, restart recovery, and restore pass for Git and jj;
+- restoring one thread does not move bookmarks or other workspaces;
+- interrupted restore yields a recoverable structured state.
+
+### Phase 9: client semantics and settings
+
+Expose capabilities and jj terms without duplicating whole clients.
+
+Tasks:
+
+- rename generic surfaces from “Git” to “Source control” where both drivers apply;
+- show “branch” for Git and “bookmark” for jj;
+- show “worktree” for Git and “workspace” for jj;
+- show workspace change and publish bookmark as separate fields;
+- replace “Pull” with a driver-provided label; jj should normally say “Fetch updates” and show a separate rebase action when needed;
+- add content-conflict and bookmark-conflict indicators;
+- disable unsupported actions from capabilities with a reason, not by hiding repository state;
+- add repository selection and detection details to settings;
+- update web first, then mobile using shared client-runtime selectors and labels;
+- migrate `git.*` client calls to `vcs.*`, then remove compatibility aliases after one release window.
+
+Exit criteria:
+
+- no jj screen claims there is a checked-out branch;
+- the same state produces the same enabled actions in web and mobile;
+- Git terminology and behavior remain unchanged for Git repositories.
+
+### Phase 10: rollout, observability, and documentation
+
+Ship progressively.
+
+Tasks:
+
+- gate jj mutation workflows behind an experimental setting initially;
+- allow read-only status/diff before mutation workflows are enabled;
+- record operation duration, cancellation, failure class, VCS kind, and workflow name without recording paths, messages, patches, or remote credentials;
+- add recovery logs containing repository-safe IDs and suggested commands;
+- publish setup, conversion, supported-version, limitations, and recovery documentation;
+- document colocation implications for users and agents that also run Git;
+- remove the experimental gate only after checkpoint, provider, and concurrent-workspace criteria pass;
+- plan pure/non-colocated jj support as a separate proposal.
+
+Exit criteria:
+
+- a user can complete the full acceptance matrix below using jj without a Git-only escape hatch;
+- support docs identify every intentional semantic difference;
+- failure telemetry shows no unclassified jj command failures in the beta cohort.
+
+## Workflow acceptance matrix
+
+| Workflow | Required jj outcome |
+| --- | --- |
+| Detect | Colocated `.jj` repository resolves to jj; explicit config overrides auto-detection |
+| Initialize | Existing directory becomes a colocated Git-backed jj repository |
+| Clone | Hosted Git repository becomes a colocated jj workspace with tracked default bookmark |
+| Publish new repo | Provider repo and remote are created; one explicit bookmark is pushed |
+| Status | Changed files, workspace revision, publish bookmark, divergence, and conflicts are accurate |
+| New local thread | New empty change is created from the chosen base in the current workspace |
+| New isolated thread | New jj workspace and empty change are created from the chosen base |
+| Finalize all | Current change is described/finalized; workspace moves to a new empty change |
+| Finalize selected | Selected files are finalized; excluded files remain in the workspace change |
+| AI message | Message context comes from the current change patch and follows existing confirmation rules |
+| Push | Only the chosen publish bookmark moves remotely; safety rejection is preserved |
+| Fetch updates | Remote bookmarks update; unsafe local rebase is not automatic |
+| Create PR | Provider PR head is the explicit publish bookmark |
+| Checkout PR | PR head becomes the base of a new local change in current or isolated workspace |
+| Review | Working-copy and range diffs support file navigation and line comments |
+| Checkpoint | Capture and preview survive restart for the documented retention window |
+| Restore | Only the target workspace contents/description change |
+| Recovery | Stale workspace, interrupted command, and conflicts return structured next actions |
+
+## Test strategy
+
+### Contract tests
+
+- Run shared repository, status, workspace, change, sync, diff, and checkpoint suites against both drivers.
+- Require every optional capability to have both a positive test and an unsupported-path test.
+- Keep Git regression fixtures while jj is added.
+
+### Real CLI integration tests
+
+- Install the minimum supported jj version in CI.
+- Test initialization, clone, workspace concurrency, selected files, fetch divergence, bookmark conflicts, content conflicts, push rejection, stale workspace recovery, checkpoint retention, and cancellation.
+- Use local bare Git remotes; provider network tests remain separate.
+- Cover paths and messages with spaces, Unicode, and newlines.
+
+### Server tests
+
+- Test registry selection, layer wiring, RPC compatibility, persistence migration, command serialization, redaction, and error mapping.
+- Use fake provider APIs for create, publish, and PR checkout orchestration.
+- Verify no generic service imports a concrete Git or jj driver.
+
+### Client tests
+
+- Test capability-derived labels and enabled actions.
+- Test separate workspace revision/publish bookmark rendering.
+- Test conflict and needs-rebase states in web and mobile.
+
+### End-to-end scenarios
+
+1. Clone, create isolated thread, edit, finalize, push, create PR.
+2. Finalize selected files while retaining excluded changes.
+3. Fetch a remote advance with an empty workspace change.
+4. Fetch a remote advance with local work and require explicit rebase.
+5. Check out same-repo and fork PRs into new workspaces.
+6. Capture, restart server, preview, and restore a checkpoint.
+7. Run two workspaces concurrently and recover one stale workspace.
+8. Trigger content and bookmark conflicts and verify safe, actionable UI.
+
+Before each implementation slice is complete, run the focused tests plus repository-required `vp check` and `vp run typecheck`. Native mobile slices also require `vp run lint:mobile`.
+
+## Migration order
+
+Land work as small vertical slices:
+
+1. Generic contracts and Git adapter with no behavior change.
+2. jj detection, repository operations, and read-only status.
+3. jj diffs and review.
+4. jj thread workspaces.
+5. jj finalize and selected-file workflows.
+6. jj fetch and explicit bookmark push.
+7. provider PR create/checkout.
+8. durable checkpoints and restore.
+9. mobile parity, migration cleanup, and removal of `git.*` aliases.
+
+Each slice must be independently releasable behind capabilities or the experimental gate. Do not land client controls before the server reports the matching capability.
+
+## Main risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Git-shaped contracts force incorrect jj behavior | Separate workspace revision from publish ref before driver work |
+| Human CLI output changes between jj versions | Pin minimum version; use explicit templates; integration-test current stable |
+| Colocated Git and jj commands race | Serialize repository mutations; snapshot/import at workflow boundaries; document colocation |
+| Operation restore affects every workspace | Never use repository-wide restore for thread rollback |
+| Checkpoint revisions are garbage-collected | Prove and implement bounded retention before claiming support |
+| Fetch creates bookmark divergence/conflict | Return structured state; never auto-force or auto-resolve |
+| Provider tools assume Git branch state | Pass explicit repo/head data; isolate provider CLI compatibility adapters |
+| Selected-file commit differs from Git staging | Use jj filesets and test excluded-change preservation |
+| Stale workspace after cross-workspace rewrite | Detect and expose repair; test interruption and recovery |
+| Git hooks do not map to jj | Use an explicit VCS-neutral validation workflow; do not emulate the Git index |
+
+## Non-goals for first release
+
+- a full jj operation-log or revset UI;
+- arbitrary history editing, absorb, squash, split, or stack-management UI;
+- automatic conflict resolution;
+- pure jj or non-colocated Git-backed repositories;
+- Git index or Git commit-hook emulation;
+- changing provider APIs beyond what generic VCS orchestration requires;
+- automatically publishing every bookmark;
+- silently converting an existing Git repository to jj.
+
+## References
+
+- [jj working copy and workspaces](https://docs.jj-vcs.dev/latest/working-copy/)
+- [jj bookmarks and remote tracking](https://docs.jj-vcs.dev/latest/bookmarks/)
+- [jj CLI reference](https://docs.jj-vcs.dev/latest/cli-reference/)
+- [jj conflict model](https://docs.jj-vcs.dev/latest/conflicts/)

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -6,6 +6,9 @@ Scope: server, shared contracts, web, mobile, provider integrations, tests, and 
 
 Target: Git-backed, colocated Jujutsu repositories first
 
+Execution note: this plan is suitable for a one-shot, one-pass run from planning through completion.
+Within each phase, make it work, validate it, then make it good before moving to the next phase.
+
 ## Goal
 
 Give a repository selected as `jj` the same product outcomes currently available for Git:

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -1,6 +1,6 @@
 # jj Equivalent Workflows Plan
 
-Status: Phases 0-6 implemented locally; Phase 7 next
+Status: Phases 0-10 implemented locally; required repository validation passes
 
 Scope: server, shared contracts, web, mobile, provider integrations, tests, and documentation
 
@@ -299,6 +299,11 @@ Exit criteria:
 
 ### Phase 7: pull-request checkout
 
+Implementation status: implemented locally. Provider change-request checkout now routes colocated
+jj repositories through a dedicated review service. It creates a deterministic review bookmark,
+starts an empty local change or isolated workspace from the published head, reuses repeated
+checkouts, and adds fork remotes without moving the published revision.
+
 Implement review checkout without editing published history accidentally.
 
 Tasks:
@@ -318,6 +323,11 @@ Exit criteria:
 - current-workspace and isolated-workspace modes behave consistently.
 
 ### Phase 8: checkpoints and rollback
+
+Implementation status: implemented locally. JJ checkpoints snapshot `@`, retain its commit through
+hidden Git refs, store operation/revision metadata in hidden blob refs, diff recorded commits, and
+restore content plus description with jj-native commands. Capture/delete update retention anchors
+through the generic checkpoint driver contract; repository-wide operation restore is never used.
 
 Use jj’s snapshot and operation model, but keep rollback thread-local.
 
@@ -343,6 +353,11 @@ Exit criteria:
 
 ### Phase 9: client semantics and settings
 
+Implementation status: implemented locally. Shared client-runtime presentation selectors provide
+Git branch/worktree and jj bookmark/workspace language to web and mobile. PR checkout, source-control
+progress, version-control settings, and mobile ref/workspace surfaces use the detected driver while
+keeping compatibility RPC field names unchanged.
+
 Expose capabilities and jj terms without duplicating whole clients.
 
 Tasks:
@@ -365,6 +380,12 @@ Exit criteria:
 - Git terminology and behavior remain unchanged for Git repositories.
 
 ### Phase 10: rollout, observability, and documentation
+
+Implementation status: implemented locally. Workflow spans carry only safe VCS kind/workflow/operation
+attributes, user setup and recovery documentation is published, colocation limits are explicit, and
+pure/non-colocated jj support has a separate proposal. The initial mutation gate is considered
+graduated because workspace, provider, and durable-checkpoint criteria now pass; no permanent gate
+is retained in the completed implementation.
 
 Ship progressively.
 

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -1,6 +1,6 @@
 # jj Equivalent Workflows Plan
 
-Status: Phases 0-5 implemented locally; Phase 6 next
+Status: Phases 0-6 implemented locally; Phase 7 next
 
 Scope: server, shared contracts, web, mobile, provider integrations, tests, and documentation
 
@@ -259,6 +259,11 @@ Exit criteria:
 - no finalized revision is pushed until an explicit publish action.
 
 ### Phase 6: fetch, publish, and change requests
+
+Implementation status: implemented locally. JJ fetch now returns structured safe-advance,
+needs-rebase, and needs-resolution outcomes. Publish actions require one explicit bookmark, move it
+to the selected finalized revision, push only that bookmark without force, and use it as the change
+request head. Hosted repository creation adds a JJ remote before the same exact-bookmark publish.
 
 Make remote mutation explicit and conservative.
 

--- a/.plans/jj-equivalent-workflows.md
+++ b/.plans/jj-equivalent-workflows.md
@@ -1,6 +1,6 @@
 # jj Equivalent Workflows Plan
 
-Status: Phases 0-4 implemented locally; Phase 5 next
+Status: Phases 0-5 implemented locally; Phase 6 next
 
 Scope: server, shared contracts, web, mobile, provider integrations, tests, and documentation
 
@@ -225,6 +225,11 @@ Exit criteria:
 - deleting one thread cannot change or forget another workspace.
 
 ### Phase 5: change finalization and AI messages
+
+Implementation status: implemented locally. JJ actions now use `@` patch context, support custom or
+AI-generated messages, finalize all or selected files, preserve excluded edits in the new `@`, and
+return both finalized and workspace revisions. A publish bookmark is created only when the existing
+feature-ref option explicitly requests one; no remote publish occurs.
 
 Implement the current commit workflows with jj-native behavior.
 

--- a/.plans/jj-pure-repository-support.md
+++ b/.plans/jj-pure-repository-support.md
@@ -1,0 +1,32 @@
+# Pure Jujutsu Repository Support Proposal
+
+Status: follow-up proposal, not an official feature
+
+## Goal
+
+Support pure jj and non-colocated Git-backed repositories without weakening current colocated safety
+or provider behavior.
+
+## Required decisions
+
+- Define provider identity when no `.git` worktree is available to hosting CLIs.
+- Replace hidden Git checkpoint refs with a jj-native durable retention mechanism.
+- Separate Git-provider compatibility capability from core repository capability.
+- Decide whether provider CLIs run against a temporary compatibility checkout or provider APIs only.
+- Prove clone, fetch, publish, review checkout, checkpoints, and recovery against supported backends.
+
+## Constraints
+
+- No implicit conversion to colocated mode.
+- No repository-wide operation restore for thread rollback.
+- No fictional current bookmark.
+- No fallback from failed jj mutation to direct Git mutation.
+- No provider command may require or synthesize user credentials outside existing secret handling.
+
+## Acceptance boundary
+
+- Shared workflow contracts and clients remain unchanged.
+- Pure repositories pass driver, workspace, sync, review, and checkpoint suites.
+- Provider-less local workflows work without Git.
+- Hosted change requests expose explicit unsupported reasons until provider compatibility passes.
+- Colocated repositories retain current behavior and performance.

--- a/apps/marketing/src/pages/security-policy.astro
+++ b/apps/marketing/src/pages/security-policy.astro
@@ -55,10 +55,13 @@ const sections = [
     <p class="section-number">02</p>
     <h2>Reporting Security Issues</h2>
     <p>
-      If you believe you have found a security vulnerability affecting T3 Code or T3 Tools-operated
-      infrastructure, email{" "}<a href="mailto:security@ping.gg">security@ping.gg</a>. Please do not
-      disclose the issue publicly until we have had a reasonable opportunity to investigate and
-      remediate it.
+      Report vulnerabilities introduced by or specific to this fork through a{" "}<a
+        href="https://github.com/michft/t3code/security/advisories/new"
+        >private GitHub security advisory</a
+      >. For issues independently affecting upstream-operated T3 Code, T3 Tools code, or services,
+      email{" "}<a href="mailto:security@ping.gg">security@ping.gg</a>. Please do not disclose the issue
+      publicly until the responsible maintainers have had a reasonable opportunity to investigate
+      and remediate it.
     </p>
     <p>Please include, when available:</p>
     <ul>

--- a/apps/marketing/src/pages/security-policy.astro
+++ b/apps/marketing/src/pages/security-policy.astro
@@ -18,12 +18,22 @@ const sections = [
   heading="T3 Code Security Policy"
   lede="Security is a shared responsibility. This policy explains how to report a vulnerability, how we protect T3 Tools-operated services, and how you can secure the environments and providers you connect to T3 Code."
   effectiveDate="2026-07-15"
-  lastUpdated="2026-07-15"
+  lastUpdated="2026-07-19"
   sections={sections}
 >
   <section id="introduction">
     <p class="section-number">01</p>
     <h2>Introduction</h2>
+    <p>
+      <strong>Fork notice:</strong> This repository is the independently maintained{" "}<a
+        href="https://github.com/michft/t3code">michft/t3code fork</a
+      >. Report vulnerabilities introduced by or specific to this fork through a{" "}<a
+        href="https://github.com/michft/t3code/security/advisories/new"
+        >private GitHub security advisory</a
+      >. Do not send fork-specific security reports, bug reports, or support requests to the
+      upstream T3 Code project or its maintainers. Upstream contacts listed below apply only to
+      issues independently affecting upstream-operated code or services.
+    </p>
     <p>
       This Security Policy describes the vulnerability-reporting process and security practices for
       the T3 Code desktop and mobile applications, the hosted application at{" "}<a

--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -700,6 +700,7 @@ export function ReviewSheet(props: ReviewSheetProps) {
               environmentId={environmentId}
               threadId={threadId}
               currentBranch={selectedThread.branch ?? null}
+              publishRef={selectedThread.vcsWorkspace?.publishRef ?? null}
               gitStatus={gitStatusQuery.data}
               gitOperationLabel={gitState.gitOperationLabel}
               onPull={gitActions.onPullSelectedThreadBranch}

--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -3,6 +3,7 @@ import {
   type GitRunStackedActionResult,
   type ProjectScript,
   ThreadId,
+  type VcsNamedRef,
   type VcsStatusResult,
 } from "@t3tools/contracts";
 import {
@@ -83,6 +84,7 @@ export type ThreadGitMenuProps = {
   readonly threadId: ThreadId | string;
   readonly currentBranch: string | null;
   readonly gitStatus: VcsStatusResult | null;
+  readonly publishRef: VcsNamedRef | null;
   readonly gitOperationLabel: string | null;
   readonly onOpenFilesInspector?: () => void;
   readonly onOpenGitInspector?: () => void;
@@ -121,14 +123,14 @@ function useThreadGitControlModel(props: ThreadGitMenuProps) {
   const quickAction = useMemo(
     () =>
       isRepo
-        ? resolveQuickAction(gitStatus, busy, isDefaultRef, hasPrimaryRemote)
+        ? resolveQuickAction(gitStatus, busy, isDefaultRef, hasPrimaryRemote, props.publishRef)
         : {
             label: "Git unavailable",
             disabled: true,
             kind: "show_hint" as const,
             hint: "This workspace is not a git repository.",
           },
-    [busy, gitStatus, hasPrimaryRemote, isDefaultRef, isRepo],
+    [busy, gitStatus, hasPrimaryRemote, isDefaultRef, isRepo, props.publishRef],
   );
 
   const quickActionHint = quickAction.disabled

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -604,6 +604,7 @@ function ThreadRouteContent(
     onOpenGitInspector: fileInspector.supported ? handleOpenGitInspector : undefined,
     currentBranch: selectedThread?.branch ?? null,
     gitStatus: gitStatus.data,
+    publishRef: selectedThread?.vcsWorkspace?.publishRef ?? null,
     gitOperationLabel: gitState.gitOperationLabel,
     canOpenTerminal: Boolean(selectedThreadProject?.workspaceRoot),
     canOpenFiles: Boolean(selectedThreadProject?.workspaceRoot),

--- a/apps/mobile/src/features/threads/git/GitBranchesSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitBranchesSheet.tsx
@@ -1,4 +1,5 @@
 import { sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { capitalizeVcsTerm, getVcsPresentation } from "@t3tools/client-runtime/state/vcs";
 import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { useState } from "react";
 import { Platform, Pressable, ScrollView, View } from "react-native";
@@ -37,7 +38,10 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
       : null,
   );
 
-  const currentBranchLabel = gitStatus.data?.refName ?? selectedThread?.branch ?? "Detached HEAD";
+  const vcsPresentation = getVcsPresentation(gitStatus.data?.driverKind);
+  const refsLabel = capitalizeVcsTerm(vcsPresentation.refPlural);
+  const currentBranchLabel =
+    gitStatus.data?.refName ?? selectedThread?.branch ?? vcsPresentation.currentRefFallback;
   const currentWorktreePath = selectedThreadWorktreePath;
   const availableBranches = gitState.selectedThreadBranches;
   const branchesLoading = gitState.selectedThreadBranchesLoading;
@@ -45,7 +49,7 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
 
   const [newBranchName, setNewBranchName] = useState("");
   const [worktreeBaseBranch, setWorktreeBaseBranch] = useState(
-    currentBranchLabel === "Detached HEAD" ? "main" : currentBranchLabel,
+    currentBranchLabel === vcsPresentation.currentRefFallback ? "main" : currentBranchLabel,
   );
   const [worktreeBranchName, setWorktreeBranchName] = useState("");
 
@@ -60,7 +64,10 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
       {Platform.OS === "android" ? (
-        <AndroidSheetHeader title="Branches & worktrees" onBack={() => navigation.goBack()} />
+        <AndroidSheetHeader
+          title={`${refsLabel} & ${vcsPresentation.workspacePlural}`}
+          onBack={() => navigation.goBack()}
+        />
       ) : null}
       <ScrollView
         className="flex-1"
@@ -70,7 +77,7 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
       >
         <View className="gap-2 rounded-[18px] border border-border bg-card px-4 py-4">
           <Text className="text-foreground-secondary text-2xs font-t3-bold tracking-[1px] uppercase">
-            New branch
+            New {vcsPresentation.refSingular}
           </Text>
           <TextInput
             value={newBranchName}
@@ -96,7 +103,7 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
 
         <View className="gap-2 rounded-[18px] border border-border bg-card px-4 py-4">
           <Text className="text-foreground-secondary text-2xs font-t3-bold tracking-[1px] uppercase">
-            New worktree
+            New {vcsPresentation.workspaceSingular}
           </Text>
           <TextInput
             value={worktreeBaseBranch}
@@ -112,7 +119,7 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
           />
           <SheetActionButton
             icon="square.split.2x1"
-            label="Create worktree"
+            label={`Create ${vcsPresentation.workspaceSingular}`}
             tone="primary"
             disabled={
               busy ||
@@ -133,16 +140,16 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
 
         <View className="gap-2">
           <Text className="text-foreground-secondary text-2xs font-t3-bold tracking-[1px] uppercase">
-            Existing branches
+            Existing {vcsPresentation.refPlural}
           </Text>
           {branchesLoading ? (
             <Text className="text-foreground-secondary text-sm font-medium">
-              Loading branches...
+              Loading {vcsPresentation.refPlural}...
             </Text>
           ) : null}
           {!branchesLoading && availableBranches.length === 0 ? (
             <Text className="text-foreground-secondary text-sm font-medium">
-              No local branches found.
+              No local {vcsPresentation.refPlural} found.
             </Text>
           ) : null}
           {availableBranches.map((branch) => {
@@ -150,10 +157,10 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
             const subtitle = branch.worktreePath
               ? branch.worktreePath === currentWorktreePath
                 ? "Checked out in this thread"
-                : "Checked out in another worktree"
+                : `Checked out in another ${vcsPresentation.workspaceSingular}`
               : branch.isDefault
-                ? "Default branch"
-                : "Local branch";
+                ? `Default ${vcsPresentation.refSingular}`
+                : `Local ${vcsPresentation.refSingular}`;
 
             return (
               <Pressable

--- a/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
@@ -38,6 +38,8 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
 
   const busy = gitState.gitOperationLabel !== null;
   const isJjRepository = gitStatus.data?.driverKind === "jj";
+  const jjPublishRef = selectedThread?.vcsWorkspace?.publishRef ?? null;
+  const hasJjPublishRef = isJjRepository && jjPublishRef !== null;
   const isDefaultRef = gitStatus.data?.isDefaultRef ?? false;
   const allFiles = gitStatus.data?.workingTree?.files ?? [];
 
@@ -57,13 +59,13 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
       const commitMessage = dialogCommitMessage.trim();
       navigation.goBack();
       await gitActions.onRunSelectedThreadGitAction({
-        action: "commit",
+        action: !featureBranch && hasJjPublishRef ? "commit_push" : "commit",
         featureBranch,
         ...(commitMessage ? { commitMessage } : {}),
         ...(!allSelected ? { filePaths: selectedFiles.map((file) => file.path) } : {}),
       });
     },
-    [allSelected, dialogCommitMessage, gitActions, navigation, selectedFiles],
+    [allSelected, dialogCommitMessage, gitActions, hasJjPublishRef, navigation, selectedFiles],
   );
 
   return (
@@ -230,7 +232,9 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
           <View className="flex-1">
             <SheetActionButton
               icon="checkmark.circle"
-              label={isJjRepository ? "Finalize" : "Commit"}
+              label={
+                isJjRepository ? (hasJjPublishRef ? "Finalize & publish" : "Finalize") : "Commit"
+              }
               tone="primary"
               disabled={noneSelected || busy}
               onPress={() => void runCommitAction(false)}

--- a/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
@@ -37,6 +37,7 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
   );
 
   const busy = gitState.gitOperationLabel !== null;
+  const isJjRepository = gitStatus.data?.driverKind === "jj";
   const isDefaultRef = gitStatus.data?.isDefaultRef ?? false;
   const allFiles = gitStatus.data?.workingTree?.files ?? [];
 
@@ -68,7 +69,10 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
       {Platform.OS === "android" ? (
-        <AndroidSheetHeader title="Commit changes" onBack={() => navigation.goBack()} />
+        <AndroidSheetHeader
+          title={isJjRepository ? "Finalize change" : "Commit changes"}
+          onBack={() => navigation.goBack()}
+        />
       ) : null}
       <ScrollView
         className="flex-1"
@@ -79,12 +83,16 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
       >
         <View className="gap-3 rounded-[22px] border border-border bg-card px-4 py-4">
           <View className="flex-row items-center justify-between gap-3">
-            <Text className="text-foreground-muted text-sm font-medium">Branch</Text>
+            <Text className="text-foreground-muted text-sm font-medium">
+              {isJjRepository ? "Workspace change" : "Branch"}
+            </Text>
             <Text className="text-foreground text-base font-t3-bold">
-              {gitStatus.data?.refName ?? "(detached HEAD)"}
+              {isJjRepository
+                ? (gitStatus.data?.workspaceRevision ?? "unknown")
+                : (gitStatus.data?.refName ?? "(detached HEAD)")}
             </Text>
           </View>
-          {isDefaultRef ? (
+          {!isJjRepository && isDefaultRef ? (
             <Text className="text-xs leading-normal text-amber-700 dark:text-amber-400">
               Warning: this is the default branch.
             </Text>
@@ -197,7 +205,9 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
         </View>
 
         <View className="gap-2">
-          <Text className="text-foreground text-sm font-t3-bold">Commit message</Text>
+          <Text className="text-foreground text-sm font-t3-bold">
+            {isJjRepository ? "Change message" : "Commit message"}
+          </Text>
           <TextInput
             multiline
             value={dialogCommitMessage}
@@ -212,7 +222,7 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
           <View className="flex-1">
             <SheetActionButton
               icon="arrow.branch"
-              label="Commit on new branch"
+              label={isJjRepository ? "Finalize with bookmark" : "Commit on new branch"}
               disabled={noneSelected || busy}
               onPress={() => void runCommitAction(true)}
             />
@@ -220,7 +230,7 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
           <View className="flex-1">
             <SheetActionButton
               icon="checkmark.circle"
-              label="Commit"
+              label={isJjRepository ? "Finalize" : "Commit"}
               tone="primary"
               disabled={noneSelected || busy}
               onPress={() => void runCommitAction(false)}

--- a/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
@@ -77,8 +77,16 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
   const isDefaultRef = gitStatus.data?.isDefaultRef ?? false;
 
   const menuItems = useMemo(
-    () => (isRepo ? buildMenuItems(gitStatus.data, busy, hasPrimaryRemote) : []),
-    [busy, gitStatus.data, hasPrimaryRemote, isRepo],
+    () =>
+      isRepo
+        ? buildMenuItems(
+            gitStatus.data,
+            busy,
+            hasPrimaryRemote,
+            selectedThread?.vcsWorkspace?.publishRef ?? null,
+          )
+        : [],
+    [busy, gitStatus.data, hasPrimaryRemote, isRepo, selectedThread?.vcsWorkspace?.publishRef],
   );
 
   const sheetMenuItems = useMemo(
@@ -153,7 +161,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
         await openExistingPr();
         return;
       }
-      if (item.dialogAction === "commit") {
+      if (item.dialogAction === "commit" || item.dialogAction === "commit_push") {
         navigation.navigate("GitCommit", {
           environmentId: String(environmentId),
           threadId: String(threadId),
@@ -179,7 +187,10 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
       if (status == null) {
         return undefined;
       }
-      if (item.dialogAction === "commit" && status.hasWorkingTreeChanges) {
+      if (
+        (item.dialogAction === "commit" || item.dialogAction === "commit_push") &&
+        status.hasWorkingTreeChanges
+      ) {
         const fileCount = status.workingTree?.files.length ?? 0;
         return `${fileCount} file${fileCount === 1 ? "" : "s"} changed`;
       }

--- a/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
@@ -1,6 +1,8 @@
 import {
   type GitActionRequestInput,
   buildMenuItems,
+  capitalizeVcsTerm,
+  getVcsPresentation,
   getGitActionDisabledReason,
   requiresDefaultBranchConfirmation,
 } from "@t3tools/client-runtime/state/vcs";
@@ -67,7 +69,10 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
       : null,
   );
 
-  const currentBranchLabel = gitStatus.data?.refName ?? selectedThread?.branch ?? "Detached HEAD";
+  const vcsPresentation = getVcsPresentation(gitStatus.data?.driverKind);
+  const refsLabel = capitalizeVcsTerm(vcsPresentation.refPlural);
+  const currentBranchLabel =
+    gitStatus.data?.refName ?? selectedThread?.branch ?? vcsPresentation.currentRefFallback;
   const currentStatusSummary = statusSummary(gitStatus.data);
   const currentWorktreePath = selectedThreadWorktreePath;
   const gitOperationLabel = gitState.gitOperationLabel;
@@ -271,7 +276,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
         <SheetListRow
           icon="text.bubble"
           title="Review changes"
-          subtitle="Inspect turn diffs, worktree changes, and base branch diff"
+          subtitle={`Inspect turn diffs, ${vcsPresentation.workspaceSingular} changes, and base ${vcsPresentation.refSingular} diff`}
           disabled={busy || !isRepo}
           onPress={() => {
             const params = { environmentId, threadId };
@@ -285,8 +290,8 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
         <View className="ml-12 h-px bg-border" />
         <SheetListRow
           icon="point.topleft.down.curvedto.point.bottomright.up"
-          title="Branches & worktrees"
-          subtitle="Switch branch, create branch, or move to a worktree"
+          title={`${refsLabel} & ${vcsPresentation.workspacePlural}`}
+          subtitle={`Switch ${vcsPresentation.refSingular}, create ${vcsPresentation.refSingular}, or move to a ${vcsPresentation.workspaceSingular}`}
           disabled={busy || !isRepo}
           onPress={() =>
             navigation.navigate("GitBranches", {
@@ -297,7 +302,12 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
         />
       </View>
 
-      {currentWorktreePath ? <MetaCard label="Worktree" value={currentWorktreePath} /> : null}
+      {currentWorktreePath ? (
+        <MetaCard
+          label={capitalizeVcsTerm(vcsPresentation.workspaceSingular)}
+          value={currentWorktreePath}
+        />
+      ) : null}
     </ScrollView>
   );
 

--- a/apps/mobile/src/state/use-selected-thread-git-actions.ts
+++ b/apps/mobile/src/state/use-selected-thread-git-actions.ts
@@ -310,18 +310,55 @@ export function useSelectedThreadGitActions() {
         if (AsyncResult.isFailure(result)) {
           return result;
         }
-        await refreshSelectedThreadGitStatus({ quiet: true, cwd });
+        if (result.value.workspaceRevision && thread.vcsWorkspace) {
+          const syncResult = await syncSelectedThreadBranchState({
+            thread,
+            cwd,
+            nextThreadState: {
+              vcsWorkspace: {
+                ...thread.vcsWorkspace,
+                workspaceRevision: result.value.workspaceRevision,
+              },
+            },
+          });
+          if (AsyncResult.isFailure(syncResult)) {
+            return AsyncResult.failure(syncResult.cause);
+          }
+        } else {
+          await refreshSelectedThreadGitStatus({ quiet: true, cwd });
+        }
+        const needsRebase = result.value.status === "fetched_needs_rebase";
+        const needsResolution = result.value.status === "fetched_needs_resolution";
+        const conflictDescription =
+          needsResolution && result.value.conflicts?.length
+            ? result.value.conflicts
+                .map((conflict) =>
+                  conflict.kind === "content"
+                    ? `File conflict: ${conflict.path}`
+                    : `Bookmark conflict: ${conflict.ref.name}`,
+                )
+                .join("\n")
+            : undefined;
         showGitActionResult({
           type: "success",
-          title:
-            result.value.status === "skipped_up_to_date"
-              ? "Already up to date"
-              : `Pulled latest on ${result.value.refName}`,
+          title: needsResolution
+            ? "Fetched; resolution needed"
+            : needsRebase
+              ? "Fetched; rebase needed"
+              : result.value.status === "skipped_up_to_date"
+                ? "Already up to date"
+                : `Updated ${result.value.refName}`,
+          description: conflictDescription,
         });
         return result;
       },
     );
-  }, [pull, refreshSelectedThreadGitStatus, runSelectedThreadGitMutation]);
+  }, [
+    pull,
+    refreshSelectedThreadGitStatus,
+    runSelectedThreadGitMutation,
+    syncSelectedThreadBranchState,
+  ]);
 
   const onRunSelectedThreadGitAction = useCallback(
     async (input: GitActionRequestInput): Promise<GitRunStackedActionResult | null> => {
@@ -336,6 +373,9 @@ export function useSelectedThreadGitActions() {
             ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
             ...(input.featureBranch ? { featureBranch: input.featureBranch } : {}),
             ...(input.filePaths?.length ? { filePaths: [...input.filePaths] } : {}),
+            ...(!input.featureBranch && thread.vcsWorkspace?.publishRef
+              ? { publishRef: thread.vcsWorkspace.publishRef }
+              : {}),
           });
           if (AsyncResult.isFailure(result)) {
             return result;
@@ -349,14 +389,18 @@ export function useSelectedThreadGitActions() {
               result.value.toast.cta.kind === "open_pr" ? result.value.toast.cta.url : undefined,
           });
 
-          if (result.value.commit.workspaceRevision && thread.vcsWorkspace) {
+          if (
+            (result.value.commit.workspaceRevision || result.value.commit.publishRef) &&
+            thread.vcsWorkspace
+          ) {
             const syncResult = await syncSelectedThreadBranchState({
               thread,
               cwd,
               nextThreadState: {
                 vcsWorkspace: {
                   ...thread.vcsWorkspace,
-                  workspaceRevision: result.value.commit.workspaceRevision,
+                  workspaceRevision:
+                    result.value.commit.workspaceRevision ?? thread.vcsWorkspace.workspaceRevision,
                   ...(result.value.commit.publishRef
                     ? { publishRef: result.value.commit.publishRef }
                     : {}),

--- a/apps/mobile/src/state/use-selected-thread-git-actions.ts
+++ b/apps/mobile/src/state/use-selected-thread-git-actions.ts
@@ -61,6 +61,7 @@ export function useSelectedThreadGitActions() {
       nextState: {
         readonly branch?: string | null;
         readonly worktreePath?: string | null;
+        readonly vcsWorkspace?: EnvironmentThreadShell["vcsWorkspace"];
       },
     ) => {
       return updateThreadMetadata({
@@ -69,6 +70,7 @@ export function useSelectedThreadGitActions() {
           threadId: thread.id,
           ...(nextState.branch !== undefined ? { branch: nextState.branch } : {}),
           ...(nextState.worktreePath !== undefined ? { worktreePath: nextState.worktreePath } : {}),
+          ...(nextState.vcsWorkspace !== undefined ? { vcsWorkspace: nextState.vcsWorkspace } : {}),
         },
       });
     },
@@ -178,6 +180,7 @@ export function useSelectedThreadGitActions() {
       readonly nextThreadState?: {
         readonly branch?: string | null;
         readonly worktreePath?: string | null;
+        readonly vcsWorkspace?: EnvironmentThreadShell["vcsWorkspace"];
       };
     }): Promise<AtomCommandResult<void, unknown>> => {
       if (input.nextThreadState) {
@@ -269,6 +272,7 @@ export function useSelectedThreadGitActions() {
             environmentId: thread.environmentId,
             input: {
               cwd: project.workspaceRoot,
+              threadId: thread.id,
               refName: nextWorktree.baseBranch,
               newRefName: sanitizeFeatureBranchName(nextWorktree.newBranch),
               path: null,
@@ -281,8 +285,10 @@ export function useSelectedThreadGitActions() {
             thread,
             cwd: result.value.worktree.path,
             nextThreadState: {
-              branch: result.value.worktree.refName,
+              branch:
+                result.value.workspace?.driverKind === "jj" ? null : result.value.worktree.refName,
               worktreePath: result.value.worktree.path,
+              ...(result.value.workspace ? { vcsWorkspace: result.value.workspace } : {}),
             },
           });
           return AsyncResult.isFailure(syncResult) ? AsyncResult.failure(syncResult.cause) : result;

--- a/apps/mobile/src/state/use-selected-thread-git-actions.ts
+++ b/apps/mobile/src/state/use-selected-thread-git-actions.ts
@@ -349,7 +349,24 @@ export function useSelectedThreadGitActions() {
               result.value.toast.cta.kind === "open_pr" ? result.value.toast.cta.url : undefined,
           });
 
-          if (result.value.branch.status === "created" && result.value.branch.name) {
+          if (result.value.commit.workspaceRevision && thread.vcsWorkspace) {
+            const syncResult = await syncSelectedThreadBranchState({
+              thread,
+              cwd,
+              nextThreadState: {
+                vcsWorkspace: {
+                  ...thread.vcsWorkspace,
+                  workspaceRevision: result.value.commit.workspaceRevision,
+                  ...(result.value.commit.publishRef
+                    ? { publishRef: result.value.commit.publishRef }
+                    : {}),
+                },
+              },
+            });
+            if (AsyncResult.isFailure(syncResult)) {
+              return AsyncResult.failure(syncResult.cause);
+            }
+          } else if (result.value.branch.status === "created" && result.value.branch.name) {
             const syncResult = await syncSelectedThreadBranchState({
               thread,
               cwd,

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -77,6 +77,7 @@ import * as VcsDriverRegistry from "../src/vcs/VcsDriverRegistry.ts";
 import { VcsStatusBroadcaster } from "../src/vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../src/git/GitWorkflowService.ts";
 import * as VcsProcess from "../src/vcs/VcsProcess.ts";
+import { VcsWorkspaceService } from "../src/vcs/VcsWorkspaceService.ts";
 import * as AgentAwarenessRelay from "../src/relay/AgentAwarenessRelay.ts";
 
 const decodeCodexSettings = Schema.decodeEffect(CodexSettings);
@@ -370,6 +371,13 @@ export const makeOrchestrationIntegrationHarness = (
         Layer.succeed(AgentAwarenessRelay.AgentAwarenessRelay, {
           publishThread: () => Effect.void,
           start: () => Effect.void,
+        }),
+      ),
+      Layer.provideMerge(
+        Layer.mock(VcsWorkspaceService)({
+          createThreadWorkspace: () => Effect.die("unexpected workspace creation"),
+          ensureThreadWorkspace: ({ workspace }) => Effect.succeed(workspace),
+          removeThreadWorkspace: () => Effect.void,
         }),
       ),
     );

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -112,6 +112,18 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
         expect(yield* checkpointStore.isGitRepository(tmp)).toBe(true);
       }),
     );
+
+    it.effect("returns true when a Jujutsu repository supports checkpoints", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+        const jj = yield* registry.get("jj");
+        yield* jj.initRepository({ cwd: tmp, kind: "jj" });
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        expect(yield* checkpointStore.isGitRepository(tmp)).toBe(true);
+      }),
+    );
   });
 
   describe("diffCheckpoints", () => {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -1,7 +1,7 @@
 /**
  * CheckpointStore - Repository interface for filesystem-backed workspace checkpoints.
  *
- * Owns hidden Git-ref checkpoint capture/restore and diff computation for a
+ * Owns driver-backed checkpoint capture/restore and diff computation for a
  * workspace thread timeline. It does not store user-facing checkpoint metadata
  * and does not coordinate provider conversation rollback.
  *
@@ -50,7 +50,7 @@ export interface DeleteCheckpointRefsInput {
 export class CheckpointStore extends Context.Service<
   CheckpointStore,
   {
-    /** Check whether cwd is inside a Git worktree. */
+    /** Check whether cwd is inside a repository with checkpoint support. */
     readonly isGitRepository: (cwd: string) => Effect.Effect<boolean, CheckpointStoreError>;
 
     /**
@@ -116,8 +116,8 @@ export const make = Effect.gen(function* () {
 
   const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
     vcsRegistry
-      .detect({ cwd, requestedKind: "git" })
-      .pipe(Effect.map((repository) => repository !== null));
+      .detect({ cwd })
+      .pipe(Effect.map((handle) => handle?.driver.checkpoints !== undefined));
 
   const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
     "captureCheckpoint",

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -23,6 +23,7 @@ import { GitCommandError, TextGenerationError } from "@t3tools/contracts";
 import * as GitHubCli from "../sourceControl/GitHubCli.ts";
 import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsChangeService from "../vcs/VcsChangeService.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubSourceControlProvider from "../sourceControl/GitHubSourceControlProvider.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
@@ -638,6 +639,7 @@ function makeManager(input?: {
   ghScenario?: FakeGhScenario;
   textGeneration?: Partial<FakeGitTextGeneration>;
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
+  vcsChangeService?: VcsChangeService.VcsChangeService["Service"];
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
   const textGeneration = createTextGeneration(input?.textGeneration);
@@ -669,6 +671,14 @@ function makeManager(input?: {
 
   const managerLayer = Layer.mergeAll(
     Layer.succeed(TextGeneration.TextGeneration, textGeneration),
+    Layer.succeed(
+      VcsChangeService.VcsChangeService,
+      input?.vcsChangeService ?? {
+        detectKind: () => Effect.succeed("git" as const),
+        prepareMessageContext: () => Effect.die("unexpected jj change context"),
+        finalizeChange: () => Effect.die("unexpected jj change finalization"),
+      },
+    ),
     Layer.succeed(
       ProjectSetupScriptRunner.ProjectSetupScriptRunner,
       input?.setupScriptRunner ?? {
@@ -1411,6 +1421,62 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           Effect.map((result) => result.stdout.trim()),
         ),
       ).toContain("- details from user");
+    }),
+  );
+
+  it.effect("routes jj finalization through VcsChangeService with AI context", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-jj-manager-");
+      let finalizeInput: VcsChangeService.VcsFinalizeChangeInput | null = null;
+      const { manager } = yield* makeManager({
+        vcsChangeService: {
+          detectKind: () => Effect.succeed("jj"),
+          prepareMessageContext: () =>
+            Effect.succeed({
+              summary: "modified\tsrc/change.ts",
+              patch: "diff --git a/src/change.ts b/src/change.ts\n",
+              workspaceRevision: { commitId: "before-commit", changeId: "before-change" },
+            }),
+          finalizeChange: (input) => {
+            finalizeInput = input;
+            return Effect.succeed({
+              status: "created" as const,
+              finalizedRevision: { commitId: "finalized-commit", changeId: "finalized-change" },
+              workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+              publishRef: {
+                kind: "bookmark" as const,
+                name: "feature/implement-stacked-git-actions",
+                target: { commitId: "finalized-commit", changeId: "finalized-change" },
+              },
+            });
+          },
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit",
+        featureBranch: true,
+        filePaths: ["src/change.ts"],
+      });
+
+      expect(finalizeInput).toMatchObject({
+        cwd: repoDir,
+        message: "Implement stacked git actions",
+        filePaths: ["src/change.ts"],
+        createPublishRef: "feature/implement-stacked-git-actions",
+      });
+      expect(result.branch).toEqual({
+        status: "created",
+        name: "feature/implement-stacked-git-actions",
+      });
+      expect(result.commit).toMatchObject({
+        status: "created",
+        commitSha: "finalized-commit",
+        finalizedRevision: { commitId: "finalized-commit", changeId: "finalized-change" },
+        workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+      });
+      expect(result.toast.title).toBe("Finalized finaliz");
     }),
   );
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -15,8 +15,10 @@ import { expect } from "vite-plus/test";
 import type {
   GitActionProgressEvent,
   GitPreparePullRequestThreadInput,
+  GitRunStackedActionInput,
   ModelSelection,
   ThreadId,
+  VcsNamedRef,
 } from "@t3tools/contracts";
 
 import { GitCommandError, TextGenerationError } from "@t3tools/contracts";
@@ -24,6 +26,7 @@ import * as GitHubCli from "../sourceControl/GitHubCli.ts";
 import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsChangeService from "../vcs/VcsChangeService.ts";
+import * as VcsSyncService from "../vcs/VcsSyncService.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubSourceControlProvider from "../sourceControl/GitHubSourceControlProvider.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
@@ -609,6 +612,7 @@ function runStackedAction(
     commitMessage?: string;
     featureBranch?: boolean;
     filePaths?: readonly string[];
+    publishRef?: GitRunStackedActionInput["publishRef"];
   },
   options?: Parameters<GitManager.GitManager["Service"]["runStackedAction"]>[1],
 ) {
@@ -640,6 +644,7 @@ function makeManager(input?: {
   textGeneration?: Partial<FakeGitTextGeneration>;
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
   vcsChangeService?: VcsChangeService.VcsChangeService["Service"];
+  vcsSyncService?: VcsSyncService.VcsSyncService["Service"];
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
   const textGeneration = createTextGeneration(input?.textGeneration);
@@ -677,6 +682,14 @@ function makeManager(input?: {
         detectKind: () => Effect.succeed("git" as const),
         prepareMessageContext: () => Effect.die("unexpected jj change context"),
         finalizeChange: () => Effect.die("unexpected jj change finalization"),
+      },
+    ),
+    Layer.succeed(
+      VcsSyncService.VcsSyncService,
+      input?.vcsSyncService ?? {
+        fetch: () => Effect.die("unexpected jj fetch"),
+        publish: () => Effect.die("unexpected jj publish"),
+        readRangeContext: () => Effect.die("unexpected jj range context"),
       },
     ),
     Layer.succeed(
@@ -1477,6 +1490,136 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
       });
       expect(result.toast.title).toBe("Finalized finaliz");
+    }),
+  );
+
+  it.effect("moves and publishes only the explicit jj bookmark", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-jj-publish-");
+      const existingPublishRef = {
+        kind: "bookmark" as const,
+        name: "feature/phase-6",
+        target: { commitId: "previous-commit", changeId: "previous-change" },
+      };
+      let finalizeInput: VcsChangeService.VcsFinalizeChangeInput | null = null;
+      let publishedRef: VcsNamedRef | null = null;
+      const { manager } = yield* makeManager({
+        vcsChangeService: {
+          detectKind: () => Effect.succeed("jj"),
+          prepareMessageContext: () =>
+            Effect.succeed({
+              summary: "modified\tchange.txt",
+              patch: "diff --git a/change.txt b/change.txt\n",
+              workspaceRevision: { commitId: "before", changeId: "before-change" },
+            }),
+          finalizeChange: (input) => {
+            finalizeInput = input;
+            return Effect.succeed({
+              status: "created" as const,
+              finalizedRevision: { commitId: "published-commit", changeId: "published-change" },
+              workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+              publishRef: {
+                kind: "bookmark" as const,
+                name: existingPublishRef.name,
+                target: { commitId: "published-commit", changeId: "published-change" },
+              },
+            });
+          },
+        },
+        vcsSyncService: {
+          fetch: () => Effect.die("unexpected jj fetch"),
+          publish: (input) => {
+            publishedRef = input.publishRef;
+            return Effect.succeed({
+              status: "pushed" as const,
+              remoteName: "origin",
+              publishRef: { ...input.publishRef, remoteName: "origin" },
+            });
+          },
+          readRangeContext: () => Effect.die("unexpected jj range context"),
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit_push",
+        commitMessage: "Publish Phase 6",
+        publishRef: existingPublishRef,
+      });
+
+      expect(finalizeInput).toMatchObject({ publishRef: existingPublishRef });
+      expect(publishedRef).toMatchObject({
+        name: existingPublishRef.name,
+        target: { commitId: "published-commit" },
+      });
+      expect(result.push).toEqual({
+        status: "pushed",
+        branch: existingPublishRef.name,
+        upstreamBranch: `origin/${existingPublishRef.name}`,
+        setUpstream: true,
+      });
+      expect(result.commit.publishRef?.remoteName).toBe("origin");
+    }),
+  );
+
+  it.effect("uses the published jj bookmark as the change-request head", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-jj-pr-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "--set-upstream", "origin", "main"]);
+      const baseRevision = (yield* runGit(repoDir, [
+        "rev-parse",
+        "refs/remotes/origin/main",
+      ])).stdout.trim();
+      const publishRef = {
+        kind: "bookmark" as const,
+        name: "feature/phase-6-pr",
+        remoteName: "origin",
+        target: { commitId: "published-commit", changeId: "published-change" },
+      };
+      const createdPr =
+        '[{"number":106,"title":"Phase 6 change request","url":"https://github.com/michft/t3code/pull/106","baseRefName":"main","headRefName":"feature/phase-6-pr","state":"OPEN"}]';
+      let observedBaseRevision: string | null = null;
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: { prListSequence: ["[]", createdPr], defaultBranch: "main" },
+        vcsChangeService: {
+          detectKind: () => Effect.succeed("jj"),
+          prepareMessageContext: () => Effect.die("unexpected jj change context"),
+          finalizeChange: () => Effect.die("unexpected jj finalization"),
+        },
+        vcsSyncService: {
+          fetch: () => Effect.die("unexpected jj fetch"),
+          publish: () =>
+            Effect.succeed({ status: "pushed" as const, remoteName: "origin", publishRef }),
+          readRangeContext: (input) => {
+            observedBaseRevision = input.baseRevision;
+            return Effect.succeed({
+              commitSummary: "published Phase 6",
+              diffSummary: "1 change",
+              diffPatch: "diff --git a/change.txt b/change.txt\n",
+            });
+          },
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+        publishRef,
+      });
+
+      expect(result.pr).toMatchObject({
+        status: "created",
+        number: 106,
+        headBranch: publishRef.name,
+      });
+      expect(observedBaseRevision).toBe(baseRevision);
+      expect(ghCalls.some((call) => call.includes(`--head ${publishRef.name}`))).toBe(true);
+      expect(
+        ghCalls.some((call) => call.includes("pr create") && call.includes(publishRef.name)),
+      ).toBe(true);
     }),
   );
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -27,6 +27,7 @@ import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsChangeService from "../vcs/VcsChangeService.ts";
 import * as VcsSyncService from "../vcs/VcsSyncService.ts";
+import * as VcsReviewService from "../vcs/VcsReviewService.ts";
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubSourceControlProvider from "../sourceControl/GitHubSourceControlProvider.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
@@ -645,6 +646,7 @@ function makeManager(input?: {
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
   vcsChangeService?: VcsChangeService.VcsChangeService["Service"];
   vcsSyncService?: VcsSyncService.VcsSyncService["Service"];
+  vcsReviewService?: VcsReviewService.VcsReviewService["Service"];
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
   const textGeneration = createTextGeneration(input?.textGeneration);
@@ -690,6 +692,12 @@ function makeManager(input?: {
         fetch: () => Effect.die("unexpected jj fetch"),
         publish: () => Effect.die("unexpected jj publish"),
         readRangeContext: () => Effect.die("unexpected jj range context"),
+      },
+    ),
+    Layer.succeed(
+      VcsReviewService.VcsReviewService,
+      input?.vcsReviewService ?? {
+        prepareReview: () => Effect.die("unexpected jj review preparation"),
       },
     ),
     Layer.succeed(
@@ -2789,6 +2797,61 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       const branch = (yield* runGit(repoDir, ["branch", "--show-current"])).stdout.trim();
       expect(branch).toBe("feature/pr-local");
       expect(ghCalls).toContain("pr checkout 64 --force");
+    }),
+  );
+
+  it.effect("routes Jujutsu pull request preparation through the review service", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const reviewCalls: Array<
+        Parameters<VcsReviewService.VcsReviewService["Service"]["prepareReview"]>[0]
+      > = [];
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          pullRequest: {
+            number: 67,
+            title: "JJ review",
+            url: "https://github.com/michft/t3code/pull/67",
+            baseRefName: "main",
+            headRefName: "feature/jj-review",
+            state: "open",
+          },
+        },
+        vcsChangeService: {
+          detectKind: () => Effect.succeed("jj" as const),
+          prepareMessageContext: () => Effect.die("unexpected jj change context"),
+          finalizeChange: () => Effect.die("unexpected jj change finalization"),
+        },
+        vcsReviewService: {
+          prepareReview: (input) => {
+            reviewCalls.push(input);
+            return Effect.succeed({
+              bookmarkName: "t3code-review-67",
+              remoteName: "origin",
+              workspacePath: null,
+            });
+          },
+        },
+      });
+
+      const result = yield* preparePullRequestThread(manager, {
+        cwd: repoDir,
+        reference: "#67",
+        mode: "local",
+      });
+
+      expect(result.branch).toBe("t3code-review-67");
+      expect(result.worktreePath).toBeNull();
+      expect(reviewCalls).toEqual([
+        {
+          cwd: repoDir,
+          changeRequestNumber: 67,
+          headRefName: "feature/jj-review",
+          mode: "local",
+        },
+      ]);
+      expect(ghCalls).not.toContain("pr checkout 67 --force");
     }),
   );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -51,6 +51,7 @@ import type { GitManagerServiceError } from "@t3tools/contracts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsChangeService from "../vcs/VcsChangeService.ts";
 import * as VcsSyncService from "../vcs/VcsSyncService.ts";
+import * as VcsReviewService from "../vcs/VcsReviewService.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import type { ChangeRequest } from "@t3tools/contracts";
 
@@ -528,6 +529,7 @@ export const make = Effect.gen(function* () {
   const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
   const vcsChangeService = yield* VcsChangeService.VcsChangeService;
   const vcsSyncService = yield* VcsSyncService.VcsSyncService;
+  const vcsReviewService = yield* VcsReviewService.VcsReviewService;
   const crypto = yield* Crypto.Crypto;
 
   const sourceControlProvider = (cwd: string) => sourceControlProviders.resolve({ cwd });
@@ -1495,6 +1497,70 @@ export const make = Effect.gen(function* () {
         reference: normalizedReference,
       });
       const pullRequest = toResolvedPullRequest(pullRequestSummary);
+      const driverKind = yield* vcsChangeService.detectKind(input.cwd).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitManagerError({
+              operation: "preparePullRequestThread",
+              cwd: input.cwd,
+              detail: cause.message,
+              cause,
+            }),
+        ),
+      );
+
+      if (driverKind === "jj") {
+        const remoteInfo = toPullRequestHeadRemoteInfo(pullRequestSummary);
+        const headRepository = resolveHeadRepositoryNameWithOwner({
+          ...pullRequest,
+          ...remoteInfo,
+        });
+        let remoteUrl: string | undefined;
+        let remoteName: string | undefined;
+        if (remoteInfo.isCrossRepository && headRepository) {
+          const cloneUrls = yield* (yield* sourceControlProvider(input.cwd)).getRepositoryCloneUrls(
+            {
+              cwd: input.cwd,
+              repository: headRepository,
+            },
+          );
+          const originRemoteUrl = yield* gitCore.readConfigValue(input.cwd, "remote.origin.url");
+          remoteUrl = shouldPreferSshRemote(originRemoteUrl) ? cloneUrls.sshUrl : cloneUrls.url;
+          remoteName =
+            remoteInfo.headRepositoryOwnerLogin?.trim() ||
+            headRepository.split("/")[0]?.trim() ||
+            undefined;
+        }
+        const prepared = yield* vcsReviewService
+          .prepareReview({
+            cwd: input.cwd,
+            changeRequestNumber: pullRequest.number,
+            headRefName: pullRequest.headBranch,
+            mode: input.mode,
+            ...(input.threadId ? { threadId: input.threadId } : {}),
+            ...(remoteName ? { remoteName } : {}),
+            ...(remoteUrl ? { remoteUrl } : {}),
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitManagerError({
+                  operation: "preparePullRequestThread",
+                  cwd: input.cwd,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+        if (prepared.workspacePath) {
+          yield* maybeRunSetupScript(prepared.workspacePath);
+        }
+        return {
+          pullRequest,
+          branch: prepared.bookmarkName,
+          worktreePath: prepared.workspacePath,
+        };
+      }
 
       if (input.mode === "local") {
         yield* (yield* sourceControlProvider(input.cwd)).checkoutChangeRequest({

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -28,6 +28,7 @@ import {
   type VcsStatusRemoteResult,
   VcsStatusResult,
   ModelSelection,
+  type VcsNamedRef,
 } from "@t3tools/contracts";
 import {
   detectSourceControlProviderFromGitRemoteUrl,
@@ -49,6 +50,7 @@ import * as ServerSettings from "../serverSettings.ts";
 import type { GitManagerServiceError } from "@t3tools/contracts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsChangeService from "../vcs/VcsChangeService.ts";
+import * as VcsSyncService from "../vcs/VcsSyncService.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import type { ChangeRequest } from "@t3tools/contracts";
 
@@ -525,6 +527,7 @@ export const make = Effect.gen(function* () {
   const textGeneration = yield* TextGeneration.TextGeneration;
   const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
   const vcsChangeService = yield* VcsChangeService.VcsChangeService;
+  const vcsSyncService = yield* VcsSyncService.VcsSyncService;
   const crypto = yield* Crypto.Crypto;
 
   const sourceControlProvider = (cwd: string) => sourceControlProviders.resolve({ cwd });
@@ -1120,10 +1123,11 @@ export const make = Effect.gen(function* () {
   const resolveBaseRangeRef = Effect.fn("resolveBaseRangeRef")(function* (
     cwd: string,
     baseBranch: string,
+    preferredRemoteName?: string,
   ) {
-    const remoteName = yield* gitCore
-      .resolvePrimaryRemoteName(cwd)
-      .pipe(Effect.orElseSucceed(() => null));
+    const remoteName =
+      preferredRemoteName ??
+      (yield* gitCore.resolvePrimaryRemoteName(cwd).pipe(Effect.orElseSucceed(() => null)));
     if (!remoteName) return baseBranch;
 
     return yield* gitCore
@@ -1674,7 +1678,7 @@ export const make = Effect.gen(function* () {
   ) {
     const progress = yield* createProgressEmitter(input, options);
     const currentPhase = yield* Ref.make<Option.Option<GitActionProgressPhase>>(Option.none());
-    const mapChangeError = (cause: unknown) =>
+    const mapWorkflowError = (cause: unknown) =>
       new GitManagerError({
         operation: "runJjStackedAction",
         cwd: input.cwd,
@@ -1682,18 +1686,145 @@ export const make = Effect.gen(function* () {
         cause,
       });
 
+    const runJjPrStep = Effect.fn("runJjStackedAction.runPrStep")(function* (
+      modelSelection: ModelSelection,
+      publishRef: VcsNamedRef,
+    ) {
+      if (!publishRef.remoteName || !publishRef.target) {
+        return yield* new GitManagerError({
+          operation: "runJjStackedAction.runPrStep",
+          cwd: input.cwd,
+          detail: "Publish the Jujutsu bookmark before creating a change request.",
+        });
+      }
+      const provider = yield* sourceControlProvider(input.cwd);
+      const terms = getChangeRequestTerminologyForKind(provider.kind);
+      const existing = yield* provider.listChangeRequests({
+        cwd: input.cwd,
+        headSelector: publishRef.name,
+        state: "open",
+        limit: 20,
+      });
+      const open = existing.find((changeRequest) => changeRequest.headRefName === publishRef.name);
+      if (open) {
+        return {
+          status: "opened_existing" as const,
+          url: open.url,
+          number: open.number,
+          baseBranch: open.baseRefName,
+          headBranch: open.headRefName,
+          title: open.title,
+        };
+      }
+
+      const baseBranch = yield* provider
+        .getDefaultBranch({ cwd: input.cwd })
+        .pipe(Effect.map((branch) => branch ?? "main"));
+      const baseRevision = yield* resolveBaseRangeRef(input.cwd, baseBranch, publishRef.remoteName);
+      yield* progress.emit({
+        kind: "phase_started",
+        phase: "pr",
+        label: `Generating ${terms.shortLabel} content...`,
+      });
+      const rangeContext = yield* vcsSyncService
+        .readRangeContext({
+          cwd: input.cwd,
+          baseRevision,
+          targetRevision: publishRef.target.commitId,
+        })
+        .pipe(Effect.mapError(mapWorkflowError));
+      const generated = yield* textGeneration.generatePrContent({
+        cwd: input.cwd,
+        baseBranch,
+        headBranch: publishRef.name,
+        commitSummary: limitContext(rangeContext.commitSummary, 20_000),
+        diffSummary: limitContext(rangeContext.diffSummary, 20_000),
+        diffPatch: limitContext(rangeContext.diffPatch, 60_000),
+        modelSelection,
+      });
+      const bodyFile = path.join(
+        tempDir,
+        `t3code-pr-body-${process.pid}-${yield* randomUUIDv4(input.cwd)}.md`,
+      );
+      yield* fileSystem.writeFileString(bodyFile, generated.body).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitManagerError({
+              operation: "runJjStackedAction.runPrStep",
+              cwd: input.cwd,
+              detail: "Failed to write change-request body temp file.",
+              cause,
+            }),
+        ),
+      );
+      yield* progress.emit({
+        kind: "phase_started",
+        phase: "pr",
+        label: `Creating ${terms.singular}...`,
+      });
+      yield* provider
+        .createChangeRequest({
+          cwd: input.cwd,
+          baseRefName: baseBranch,
+          headSelector: publishRef.name,
+          title: generated.title,
+          bodyFile,
+        })
+        .pipe(Effect.ensuring(fileSystem.remove(bodyFile).pipe(Effect.catch(() => Effect.void))));
+      const created = yield* provider.listChangeRequests({
+        cwd: input.cwd,
+        headSelector: publishRef.name,
+        state: "open",
+        limit: 20,
+      });
+      const found = created.find((changeRequest) => changeRequest.headRefName === publishRef.name);
+      return {
+        status: "created" as const,
+        ...(found
+          ? {
+              url: found.url,
+              number: found.number,
+              baseBranch: found.baseRefName,
+              headBranch: found.headRefName,
+              title: found.title,
+            }
+          : {
+              baseBranch,
+              headBranch: publishRef.name,
+              title: generated.title,
+            }),
+      };
+    });
+
     const runAction = Effect.fn("runJjStackedAction.runAction")(function* () {
-      if (input.action !== "commit") {
+      const wantsCommit = isCommitAction(input.action);
+      const wantsPush =
+        input.action === "push" ||
+        input.action === "create_pr" ||
+        input.action === "commit_push" ||
+        input.action === "commit_push_pr";
+      const wantsPr = input.action === "create_pr" || input.action === "commit_push_pr";
+      if (input.featureBranch && !wantsCommit) {
         return yield* new GitManagerError({
           operation: "runJjStackedAction",
           cwd: input.cwd,
-          detail: "Jujutsu publishing and change requests are not available until Phase 6.",
+          detail: "A new publish bookmark can only be created while finalizing a change.",
+        });
+      }
+      if (wantsPush && !input.featureBranch && !input.publishRef) {
+        return yield* new GitManagerError({
+          operation: "runJjStackedAction",
+          cwd: input.cwd,
+          detail: "Create or select an explicit Jujutsu publish bookmark before publishing.",
         });
       }
 
-      yield* progress.emit({ kind: "action_started", phases: ["commit"] });
-      yield* Ref.set(currentPhase, Option.some("commit"));
-
+      const phases: GitActionProgressPhase[] = [
+        ...(wantsCommit ? (["commit"] as const) : []),
+        ...(wantsPush ? (["push"] as const) : []),
+        ...(wantsPr ? (["pr"] as const) : []),
+      ];
+      yield* progress.emit({ kind: "action_started", phases });
       const modelSelection = yield* serverSettingsService.getSettings.pipe(
         Effect.map((settings) => settings.textGenerationModelSelection),
         Effect.mapError(
@@ -1706,116 +1837,169 @@ export const make = Effect.gen(function* () {
             }),
         ),
       );
-      const context = yield* vcsChangeService
-        .prepareMessageContext({
-          cwd: input.cwd,
-          ...(input.filePaths ? { filePaths: input.filePaths } : {}),
-        })
-        .pipe(Effect.mapError(mapChangeError));
 
-      if (!context) {
-        const result: GitRunStackedActionResult = {
-          action: input.action,
-          branch: { status: "skipped_not_requested" },
-          commit: { status: "skipped_no_changes" },
-          push: { status: "skipped_not_requested" },
-          pr: { status: "skipped_not_requested" },
-          toast: {
-            title: "No changes to finalize",
-            cta: { kind: "none" },
-          },
-        };
-        yield* progress.emit({ kind: "action_finished", result });
-        return result;
+      let commitStep: GitRunStackedActionResult["commit"] = {
+        status: "skipped_not_requested",
+      };
+      let branchStep: GitRunStackedActionResult["branch"] = {
+        status: "skipped_not_requested",
+      };
+      let currentPublishRef = input.publishRef;
+
+      if (wantsCommit) {
+        yield* Ref.set(currentPhase, Option.some("commit"));
+        const context = yield* vcsChangeService
+          .prepareMessageContext({
+            cwd: input.cwd,
+            ...(input.filePaths ? { filePaths: input.filePaths } : {}),
+          })
+          .pipe(Effect.mapError(mapWorkflowError));
+        if (context) {
+          const customCommit = parseCustomCommitMessage(input.commitMessage ?? "");
+          let suggestion: CommitAndBranchSuggestion;
+          if (customCommit) {
+            suggestion = {
+              subject: customCommit.subject,
+              body: customCommit.body,
+              ...(input.featureBranch
+                ? { branch: sanitizeFeatureBranchName(customCommit.subject) }
+                : {}),
+              commitMessage: formatCommitMessage(customCommit.subject, customCommit.body),
+            };
+          } else {
+            yield* progress.emit({
+              kind: "phase_started",
+              phase: "commit",
+              label: "Generating change message...",
+            });
+            const generated = yield* textGeneration
+              .generateCommitMessage({
+                cwd: input.cwd,
+                branch: null,
+                stagedSummary: limitContext(context.summary, 8_000),
+                stagedPatch: limitContext(context.patch, 50_000),
+                ...(input.featureBranch ? { includeBranch: true } : {}),
+                modelSelection,
+              })
+              .pipe(Effect.map((result) => sanitizeCommitMessage(result)));
+            suggestion = {
+              subject: generated.subject,
+              body: generated.body,
+              ...(generated.branch !== undefined ? { branch: generated.branch } : {}),
+              commitMessage: formatCommitMessage(generated.subject, generated.body),
+            };
+          }
+
+          yield* progress.emit({
+            kind: "phase_started",
+            phase: "commit",
+            label: "Finalizing change...",
+          });
+          const preferredPublishRef = input.featureBranch
+            ? (suggestion.branch ?? sanitizeFeatureBranchName(suggestion.subject))
+            : undefined;
+          const publishRefToMove = wantsPush ? currentPublishRef : undefined;
+          const finalized = yield* vcsChangeService
+            .finalizeChange({
+              cwd: input.cwd,
+              message: suggestion.commitMessage,
+              ...(input.filePaths ? { filePaths: input.filePaths } : {}),
+              ...(preferredPublishRef ? { createPublishRef: preferredPublishRef } : {}),
+              ...(publishRefToMove ? { publishRef: publishRefToMove } : {}),
+            })
+            .pipe(Effect.mapError(mapWorkflowError));
+          if (finalized.status === "created") {
+            currentPublishRef = finalized.publishRef ?? currentPublishRef;
+            branchStep = finalized.publishRef
+              ? { status: "created", name: finalized.publishRef.name }
+              : branchStep;
+            commitStep = {
+              status: "created",
+              commitSha: finalized.finalizedRevision.commitId,
+              subject: suggestion.subject,
+              finalizedRevision: finalized.finalizedRevision,
+              workspaceRevision: finalized.workspaceRevision,
+              ...(currentPublishRef ? { publishRef: currentPublishRef } : {}),
+            };
+          } else {
+            commitStep = { status: "skipped_no_changes" };
+          }
+        } else {
+          commitStep = { status: "skipped_no_changes" };
+        }
       }
 
-      const customCommit = parseCustomCommitMessage(input.commitMessage ?? "");
-      let suggestion: CommitAndBranchSuggestion;
-      if (customCommit) {
-        suggestion = {
-          subject: customCommit.subject,
-          body: customCommit.body,
-          ...(input.featureBranch
-            ? { branch: sanitizeFeatureBranchName(customCommit.subject) }
-            : {}),
-          commitMessage: formatCommitMessage(customCommit.subject, customCommit.body),
-        };
-      } else {
+      let pushStep: GitRunStackedActionResult["push"] = {
+        status: "skipped_not_requested",
+      };
+      if (wantsPush) {
+        if (!currentPublishRef) {
+          return yield* new GitManagerError({
+            operation: "runJjStackedAction",
+            cwd: input.cwd,
+            detail: "No explicit Jujutsu publish bookmark is available.",
+          });
+        }
+        yield* Ref.set(currentPhase, Option.some("push"));
         yield* progress.emit({
           kind: "phase_started",
-          phase: "commit",
-          label: "Generating change message...",
+          phase: "push",
+          label: `Publishing bookmark ${currentPublishRef.name}...`,
         });
-        const generated = yield* textGeneration
-          .generateCommitMessage({
+        const published = yield* vcsSyncService
+          .publish({ cwd: input.cwd, publishRef: currentPublishRef })
+          .pipe(Effect.mapError(mapWorkflowError));
+        currentPublishRef = published.publishRef;
+        commitStep = { ...commitStep, publishRef: currentPublishRef };
+        pushStep = {
+          status: "pushed",
+          branch: currentPublishRef.name,
+          upstreamBranch: `${published.remoteName}/${currentPublishRef.name}`,
+          setUpstream: true,
+        };
+      }
+
+      let prStep: GitRunStackedActionResult["pr"] = { status: "skipped_not_requested" };
+      if (wantsPr) {
+        if (!currentPublishRef) {
+          return yield* new GitManagerError({
+            operation: "runJjStackedAction",
             cwd: input.cwd,
-            branch: null,
-            stagedSummary: limitContext(context.summary, 8_000),
-            stagedPatch: limitContext(context.patch, 50_000),
-            ...(input.featureBranch ? { includeBranch: true } : {}),
-            modelSelection,
-          })
-          .pipe(Effect.map((result) => sanitizeCommitMessage(result)));
-        suggestion = {
-          subject: generated.subject,
-          body: generated.body,
-          ...(generated.branch !== undefined ? { branch: generated.branch } : {}),
-          commitMessage: formatCommitMessage(generated.subject, generated.body),
-        };
+            detail: "No published Jujutsu bookmark is available for a change request.",
+          });
+        }
+        yield* Ref.set(currentPhase, Option.some("pr"));
+        prStep = yield* runJjPrStep(modelSelection, currentPublishRef);
       }
 
-      yield* progress.emit({
-        kind: "phase_started",
-        phase: "commit",
-        label: "Finalizing change...",
-      });
-      const preferredPublishRef = input.featureBranch
-        ? (suggestion.branch ?? sanitizeFeatureBranchName(suggestion.subject))
-        : undefined;
-      const finalized = yield* vcsChangeService
-        .finalizeChange({
-          cwd: input.cwd,
-          message: suggestion.commitMessage,
-          ...(input.filePaths ? { filePaths: input.filePaths } : {}),
-          ...(preferredPublishRef ? { createPublishRef: preferredPublishRef } : {}),
-        })
-        .pipe(Effect.mapError(mapChangeError));
-
-      if (finalized.status === "skipped_no_changes") {
-        const result: GitRunStackedActionResult = {
-          action: input.action,
-          branch: { status: "skipped_not_requested" },
-          commit: { status: "skipped_no_changes" },
-          push: { status: "skipped_not_requested" },
-          pr: { status: "skipped_not_requested" },
-          toast: { title: "No changes to finalize", cta: { kind: "none" } },
-        };
-        yield* progress.emit({ kind: "action_finished", result });
-        return result;
-      }
-
-      const shortCommit = finalized.finalizedRevision.commitId.slice(0, SHORT_SHA_LENGTH);
+      const shortCommit = commitStep.commitSha?.slice(0, SHORT_SHA_LENGTH);
+      const title =
+        prStep.status === "created" || prStep.status === "opened_existing"
+          ? `${prStep.status === "created" ? "Created" : "Opened"} change request${prStep.number ? ` #${prStep.number}` : ""}`
+          : pushStep.status === "pushed"
+            ? `Published ${currentPublishRef?.name ?? "bookmark"}`
+            : shortCommit
+              ? `Finalized ${shortCommit}`
+              : "No changes to finalize";
       const result: GitRunStackedActionResult = {
         action: input.action,
-        branch: finalized.publishRef
-          ? { status: "created", name: finalized.publishRef.name }
-          : { status: "skipped_not_requested" },
-        commit: {
-          status: "created",
-          commitSha: finalized.finalizedRevision.commitId,
-          subject: suggestion.subject,
-          finalizedRevision: finalized.finalizedRevision,
-          workspaceRevision: finalized.workspaceRevision,
-          ...(finalized.publishRef ? { publishRef: finalized.publishRef } : {}),
-        },
-        push: { status: "skipped_not_requested" },
-        pr: { status: "skipped_not_requested" },
+        branch: branchStep,
+        commit: commitStep,
+        push: pushStep,
+        pr: prStep,
         toast: {
-          title: `Finalized ${shortCommit}`,
-          description: finalized.publishRef
-            ? `Created bookmark ${finalized.publishRef.name}`
-            : "Created a new working-copy change",
-          cta: { kind: "none" },
+          title,
+          ...(commitStep.status === "created" && pushStep.status !== "pushed"
+            ? {
+                description: currentPublishRef
+                  ? `Prepared bookmark ${currentPublishRef.name}`
+                  : "Created a new working-copy change",
+              }
+            : {}),
+          cta:
+            (prStep.status === "created" || prStep.status === "opened_existing") && prStep.url
+              ? { kind: "open_pr", label: "View change request", url: prStep.url }
+              : { kind: "none" },
         },
       };
       yield* progress.emit({ kind: "action_finished", result });

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -48,6 +48,7 @@ import { extractBranchNameFromRemoteRef } from "./remoteRefs.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import type { GitManagerServiceError } from "@t3tools/contracts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsChangeService from "../vcs/VcsChangeService.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import type { ChangeRequest } from "@t3tools/contracts";
 
@@ -523,6 +524,7 @@ export const make = Effect.gen(function* () {
   const sourceControlProviders = yield* SourceControlProviderRegistry.SourceControlProviderRegistry;
   const textGeneration = yield* TextGeneration.TextGeneration;
   const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+  const vcsChangeService = yield* VcsChangeService.VcsChangeService;
   const crypto = yield* Crypto.Crypto;
 
   const sourceControlProvider = (cwd: string) => sourceControlProviders.resolve({ cwd });
@@ -1666,8 +1668,190 @@ export const make = Effect.gen(function* () {
     };
   });
 
+  const runJjStackedAction = Effect.fn("runJjStackedAction")(function* (
+    input: GitRunStackedActionInput,
+    options?: GitRunStackedActionOptions,
+  ) {
+    const progress = yield* createProgressEmitter(input, options);
+    const currentPhase = yield* Ref.make<Option.Option<GitActionProgressPhase>>(Option.none());
+    const mapChangeError = (cause: unknown) =>
+      new GitManagerError({
+        operation: "runJjStackedAction",
+        cwd: input.cwd,
+        detail: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      });
+
+    const runAction = Effect.fn("runJjStackedAction.runAction")(function* () {
+      if (input.action !== "commit") {
+        return yield* new GitManagerError({
+          operation: "runJjStackedAction",
+          cwd: input.cwd,
+          detail: "Jujutsu publishing and change requests are not available until Phase 6.",
+        });
+      }
+
+      yield* progress.emit({ kind: "action_started", phases: ["commit"] });
+      yield* Ref.set(currentPhase, Option.some("commit"));
+
+      const modelSelection = yield* serverSettingsService.getSettings.pipe(
+        Effect.map((settings) => settings.textGenerationModelSelection),
+        Effect.mapError(
+          (cause) =>
+            new GitManagerError({
+              operation: "runJjStackedAction",
+              cwd: input.cwd,
+              detail: "Failed to get server settings.",
+              cause,
+            }),
+        ),
+      );
+      const context = yield* vcsChangeService
+        .prepareMessageContext({
+          cwd: input.cwd,
+          ...(input.filePaths ? { filePaths: input.filePaths } : {}),
+        })
+        .pipe(Effect.mapError(mapChangeError));
+
+      if (!context) {
+        const result: GitRunStackedActionResult = {
+          action: input.action,
+          branch: { status: "skipped_not_requested" },
+          commit: { status: "skipped_no_changes" },
+          push: { status: "skipped_not_requested" },
+          pr: { status: "skipped_not_requested" },
+          toast: {
+            title: "No changes to finalize",
+            cta: { kind: "none" },
+          },
+        };
+        yield* progress.emit({ kind: "action_finished", result });
+        return result;
+      }
+
+      const customCommit = parseCustomCommitMessage(input.commitMessage ?? "");
+      let suggestion: CommitAndBranchSuggestion;
+      if (customCommit) {
+        suggestion = {
+          subject: customCommit.subject,
+          body: customCommit.body,
+          ...(input.featureBranch
+            ? { branch: sanitizeFeatureBranchName(customCommit.subject) }
+            : {}),
+          commitMessage: formatCommitMessage(customCommit.subject, customCommit.body),
+        };
+      } else {
+        yield* progress.emit({
+          kind: "phase_started",
+          phase: "commit",
+          label: "Generating change message...",
+        });
+        const generated = yield* textGeneration
+          .generateCommitMessage({
+            cwd: input.cwd,
+            branch: null,
+            stagedSummary: limitContext(context.summary, 8_000),
+            stagedPatch: limitContext(context.patch, 50_000),
+            ...(input.featureBranch ? { includeBranch: true } : {}),
+            modelSelection,
+          })
+          .pipe(Effect.map((result) => sanitizeCommitMessage(result)));
+        suggestion = {
+          subject: generated.subject,
+          body: generated.body,
+          ...(generated.branch !== undefined ? { branch: generated.branch } : {}),
+          commitMessage: formatCommitMessage(generated.subject, generated.body),
+        };
+      }
+
+      yield* progress.emit({
+        kind: "phase_started",
+        phase: "commit",
+        label: "Finalizing change...",
+      });
+      const preferredPublishRef = input.featureBranch
+        ? (suggestion.branch ?? sanitizeFeatureBranchName(suggestion.subject))
+        : undefined;
+      const finalized = yield* vcsChangeService
+        .finalizeChange({
+          cwd: input.cwd,
+          message: suggestion.commitMessage,
+          ...(input.filePaths ? { filePaths: input.filePaths } : {}),
+          ...(preferredPublishRef ? { createPublishRef: preferredPublishRef } : {}),
+        })
+        .pipe(Effect.mapError(mapChangeError));
+
+      if (finalized.status === "skipped_no_changes") {
+        const result: GitRunStackedActionResult = {
+          action: input.action,
+          branch: { status: "skipped_not_requested" },
+          commit: { status: "skipped_no_changes" },
+          push: { status: "skipped_not_requested" },
+          pr: { status: "skipped_not_requested" },
+          toast: { title: "No changes to finalize", cta: { kind: "none" } },
+        };
+        yield* progress.emit({ kind: "action_finished", result });
+        return result;
+      }
+
+      const shortCommit = finalized.finalizedRevision.commitId.slice(0, SHORT_SHA_LENGTH);
+      const result: GitRunStackedActionResult = {
+        action: input.action,
+        branch: finalized.publishRef
+          ? { status: "created", name: finalized.publishRef.name }
+          : { status: "skipped_not_requested" },
+        commit: {
+          status: "created",
+          commitSha: finalized.finalizedRevision.commitId,
+          subject: suggestion.subject,
+          finalizedRevision: finalized.finalizedRevision,
+          workspaceRevision: finalized.workspaceRevision,
+          ...(finalized.publishRef ? { publishRef: finalized.publishRef } : {}),
+        },
+        push: { status: "skipped_not_requested" },
+        pr: { status: "skipped_not_requested" },
+        toast: {
+          title: `Finalized ${shortCommit}`,
+          description: finalized.publishRef
+            ? `Created bookmark ${finalized.publishRef.name}`
+            : "Created a new working-copy change",
+          cta: { kind: "none" },
+        },
+      };
+      yield* progress.emit({ kind: "action_finished", result });
+      return result;
+    });
+
+    return yield* runAction().pipe(
+      Effect.ensuring(invalidateStatus(input.cwd)),
+      Effect.tapError((error) =>
+        Effect.flatMap(Ref.get(currentPhase), (phase) =>
+          progress.emit({
+            kind: "action_failed",
+            phase: Option.getOrNull(phase),
+            message: error.message,
+          }),
+        ),
+      ),
+    );
+  });
+
   const runStackedAction: GitManager["Service"]["runStackedAction"] = Effect.fn("runStackedAction")(
     function* (input, options) {
+      const driverKind = yield* vcsChangeService.detectKind(input.cwd).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitManagerError({
+              operation: "runStackedAction.detectKind",
+              cwd: input.cwd,
+              detail: cause.message,
+              cause,
+            }),
+        ),
+      );
+      if (driverKind === "jj") {
+        return yield* runJjStackedAction(input, options);
+      }
       const progress = yield* createProgressEmitter(input, options);
       const currentPhase = yield* Ref.make<Option.Option<GitActionProgressPhase>>(Option.none());
 

--- a/apps/server/src/git/GitWorkflowService.test.ts
+++ b/apps/server/src/git/GitWorkflowService.test.ts
@@ -48,6 +48,7 @@ function mockJjDriver(
 
 function makeLayer(input: {
   readonly detect: VcsDriverRegistry.VcsDriverRegistry["Service"]["detect"];
+  readonly manager?: Partial<GitManager.GitManager["Service"]>;
 }) {
   return GitWorkflowService.layer.pipe(
     Layer.provide(
@@ -56,11 +57,60 @@ function makeLayer(input: {
       }),
     ),
     Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
-    Layer.provide(Layer.mock(GitManager.GitManager)({})),
+    Layer.provide(Layer.mock(GitManager.GitManager)(input.manager ?? {})),
   );
 }
 
 describe("GitWorkflowService", () => {
+  it.effect("lets GitManager route jj stacked actions", () => {
+    const driver = mockJjDriver({});
+    let receivedAction: string | null = null;
+    return Effect.gen(function* () {
+      const workflow = yield* GitWorkflowService.GitWorkflowService;
+      const result = yield* workflow.runStackedAction({
+        actionId: "jj-action",
+        cwd: "/jj-repo",
+        action: "push",
+        publishRef: { kind: "bookmark", name: "feature/phase-6" },
+      });
+      assert.equal(receivedAction, "push");
+      assert.equal(result.push.status, "pushed");
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          detect: () =>
+            Effect.succeed({
+              kind: "jj" as const,
+              repository: {
+                kind: "jj" as const,
+                rootPath: "/jj-repo",
+                metadataPath: "/jj-repo/.jj",
+                freshness: {
+                  source: "live-local" as const,
+                  observedAt: DateTime.makeUnsafe("2026-01-01T00:00:00.000Z"),
+                  expiresAt: Option.none(),
+                },
+              },
+              driver,
+            }),
+          manager: {
+            runStackedAction: (input) => {
+              receivedAction = input.action;
+              return Effect.succeed({
+                action: input.action,
+                branch: { status: "skipped_not_requested" as const },
+                commit: { status: "skipped_not_requested" as const },
+                push: { status: "pushed" as const, branch: "feature/phase-6" },
+                pr: { status: "skipped_not_requested" as const },
+                toast: { title: "Published feature/phase-6", cta: { kind: "none" as const } },
+              });
+            },
+          },
+        }),
+      ),
+    );
+  });
+
   it.effect("routes status and ref reads through a detected jj driver", () => {
     const driver = mockJjDriver({
       getLocalStatus: () =>

--- a/apps/server/src/git/GitWorkflowService.test.ts
+++ b/apps/server/src/git/GitWorkflowService.test.ts
@@ -1,13 +1,50 @@
 import { assert, describe, expect, it, vi } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 
 import { VcsRepositoryDetectionError } from "@t3tools/contracts";
 
 import * as GitManager from "./GitManager.ts";
 import * as GitWorkflowService from "./GitWorkflowService.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsDriver from "../vcs/VcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+
+function mockJjDriver(
+  overrides: Partial<VcsDriver.VcsDriver["Service"]>,
+): VcsDriver.VcsDriver["Service"] {
+  const unexpected = () => Effect.die("unexpected jj driver call");
+  return VcsDriver.VcsDriver.of({
+    capabilities: {
+      kind: "jj",
+      supportsWorktrees: false,
+      supportsBookmarks: true,
+      supportsAtomicSnapshot: true,
+      supportsPushDefaultRemote: true,
+      supportsWorkspaces: true,
+      supportsNamedPublishRefs: true,
+      supportsSelectedFileFinalize: true,
+      supportsThreadLocalRestore: true,
+      supportsDefaultRemotePush: true,
+      supportsGitProviderCompatibility: true,
+      ignoreClassifier: "native",
+    },
+    execute: unexpected,
+    detectRepository: unexpected,
+    isInsideWorkTree: unexpected,
+    listWorkspaceFiles: unexpected,
+    listRemotes: unexpected,
+    addRemote: unexpected,
+    removeRemote: unexpected,
+    resolveDefaultRemote: unexpected,
+    filterIgnoredPaths: unexpected,
+    initRepository: unexpected,
+    cloneRepository: unexpected,
+    ...overrides,
+  });
+}
 
 function makeLayer(input: {
   readonly detect: VcsDriverRegistry.VcsDriverRegistry["Service"]["detect"];
@@ -24,6 +61,84 @@ function makeLayer(input: {
 }
 
 describe("GitWorkflowService", () => {
+  it.effect("routes status and ref reads through a detected jj driver", () => {
+    const driver = mockJjDriver({
+      getLocalStatus: () =>
+        Effect.succeed({
+          isRepo: true,
+          driverKind: "jj",
+          workspaceRevision: "change-id",
+          publishRef: null,
+          defaultRef: "main@origin",
+          conflicts: [],
+          hasPrimaryRemote: true,
+          isDefaultRef: false,
+          refName: null,
+          hasWorkingTreeChanges: true,
+          workingTree: {
+            files: [{ path: "file.txt", insertions: 1, deletions: 0 }],
+            insertions: 1,
+            deletions: 0,
+          },
+        }),
+      getRemoteStatus: () =>
+        Effect.succeed({
+          trackedRemote: { remoteName: "origin", refName: "main" },
+          hasUpstream: true,
+          aheadCount: 1,
+          behindCount: 0,
+          aheadOfDefaultCount: 1,
+          pr: null,
+        }),
+      listRefs: () =>
+        Effect.succeed({
+          refs: [
+            {
+              kind: "bookmark",
+              name: "main@origin",
+              isRemote: true,
+              remoteName: "origin",
+              current: false,
+              isDefault: true,
+              worktreePath: null,
+            },
+          ],
+          isRepo: true,
+          hasPrimaryRemote: true,
+          nextCursor: null,
+          totalCount: 1,
+        }),
+    });
+    const detect = () =>
+      DateTime.now.pipe(
+        Effect.map((observedAt) => ({
+          kind: "jj" as const,
+          repository: {
+            kind: "jj" as const,
+            rootPath: "/repo",
+            metadataPath: "/repo/.jj",
+            colocated: true,
+            freshness: { source: "live-local" as const, observedAt, expiresAt: Option.none() },
+          },
+          driver,
+        })),
+      );
+
+    return Effect.gen(function* () {
+      const workflow = yield* GitWorkflowService.GitWorkflowService;
+      const status = yield* workflow.status({ cwd: "/repo" });
+      const refs = yield* workflow.listRefs({ cwd: "/repo" });
+
+      assert.equal(status.driverKind, "jj");
+      assert.equal(status.refName, null);
+      assert.equal(status.workspaceRevision, "change-id");
+      assert.equal(status.aheadCount, 1);
+      assert.equal(status.trackedRemote?.refName, "main");
+      assert.equal(refs.refs[0]?.kind, "bookmark");
+      assert.isFalse(refs.refs[0]?.current);
+    }).pipe(Effect.provide(makeLayer({ detect })));
+  });
+
   it.effect("returns an empty local status when no VCS repository is detected", () =>
     Effect.gen(function* () {
       const workflow = yield* GitWorkflowService.GitWorkflowService;
@@ -150,7 +265,7 @@ describe("GitWorkflowService", () => {
         _tag: "GitManagerError",
         operation: "GitWorkflowService.status",
         cwd: "/repo",
-        detail: "Failed to detect a VCS repository for this Git workflow.",
+        detail: "Failed to detect a VCS repository for this status workflow.",
       });
       expect(error.message).not.toContain(cause.detail);
     }).pipe(
@@ -178,7 +293,7 @@ describe("GitWorkflowService", () => {
         operation: "GitWorkflowService.listRefs",
         command: "vcs-route",
         cwd: "/repo",
-        detail: "Failed to detect a VCS repository for this Git command.",
+        detail: "Failed to detect a VCS repository for this command.",
       });
       expect(error.message).not.toContain(cause.detail);
     }).pipe(

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -31,6 +31,7 @@ import {
 import * as GitManager from "./GitManager.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import { mergeGitStatusParts } from "@t3tools/shared/git";
 
 export class GitWorkflowService extends Context.Service<
   GitWorkflowService,
@@ -185,7 +186,7 @@ export const make = Effect.gen(function* () {
     }
   });
 
-  const detectGitRepositoryForStatus = Effect.fn("GitWorkflowService.detectGitRepositoryForStatus")(
+  const detectRepositoryForStatus = Effect.fn("GitWorkflowService.detectRepositoryForStatus")(
     function* (operation: string, cwd: string) {
       const handle = yield* registry.detect({ cwd }).pipe(
         Effect.mapError(
@@ -193,52 +194,77 @@ export const make = Effect.gen(function* () {
             new GitManagerError({
               operation,
               cwd,
-              detail: "Failed to detect a VCS repository for this Git workflow.",
+              detail: "Failed to detect a VCS repository for this status workflow.",
               cause,
             }),
         ),
       );
-      if (!handle) {
-        return false;
-      }
-      if (handle.kind !== "git") {
-        return yield* new GitManagerError({
-          operation,
-          cwd,
-          detail: `The ${operation} workflow currently supports Git repositories only; detected ${handle.kind}. (${cwd})`,
-        });
-      }
-      return true;
+      return handle;
     },
   );
 
-  const detectGitRepositoryForCommand = Effect.fn(
-    "GitWorkflowService.detectGitRepositoryForCommand",
-  )(function* (operation: string, cwd: string) {
-    const handle = yield* registry.detect({ cwd }).pipe(
+  const detectRepositoryForCommand = Effect.fn("GitWorkflowService.detectRepositoryForCommand")(
+    function* (operation: string, cwd: string) {
+      const handle = yield* registry.detect({ cwd }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitCommandError({
+              operation,
+              command: "vcs-route",
+              cwd,
+              detail: "Failed to detect a VCS repository for this command.",
+              cause,
+            }),
+        ),
+      );
+      return handle;
+    },
+  );
+
+  const runDriverLocalStatus = Effect.fn("GitWorkflowService.runDriverLocalStatus")(function* (
+    operation: string,
+    input: VcsStatusInput,
+    handle: VcsDriverRegistry.VcsDriverHandle,
+  ) {
+    if (!handle.driver.getLocalStatus) {
+      return yield* new GitManagerError({
+        operation,
+        cwd: input.cwd,
+        detail: `The ${handle.kind} VCS driver does not support status reads.`,
+      });
+    }
+    return yield* handle.driver.getLocalStatus(input).pipe(
       Effect.mapError(
         (cause) =>
-          new GitCommandError({
+          new GitManagerError({
             operation,
-            command: "vcs-route",
-            cwd,
-            detail: "Failed to detect a VCS repository for this Git command.",
+            cwd: input.cwd,
+            detail: `Failed to read ${handle.kind} local status.`,
             cause,
           }),
       ),
     );
-    if (!handle) {
-      return false;
+  });
+
+  const runDriverRemoteStatus = Effect.fn("GitWorkflowService.runDriverRemoteStatus")(function* (
+    operation: string,
+    input: VcsStatusInput,
+    handle: VcsDriverRegistry.VcsDriverHandle,
+  ) {
+    if (!handle.driver.getRemoteStatus) {
+      return null;
     }
-    if (handle.kind !== "git") {
-      return yield* new GitCommandError({
-        operation,
-        command: "vcs-route",
-        cwd,
-        detail: `The ${operation} command currently supports Git repositories only; detected ${handle.kind}.`,
-      });
-    }
-    return true;
+    return yield* handle.driver.getRemoteStatus(input).pipe(
+      Effect.mapError(
+        (cause) =>
+          new GitManagerError({
+            operation,
+            cwd: input.cwd,
+            detail: `Failed to read ${handle.kind} remote status.`,
+            cause,
+          }),
+      ),
+    );
   });
 
   const routeGitManager =
@@ -251,24 +277,42 @@ export const make = Effect.gen(function* () {
 
   return GitWorkflowService.of({
     status: (input) =>
-      detectGitRepositoryForStatus("GitWorkflowService.status", input.cwd).pipe(
-        Effect.flatMap((isGitRepository) =>
-          isGitRepository ? gitManager.status(input) : Effect.succeed(nonRepositoryStatus()),
-        ),
+      detectRepositoryForStatus("GitWorkflowService.status", input.cwd).pipe(
+        Effect.flatMap((handle) => {
+          if (!handle) return Effect.succeed(nonRepositoryStatus());
+          if (handle.kind === "git") return gitManager.status(input);
+          return Effect.gen(function* () {
+            const local = yield* runDriverLocalStatus(
+              "GitWorkflowService.status.local",
+              input,
+              handle,
+            );
+            const remote = yield* runDriverRemoteStatus(
+              "GitWorkflowService.status.remote",
+              input,
+              handle,
+            );
+            return mergeGitStatusParts(local, remote);
+          });
+        }),
       ),
     localStatus: (input) =>
-      detectGitRepositoryForStatus("GitWorkflowService.localStatus", input.cwd).pipe(
-        Effect.flatMap((isGitRepository) =>
-          isGitRepository
+      detectRepositoryForStatus("GitWorkflowService.localStatus", input.cwd).pipe(
+        Effect.flatMap((handle) => {
+          if (!handle) return Effect.succeed(nonRepositoryLocalStatus());
+          return handle.kind === "git"
             ? gitManager.localStatus(input)
-            : Effect.succeed(nonRepositoryLocalStatus()),
-        ),
+            : runDriverLocalStatus("GitWorkflowService.localStatus", input, handle);
+        }),
       ),
     remoteStatus: (input, options) =>
-      detectGitRepositoryForStatus("GitWorkflowService.remoteStatus", input.cwd).pipe(
-        Effect.flatMap((isGitRepository) =>
-          isGitRepository ? gitManager.remoteStatus(input, options) : Effect.succeed(null),
-        ),
+      detectRepositoryForStatus("GitWorkflowService.remoteStatus", input.cwd).pipe(
+        Effect.flatMap((handle) => {
+          if (!handle) return Effect.succeed(null);
+          return handle.kind === "git"
+            ? gitManager.remoteStatus(input, options)
+            : runDriverRemoteStatus("GitWorkflowService.remoteStatus", input, handle);
+        }),
       ),
     invalidateLocalStatus: gitManager.invalidateLocalStatus,
     invalidateRemoteStatus: gitManager.invalidateRemoteStatus,
@@ -290,10 +334,33 @@ export const make = Effect.gen(function* () {
       gitManager.preparePullRequestThread,
     ),
     listRefs: (input) =>
-      detectGitRepositoryForCommand("GitWorkflowService.listRefs", input.cwd).pipe(
-        Effect.flatMap((isGitRepository) =>
-          isGitRepository ? git.listRefs(input) : Effect.succeed(nonRepositoryListRefs()),
-        ),
+      detectRepositoryForCommand("GitWorkflowService.listRefs", input.cwd).pipe(
+        Effect.flatMap((handle) => {
+          if (!handle) return Effect.succeed(nonRepositoryListRefs());
+          if (handle.kind === "git") return git.listRefs(input);
+          if (!handle.driver.listRefs) {
+            return Effect.fail(
+              new GitCommandError({
+                operation: "GitWorkflowService.listRefs",
+                command: "vcs-route",
+                cwd: input.cwd,
+                detail: `The ${handle.kind} VCS driver does not support ref listing.`,
+              }),
+            );
+          }
+          return handle.driver.listRefs(input).pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitCommandError({
+                  operation: "GitWorkflowService.listRefs",
+                  command: "vcs-route",
+                  cwd: input.cwd,
+                  detail: `Failed to list ${handle.kind} refs.`,
+                  cause,
+                }),
+            ),
+          );
+        }),
       ),
     createWorktree: (input) =>
       ensureGitCommand("GitWorkflowService.createWorktree", input.cwd).pipe(

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -31,6 +31,7 @@ import {
 import * as GitManager from "./GitManager.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsSyncService from "../vcs/VcsSyncService.ts";
 import { mergeGitStatusParts } from "@t3tools/shared/git";
 
 export class GitWorkflowService extends Context.Service<
@@ -135,6 +136,7 @@ export const make = Effect.gen(function* () {
   const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const git = yield* GitVcsDriver.GitVcsDriver;
   const gitManager = yield* GitManager.GitManager;
+  const vcsSync = yield* VcsSyncService.VcsSyncService;
 
   const ensureGit = Effect.fn("GitWorkflowService.ensureGit")(function* (
     operation: string,
@@ -318,13 +320,48 @@ export const make = Effect.gen(function* () {
     invalidateRemoteStatus: gitManager.invalidateRemoteStatus,
     invalidateStatus: gitManager.invalidateStatus,
     pullCurrentBranch: (cwd) =>
-      ensureGitCommand("GitWorkflowService.pullCurrentBranch", cwd).pipe(
-        Effect.andThen(git.pullCurrentBranch(cwd)),
+      detectRepositoryForCommand("GitWorkflowService.pullCurrentBranch", cwd).pipe(
+        Effect.flatMap((handle) => {
+          if (!handle || handle.kind === "git") return git.pullCurrentBranch(cwd);
+          if (handle.kind !== "jj") {
+            return Effect.fail(
+              new GitCommandError({
+                operation: "GitWorkflowService.pullCurrentBranch",
+                command: "vcs-route",
+                cwd,
+                detail: `Fetch is unavailable for ${handle.kind} repositories.`,
+              }),
+            );
+          }
+          return vcsSync.fetch({ cwd }).pipe(
+            Effect.map((result) => ({
+              status:
+                result.status === "updated"
+                  ? ("pulled" as const)
+                  : result.status === "needs-rebase"
+                    ? ("fetched_needs_rebase" as const)
+                    : result.status === "needs-resolution"
+                      ? ("fetched_needs_resolution" as const)
+                      : ("skipped_up_to_date" as const),
+              refName: result.refName,
+              upstreamRef: result.upstreamRef,
+              workspaceRevision: result.workspaceRevision,
+              conflicts: result.conflicts,
+            })),
+            Effect.mapError(
+              (cause) =>
+                new GitCommandError({
+                  operation: "GitWorkflowService.pullCurrentBranch",
+                  command: "jj",
+                  cwd,
+                  detail: cause.detail,
+                  cause,
+                }),
+            ),
+          );
+        }),
       ),
-    runStackedAction: (input, options) =>
-      ensureGit("GitWorkflowService.runStackedAction", input.cwd).pipe(
-        Effect.andThen(gitManager.runStackedAction(input, options)),
-      ),
+    runStackedAction: gitManager.runStackedAction,
     resolvePullRequest: routeGitManager(
       "GitWorkflowService.resolvePullRequest",
       gitManager.resolvePullRequest,
@@ -393,4 +430,6 @@ export const make = Effect.gen(function* () {
   });
 });
 
-export const layer = Layer.effect(GitWorkflowService, make);
+export const layer = Layer.effect(GitWorkflowService, make).pipe(
+  Layer.provide(VcsSyncService.layer),
+);

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -32,7 +32,6 @@ import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts"
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import type { OrchestrationDispatchError } from "../Errors.ts";
-import { isGitRepository } from "../../git/Utils.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
 
@@ -174,12 +173,13 @@ const make = Effect.gen(function* () {
     return project ? [project] : [];
   });
 
-  const isGitWorkspace = (cwd: string) => isGitRepository(cwd);
+  const isCheckpointWorkspace = (cwd: string) =>
+    checkpointStore.isGitRepository(cwd).pipe(Effect.orElseSucceed(() => false));
 
   // Resolves the workspace CWD for checkpoint operations, preferring the
   // active provider session CWD and falling back to the thread/project config.
   // Returns undefined when no CWD can be determined or the workspace is not
-  // a git repository.
+  // a repository with checkpoint support.
   const resolveCheckpointCwd = Effect.fn("resolveCheckpointCwd")(function* (input: {
     readonly threadId: ThreadId;
     readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
@@ -206,13 +206,13 @@ const make = Effect.gen(function* () {
     if (!cwd) {
       return undefined;
     }
-    if (!isGitWorkspace(cwd)) {
+    if (!(yield* isCheckpointWorkspace(cwd))) {
       return undefined;
     }
     return cwd;
   });
 
-  // Shared tail for both capture paths: creates the git checkpoint ref, diffs
+  // Shared tail for both capture paths: creates the checkpoint ref, diffs
   // it against the previous turn, then dispatches the domain events to update
   // the orchestration read model.
   const captureAndDispatchCheckpoint = Effect.fn("captureAndDispatchCheckpoint")(function* (input: {
@@ -633,11 +633,11 @@ const make = Effect.gen(function* () {
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
-    if (!isGitWorkspace(sessionRuntime.value.cwd)) {
+    if (!(yield* isCheckpointWorkspace(sessionRuntime.value.cwd))) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,
         turnCount: event.payload.turnCount,
-        detail: "Checkpoints are unavailable because this project is not a git repository.",
+        detail: "Checkpoints are unavailable because this project has no checkpoint-capable VCS.",
         createdAt: now,
       }).pipe(Effect.catch(() => Effect.void));
       return;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -535,6 +535,19 @@ describe("OrchestrationEngine", () => {
     const { engine } = system;
     const createdAt = now();
 
+    const vcsWorkspace = {
+      driverKind: "jj" as const,
+      name: "thread-worktree-bootstrap",
+      rootPath: "/tmp/project-worktree-bootstrap-worktree",
+      workspaceRevision: {
+        commitId: "commit-1",
+        changeId: "change-1",
+      },
+      publishRef: {
+        kind: "bookmark" as const,
+        name: "t3code/1234abcd",
+      },
+    };
     await system.run(
       engine.dispatch({
         type: "project.create",
@@ -574,12 +587,20 @@ describe("OrchestrationEngine", () => {
         threadId: ThreadId.make("thread-worktree-bootstrap"),
         branch: "t3code/1234abcd",
         worktreePath: "/tmp/project-worktree-bootstrap-worktree",
+        vcsWorkspace,
       }),
     );
 
     const snapshot = await system.readModel();
     expect(snapshot.threads[0]?.branch).toBe("t3code/1234abcd");
     expect(snapshot.threads[0]?.worktreePath).toBe("/tmp/project-worktree-bootstrap-worktree");
+    const events = await system.run(
+      Stream.runCollect(engine.readEvents(0)).pipe(
+        Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
+      ),
+    );
+    const metaUpdated = events.find((event) => event.type === "thread.meta-updated");
+    expect(metaUpdated?.payload.vcsWorkspace).toEqual(vcsWorkspace);
     await system.dispose();
   });
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -603,6 +603,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             interactionMode: event.payload.interactionMode,
             branch: event.payload.branch,
             worktreePath: event.payload.worktreePath,
+            vcsWorkspace: event.payload.vcsWorkspace ?? null,
             latestTurnId: null,
             createdAt: event.payload.createdAt,
             updatedAt: event.payload.updatedAt,
@@ -661,6 +662,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             ...(event.payload.branch !== undefined ? { branch: event.payload.branch } : {}),
             ...(event.payload.worktreePath !== undefined
               ? { worktreePath: event.payload.worktreePath }
+              : {}),
+            ...(event.payload.vcsWorkspace !== undefined
+              ? { vcsWorkspace: event.payload.vcsWorkspace }
               : {}),
             updatedAt: event.payload.updatedAt,
           });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -293,6 +293,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
+          vcsWorkspace: null,
           latestTurn: {
             turnId: asTurnId("turn-1"),
             state: "completed",
@@ -403,6 +404,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           runtimeMode: "full-access",
           branch: null,
           worktreePath: null,
+          vcsWorkspace: null,
           latestTurn: {
             turnId: asTurnId("turn-1"),
             state: "completed",

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -24,6 +24,7 @@ import {
   ModelSelection,
   ProjectId,
   ThreadId,
+  VcsWorkspaceIdentity,
 } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
@@ -78,6 +79,7 @@ const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
 const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
+    vcsWorkspace: Schema.NullOr(Schema.fromJsonString(VcsWorkspaceIdentity)),
   }),
 );
 const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
@@ -330,6 +332,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          vcs_workspace_json AS "vcsWorkspace",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -358,6 +361,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          vcs_workspace_json AS "vcsWorkspace",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -388,6 +392,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          vcs_workspace_json AS "vcsWorkspace",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -750,6 +755,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          vcs_workspace_json AS "vcsWorkspace",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -1182,6 +1188,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 interactionMode: row.interactionMode,
                 branch: row.branch,
                 worktreePath: row.worktreePath,
+                vcsWorkspace: row.vcsWorkspace,
                 latestTurn: latestTurnByThread.get(row.threadId) ?? null,
                 createdAt: row.createdAt,
                 updatedAt: row.updatedAt,
@@ -1380,6 +1387,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   interactionMode: row.interactionMode,
                   branch: row.branch,
                   worktreePath: row.worktreePath,
+                  vcsWorkspace: row.vcsWorkspace,
                   latestTurn: latestTurnByThread.get(row.threadId) ?? null,
                   createdAt: row.createdAt,
                   updatedAt: row.updatedAt,
@@ -1509,6 +1517,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                       interactionMode: row.interactionMode,
                       branch: row.branch,
                       worktreePath: row.worktreePath,
+                      vcsWorkspace: row.vcsWorkspace,
                       latestTurn: latestTurnByThread.get(row.threadId) ?? null,
                       createdAt: row.createdAt,
                       updatedAt: row.updatedAt,
@@ -1643,6 +1652,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   interactionMode: row.interactionMode,
                   branch: row.branch,
                   worktreePath: row.worktreePath,
+                  vcsWorkspace: row.vcsWorkspace,
                   latestTurn: latestTurnByThread.get(row.threadId) ?? null,
                   createdAt: row.createdAt,
                   updatedAt: row.updatedAt,
@@ -1883,6 +1893,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         interactionMode: threadRow.value.interactionMode,
         branch: threadRow.value.branch,
         worktreePath: threadRow.value.worktreePath,
+        vcsWorkspace: threadRow.value.vcsWorkspace,
         latestTurn: Option.isSome(latestTurnRow) ? mapLatestTurn(latestTurnRow.value) : null,
         createdAt: threadRow.value.createdAt,
         updatedAt: threadRow.value.updatedAt,
@@ -1977,6 +1988,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         interactionMode: threadRow.value.interactionMode,
         branch: threadRow.value.branch,
         worktreePath: threadRow.value.worktreePath,
+        vcsWorkspace: threadRow.value.vcsWorkspace,
         latestTurn: Option.isSome(latestTurnRow) ? mapLatestTurn(latestTurnRow.value) : null,
         createdAt: threadRow.value.createdAt,
         updatedAt: threadRow.value.updatedAt,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -60,6 +60,7 @@ import * as Clock from "effect/Clock";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import * as GitWorkflowService from "../../git/GitWorkflowService.ts";
+import { VcsWorkspaceService } from "../../vcs/VcsWorkspaceService.ts";
 
 const asProjectId = (value: string): ProjectId => ProjectId.make(value);
 const asApprovalRequestId = (value: string): ApprovalRequestId => ApprovalRequestId.make(value);
@@ -352,6 +353,13 @@ describe("ProviderCommandReactor", () => {
         Layer.mock(GitWorkflowService.GitWorkflowService)({
           renameBranch,
         } satisfies Partial<GitWorkflowService.GitWorkflowService["Service"]>),
+      ),
+      Layer.provideMerge(
+        Layer.mock(VcsWorkspaceService)({
+          createThreadWorkspace: () => Effect.die("unexpected workspace creation"),
+          ensureThreadWorkspace: ({ workspace }) => Effect.succeed(workspace),
+          removeThreadWorkspace: () => Effect.void,
+        }),
       ),
       Layer.provideMerge(
         Layer.succeed(VcsStatusBroadcaster, {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -40,6 +40,7 @@ import {
 } from "../Services/ProviderCommandReactor.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
+import { VcsWorkspaceService } from "../../vcs/VcsWorkspaceService.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
@@ -194,6 +195,7 @@ const make = Effect.gen(function* () {
   const providerRegistry = yield* ProviderRegistry;
   const gitWorkflow = yield* GitWorkflowService;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
+  const vcsWorkspaceService = yield* VcsWorkspaceService;
   const textGeneration = yield* TextGeneration;
   const serverSettingsService = yield* ServerSettingsService;
   const serverCommandId = (tag: string) =>
@@ -752,10 +754,44 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const thread = yield* resolveThread(event.payload.threadId);
-    if (!thread) {
+    const resolvedThread = yield* resolveThread(event.payload.threadId);
+    if (!resolvedThread) {
       return;
     }
+    const project = yield* resolveProject(resolvedThread.projectId);
+    const thread = yield* Effect.gen(function* () {
+      if (!resolvedThread.vcsWorkspace || !project) {
+        return resolvedThread;
+      }
+      const workspace = yield* vcsWorkspaceService.ensureThreadWorkspace({
+        cwd: project.workspaceRoot,
+        threadId: resolvedThread.id,
+        workspace: resolvedThread.vcsWorkspace,
+      });
+      const workspaceChanged =
+        workspace.name !== resolvedThread.vcsWorkspace.name ||
+        workspace.rootPath !== resolvedThread.vcsWorkspace.rootPath ||
+        workspace.workspaceRevision?.commitId !==
+          resolvedThread.vcsWorkspace.workspaceRevision?.commitId ||
+        workspace.workspaceRevision?.changeId !==
+          resolvedThread.vcsWorkspace.workspaceRevision?.changeId ||
+        workspace.baseRevision?.commitId !== resolvedThread.vcsWorkspace.baseRevision?.commitId ||
+        workspace.baseRevision?.changeId !== resolvedThread.vcsWorkspace.baseRevision?.changeId;
+      if (workspaceChanged) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.meta.update",
+          commandId: yield* serverCommandId("thread-workspace-refresh"),
+          threadId: resolvedThread.id,
+          worktreePath: workspace.rootPath,
+          vcsWorkspace: workspace,
+        });
+      }
+      return {
+        ...resolvedThread,
+        worktreePath: workspace.rootPath,
+        vcsWorkspace: workspace,
+      };
+    });
 
     const message = thread.messages.find((entry) => entry.id === event.payload.messageId);
     if (!message || message.role !== "user") {
@@ -773,7 +809,6 @@ const make = Effect.gen(function* () {
     const isFirstUserMessageTurn =
       thread.messages.filter((entry) => entry.role === "user").length === 1;
     if (isFirstUserMessageTurn) {
-      const project = yield* resolveProject(thread.projectId);
       const generationCwd =
         resolveThreadWorkspaceCwd({
           thread,

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -7,6 +7,7 @@ import * as Stream from "effect/Stream";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import * as TerminalManager from "../../terminal/Manager.ts";
+import { VcsWorkspaceService } from "../../vcs/VcsWorkspaceService.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import {
   ThreadDeletionReactor,
@@ -40,6 +41,7 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const providerService = yield* ProviderService;
   const terminalManager = yield* TerminalManager.TerminalManager;
+  const vcsWorkspaceService = yield* VcsWorkspaceService;
 
   const stopProviderSession = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
     logCleanupCauseUnlessInterrupted({
@@ -58,9 +60,19 @@ const make = Effect.gen(function* () {
   const processThreadDeleted = Effect.fn("processThreadDeleted")(function* (
     event: ThreadDeletedEvent,
   ) {
-    const { threadId } = event.payload;
+    const { threadId, vcsWorkspace, workspaceRoot } = event.payload;
     yield* stopProviderSession(threadId);
     yield* closeThreadTerminals(threadId);
+    if (vcsWorkspace) {
+      yield* logCleanupCauseUnlessInterrupted({
+        effect: vcsWorkspaceService.removeThreadWorkspace({
+          cwd: workspaceRoot ?? vcsWorkspace.rootPath,
+          workspace: vcsWorkspace,
+        }),
+        message: "thread deletion cleanup skipped VCS workspace removal",
+        threadId,
+      });
+    }
   });
 
   const processThreadDeletedSafely = (event: ThreadDeletedEvent) =>

--- a/apps/server/src/orchestration/decider.delete.test.ts
+++ b/apps/server/src/orchestration/decider.delete.test.ts
@@ -67,7 +67,15 @@ const seedReadModel = Effect.gen(function* () {
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
       runtimeMode: "approval-required",
       branch: null,
-      worktreePath: null,
+      worktreePath: "/tmp/workspaces/thread-delete-1",
+      vcsWorkspace: {
+        driverKind: "jj",
+        name: "t3code-thread-delete-1",
+        rootPath: "/tmp/workspaces/thread-delete-1",
+        workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+        baseRevision: { commitId: "base-commit", changeId: "base-change" },
+        publishRef: null,
+      },
       createdAt: now,
       updatedAt: now,
     },
@@ -137,6 +145,25 @@ function normalizeDeleteEvent(event: PlannedEvent | ReadonlyArray<PlannedEvent>)
 }
 
 it.layer(NodeServices.layer)("decider deletion flows", (it) => {
+  it.effect("carries workspace identity into thread cleanup events", () =>
+    Effect.gen(function* () {
+      const readModel = yield* seedReadModel;
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.delete",
+          commandId: asCommandId("cmd-thread-delete-workspace"),
+          threadId: asThreadId("thread-delete-1"),
+        },
+        readModel,
+      });
+      const event = Array.isArray(result) ? result[0] : result;
+      expect(event?.type).toBe("thread.deleted");
+      if (event?.type !== "thread.deleted") return;
+      expect(event.payload.workspaceRoot).toBe("/tmp/project-delete");
+      expect(event.payload.vcsWorkspace?.name).toBe("t3code-thread-delete-1");
+    }),
+  );
+
   it.effect("rejects deleting a non-empty project without force", () =>
     Effect.gen(function* () {
       const readModel = yield* seedReadModel;

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -356,6 +356,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             : {}),
           ...(branch !== undefined ? { branch } : {}),
           ...(command.worktreePath !== undefined ? { worktreePath: command.worktreePath } : {}),
+          ...(command.vcsWorkspace !== undefined ? { vcsWorkspace: command.vcsWorkspace } : {}),
           updatedAt: occurredAt,
         },
       };

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -254,6 +254,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           interactionMode: command.interactionMode,
           branch: command.branch,
           worktreePath: command.worktreePath,
+          ...(command.vcsWorkspace !== undefined ? { vcsWorkspace: command.vcsWorkspace } : {}),
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },
@@ -261,12 +262,13 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.delete": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
       const occurredAt = yield* nowIso;
+      const project = readModel.projects.find((candidate) => candidate.id === thread.projectId);
       return {
         ...(yield* withEventBase({
           aggregateKind: "thread",
@@ -277,6 +279,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         type: "thread.deleted",
         payload: {
           threadId: command.threadId,
+          ...(thread.vcsWorkspace !== undefined ? { vcsWorkspace: thread.vcsWorkspace } : {}),
+          ...(project ? { workspaceRoot: project.workspaceRoot } : {}),
           deletedAt: occurredAt,
         },
       };

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -6,6 +6,7 @@ import {
   ThreadId,
   type OrchestrationEvent,
 } from "@t3tools/contracts";
+import { it as effectIt } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -98,6 +99,64 @@ describe("orchestration projector", () => {
       },
     ]);
   });
+
+  effectIt.effect("replays vcs workspace metadata updates", () =>
+    Effect.gen(function* () {
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const updatedAt = "2026-01-01T00:00:01.000Z";
+      const afterCreate = yield* projectEvent(
+        createEmptyReadModel(createdAt),
+        makeEvent({
+          sequence: 1,
+          type: "thread.created",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: createdAt,
+          commandId: "cmd-thread-create",
+          payload: {
+            threadId: "thread-1",
+            projectId: "project-1",
+            title: "demo",
+            modelSelection: {
+              provider: ProviderDriverKind.make("codex"),
+              model: "gpt-5-codex",
+            },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt,
+            updatedAt: createdAt,
+          },
+        }),
+      );
+      const vcsWorkspace = {
+        driverKind: "jj",
+        name: "thread-1",
+        rootPath: "/repo/thread-1",
+        workspaceRevision: { commitId: "commit-1", changeId: "change-1" },
+        publishRef: { kind: "bookmark", name: "t3code/thread-1" },
+      };
+
+      const next = yield* projectEvent(
+        afterCreate,
+        makeEvent({
+          sequence: 2,
+          type: "thread.meta-updated",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: updatedAt,
+          commandId: "cmd-thread-meta-update",
+          payload: {
+            threadId: "thread-1",
+            vcsWorkspace,
+            updatedAt,
+          },
+        }),
+      );
+
+      expect(next.threads[0]?.vcsWorkspace).toEqual(vcsWorkspace);
+    }),
+  );
 
   it("fails when event payload cannot be decoded by runtime schema", async () => {
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -348,6 +348,7 @@ export function projectEvent(
               : {}),
             ...(payload.branch !== undefined ? { branch: payload.branch } : {}),
             ...(payload.worktreePath !== undefined ? { worktreePath: payload.worktreePath } : {}),
+            ...(payload.vcsWorkspace !== undefined ? { vcsWorkspace: payload.vcsWorkspace } : {}),
             updatedAt: payload.updatedAt,
           }),
         })),

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -282,6 +282,7 @@ export function projectEvent(
             interactionMode: payload.interactionMode,
             branch: payload.branch,
             worktreePath: payload.worktreePath,
+            ...(payload.vcsWorkspace !== undefined ? { vcsWorkspace: payload.vcsWorkspace } : {}),
             latestTurn: null,
             createdAt: payload.createdAt,
             updatedAt: payload.updatedAt,

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -74,6 +74,14 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
     Effect.gen(function* () {
       const threads = yield* ProjectionThreadRepository;
       const sql = yield* SqlClient.SqlClient;
+      const vcsWorkspace = {
+        driverKind: "jj" as const,
+        name: "t3code-thread-null-options",
+        rootPath: "/tmp/workspaces/thread-null-options",
+        workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+        baseRevision: { commitId: "base-commit", changeId: "base-change" },
+        publishRef: { kind: "bookmark" as const, name: "feature/null-options" },
+      };
 
       yield* threads.upsert({
         threadId: ThreadId.make("thread-null-options"),
@@ -87,6 +95,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         interactionMode: "default",
         branch: null,
         worktreePath: null,
+        vcsWorkspace,
         latestTurnId: null,
         createdAt: "2026-03-24T00:00:00.000Z",
         updatedAt: "2026-03-24T00:00:00.000Z",
@@ -126,6 +135,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         instanceId: ProviderInstanceId.make("claudeAgent"),
         model: "claude-opus-4-6",
       });
+      assert.deepStrictEqual(Option.getOrNull(persisted)?.vcsWorkspace, vcsWorkspace);
     }),
   );
 });

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -14,11 +14,12 @@ import {
   ProjectionThreadRepository,
   type ProjectionThreadRepositoryShape,
 } from "../Services/ProjectionThreads.ts";
-import { ModelSelection } from "@t3tools/contracts";
+import { ModelSelection, VcsWorkspaceIdentity } from "@t3tools/contracts";
 
 const ProjectionThreadDbRow = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
+    vcsWorkspace: Schema.NullOr(Schema.fromJsonString(VcsWorkspaceIdentity)),
   }),
 );
 type ProjectionThreadDbRow = typeof ProjectionThreadDbRow.Type;
@@ -39,6 +40,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode,
           branch,
           worktree_path,
+          vcs_workspace_json,
           latest_turn_id,
           created_at,
           updated_at,
@@ -58,6 +60,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           ${row.interactionMode},
           ${row.branch},
           ${row.worktreePath},
+          ${row.vcsWorkspace === null ? null : JSON.stringify(row.vcsWorkspace)},
           ${row.latestTurnId},
           ${row.createdAt},
           ${row.updatedAt},
@@ -77,6 +80,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode = excluded.interaction_mode,
           branch = excluded.branch,
           worktree_path = excluded.worktree_path,
+          vcs_workspace_json = excluded.vcs_workspace_json,
           latest_turn_id = excluded.latest_turn_id,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at,
@@ -103,6 +107,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          vcs_workspace_json AS "vcsWorkspace",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
@@ -131,6 +136,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           interaction_mode AS "interactionMode",
           branch,
           worktree_path AS "worktreePath",
+          vcs_workspace_json AS "vcsWorkspace",
           latest_turn_id AS "latestTurnId",
           created_at AS "createdAt",
           updated_at AS "updatedAt",

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -45,6 +45,7 @@ import Migration0029 from "./Migrations/029_ProjectionThreadDetailOrderingIndexe
 import Migration0030 from "./Migrations/030_ProjectionThreadShellArchiveIndexes.ts";
 import Migration0031 from "./Migrations/031_AuthAuthorizationScopes.ts";
 import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
+import Migration0033 from "./Migrations/033_ProjectionThreadVcsWorkspace.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -89,6 +90,7 @@ export const migrationEntries = [
   [30, "ProjectionThreadShellArchiveIndexes", Migration0030],
   [31, "AuthAuthorizationScopes", Migration0031],
   [32, "AuthPairingProofKeyThumbprint", Migration0032],
+  [33, "ProjectionThreadVcsWorkspace", Migration0033],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/033_ProjectionThreadVcsWorkspace.ts
+++ b/apps/server/src/persistence/Migrations/033_ProjectionThreadVcsWorkspace.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_threads)
+  `;
+  if (columns.some((column) => column.name === "vcs_workspace_json")) {
+    return;
+  }
+  yield* sql`
+    ALTER TABLE projection_threads
+    ADD COLUMN vcs_workspace_json TEXT
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -15,11 +15,12 @@ import {
   RuntimeMode,
   ThreadId,
   TurnId,
+  VcsWorkspaceIdentity,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Context from "effect/Context";
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
 
 import type { ProjectionRepositoryError } from "../Errors.ts";
 
@@ -32,6 +33,9 @@ export const ProjectionThread = Schema.Struct({
   interactionMode: ProviderInteractionMode,
   branch: Schema.NullOr(Schema.String),
   worktreePath: Schema.NullOr(Schema.String),
+  vcsWorkspace: Schema.NullOr(VcsWorkspaceIdentity).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
+  ),
   latestTurnId: Schema.NullOr(TurnId),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,

--- a/apps/server/src/review/ReviewService.test.ts
+++ b/apps/server/src/review/ReviewService.test.ts
@@ -6,8 +6,9 @@ import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 
 import { ServerConfig } from "../config.ts";
-import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
+import type * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as ReviewService from "./ReviewService.ts";
 
 function makeLayer(input: {
@@ -27,7 +28,11 @@ function makeLayer(input: {
           }),
       }),
     ),
-    Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)({})),
+    Layer.provide(
+      Layer.mock(VcsGitProviderCompatibility.VcsGitProviderCompatibility)({
+        git: {} as GitVcsDriver.GitVcsDriver["Service"],
+      }),
+    ),
     Layer.provide(ServerConfig.layerTest(input.workspaceRoot, input.baseDir)),
     Layer.provideMerge(NodeServices.layer),
   );

--- a/apps/server/src/review/ReviewService.ts
+++ b/apps/server/src/review/ReviewService.ts
@@ -14,8 +14,8 @@ import {
 } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
-import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
 
 export class ReviewService extends Context.Service<
   ReviewService,
@@ -31,7 +31,7 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
-  const git = yield* GitVcsDriver.GitVcsDriver;
+  const git = (yield* VcsGitProviderCompatibility.VcsGitProviderCompatibility).git;
 
   const canonicalizePath = (value: string) => {
     const resolvedPath = path.resolve(value);

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4804,6 +4804,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
   it.effect("routes websocket rpc git methods", () =>
     Effect.gen(function* () {
+      const refreshedStatusCwds: string[] = [];
       yield* buildAppUnderTest({
         config: {
           cwd: "/tmp/repo",
@@ -4949,18 +4950,21 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             switchRef: (input) => Effect.succeed({ refName: input.refName }),
           },
           vcsStatusBroadcaster: {
-            refreshStatus: () =>
-              Effect.succeed({
-                isRepo: true,
-                hasPrimaryRemote: true,
-                isDefaultRef: true,
-                refName: "main",
-                hasWorkingTreeChanges: false,
-                workingTree: { files: [], insertions: 0, deletions: 0 },
-                hasUpstream: true,
-                aheadCount: 0,
-                behindCount: 0,
-                pr: null,
+            refreshStatus: (cwd) =>
+              Effect.sync(() => {
+                refreshedStatusCwds.push(cwd);
+                return {
+                  isRepo: true,
+                  hasPrimaryRemote: true,
+                  isDefaultRef: true,
+                  refName: "main",
+                  hasWorkingTreeChanges: false,
+                  workingTree: { files: [], insertions: 0, deletions: 0 },
+                  hasUpstream: true,
+                  aheadCount: 0,
+                  behindCount: 0,
+                  pr: null,
+                };
               }),
           },
           reviewService: {
@@ -5091,13 +5095,16 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
 
+      const refreshCountBeforeInit = refreshedStatusCwds.length;
       yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
           client[WS_METHODS.vcsInit]({
             cwd: "/tmp/repo",
+            kind: "jj",
           }),
         ),
       );
+      assert.equal(refreshedStatusCwds.length, refreshCountBeforeInit + 1);
 
       const diffPreview = yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
@@ -5331,6 +5338,21 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             gitManager: {
               invalidateLocalStatus: () => Effect.void,
               invalidateRemoteStatus: () => Effect.void,
+              status: () =>
+                Effect.sleep(Duration.seconds(2)).pipe(
+                  Effect.as({
+                    isRepo: true,
+                    hasPrimaryRemote: true,
+                    isDefaultRef: false,
+                    refName: "feature/demo",
+                    hasWorkingTreeChanges: false,
+                    workingTree: { files: [], insertions: 0, deletions: 0 },
+                    hasUpstream: true,
+                    aheadCount: 0,
+                    behindCount: 0,
+                    pr: null,
+                  }),
+                ),
               localStatus: () =>
                 Effect.succeed({
                   isRepo: true,
@@ -5407,6 +5429,24 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             gitManager: {
               invalidateLocalStatus: () => Effect.void,
               invalidateRemoteStatus: () => Effect.void,
+              status: () =>
+                Deferred.succeed(localRefreshStarted, undefined).pipe(
+                  Effect.ignore,
+                  Effect.andThen(
+                    Effect.succeed({
+                      isRepo: true,
+                      hasPrimaryRemote: true,
+                      isDefaultRef: false,
+                      refName: "feature/demo",
+                      hasWorkingTreeChanges: false,
+                      workingTree: { files: [], insertions: 0, deletions: 0 },
+                      hasUpstream: true,
+                      aheadCount: 0,
+                      behindCount: 0,
+                      pr: null,
+                    }),
+                  ),
+                ),
               localStatus: () =>
                 Deferred.succeed(localRefreshStarted, undefined).pipe(
                   Effect.ignore,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -102,6 +102,7 @@ import * as VcsDriver from "./vcs/VcsDriver.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
+import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
@@ -422,8 +423,12 @@ const buildAppUnderTest = (options?: {
             expiresAt: Option.none(),
           },
         }),
+      addRemote: () => Effect.void,
+      removeRemote: () => Effect.void,
+      resolveDefaultRemote: () => Effect.succeed(null),
       filterIgnoredPaths: (_cwd, relativePaths) => Effect.succeed(relativePaths),
       initRepository: () => Effect.void,
+      cloneRepository: () => Effect.void,
       ...options?.layers?.vcsDriver,
     };
     const vcsDriverRegistryLayer = Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
@@ -482,6 +487,9 @@ const buildAppUnderTest = (options?: {
     const gitVcsDriverLayer = Layer.mock(GitVcsDriver.GitVcsDriver)({
       ...options?.layers?.gitVcsDriver,
     });
+    const gitProviderCompatibilityLayer = VcsGitProviderCompatibility.layer.pipe(
+      Layer.provide(gitVcsDriverLayer),
+    );
     const gitManagerLayer = Layer.mock(GitManager.GitManager)({
       ...options?.layers?.gitManager,
     });
@@ -511,7 +519,7 @@ const buildAppUnderTest = (options?: {
           ...options.layers.reviewService,
         })
       : ReviewService.layer.pipe(
-          Layer.provideMerge(gitVcsDriverLayer),
+          Layer.provideMerge(gitProviderCompatibilityLayer),
           Layer.provide(vcsDriverRegistryLayer),
         );
     const vcsStatusBroadcasterLayer = options?.layers?.vcsStatusBroadcaster

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -102,6 +102,7 @@ import * as VcsDriver from "./vcs/VcsDriver.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
+import * as VcsWorkspaceService from "./vcs/VcsWorkspaceService.ts";
 import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
@@ -329,6 +330,7 @@ const buildAppUnderTest = (options?: {
     >;
     reviewService?: Partial<ReviewService.ReviewService["Service"]>;
     vcsStatusBroadcaster?: Partial<VcsStatusBroadcaster.VcsStatusBroadcaster["Service"]>;
+    vcsWorkspaceService?: Partial<VcsWorkspaceService.VcsWorkspaceService["Service"]>;
     projectSetupScriptRunner?: Partial<
       ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"]
     >;
@@ -397,7 +399,7 @@ const buildAppUnderTest = (options?: {
       execute: () =>
         Effect.succeed({
           exitCode: ChildProcessSpawner.ExitCode(0),
-          stdout: "",
+          stdout: "0000000000000000000000000000000000000000\n",
           stderr: "",
           stdoutTruncated: false,
           stderrTruncated: false,
@@ -514,6 +516,14 @@ const buildAppUnderTest = (options?: {
     const vcsProvisioningLayer = VcsProvisioningService.layer.pipe(
       Layer.provide(vcsDriverRegistryLayer),
     );
+    const vcsWorkspaceLayer = options?.layers?.vcsWorkspaceService
+      ? Layer.mock(VcsWorkspaceService.VcsWorkspaceService)({
+          ...options.layers.vcsWorkspaceService,
+        })
+      : VcsWorkspaceService.layer.pipe(
+          Layer.provideMerge(vcsDriverRegistryLayer),
+          Layer.provideMerge(gitWorkflowLayer),
+        );
     const reviewLayer = options?.layers?.reviewService
       ? Layer.mock(ReviewService.ReviewService)({
           ...options.layers.reviewService,
@@ -639,6 +649,7 @@ const buildAppUnderTest = (options?: {
       Layer.provide(gitWorkflowLayer),
       Layer.provide(reviewLayer),
       Layer.provide(vcsProvisioningLayer),
+      Layer.provide(vcsWorkspaceLayer),
       Layer.provide(
         Layer.mock(SourceControlRepositoryService.SourceControlRepositoryService)({
           ...options?.layers?.sourceControlRepositoryService,
@@ -718,6 +729,9 @@ const buildAppUnderTest = (options?: {
           ...options?.layers?.projectionSnapshotQuery,
         }),
       ),
+    );
+
+    const appLayer = servedRoutesLayer.pipe(
       Layer.provide(
         Layer.mock(CheckpointDiffQuery.CheckpointDiffQuery)({
           getTurnDiff: () =>
@@ -737,9 +751,6 @@ const buildAppUnderTest = (options?: {
           ...options?.layers?.checkpointDiffQuery,
         }),
       ),
-    );
-
-    const appLayer = servedRoutesLayer.pipe(
       Layer.provide(
         Layer.mock(BrowserTraceCollector.BrowserTraceCollector)({
           record: () => Effect.void,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -66,6 +66,7 @@ import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsChangeService from "./vcs/VcsChangeService.ts";
 import * as VcsSyncService from "./vcs/VcsSyncService.ts";
+import * as VcsReviewService from "./vcs/VcsReviewService.ts";
 import * as VcsWorkspaceService from "./vcs/VcsWorkspaceService.ts";
 import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
@@ -210,6 +211,10 @@ const VcsChangeLayerLive = VcsChangeService.layer.pipe(
 
 const VcsSyncLayerLive = VcsSyncService.layer.pipe(Layer.provideMerge(VcsDriverRegistryLayerLive));
 
+const VcsReviewLayerLive = VcsReviewService.layer.pipe(
+  Layer.provideMerge(VcsDriverRegistryLayerLive),
+);
+
 const GitManagerLayerLive = GitManager.layer.pipe(
   Layer.provideMerge(ProjectSetupScriptRunner.layer),
   Layer.provideMerge(GitVcsDriver.layer),
@@ -217,6 +222,7 @@ const GitManagerLayerLive = GitManager.layer.pipe(
   Layer.provideMerge(TextGeneration.layer),
   Layer.provideMerge(VcsChangeLayerLive),
   Layer.provideMerge(VcsSyncLayerLive),
+  Layer.provideMerge(VcsReviewLayerLive),
 );
 
 const GitLayerLive = Layer.empty.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,6 +64,7 @@ import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
+import * as VcsChangeService from "./vcs/VcsChangeService.ts";
 import * as VcsWorkspaceService from "./vcs/VcsWorkspaceService.ts";
 import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
@@ -202,11 +203,16 @@ const SourceControlProviderRegistryLayerLive = SourceControlProviderRegistry.lay
   Layer.provideMerge(VcsDriverRegistryLayerLive),
 );
 
+const VcsChangeLayerLive = VcsChangeService.layer.pipe(
+  Layer.provideMerge(VcsDriverRegistryLayerLive),
+);
+
 const GitManagerLayerLive = GitManager.layer.pipe(
   Layer.provideMerge(ProjectSetupScriptRunner.layer),
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
   Layer.provideMerge(TextGeneration.layer),
+  Layer.provideMerge(VcsChangeLayerLive),
 );
 
 const GitLayerLive = Layer.empty.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,6 +64,7 @@ import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
+import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as SourceControlProviderRegistry from "./sourceControl/SourceControlProviderRegistry.ts";
@@ -187,11 +188,16 @@ const VcsDriverRegistryLayerLive = VcsDriverRegistry.layer.pipe(
   Layer.provide(VcsProjectConfig.layer),
 );
 
+const VcsGitProviderCompatibilityLayerLive = VcsGitProviderCompatibility.layer.pipe(
+  Layer.provide(GitVcsDriver.layer),
+);
+
 const SourceControlProviderRegistryLayerLive = SourceControlProviderRegistry.layer.pipe(
   Layer.provide(
     Layer.mergeAll(AzureDevOpsCli.layer, BitbucketApi.layer, GitHubCli.layer, GitLabCli.layer),
   ),
   Layer.provideMerge(GitVcsDriver.layer),
+  Layer.provideMerge(VcsGitProviderCompatibilityLayerLive),
   Layer.provideMerge(VcsDriverRegistryLayerLive),
 );
 
@@ -213,13 +219,13 @@ const GitWorkflowLayerLive = GitWorkflowService.layer.pipe(
 );
 
 const SourceControlRepositoryServiceLayerLive = SourceControlRepositoryService.layer.pipe(
-  Layer.provideMerge(GitVcsDriver.layer),
+  Layer.provideMerge(VcsGitProviderCompatibilityLayerLive),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
 );
 
 const ReviewLayerLive = ReviewService.layer.pipe(
-  Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(VcsDriverRegistryLayerLive),
+  Layer.provideMerge(VcsGitProviderCompatibilityLayerLive),
 );
 
 const VcsLayerLive = Layer.empty.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,6 +64,7 @@ import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
+import * as VcsWorkspaceService from "./vcs/VcsWorkspaceService.ts";
 import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
@@ -218,6 +219,11 @@ const GitWorkflowLayerLive = GitWorkflowService.layer.pipe(
   Layer.provideMerge(GitLayerLive),
 );
 
+const VcsWorkspaceLayerLive = VcsWorkspaceService.layer.pipe(
+  Layer.provideMerge(VcsDriverRegistryLayerLive),
+  Layer.provideMerge(GitWorkflowLayerLive),
+);
+
 const SourceControlRepositoryServiceLayerLive = SourceControlRepositoryService.layer.pipe(
   Layer.provideMerge(VcsGitProviderCompatibilityLayerLive),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
@@ -233,6 +239,7 @@ const VcsLayerLive = Layer.empty.pipe(
   Layer.provideMerge(VcsDriverRegistryLayerLive),
   Layer.provideMerge(VcsProvisioningService.layer.pipe(Layer.provide(VcsDriverRegistryLayerLive))),
   Layer.provideMerge(GitWorkflowLayerLive),
+  Layer.provideMerge(VcsWorkspaceLayerLive),
   Layer.provideMerge(ReviewLayerLive),
   Layer.provideMerge(SourceControlRepositoryServiceLayerLive),
   Layer.provideMerge(VcsStatusBroadcaster.layer.pipe(Layer.provide(GitWorkflowLayerLive))),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -65,6 +65,7 @@ import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsChangeService from "./vcs/VcsChangeService.ts";
+import * as VcsSyncService from "./vcs/VcsSyncService.ts";
 import * as VcsWorkspaceService from "./vcs/VcsWorkspaceService.ts";
 import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
@@ -207,12 +208,15 @@ const VcsChangeLayerLive = VcsChangeService.layer.pipe(
   Layer.provideMerge(VcsDriverRegistryLayerLive),
 );
 
+const VcsSyncLayerLive = VcsSyncService.layer.pipe(Layer.provideMerge(VcsDriverRegistryLayerLive));
+
 const GitManagerLayerLive = GitManager.layer.pipe(
   Layer.provideMerge(ProjectSetupScriptRunner.layer),
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
   Layer.provideMerge(TextGeneration.layer),
   Layer.provideMerge(VcsChangeLayerLive),
+  Layer.provideMerge(VcsSyncLayerLive),
 );
 
 const GitLayerLive = Layer.empty.pipe(
@@ -233,6 +237,8 @@ const VcsWorkspaceLayerLive = VcsWorkspaceService.layer.pipe(
 const SourceControlRepositoryServiceLayerLive = SourceControlRepositoryService.layer.pipe(
   Layer.provideMerge(VcsGitProviderCompatibilityLayerLive),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
+  Layer.provideMerge(VcsDriverRegistryLayerLive),
+  Layer.provideMerge(VcsSyncLayerLive),
 );
 
 const ReviewLayerLive = ReviewService.layer.pipe(

--- a/apps/server/src/sourceControl/BitbucketApi.test.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.test.ts
@@ -16,6 +16,7 @@ import {
 import { GitCommandError } from "@t3tools/contracts";
 import * as BitbucketApi from "./BitbucketApi.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 import type * as VcsDriver from "../vcs/VcsDriver.ts";
 
@@ -145,7 +146,11 @@ function makeLayer(input: {
           }),
       }),
     ),
-    Layer.provide(Layer.mock(GitVcsDriver.GitVcsDriver)(git)),
+    Layer.provide(
+      Layer.mock(VcsGitProviderCompatibility.VcsGitProviderCompatibility)({
+        git: git as GitVcsDriver.GitVcsDriver["Service"],
+      }),
+    ),
     Layer.provide(
       ConfigProvider.layer(
         ConfigProvider.fromEnv({

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -23,7 +23,7 @@ import {
   type NormalizedBitbucketPullRequestRecord,
 } from "./bitbucketPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
-import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
 
 const DEFAULT_API_BASE_URL = "https://api.bitbucket.org/2.0";
@@ -502,7 +502,7 @@ export const make = Effect.gen(function* () {
   const config = yield* BitbucketApiEnvConfig;
   const httpClient = yield* HttpClient.HttpClient;
   const fileSystem = yield* FileSystem.FileSystem;
-  const git = yield* GitVcsDriver.GitVcsDriver;
+  const git = (yield* VcsGitProviderCompatibility.VcsGitProviderCompatibility).git;
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
 
   const apiUrl = (path: string) => `${config.baseUrl.replace(/\/+$/u, "")}${path}`;
@@ -818,8 +818,8 @@ export const make = Effect.gen(function* () {
         Effect.map(defaultChangeRequestTargetBranch),
       ),
     // Bitbucket Cloud pull requests are Git-backed and Bitbucket does not provide
-    // an official checkout CLI. This provider-local path uses GitVcsDriver as a
-    // narrow escape hatch to materialize Bitbucket PR refs. Do not generalize this
+    // an official checkout CLI. This provider-local path uses the explicit Git
+    // compatibility adapter to materialize Bitbucket PR refs. Do not generalize this
     // as the source-control provider model: if we support non-Git-compatible
     // hosting providers or native JJ/Sapling checkout flows, move this into a
     // VCS-specific change-request checkout capability.

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -209,11 +209,13 @@ export class GitHubCli extends Context.Service<
       readonly cwd: string;
       readonly headSelector: string;
       readonly limit?: number;
+      readonly repository?: string;
     }) => Effect.Effect<ReadonlyArray<GitHubPullRequestSummary>, GitHubCliError>;
 
     readonly getPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
+      readonly repository?: string;
     }) => Effect.Effect<GitHubPullRequestSummary, GitHubCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
@@ -233,10 +235,12 @@ export class GitHubCli extends Context.Service<
       readonly headSelector: string;
       readonly title: string;
       readonly bodyFile: string;
+      readonly repository?: string;
     }) => Effect.Effect<void, GitHubCliError>;
 
     readonly getDefaultBranch: (input: {
       readonly cwd: string;
+      readonly repository?: string;
     }) => Effect.Effect<string | null, GitHubCliError>;
 
     readonly checkoutPullRequest: (input: {
@@ -333,6 +337,7 @@ export const make = Effect.gen(function* () {
           String(input.limit ?? 1),
           "--json",
           "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          ...(input.repository ? ["--repo", input.repository] : []),
         ],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
@@ -367,6 +372,7 @@ export const make = Effect.gen(function* () {
           input.reference,
           "--json",
           "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          ...(input.repository ? ["--repo", input.repository] : []),
         ],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
@@ -433,12 +439,21 @@ export const make = Effect.gen(function* () {
           input.title,
           "--body-file",
           input.bodyFile,
+          ...(input.repository ? ["--repo", input.repository] : []),
         ],
       }).pipe(Effect.asVoid),
     getDefaultBranch: (input) =>
       execute({
         cwd: input.cwd,
-        args: ["repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"],
+        args: [
+          "repo",
+          "view",
+          ...(input.repository ? [input.repository] : []),
+          "--json",
+          "defaultBranchRef",
+          "--jq",
+          ".defaultBranchRef.name",
+        ],
       }).pipe(
         Effect.map((value) => {
           const trimmed = value.stdout.trim();

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -191,6 +191,15 @@ it.effect("creates GitHub PRs through provider-neutral input names", () =>
 
     yield* provider.createChangeRequest({
       cwd: "/repo",
+      context: {
+        provider: {
+          kind: "github",
+          name: "GitHub",
+          baseUrl: "https://github.com",
+        },
+        remoteName: "origin",
+        remoteUrl: "git@github.com:michft/t3code.git",
+      },
       baseRefName: "main",
       headSelector: "owner:feature/provider",
       title: "Provider PR",
@@ -203,6 +212,7 @@ it.effect("creates GitHub PRs through provider-neutral input names", () =>
       headSelector: "owner:feature/provider",
       title: "Provider PR",
       bodyFile: "/tmp/body.md",
+      repository: "michft/t3code",
     });
   }),
 );

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -7,6 +7,7 @@ import {
   type ChangeRequest,
   type ChangeRequestState,
 } from "@t3tools/contracts";
+import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
 
 import * as GitHubCli from "./GitHubCli.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
@@ -97,13 +98,26 @@ export const discovery = {
 export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
 
+  const contextRepository = (
+    context: SourceControlProvider.SourceControlProviderContext | undefined,
+  ): string | undefined =>
+    parseGitHubRepositoryNameWithOwnerFromRemoteUrl(context?.remoteUrl ?? null) ?? undefined;
+  const contextRepositoryInput = (
+    context: SourceControlProvider.SourceControlProviderContext | undefined,
+  ): { readonly repository?: string } => {
+    const repository = contextRepository(context);
+    return repository ? { repository } : {};
+  };
+
   const listChangeRequests: SourceControlProvider.SourceControlProvider["Service"]["listChangeRequests"] =
     (input) => {
+      const repository = contextRepository(input.context);
       if (input.state === "open") {
         return github
           .listOpenPullRequests({
             cwd: input.cwd,
             headSelector: input.headSelector,
+            ...(repository ? { repository } : {}),
             ...(input.limit !== undefined ? { limit: input.limit } : {}),
           })
           .pipe(
@@ -140,6 +154,7 @@ export const make = Effect.gen(function* () {
             String(input.limit ?? 20),
             "--json",
             "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            ...(repository ? ["--repo", repository] : []),
           ],
         })
         .pipe(
@@ -188,23 +203,29 @@ export const make = Effect.gen(function* () {
     kind: "github",
     listChangeRequests,
     getChangeRequest: (input) =>
-      github.getPullRequest(input).pipe(
-        Effect.map(toChangeRequest),
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "github",
-              operation: "getChangeRequest",
-              command: error.command,
-              cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
+      github
+        .getPullRequest({
+          cwd: input.cwd,
+          reference: input.reference,
+          ...contextRepositoryInput(input.context),
+        })
+        .pipe(
+          Effect.map(toChangeRequest),
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "github",
+                operation: "getChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
     createChangeRequest: (input) =>
       github
         .createPullRequest({
@@ -213,6 +234,7 @@ export const make = Effect.gen(function* () {
           headSelector: input.headSelector,
           title: input.title,
           bodyFile: input.bodyFile,
+          ...contextRepositoryInput(input.context),
         })
         .pipe(
           Effect.mapError(
@@ -265,19 +287,24 @@ export const make = Effect.gen(function* () {
         ),
       ),
     getDefaultBranch: (input) =>
-      github.getDefaultBranch(input).pipe(
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "github",
-              operation: "getDefaultBranch",
-              command: error.command,
-              cwd: input.cwd,
-              detail: error.detail,
-              cause: error,
-            }),
+      github
+        .getDefaultBranch({
+          cwd: input.cwd,
+          ...contextRepositoryInput(input.context),
+        })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "github",
+                operation: "getDefaultBranch",
+                command: error.command,
+                cwd: input.cwd,
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
     checkoutChangeRequest: (input) =>
       github.checkoutPullRequest(input).pipe(
         Effect.mapError(

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -122,16 +122,10 @@ export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliComm
   ): GitLabCliError {
     return Match.valueTags(error, {
       VcsProcessSpawnError: (cause) => new GitLabCliUnavailableError({ ...context, cause }),
-      VcsProcessExitError: (cause) => {
-        switch (cause.failureKind) {
-          case "authentication":
-            return new GitLabCliAuthenticationError({ ...context, cause });
-          case "not-found":
-          case "command-failed":
-          case undefined:
-            return new GitLabCliCommandError({ ...context, cause });
-        }
-      },
+      VcsProcessExitError: (cause) =>
+        cause.failureKind === "authentication"
+          ? new GitLabCliAuthenticationError({ ...context, cause })
+          : new GitLabCliCommandError({ ...context, cause }),
       VcsProcessTimeoutError: (cause) => new GitLabCliCommandError({ ...context, cause }),
       VcsProcessStdinWriteError: (cause) => new GitLabCliCommandError({ ...context, cause }),
       VcsProcessOutputReadError: (cause) => new GitLabCliCommandError({ ...context, cause }),

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -133,6 +133,7 @@ export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliComm
       VcsProcessMissingExitCodeError: (cause) => new GitLabCliCommandError({ ...context, cause }),
       VcsRepositoryDetectionError: (cause) => new GitLabCliCommandError({ ...context, cause }),
       VcsUnsupportedOperationError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsWorkflowError: (cause) => new GitLabCliCommandError({ ...context, cause }),
     });
   }
 }

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsProcessSpawnError } from "@t3tools/contracts";
+import { JJ_MINIMUM_SUPPORTED_VERSION } from "@t3tools/shared/jjCli";
 
 import * as ServerConfig from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -278,6 +279,62 @@ Logged in to gitlab.com as gitlab-user
           detail: Option.none(),
         },
       ],
+    );
+  }).pipe(Effect.provide(testLayer));
+});
+
+it.effect("reports unsupported jj versions with an actionable minimum", () => {
+  const processMock = {
+    run: (input: VcsProcess.VcsProcessInput) => {
+      if (input.command === "git") {
+        return Effect.succeed(processOutput("git version 2.51.0\n"));
+      }
+      if (input.command === "jj") {
+        return Effect.succeed(processOutput("jj 0.41.0\n"));
+      }
+      return Effect.fail(
+        new VcsProcessSpawnError({
+          operation: input.operation,
+          command: input.command,
+          cwd: input.cwd,
+          cause: new Error(`${input.command} not found`),
+        }),
+      );
+    },
+  } satisfies Partial<VcsProcess.VcsProcess["Service"]>;
+  const testLayer = SourceControlDiscovery.layer.pipe(
+    Layer.provide(
+      ServerConfig.layerTest(process.cwd(), {
+        prefix: "t3-source-control-jj-version-discovery-",
+      }),
+    ),
+    Layer.provide(Layer.mock(VcsProcess.VcsProcess)(processMock)),
+    Layer.provide(
+      sourceControlProviderRegistryTestLayer({
+        process: processMock,
+        bitbucket: {
+          probeAuth: Effect.succeed({
+            status: "unauthenticated",
+            account: Option.none(),
+            host: Option.some("bitbucket.org"),
+            detail: Option.none(),
+          }),
+        },
+      }),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  );
+
+  return Effect.gen(function* () {
+    const discovery = yield* SourceControlDiscovery.SourceControlDiscovery;
+    const result = yield* discovery.discover;
+    const jj = result.versionControlSystems.find((item) => item.kind === "jj");
+
+    assert.ok(jj);
+    assert.strictEqual(jj.status, "unsupported");
+    assert.strictEqual(
+      Option.getOrNull(jj.detail),
+      `Jujutsu 0.41.0 is unsupported. T3 Code requires jj ${JJ_MINIMUM_SUPPORTED_VERSION} or newer.`,
     );
   }).pipe(Effect.provide(testLayer));
 });

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -127,7 +127,7 @@ it.effect("reports implemented tools separately from locally available executabl
       })),
       [
         { kind: "git", implemented: true, status: "available" },
-        { kind: "jj", implemented: false, status: "missing" },
+        { kind: "jj", implemented: true, status: "missing" },
       ],
     );
     assert.deepStrictEqual(

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -284,13 +284,17 @@ Logged in to gitlab.com as gitlab-user
 });
 
 it.effect("reports unsupported jj versions with an actionable minimum", () => {
+  let jjOutput = {
+    stdout: "warning: development build\n",
+    stderr: "jj 0.41.0\n",
+  };
   const processMock = {
     run: (input: VcsProcess.VcsProcessInput) => {
       if (input.command === "git") {
         return Effect.succeed(processOutput("git version 2.51.0\n"));
       }
       if (input.command === "jj") {
-        return Effect.succeed(processOutput("jj 0.41.0\n"));
+        return Effect.sync(() => processOutput(jjOutput.stdout, { stderr: jjOutput.stderr }));
       }
       return Effect.fail(
         new VcsProcessSpawnError({
@@ -336,5 +340,12 @@ it.effect("reports unsupported jj versions with an actionable minimum", () => {
       Option.getOrNull(jj.detail),
       `Jujutsu 0.41.0 is unsupported. T3 Code requires jj ${JJ_MINIMUM_SUPPORTED_VERSION} or newer.`,
     );
+
+    jjOutput = { stdout: "", stderr: "" };
+    const emptyResult = yield* discovery.discover;
+    const emptyJj = emptyResult.versionControlSystems.find((item) => item.kind === "jj");
+    assert.ok(emptyJj);
+    assert.strictEqual(emptyJj.status, "unsupported");
+    assert.isTrue(Option.isNone(emptyJj.version));
   }).pipe(Effect.provide(testLayer));
 });

--- a/apps/server/src/sourceControl/SourceControlDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.ts
@@ -54,7 +54,7 @@ const VCS_PROBES: ReadonlyArray<VcsProbe> = [
     label: "Jujutsu",
     executable: "jj",
     versionArgs: ["--version"],
-    implemented: false,
+    implemented: true,
     installHint: "Install Jujutsu with `brew install jj` or from https://github.com/jj-vcs/jj.",
   },
 ];

--- a/apps/server/src/sourceControl/SourceControlDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.ts
@@ -1,8 +1,10 @@
 import {
   type SourceControlDiscoveryResult,
+  type SourceControlDiscoveryStatus,
   type VcsDiscoveryItem,
   type VcsDriverKind,
 } from "@t3tools/contracts";
+import { inspectJjVersion } from "@t3tools/shared/jjCli";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -32,7 +34,7 @@ interface DiscoveryProbeResult<Kind extends string> {
   readonly label: string;
   readonly executable?: string;
   readonly implemented: boolean;
-  readonly status: "available" | "missing";
+  readonly status: SourceControlDiscoveryStatus;
   readonly version: Option.Option<string>;
   readonly installHint: string;
   readonly detail: Option.Option<string>;
@@ -98,21 +100,38 @@ export const make = Effect.gen(function* () {
         appendTruncationMarker: true,
       })
       .pipe(
-        Effect.map(
-          (result) =>
-            ({
-              kind: input.kind,
-              label: input.label,
-              executable,
-              implemented: input.implemented,
-              status: "available" as const,
-              version: Option.orElse(firstNonEmptyLine(result.stdout), () =>
-                firstNonEmptyLine(result.stderr),
-              ),
-              installHint: input.installHint,
-              detail: Option.none<string>(),
-            }) satisfies DiscoveryProbeResult<Kind>,
-        ),
+        Effect.map((result) => {
+          const version = Option.orElse(firstNonEmptyLine(result.stdout), () =>
+            firstNonEmptyLine(result.stderr),
+          );
+
+          if (input.kind === "jj" && Option.isSome(version)) {
+            const support = inspectJjVersion(version.value);
+            if (support.status !== "supported") {
+              return {
+                kind: input.kind,
+                label: input.label,
+                executable,
+                implemented: input.implemented,
+                status: "unsupported" as const,
+                version,
+                installHint: input.installHint,
+                detail: Option.some(support.detail),
+              } satisfies DiscoveryProbeResult<Kind>;
+            }
+          }
+
+          return {
+            kind: input.kind,
+            label: input.label,
+            executable,
+            implemented: input.implemented,
+            status: "available" as const,
+            version,
+            installHint: input.installHint,
+            detail: Option.none<string>(),
+          } satisfies DiscoveryProbeResult<Kind>;
+        }),
         Effect.catch((cause) =>
           Effect.succeed({
             kind: input.kind,

--- a/apps/server/src/sourceControl/SourceControlDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.ts
@@ -101,12 +101,10 @@ export const make = Effect.gen(function* () {
       })
       .pipe(
         Effect.map((result) => {
-          const version = Option.orElse(firstNonEmptyLine(result.stdout), () =>
-            firstNonEmptyLine(result.stderr),
-          );
-
-          if (input.kind === "jj" && Option.isSome(version)) {
-            const support = inspectJjVersion(version.value);
+          if (input.kind === "jj") {
+            const support = inspectJjVersion([result.stdout, result.stderr].join("\n"));
+            const version =
+              support.status === "invalid" ? Option.none<string>() : Option.some(support.version);
             if (support.status !== "supported") {
               return {
                 kind: input.kind,
@@ -119,7 +117,22 @@ export const make = Effect.gen(function* () {
                 detail: Option.some(support.detail),
               } satisfies DiscoveryProbeResult<Kind>;
             }
+
+            return {
+              kind: input.kind,
+              label: input.label,
+              executable,
+              implemented: input.implemented,
+              status: "available" as const,
+              version,
+              installHint: input.installHint,
+              detail: Option.none<string>(),
+            } satisfies DiscoveryProbeResult<Kind>;
           }
+
+          const version = Option.orElse(firstNonEmptyLine(result.stdout), () =>
+            firstNonEmptyLine(result.stderr),
+          );
 
           return {
             kind: input.kind,

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -11,6 +11,7 @@ import { GitCommandError, SourceControlProviderError } from "@t3tools/contracts"
 
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
 import type * as SourceControlProvider from "./SourceControlProvider.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 import * as SourceControlRepositoryService from "./SourceControlRepositoryService.ts";
@@ -65,17 +66,19 @@ function makeLayer(input: {
       }),
     ),
     Layer.provide(
-      Layer.mock(GitVcsDriver.GitVcsDriver)({
-        execute: () => Effect.succeed(processOutput()),
-        ensureRemote: () => Effect.succeed("origin"),
-        pushCurrentBranch: () =>
-          Effect.succeed({
-            status: "pushed" as const,
-            branch: "feature/remote-v1",
-            upstreamBranch: "origin/feature/remote-v1",
-            setUpstream: true,
-          }),
-        ...input.git,
+      Layer.mock(VcsGitProviderCompatibility.VcsGitProviderCompatibility)({
+        git: {
+          execute: () => Effect.succeed(processOutput()),
+          ensureRemote: () => Effect.succeed("origin"),
+          pushCurrentBranch: () =>
+            Effect.succeed({
+              status: "pushed" as const,
+              branch: "feature/remote-v1",
+              upstreamBranch: "origin/feature/remote-v1",
+              setUpstream: true,
+            }),
+          ...input.git,
+        } as GitVcsDriver.GitVcsDriver["Service"],
       }),
     ),
     Layer.provide(

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -2,8 +2,10 @@ import * as NodePath from "@effect/platform-node/NodePath";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as DateTime from "effect/DateTime";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -12,6 +14,9 @@ import { GitCommandError, SourceControlProviderError } from "@t3tools/contracts"
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsDriver from "../vcs/VcsDriver.ts";
+import * as VcsSyncService from "../vcs/VcsSyncService.ts";
 import type * as SourceControlProvider from "./SourceControlProvider.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 import * as SourceControlRepositoryService from "./SourceControlRepositoryService.ts";
@@ -54,10 +59,46 @@ function processOutput(): GitVcsDriver.ExecuteGitResult {
   };
 }
 
+function mockJjDriver(
+  overrides: Partial<VcsDriver.VcsDriver["Service"]>,
+): VcsDriver.VcsDriver["Service"] {
+  const unexpected = () => Effect.die("unexpected jj driver call");
+  return VcsDriver.VcsDriver.of({
+    capabilities: {
+      kind: "jj",
+      supportsWorktrees: false,
+      supportsBookmarks: true,
+      supportsAtomicSnapshot: true,
+      supportsPushDefaultRemote: true,
+      supportsWorkspaces: true,
+      supportsNamedPublishRefs: true,
+      supportsSelectedFileFinalize: true,
+      supportsThreadLocalRestore: true,
+      supportsDefaultRemotePush: true,
+      supportsGitProviderCompatibility: true,
+      ignoreClassifier: "native",
+    },
+    execute: unexpected,
+    detectRepository: unexpected,
+    isInsideWorkTree: unexpected,
+    listWorkspaceFiles: unexpected,
+    listRemotes: unexpected,
+    addRemote: unexpected,
+    removeRemote: unexpected,
+    resolveDefaultRemote: unexpected,
+    filterIgnoredPaths: unexpected,
+    initRepository: unexpected,
+    cloneRepository: unexpected,
+    ...overrides,
+  });
+}
+
 function makeLayer(input: {
   readonly provider?: SourceControlProvider.SourceControlProvider["Service"];
   readonly git?: Partial<GitVcsDriver.GitVcsDriver["Service"]>;
   readonly fileSystem?: FileSystem.FileSystem;
+  readonly vcsDriver?: VcsDriver.VcsDriver["Service"];
+  readonly vcsSync?: Partial<VcsSyncService.VcsSyncService["Service"]>;
 }) {
   const serviceLayer = SourceControlRepositoryService.layer.pipe(
     Layer.provide(
@@ -79,6 +120,24 @@ function makeLayer(input: {
             }),
           ...input.git,
         } as GitVcsDriver.GitVcsDriver["Service"],
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({
+        resolve: () =>
+          Effect.succeed({
+            kind: input.vcsDriver?.capabilities.kind ?? ("git" as const),
+            repository: null!,
+            driver: input.vcsDriver ?? null!,
+          }),
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(VcsSyncService.VcsSyncService)({
+        fetch: () => Effect.die("unexpected jj fetch"),
+        publish: () => Effect.die("unexpected jj publish"),
+        readRangeContext: () => Effect.die("unexpected jj range context"),
+        ...input.vcsSync,
       }),
     ),
     Layer.provide(
@@ -393,6 +452,73 @@ it.effect("publish succeeds with status remote_added when the local repo has no 
                 branch: "main",
                 upstreamBranch: "origin/main",
                 setUpstream: true,
+              };
+            }),
+        },
+      }),
+    ),
+  );
+});
+
+it.effect("publishes a new hosted jj repository through one explicit bookmark", () => {
+  const remoteCalls: Array<{ name: string; url: string }> = [];
+  let publishedBookmark: string | null = null;
+  const publishRef = {
+    kind: "bookmark" as const,
+    name: "feature/phase-6",
+    target: { commitId: "published-commit", changeId: "published-change" },
+  };
+  const driver = mockJjDriver({
+    listRemotes: () =>
+      Effect.succeed({
+        remotes: [],
+        freshness: {
+          source: "live-local",
+          observedAt: DateTime.makeUnsafe("2026-01-01T00:00:00.000Z"),
+          expiresAt: Option.none(),
+        },
+      }),
+    addRemote: (input) =>
+      Effect.sync(() => {
+        remoteCalls.push({ name: input.name, url: input.url });
+      }),
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+    const result = yield* service.publishRepository({
+      cwd: "/jj-workspace",
+      provider: "github",
+      repository: "octocat/t3code",
+      visibility: "private",
+      remoteName: "origin",
+      protocol: "ssh",
+      publishRef,
+    });
+
+    assert.equal(publishedBookmark, publishRef.name);
+    assert.deepStrictEqual(remoteCalls, [{ name: "origin", url: CLONE_URLS.sshUrl }]);
+    assert.deepStrictEqual(result, {
+      repository: { provider: "github", ...CLONE_URLS },
+      remoteName: "origin",
+      remoteUrl: CLONE_URLS.sshUrl,
+      branch: publishRef.name,
+      upstreamBranch: `origin/${publishRef.name}`,
+      status: "pushed",
+      publishRef: { ...publishRef, remoteName: "origin" },
+    });
+  }).pipe(
+    Effect.provide(
+      makeLayer({
+        vcsDriver: driver,
+        vcsSync: {
+          publish: (input) =>
+            Effect.sync(() => {
+              publishedBookmark = input.publishRef.name;
+              return {
+                status: "pushed" as const,
+                remoteName: input.remoteName ?? "origin",
+                publishRef: { ...input.publishRef, remoteName: input.remoteName ?? "origin" },
               };
             }),
         },

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -21,6 +21,8 @@ import {
 
 import { ServerConfig } from "../config.ts";
 import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import * as VcsSyncService from "../vcs/VcsSyncService.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
 
@@ -91,6 +93,8 @@ export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
   const git = (yield* VcsGitProviderCompatibility.VcsGitProviderCompatibility).git;
+  const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
+  const vcsSync = yield* VcsSyncService.VcsSyncService;
   const path = yield* Path.Path;
   const providers = yield* SourceControlProviderRegistry.SourceControlProviderRegistry;
 
@@ -231,6 +235,45 @@ export const make = Effect.gen(function* () {
         visibility: input.visibility,
       });
       const remoteUrl = selectRemoteUrl(urls, input.protocol);
+      const handle = yield* vcsRegistry.resolve({ cwd: input.cwd });
+      if (handle.kind === "jj") {
+        const preferredRemoteName = input.remoteName?.trim() || "origin";
+        const remotes = yield* handle.driver.listRemotes(input.cwd);
+        const matchingRemote = remotes.remotes.find((remote) => remote.url === remoteUrl);
+        const usedNames = new Set(remotes.remotes.map((remote) => remote.name));
+        let remoteName = matchingRemote?.name ?? preferredRemoteName;
+        if (!matchingRemote) {
+          let suffix = 2;
+          while (usedNames.has(remoteName)) {
+            remoteName = `${preferredRemoteName}-${suffix}`;
+            suffix += 1;
+          }
+          yield* handle.driver.addRemote({ cwd: input.cwd, name: remoteName, url: remoteUrl });
+        }
+        if (!input.publishRef) {
+          return {
+            repository: toRepositoryInfo(providerKind, urls),
+            remoteName,
+            remoteUrl,
+            branch: "main",
+            status: "remote_added" as const,
+          };
+        }
+        const published = yield* vcsSync.publish({
+          cwd: input.cwd,
+          remoteName,
+          publishRef: input.publishRef,
+        });
+        return {
+          repository: toRepositoryInfo(providerKind, urls),
+          remoteName,
+          remoteUrl,
+          branch: published.publishRef.name,
+          upstreamBranch: `${remoteName}/${published.publishRef.name}`,
+          status: "pushed" as const,
+          publishRef: published.publishRef,
+        };
+      }
       const remoteName = yield* git.ensureRemote({
         cwd: input.cwd,
         preferredName: input.remoteName?.trim() || "origin",

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -20,7 +20,7 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../config.ts";
-import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsGitProviderCompatibility from "../vcs/VcsGitProviderCompatibility.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
 
@@ -90,7 +90,7 @@ function expandHomePath(input: string, path: Path.Path): string {
 export const make = Effect.gen(function* () {
   const config = yield* ServerConfig;
   const fileSystem = yield* FileSystem.FileSystem;
-  const git = yield* GitVcsDriver.GitVcsDriver;
+  const git = (yield* VcsGitProviderCompatibility.VcsGitProviderCompatibility).git;
   const path = yield* Path.Path;
   const providers = yield* SourceControlProviderRegistry.SourceControlProviderRegistry;
 

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -401,6 +401,12 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
     supportsBookmarks: false,
     supportsAtomicSnapshot: false,
     supportsPushDefaultRemote: true,
+    supportsWorkspaces: true,
+    supportsNamedPublishRefs: true,
+    supportsSelectedFileFinalize: true,
+    supportsThreadLocalRestore: true,
+    supportsDefaultRemotePush: true,
+    supportsGitProviderCompatibility: true,
     ignoreClassifier: "native" as const,
   };
 
@@ -543,6 +549,29 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
     },
   );
 
+  const addRemote: VcsDriver.VcsDriver["Service"]["addRemote"] = (input) =>
+    gitCommand(vcsProcess, "GitVcsDriver.addRemote", input.cwd, [
+      "remote",
+      "add",
+      input.name,
+      input.url,
+    ]).pipe(Effect.asVoid);
+
+  const removeRemote: VcsDriver.VcsDriver["Service"]["removeRemote"] = (input) =>
+    gitCommand(vcsProcess, "GitVcsDriver.removeRemote", input.cwd, [
+      "remote",
+      "remove",
+      input.name,
+    ]).pipe(Effect.asVoid);
+
+  const resolveDefaultRemote: VcsDriver.VcsDriver["Service"]["resolveDefaultRemote"] = (cwd) =>
+    listRemotes(cwd).pipe(
+      Effect.map(
+        ({ remotes }) =>
+          remotes.find((remote) => remote.isPrimary)?.name ?? remotes[0]?.name ?? null,
+      ),
+    );
+
   const filterIgnoredPaths: VcsDriver.VcsDriver["Service"]["filterIgnoredPaths"] = Effect.fn(
     "filterIgnoredPaths",
   )(function* (cwd, relativePaths) {
@@ -595,6 +624,19 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       timeoutMs: 10_000,
       maxOutputBytes: 64 * 1024,
     }).pipe(Effect.asVoid);
+
+  const cloneRepository: VcsDriver.VcsDriver["Service"]["cloneRepository"] = (input) =>
+    vcsProcess
+      .run({
+        operation: "GitVcsDriver.cloneRepository",
+        command: "git",
+        args: ["clone", input.source, input.destination],
+        cwd: input.destination,
+        spawnCwd: globalThis.process.cwd(),
+        timeoutMs: 120_000,
+        maxOutputBytes: 1_000_000,
+      })
+      .pipe(Effect.asVoid);
 
   const resolveHeadCommit = (cwd: string) =>
     execute({
@@ -858,8 +900,12 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
     isInsideWorkTree,
     listWorkspaceFiles,
     listRemotes,
+    addRemote,
+    removeRemote,
+    resolveDefaultRemote,
     filterIgnoredPaths,
     initRepository,
+    cloneRepository,
   };
 });
 

--- a/apps/server/src/vcs/JjProcess.test.ts
+++ b/apps/server/src/vcs/JjProcess.test.ts
@@ -1,0 +1,52 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as JjProcess from "./JjProcess.ts";
+import * as VcsProcess from "./VcsProcess.ts";
+
+const output = (stdout: string): VcsProcess.VcsProcessOutput => ({
+  exitCode: ChildProcessSpawner.ExitCode(0),
+  stdout,
+  stderr: "",
+  stdoutTruncated: false,
+  stderrTruncated: false,
+});
+
+it.effect("accepts the minimum supported jj version", () =>
+  Effect.gen(function* () {
+    const process = yield* JjProcess.JjProcess;
+    assert.equal(yield* process.ensureSupportedVersion("/repo"), "0.42.0");
+  }).pipe(
+    Effect.provide(
+      Layer.effect(JjProcess.JjProcess, JjProcess.make).pipe(
+        Layer.provide(
+          Layer.mock(VcsProcess.VcsProcess)({
+            run: () => Effect.succeed(output("jj 0.42.0\n")),
+          }),
+        ),
+      ),
+    ),
+  ),
+);
+
+it.effect("rejects unsupported jj versions with actionable detail", () =>
+  Effect.gen(function* () {
+    const process = yield* JjProcess.JjProcess;
+    const error = yield* process.ensureSupportedVersion("/repo").pipe(Effect.flip);
+    assert.equal(error._tag, "VcsUnsupportedOperationError");
+    if (error._tag !== "VcsUnsupportedOperationError") return;
+    assert.match(error.detail, /requires jj 0\.42\.0 or newer/);
+  }).pipe(
+    Effect.provide(
+      Layer.effect(JjProcess.JjProcess, JjProcess.make).pipe(
+        Layer.provide(
+          Layer.mock(VcsProcess.VcsProcess)({
+            run: () => Effect.succeed(output("jj 0.41.0\n")),
+          }),
+        ),
+      ),
+    ),
+  ),
+);

--- a/apps/server/src/vcs/JjProcess.test.ts
+++ b/apps/server/src/vcs/JjProcess.test.ts
@@ -50,3 +50,28 @@ it.effect("rejects unsupported jj versions with actionable detail", () =>
     ),
   ),
 );
+
+it.effect("forwards execution environment variables", () => {
+  let observedEnv: NodeJS.ProcessEnv | undefined;
+  const layer = Layer.effect(JjProcess.JjProcess, JjProcess.make).pipe(
+    Layer.provide(
+      Layer.mock(VcsProcess.VcsProcess)({
+        run: (input) => {
+          observedEnv = input.env;
+          return Effect.succeed(output(""));
+        },
+      }),
+    ),
+  );
+
+  return Effect.gen(function* () {
+    const process = yield* JjProcess.JjProcess;
+    yield* process.run({
+      operation: "JjProcess.test.env",
+      cwd: "/repo",
+      args: ["status"],
+      env: { JJ_USER: "T3 Code" },
+    });
+    assert.deepStrictEqual(observedEnv, { JJ_USER: "T3 Code" });
+  }).pipe(Effect.provide(layer));
+});

--- a/apps/server/src/vcs/JjProcess.ts
+++ b/apps/server/src/vcs/JjProcess.ts
@@ -1,0 +1,76 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { VcsUnsupportedOperationError, type VcsError } from "@t3tools/contracts";
+import { inspectJjVersion } from "@t3tools/shared/jjCli";
+import * as VcsProcess from "./VcsProcess.ts";
+
+const MACHINE_ARGS = ["--color=never", "--no-pager"] as const;
+
+export interface JjProcessInput {
+  readonly operation: string;
+  readonly cwd: string;
+  readonly args: ReadonlyArray<string>;
+  readonly repository?: string;
+  readonly stdin?: string;
+  readonly allowNonZeroExit?: boolean;
+  readonly timeoutMs?: number;
+  readonly maxOutputBytes?: number;
+  readonly appendTruncationMarker?: boolean;
+}
+
+export class JjProcess extends Context.Service<
+  JjProcess,
+  {
+    readonly ensureSupportedVersion: (cwd: string) => Effect.Effect<string, VcsError>;
+    readonly run: (input: JjProcessInput) => Effect.Effect<VcsProcess.VcsProcessOutput, VcsError>;
+  }
+>()("t3/vcs/JjProcess") {}
+
+export const make = Effect.gen(function* () {
+  const process = yield* VcsProcess.VcsProcess;
+
+  const ensureSupportedVersion: JjProcess["Service"]["ensureSupportedVersion"] = Effect.fn(
+    "JjProcess.ensureSupportedVersion",
+  )(function* (cwd) {
+    const result = yield* process.run({
+      operation: "JjProcess.ensureSupportedVersion",
+      command: "jj",
+      args: ["--version"],
+      cwd,
+      spawnCwd: globalThis.process.cwd(),
+      timeoutMs: 5_000,
+      maxOutputBytes: 4_096,
+    });
+    const support = inspectJjVersion(result.stdout);
+    if (support.status !== "supported") {
+      return yield* new VcsUnsupportedOperationError({
+        operation: "JjProcess.ensureSupportedVersion",
+        kind: "jj",
+        detail: support.detail,
+      });
+    }
+    return support.version;
+  });
+
+  const run: JjProcess["Service"]["run"] = (input) =>
+    process.run({
+      operation: input.operation,
+      command: "jj",
+      args: [...MACHINE_ARGS, ...input.args],
+      cwd: input.cwd,
+      spawnCwd: input.repository ?? globalThis.process.cwd(),
+      ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+      ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
+      ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+      ...(input.appendTruncationMarker !== undefined
+        ? { appendTruncationMarker: input.appendTruncationMarker }
+        : {}),
+    });
+
+  return JjProcess.of({ ensureSupportedVersion, run });
+});
+
+export const layer = Layer.effect(JjProcess, make).pipe(Layer.provide(VcsProcess.layer));

--- a/apps/server/src/vcs/JjProcess.ts
+++ b/apps/server/src/vcs/JjProcess.ts
@@ -14,6 +14,7 @@ export interface JjProcessInput {
   readonly args: ReadonlyArray<string>;
   readonly repository?: string;
   readonly stdin?: string;
+  readonly env?: NodeJS.ProcessEnv;
   readonly allowNonZeroExit?: boolean;
   readonly timeoutMs?: number;
   readonly maxOutputBytes?: number;
@@ -62,6 +63,7 @@ export const make = Effect.gen(function* () {
       cwd: input.cwd,
       spawnCwd: input.repository ?? globalThis.process.cwd(),
       ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+      ...(input.env !== undefined ? { env: input.env } : {}),
       ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
       ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),

--- a/apps/server/src/vcs/JjVcsDriver.test.ts
+++ b/apps/server/src/vcs/JjVcsDriver.test.ts
@@ -7,7 +7,7 @@ import * as Path from "effect/Path";
 import type * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { VcsProcessExitError, type VcsError } from "@t3tools/contracts";
+import { CheckpointRef, VcsProcessExitError, type VcsError } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as ServerConfig from "../config.ts";
 import { parseTurnDiffFilesFromUnifiedDiff } from "../checkpointing/Diffs.ts";
@@ -55,6 +55,11 @@ const mockedJjDriverLayer = (run: JjProcess.JjProcess["Service"]["run"]) =>
       Layer.mock(JjProcess.JjProcess)({
         ensureSupportedVersion: () => Effect.succeed("0.42.0"),
         run,
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(VcsProcess.VcsProcess)({
+        run: () => Effect.die("unexpected Git checkpoint process"),
       }),
     ),
     Layer.provideMerge(NodeServices.layer),
@@ -557,4 +562,67 @@ it.effect("reads tracked remote bookmarks without inventing a current bookmark",
       assert.isFalse(refs.refs.some((ref) => ref.current));
     }).pipe(Effect.provide(JjContractLayer));
   }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("captures, diffs, restores, and deletes Jujutsu checkpoints", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const driver = yield* VcsDriver.VcsDriver;
+    const checkpoints = driver.checkpoints;
+    assert.isDefined(checkpoints);
+    if (!checkpoints) return;
+    const repository = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-checkpoint-" });
+    yield* driver.initRepository({ cwd: repository, kind: "jj" });
+    const file = path.join(repository, "checkpoint.txt");
+    const firstRef = CheckpointRef.make("refs/t3code/checkpoints/jj-test/0");
+    const secondRef = CheckpointRef.make("refs/t3code/checkpoints/jj-test/1");
+
+    yield* fileSystem.writeFileString(file, "first\n");
+    yield* driver.execute({
+      operation: "JjVcsDriver.checkpointTest.describeFirst",
+      cwd: repository,
+      args: ["describe", "--message", "First checkpoint"],
+    });
+    yield* checkpoints.captureCheckpoint({ cwd: repository, checkpointRef: firstRef });
+
+    yield* fileSystem.writeFileString(file, "second\n");
+    yield* driver.execute({
+      operation: "JjVcsDriver.checkpointTest.describeSecond",
+      cwd: repository,
+      args: ["describe", "--message", "Second checkpoint"],
+    });
+    yield* checkpoints.captureCheckpoint({ cwd: repository, checkpointRef: secondRef });
+
+    assert.isTrue(
+      yield* checkpoints.hasCheckpointRef({ cwd: repository, checkpointRef: firstRef }),
+    );
+    const diff = yield* checkpoints.diffCheckpoints({
+      cwd: repository,
+      fromCheckpointRef: firstRef,
+      toCheckpointRef: secondRef,
+      ignoreWhitespace: false,
+    });
+    assert.include(diff, "-first");
+    assert.include(diff, "+second");
+
+    assert.isTrue(
+      yield* checkpoints.restoreCheckpoint({ cwd: repository, checkpointRef: firstRef }),
+    );
+    assert.equal(yield* fileSystem.readFileString(file), "first\n");
+    const description = yield* driver.execute({
+      operation: "JjVcsDriver.checkpointTest.readDescription",
+      cwd: repository,
+      args: ["log", "--no-graph", "--revisions", "@", "--template", "description"],
+    });
+    assert.equal(description.stdout, "First checkpoint\n");
+
+    yield* checkpoints.deleteCheckpointRefs({
+      cwd: repository,
+      checkpointRefs: [firstRef, secondRef],
+    });
+    assert.isFalse(
+      yield* checkpoints.hasCheckpointRef({ cwd: repository, checkpointRef: firstRef }),
+    );
+  }).pipe(Effect.provide(JjContractLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );

--- a/apps/server/src/vcs/JjVcsDriver.test.ts
+++ b/apps/server/src/vcs/JjVcsDriver.test.ts
@@ -5,11 +5,14 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import type * as PlatformError from "effect/PlatformError";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
-import type { VcsError } from "@t3tools/contracts";
+import { VcsProcessExitError, type VcsError } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as ServerConfig from "../config.ts";
 import { parseTurnDiffFilesFromUnifiedDiff } from "../checkpointing/Diffs.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
+import * as JjProcess from "./JjProcess.ts";
 import * as JjVcsDriver from "./JjVcsDriver.ts";
 import * as VcsDriver from "./VcsDriver.ts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -35,6 +38,28 @@ const runJj = (cwd: string, args: ReadonlyArray<string>) =>
 
 type JjContractError = VcsError | PlatformError.PlatformError;
 
+const processOutput = (
+  stdout: string,
+  options?: { readonly stdoutTruncated?: boolean },
+): VcsProcess.VcsProcessOutput => ({
+  exitCode: ChildProcessSpawner.ExitCode(0),
+  stdout,
+  stderr: "",
+  stdoutTruncated: options?.stdoutTruncated ?? false,
+  stderrTruncated: false,
+});
+
+const mockedJjDriverLayer = (run: JjProcess.JjProcess["Service"]["run"]) =>
+  Layer.effect(VcsDriver.VcsDriver, JjVcsDriver.make).pipe(
+    Layer.provide(
+      Layer.mock(JjProcess.JjProcess)({
+        ensureSupportedVersion: () => Effect.succeed("0.42.0"),
+        run,
+      }),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  );
+
 it("keeps content and bookmark conflicts distinct", () => {
   assert.deepStrictEqual(
     JjVcsDriver.collectJjStatusConflicts({
@@ -50,6 +75,176 @@ it("keeps content and bookmark conflicts distinct", () => {
       { kind: "named-ref", refName: "feature" },
     ],
   );
+});
+
+it.effect("rejects truncated jj workspace paths and status totals", () => {
+  const revision = `${JSON.stringify({
+    commitId: "commit",
+    changeId: "change",
+    description: "",
+    conflict: false,
+    empty: false,
+    parents: ["parent"],
+    workingCopies: [],
+  })}\n`;
+  const changedFile = `${JSON.stringify({
+    path: "partial.txt",
+    status: "modified",
+    conflict: false,
+  })}\n`;
+  const layer = mockedJjDriverLayer((input) => {
+    if (input.operation === "JjVcsDriver.listWorkspaceFiles") {
+      return Effect.succeed(processOutput('"partial.txt"\n', { stdoutTruncated: true }));
+    }
+    if (input.operation === "JjVcsDriver.readRevision") {
+      return Effect.succeed(processOutput(revision));
+    }
+    if (input.operation === "JjVcsDriver.readChangedFiles") {
+      return Effect.succeed(processOutput(changedFile));
+    }
+    if (input.operation === "JjVcsDriver.readStatusState.diff") {
+      return Effect.succeed(
+        processOutput("diff --git a/partial.txt b/partial.txt\n", { stdoutTruncated: true }),
+      );
+    }
+    return Effect.succeed(processOutput(""));
+  });
+
+  return Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    const workspaceError = yield* driver.listWorkspaceFiles("/repo").pipe(Effect.flip);
+    assert.instanceOf(workspaceError, VcsProcessExitError);
+    assert.include(workspaceError.detail, "truncated");
+
+    const getLocalStatus = driver.getLocalStatus;
+    assert.isDefined(getLocalStatus);
+    if (!getLocalStatus) return;
+    const statusError = yield* getLocalStatus({ cwd: "/repo" }).pipe(Effect.flip);
+    assert.instanceOf(statusError, VcsProcessExitError);
+    assert.include(statusError.detail, "truncated");
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("requires one jj tracking target before reporting an upstream", () => {
+  let trackingTargets: ReadonlyArray<string> | undefined;
+  const countRanges: string[] = [];
+  const revision = `${JSON.stringify({
+    commitId: "commit",
+    changeId: "change",
+    description: "",
+    conflict: false,
+    empty: true,
+    parents: ["workspace-base"],
+    workingCopies: [],
+  })}\n`;
+  const layer = mockedJjDriverLayer((input) => {
+    if (input.operation === "JjVcsDriver.readRevision") {
+      return Effect.succeed(processOutput(revision));
+    }
+    if (input.operation === "JjVcsDriver.readBookmarks") {
+      const bookmark = {
+        name: "main",
+        remote: "origin",
+        target: ["visible-target"],
+        ...(trackingTargets === undefined ? {} : { tracking_target: trackingTargets }),
+      };
+      return Effect.succeed(processOutput(`${JSON.stringify(bookmark)}\n`));
+    }
+    if (input.operation === "JjVcsDriver.listRemotes") {
+      return Effect.succeed(processOutput("origin https://example.test/repo.git\n"));
+    }
+    if (input.operation === "JjVcsDriver.countRevisionRange") {
+      countRanges.push(input.args.join(" "));
+      return Effect.succeed(processOutput("commit\n"));
+    }
+    return Effect.succeed(processOutput(""));
+  });
+
+  return Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    const getRemoteStatus = driver.getRemoteStatus;
+    assert.isDefined(getRemoteStatus);
+    if (!getRemoteStatus) return;
+
+    assert.isFalse((yield* getRemoteStatus({ cwd: "/repo" }))?.hasUpstream);
+    trackingTargets = ["left", "right"];
+    assert.isFalse((yield* getRemoteStatus({ cwd: "/repo" }))?.hasUpstream);
+    assert.deepStrictEqual(countRanges, []);
+
+    trackingTargets = ["tracked-target"];
+    assert.isTrue((yield* getRemoteStatus({ cwd: "/repo" }))?.hasUpstream);
+    assert.lengthOf(countRanges, 2);
+    assert.isTrue(countRanges.every((range) => range.includes("tracked-target")));
+    assert.isFalse(countRanges.some((range) => range.includes("visible-target")));
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("forwards execution environment variables to jj", () => {
+  let observedEnv: NodeJS.ProcessEnv | undefined;
+  const layer = mockedJjDriverLayer((input) => {
+    observedEnv = input.env;
+    return Effect.succeed(processOutput(""));
+  });
+
+  return Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    yield* driver.execute({
+      operation: "JjVcsDriver.test.env",
+      cwd: "/repo",
+      args: ["status"],
+      env: { JJ_USER: "T3 Code" },
+    });
+    assert.deepStrictEqual(observedEnv, { JJ_USER: "T3 Code" });
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("counts divergence only for remote bookmarks on the returned page", () => {
+  const countRanges: string[] = [];
+  const bookmarks = [
+    { name: "main", target: ["local-main"] },
+    { name: "main", remote: "origin", target: ["remote-main"] },
+    { name: "other", target: ["local-other"] },
+    { name: "other", remote: "origin", target: ["remote-other"] },
+  ];
+  const layer = mockedJjDriverLayer((input) => {
+    if (input.operation === "JjVcsDriver.readBookmarks") {
+      return Effect.succeed(
+        processOutput(bookmarks.map((bookmark) => JSON.stringify(bookmark)).join("\n") + "\n"),
+      );
+    }
+    if (input.operation === "JjVcsDriver.listRemotes") {
+      return Effect.succeed(processOutput("origin https://example.test/repo.git\n"));
+    }
+    if (input.operation === "JjVcsDriver.countRevisionRange") {
+      countRanges.push(input.args.join(" "));
+      return Effect.succeed(processOutput("commit\n"));
+    }
+    return Effect.succeed(processOutput(""));
+  });
+
+  return Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    const listRefs = driver.listRefs;
+    assert.isDefined(listRefs);
+    if (!listRefs) return;
+
+    const result = yield* listRefs({
+      cwd: "/repo",
+      refKind: "remote",
+      includeMatchingRemoteRefs: true,
+      limit: 1,
+    });
+
+    assert.deepStrictEqual(
+      result.refs.map((ref) => ref.name),
+      ["main@origin"],
+    );
+    assert.equal(result.totalCount, 2);
+    assert.equal(result.nextCursor, 1);
+    assert.lengthOf(countRanges, 2);
+    assert.isTrue(countRanges.every((range) => range.includes("main")));
+    assert.isFalse(countRanges.some((range) => range.includes("other")));
+  }).pipe(Effect.provide(layer));
 });
 
 runVcsDriverContractSuite<VcsDriver.VcsDriver, JjContractError>({
@@ -184,6 +379,7 @@ it.layer(JjContractLayer)("preserves jj Git-format review metadata", (it) =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
+      const hostPlatform = yield* HostProcessPlatform;
       const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-review-metadata-" });
       const driver = yield* VcsDriver.VcsDriver;
       yield* driver.initRepository({ cwd, kind: "jj" });
@@ -195,7 +391,9 @@ it.layer(JjContractLayer)("preserves jj Git-format review metadata", (it) =>
 
       yield* fileSystem.rename(path.join(cwd, "rename-old.txt"), path.join(cwd, "rename-new.txt"));
       yield* fileSystem.remove(path.join(cwd, "deleted.txt"));
-      yield* fileSystem.chmod(path.join(cwd, "script.sh"), 0o755);
+      if (hostPlatform !== "win32") {
+        yield* fileSystem.chmod(path.join(cwd, "script.sh"), 0o755);
+      }
       yield* fileSystem.writeFile(path.join(cwd, "binary.bin"), new Uint8Array([0, 3, 2]));
 
       const getDiffPreview = driver.getDiffPreview;
@@ -205,8 +403,10 @@ it.layer(JjContractLayer)("preserves jj Git-format review metadata", (it) =>
       assert.include(diff, "rename from rename-old.txt");
       assert.include(diff, "rename to rename-new.txt");
       assert.include(diff, "deleted file mode 100644");
-      assert.include(diff, "old mode 100644");
-      assert.include(diff, "new mode 100755");
+      if (hostPlatform !== "win32") {
+        assert.include(diff, "old mode 100644");
+        assert.include(diff, "new mode 100755");
+      }
       assert.match(diff, /Binary files .*binary\.bin.* differ/);
     }),
   ),

--- a/apps/server/src/vcs/JjVcsDriver.test.ts
+++ b/apps/server/src/vcs/JjVcsDriver.test.ts
@@ -1,0 +1,360 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import type * as PlatformError from "effect/PlatformError";
+
+import type { VcsError } from "@t3tools/contracts";
+import * as ServerConfig from "../config.ts";
+import { parseTurnDiffFilesFromUnifiedDiff } from "../checkpointing/Diffs.ts";
+import * as GitVcsDriver from "./GitVcsDriver.ts";
+import * as JjVcsDriver from "./JjVcsDriver.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsProcess from "./VcsProcess.ts";
+import { runVcsDriverContractSuite } from "./testing/VcsDriverContractHarness.ts";
+
+const JjContractLayer = JjVcsDriver.layer.pipe(Layer.provideMerge(NodeServices.layer));
+const GitReviewLayer = GitVcsDriver.vcsLayer.pipe(
+  Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-vcs-review-equivalence-" })),
+  Layer.provideMerge(VcsProcess.layer),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const runJj = (cwd: string, args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    yield* driver.execute({
+      operation: "JjVcsDriver.contract.jj",
+      cwd,
+      args,
+      timeoutMs: 10_000,
+    });
+  });
+
+type JjContractError = VcsError | PlatformError.PlatformError;
+
+it("keeps content and bookmark conflicts distinct", () => {
+  assert.deepStrictEqual(
+    JjVcsDriver.collectJjStatusConflicts({
+      revision: { conflict: true },
+      changedFiles: [{ path: "conflicted.txt", conflict: true }],
+      bookmarks: [
+        { name: "feature", target: ["left", "right"] },
+        { name: "main", remote: "origin", target: ["base"] },
+      ],
+    }),
+    [
+      { kind: "content", path: "conflicted.txt" },
+      { kind: "named-ref", refName: "feature" },
+    ],
+  );
+});
+
+runVcsDriverContractSuite<VcsDriver.VcsDriver, JjContractError>({
+  name: "Jujutsu",
+  kind: "jj",
+  layer: JjContractLayer,
+  fixture: {
+    createRepo: (cwd) =>
+      Effect.gen(function* () {
+        const driver = yield* VcsDriver.VcsDriver;
+        yield* driver.initRepository({ cwd, kind: "jj" });
+      }),
+    writeFile: (cwd, relativePath, contents) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const absolutePath = path.join(cwd, relativePath);
+        yield* fileSystem.makeDirectory(path.dirname(absolutePath), { recursive: true });
+        yield* fileSystem.writeFileString(absolutePath, contents);
+      }),
+    ignorePath: (cwd, pattern) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* fileSystem.writeFileString(path.join(cwd, ".gitignore"), `${pattern}\n`);
+      }),
+  },
+});
+
+it.layer(JjContractLayer)("adds, selects, and removes jj Git remotes", (it) =>
+  it.effect("manages remotes through jj", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-remotes-" });
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd, kind: "jj" });
+
+      yield* driver.addRemote({ cwd, name: "upstream", url: "https://example.test/repo.git" });
+      assert.equal(yield* driver.resolveDefaultRemote(cwd), "upstream");
+      assert.deepStrictEqual(
+        (yield* driver.listRemotes(cwd)).remotes.map(({ name, url, isPrimary }) => ({
+          name,
+          url,
+          isPrimary,
+        })),
+        [{ name: "upstream", url: "https://example.test/repo.git", isPrimary: true }],
+      );
+
+      yield* driver.removeRemote({ cwd, name: "upstream" });
+      assert.deepStrictEqual((yield* driver.listRemotes(cwd)).remotes, []);
+    }),
+  ),
+);
+
+it.layer(JjContractLayer)("clones a colocated repository through jj", (it) =>
+  it.effect("clones", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-clone-" });
+      const source = path.join(root, "source");
+      const destination = path.join(root, "destination");
+      yield* fileSystem.makeDirectory(source);
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd: source, kind: "jj" });
+      yield* fileSystem.writeFileString(path.join(source, "README.md"), "fixture\n");
+      yield* runJj(source, ["commit", "-m", "fixture"]);
+
+      yield* driver.cloneRepository({ kind: "jj", source, destination });
+
+      assert.isTrue(yield* fileSystem.exists(path.join(destination, ".jj")));
+      assert.isTrue(yield* fileSystem.exists(path.join(destination, ".git")));
+      assert.equal((yield* driver.detectRepository(destination))?.kind, "jj");
+    }),
+  ),
+);
+
+it.layer(JjContractLayer)("reads jj status, bookmarks, and review diffs", (it) =>
+  it.effect("models workspace state without a fictional current bookmark", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-status-" });
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd, kind: "jj" });
+      yield* fileSystem.writeFileString(path.join(cwd, "alpha.txt"), "one\ntwo\n");
+      yield* runJj(cwd, ["bookmark", "create", "feature", "-r", "@"]);
+
+      const getLocalStatus = driver.getLocalStatus;
+      const listRefs = driver.listRefs;
+      const getDiffPreview = driver.getDiffPreview;
+      assert.isDefined(getLocalStatus);
+      assert.isDefined(listRefs);
+      assert.isDefined(getDiffPreview);
+      if (!getLocalStatus || !listRefs || !getDiffPreview) return;
+
+      const status = yield* getLocalStatus({ cwd });
+      assert.equal(status.driverKind, "jj");
+      assert.equal(status.refName, null);
+      assert.equal(status.publishRef, null);
+      assert.equal(status.hasWorkingTreeChanges, true);
+      assert.equal(status.workingTree.insertions, 2);
+      assert.deepStrictEqual(status.workingTree.files, [
+        { path: "alpha.txt", insertions: 2, deletions: 0 },
+      ]);
+      assert.equal(status.workspaceRevisionDetails?.changeId, status.workspaceRevision);
+      assert.equal(status.workspaceRevisionDetails?.empty, false);
+
+      const refs = yield* listRefs({ cwd, includeMatchingRemoteRefs: true });
+      assert.deepInclude(
+        refs.refs.find((ref) => ref.name === "feature"),
+        {
+          kind: "bookmark",
+          name: "feature",
+          isRemote: false,
+          current: false,
+        },
+      );
+      assert.isFalse(refs.refs.some((ref) => ref.current));
+
+      const preview = yield* getDiffPreview({ cwd });
+      assert.deepStrictEqual(preview.sources[0]?.diff.match(/^diff --git /gm)?.length, 1);
+      assert.include(preview.sources[0]?.diff ?? "", "a/alpha.txt");
+      assert.equal(preview.sources[0]?.headRef, status.workspaceRevision);
+      assert.match(preview.sources[0]?.id ?? "", /^jj-working-copy:/);
+    }),
+  ),
+);
+
+it.layer(JjContractLayer)("preserves jj Git-format review metadata", (it) =>
+  it.effect("keeps rename, deletion, mode, and binary markers", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-review-metadata-" });
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd, kind: "jj" });
+      yield* fileSystem.writeFileString(path.join(cwd, "rename-old.txt"), "rename\n");
+      yield* fileSystem.writeFileString(path.join(cwd, "deleted.txt"), "deleted\n");
+      yield* fileSystem.writeFileString(path.join(cwd, "script.sh"), "#!/bin/sh\n");
+      yield* fileSystem.writeFile(path.join(cwd, "binary.bin"), new Uint8Array([0, 1, 2]));
+      yield* runJj(cwd, ["commit", "-m", "base"]);
+
+      yield* fileSystem.rename(path.join(cwd, "rename-old.txt"), path.join(cwd, "rename-new.txt"));
+      yield* fileSystem.remove(path.join(cwd, "deleted.txt"));
+      yield* fileSystem.chmod(path.join(cwd, "script.sh"), 0o755);
+      yield* fileSystem.writeFile(path.join(cwd, "binary.bin"), new Uint8Array([0, 3, 2]));
+
+      const getDiffPreview = driver.getDiffPreview;
+      assert.isDefined(getDiffPreview);
+      if (!getDiffPreview) return;
+      const diff = (yield* getDiffPreview({ cwd })).sources[0]?.diff ?? "";
+      assert.include(diff, "rename from rename-old.txt");
+      assert.include(diff, "rename to rename-new.txt");
+      assert.include(diff, "deleted file mode 100644");
+      assert.include(diff, "old mode 100644");
+      assert.include(diff, "new mode 100755");
+      assert.match(diff, /Binary files .*binary\.bin.* differ/);
+    }),
+  ),
+);
+
+it.effect("produces equivalent Git and jj review file lists", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-vcs-review-" });
+    const gitCwd = path.join(root, "git");
+    const jjCwd = path.join(root, "jj");
+    yield* fileSystem.makeDirectory(gitCwd);
+    yield* fileSystem.makeDirectory(jjCwd);
+
+    const gitPatch = yield* Effect.gen(function* () {
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd: gitCwd, kind: "git" });
+      yield* driver.execute({
+        operation: "VcsReviewEquivalence.git.configEmail",
+        cwd: gitCwd,
+        args: ["config", "user.email", "test@example.test"],
+      });
+      yield* driver.execute({
+        operation: "VcsReviewEquivalence.git.configName",
+        cwd: gitCwd,
+        args: ["config", "user.name", "Test"],
+      });
+      yield* fileSystem.writeFileString(path.join(gitCwd, "changed.txt"), "before\n");
+      yield* fileSystem.writeFileString(path.join(gitCwd, "deleted.txt"), "delete\n");
+      yield* driver.execute({
+        operation: "VcsReviewEquivalence.git.add",
+        cwd: gitCwd,
+        args: ["add", "."],
+      });
+      yield* driver.execute({
+        operation: "VcsReviewEquivalence.git.commit",
+        cwd: gitCwd,
+        args: ["commit", "-m", "base"],
+      });
+      yield* fileSystem.writeFileString(path.join(gitCwd, "changed.txt"), "after\n");
+      yield* fileSystem.remove(path.join(gitCwd, "deleted.txt"));
+      return (yield* driver.execute({
+        operation: "VcsReviewEquivalence.git.diff",
+        cwd: gitCwd,
+        args: ["diff", "--patch", "HEAD"],
+      })).stdout;
+    }).pipe(Effect.provide(GitReviewLayer));
+
+    const jjPatch = yield* Effect.gen(function* () {
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd: jjCwd, kind: "jj" });
+      yield* fileSystem.writeFileString(path.join(jjCwd, "changed.txt"), "before\n");
+      yield* fileSystem.writeFileString(path.join(jjCwd, "deleted.txt"), "delete\n");
+      yield* driver.execute({
+        operation: "VcsReviewEquivalence.jj.commit",
+        cwd: jjCwd,
+        args: ["commit", "-m", "base"],
+      });
+      yield* fileSystem.writeFileString(path.join(jjCwd, "changed.txt"), "after\n");
+      yield* fileSystem.remove(path.join(jjCwd, "deleted.txt"));
+      const getDiffPreview = driver.getDiffPreview;
+      assert.isDefined(getDiffPreview);
+      if (!getDiffPreview) return "";
+      return (yield* getDiffPreview({ cwd: jjCwd })).sources[0]?.diff ?? "";
+    }).pipe(Effect.provide(JjContractLayer));
+
+    const paths = (patch: string) =>
+      parseTurnDiffFilesFromUnifiedDiff(patch)
+        .map((file) => file.path)
+        .toSorted();
+    assert.deepStrictEqual(paths(jjPatch), paths(gitPatch));
+    assert.deepStrictEqual(paths(jjPatch), ["changed.txt", "deleted.txt"]);
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("reads tracked remote bookmarks without inventing a current bookmark", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-remote-status-" });
+    const source = path.join(root, "source");
+    const destination = path.join(root, "destination");
+    yield* fileSystem.makeDirectory(source);
+
+    yield* Effect.gen(function* () {
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.initRepository({ cwd: source, kind: "git" });
+      yield* driver.execute({
+        operation: "JjVcsDriver.remoteFixture.defaultBranch",
+        cwd: source,
+        args: ["symbolic-ref", "HEAD", "refs/heads/main"],
+      });
+      yield* driver.execute({
+        operation: "JjVcsDriver.remoteFixture.configEmail",
+        cwd: source,
+        args: ["config", "user.email", "test@example.test"],
+      });
+      yield* driver.execute({
+        operation: "JjVcsDriver.remoteFixture.configName",
+        cwd: source,
+        args: ["config", "user.name", "Test"],
+      });
+      yield* fileSystem.writeFileString(path.join(source, "README.md"), "fixture\n");
+      yield* driver.execute({
+        operation: "JjVcsDriver.remoteFixture.add",
+        cwd: source,
+        args: ["add", "."],
+      });
+      yield* driver.execute({
+        operation: "JjVcsDriver.remoteFixture.commit",
+        cwd: source,
+        args: ["commit", "-m", "base"],
+      });
+    }).pipe(Effect.provide(GitReviewLayer));
+
+    yield* Effect.gen(function* () {
+      const driver = yield* VcsDriver.VcsDriver;
+      yield* driver.cloneRepository({ kind: "jj", source, destination });
+      const getLocalStatus = driver.getLocalStatus;
+      const getRemoteStatus = driver.getRemoteStatus;
+      const listRefs = driver.listRefs;
+      assert.isDefined(getLocalStatus);
+      assert.isDefined(getRemoteStatus);
+      assert.isDefined(listRefs);
+      if (!getLocalStatus || !getRemoteStatus || !listRefs) return;
+
+      const [local, remote, refs] = yield* Effect.all([
+        getLocalStatus({ cwd: destination }),
+        getRemoteStatus({ cwd: destination }),
+        listRefs({ cwd: destination, includeMatchingRemoteRefs: true }),
+      ]);
+      assert.equal(local.refName, null);
+      assert.equal(local.publishRef, null);
+      assert.equal(local.defaultRef, "main@origin");
+      assert.equal(remote?.trackedRemote?.remoteName, "origin");
+      assert.equal(remote?.trackedRemote?.refName, "main");
+      assert.equal(remote?.aheadCount, 0);
+      assert.equal(remote?.behindCount, 0);
+      const remoteMain = refs.refs.find((ref) => ref.name === "main@origin");
+      assert.deepInclude(remoteMain, {
+        kind: "bookmark",
+        remoteName: "origin",
+        tracked: true,
+        current: false,
+        isDefault: true,
+      });
+      assert.isFalse(refs.refs.some((ref) => ref.current));
+    }).pipe(Effect.provide(JjContractLayer));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);

--- a/apps/server/src/vcs/JjVcsDriver.ts
+++ b/apps/server/src/vcs/JjVcsDriver.ts
@@ -52,9 +52,20 @@ function parseRecords<T>(input: {
   readonly operation: string;
   readonly cwd: string;
   readonly output: string;
+  readonly truncated: boolean;
   readonly guard: (value: unknown) => value is T;
   readonly label: string;
 }) {
+  if (input.truncated) {
+    return Effect.fail(
+      dataContractError(
+        input.operation,
+        input.cwd,
+        `jj returned truncated ${input.label} machine output.`,
+      ),
+    );
+  }
+
   return Effect.try({
     try: () => {
       const records = parseJjJsonLines(input.output);
@@ -91,18 +102,19 @@ export function collectJjStatusConflicts(input: {
   readonly revision: Pick<JjRevisionRecord, "conflict">;
   readonly changedFiles: ReadonlyArray<Pick<JjChangedFileRecord, "path" | "conflict">>;
   readonly bookmarks: ReadonlyArray<Pick<JjBookmarkRecord, "name" | "remote" | "target">>;
-}): ReadonlyArray<{
-  readonly kind: "content" | "named-ref";
-  readonly path?: string;
-  readonly refName?: string;
-}> {
-  const contentConflicts: Array<{ readonly kind: "content"; readonly path?: string }> =
-    input.changedFiles
-      .filter((file) => file.conflict)
-      .map((file) => ({ kind: "content", path: file.path }));
-  if (input.revision.conflict && contentConflicts.length === 0) {
-    contentConflicts.push({ kind: "content" });
-  }
+}): ReadonlyArray<
+  | {
+      readonly kind: "content";
+      readonly path: string;
+    }
+  | {
+      readonly kind: "named-ref";
+      readonly refName: string;
+    }
+> {
+  const contentConflicts = input.changedFiles
+    .filter((file) => file.conflict)
+    .map((file) => ({ kind: "content" as const, path: file.path }));
   const namedRefConflicts = input.bookmarks
     .filter((bookmark) => bookmark.target.length > 1)
     .map((bookmark) => ({
@@ -183,6 +195,7 @@ export const make = Effect.gen(function* () {
       repository: input.cwd,
       args: input.args,
       ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+      ...(input.env !== undefined ? { env: input.env } : {}),
       ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
       ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
@@ -220,6 +233,7 @@ export const make = Effect.gen(function* () {
       operation,
       cwd,
       output: result.stdout,
+      truncated: result.stdoutTruncated,
       guard: isJjRevisionRecord,
       label: "revision",
     });
@@ -257,6 +271,7 @@ export const make = Effect.gen(function* () {
       operation,
       cwd,
       output: result.stdout,
+      truncated: result.stdoutTruncated,
       guard: isJjChangedFileRecord,
       label: "changed-file",
     });
@@ -276,6 +291,7 @@ export const make = Effect.gen(function* () {
       operation,
       cwd,
       output: result.stdout,
+      truncated: result.stdoutTruncated,
       guard: isJjBookmarkRecord,
       label: "bookmark",
     });
@@ -372,6 +388,13 @@ export const make = Effect.gen(function* () {
       maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
       appendTruncationMarker: false,
     });
+    if (result.stdoutTruncated) {
+      return yield* dataContractError(
+        "JjVcsDriver.listWorkspaceFiles",
+        cwd,
+        "jj file list returned truncated machine output.",
+      );
+    }
     const records = parseJjJsonLines(result.stdout);
     const paths = records.flatMap((record) => (typeof record === "string" ? [record] : []));
     if (paths.length !== records.length) {
@@ -520,6 +543,13 @@ export const make = Effect.gen(function* () {
     "JjVcsDriver.getLocalStatus",
   )(function* (input) {
     const state = yield* readStatusState(input.cwd);
+    if (state.patchResult.stdoutTruncated) {
+      return yield* dataContractError(
+        "JjVcsDriver.getLocalStatus.diffStats",
+        input.cwd,
+        "jj status patch output was truncated.",
+      );
+    }
     const parsedStats = yield* Effect.try({
       try: () => parseTurnDiffFilesFromUnifiedDiff(state.patchResult.stdout),
       catch: () =>
@@ -578,9 +608,10 @@ export const make = Effect.gen(function* () {
   )(function* (input) {
     const state = yield* readReferenceState(input.cwd);
     const remoteBookmark = state.defaultRemoteBookmark;
-    const remoteTarget = remoteBookmark?.target.length === 1 ? remoteBookmark.target[0] : null;
+    const trackingTarget =
+      remoteBookmark?.tracking_target?.length === 1 ? remoteBookmark.tracking_target[0] : null;
     const workspaceBase = state.revision.parents[0] ?? null;
-    if (!remoteBookmark || !state.defaultRemoteName || !remoteTarget || !workspaceBase) {
+    if (!remoteBookmark || !state.defaultRemoteName || !trackingTarget || !workspaceBase) {
       return {
         trackedRemote: null,
         hasUpstream: false,
@@ -590,12 +621,12 @@ export const make = Effect.gen(function* () {
         pr: null,
       };
     }
-    const quotedRemoteTarget = quoteJjSymbol(remoteTarget);
+    const quotedTrackingTarget = quoteJjSymbol(trackingTarget);
     const quotedWorkspaceBase = quoteJjSymbol(workspaceBase);
     const [aheadCount, behindCount] = yield* Effect.all(
       [
-        countRevisionRange(input.cwd, `${quotedRemoteTarget}..${quotedWorkspaceBase}`),
-        countRevisionRange(input.cwd, `${quotedWorkspaceBase}..${quotedRemoteTarget}`),
+        countRevisionRange(input.cwd, `${quotedTrackingTarget}..${quotedWorkspaceBase}`),
+        countRevisionRange(input.cwd, `${quotedWorkspaceBase}..${quotedTrackingTarget}`),
       ],
       { concurrency: "unbounded" },
     );
@@ -642,45 +673,26 @@ export const make = Effect.gen(function* () {
         .filter((bookmark) => bookmark.remote === undefined)
         .map((bookmark) => [bookmark.name, bookmark]),
     );
-    const refs = yield* Effect.forEach(
-      usableBookmarks,
-      (bookmark) =>
-        Effect.gen(function* () {
-          const isRemote = bookmark.remote !== undefined;
-          const local = isRemote ? localByName.get(bookmark.name) : undefined;
-          const target = bookmark.target.length === 1 ? bookmark.target[0] : null;
-          let aheadCount = 0;
-          let behindCount = 0;
-          if (isRemote && local?.target.length === 1 && target) {
-            const localTarget = quoteJjSymbol(local.target[0] as string);
-            const remoteTarget = quoteJjSymbol(target);
-            [aheadCount, behindCount] = yield* Effect.all(
-              [
-                countRevisionRange(input.cwd, `${remoteTarget}..${localTarget}`),
-                countRevisionRange(input.cwd, `${localTarget}..${remoteTarget}`),
-              ],
-              { concurrency: "unbounded" },
-            );
-          }
-          return {
-            kind: "bookmark" as const,
-            name: remoteBookmarkName(bookmark),
-            ...(isRemote ? { isRemote: true, remoteName: bookmark.remote } : { isRemote: false }),
-            tracked: isRemote && bookmark.tracking_target !== undefined,
-            conflicted: bookmark.target.length > 1,
-            targetRevision: target,
-            aheadCount,
-            behindCount,
-            current: false,
-            isDefault:
-              defaultRemoteBookmark !== null &&
-              bookmark.name === defaultRemoteBookmark.name &&
-              bookmark.remote === defaultRemoteBookmark.remote,
-            worktreePath: null,
-          } satisfies VcsRef;
-        }),
-      { concurrency: 4 },
+    const bookmarkByRefName = new Map(
+      usableBookmarks.map((bookmark) => [remoteBookmarkName(bookmark), bookmark]),
     );
+    const refs: ReadonlyArray<VcsRef> = usableBookmarks.map((bookmark) => {
+      const isRemote = bookmark.remote !== undefined;
+      return {
+        kind: "bookmark",
+        name: remoteBookmarkName(bookmark),
+        ...(isRemote ? { isRemote: true, remoteName: bookmark.remote } : { isRemote: false }),
+        tracked: isRemote && bookmark.tracking_target !== undefined,
+        conflicted: bookmark.target.length > 1,
+        targetRevision: bookmark.target.length === 1 ? bookmark.target[0] : null,
+        current: false,
+        isDefault:
+          defaultRemoteBookmark !== null &&
+          bookmark.name === defaultRemoteBookmark.name &&
+          bookmark.remote === defaultRemoteBookmark.remote,
+        worktreePath: null,
+      } satisfies VcsRef;
+    });
     const localNames = new Set(
       refs.filter((ref) => !ref.isRemote).map((ref) => ref.name.toLocaleLowerCase()),
     );
@@ -705,8 +717,34 @@ export const make = Effect.gen(function* () {
         return leftPriority - rightPriority || left.name.localeCompare(right.name);
       });
     const page = paginateRefs(filteredRefs, input);
+    const pageRefs = yield* Effect.forEach(
+      page.refs,
+      (ref) =>
+        Effect.gen(function* () {
+          let aheadCount = 0;
+          let behindCount = 0;
+          if (ref.isRemote) {
+            const bookmark = bookmarkByRefName.get(ref.name);
+            const local = bookmark ? localByName.get(bookmark.name) : undefined;
+            const remoteTarget = ref.targetRevision;
+            if (local?.target.length === 1 && remoteTarget) {
+              const quotedLocalTarget = quoteJjSymbol(local.target[0] as string);
+              const quotedRemoteTarget = quoteJjSymbol(remoteTarget);
+              [aheadCount, behindCount] = yield* Effect.all(
+                [
+                  countRevisionRange(input.cwd, `${quotedRemoteTarget}..${quotedLocalTarget}`),
+                  countRevisionRange(input.cwd, `${quotedLocalTarget}..${quotedRemoteTarget}`),
+                ],
+                { concurrency: "unbounded" },
+              );
+            }
+          }
+          return { ...ref, aheadCount, behindCount };
+        }),
+      { concurrency: 4 },
+    );
     return {
-      refs: [...page.refs],
+      refs: pageRefs,
       isRepo: true,
       hasPrimaryRemote: defaultRemoteName !== null,
       nextCursor: page.nextCursor,

--- a/apps/server/src/vcs/JjVcsDriver.ts
+++ b/apps/server/src/vcs/JjVcsDriver.ts
@@ -1,0 +1,821 @@
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+
+import {
+  VcsProcessExitError,
+  VcsRepositoryDetectionError,
+  type VcsListRemotesResult,
+  type VcsRef,
+} from "@t3tools/contracts";
+import { detectSourceControlProviderFromGitRemoteUrl } from "@t3tools/shared/git";
+import {
+  JJ_BOOKMARK_JSON_TEMPLATE,
+  JJ_CHANGED_FILE_JSON_TEMPLATE,
+  JJ_REVISION_JSON_TEMPLATE,
+  isJjBookmarkRecord,
+  isJjChangedFileRecord,
+  isJjRevisionRecord,
+  parseJjJsonLines,
+  quoteJjSymbol,
+  type JjBookmarkRecord,
+  type JjChangedFileRecord,
+  type JjRevisionRecord,
+} from "@t3tools/shared/jjCli";
+import { parseTurnDiffFilesFromUnifiedDiff } from "../checkpointing/Diffs.ts";
+import * as JjProcess from "./JjProcess.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+
+const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+const REMOTES_MAX_OUTPUT_BYTES = 256 * 1024;
+const STATUS_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+const REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES = 120_000;
+const FILE_TEMPLATE = 'json(path) ++ "\\n"';
+const COUNT_TEMPLATE = 'commit_id ++ "\\n"';
+
+function dataContractError(operation: string, cwd: string, detail: string) {
+  return new VcsProcessExitError({
+    operation,
+    command: "jj",
+    cwd,
+    exitCode: 0,
+    detail,
+  });
+}
+
+function parseRecords<T>(input: {
+  readonly operation: string;
+  readonly cwd: string;
+  readonly output: string;
+  readonly guard: (value: unknown) => value is T;
+  readonly label: string;
+}) {
+  return Effect.try({
+    try: () => {
+      const records = parseJjJsonLines(input.output);
+      if (!records.every(input.guard)) {
+        throw new Error(`jj returned an invalid ${input.label} JSON record.`);
+      }
+      return records;
+    },
+    catch: () =>
+      dataContractError(
+        input.operation,
+        input.cwd,
+        `jj returned invalid ${input.label} machine output.`,
+      ),
+  });
+}
+
+function paginateRefs(
+  refs: ReadonlyArray<VcsRef>,
+  input: { readonly cursor?: number | undefined; readonly limit?: number | undefined },
+) {
+  const cursor = input.cursor ?? 0;
+  const limit = input.limit ?? 100;
+  const page = refs.slice(cursor, cursor + limit);
+  const nextCursor = cursor + page.length < refs.length ? cursor + page.length : null;
+  return { refs: page, nextCursor, totalCount: refs.length };
+}
+
+function remoteBookmarkName(record: Pick<JjBookmarkRecord, "name" | "remote">): string {
+  return record.remote ? `${record.name}@${record.remote}` : record.name;
+}
+
+export function collectJjStatusConflicts(input: {
+  readonly revision: Pick<JjRevisionRecord, "conflict">;
+  readonly changedFiles: ReadonlyArray<Pick<JjChangedFileRecord, "path" | "conflict">>;
+  readonly bookmarks: ReadonlyArray<Pick<JjBookmarkRecord, "name" | "remote" | "target">>;
+}): ReadonlyArray<{
+  readonly kind: "content" | "named-ref";
+  readonly path?: string;
+  readonly refName?: string;
+}> {
+  const contentConflicts: Array<{ readonly kind: "content"; readonly path?: string }> =
+    input.changedFiles
+      .filter((file) => file.conflict)
+      .map((file) => ({ kind: "content", path: file.path }));
+  if (input.revision.conflict && contentConflicts.length === 0) {
+    contentConflicts.push({ kind: "content" });
+  }
+  const namedRefConflicts = input.bookmarks
+    .filter((bookmark) => bookmark.target.length > 1)
+    .map((bookmark) => ({
+      kind: "named-ref" as const,
+      refName: remoteBookmarkName(bookmark),
+    }));
+  return [...contentConflicts, ...namedRefConflicts];
+}
+
+const nowFreshness = Effect.fn("JjVcsDriver.nowFreshness")(function* () {
+  return {
+    source: "live-local" as const,
+    observedAt: yield* DateTime.now,
+    expiresAt: Option.none(),
+  };
+});
+
+function parseRemoteList(output: string): ReadonlyArray<{ name: string; url: string }> {
+  return output.split("\n").flatMap((line) => {
+    const match = /^(\S+)\s+(.+)$/.exec(line.trim());
+    return match?.[1] && match[2] ? [{ name: match[1], url: match[2] }] : [];
+  });
+}
+
+export const make = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const jj = yield* JjProcess.JjProcess;
+
+  const capabilities = {
+    kind: "jj" as const,
+    supportsWorktrees: false,
+    supportsBookmarks: true,
+    supportsAtomicSnapshot: true,
+    supportsPushDefaultRemote: true,
+    supportsWorkspaces: true,
+    supportsNamedPublishRefs: true,
+    supportsSelectedFileFinalize: true,
+    supportsThreadLocalRestore: true,
+    supportsDefaultRemotePush: true,
+    supportsGitProviderCompatibility: true,
+    ignoreClassifier: "native" as const,
+  };
+
+  const exists = (cwd: string, candidate: string, operation: string) =>
+    fileSystem.exists(candidate).pipe(
+      Effect.mapError(
+        (cause) =>
+          new VcsRepositoryDetectionError({
+            operation,
+            cwd,
+            detail: `Failed to inspect ${candidate}.`,
+            cause,
+          }),
+      ),
+    );
+
+  const findMetadataPath = Effect.fn("JjVcsDriver.findMetadataPath")(function* (cwd: string) {
+    let current = path.resolve(cwd);
+    while (true) {
+      const candidate = path.join(current, ".jj");
+      if (yield* exists(cwd, candidate, "JjVcsDriver.findMetadataPath")) {
+        return candidate;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return null;
+      }
+      current = parent;
+    }
+  });
+
+  const execute: VcsDriver.VcsDriver["Service"]["execute"] = (input) =>
+    jj.run({
+      operation: input.operation,
+      cwd: input.cwd,
+      repository: input.cwd,
+      args: input.args,
+      ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+      ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
+      ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+      ...(input.appendTruncationMarker !== undefined
+        ? { appendTruncationMarker: input.appendTruncationMarker }
+        : {}),
+    });
+
+  const snapshot = (cwd: string, operation: string) =>
+    jj
+      .run({
+        operation,
+        cwd,
+        repository: cwd,
+        args: ["util", "snapshot"],
+        timeoutMs: 20_000,
+        maxOutputBytes: 256 * 1024,
+      })
+      .pipe(Effect.asVoid);
+
+  const readRevision = Effect.fn("JjVcsDriver.readRevision")(function* (
+    cwd: string,
+    revision = "@",
+  ) {
+    const operation = "JjVcsDriver.readRevision";
+    const result = yield* jj.run({
+      operation,
+      cwd,
+      repository: cwd,
+      args: ["log", "--no-graph", "--revisions", revision, "--template", JJ_REVISION_JSON_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: STATUS_MAX_OUTPUT_BYTES,
+    });
+    const records = yield* parseRecords({
+      operation,
+      cwd,
+      output: result.stdout,
+      guard: isJjRevisionRecord,
+      label: "revision",
+    });
+    if (records.length !== 1) {
+      return yield* dataContractError(
+        operation,
+        cwd,
+        `jj revision query returned ${records.length} records; expected exactly one.`,
+      );
+    }
+    return records[0] as JjRevisionRecord;
+  });
+
+  const readChangedFiles = Effect.fn("JjVcsDriver.readChangedFiles")(function* (
+    cwd: string,
+    revision = "@",
+  ) {
+    const operation = "JjVcsDriver.readChangedFiles";
+    const result = yield* jj.run({
+      operation,
+      cwd,
+      repository: cwd,
+      args: [
+        "log",
+        "--no-graph",
+        "--revisions",
+        revision,
+        "--template",
+        JJ_CHANGED_FILE_JSON_TEMPLATE,
+      ],
+      timeoutMs: 10_000,
+      maxOutputBytes: STATUS_MAX_OUTPUT_BYTES,
+    });
+    return yield* parseRecords({
+      operation,
+      cwd,
+      output: result.stdout,
+      guard: isJjChangedFileRecord,
+      label: "changed-file",
+    });
+  });
+
+  const readBookmarks = Effect.fn("JjVcsDriver.readBookmarks")(function* (cwd: string) {
+    const operation = "JjVcsDriver.readBookmarks";
+    const result = yield* jj.run({
+      operation,
+      cwd,
+      repository: cwd,
+      args: ["bookmark", "list", "--all-remotes", "--template", JJ_BOOKMARK_JSON_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: STATUS_MAX_OUTPUT_BYTES,
+    });
+    return yield* parseRecords({
+      operation,
+      cwd,
+      output: result.stdout,
+      guard: isJjBookmarkRecord,
+      label: "bookmark",
+    });
+  });
+
+  const readPatch = (input: {
+    readonly cwd: string;
+    readonly operation: string;
+    readonly args: ReadonlyArray<string>;
+    readonly appendTruncationMarker?: boolean;
+  }) =>
+    jj.run({
+      operation: input.operation,
+      cwd: input.cwd,
+      repository: input.cwd,
+      args: ["diff", "--git", ...input.args],
+      timeoutMs: 30_000,
+      maxOutputBytes: REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: input.appendTruncationMarker ?? true,
+    });
+
+  const hashDiff = (cwd: string, diff: string) =>
+    crypto.digest("SHA-256", new TextEncoder().encode(diff)).pipe(
+      Effect.map(Encoding.encodeHex),
+      Effect.mapError(() =>
+        dataContractError("JjVcsDriver.getDiffPreview.hash", cwd, "Failed to hash jj review diff."),
+      ),
+    );
+
+  const countRevisionRange = Effect.fn("JjVcsDriver.countRevisionRange")(function* (
+    cwd: string,
+    revision: string,
+  ) {
+    const result = yield* jj.run({
+      operation: "JjVcsDriver.countRevisionRange",
+      cwd,
+      repository: cwd,
+      args: ["log", "--no-graph", "--revisions", revision, "--template", COUNT_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: STATUS_MAX_OUTPUT_BYTES,
+    });
+    return result.stdout.split("\n").filter((line) => line.length > 0).length;
+  });
+
+  const detectRepository: VcsDriver.VcsDriver["Service"]["detectRepository"] = Effect.fn(
+    "JjVcsDriver.detectRepository",
+  )(function* (cwd) {
+    const metadataPath = yield* findMetadataPath(cwd);
+    if (metadataPath === null) {
+      return null;
+    }
+
+    yield* jj.ensureSupportedVersion(cwd);
+    const rootResult = yield* jj.run({
+      operation: "JjVcsDriver.detectRepository.root",
+      cwd,
+      repository: cwd,
+      args: ["workspace", "root"],
+      timeoutMs: 5_000,
+      maxOutputBytes: 16 * 1024,
+    });
+    const rootPath = rootResult.stdout.trim();
+    if (rootPath.length === 0) {
+      return yield* new VcsProcessExitError({
+        operation: "JjVcsDriver.detectRepository.root",
+        command: "jj workspace root",
+        cwd,
+        exitCode: rootResult.exitCode,
+        detail: "jj workspace root returned an empty path.",
+      });
+    }
+
+    return {
+      kind: "jj" as const,
+      rootPath,
+      metadataPath,
+      colocated: yield* exists(cwd, path.join(rootPath, ".git"), "JjVcsDriver.detectRepository"),
+      freshness: yield* nowFreshness(),
+    };
+  });
+
+  const isInsideWorkTree: VcsDriver.VcsDriver["Service"]["isInsideWorkTree"] = (cwd) =>
+    findMetadataPath(cwd).pipe(Effect.map((metadataPath) => metadataPath !== null));
+
+  const listWorkspaceFiles: VcsDriver.VcsDriver["Service"]["listWorkspaceFiles"] = Effect.fn(
+    "JjVcsDriver.listWorkspaceFiles",
+  )(function* (cwd) {
+    const result = yield* jj.run({
+      operation: "JjVcsDriver.listWorkspaceFiles",
+      cwd,
+      repository: cwd,
+      args: ["file", "list", "--revision", "@", "--template", FILE_TEMPLATE],
+      timeoutMs: 20_000,
+      maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: false,
+    });
+    const records = parseJjJsonLines(result.stdout);
+    const paths = records.flatMap((record) => (typeof record === "string" ? [record] : []));
+    if (paths.length !== records.length) {
+      return yield* new VcsProcessExitError({
+        operation: "JjVcsDriver.listWorkspaceFiles",
+        command: "jj file list",
+        cwd,
+        exitCode: 0,
+        detail: "jj file list returned a non-string JSON record.",
+      });
+    }
+    return {
+      paths,
+      truncated: result.stdoutTruncated,
+      freshness: yield* nowFreshness(),
+    };
+  });
+
+  const listRemotes: VcsDriver.VcsDriver["Service"]["listRemotes"] = Effect.fn(
+    "JjVcsDriver.listRemotes",
+  )(function* (cwd) {
+    const result = yield* jj.run({
+      operation: "JjVcsDriver.listRemotes",
+      cwd,
+      repository: cwd,
+      args: ["git", "remote", "list"],
+      timeoutMs: 5_000,
+      maxOutputBytes: REMOTES_MAX_OUTPUT_BYTES,
+    });
+    const parsed = parseRemoteList(result.stdout);
+    const primaryName = parsed.some((remote) => remote.name === "origin")
+      ? "origin"
+      : (parsed[0]?.name ?? null);
+    return {
+      remotes: parsed.map((remote) => ({
+        ...remote,
+        pushUrl: Option.none(),
+        isPrimary: remote.name === primaryName,
+      })),
+      freshness: yield* nowFreshness(),
+    };
+  });
+
+  const addRemote: VcsDriver.VcsDriver["Service"]["addRemote"] = (input) =>
+    jj
+      .run({
+        operation: "JjVcsDriver.addRemote",
+        cwd: input.cwd,
+        repository: input.cwd,
+        args: ["git", "remote", "add", input.name, input.url],
+      })
+      .pipe(Effect.asVoid);
+
+  const removeRemote: VcsDriver.VcsDriver["Service"]["removeRemote"] = (input) =>
+    jj
+      .run({
+        operation: "JjVcsDriver.removeRemote",
+        cwd: input.cwd,
+        repository: input.cwd,
+        args: ["git", "remote", "remove", input.name],
+      })
+      .pipe(Effect.asVoid);
+
+  const resolveDefaultRemote: VcsDriver.VcsDriver["Service"]["resolveDefaultRemote"] = (cwd) =>
+    listRemotes(cwd).pipe(
+      Effect.map(
+        ({ remotes }) =>
+          remotes.find((remote) => remote.isPrimary)?.name ?? remotes[0]?.name ?? null,
+      ),
+    );
+
+  const filterIgnoredPaths: VcsDriver.VcsDriver["Service"]["filterIgnoredPaths"] = Effect.fn(
+    "JjVcsDriver.filterIgnoredPaths",
+  )(function* (cwd, relativePaths) {
+    if (relativePaths.length === 0) {
+      return relativePaths;
+    }
+    const listed = new Set((yield* listWorkspaceFiles(cwd)).paths);
+    return yield* Effect.filter(relativePaths, (relativePath) =>
+      exists(cwd, path.join(cwd, relativePath), "JjVcsDriver.filterIgnoredPaths").pipe(
+        Effect.map((exists) => !exists || listed.has(relativePath)),
+      ),
+    );
+  });
+
+  const readStatusState = Effect.fn("JjVcsDriver.readStatusState")(function* (cwd: string) {
+    yield* snapshot(cwd, "JjVcsDriver.readStatusState.snapshot");
+    const [revision, changedFiles, patchResult, bookmarks, remotesResult] = yield* Effect.all(
+      [
+        readRevision(cwd),
+        readChangedFiles(cwd),
+        readPatch({ cwd, operation: "JjVcsDriver.readStatusState.diff", args: ["-r", "@"] }),
+        readBookmarks(cwd),
+        listRemotes(cwd),
+      ],
+      { concurrency: "unbounded" },
+    );
+    const referenceState = normalizeReferenceState({
+      revision,
+      bookmarks,
+      remotesResult,
+    });
+    return { ...referenceState, changedFiles, patchResult };
+  });
+
+  const normalizeReferenceState = (input: {
+    readonly revision: JjRevisionRecord;
+    readonly bookmarks: ReadonlyArray<JjBookmarkRecord>;
+    readonly remotesResult: VcsListRemotesResult;
+  }) => {
+    const remoteNames = new Set(input.remotesResult.remotes.map((remote) => remote.name));
+    const usableBookmarks = input.bookmarks.filter(
+      (bookmark) => bookmark.remote === undefined || remoteNames.has(bookmark.remote),
+    );
+    const defaultRemoteName =
+      input.remotesResult.remotes.find((remote) => remote.isPrimary)?.name ??
+      input.remotesResult.remotes[0]?.name ??
+      null;
+    const remoteBookmarks = usableBookmarks.filter(
+      (bookmark) => bookmark.remote === defaultRemoteName,
+    );
+    const defaultRemoteBookmark =
+      remoteBookmarks.find((bookmark) => bookmark.name === "main") ??
+      remoteBookmarks.find((bookmark) => bookmark.name === "master") ??
+      remoteBookmarks.toSorted((left, right) => left.name.localeCompare(right.name))[0] ??
+      null;
+    return {
+      revision: input.revision,
+      bookmarks: usableBookmarks,
+      remotesResult: input.remotesResult,
+      defaultRemoteName,
+      defaultRemoteBookmark,
+    };
+  };
+
+  const readReferenceState = Effect.fn("JjVcsDriver.readReferenceState")(function* (cwd: string) {
+    yield* snapshot(cwd, "JjVcsDriver.readReferenceState.snapshot");
+    const [revision, bookmarks, remotesResult] = yield* Effect.all(
+      [readRevision(cwd), readBookmarks(cwd), listRemotes(cwd)],
+      { concurrency: "unbounded" },
+    );
+    return normalizeReferenceState({ revision, bookmarks, remotesResult });
+  });
+
+  const getLocalStatus: NonNullable<VcsDriver.VcsDriver["Service"]["getLocalStatus"]> = Effect.fn(
+    "JjVcsDriver.getLocalStatus",
+  )(function* (input) {
+    const state = yield* readStatusState(input.cwd);
+    const parsedStats = yield* Effect.try({
+      try: () => parseTurnDiffFilesFromUnifiedDiff(state.patchResult.stdout),
+      catch: () =>
+        dataContractError(
+          "JjVcsDriver.getLocalStatus.diffStats",
+          input.cwd,
+          "Failed to parse jj Git-format status patch.",
+        ),
+    });
+    const statsByPath = new Map(parsedStats.map((file) => [file.path, file]));
+    let insertions = 0;
+    let deletions = 0;
+    const files = state.changedFiles
+      .map((file) => {
+        const stats = statsByPath.get(file.path) ?? { additions: 0, deletions: 0 };
+        insertions += stats.additions;
+        deletions += stats.deletions;
+        return { path: file.path, insertions: stats.additions, deletions: stats.deletions };
+      })
+      .toSorted((left, right) => left.path.localeCompare(right.path));
+    const conflicts = collectJjStatusConflicts(state);
+    const primaryRemote =
+      state.remotesResult.remotes.find((remote) => remote.isPrimary) ??
+      state.remotesResult.remotes[0];
+    const sourceControlProvider = primaryRemote
+      ? detectSourceControlProviderFromGitRemoteUrl(primaryRemote.url)
+      : null;
+
+    return {
+      isRepo: true,
+      driverKind: "jj" as const,
+      workspaceRevision: state.revision.changeId,
+      workspaceRevisionDetails: {
+        commitId: state.revision.commitId,
+        changeId: state.revision.changeId,
+        description: state.revision.description,
+        parents: [...state.revision.parents],
+        empty: state.revision.empty,
+      },
+      publishRef: null,
+      defaultRef: state.defaultRemoteBookmark
+        ? remoteBookmarkName(state.defaultRemoteBookmark)
+        : null,
+      conflicts: [...conflicts],
+      ...(sourceControlProvider ? { sourceControlProvider } : {}),
+      hasPrimaryRemote: state.defaultRemoteName !== null,
+      isDefaultRef: false,
+      refName: null,
+      hasWorkingTreeChanges: !state.revision.empty,
+      workingTree: { files, insertions, deletions },
+    };
+  });
+
+  const getRemoteStatus: NonNullable<VcsDriver.VcsDriver["Service"]["getRemoteStatus"]> = Effect.fn(
+    "JjVcsDriver.getRemoteStatus",
+  )(function* (input) {
+    const state = yield* readReferenceState(input.cwd);
+    const remoteBookmark = state.defaultRemoteBookmark;
+    const remoteTarget = remoteBookmark?.target.length === 1 ? remoteBookmark.target[0] : null;
+    const workspaceBase = state.revision.parents[0] ?? null;
+    if (!remoteBookmark || !state.defaultRemoteName || !remoteTarget || !workspaceBase) {
+      return {
+        trackedRemote: null,
+        hasUpstream: false,
+        aheadCount: 0,
+        behindCount: 0,
+        aheadOfDefaultCount: 0,
+        pr: null,
+      };
+    }
+    const quotedRemoteTarget = quoteJjSymbol(remoteTarget);
+    const quotedWorkspaceBase = quoteJjSymbol(workspaceBase);
+    const [aheadCount, behindCount] = yield* Effect.all(
+      [
+        countRevisionRange(input.cwd, `${quotedRemoteTarget}..${quotedWorkspaceBase}`),
+        countRevisionRange(input.cwd, `${quotedWorkspaceBase}..${quotedRemoteTarget}`),
+      ],
+      { concurrency: "unbounded" },
+    );
+    return {
+      trackedRemote: {
+        remoteName: state.defaultRemoteName,
+        refName: remoteBookmark.name,
+      },
+      hasUpstream: true,
+      aheadCount,
+      behindCount,
+      aheadOfDefaultCount: aheadCount,
+      pr: null,
+    };
+  });
+
+  const listRefs: NonNullable<VcsDriver.VcsDriver["Service"]["listRefs"]> = Effect.fn(
+    "JjVcsDriver.listRefs",
+  )(function* (input) {
+    yield* snapshot(input.cwd, "JjVcsDriver.listRefs.snapshot");
+    const [bookmarks, remotesResult] = yield* Effect.all(
+      [readBookmarks(input.cwd), listRemotes(input.cwd)],
+      { concurrency: "unbounded" },
+    );
+    const remoteNames = new Set(remotesResult.remotes.map((remote) => remote.name));
+    const defaultRemoteName =
+      remotesResult.remotes.find((remote) => remote.isPrimary)?.name ??
+      remotesResult.remotes[0]?.name ??
+      null;
+    const usableBookmarks = bookmarks.filter(
+      (bookmark) => bookmark.remote === undefined || remoteNames.has(bookmark.remote),
+    );
+    const defaultRemoteBookmark =
+      usableBookmarks.find(
+        (bookmark) => bookmark.remote === defaultRemoteName && bookmark.name === "main",
+      ) ??
+      usableBookmarks.find(
+        (bookmark) => bookmark.remote === defaultRemoteName && bookmark.name === "master",
+      ) ??
+      usableBookmarks.find((bookmark) => bookmark.remote === defaultRemoteName) ??
+      null;
+    const localByName = new Map(
+      usableBookmarks
+        .filter((bookmark) => bookmark.remote === undefined)
+        .map((bookmark) => [bookmark.name, bookmark]),
+    );
+    const refs = yield* Effect.forEach(
+      usableBookmarks,
+      (bookmark) =>
+        Effect.gen(function* () {
+          const isRemote = bookmark.remote !== undefined;
+          const local = isRemote ? localByName.get(bookmark.name) : undefined;
+          const target = bookmark.target.length === 1 ? bookmark.target[0] : null;
+          let aheadCount = 0;
+          let behindCount = 0;
+          if (isRemote && local?.target.length === 1 && target) {
+            const localTarget = quoteJjSymbol(local.target[0] as string);
+            const remoteTarget = quoteJjSymbol(target);
+            [aheadCount, behindCount] = yield* Effect.all(
+              [
+                countRevisionRange(input.cwd, `${remoteTarget}..${localTarget}`),
+                countRevisionRange(input.cwd, `${localTarget}..${remoteTarget}`),
+              ],
+              { concurrency: "unbounded" },
+            );
+          }
+          return {
+            kind: "bookmark" as const,
+            name: remoteBookmarkName(bookmark),
+            ...(isRemote ? { isRemote: true, remoteName: bookmark.remote } : { isRemote: false }),
+            tracked: isRemote && bookmark.tracking_target !== undefined,
+            conflicted: bookmark.target.length > 1,
+            targetRevision: target,
+            aheadCount,
+            behindCount,
+            current: false,
+            isDefault:
+              defaultRemoteBookmark !== null &&
+              bookmark.name === defaultRemoteBookmark.name &&
+              bookmark.remote === defaultRemoteBookmark.remote,
+            worktreePath: null,
+          } satisfies VcsRef;
+        }),
+      { concurrency: 4 },
+    );
+    const localNames = new Set(
+      refs.filter((ref) => !ref.isRemote).map((ref) => ref.name.toLocaleLowerCase()),
+    );
+    const dedupedRefs = input.includeMatchingRemoteRefs
+      ? refs
+      : refs.filter(
+          (ref) =>
+            !ref.isRemote || !localNames.has(ref.name.replace(/@[^@]+$/, "").toLocaleLowerCase()),
+        );
+    const refsForKind =
+      input.refKind === "local"
+        ? dedupedRefs.filter((ref) => !ref.isRemote)
+        : input.refKind === "remote"
+          ? dedupedRefs.filter((ref) => ref.isRemote)
+          : dedupedRefs;
+    const normalizedQuery = input.query?.toLocaleLowerCase() ?? "";
+    const filteredRefs = refsForKind
+      .filter((ref) => ref.name.toLocaleLowerCase().includes(normalizedQuery))
+      .toSorted((left, right) => {
+        const leftPriority = left.isDefault ? 0 : left.isRemote ? 2 : 1;
+        const rightPriority = right.isDefault ? 0 : right.isRemote ? 2 : 1;
+        return leftPriority - rightPriority || left.name.localeCompare(right.name);
+      });
+    const page = paginateRefs(filteredRefs, input);
+    return {
+      refs: [...page.refs],
+      isRepo: true,
+      hasPrimaryRemote: defaultRemoteName !== null,
+      nextCursor: page.nextCursor,
+      totalCount: page.totalCount,
+    };
+  });
+
+  const getDiffPreview: NonNullable<VcsDriver.VcsDriver["Service"]["getDiffPreview"]> = Effect.fn(
+    "JjVcsDriver.getDiffPreview",
+  )(function* (input) {
+    yield* snapshot(input.cwd, "JjVcsDriver.getDiffPreview.snapshot");
+    const revision = yield* readRevision(input.cwd);
+    const baseRef = input.baseRef ?? revision.parents[0] ?? null;
+    const workingResult = yield* readPatch({
+      cwd: input.cwd,
+      operation: "JjVcsDriver.getDiffPreview.workingCopy",
+      args: [...(input.ignoreWhitespace ? ["--ignore-all-space"] : []), "--revision", "@"],
+    });
+    const baseResult = baseRef
+      ? yield* readPatch({
+          cwd: input.cwd,
+          operation: "JjVcsDriver.getDiffPreview.base",
+          args: [
+            ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
+            "--from",
+            quoteJjSymbol(baseRef),
+            "--to",
+            "@",
+          ],
+        })
+      : null;
+    const workingDiff = workingResult.stdout;
+    const baseDiff = baseResult?.stdout ?? "";
+    const [workingDiffHash, baseDiffHash] = yield* Effect.all([
+      hashDiff(input.cwd, workingDiff),
+      hashDiff(input.cwd, baseDiff),
+    ]);
+    return {
+      cwd: input.cwd,
+      generatedAt: yield* DateTime.now,
+      sources: [
+        {
+          id: `jj-working-copy:${revision.changeId}`,
+          kind: "working-tree" as const,
+          title: "Working-copy change",
+          baseRef: revision.parents[0] ?? null,
+          headRef: revision.changeId,
+          diff: workingDiff,
+          diffHash: workingDiffHash,
+          truncated: workingResult.stdoutTruncated,
+        },
+        {
+          id: `jj-range:${baseRef ?? "root"}:${revision.changeId}`,
+          kind: "branch-range" as const,
+          title: baseRef ? `Against ${baseRef}` : "Root change",
+          baseRef,
+          headRef: revision.changeId,
+          diff: baseDiff,
+          diffHash: baseDiffHash,
+          truncated: baseResult?.stdoutTruncated ?? false,
+        },
+      ],
+    };
+  });
+
+  const initRepository: VcsDriver.VcsDriver["Service"]["initRepository"] = Effect.fn(
+    "JjVcsDriver.initRepository",
+  )(function* (input) {
+    yield* jj.ensureSupportedVersion(input.cwd);
+    yield* jj.run({
+      operation: "JjVcsDriver.initRepository",
+      cwd: input.cwd,
+      args: ["git", "init", "--colocate", input.cwd],
+      timeoutMs: 20_000,
+      maxOutputBytes: 256 * 1024,
+    });
+  });
+
+  const cloneRepository: VcsDriver.VcsDriver["Service"]["cloneRepository"] = Effect.fn(
+    "JjVcsDriver.cloneRepository",
+  )(function* (input) {
+    yield* jj.ensureSupportedVersion(path.dirname(input.destination));
+    yield* jj.run({
+      operation: "JjVcsDriver.cloneRepository",
+      cwd: input.destination,
+      args: ["git", "clone", "--colocate", input.source, input.destination],
+      timeoutMs: 120_000,
+      maxOutputBytes: 1_000_000,
+    });
+  });
+
+  return VcsDriver.VcsDriver.of({
+    capabilities,
+    execute,
+    detectRepository,
+    isInsideWorkTree,
+    listWorkspaceFiles,
+    listRemotes,
+    addRemote,
+    removeRemote,
+    resolveDefaultRemote,
+    filterIgnoredPaths,
+    initRepository,
+    cloneRepository,
+    getLocalStatus,
+    getRemoteStatus,
+    listRefs,
+    getDiffPreview,
+  });
+});
+
+export const layer = Layer.effect(VcsDriver.VcsDriver, make).pipe(Layer.provide(JjProcess.layer));

--- a/apps/server/src/vcs/JjVcsDriver.ts
+++ b/apps/server/src/vcs/JjVcsDriver.ts
@@ -6,6 +6,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
 
 import {
   VcsProcessExitError,
@@ -30,13 +31,16 @@ import {
 import { parseTurnDiffFilesFromUnifiedDiff } from "../checkpointing/Diffs.ts";
 import * as JjProcess from "./JjProcess.ts";
 import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsProcess from "./VcsProcess.ts";
 
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const REMOTES_MAX_OUTPUT_BYTES = 256 * 1024;
 const STATUS_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 const REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES = 120_000;
+const CHECKPOINT_DIFF_MAX_OUTPUT_BYTES = 10_000_000;
 const FILE_TEMPLATE = 'json(path) ++ "\\n"';
 const COUNT_TEMPLATE = 'commit_id ++ "\\n"';
+const encodeCheckpointMetadata = Schema.encodeEffect(Schema.UnknownFromJsonString);
 
 function dataContractError(operation: string, cwd: string, detail: string) {
   return new VcsProcessExitError({
@@ -144,6 +148,7 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const jj = yield* JjProcess.JjProcess;
+  const vcsProcess = yield* VcsProcess.VcsProcess;
 
   const capabilities = {
     kind: "jj" as const,
@@ -836,9 +841,226 @@ export const make = Effect.gen(function* () {
     });
   });
 
+  const runCheckpointGit = Effect.fn("JjVcsDriver.checkpoints.runGit")(function* (input: {
+    readonly operation: string;
+    readonly cwd: string;
+    readonly args: ReadonlyArray<string>;
+    readonly stdin?: string;
+    readonly allowNonZeroExit?: boolean;
+    readonly maxOutputBytes?: number;
+  }) {
+    return yield* vcsProcess.run({
+      operation: input.operation,
+      command: "git",
+      cwd: input.cwd,
+      args: input.args,
+      ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+      ...(input.allowNonZeroExit !== undefined ? { allowNonZeroExit: input.allowNonZeroExit } : {}),
+      ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+    });
+  });
+
+  const checkpointMetadataRef = (cwd: string, checkpointRef: string) =>
+    crypto.digest("SHA-256", new TextEncoder().encode(checkpointRef)).pipe(
+      Effect.map(Encoding.encodeHex),
+      Effect.map((digest) => `refs/t3code/checkpoint-metadata/${digest}`),
+      Effect.mapError(() =>
+        dataContractError(
+          "JjVcsDriver.checkpoints.metadataRef",
+          cwd,
+          "Failed to hash checkpoint metadata ref.",
+        ),
+      ),
+    );
+
+  const resolveCheckpointCommit = Effect.fn("JjVcsDriver.checkpoints.resolveCommit")(function* (
+    cwd: string,
+    checkpointRef: string,
+  ) {
+    const result = yield* runCheckpointGit({
+      operation: "JjVcsDriver.checkpoints.resolveCommit",
+      cwd,
+      args: ["rev-parse", "--verify", "--quiet", `${checkpointRef}^{commit}`],
+      allowNonZeroExit: true,
+    });
+    if (result.exitCode !== 0) return null;
+    const commitId = result.stdout.trim();
+    return commitId.length > 0 ? commitId : null;
+  });
+
+  const checkpoints: VcsDriver.VcsCheckpointOps = {
+    captureCheckpoint: Effect.fn("JjVcsDriver.checkpoints.captureCheckpoint")(function* (input) {
+      yield* snapshot(input.cwd, "JjVcsDriver.checkpoints.captureCheckpoint.snapshot");
+      const revision = yield* readRevision(input.cwd);
+      const operationResult = yield* jj.run({
+        operation: "JjVcsDriver.checkpoints.captureCheckpoint.operation",
+        cwd: input.cwd,
+        repository: input.cwd,
+        args: ["operation", "log", "--no-graph", "--limit", "1", "--template", 'id ++ "\\n"'],
+        timeoutMs: 10_000,
+        maxOutputBytes: 256 * 1024,
+      });
+      const operationId = operationResult.stdout.trim();
+      if (operationResult.stdoutTruncated || operationId.length === 0) {
+        return yield* dataContractError(
+          "JjVcsDriver.checkpoints.captureCheckpoint",
+          input.cwd,
+          "jj returned invalid operation metadata.",
+        );
+      }
+      const metadata = yield* encodeCheckpointMetadata({
+        version: 1,
+        checkpointRef: input.checkpointRef,
+        operationId,
+        revision: {
+          commitId: revision.commitId,
+          changeId: revision.changeId,
+          parents: revision.parents,
+          description: revision.description,
+        },
+        workingCopies: revision.workingCopies,
+      }).pipe(
+        Effect.mapError(() =>
+          dataContractError(
+            "JjVcsDriver.checkpoints.captureCheckpoint",
+            input.cwd,
+            "Failed to encode checkpoint metadata.",
+          ),
+        ),
+      );
+      const blob = yield* runCheckpointGit({
+        operation: "JjVcsDriver.checkpoints.captureCheckpoint.hashMetadata",
+        cwd: input.cwd,
+        args: ["hash-object", "-w", "--stdin"],
+        stdin: metadata,
+      });
+      const blobId = blob.stdout.trim();
+      if (blobId.length === 0) {
+        return yield* dataContractError(
+          "JjVcsDriver.checkpoints.captureCheckpoint",
+          input.cwd,
+          "git returned an empty checkpoint metadata object id.",
+        );
+      }
+      const metadataRef = yield* checkpointMetadataRef(input.cwd, input.checkpointRef);
+      yield* runCheckpointGit({
+        operation: "JjVcsDriver.checkpoints.captureCheckpoint.updateRefs",
+        cwd: input.cwd,
+        args: ["update-ref", "--stdin"],
+        stdin: [
+          "start",
+          `update ${input.checkpointRef} ${revision.commitId}`,
+          `update ${metadataRef} ${blobId}`,
+          "prepare",
+          "commit",
+          "",
+        ].join("\n"),
+      });
+    }),
+
+    hasCheckpointRef: (input) =>
+      resolveCheckpointCommit(input.cwd, input.checkpointRef).pipe(
+        Effect.map((commitId) => commitId !== null),
+      ),
+
+    restoreCheckpoint: Effect.fn("JjVcsDriver.checkpoints.restoreCheckpoint")(function* (input) {
+      let commitId = yield* resolveCheckpointCommit(input.cwd, input.checkpointRef);
+      if (!commitId && input.fallbackToHead === true) {
+        commitId = (yield* readRevision(input.cwd)).commitId;
+      }
+      if (!commitId) return false;
+
+      const checkpointRevision = yield* readRevision(input.cwd, quoteJjSymbol(commitId));
+      yield* jj.run({
+        operation: "JjVcsDriver.checkpoints.restoreCheckpoint.content",
+        cwd: input.cwd,
+        repository: input.cwd,
+        args: ["restore", "--from", quoteJjSymbol(commitId), "--into", "@"],
+        timeoutMs: 60_000,
+        maxOutputBytes: 1_000_000,
+      });
+      yield* jj.run({
+        operation: "JjVcsDriver.checkpoints.restoreCheckpoint.description",
+        cwd: input.cwd,
+        repository: input.cwd,
+        args: ["describe", "--stdin", "@"],
+        stdin: checkpointRevision.description,
+        timeoutMs: 20_000,
+        maxOutputBytes: 256 * 1024,
+      });
+      return true;
+    }),
+
+    diffCheckpoints: Effect.fn("JjVcsDriver.checkpoints.diffCheckpoints")(function* (input) {
+      let fromCommit = yield* resolveCheckpointCommit(input.cwd, input.fromCheckpointRef);
+      if (!fromCommit && input.fallbackFromToHead === true) {
+        fromCommit = (yield* readRevision(input.cwd)).commitId;
+      }
+      const toCommit = yield* resolveCheckpointCommit(input.cwd, input.toCheckpointRef);
+      if (!fromCommit || !toCommit) {
+        return yield* dataContractError(
+          "JjVcsDriver.checkpoints.diffCheckpoints",
+          input.cwd,
+          "Checkpoint ref is unavailable for diff operation.",
+        );
+      }
+      const result = yield* jj.run({
+        operation: "JjVcsDriver.checkpoints.diffCheckpoints",
+        cwd: input.cwd,
+        repository: input.cwd,
+        args: [
+          "diff",
+          "--git",
+          ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
+          "--from",
+          quoteJjSymbol(fromCommit),
+          "--to",
+          quoteJjSymbol(toCommit),
+        ],
+        timeoutMs: 60_000,
+        maxOutputBytes: CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
+        appendTruncationMarker: false,
+      });
+      if (result.stdoutTruncated) {
+        return yield* dataContractError(
+          "JjVcsDriver.checkpoints.diffCheckpoints",
+          input.cwd,
+          "jj returned truncated checkpoint diff output.",
+        );
+      }
+      return result.stdout;
+    }),
+
+    deleteCheckpointRefs: Effect.fn("JjVcsDriver.checkpoints.deleteCheckpointRefs")(
+      function* (input) {
+        yield* Effect.forEach(
+          input.checkpointRefs,
+          (checkpointRef) =>
+            Effect.gen(function* () {
+              const metadataRef = yield* checkpointMetadataRef(input.cwd, checkpointRef);
+              yield* runCheckpointGit({
+                operation: "JjVcsDriver.checkpoints.deleteCheckpointRefs",
+                cwd: input.cwd,
+                args: ["update-ref", "-d", checkpointRef],
+                allowNonZeroExit: true,
+              });
+              yield* runCheckpointGit({
+                operation: "JjVcsDriver.checkpoints.deleteCheckpointMetadata",
+                cwd: input.cwd,
+                args: ["update-ref", "-d", metadataRef],
+                allowNonZeroExit: true,
+              });
+            }),
+          { discard: true },
+        );
+      },
+    ),
+  };
+
   return VcsDriver.VcsDriver.of({
     capabilities,
     execute,
+    checkpoints,
     detectRepository,
     isInsideWorkTree,
     listWorkspaceFiles,
@@ -856,4 +1078,7 @@ export const make = Effect.gen(function* () {
   });
 });
 
-export const layer = Layer.effect(VcsDriver.VcsDriver, make).pipe(Layer.provide(JjProcess.layer));
+export const layer = Layer.effect(VcsDriver.VcsDriver, make).pipe(
+  Layer.provide(JjProcess.layer),
+  Layer.provide(VcsProcess.layer),
+);

--- a/apps/server/src/vcs/VcsChangeService.test.ts
+++ b/apps/server/src/vcs/VcsChangeService.test.ts
@@ -1,0 +1,132 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as JjVcsDriver from "./JjVcsDriver.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+import { VcsChangeService, layer } from "./VcsChangeService.ts";
+
+const RegistryLayer = Layer.effect(
+  VcsDriverRegistry.VcsDriverRegistry,
+  Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    return VcsDriverRegistry.VcsDriverRegistry.of({
+      get: () => Effect.succeed(driver),
+      detect: (input) =>
+        driver
+          .detectRepository(input.cwd)
+          .pipe(
+            Effect.map((repository) =>
+              repository ? { kind: "jj" as const, repository, driver } : null,
+            ),
+          ),
+      resolve: (input) =>
+        driver
+          .detectRepository(input.cwd)
+          .pipe(
+            Effect.flatMap((repository) =>
+              repository
+                ? Effect.succeed({ kind: "jj" as const, repository, driver })
+                : Effect.die(`Expected a Jujutsu repository at ${input.cwd}`),
+            ),
+          ),
+    });
+  }),
+).pipe(Layer.provide(JjVcsDriver.layer));
+
+const TestLayer = Layer.merge(layer.pipe(Layer.provide(RegistryLayer)), JjVcsDriver.layer).pipe(
+  Layer.provideMerge(NodeServices.layer),
+);
+
+it.layer(TestLayer)("VcsChangeService", (it) => {
+  it.effect("prepares AI context and finalizes selected and remaining jj changes", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const driver = yield* VcsDriver.VcsDriver;
+      const changes = yield* VcsChangeService;
+      const repository = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-phase5-" });
+      yield* driver.initRepository({ cwd: repository, kind: "jj" });
+
+      const selectedPath = "selected snow-雪.txt";
+      const excludedPath = "excluded.txt";
+      yield* fileSystem.writeFileString(path.join(repository, selectedPath), "selected\n");
+      yield* fileSystem.writeFileString(path.join(repository, excludedPath), "excluded\n");
+
+      const context = yield* changes.prepareMessageContext({
+        cwd: repository,
+        filePaths: [selectedPath],
+      });
+      assert.isNotNull(context);
+      assert.include(context?.summary ?? "", selectedPath);
+      assert.notInclude(context?.summary ?? "", excludedPath);
+      assert.include(context?.patch ?? "", selectedPath);
+      assert.notInclude(context?.patch ?? "", excludedPath);
+
+      const selected = yield* changes.finalizeChange({
+        cwd: repository,
+        message: "Finalize selected file",
+        filePaths: [selectedPath],
+        createPublishRef: "feature/selected-change",
+      });
+      assert.equal(selected.status, "created");
+      if (selected.status !== "created") return;
+      assert.notEqual(selected.finalizedRevision.changeId, selected.workspaceRevision.changeId);
+      assert.deepStrictEqual(selected.publishRef, {
+        kind: "bookmark",
+        name: "feature/selected-change",
+        target: selected.finalizedRevision,
+      });
+
+      const finalizedPatch = yield* driver.execute({
+        operation: "VcsChangeService.test.finalizedPatch",
+        cwd: repository,
+        args: ["diff", "--git", "--revision", "@-"],
+      });
+      assert.include(finalizedPatch.stdout, selectedPath);
+      assert.notInclude(finalizedPatch.stdout, excludedPath);
+
+      const remainingPatch = yield* driver.execute({
+        operation: "VcsChangeService.test.remainingPatch",
+        cwd: repository,
+        args: ["diff", "--git", "--revision", "@"],
+      });
+      assert.include(remainingPatch.stdout, excludedPath);
+      assert.notInclude(remainingPatch.stdout, selectedPath);
+
+      const remaining = yield* changes.finalizeChange({
+        cwd: repository,
+        message: "Finalize remaining file",
+      });
+      assert.equal(remaining.status, "created");
+
+      const empty = yield* changes.finalizeChange({ cwd: repository, message: "Nothing left" });
+      assert.deepStrictEqual(empty, { status: "skipped_no_changes" });
+    }),
+  );
+
+  it.effect("rejects empty messages and invalid selected paths", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const driver = yield* VcsDriver.VcsDriver;
+      const changes = yield* VcsChangeService;
+      const repository = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-phase5-" });
+      yield* driver.initRepository({ cwd: repository, kind: "jj" });
+
+      yield* Effect.flip(changes.finalizeChange({ cwd: repository, message: "   " }));
+      yield* fileSystem.writeFileString(`${repository}/changed.txt`, "changed\n");
+      const error = yield* Effect.flip(
+        changes.finalizeChange({
+          cwd: repository,
+          message: "Invalid selection",
+          filePaths: ["../outside.txt"],
+        }),
+      );
+      assert.include(error.detail, "not changed");
+    }),
+  );
+});

--- a/apps/server/src/vcs/VcsChangeService.test.ts
+++ b/apps/server/src/vcs/VcsChangeService.test.ts
@@ -81,6 +81,7 @@ it.layer(TestLayer)("VcsChangeService", (it) => {
         name: "feature/selected-change",
         target: selected.finalizedRevision,
       });
+      assert.isDefined(selected.publishRef);
 
       const finalizedPatch = yield* driver.execute({
         operation: "VcsChangeService.test.finalizedPatch",
@@ -101,8 +102,12 @@ it.layer(TestLayer)("VcsChangeService", (it) => {
       const remaining = yield* changes.finalizeChange({
         cwd: repository,
         message: "Finalize remaining file",
+        publishRef: selected.publishRef,
       });
       assert.equal(remaining.status, "created");
+      if (remaining.status === "created") {
+        assert.equal(remaining.publishRef?.target?.commitId, remaining.finalizedRevision.commitId);
+      }
 
       const empty = yield* changes.finalizeChange({ cwd: repository, message: "Nothing left" });
       assert.deepStrictEqual(empty, { status: "skipped_no_changes" });

--- a/apps/server/src/vcs/VcsChangeService.ts
+++ b/apps/server/src/vcs/VcsChangeService.ts
@@ -291,6 +291,11 @@ export const make = Effect.gen(function* () {
     "VcsChangeService.prepareMessageContext",
   )(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": "jj",
+        "vcs.workflow": "change",
+        "vcs.operation": "prepare-message-context",
+      });
       const driver = yield* resolveJjDriver(input.cwd);
       const selected = yield* snapshotAndSelect({
         driver,
@@ -335,6 +340,11 @@ export const make = Effect.gen(function* () {
     "VcsChangeService.finalizeChange",
   )(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": "jj",
+        "vcs.workflow": "change",
+        "vcs.operation": "finalize",
+      });
       const message = input.message.trim();
       if (message.length === 0) {
         return yield* changeError({

--- a/apps/server/src/vcs/VcsChangeService.ts
+++ b/apps/server/src/vcs/VcsChangeService.ts
@@ -1,0 +1,446 @@
+import { VcsWorkflowError, type VcsNamedRef, type VcsRevision } from "@t3tools/contracts";
+import {
+  JJ_BOOKMARK_JSON_TEMPLATE,
+  JJ_CHANGED_FILE_JSON_TEMPLATE,
+  JJ_REVISION_JSON_TEMPLATE,
+  classifyJjCommandFailure,
+  isJjBookmarkRecord,
+  isJjChangedFileRecord,
+  isJjRevisionRecord,
+  parseJjJsonLines,
+  quoteJjRootFileFileset,
+  quoteJjSymbol,
+  type JjChangedFileRecord,
+  type JjRevisionRecord,
+} from "@t3tools/shared/jjCli";
+import { resolveAutoFeatureBranchName } from "@t3tools/shared/git";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+
+const CHANGE_METADATA_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+const CHANGE_PATCH_MAX_OUTPUT_BYTES = 120_000;
+const FINALIZE_TIMEOUT_MS = 10 * 60_000;
+const MESSAGE_MAX_LENGTH = 10_000;
+
+export interface VcsChangeMessageContext {
+  readonly summary: string;
+  readonly patch: string;
+  readonly workspaceRevision: VcsRevision;
+}
+
+export interface VcsFinalizeChangeInput {
+  readonly cwd: string;
+  readonly message: string;
+  readonly filePaths?: ReadonlyArray<string>;
+  readonly createPublishRef?: string;
+}
+
+export type VcsFinalizeChangeResult =
+  | { readonly status: "skipped_no_changes" }
+  | {
+      readonly status: "created";
+      readonly finalizedRevision: VcsRevision;
+      readonly workspaceRevision: VcsRevision;
+      readonly publishRef?: VcsNamedRef;
+    };
+
+export class VcsChangeService extends Context.Service<
+  VcsChangeService,
+  {
+    readonly detectKind: (cwd: string) => Effect.Effect<"git" | "jj" | "unknown", VcsWorkflowError>;
+    readonly prepareMessageContext: (input: {
+      readonly cwd: string;
+      readonly filePaths?: ReadonlyArray<string>;
+    }) => Effect.Effect<VcsChangeMessageContext | null, VcsWorkflowError>;
+    readonly finalizeChange: (
+      input: VcsFinalizeChangeInput,
+    ) => Effect.Effect<VcsFinalizeChangeResult, VcsWorkflowError>;
+  }
+>()("t3/vcs/VcsChangeService") {}
+
+function changeError(input: {
+  readonly operation: string;
+  readonly kind?: "git" | "jj" | "unknown";
+  readonly detail: string;
+  readonly recoverable?: boolean;
+}): VcsWorkflowError {
+  return new VcsWorkflowError({
+    workflow: "change",
+    operation: input.operation,
+    kind: input.kind ?? "jj",
+    detail: input.detail,
+    recoverable: input.recoverable ?? false,
+  });
+}
+
+function errorDetail(cause: unknown): string {
+  return cause instanceof Error && cause.message.trim().length > 0 ? cause.message : String(cause);
+}
+
+function toRevision(record: JjRevisionRecord): VcsRevision {
+  return { commitId: record.commitId, changeId: record.changeId };
+}
+
+const isVcsWorkflowError = Schema.is(VcsWorkflowError);
+
+export const make = Effect.gen(function* () {
+  const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+
+  const resolveJjDriver = Effect.fn("VcsChangeService.resolveJjDriver")(function* (cwd: string) {
+    const handle = yield* registry.resolve({ cwd });
+    if (handle.kind !== "jj") {
+      return yield* changeError({
+        operation: "resolve-driver",
+        kind: handle.kind,
+        detail: "Jujutsu change finalization requires a jj repository.",
+      });
+    }
+    return handle.driver;
+  });
+
+  const readRevision = Effect.fn("VcsChangeService.readRevision")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    revision: string,
+  ) {
+    const result = yield* driver.execute({
+      operation: "VcsChangeService.readRevision",
+      cwd,
+      args: ["log", "--no-graph", "--revisions", revision, "--template", JJ_REVISION_JSON_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: CHANGE_METADATA_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: false,
+    });
+    if (result.stdoutTruncated) {
+      return yield* changeError({
+        operation: "read-revision",
+        detail: "jj returned truncated revision metadata.",
+      });
+    }
+    const records = yield* Effect.try({
+      try: () => parseJjJsonLines(result.stdout),
+      catch: (cause) =>
+        changeError({
+          operation: "read-revision",
+          detail: `jj returned invalid revision metadata: ${errorDetail(cause)}`,
+        }),
+    });
+    if (records.length !== 1 || !isJjRevisionRecord(records[0])) {
+      return yield* changeError({
+        operation: "read-revision",
+        detail: "jj returned invalid revision metadata.",
+      });
+    }
+    return records[0];
+  });
+
+  const readChangedFiles = Effect.fn("VcsChangeService.readChangedFiles")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+  ) {
+    const result = yield* driver.execute({
+      operation: "VcsChangeService.readChangedFiles",
+      cwd,
+      args: ["log", "--no-graph", "--revisions", "@", "--template", JJ_CHANGED_FILE_JSON_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: CHANGE_METADATA_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: false,
+    });
+    if (result.stdoutTruncated) {
+      return yield* changeError({
+        operation: "read-changed-files",
+        detail: "jj returned truncated changed-file metadata.",
+      });
+    }
+    const records = yield* Effect.try({
+      try: () => parseJjJsonLines(result.stdout),
+      catch: (cause) =>
+        changeError({
+          operation: "read-changed-files",
+          detail: `jj returned invalid changed-file metadata: ${errorDetail(cause)}`,
+        }),
+    });
+    if (!records.every(isJjChangedFileRecord)) {
+      return yield* changeError({
+        operation: "read-changed-files",
+        detail: "jj returned invalid changed-file metadata.",
+      });
+    }
+    return records as ReadonlyArray<JjChangedFileRecord>;
+  });
+
+  const resolveAvailablePublishRef = Effect.fn("VcsChangeService.resolveAvailablePublishRef")(
+    function* (driver: VcsDriver.VcsDriver["Service"], cwd: string, preferredName: string) {
+      const result = yield* driver.execute({
+        operation: "VcsChangeService.readBookmarks",
+        cwd,
+        args: ["bookmark", "list", "--template", JJ_BOOKMARK_JSON_TEMPLATE],
+        timeoutMs: 10_000,
+        maxOutputBytes: CHANGE_METADATA_MAX_OUTPUT_BYTES,
+        appendTruncationMarker: false,
+      });
+      if (result.stdoutTruncated) {
+        return yield* changeError({
+          operation: "read-bookmarks",
+          detail: "jj returned truncated bookmark metadata.",
+        });
+      }
+      const records = yield* Effect.try({
+        try: () => parseJjJsonLines(result.stdout),
+        catch: (cause) =>
+          changeError({
+            operation: "read-bookmarks",
+            detail: `jj returned invalid bookmark metadata: ${errorDetail(cause)}`,
+          }),
+      });
+      if (!records.every(isJjBookmarkRecord)) {
+        return yield* changeError({
+          operation: "read-bookmarks",
+          detail: "jj returned invalid bookmark metadata.",
+        });
+      }
+      const localNames = records.flatMap((record) =>
+        isJjBookmarkRecord(record) && record.remote === undefined ? [record.name] : [],
+      );
+      return resolveAutoFeatureBranchName(localNames, preferredName);
+    },
+  );
+
+  const resolveSelection = Effect.fn("VcsChangeService.resolveSelection")(function* (
+    changedFiles: ReadonlyArray<JjChangedFileRecord>,
+    filePaths?: ReadonlyArray<string>,
+  ) {
+    if (filePaths === undefined) {
+      return { files: changedFiles, filesets: [] as ReadonlyArray<string> };
+    }
+    const uniquePaths = [...new Set(filePaths)];
+    if (uniquePaths.length === 0) {
+      return yield* changeError({
+        operation: "validate-selection",
+        detail: "Select at least one changed file to finalize.",
+      });
+    }
+    const changedByPath = new Map(changedFiles.map((file) => [file.path, file]));
+    const selected = uniquePaths.flatMap((filePath) => {
+      const file = changedByPath.get(filePath);
+      return file ? [file] : [];
+    });
+    if (selected.length !== uniquePaths.length) {
+      const missing = uniquePaths.filter((filePath) => !changedByPath.has(filePath));
+      return yield* changeError({
+        operation: "validate-selection",
+        detail: `Selected paths are not changed in the current jj change: ${missing.join(", ")}`,
+      });
+    }
+    const filesets = yield* Effect.try({
+      try: () => uniquePaths.map(quoteJjRootFileFileset),
+      catch: (cause) =>
+        changeError({
+          operation: "validate-selection",
+          detail: errorDetail(cause),
+        }),
+    });
+    return { files: selected, filesets };
+  });
+
+  const snapshotAndSelect = Effect.fn("VcsChangeService.snapshotAndSelect")(function* (input: {
+    readonly driver: VcsDriver.VcsDriver["Service"];
+    readonly cwd: string;
+    readonly filePaths?: ReadonlyArray<string>;
+  }) {
+    yield* input.driver.execute({
+      operation: "VcsChangeService.snapshot",
+      cwd: input.cwd,
+      args: ["util", "snapshot"],
+      timeoutMs: 20_000,
+      maxOutputBytes: 256 * 1024,
+    });
+    const revision = yield* readRevision(input.driver, input.cwd, "@");
+    if (revision.empty) {
+      return null;
+    }
+    const changedFiles = yield* readChangedFiles(input.driver, input.cwd);
+    const selection = yield* resolveSelection(changedFiles, input.filePaths);
+    return { revision, selection };
+  });
+
+  const detectKind: VcsChangeService["Service"]["detectKind"] = Effect.fn(
+    "VcsChangeService.detectKind",
+  )(
+    function* (cwd) {
+      const handle = yield* registry.resolve({ cwd });
+      return handle.kind;
+    },
+    Effect.mapError((cause) =>
+      changeError({
+        operation: "detect-kind",
+        kind: "unknown",
+        detail: errorDetail(cause),
+        recoverable: true,
+      }),
+    ),
+  );
+
+  const prepareMessageContext: VcsChangeService["Service"]["prepareMessageContext"] = Effect.fn(
+    "VcsChangeService.prepareMessageContext",
+  )(
+    function* (input) {
+      const driver = yield* resolveJjDriver(input.cwd);
+      const selected = yield* snapshotAndSelect({
+        driver,
+        cwd: input.cwd,
+        ...(input.filePaths ? { filePaths: input.filePaths } : {}),
+      });
+      if (!selected) {
+        return null;
+      }
+      const patchResult = yield* driver.execute({
+        operation: "VcsChangeService.prepareMessageContext.patch",
+        cwd: input.cwd,
+        args: ["diff", "--git", "--revision", "@", ...selected.selection.filesets],
+        timeoutMs: 30_000,
+        maxOutputBytes: CHANGE_PATCH_MAX_OUTPUT_BYTES,
+        appendTruncationMarker: true,
+      });
+      const summary = selected.selection.files
+        .map((file) => `${file.status}\t${file.path}`)
+        .join("\n");
+      if (summary.length === 0 || patchResult.stdout.trim().length === 0) {
+        return null;
+      }
+      return {
+        summary,
+        patch: patchResult.stdout,
+        workspaceRevision: toRevision(selected.revision),
+      };
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : changeError({
+            operation: "prepare-message-context",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  const finalizeChange: VcsChangeService["Service"]["finalizeChange"] = Effect.fn(
+    "VcsChangeService.finalizeChange",
+  )(
+    function* (input) {
+      const message = input.message.trim();
+      if (message.length === 0) {
+        return yield* changeError({
+          operation: "finalize-change",
+          detail: "Change message cannot be empty.",
+        });
+      }
+      if (message.length > MESSAGE_MAX_LENGTH) {
+        return yield* changeError({
+          operation: "finalize-change",
+          detail: `Change message cannot exceed ${MESSAGE_MAX_LENGTH} characters.`,
+        });
+      }
+
+      const driver = yield* resolveJjDriver(input.cwd);
+      const selected = yield* snapshotAndSelect({
+        driver,
+        cwd: input.cwd,
+        ...(input.filePaths ? { filePaths: input.filePaths } : {}),
+      });
+      if (!selected) {
+        return { status: "skipped_no_changes" as const };
+      }
+
+      yield* driver.execute({
+        operation: "VcsChangeService.finalizeChange",
+        cwd: input.cwd,
+        args: ["commit", "--message", message, ...selected.selection.filesets],
+        timeoutMs: FINALIZE_TIMEOUT_MS,
+        maxOutputBytes: 1_000_000,
+      });
+
+      const [finalized, workspace] = yield* Effect.all([
+        readRevision(driver, input.cwd, "@-"),
+        readRevision(driver, input.cwd, "@"),
+      ]);
+      if (finalized.empty) {
+        return yield* changeError({
+          operation: "finalize-change",
+          detail: "jj finalized an empty change instead of the selected changes.",
+        });
+      }
+
+      let publishRef: VcsNamedRef | undefined;
+      if (input.createPublishRef !== undefined) {
+        const preferredPublishName = input.createPublishRef.trim();
+        if (preferredPublishName.length === 0 || preferredPublishName.includes("\0")) {
+          return yield* changeError({
+            operation: "create-publish-ref",
+            detail: "Publish bookmark name cannot be empty or contain NUL bytes.",
+          });
+        }
+        const publishName = yield* resolveAvailablePublishRef(
+          driver,
+          input.cwd,
+          preferredPublishName,
+        );
+        const bookmarkResult = yield* driver.execute({
+          operation: "VcsChangeService.createPublishRef",
+          cwd: input.cwd,
+          args: [
+            "bookmark",
+            "create",
+            publishName,
+            "--revision",
+            quoteJjSymbol(finalized.commitId),
+          ],
+          timeoutMs: 20_000,
+          maxOutputBytes: 256 * 1024,
+        });
+        if (
+          classifyJjCommandFailure({
+            exitCode: bookmarkResult.exitCode,
+            stderr: bookmarkResult.stderr,
+          }) === "invalid-ref"
+        ) {
+          return yield* changeError({
+            operation: "create-publish-ref",
+            detail: "The bookmark cannot be exported as a Git ref.",
+          });
+        }
+        publishRef = {
+          kind: "bookmark",
+          name: publishName,
+          target: toRevision(finalized),
+        };
+      }
+
+      return {
+        status: "created" as const,
+        finalizedRevision: toRevision(finalized),
+        workspaceRevision: toRevision(workspace),
+        ...(publishRef ? { publishRef } : {}),
+      };
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : changeError({
+            operation: "finalize-change",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  return VcsChangeService.of({ detectKind, prepareMessageContext, finalizeChange });
+});
+
+export const layer = Layer.effect(VcsChangeService, make);

--- a/apps/server/src/vcs/VcsChangeService.ts
+++ b/apps/server/src/vcs/VcsChangeService.ts
@@ -38,6 +38,7 @@ export interface VcsFinalizeChangeInput {
   readonly message: string;
   readonly filePaths?: ReadonlyArray<string>;
   readonly createPublishRef?: string;
+  readonly publishRef?: VcsNamedRef;
 }
 
 export type VcsFinalizeChangeResult =
@@ -347,6 +348,18 @@ export const make = Effect.gen(function* () {
           detail: `Change message cannot exceed ${MESSAGE_MAX_LENGTH} characters.`,
         });
       }
+      if (input.createPublishRef !== undefined && input.publishRef !== undefined) {
+        return yield* changeError({
+          operation: "update-publish-ref",
+          detail: "Create and update publish bookmark requests are mutually exclusive.",
+        });
+      }
+      if (input.publishRef !== undefined && input.publishRef.kind !== "bookmark") {
+        return yield* changeError({
+          operation: "update-publish-ref",
+          detail: "Jujutsu publishing requires a bookmark.",
+        });
+      }
 
       const driver = yield* resolveJjDriver(input.cwd);
       const selected = yield* snapshotAndSelect({
@@ -378,7 +391,37 @@ export const make = Effect.gen(function* () {
       }
 
       let publishRef: VcsNamedRef | undefined;
-      if (input.createPublishRef !== undefined) {
+      if (input.publishRef !== undefined) {
+        const bookmarkResult = yield* driver.execute({
+          operation: "VcsChangeService.updatePublishRef",
+          cwd: input.cwd,
+          args: [
+            "bookmark",
+            "set",
+            input.publishRef.name,
+            "--revision",
+            quoteJjSymbol(finalized.commitId),
+          ],
+          timeoutMs: 20_000,
+          maxOutputBytes: 256 * 1024,
+        });
+        if (
+          classifyJjCommandFailure({
+            exitCode: bookmarkResult.exitCode,
+            stderr: bookmarkResult.stderr,
+          }) === "invalid-ref"
+        ) {
+          return yield* changeError({
+            operation: "update-publish-ref",
+            detail: "The bookmark cannot be exported as a Git ref.",
+          });
+        }
+        publishRef = {
+          kind: "bookmark",
+          name: input.publishRef.name,
+          target: toRevision(finalized),
+        };
+      } else if (input.createPublishRef !== undefined) {
         const preferredPublishName = input.createPublishRef.trim();
         if (preferredPublishName.length === 0 || preferredPublishName.includes("\0")) {
           return yield* changeError({

--- a/apps/server/src/vcs/VcsDriver.ts
+++ b/apps/server/src/vcs/VcsDriver.ts
@@ -3,13 +3,21 @@ import type * as Effect from "effect/Effect";
 
 import type {
   VcsDriverCapabilities,
+  VcsAddRemoteInput,
+  VcsCloneRepositoryInput,
   VcsError,
   VcsInitInput,
   VcsListRemotesResult,
+  VcsListRefsInput,
+  VcsListRefsResult,
   VcsListWorkspaceFilesResult,
+  VcsRemoveRemoteInput,
   ReviewDiffPreviewInput,
   ReviewDiffPreviewResult,
   VcsRepositoryIdentity,
+  VcsStatusInput,
+  VcsStatusLocalResult,
+  VcsStatusRemoteResult,
 } from "@t3tools/contracts";
 import { CheckpointRef } from "@t3tools/contracts";
 import * as VcsProcess from "./VcsProcess.ts";
@@ -68,11 +76,22 @@ export class VcsDriver extends Context.Service<
       cwd: string,
     ) => Effect.Effect<VcsListWorkspaceFilesResult, VcsError>;
     readonly listRemotes: (cwd: string) => Effect.Effect<VcsListRemotesResult, VcsError>;
+    readonly addRemote: (input: VcsAddRemoteInput) => Effect.Effect<void, VcsError>;
+    readonly removeRemote: (input: VcsRemoveRemoteInput) => Effect.Effect<void, VcsError>;
+    readonly resolveDefaultRemote: (cwd: string) => Effect.Effect<string | null, VcsError>;
     readonly filterIgnoredPaths: (
       cwd: string,
       relativePaths: ReadonlyArray<string>,
     ) => Effect.Effect<ReadonlyArray<string>, VcsError>;
     readonly initRepository: (input: VcsInitInput) => Effect.Effect<void, VcsError>;
+    readonly cloneRepository: (input: VcsCloneRepositoryInput) => Effect.Effect<void, VcsError>;
+    readonly getLocalStatus?: (
+      input: VcsStatusInput,
+    ) => Effect.Effect<VcsStatusLocalResult, VcsError>;
+    readonly getRemoteStatus?: (
+      input: VcsStatusInput,
+    ) => Effect.Effect<VcsStatusRemoteResult | null, VcsError>;
+    readonly listRefs?: (input: VcsListRefsInput) => Effect.Effect<VcsListRefsResult, VcsError>;
     readonly getDiffPreview?: (
       input: ReviewDiffPreviewInput,
     ) => Effect.Effect<ReviewDiffPreviewResult, VcsError>;

--- a/apps/server/src/vcs/VcsDriverRegistry.test.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.test.ts
@@ -3,6 +3,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as VcsProcess from "./VcsProcess.ts";
@@ -22,28 +23,61 @@ const normalizeGitArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
   args[0] === "-C" && args.length >= 2 ? args.slice(2) : args;
 
 describe("VcsDriverRegistry", () => {
-  it.layer(
-    VcsDriverRegistry.layer.pipe(
-      Layer.provideMerge(VcsProcess.layer),
+  it.effect("prefers jj when automatic detection sees a colocated repository", () => {
+    const layer = Layer.effect(VcsDriverRegistry.VcsDriverRegistry, VcsDriverRegistry.make).pipe(
+      Layer.provide(
+        Layer.mock(VcsProjectConfig.VcsProjectConfig)({
+          resolveKind: (input) => Effect.succeed(input.requestedKind ?? "auto"),
+        }),
+      ),
+      Layer.provide(
+        Layer.effect(
+          JjProcess.JjProcess,
+          Effect.gen(function* () {
+            const fileSystem = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            return JjProcess.JjProcess.of({
+              ensureSupportedVersion: () => Effect.succeed("0.42.0"),
+              run: (input) =>
+                Effect.gen(function* () {
+                  if (input.operation === "JjVcsDriver.initRepository") {
+                    yield* fileSystem.makeDirectory(path.join(input.cwd, ".jj"), {
+                      recursive: true,
+                    });
+                    yield* fileSystem.makeDirectory(path.join(input.cwd, ".git"), {
+                      recursive: true,
+                    });
+                  }
+                  return processOutput(
+                    input.operation === "JjVcsDriver.detectRepository.root" ? `${input.cwd}\n` : "",
+                  );
+                }).pipe(Effect.orDie),
+            });
+          }),
+        ),
+      ),
+      Layer.provide(
+        Layer.mock(VcsProcess.VcsProcess)({
+          run: () => Effect.die("Git process should not run when jj detection succeeds"),
+        }),
+      ),
       Layer.provideMerge(NodeServices.layer),
-    ),
-  )("prefers jj when automatic detection sees a colocated repository", (it) =>
-    it.effect("detects jj before Git", () =>
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-registry-" });
-        const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
-        const jj = yield* registry.get("jj");
-        yield* jj.initRepository({ cwd, kind: "jj" });
+    );
 
-        const detected = yield* registry.resolve({ cwd, requestedKind: "auto" });
+    return Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-registry-" });
+      const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+      const jj = yield* registry.get("jj");
+      yield* jj.initRepository({ cwd, kind: "jj" });
 
-        assert.equal(detected.kind, "jj");
-        assert.equal(detected.repository.colocated, true);
-        assert.equal(detected.driver.capabilities.kind, "jj");
-      }),
-    ),
-  );
+      const detected = yield* registry.resolve({ cwd, requestedKind: "auto" });
+
+      assert.equal(detected.kind, "jj");
+      assert.equal(detected.repository.colocated, true);
+      assert.equal(detected.driver.capabilities.kind, "jj");
+    }).pipe(Effect.provide(layer));
+  });
 
   it.effect("routes directly by VCS driver kind for non-repository workflows", () => {
     const layer = Layer.effect(VcsDriverRegistry.VcsDriverRegistry, VcsDriverRegistry.make).pipe(

--- a/apps/server/src/vcs/VcsDriverRegistry.test.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.test.ts
@@ -2,9 +2,11 @@ import { assert, it, describe } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as FileSystem from "effect/FileSystem";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as VcsProcess from "./VcsProcess.ts";
+import * as JjProcess from "./JjProcess.ts";
 import * as VcsProjectConfig from "./VcsProjectConfig.ts";
 import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
 
@@ -20,12 +22,41 @@ const normalizeGitArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
   args[0] === "-C" && args.length >= 2 ? args.slice(2) : args;
 
 describe("VcsDriverRegistry", () => {
+  it.layer(
+    VcsDriverRegistry.layer.pipe(
+      Layer.provideMerge(VcsProcess.layer),
+      Layer.provideMerge(NodeServices.layer),
+    ),
+  )("prefers jj when automatic detection sees a colocated repository", (it) =>
+    it.effect("detects jj before Git", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const cwd = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-registry-" });
+        const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+        const jj = yield* registry.get("jj");
+        yield* jj.initRepository({ cwd, kind: "jj" });
+
+        const detected = yield* registry.resolve({ cwd, requestedKind: "auto" });
+
+        assert.equal(detected.kind, "jj");
+        assert.equal(detected.repository.colocated, true);
+        assert.equal(detected.driver.capabilities.kind, "jj");
+      }),
+    ),
+  );
+
   it.effect("routes directly by VCS driver kind for non-repository workflows", () => {
     const layer = Layer.effect(VcsDriverRegistry.VcsDriverRegistry, VcsDriverRegistry.make).pipe(
       Layer.provide(NodeServices.layer),
       Layer.provide(
         Layer.mock(VcsProjectConfig.VcsProjectConfig)({
           resolveKind: (input) => Effect.succeed(input.requestedKind ?? "auto"),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(JjProcess.JjProcess)({
+          ensureSupportedVersion: () => Effect.succeed("0.42.0"),
+          run: () => Effect.succeed(processOutput("")),
         }),
       ),
       Layer.provide(
@@ -50,6 +81,12 @@ describe("VcsDriverRegistry", () => {
       Layer.provide(
         Layer.mock(VcsProjectConfig.VcsProjectConfig)({
           resolveKind: (input) => Effect.succeed(input.requestedKind ?? "auto"),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(JjProcess.JjProcess)({
+          ensureSupportedVersion: () => Effect.succeed("0.42.0"),
+          run: () => Effect.succeed(processOutput("")),
         }),
       ),
       Layer.provide(

--- a/apps/server/src/vcs/VcsDriverRegistry.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.ts
@@ -12,6 +12,7 @@ import * as JjProcess from "./JjProcess.ts";
 import * as JjVcsDriver from "./JjVcsDriver.ts";
 import * as VcsProjectConfig from "./VcsProjectConfig.ts";
 import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsProcess from "./VcsProcess.ts";
 
 const DETECTION_CACHE_CAPACITY = 2_048;
 const DETECTION_CACHE_TTL = Duration.seconds(2);
@@ -163,4 +164,5 @@ export const make = Effect.gen(function* () {
 export const layer = Layer.effect(VcsDriverRegistry, make).pipe(
   Layer.provide(VcsProjectConfig.layer),
   Layer.provide(JjProcess.layer),
+  Layer.provide(VcsProcess.layer),
 );

--- a/apps/server/src/vcs/VcsDriverRegistry.ts
+++ b/apps/server/src/vcs/VcsDriverRegistry.ts
@@ -8,6 +8,8 @@ import * as Layer from "effect/Layer";
 import type { VcsDriverKind, VcsError, VcsRepositoryIdentity } from "@t3tools/contracts";
 import { VcsUnsupportedOperationError } from "@t3tools/contracts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
+import * as JjProcess from "./JjProcess.ts";
+import * as JjVcsDriver from "./JjVcsDriver.ts";
 import * as VcsProjectConfig from "./VcsProjectConfig.ts";
 import * as VcsDriver from "./VcsDriver.ts";
 
@@ -63,8 +65,10 @@ function parseDetectionCacheKey(key: string): {
 export const make = Effect.gen(function* () {
   const projectConfig = yield* VcsProjectConfig.VcsProjectConfig;
   const git = yield* GitVcsDriver.makeVcsDriver;
+  const jj = yield* JjVcsDriver.make;
   const drivers: Partial<Record<VcsDriverKind, VcsDriver.VcsDriver["Service"]>> = {
     git,
+    jj,
   };
 
   const get: VcsDriverRegistry["Service"]["get"] = (kind) => {
@@ -108,6 +112,10 @@ export const make = Effect.gen(function* () {
       return yield* detectWithDriver(requestedKind, driver, input.cwd);
     }
 
+    const jjRepository = yield* detectWithDriver("jj", jj, input.cwd);
+    if (jjRepository) {
+      return jjRepository;
+    }
     return yield* detectWithDriver("git", git, input.cwd);
   });
 
@@ -154,4 +162,5 @@ export const make = Effect.gen(function* () {
 
 export const layer = Layer.effect(VcsDriverRegistry, make).pipe(
   Layer.provide(VcsProjectConfig.layer),
+  Layer.provide(JjProcess.layer),
 );

--- a/apps/server/src/vcs/VcsGitProviderCompatibility.ts
+++ b/apps/server/src/vcs/VcsGitProviderCompatibility.ts
@@ -1,0 +1,24 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as GitVcsDriver from "./GitVcsDriver.ts";
+
+/**
+ * Narrow compatibility boundary for provider CLIs/APIs that still require
+ * Git branch and ref semantics in colocated repositories.
+ */
+export class VcsGitProviderCompatibility extends Context.Service<
+  VcsGitProviderCompatibility,
+  {
+    readonly git: GitVcsDriver.GitVcsDriver["Service"];
+  }
+>()("t3/vcs/VcsGitProviderCompatibility") {}
+
+export const make = Effect.gen(function* () {
+  return VcsGitProviderCompatibility.of({
+    git: yield* GitVcsDriver.GitVcsDriver,
+  });
+});
+
+export const layer = Layer.effect(VcsGitProviderCompatibility, make);

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import { TestClock } from "effect/testing";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   VcsProcessExitError,
@@ -34,13 +35,14 @@ const baseInput = {
 
 const captureProcessResult = (
   result: Effect.Effect<ProcessRunner.ProcessRunOutput, ProcessRunner.ProcessRunError>,
+  input: VcsProcess.VcsProcessInput = baseInput,
 ) =>
   VcsProcess.make.pipe(
     Effect.provideService(
       ProcessRunner.ProcessRunner,
       ProcessRunner.ProcessRunner.of({ run: () => result }),
     ),
-    Effect.flatMap((service) => service.run(baseInput)),
+    Effect.flatMap((service) => service.run(input)),
     Effect.flip,
   );
 
@@ -138,6 +140,36 @@ describe("VcsProcess.run", () => {
       expect(error.message).not.toContain(secretStderr);
       expect(error.message).not.toContain("super-secret-token");
     }).pipe(provideLive),
+  );
+
+  it.effect("classifies jj failures without retaining stderr", () =>
+    Effect.gen(function* () {
+      const secretStderr = "Working copy is stale. token super-secret-token";
+      const error = yield* captureProcessResult(
+        Effect.succeed({
+          stdout: "",
+          stderr: secretStderr,
+          code: ChildProcessSpawner.ExitCode(1),
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        }),
+        {
+          operation: "test.jj-stale-workspace",
+          command: "jj",
+          args: ["status"],
+          cwd: process.cwd(),
+        },
+      );
+
+      expect(error).toMatchObject({
+        _tag: "VcsProcessExitError",
+        failureKind: "stale-workspace",
+        detail: "The Jujutsu workspace is stale and must be updated.",
+      });
+      expect(error.message).not.toContain(secretStderr);
+      expect(error.message).not.toContain("super-secret-token");
+    }),
   );
 
   it.effect("retains spawn causes without exposing process arguments in the error message", () =>

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -15,6 +15,7 @@ import {
   VcsProcessStdinWriteError,
   VcsProcessTimeoutError,
 } from "@t3tools/contracts";
+import { classifyJjCommandFailure } from "@t3tools/shared/jjCli";
 import * as ProcessRunner from "../processRunner.ts";
 
 export interface VcsProcessInput {
@@ -50,7 +51,15 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 
-const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFailureKind => {
+const classifyNonZeroExit = (
+  command: string,
+  stderr: string,
+  exitCode: number,
+): VcsProcessExitFailureKind => {
+  if (command === "jj") {
+    return classifyJjCommandFailure({ exitCode, stderr }) ?? "command-failed";
+  }
+
   const normalized = stderr.toLowerCase();
 
   if (
@@ -153,7 +162,7 @@ export const make = Effect.gen(function* () {
           stderr: result.stderr,
           stderrTruncated: result.stderrTruncated,
         },
-        classifyNonZeroExit(input.command, result.stderr),
+        classifyNonZeroExit(input.command, result.stderr, result.code),
       );
     }
 

--- a/apps/server/src/vcs/VcsProvisioningService.test.ts
+++ b/apps/server/src/vcs/VcsProvisioningService.test.ts
@@ -50,10 +50,17 @@ function makeDriver(calls: string[]): VcsDriver.VcsDriver["Service"] {
           expiresAt: Option.none(),
         },
       }),
+    addRemote: () => Effect.void,
+    removeRemote: () => Effect.void,
+    resolveDefaultRemote: () => Effect.succeed(null),
     filterIgnoredPaths: (_cwd, relativePaths) => Effect.succeed(relativePaths),
     initRepository: (input) =>
       Effect.sync(() => {
         calls.push(`${input.kind ?? "default"}:${input.cwd}`);
+      }),
+    cloneRepository: (input) =>
+      Effect.sync(() => {
+        calls.push(`${input.kind ?? "default"}:${input.source}->${input.destination}`);
       }),
   };
 }

--- a/apps/server/src/vcs/VcsProvisioningService.ts
+++ b/apps/server/src/vcs/VcsProvisioningService.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import {
   type VcsDriverKind,
   type VcsError,
+  type VcsCloneRepositoryInput,
   type VcsInitInput,
   VcsUnsupportedOperationError,
 } from "@t3tools/contracts";
@@ -14,6 +15,7 @@ export class VcsProvisioningService extends Context.Service<
   VcsProvisioningService,
   {
     readonly initRepository: (input: VcsInitInput) => Effect.Effect<void, VcsError>;
+    readonly cloneRepository: (input: VcsCloneRepositoryInput) => Effect.Effect<void, VcsError>;
   }
 >()("t3/vcs/VcsProvisioningService") {}
 
@@ -46,8 +48,17 @@ export const make = Effect.gen(function* () {
     return yield* driver.initRepository(input);
   });
 
+  const cloneRepository: VcsProvisioningService["Service"]["cloneRepository"] = Effect.fn(
+    "VcsProvisioningService.cloneRepository",
+  )(function* (input) {
+    const kind = yield* resolveRequestedKind(input.kind);
+    const driver = yield* registry.get(kind);
+    return yield* driver.cloneRepository(input);
+  });
+
   return VcsProvisioningService.of({
     initRepository,
+    cloneRepository,
   });
 });
 

--- a/apps/server/src/vcs/VcsReviewService.ts
+++ b/apps/server/src/vcs/VcsReviewService.ts
@@ -196,6 +196,11 @@ export const make = Effect.gen(function* () {
     "VcsReviewService.prepareReview",
   )(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": "jj",
+        "vcs.workflow": "sync",
+        "vcs.operation": "prepare-review",
+      });
       const { driver, repositoryRoot } = yield* resolveJjDriver(input.cwd);
       const bookmarkName = `t3code-review-${input.changeRequestNumber}`;
       let remoteName = input.remoteName?.trim() ?? "";

--- a/apps/server/src/vcs/VcsReviewService.ts
+++ b/apps/server/src/vcs/VcsReviewService.ts
@@ -1,0 +1,327 @@
+import * as NodeCrypto from "node:crypto";
+
+import { VcsWorkflowError, type ThreadId } from "@t3tools/contracts";
+import {
+  JJ_BOOKMARK_JSON_TEMPLATE,
+  JJ_REVISION_JSON_TEMPLATE,
+  JJ_WORKSPACE_JSON_TEMPLATE,
+  isJjBookmarkRecord,
+  isJjRevisionRecord,
+  isJjWorkspaceRecord,
+  parseJjJsonLines,
+  quoteJjSymbol,
+  type JjBookmarkRecord,
+  type JjRevisionRecord,
+  type JjWorkspaceRecord,
+} from "@t3tools/shared/jjCli";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import * as ServerConfig from "../config.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+
+const METADATA_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+const REMOTE_OPERATION_TIMEOUT_MS = 10 * 60_000;
+
+export interface VcsPrepareReviewResult {
+  readonly bookmarkName: string;
+  readonly remoteName: string;
+  readonly workspacePath: string | null;
+}
+
+export class VcsReviewService extends Context.Service<
+  VcsReviewService,
+  {
+    readonly prepareReview: (input: {
+      readonly cwd: string;
+      readonly changeRequestNumber: number;
+      readonly headRefName: string;
+      readonly mode: "local" | "worktree";
+      readonly threadId?: ThreadId;
+      readonly remoteName?: string;
+      readonly remoteUrl?: string;
+    }) => Effect.Effect<VcsPrepareReviewResult, VcsWorkflowError>;
+  }
+>()("t3/vcs/VcsReviewService") {}
+
+function reviewError(input: {
+  readonly operation: string;
+  readonly detail: string;
+  readonly recoverable?: boolean;
+}): VcsWorkflowError {
+  return new VcsWorkflowError({
+    workflow: "sync",
+    operation: input.operation,
+    kind: "jj",
+    detail: input.detail,
+    recoverable: input.recoverable ?? false,
+  });
+}
+
+function errorDetail(cause: unknown): string {
+  return cause instanceof Error && cause.message.trim().length > 0 ? cause.message : String(cause);
+}
+
+const isVcsWorkflowError = Schema.is(VcsWorkflowError);
+
+export const make = Effect.gen(function* () {
+  const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const { worktreesDir } = yield* ServerConfig.ServerConfig;
+
+  const resolveJjDriver = Effect.fn("VcsReviewService.resolveJjDriver")(function* (cwd: string) {
+    const handle = yield* registry.resolve({ cwd });
+    if (handle.kind !== "jj") {
+      return yield* reviewError({
+        operation: "resolve-driver",
+        detail: `Jujutsu review preparation requires a jj repository; detected ${handle.kind}.`,
+      });
+    }
+    return { driver: handle.driver, repositoryRoot: handle.repository.rootPath };
+  });
+
+  const readRecords = Effect.fn("VcsReviewService.readRecords")(function* <T>(input: {
+    readonly driver: VcsDriver.VcsDriver["Service"];
+    readonly cwd: string;
+    readonly operation: string;
+    readonly args: ReadonlyArray<string>;
+    readonly label: string;
+    readonly guard: (value: unknown) => value is T;
+  }) {
+    const result = yield* input.driver.execute({
+      operation: input.operation,
+      cwd: input.cwd,
+      args: input.args,
+      timeoutMs: 20_000,
+      maxOutputBytes: METADATA_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: false,
+    });
+    if (result.stdoutTruncated) {
+      return yield* reviewError({
+        operation: input.operation,
+        detail: `jj returned truncated ${input.label} metadata.`,
+      });
+    }
+    const records = yield* Effect.try({
+      try: () => parseJjJsonLines(result.stdout),
+      catch: (cause) =>
+        reviewError({
+          operation: input.operation,
+          detail: `jj returned invalid ${input.label} metadata: ${errorDetail(cause)}`,
+        }),
+    });
+    if (!records.every(input.guard)) {
+      return yield* reviewError({
+        operation: input.operation,
+        detail: `jj returned invalid ${input.label} metadata.`,
+      });
+    }
+    return records as ReadonlyArray<T>;
+  });
+
+  const readRevision = Effect.fn("VcsReviewService.readRevision")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    revision: string,
+  ) {
+    const records = yield* readRecords({
+      driver,
+      cwd,
+      operation: "VcsReviewService.readRevision",
+      args: ["log", "--no-graph", "--revisions", revision, "--template", JJ_REVISION_JSON_TEMPLATE],
+      label: "revision",
+      guard: isJjRevisionRecord,
+    });
+    if (records.length !== 1) {
+      return yield* reviewError({
+        operation: "read-revision",
+        detail: `Expected one jj revision for ${revision}; received ${records.length}.`,
+      });
+    }
+    return records[0] as JjRevisionRecord;
+  });
+
+  const readBookmarks = Effect.fn("VcsReviewService.readBookmarks")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+  ) {
+    return yield* readRecords<JjBookmarkRecord>({
+      driver,
+      cwd,
+      operation: "VcsReviewService.readBookmarks",
+      args: ["bookmark", "list", "--all-remotes", "--template", JJ_BOOKMARK_JSON_TEMPLATE],
+      label: "bookmark",
+      guard: isJjBookmarkRecord,
+    });
+  });
+
+  const readWorkspaces = Effect.fn("VcsReviewService.readWorkspaces")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+  ) {
+    return yield* readRecords<JjWorkspaceRecord>({
+      driver,
+      cwd,
+      operation: "VcsReviewService.readWorkspaces",
+      args: ["workspace", "list", "--template", JJ_WORKSPACE_JSON_TEMPLATE],
+      label: "workspace",
+      guard: isJjWorkspaceRecord,
+    });
+  });
+
+  const resolveRemoteName = Effect.fn("VcsReviewService.resolveRemoteName")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    requested?: string,
+  ) {
+    const trimmed = requested?.trim() ?? "";
+    if (trimmed.length > 0) return trimmed;
+    const remoteName = yield* driver.resolveDefaultRemote(cwd);
+    if (!remoteName) {
+      return yield* reviewError({
+        operation: "resolve-remote",
+        detail: "No Git remote is configured for this Jujutsu repository.",
+      });
+    }
+    return remoteName;
+  });
+
+  const prepareReview: VcsReviewService["Service"]["prepareReview"] = Effect.fn(
+    "VcsReviewService.prepareReview",
+  )(
+    function* (input) {
+      const { driver, repositoryRoot } = yield* resolveJjDriver(input.cwd);
+      const bookmarkName = `t3code-review-${input.changeRequestNumber}`;
+      let remoteName = input.remoteName?.trim() ?? "";
+
+      if (input.remoteUrl) {
+        const remotes = yield* driver.listRemotes(input.cwd);
+        const matchingRemote = remotes.remotes.find((remote) => remote.url === input.remoteUrl);
+        if (matchingRemote) {
+          remoteName = matchingRemote.name;
+        } else {
+          const preferredName = remoteName || bookmarkName;
+          const collision = remotes.remotes.find((remote) => remote.name === preferredName);
+          remoteName = collision
+            ? `${preferredName}-${NodeCrypto.createHash("sha256").update(input.remoteUrl).digest("hex").slice(0, 8)}`
+            : preferredName;
+          yield* driver.addRemote({ cwd: input.cwd, name: remoteName, url: input.remoteUrl });
+        }
+      } else {
+        remoteName = yield* resolveRemoteName(driver, input.cwd, remoteName || undefined);
+      }
+
+      yield* driver.execute({
+        operation: "VcsReviewService.prepareReview.fetch",
+        cwd: input.cwd,
+        args: ["git", "fetch", "--remote", remoteName],
+        timeoutMs: REMOTE_OPERATION_TIMEOUT_MS,
+        maxOutputBytes: 1_000_000,
+      });
+      const bookmarks = yield* readBookmarks(driver, input.cwd);
+      const remoteBookmark = bookmarks.find(
+        (bookmark) => bookmark.remote === remoteName && bookmark.name === input.headRefName,
+      );
+      const target = remoteBookmark?.target.length === 1 ? remoteBookmark.target[0] : undefined;
+      if (!target) {
+        return yield* reviewError({
+          operation: "prepare-review",
+          detail: `Remote bookmark ${input.headRefName}@${remoteName} is missing or conflicted.`,
+          recoverable: true,
+        });
+      }
+
+      yield* driver.execute({
+        operation: "VcsReviewService.prepareReview.bookmark",
+        cwd: input.cwd,
+        args: ["bookmark", "set", bookmarkName, "--revision", quoteJjSymbol(target)],
+        timeoutMs: 20_000,
+        maxOutputBytes: 256 * 1024,
+      });
+
+      if (input.mode === "local") {
+        const current = yield* readRevision(driver, input.cwd, "@");
+        if (!(current.empty && current.parents.length === 1 && current.parents[0] === target)) {
+          yield* driver.execute({
+            operation: "VcsReviewService.prepareReview.new",
+            cwd: input.cwd,
+            args: ["new", quoteJjSymbol(target)],
+            timeoutMs: 20_000,
+            maxOutputBytes: 256 * 1024,
+          });
+        }
+        return { bookmarkName, remoteName, workspacePath: null };
+      }
+
+      if (!input.threadId) {
+        return yield* reviewError({
+          operation: "prepare-review",
+          detail: "A thread id is required for an isolated Jujutsu workspace.",
+        });
+      }
+      const workspaceName = `t3code-${NodeCrypto.createHash("sha256")
+        .update(input.threadId, "utf8")
+        .digest("hex")
+        .slice(0, 20)}`;
+      const workspacePath = path.join(worktreesDir, path.basename(repositoryRoot), workspaceName);
+      if (yield* fileSystem.exists(workspacePath)) {
+        const existing = yield* readRevision(driver, workspacePath, "@").pipe(Effect.option);
+        if (existing._tag === "None") {
+          return yield* reviewError({
+            operation: "prepare-review",
+            detail: `Refusing to replace invalid workspace path '${workspacePath}'.`,
+            recoverable: true,
+          });
+        }
+        return { bookmarkName, remoteName, workspacePath };
+      }
+
+      const workspaces = yield* readWorkspaces(driver, input.cwd);
+      if (workspaces.some((workspace) => workspace.name === workspaceName)) {
+        yield* driver.execute({
+          operation: "VcsReviewService.prepareReview.forgetMissing",
+          cwd: input.cwd,
+          args: ["workspace", "forget", workspaceName],
+          timeoutMs: 20_000,
+          maxOutputBytes: 256 * 1024,
+        });
+      }
+      yield* fileSystem.makeDirectory(path.dirname(workspacePath), { recursive: true });
+      yield* driver.execute({
+        operation: "VcsReviewService.prepareReview.workspace",
+        cwd: input.cwd,
+        args: [
+          "workspace",
+          "add",
+          workspacePath,
+          "--name",
+          workspaceName,
+          "--revision",
+          quoteJjSymbol(target),
+        ],
+        timeoutMs: 120_000,
+        maxOutputBytes: 1_000_000,
+      });
+      return { bookmarkName, remoteName, workspacePath };
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : reviewError({
+            operation: "prepare-review",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  return VcsReviewService.of({ prepareReview });
+});
+
+export const layer = Layer.effect(VcsReviewService, make);

--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -135,7 +135,7 @@ describe("VcsStatusBroadcaster", () => {
       assert.deepStrictEqual(first, baseStatus);
       assert.deepStrictEqual(second, baseStatus);
       assert.equal(state.localStatusCalls, 1);
-      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 2);
       assert.equal(state.localInvalidationCalls, 0);
       assert.equal(state.remoteInvalidationCalls, 0);
     }).pipe(Effect.provide(makeTestLayer(state)));
@@ -176,9 +176,50 @@ describe("VcsStatusBroadcaster", () => {
         ...state.currentRemoteStatus,
       });
       assert.equal(state.localStatusCalls, 2);
-      assert.equal(state.remoteStatusCalls, 2);
+      assert.equal(state.remoteStatusCalls, 4);
       assert.equal(state.localInvalidationCalls, 1);
       assert.equal(state.remoteInvalidationCalls, 1);
+    }).pipe(Effect.provide(makeTestLayer(state)));
+  });
+
+  it.effect("preserves unavailable remote status in combined cache refreshes", () => {
+    const state = {
+      currentLocalStatus: baseLocalStatus,
+      currentRemoteStatus: null,
+      localStatusCalls: 0,
+      remoteStatusCalls: 0,
+      localInvalidationCalls: 0,
+      remoteInvalidationCalls: 0,
+    };
+
+    return Effect.gen(function* () {
+      const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+      yield* broadcaster.getStatus({ cwd: "/repo" });
+      const initial = yield* Stream.runHead(
+        broadcaster.streamStatus(
+          { cwd: "/repo" },
+          { automaticRemoteRefreshInterval: Effect.succeed(Duration.zero) },
+        ),
+      );
+
+      assert.deepStrictEqual(Option.getOrThrow(initial), {
+        _tag: "snapshot",
+        local: baseLocalStatus,
+        remote: null,
+      } satisfies VcsStatusStreamEvent);
+
+      yield* broadcaster.refreshStatus("/repo");
+      const refreshed = yield* Stream.runHead(
+        broadcaster.streamStatus(
+          { cwd: "/repo" },
+          { automaticRemoteRefreshInterval: Effect.succeed(Duration.zero) },
+        ),
+      );
+      assert.deepStrictEqual(Option.getOrThrow(refreshed), {
+        _tag: "snapshot",
+        local: baseLocalStatus,
+        remote: null,
+      } satisfies VcsStatusStreamEvent);
     }).pipe(Effect.provide(makeTestLayer(state)));
   });
 
@@ -295,7 +336,7 @@ describe("VcsStatusBroadcaster", () => {
         ...baseRemoteStatus,
       });
       assert.equal(state.localStatusCalls, 2);
-      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 2);
       assert.equal(state.localInvalidationCalls, 1);
       assert.equal(state.remoteInvalidationCalls, 0);
     }).pipe(Effect.provide(makeTestLayer(state)));
@@ -366,9 +407,9 @@ describe("VcsStatusBroadcaster", () => {
       yield* broadcaster.getStatus({ cwd: linkDir });
       yield* broadcaster.getStatus({ cwd: realDir });
 
-      assert.deepStrictEqual(seenCwds, [realPath, realPath]);
+      assert.deepStrictEqual(seenCwds, [realPath, realPath, realPath]);
       assert.equal(state.localStatusCalls, 1);
-      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 2);
     }).pipe(Effect.provide(testLayer));
   });
 
@@ -615,15 +656,15 @@ describe("VcsStatusBroadcaster", () => {
       ).pipe(Effect.forkIn(scope));
 
       yield* Deferred.await(snapshotDeferred);
-      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 2);
       assert.equal(state.remoteInvalidationCalls, 0);
 
       yield* TestClock.adjust(Duration.seconds(59));
-      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 2);
 
       yield* TestClock.adjust(Duration.seconds(1));
       yield* Effect.yieldNow;
-      assert.equal(state.remoteStatusCalls, 2);
+      assert.equal(state.remoteStatusCalls, 3);
       assert.equal(state.remoteInvalidationCalls, 1);
 
       yield* Scope.close(scope, Exit.void);

--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -75,6 +75,22 @@ function makeTestLayer(state: {
     Layer.provideMerge(NodeServices.layer),
     Layer.provide(
       Layer.mock(GitWorkflowService.GitWorkflowService)({
+        status: () =>
+          Effect.sync(() => {
+            state.localStatusCalls += 1;
+            state.remoteStatusCalls += 1;
+            state.remoteStatusRefreshUpstreamValues?.push(undefined);
+            return {
+              ...state.currentLocalStatus,
+              ...(state.currentRemoteStatus ?? {
+                hasUpstream: false,
+                aheadCount: 0,
+                behindCount: 0,
+                aheadOfDefaultCount: 0,
+                pr: null,
+              }),
+            };
+          }),
         localStatus: () =>
           Effect.sync(() => {
             state.localStatusCalls += 1;
@@ -180,6 +196,23 @@ describe("VcsStatusBroadcaster", () => {
       Layer.provideMerge(NodeServices.layer),
       Layer.provide(
         Layer.mock(GitWorkflowService.GitWorkflowService)({
+          status: () =>
+            Effect.suspend(() => {
+              state.localStatusCalls += 1;
+              state.remoteStatusCalls += 1;
+              return state.failRemoteStatus
+                ? Effect.fail(
+                    new GitManagerError({
+                      operation: "VcsStatusBroadcaster.test",
+                      cwd: "/repo",
+                      detail: "remote status failed",
+                    }),
+                  )
+                : Effect.succeed({
+                    ...state.currentLocalStatus,
+                    ...state.currentRemoteStatus,
+                  });
+            }),
           localStatus: () =>
             Effect.sync(() => {
               state.localStatusCalls += 1;
@@ -282,6 +315,16 @@ describe("VcsStatusBroadcaster", () => {
       Layer.provideMerge(NodeServices.layer),
       Layer.provide(
         Layer.mock(GitWorkflowService.GitWorkflowService)({
+          status: (input) =>
+            Effect.sync(() => {
+              seenCwds.push(input.cwd, input.cwd);
+              state.localStatusCalls += 1;
+              state.remoteStatusCalls += 1;
+              return {
+                ...state.currentLocalStatus,
+                ...state.currentRemoteStatus,
+              };
+            }),
           localStatus: (input) =>
             Effect.sync(() => {
               seenCwds.push(input.cwd);

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -20,7 +20,7 @@ import type {
   VcsStatusResult,
   VcsStatusStreamEvent,
 } from "@t3tools/contracts";
-import { mergeGitStatusParts } from "@t3tools/shared/git";
+import { mergeGitStatusParts, toLocalStatusPart, toRemoteStatusPart } from "@t3tools/shared/git";
 
 import * as GitWorkflowService from "../git/GitWorkflowService.ts";
 
@@ -326,6 +326,12 @@ export const make = Effect.gen(function* () {
     if (cached?.local && cached.remote) {
       return mergeGitStatusParts(cached.local.value, cached.remote.value);
     }
+    if (!cached?.local && !cached?.remote) {
+      const status = yield* workflow.status({ cwd });
+      const local = toLocalStatusPart(status);
+      const remote = local.isRepo ? toRemoteStatusPart(status) : null;
+      return yield* updateCachedStatus(cwd, local, remote);
+    }
     const [local, remote] = yield* Effect.all(
       [
         cached?.local ? Effect.succeed(cached.local.value) : workflow.localStatus({ cwd }),
@@ -370,10 +376,9 @@ export const make = Effect.gen(function* () {
       concurrency: "unbounded",
       discard: true,
     });
-    const [local, remote] = yield* Effect.all(
-      [workflow.localStatus({ cwd }), workflow.remoteStatus({ cwd })],
-      { concurrency: "unbounded" },
-    );
+    const status = yield* workflow.status({ cwd });
+    const local = toLocalStatusPart(status);
+    const remote = local.isRepo ? toRemoteStatusPart(status) : null;
     return yield* updateCachedStatus(cwd, local, remote, { publish: true });
   });
 

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -20,7 +20,7 @@ import type {
   VcsStatusResult,
   VcsStatusStreamEvent,
 } from "@t3tools/contracts";
-import { mergeGitStatusParts, toLocalStatusPart, toRemoteStatusPart } from "@t3tools/shared/git";
+import { mergeGitStatusParts, toLocalStatusPart } from "@t3tools/shared/git";
 
 import * as GitWorkflowService from "../git/GitWorkflowService.ts";
 
@@ -329,7 +329,7 @@ export const make = Effect.gen(function* () {
     if (!cached?.local && !cached?.remote) {
       const status = yield* workflow.status({ cwd });
       const local = toLocalStatusPart(status);
-      const remote = local.isRepo ? toRemoteStatusPart(status) : null;
+      const remote = local.isRepo ? yield* workflow.remoteStatus({ cwd }) : null;
       return yield* updateCachedStatus(cwd, local, remote);
     }
     const [local, remote] = yield* Effect.all(
@@ -378,7 +378,7 @@ export const make = Effect.gen(function* () {
     });
     const status = yield* workflow.status({ cwd });
     const local = toLocalStatusPart(status);
-    const remote = local.isRepo ? toRemoteStatusPart(status) : null;
+    const remote = local.isRepo ? yield* workflow.remoteStatus({ cwd }) : null;
     return yield* updateCachedStatus(cwd, local, remote, { publish: true });
   });
 

--- a/apps/server/src/vcs/VcsSyncService.test.ts
+++ b/apps/server/src/vcs/VcsSyncService.test.ts
@@ -1,0 +1,235 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as JjVcsDriver from "./JjVcsDriver.ts";
+import * as JjProcess from "./JjProcess.ts";
+import * as VcsChangeService from "./VcsChangeService.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+import * as VcsProcess from "./VcsProcess.ts";
+import { VcsSyncService, layer } from "./VcsSyncService.ts";
+
+const TestJjProcessLayer = Layer.effect(
+  JjProcess.JjProcess,
+  Effect.gen(function* () {
+    const jj = yield* JjProcess.make;
+    return JjProcess.JjProcess.of({
+      ensureSupportedVersion: jj.ensureSupportedVersion,
+      run: (input) =>
+        jj.run({
+          ...input,
+          args: [
+            "--config",
+            'user.name="T3 Code VCS test"',
+            "--config",
+            'user.email="vcs-test@example.invalid"',
+            ...input.args,
+          ],
+        }),
+    });
+  }),
+).pipe(Layer.provide(VcsProcess.layer));
+
+const TestJjDriverLayer = Layer.effect(VcsDriver.VcsDriver, JjVcsDriver.make).pipe(
+  Layer.provide(TestJjProcessLayer),
+);
+
+const RegistryLayer = Layer.effect(
+  VcsDriverRegistry.VcsDriverRegistry,
+  Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    return VcsDriverRegistry.VcsDriverRegistry.of({
+      get: () => Effect.succeed(driver),
+      detect: (input) =>
+        driver
+          .detectRepository(input.cwd)
+          .pipe(
+            Effect.map((repository) =>
+              repository ? { kind: "jj" as const, repository, driver } : null,
+            ),
+          ),
+      resolve: (input) =>
+        driver
+          .detectRepository(input.cwd)
+          .pipe(
+            Effect.flatMap((repository) =>
+              repository
+                ? Effect.succeed({ kind: "jj" as const, repository, driver })
+                : Effect.die(`Expected a Jujutsu repository at ${input.cwd}`),
+            ),
+          ),
+    });
+  }),
+).pipe(Layer.provide(TestJjDriverLayer));
+
+const TestLayer = Layer.merge(
+  layer.pipe(Layer.provide(RegistryLayer)),
+  VcsChangeService.layer.pipe(Layer.provide(RegistryLayer)),
+).pipe(Layer.provideMerge(TestJjDriverLayer), Layer.provideMerge(NodeServices.layer));
+
+function git(args: ReadonlyArray<string>): string {
+  return NodeChildProcess.execFileSync("git", [...args], { encoding: "utf8" }).trim();
+}
+
+it.layer(TestLayer)("VcsSyncService", (it) => {
+  it.effect("pushes only the explicit bookmark and records its remote", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const driver = yield* VcsDriver.VcsDriver;
+      const changes = yield* VcsChangeService.VcsChangeService;
+      const sync = yield* VcsSyncService;
+      const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-phase6-" });
+      const repository = path.join(root, "source");
+      const remote = path.join(root, "remote.git");
+      yield* fileSystem.makeDirectory(repository);
+      git(["init", "--bare", "--initial-branch=main", remote]);
+      yield* driver.initRepository({ cwd: repository, kind: "jj" });
+      yield* driver.addRemote({ cwd: repository, name: "origin", url: remote });
+      yield* fileSystem.writeFileString(path.join(repository, "change.txt"), "change\n");
+
+      const finalized = yield* changes.finalizeChange({
+        cwd: repository,
+        message: "Publish explicit bookmark",
+        createPublishRef: "feature/phase-6",
+      });
+      assert.equal(finalized.status, "created");
+      if (finalized.status !== "created") {
+        throw new Error("Expected a finalized change.");
+      }
+      assert.isDefined(finalized.publishRef);
+
+      const result = yield* sync.publish({
+        cwd: repository,
+        publishRef: finalized.publishRef,
+      });
+      assert.equal(result.remoteName, "origin");
+      assert.equal(result.publishRef.remoteName, "origin");
+      assert.equal(
+        git(["--git-dir", remote, "rev-parse", "refs/heads/feature/phase-6"]),
+        finalized.finalizedRevision.commitId,
+      );
+      const mainRef = NodeChildProcess.spawnSync(
+        "git",
+        ["--git-dir", remote, "show-ref", "--verify", "refs/heads/main"],
+        { encoding: "utf8" },
+      );
+      assert.notEqual(mainRef.status, 0);
+    }),
+  );
+
+  it.effect("advances only an empty workspace after a safe fetch", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const driver = yield* VcsDriver.VcsDriver;
+      const changes = yield* VcsChangeService.VcsChangeService;
+      const sync = yield* VcsSyncService;
+      const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-phase6-fetch-" });
+      const source = path.join(root, "source");
+      const clean = path.join(root, "clean");
+      const dirty = path.join(root, "dirty");
+      const remote = path.join(root, "remote.git");
+      yield* fileSystem.makeDirectory(source);
+      git(["init", "--bare", "--initial-branch=main", remote]);
+      yield* driver.initRepository({ cwd: source, kind: "jj" });
+      yield* driver.addRemote({ cwd: source, name: "origin", url: remote });
+      yield* fileSystem.writeFileString(path.join(source, "base.txt"), "base\n");
+      const base = yield* changes.finalizeChange({
+        cwd: source,
+        message: "Base",
+        createPublishRef: "main",
+      });
+      assert.equal(base.status, "created");
+      if (base.status !== "created") {
+        throw new Error("Expected a finalized base change.");
+      }
+      assert.isDefined(base.publishRef);
+      yield* sync.publish({ cwd: source, publishRef: base.publishRef });
+
+      yield* driver.cloneRepository({ kind: "jj", source: remote, destination: clean });
+      yield* driver.cloneRepository({ kind: "jj", source: remote, destination: dirty });
+      yield* driver.execute({
+        operation: "VcsSyncService.test.baseCleanWorkspace",
+        cwd: clean,
+        args: ["new", base.finalizedRevision.commitId],
+      });
+      yield* driver.execute({
+        operation: "VcsSyncService.test.baseDirtyWorkspace",
+        cwd: dirty,
+        args: ["new", base.finalizedRevision.commitId],
+      });
+      yield* fileSystem.writeFileString(path.join(dirty, "local.txt"), "local\n");
+      yield* driver.execute({
+        operation: "VcsSyncService.test.snapshotDirty",
+        cwd: dirty,
+        args: ["util", "snapshot"],
+      });
+
+      yield* fileSystem.writeFileString(path.join(source, "next.txt"), "next\n");
+      const next = yield* changes.finalizeChange({
+        cwd: source,
+        message: "Next",
+        publishRef: base.publishRef,
+      });
+      assert.equal(next.status, "created");
+      if (next.status !== "created") {
+        throw new Error("Expected a finalized follow-up change.");
+      }
+      assert.isDefined(next.publishRef);
+      yield* sync.publish({ cwd: source, publishRef: next.publishRef });
+
+      const cleanResult = yield* sync.fetch({ cwd: clean });
+      assert.equal(cleanResult.status, "updated");
+      const cleanAfter = yield* driver.execute({
+        operation: "VcsSyncService.test.cleanAfter",
+        cwd: clean,
+        args: [
+          "log",
+          "--no-graph",
+          "--revisions",
+          "@",
+          "--template",
+          'parents.map(|p| p.commit_id()).join("\n")',
+        ],
+      });
+      assert.equal(cleanAfter.stdout.trim(), next.finalizedRevision.commitId);
+
+      const dirtyBefore = yield* driver.execute({
+        operation: "VcsSyncService.test.dirtyBefore",
+        cwd: dirty,
+        args: [
+          "log",
+          "--no-graph",
+          "--revisions",
+          "@",
+          "--template",
+          'parents.map(|p| p.commit_id()).join("\n")',
+        ],
+      });
+      assert.equal(dirtyBefore.stdout.trim(), base.finalizedRevision.commitId);
+      const dirtyResult = yield* sync.fetch({ cwd: dirty });
+      assert.equal(dirtyResult.status, "needs-rebase");
+      const dirtyAfter = yield* driver.execute({
+        operation: "VcsSyncService.test.dirtyAfter",
+        cwd: dirty,
+        args: [
+          "log",
+          "--no-graph",
+          "--revisions",
+          "@",
+          "--template",
+          'parents.map(|p| p.commit_id()).join("\n")',
+        ],
+      });
+      assert.equal(dirtyAfter.stdout, dirtyBefore.stdout);
+    }),
+  );
+});

--- a/apps/server/src/vcs/VcsSyncService.test.ts
+++ b/apps/server/src/vcs/VcsSyncService.test.ts
@@ -42,6 +42,7 @@ const TestJjProcessLayer = Layer.effect(
 
 const TestJjDriverLayer = Layer.effect(VcsDriver.VcsDriver, JjVcsDriver.make).pipe(
   Layer.provide(TestJjProcessLayer),
+  Layer.provide(VcsProcess.layer),
 );
 
 const RegistryLayer = Layer.effect(

--- a/apps/server/src/vcs/VcsSyncService.test.ts
+++ b/apps/server/src/vcs/VcsSyncService.test.ts
@@ -7,13 +7,16 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import type { ThreadId } from "@t3tools/contracts";
 
+import * as ServerConfig from "../config.ts";
 import * as JjVcsDriver from "./JjVcsDriver.ts";
 import * as JjProcess from "./JjProcess.ts";
 import * as VcsChangeService from "./VcsChangeService.ts";
 import * as VcsDriver from "./VcsDriver.ts";
 import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
 import * as VcsProcess from "./VcsProcess.ts";
+import * as VcsReviewService from "./VcsReviewService.ts";
 import { VcsSyncService, layer } from "./VcsSyncService.ts";
 
 const TestJjProcessLayer = Layer.effect(
@@ -69,8 +72,12 @@ const RegistryLayer = Layer.effect(
   }),
 ).pipe(Layer.provide(TestJjDriverLayer));
 
-const TestLayer = Layer.merge(
+const TestLayer = Layer.mergeAll(
   layer.pipe(Layer.provide(RegistryLayer)),
+  VcsReviewService.layer.pipe(
+    Layer.provide(RegistryLayer),
+    Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-jj-sync-test-" })),
+  ),
   VcsChangeService.layer.pipe(Layer.provide(RegistryLayer)),
 ).pipe(Layer.provideMerge(TestJjDriverLayer), Layer.provideMerge(NodeServices.layer));
 
@@ -230,6 +237,100 @@ it.layer(TestLayer)("VcsSyncService", (it) => {
         ],
       });
       assert.equal(dirtyAfter.stdout, dirtyBefore.stdout);
+    }),
+  );
+
+  it.effect("prepares idempotent local and isolated review workspaces", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const driver = yield* VcsDriver.VcsDriver;
+      const changes = yield* VcsChangeService.VcsChangeService;
+      const sync = yield* VcsSyncService;
+      const reviews = yield* VcsReviewService.VcsReviewService;
+      const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-phase7-review-" });
+      const source = path.join(root, "source");
+      const review = path.join(root, "review");
+      const remote = path.join(root, "remote.git");
+      yield* fileSystem.makeDirectory(source);
+      git(["init", "--bare", "--initial-branch=main", remote]);
+      yield* driver.initRepository({ cwd: source, kind: "jj" });
+      yield* driver.addRemote({ cwd: source, name: "origin", url: remote });
+      yield* fileSystem.writeFileString(path.join(source, "review.txt"), "review\n");
+      const finalized = yield* changes.finalizeChange({
+        cwd: source,
+        message: "Review target",
+        createPublishRef: "feature/review",
+      });
+      assert.equal(finalized.status, "created");
+      if (finalized.status !== "created") {
+        throw new Error("Expected a finalized review change.");
+      }
+      assert.isDefined(finalized.publishRef);
+      yield* sync.publish({ cwd: source, publishRef: finalized.publishRef });
+      yield* driver.cloneRepository({ kind: "jj", source: remote, destination: review });
+
+      const local = yield* reviews.prepareReview({
+        cwd: review,
+        changeRequestNumber: 42,
+        headRefName: "feature/review",
+        mode: "local",
+      });
+      assert.equal(local.bookmarkName, "t3code-review-42");
+      assert.isNull(local.workspacePath);
+      const firstCurrent = yield* driver.execute({
+        operation: "VcsSyncService.test.reviewCurrent",
+        cwd: review,
+        args: ["log", "--no-graph", "--revisions", "@", "--template", "commit_id"],
+      });
+      const localParent = yield* driver.execute({
+        operation: "VcsSyncService.test.reviewParent",
+        cwd: review,
+        args: ["log", "--no-graph", "--revisions", "@-", "--template", "commit_id"],
+      });
+      assert.equal(localParent.stdout, finalized.finalizedRevision.commitId);
+
+      yield* reviews.prepareReview({
+        cwd: review,
+        changeRequestNumber: 42,
+        headRefName: "feature/review",
+        mode: "local",
+      });
+      const repeatedCurrent = yield* driver.execute({
+        operation: "VcsSyncService.test.reviewRepeatedCurrent",
+        cwd: review,
+        args: ["log", "--no-graph", "--revisions", "@", "--template", "commit_id"],
+      });
+      assert.equal(repeatedCurrent.stdout, firstCurrent.stdout);
+
+      const isolated = yield* reviews.prepareReview({
+        cwd: review,
+        changeRequestNumber: 42,
+        headRefName: "feature/review",
+        mode: "worktree",
+        threadId: "thread-phase-7-review" as ThreadId,
+      });
+      assert.isNotNull(isolated.workspacePath);
+      assert.isTrue(yield* fileSystem.exists(isolated.workspacePath as string));
+      const isolatedParent = yield* driver.execute({
+        operation: "VcsSyncService.test.reviewWorkspaceParent",
+        cwd: isolated.workspacePath as string,
+        args: ["log", "--no-graph", "--revisions", "@-", "--template", "commit_id"],
+      });
+      assert.equal(isolatedParent.stdout, finalized.finalizedRevision.commitId);
+
+      const repeatedIsolated = yield* reviews.prepareReview({
+        cwd: review,
+        changeRequestNumber: 42,
+        headRefName: "feature/review",
+        mode: "worktree",
+        threadId: "thread-phase-7-review" as ThreadId,
+      });
+      assert.equal(repeatedIsolated.workspacePath, isolated.workspacePath);
+      assert.equal(
+        git(["--git-dir", remote, "rev-parse", "refs/heads/feature/review"]),
+        finalized.finalizedRevision.commitId,
+      );
     }),
   );
 });

--- a/apps/server/src/vcs/VcsSyncService.ts
+++ b/apps/server/src/vcs/VcsSyncService.ts
@@ -1,0 +1,488 @@
+import {
+  VcsWorkflowError,
+  type VcsConflict,
+  type VcsNamedRef,
+  type VcsRevision,
+} from "@t3tools/contracts";
+import {
+  JJ_BOOKMARK_JSON_TEMPLATE,
+  JJ_REVISION_JSON_TEMPLATE,
+  isJjBookmarkRecord,
+  isJjRevisionRecord,
+  parseJjJsonLines,
+  quoteJjSymbol,
+  type JjBookmarkRecord,
+  type JjRevisionRecord,
+} from "@t3tools/shared/jjCli";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+
+const METADATA_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+const PATCH_MAX_OUTPUT_BYTES = 120_000;
+const REMOTE_OPERATION_TIMEOUT_MS = 10 * 60_000;
+
+export type VcsFetchStatus = "updated" | "up-to-date" | "needs-rebase" | "needs-resolution";
+
+export interface VcsFetchResult {
+  readonly status: VcsFetchStatus;
+  readonly remoteName: string;
+  readonly refName: string;
+  readonly upstreamRef: string;
+  readonly workspaceRevision: VcsRevision;
+  readonly conflicts: ReadonlyArray<VcsConflict>;
+}
+
+export interface VcsPublishResult {
+  readonly status: "pushed";
+  readonly remoteName: string;
+  readonly publishRef: VcsNamedRef;
+}
+
+export interface VcsRangeContext {
+  readonly commitSummary: string;
+  readonly diffSummary: string;
+  readonly diffPatch: string;
+}
+
+export class VcsSyncService extends Context.Service<
+  VcsSyncService,
+  {
+    readonly fetch: (input: {
+      readonly cwd: string;
+      readonly remoteName?: string;
+    }) => Effect.Effect<VcsFetchResult, VcsWorkflowError>;
+    readonly publish: (input: {
+      readonly cwd: string;
+      readonly publishRef: VcsNamedRef;
+      readonly remoteName?: string;
+    }) => Effect.Effect<VcsPublishResult, VcsWorkflowError>;
+    readonly readRangeContext: (input: {
+      readonly cwd: string;
+      readonly baseRevision: string;
+      readonly targetRevision: string;
+    }) => Effect.Effect<VcsRangeContext, VcsWorkflowError>;
+  }
+>()("t3/vcs/VcsSyncService") {}
+
+function syncError(input: {
+  readonly operation: string;
+  readonly detail: string;
+  readonly recoverable?: boolean;
+}): VcsWorkflowError {
+  return new VcsWorkflowError({
+    workflow: "sync",
+    operation: input.operation,
+    kind: "jj",
+    detail: input.detail,
+    recoverable: input.recoverable ?? false,
+  });
+}
+
+function errorDetail(cause: unknown): string {
+  return cause instanceof Error && cause.message.trim().length > 0 ? cause.message : String(cause);
+}
+
+function toRevision(record: JjRevisionRecord): VcsRevision {
+  return { commitId: record.commitId, changeId: record.changeId };
+}
+
+function remoteBookmarkName(bookmark: Pick<JjBookmarkRecord, "name" | "remote">): string {
+  return bookmark.remote ? `${bookmark.name}@${bookmark.remote}` : bookmark.name;
+}
+
+function bookmarkConflicts(bookmarks: ReadonlyArray<JjBookmarkRecord>): ReadonlyArray<VcsConflict> {
+  return bookmarks
+    .filter((bookmark) => bookmark.target.length > 1)
+    .map((bookmark) => ({
+      kind: "named-ref" as const,
+      ref: {
+        kind: "bookmark" as const,
+        name: bookmark.name,
+        ...(bookmark.remote ? { remoteName: bookmark.remote } : {}),
+      },
+    }));
+}
+
+const isVcsWorkflowError = Schema.is(VcsWorkflowError);
+
+export const make = Effect.gen(function* () {
+  const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+
+  const resolveJjDriver = Effect.fn("VcsSyncService.resolveJjDriver")(function* (cwd: string) {
+    const handle = yield* registry.resolve({ cwd });
+    if (handle.kind !== "jj") {
+      return yield* syncError({
+        operation: "resolve-driver",
+        detail: `Jujutsu synchronization requires a jj repository; detected ${handle.kind}.`,
+      });
+    }
+    return handle.driver;
+  });
+
+  const readRevisions = Effect.fn("VcsSyncService.readRevisions")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    revision: string,
+  ) {
+    const result = yield* driver.execute({
+      operation: "VcsSyncService.readRevisions",
+      cwd,
+      args: ["log", "--no-graph", "--revisions", revision, "--template", JJ_REVISION_JSON_TEMPLATE],
+      timeoutMs: 20_000,
+      maxOutputBytes: METADATA_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: false,
+    });
+    if (result.stdoutTruncated) {
+      return yield* syncError({
+        operation: "read-revisions",
+        detail: "jj returned truncated revision metadata.",
+      });
+    }
+    const records = yield* Effect.try({
+      try: () => parseJjJsonLines(result.stdout),
+      catch: (cause) =>
+        syncError({
+          operation: "read-revisions",
+          detail: `jj returned invalid revision metadata: ${errorDetail(cause)}`,
+        }),
+    });
+    if (!records.every(isJjRevisionRecord)) {
+      return yield* syncError({
+        operation: "read-revisions",
+        detail: "jj returned invalid revision metadata.",
+      });
+    }
+    return records as ReadonlyArray<JjRevisionRecord>;
+  });
+
+  const readRevision = Effect.fn("VcsSyncService.readRevision")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    revision: string,
+  ) {
+    const records = yield* readRevisions(driver, cwd, revision);
+    const record = records[0];
+    if (records.length !== 1 || !record) {
+      return yield* syncError({
+        operation: "read-revision",
+        detail: `Expected one jj revision for ${revision}; received ${records.length}.`,
+      });
+    }
+    return record;
+  });
+
+  const readBookmarks = Effect.fn("VcsSyncService.readBookmarks")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+  ) {
+    const result = yield* driver.execute({
+      operation: "VcsSyncService.readBookmarks",
+      cwd,
+      args: ["bookmark", "list", "--all-remotes", "--template", JJ_BOOKMARK_JSON_TEMPLATE],
+      timeoutMs: 20_000,
+      maxOutputBytes: METADATA_MAX_OUTPUT_BYTES,
+      appendTruncationMarker: false,
+    });
+    if (result.stdoutTruncated) {
+      return yield* syncError({
+        operation: "read-bookmarks",
+        detail: "jj returned truncated bookmark metadata.",
+      });
+    }
+    const records = yield* Effect.try({
+      try: () => parseJjJsonLines(result.stdout),
+      catch: (cause) =>
+        syncError({
+          operation: "read-bookmarks",
+          detail: `jj returned invalid bookmark metadata: ${errorDetail(cause)}`,
+        }),
+    });
+    if (!records.every(isJjBookmarkRecord)) {
+      return yield* syncError({
+        operation: "read-bookmarks",
+        detail: "jj returned invalid bookmark metadata.",
+      });
+    }
+    return records as ReadonlyArray<JjBookmarkRecord>;
+  });
+
+  const resolveRemoteName = Effect.fn("VcsSyncService.resolveRemoteName")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    requested?: string,
+  ) {
+    const trimmed = requested?.trim() ?? "";
+    if (trimmed.includes("\0")) {
+      return yield* syncError({
+        operation: "resolve-remote",
+        detail: "Remote name cannot contain NUL bytes.",
+      });
+    }
+    if (trimmed.length > 0) return trimmed;
+    const remoteName = yield* driver.resolveDefaultRemote(cwd);
+    if (!remoteName) {
+      return yield* syncError({
+        operation: "resolve-remote",
+        detail: "No Git remote is configured for this Jujutsu repository.",
+      });
+    }
+    return remoteName;
+  });
+
+  const defaultRemoteBookmark = (
+    bookmarks: ReadonlyArray<JjBookmarkRecord>,
+    remoteName: string,
+  ) => {
+    const remoteBookmarks = bookmarks.filter((bookmark) => bookmark.remote === remoteName);
+    return (
+      remoteBookmarks.find((bookmark) => bookmark.name === "main") ??
+      remoteBookmarks.find((bookmark) => bookmark.name === "master") ??
+      remoteBookmarks.toSorted((left, right) => left.name.localeCompare(right.name))[0] ??
+      null
+    );
+  };
+
+  const isAncestor = Effect.fn("VcsSyncService.isAncestor")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    ancestor: string,
+    descendant: string,
+  ) {
+    if (ancestor === descendant) return true;
+    const records = yield* readRevisions(
+      driver,
+      cwd,
+      `${quoteJjSymbol(descendant)} & descendants(${quoteJjSymbol(ancestor)})`,
+    );
+    return records.length === 1 && records[0]?.commitId === descendant;
+  });
+
+  const fetch: VcsSyncService["Service"]["fetch"] = Effect.fn("VcsSyncService.fetch")(
+    function* (input) {
+      const driver = yield* resolveJjDriver(input.cwd);
+      const remoteName = yield* resolveRemoteName(driver, input.cwd, input.remoteName);
+      yield* driver.execute({
+        operation: "VcsSyncService.fetch.snapshot",
+        cwd: input.cwd,
+        args: ["util", "snapshot"],
+        timeoutMs: 20_000,
+        maxOutputBytes: 256 * 1024,
+      });
+      const [beforeRevision, beforeBookmarks] = yield* Effect.all([
+        readRevision(driver, input.cwd, "@"),
+        readBookmarks(driver, input.cwd),
+      ]);
+      const beforeDefault = defaultRemoteBookmark(beforeBookmarks, remoteName);
+
+      yield* driver.execute({
+        operation: "VcsSyncService.fetch",
+        cwd: input.cwd,
+        args: ["git", "fetch", "--remote", remoteName],
+        timeoutMs: REMOTE_OPERATION_TIMEOUT_MS,
+        maxOutputBytes: 1_000_000,
+      });
+
+      let afterRevision = yield* readRevision(driver, input.cwd, "@");
+      const afterBookmarks = yield* readBookmarks(driver, input.cwd);
+      const afterDefault = defaultRemoteBookmark(afterBookmarks, remoteName);
+      const conflicts = bookmarkConflicts(afterBookmarks);
+      const refName = afterDefault?.name ?? beforeDefault?.name ?? remoteName;
+      const upstreamRef = afterDefault ? remoteBookmarkName(afterDefault) : remoteName;
+
+      if (afterRevision.conflict || conflicts.length > 0) {
+        return {
+          status: "needs-resolution" as const,
+          remoteName,
+          refName,
+          upstreamRef,
+          workspaceRevision: toRevision(afterRevision),
+          conflicts,
+        };
+      }
+
+      const beforeTarget = beforeDefault?.target.length === 1 ? beforeDefault.target[0] : null;
+      const afterTarget = afterDefault?.target.length === 1 ? afterDefault.target[0] : null;
+      if (!beforeTarget || !afterTarget || beforeTarget === afterTarget) {
+        return {
+          status: "up-to-date" as const,
+          remoteName,
+          refName,
+          upstreamRef,
+          workspaceRevision: toRevision(afterRevision),
+          conflicts,
+        };
+      }
+
+      const basedOnFetchedTarget =
+        beforeRevision.parents.length === 1 && beforeRevision.parents[0] === beforeTarget;
+      if (!basedOnFetchedTarget) {
+        return {
+          status: "updated" as const,
+          remoteName,
+          refName,
+          upstreamRef,
+          workspaceRevision: toRevision(afterRevision),
+          conflicts,
+        };
+      }
+
+      const safelySuperseded = yield* isAncestor(driver, input.cwd, beforeTarget, afterTarget);
+      if (!beforeRevision.empty || !safelySuperseded) {
+        return {
+          status: "needs-rebase" as const,
+          remoteName,
+          refName,
+          upstreamRef,
+          workspaceRevision: toRevision(afterRevision),
+          conflicts,
+        };
+      }
+
+      yield* driver.execute({
+        operation: "VcsSyncService.fetch.advanceWorkspace",
+        cwd: input.cwd,
+        args: [
+          "rebase",
+          "--revisions",
+          quoteJjSymbol(afterRevision.commitId),
+          "--destination",
+          quoteJjSymbol(afterTarget),
+        ],
+        timeoutMs: 60_000,
+        maxOutputBytes: 1_000_000,
+      });
+      afterRevision = yield* readRevision(driver, input.cwd, "@");
+      return {
+        status: "updated" as const,
+        remoteName,
+        refName,
+        upstreamRef,
+        workspaceRevision: toRevision(afterRevision),
+        conflicts,
+      };
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : syncError({
+            operation: "fetch",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  const publish: VcsSyncService["Service"]["publish"] = Effect.fn("VcsSyncService.publish")(
+    function* (input) {
+      if (input.publishRef.kind !== "bookmark") {
+        return yield* syncError({
+          operation: "publish",
+          detail: "Jujutsu publishing requires an explicit bookmark.",
+        });
+      }
+      const driver = yield* resolveJjDriver(input.cwd);
+      const remoteName = yield* resolveRemoteName(driver, input.cwd, input.remoteName);
+      const bookmarks = yield* readBookmarks(driver, input.cwd);
+      const local = bookmarks.find(
+        (bookmark) => bookmark.remote === undefined && bookmark.name === input.publishRef.name,
+      );
+      const targetCommit = local?.target.length === 1 ? local.target[0] : undefined;
+      if (!targetCommit) {
+        return yield* syncError({
+          operation: "publish",
+          detail: `Publish bookmark ${input.publishRef.name} is missing or conflicted.`,
+        });
+      }
+      if (input.publishRef.target && input.publishRef.target.commitId !== targetCommit) {
+        return yield* syncError({
+          operation: "publish",
+          detail: `Publish bookmark ${input.publishRef.name} moved since this action was prepared.`,
+          recoverable: true,
+        });
+      }
+
+      yield* driver.execute({
+        operation: "VcsSyncService.publish",
+        cwd: input.cwd,
+        args: [
+          "git",
+          "push",
+          "--remote",
+          remoteName,
+          "--bookmark",
+          `exact:${input.publishRef.name}`,
+        ],
+        timeoutMs: REMOTE_OPERATION_TIMEOUT_MS,
+        maxOutputBytes: 1_000_000,
+      });
+
+      const revision = yield* readRevision(driver, input.cwd, quoteJjSymbol(targetCommit));
+      return {
+        status: "pushed" as const,
+        remoteName,
+        publishRef: {
+          kind: "bookmark" as const,
+          name: input.publishRef.name,
+          remoteName,
+          target: toRevision(revision),
+        },
+      };
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : syncError({
+            operation: "publish",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  const readRangeContext: VcsSyncService["Service"]["readRangeContext"] = Effect.fn(
+    "VcsSyncService.readRangeContext",
+  )(
+    function* (input) {
+      const driver = yield* resolveJjDriver(input.cwd);
+      const base = quoteJjSymbol(input.baseRevision);
+      const target = quoteJjSymbol(input.targetRevision);
+      const revisions = yield* readRevisions(driver, input.cwd, `${base}..${target}`);
+      const patchResult = yield* driver.execute({
+        operation: "VcsSyncService.readRangeContext.patch",
+        cwd: input.cwd,
+        args: ["diff", "--git", "--from", base, "--to", target],
+        timeoutMs: 30_000,
+        maxOutputBytes: PATCH_MAX_OUTPUT_BYTES,
+        appendTruncationMarker: true,
+      });
+      const commitSummary = revisions
+        .map((revision) =>
+          `${revision.commitId.slice(0, 12)} ${revision.description.split("\n")[0] ?? ""}`.trim(),
+        )
+        .join("\n");
+      return {
+        commitSummary,
+        diffSummary: `${revisions.length} change${revisions.length === 1 ? "" : "s"} from ${input.baseRevision.slice(0, 12)} to ${input.targetRevision.slice(0, 12)}`,
+        diffPatch: patchResult.stdout,
+      };
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : syncError({
+            operation: "read-range-context",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  return VcsSyncService.of({ fetch, publish, readRangeContext });
+});
+
+export const layer = Layer.effect(VcsSyncService, make);

--- a/apps/server/src/vcs/VcsSyncService.ts
+++ b/apps/server/src/vcs/VcsSyncService.ts
@@ -264,6 +264,11 @@ export const make = Effect.gen(function* () {
 
   const fetch: VcsSyncService["Service"]["fetch"] = Effect.fn("VcsSyncService.fetch")(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": "jj",
+        "vcs.workflow": "sync",
+        "vcs.operation": "fetch",
+      });
       const driver = yield* resolveJjDriver(input.cwd);
       const remoteName = yield* resolveRemoteName(driver, input.cwd, input.remoteName);
       yield* driver.execute({
@@ -379,6 +384,11 @@ export const make = Effect.gen(function* () {
 
   const publish: VcsSyncService["Service"]["publish"] = Effect.fn("VcsSyncService.publish")(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": "jj",
+        "vcs.workflow": "sync",
+        "vcs.operation": "publish",
+      });
       if (input.publishRef.kind !== "bookmark") {
         return yield* syncError({
           operation: "publish",
@@ -448,6 +458,11 @@ export const make = Effect.gen(function* () {
     "VcsSyncService.readRangeContext",
   )(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": "jj",
+        "vcs.workflow": "sync",
+        "vcs.operation": "read-range-context",
+      });
       const driver = yield* resolveJjDriver(input.cwd);
       const base = quoteJjSymbol(input.baseRevision);
       const target = quoteJjSymbol(input.targetRevision);

--- a/apps/server/src/vcs/VcsWorkspaceService.test.ts
+++ b/apps/server/src/vcs/VcsWorkspaceService.test.ts
@@ -1,0 +1,152 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ThreadId } from "@t3tools/contracts";
+import { JJ_WORKSPACE_JSON_TEMPLATE, parseJjJsonLines } from "@t3tools/shared/jjCli";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as ServerConfig from "../config.ts";
+import * as GitWorkflowService from "../git/GitWorkflowService.ts";
+import * as JjVcsDriver from "./JjVcsDriver.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+import { VcsWorkspaceService, jjWorkspaceNameForThread, layer } from "./VcsWorkspaceService.ts";
+
+const RegistryLayer = Layer.effect(
+  VcsDriverRegistry.VcsDriverRegistry,
+  Effect.gen(function* () {
+    const driver = yield* VcsDriver.VcsDriver;
+    return VcsDriverRegistry.VcsDriverRegistry.of({
+      get: () => Effect.succeed(driver),
+      detect: (input) =>
+        driver
+          .detectRepository(input.cwd)
+          .pipe(
+            Effect.map((repository) =>
+              repository ? { kind: "jj" as const, repository, driver } : null,
+            ),
+          ),
+      resolve: (input) =>
+        driver
+          .detectRepository(input.cwd)
+          .pipe(
+            Effect.flatMap((repository) =>
+              repository
+                ? Effect.succeed({ kind: "jj" as const, repository, driver })
+                : Effect.die(`Expected a Jujutsu repository at ${input.cwd}`),
+            ),
+          ),
+    });
+  }),
+).pipe(Layer.provide(JjVcsDriver.layer));
+
+const TestLayer = Layer.merge(
+  layer.pipe(
+    Layer.provide(RegistryLayer),
+    Layer.provide(Layer.mock(GitWorkflowService.GitWorkflowService)({})),
+    Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-jj-workspaces-" })),
+  ),
+  JjVcsDriver.layer,
+).pipe(Layer.provideMerge(NodeServices.layer));
+
+const listWorkspaceNames = Effect.fn("listWorkspaceNames")(function* (cwd: string) {
+  const driver = yield* VcsDriver.VcsDriver;
+  const result = yield* driver.execute({
+    operation: "VcsWorkspaceService.test.list",
+    cwd,
+    args: ["workspace", "list", "--template", JJ_WORKSPACE_JSON_TEMPLATE],
+  });
+  return parseJjJsonLines(result.stdout).map((record) => {
+    assert.isObject(record);
+    assert.property(record, "name");
+    return (record as { readonly name: string }).name;
+  });
+});
+
+it.layer(TestLayer)("creates, reuses, repairs, and removes isolated Jujutsu workspaces", (it) => {
+  it.effect("keeps thread workspaces independent and cleanup scoped", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const driver = yield* VcsDriver.VcsDriver;
+      const workspaces = yield* VcsWorkspaceService;
+      const fixtureRoot = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-jj-phase4-" });
+      const repository = path.join(fixtureRoot, "repository");
+      yield* fileSystem.makeDirectory(repository, { recursive: true });
+      yield* driver.initRepository({ cwd: repository, kind: "jj" });
+
+      const base = yield* driver.execute({
+        operation: "VcsWorkspaceService.test.base",
+        cwd: repository,
+        args: ["log", "--no-graph", "-r", "@", "-T", 'commit_id ++ "\\n"'],
+      });
+      const baseCommit = base.stdout.trim();
+      const firstThread = ThreadId.make("thread-phase4-first");
+      const secondThread = ThreadId.make("thread-phase4-second");
+      const first = yield* workspaces.createThreadWorkspace({
+        cwd: repository,
+        threadId: firstThread,
+        baseRevision: baseCommit,
+        publishRef: "feature/first",
+      });
+      const second = yield* workspaces.createThreadWorkspace({
+        cwd: repository,
+        threadId: secondThread,
+        baseRevision: baseCommit,
+        publishRef: "feature/second",
+      });
+
+      assert.notEqual(first.name, second.name);
+      assert.notEqual(first.rootPath, second.rootPath);
+      assert.notEqual(first.workspaceRevision?.changeId, second.workspaceRevision?.changeId);
+      assert.equal(first.baseRevision?.commitId, baseCommit);
+      assert.equal(second.baseRevision?.commitId, baseCommit);
+      assert.isTrue(yield* fileSystem.exists(first.rootPath));
+      assert.isTrue(yield* fileSystem.exists(second.rootPath));
+
+      const reused = yield* workspaces.createThreadWorkspace({
+        cwd: repository,
+        threadId: firstThread,
+        baseRevision: baseCommit,
+        publishRef: "feature/first",
+      });
+      assert.deepStrictEqual(reused.workspaceRevision, first.workspaceRevision);
+
+      yield* driver.execute({
+        operation: "VcsWorkspaceService.test.externalRewrite",
+        cwd: repository,
+        args: [
+          "describe",
+          first.workspaceRevision?.changeId ?? "",
+          "--message",
+          "external rewrite",
+        ],
+      });
+      const repaired = yield* workspaces.ensureThreadWorkspace({
+        cwd: repository,
+        threadId: firstThread,
+        workspace: first,
+      });
+      assert.equal(repaired.name, first.name);
+      assert.notEqual(repaired.workspaceRevision?.commitId, first.workspaceRevision?.commitId);
+
+      yield* fileSystem.remove(first.rootPath, { recursive: true, force: true });
+      const recreated = yield* workspaces.ensureThreadWorkspace({
+        cwd: repository,
+        threadId: firstThread,
+        workspace: repaired,
+      });
+      assert.isTrue(yield* fileSystem.exists(recreated.rootPath));
+      assert.equal(recreated.name, jjWorkspaceNameForThread(firstThread));
+
+      yield* workspaces.removeThreadWorkspace({ cwd: repository, workspace: recreated });
+      assert.isFalse(yield* fileSystem.exists(recreated.rootPath));
+      assert.isTrue(yield* fileSystem.exists(second.rootPath));
+      const names = yield* listWorkspaceNames(repository);
+      assert.notInclude(names, recreated.name);
+      assert.include(names, second.name);
+    }),
+  );
+});

--- a/apps/server/src/vcs/VcsWorkspaceService.ts
+++ b/apps/server/src/vcs/VcsWorkspaceService.ts
@@ -366,6 +366,11 @@ export const make = Effect.gen(function* () {
   )(
     function* (input) {
       const handle = yield* registry.resolve({ cwd: input.cwd });
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": handle.kind,
+        "vcs.workflow": "workspace",
+        "vcs.operation": "create",
+      });
       if (handle.kind === "jj") {
         return yield* createJjWorkspace(input, handle.driver, handle.repository.rootPath);
       }
@@ -441,6 +446,11 @@ export const make = Effect.gen(function* () {
     "VcsWorkspaceService.ensureThreadWorkspace",
   )(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": input.workspace.driverKind,
+        "vcs.workflow": "workspace",
+        "vcs.operation": "ensure",
+      });
       if (input.workspace.driverKind !== "jj") {
         return input.workspace;
       }
@@ -495,6 +505,11 @@ export const make = Effect.gen(function* () {
     "VcsWorkspaceService.removeThreadWorkspace",
   )(
     function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "vcs.kind": input.workspace.driverKind,
+        "vcs.workflow": "workspace",
+        "vcs.operation": "remove",
+      });
       if (input.workspace.driverKind === "git") {
         yield* gitWorkflow.removeWorktree({
           cwd: input.cwd,

--- a/apps/server/src/vcs/VcsWorkspaceService.ts
+++ b/apps/server/src/vcs/VcsWorkspaceService.ts
@@ -1,0 +1,559 @@
+import * as NodeCrypto from "node:crypto";
+
+import {
+  VcsWorkflowError,
+  type ThreadId,
+  type VcsDriverKind,
+  type VcsNamedRef,
+  type VcsRevision,
+  type VcsWorkspaceIdentity,
+} from "@t3tools/contracts";
+import {
+  JJ_REVISION_JSON_TEMPLATE,
+  JJ_WORKSPACE_JSON_TEMPLATE,
+  isJjRevisionRecord,
+  isJjWorkspaceRecord,
+  parseJjJsonLines,
+  quoteJjSymbol,
+  type JjRevisionRecord,
+  type JjWorkspaceRecord,
+} from "@t3tools/shared/jjCli";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import * as ServerConfig from "../config.ts";
+import * as GitWorkflowService from "../git/GitWorkflowService.ts";
+import * as VcsDriver from "./VcsDriver.ts";
+import * as VcsDriverRegistry from "./VcsDriverRegistry.ts";
+
+export interface CreateThreadWorkspaceInput {
+  readonly cwd: string;
+  readonly threadId: ThreadId;
+  readonly baseRevision: string;
+  readonly baseRefName?: string;
+  readonly publishRef?: string;
+  readonly startFromOrigin?: boolean;
+  readonly path?: string;
+}
+
+export interface EnsureThreadWorkspaceInput {
+  readonly cwd: string;
+  readonly threadId: ThreadId;
+  readonly workspace: VcsWorkspaceIdentity;
+}
+
+export interface RemoveThreadWorkspaceInput {
+  readonly cwd: string;
+  readonly workspace: VcsWorkspaceIdentity;
+}
+
+export class VcsWorkspaceService extends Context.Service<
+  VcsWorkspaceService,
+  {
+    readonly createThreadWorkspace: (
+      input: CreateThreadWorkspaceInput,
+    ) => Effect.Effect<VcsWorkspaceIdentity, VcsWorkflowError>;
+    readonly ensureThreadWorkspace: (
+      input: EnsureThreadWorkspaceInput,
+    ) => Effect.Effect<VcsWorkspaceIdentity, VcsWorkflowError>;
+    readonly removeThreadWorkspace: (
+      input: RemoveThreadWorkspaceInput,
+    ) => Effect.Effect<void, VcsWorkflowError>;
+  }
+>()("t3/vcs/VcsWorkspaceService") {}
+
+export function jjWorkspaceNameForThread(threadId: ThreadId): string {
+  const digest = NodeCrypto.createHash("sha256").update(threadId, "utf8").digest("hex");
+  return `t3code-${digest.slice(0, 20)}`;
+}
+
+function workspaceError(input: {
+  readonly operation: string;
+  readonly kind: VcsDriverKind;
+  readonly detail: string;
+  readonly recoverable?: boolean;
+}): VcsWorkflowError {
+  return new VcsWorkflowError({
+    workflow: "workspace",
+    operation: input.operation,
+    kind: input.kind,
+    detail: input.detail,
+    recoverable: input.recoverable ?? false,
+  });
+}
+
+function errorDetail(cause: unknown): string {
+  if (cause instanceof Error && cause.message.trim().length > 0) {
+    return cause.message;
+  }
+  return String(cause);
+}
+
+function parseSingleRevision(input: {
+  readonly operation: string;
+  readonly cwd: string;
+  readonly stdout: string;
+  readonly stdoutTruncated: boolean;
+}): Effect.Effect<JjRevisionRecord, VcsWorkflowError> {
+  return Effect.try({
+    try: () => {
+      if (input.stdoutTruncated) {
+        throw new Error("jj returned truncated revision metadata.");
+      }
+      const records = parseJjJsonLines(input.stdout);
+      if (records.length !== 1 || !isJjRevisionRecord(records[0])) {
+        throw new Error("jj returned invalid revision metadata.");
+      }
+      return records[0];
+    },
+    catch: (cause) =>
+      workspaceError({
+        operation: input.operation,
+        kind: "jj",
+        detail: `${errorDetail(cause)} (${input.cwd})`,
+      }),
+  });
+}
+
+function parseWorkspaces(input: {
+  readonly operation: string;
+  readonly cwd: string;
+  readonly stdout: string;
+  readonly stdoutTruncated: boolean;
+}): Effect.Effect<ReadonlyArray<JjWorkspaceRecord>, VcsWorkflowError> {
+  return Effect.try({
+    try: () => {
+      if (input.stdoutTruncated) {
+        throw new Error("jj returned truncated workspace metadata.");
+      }
+      const records = parseJjJsonLines(input.stdout);
+      if (!records.every(isJjWorkspaceRecord)) {
+        throw new Error("jj returned invalid workspace metadata.");
+      }
+      return records;
+    },
+    catch: (cause) =>
+      workspaceError({
+        operation: input.operation,
+        kind: "jj",
+        detail: `${errorDetail(cause)} (${input.cwd})`,
+      }),
+  });
+}
+
+function currentWorkspaceName(revision: JjRevisionRecord): string | null {
+  for (const value of revision.workingCopies) {
+    if (typeof value !== "object" || value === null) continue;
+    const record = value as Record<string, unknown>;
+    if (typeof record.name === "string" && record.name.length > 0) {
+      return record.name;
+    }
+  }
+  return null;
+}
+
+function toRevision(record: JjRevisionRecord): VcsRevision {
+  return { commitId: record.commitId, changeId: record.changeId };
+}
+
+function sameRevision(left: VcsRevision | null | undefined, right: VcsRevision | null): boolean {
+  return left?.commitId === right?.commitId && left?.changeId === right?.changeId;
+}
+
+const isVcsWorkflowError = Schema.is(VcsWorkflowError);
+
+export const make = Effect.gen(function* () {
+  const registry = yield* VcsDriverRegistry.VcsDriverRegistry;
+  const gitWorkflow = yield* GitWorkflowService.GitWorkflowService;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const { worktreesDir } = yield* ServerConfig.ServerConfig;
+
+  const readJjRevision = Effect.fn("VcsWorkspaceService.readJjRevision")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+    revision: string,
+  ) {
+    const result = yield* driver.execute({
+      operation: "VcsWorkspaceService.readJjRevision",
+      cwd,
+      args: ["log", "--no-graph", "--revisions", revision, "--template", JJ_REVISION_JSON_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: 256 * 1024,
+      appendTruncationMarker: false,
+    });
+    return yield* parseSingleRevision({
+      operation: "read-revision",
+      cwd,
+      stdout: result.stdout,
+      stdoutTruncated: result.stdoutTruncated,
+    });
+  });
+
+  const listJjWorkspaces = Effect.fn("VcsWorkspaceService.listJjWorkspaces")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+  ) {
+    const result = yield* driver.execute({
+      operation: "VcsWorkspaceService.listJjWorkspaces",
+      cwd,
+      args: ["workspace", "list", "--template", JJ_WORKSPACE_JSON_TEMPLATE],
+      timeoutMs: 10_000,
+      maxOutputBytes: 512 * 1024,
+      appendTruncationMarker: false,
+    });
+    return yield* parseWorkspaces({
+      operation: "list-workspaces",
+      cwd,
+      stdout: result.stdout,
+      stdoutTruncated: result.stdoutTruncated,
+    });
+  });
+
+  const readCurrentJjRevision = Effect.fn("VcsWorkspaceService.readCurrentJjRevision")(function* (
+    driver: VcsDriver.VcsDriver["Service"],
+    cwd: string,
+  ) {
+    return yield* readJjRevision(driver, cwd, "@").pipe(
+      Effect.catchTag("VcsProcessExitError", (cause) => {
+        if (cause.failureKind !== "stale-workspace") {
+          return Effect.fail(cause);
+        }
+        return Effect.logInfo("repairing stale Jujutsu thread workspace", { cwd }).pipe(
+          Effect.andThen(
+            driver.execute({
+              operation: "VcsWorkspaceService.updateStale",
+              cwd,
+              args: ["workspace", "update-stale"],
+              timeoutMs: 20_000,
+              maxOutputBytes: 256 * 1024,
+            }),
+          ),
+          Effect.andThen(readJjRevision(driver, cwd, "@")),
+        );
+      }),
+    );
+  });
+
+  const jjIdentity = Effect.fn("VcsWorkspaceService.jjIdentity")(function* (input: {
+    readonly driver: VcsDriver.VcsDriver["Service"];
+    readonly cwd: string;
+    readonly name: string;
+    readonly workspacePath: string;
+    readonly baseRevision?: VcsRevision | null;
+    readonly publishRef?: string;
+  }) {
+    const revision = yield* readCurrentJjRevision(input.driver, input.workspacePath);
+    const actualName = currentWorkspaceName(revision);
+    if (actualName !== input.name) {
+      return yield* workspaceError({
+        operation: "validate-workspace",
+        kind: "jj",
+        detail: `Workspace path '${input.workspacePath}' belongs to '${actualName ?? "unknown"}', not '${input.name}'.`,
+      });
+    }
+    const parentId = revision.parents[0];
+    const actualBase = parentId
+      ? toRevision(
+          yield* readJjRevision(input.driver, input.workspacePath, quoteJjSymbol(parentId)),
+        )
+      : null;
+    return {
+      driverKind: "jj" as const,
+      name: input.name,
+      rootPath: input.workspacePath,
+      workspaceRevision: toRevision(revision),
+      baseRevision: input.baseRevision ?? actualBase,
+      publishRef: input.publishRef
+        ? ({ kind: "bookmark", name: input.publishRef } satisfies VcsNamedRef)
+        : null,
+    } satisfies VcsWorkspaceIdentity;
+  });
+
+  const createJjWorkspace = Effect.fn("VcsWorkspaceService.createJjWorkspace")(function* (
+    input: CreateThreadWorkspaceInput,
+    driver: VcsDriver.VcsDriver["Service"],
+    repositoryRoot: string,
+  ) {
+    const name = jjWorkspaceNameForThread(input.threadId);
+    const workspacePath =
+      input.path ?? path.join(worktreesDir, path.basename(repositoryRoot), name);
+    const base = yield* readJjRevision(driver, input.cwd, input.baseRevision);
+    const pathExists = yield* fileSystem.exists(workspacePath);
+
+    if (pathExists) {
+      const existing = yield* readCurrentJjRevision(driver, workspacePath).pipe(Effect.option);
+      if (existing._tag === "Some") {
+        if (currentWorkspaceName(existing.value) !== name) {
+          return yield* workspaceError({
+            operation: "reuse-workspace",
+            kind: "jj",
+            detail: `Refusing to reuse '${workspacePath}' because it belongs to another workspace.`,
+          });
+        }
+        return yield* jjIdentity({
+          driver,
+          cwd: input.cwd,
+          name,
+          workspacePath,
+          ...(input.publishRef ? { publishRef: input.publishRef } : {}),
+        });
+      }
+
+      const entries = yield* fileSystem.readDirectory(workspacePath);
+      if (entries.length > 0) {
+        return yield* workspaceError({
+          operation: "reuse-workspace",
+          kind: "jj",
+          detail: `Refusing to replace non-empty workspace path '${workspacePath}'.`,
+          recoverable: true,
+        });
+      }
+      yield* fileSystem.remove(workspacePath, { recursive: true, force: true });
+    }
+
+    const workspaces = yield* listJjWorkspaces(driver, input.cwd);
+    if (workspaces.some((workspace) => workspace.name === name)) {
+      yield* Effect.logInfo("forgetting missing Jujutsu thread workspace before recreation", {
+        cwd: input.cwd,
+        workspaceName: name,
+        workspacePath,
+      });
+      yield* driver.execute({
+        operation: "VcsWorkspaceService.forgetMissing",
+        cwd: input.cwd,
+        args: ["workspace", "forget", name],
+        timeoutMs: 10_000,
+        maxOutputBytes: 256 * 1024,
+      });
+    }
+
+    yield* fileSystem.makeDirectory(path.dirname(workspacePath), { recursive: true });
+    yield* driver.execute({
+      operation: "VcsWorkspaceService.createJjWorkspace",
+      cwd: input.cwd,
+      args: ["workspace", "add", workspacePath, "--name", name, "--revision", input.baseRevision],
+      timeoutMs: 120_000,
+      maxOutputBytes: 1_000_000,
+    });
+
+    const confirmed = yield* listJjWorkspaces(driver, input.cwd);
+    if (!confirmed.some((workspace) => workspace.name === name)) {
+      return yield* workspaceError({
+        operation: "confirm-workspace",
+        kind: "jj",
+        detail: `Created workspace '${name}' was not present in jj workspace metadata.`,
+        recoverable: true,
+      });
+    }
+
+    return yield* jjIdentity({
+      driver,
+      cwd: input.cwd,
+      name,
+      workspacePath,
+      baseRevision: toRevision(base),
+      ...(input.publishRef ? { publishRef: input.publishRef } : {}),
+    });
+  });
+
+  const createThreadWorkspace: VcsWorkspaceService["Service"]["createThreadWorkspace"] = Effect.fn(
+    "VcsWorkspaceService.createThreadWorkspace",
+  )(
+    function* (input) {
+      const handle = yield* registry.resolve({ cwd: input.cwd });
+      if (handle.kind === "jj") {
+        return yield* createJjWorkspace(input, handle.driver, handle.repository.rootPath);
+      }
+
+      let baseRevision = input.baseRevision;
+      if (input.startFromOrigin) {
+        yield* gitWorkflow.fetchRemote({ cwd: input.cwd, remoteName: "origin" });
+        const resolved = yield* gitWorkflow.resolveRemoteTrackingCommit({
+          cwd: input.cwd,
+          refName: input.baseRevision,
+          fallbackRemoteName: "origin",
+        });
+        baseRevision = resolved.commitSha;
+      }
+      const created = yield* gitWorkflow.createWorktree({
+        cwd: input.cwd,
+        refName: baseRevision,
+        ...(input.publishRef ? { newRefName: input.publishRef } : {}),
+        ...(input.baseRefName ? { baseRefName: input.baseRefName } : {}),
+        path: input.path ?? null,
+      });
+      const [current, base] = yield* Effect.all([
+        handle.driver.execute({
+          operation: "VcsWorkspaceService.readGitWorkspaceRevision",
+          cwd: created.worktree.path,
+          args: ["rev-parse", "--verify", "HEAD^{commit}"],
+          timeoutMs: 10_000,
+          maxOutputBytes: 4_096,
+        }),
+        handle.driver.execute({
+          operation: "VcsWorkspaceService.readGitBaseRevision",
+          cwd: input.cwd,
+          args: ["rev-parse", "--verify", `${baseRevision}^{commit}`],
+          timeoutMs: 10_000,
+          maxOutputBytes: 4_096,
+        }),
+      ]);
+      const currentCommit = current.stdout.trim();
+      const baseCommit = base.stdout.trim();
+      if (currentCommit.length === 0 || baseCommit.length === 0) {
+        return yield* workspaceError({
+          operation: "read-git-workspace-identity",
+          kind: "git",
+          detail: "Git returned an empty workspace or base revision.",
+        });
+      }
+      return {
+        driverKind: "git",
+        name: created.worktree.refName,
+        rootPath: created.worktree.path,
+        workspaceRevision: { commitId: currentCommit },
+        baseRevision: { commitId: baseCommit },
+        publishRef: {
+          kind: "branch",
+          name: created.worktree.refName,
+          target: { commitId: currentCommit },
+        },
+      } satisfies VcsWorkspaceIdentity;
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : workspaceError({
+            operation: "create-thread-workspace",
+            kind: "unknown",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  const ensureThreadWorkspace: VcsWorkspaceService["Service"]["ensureThreadWorkspace"] = Effect.fn(
+    "VcsWorkspaceService.ensureThreadWorkspace",
+  )(
+    function* (input) {
+      if (input.workspace.driverKind !== "jj") {
+        return input.workspace;
+      }
+      const baseRevision = input.workspace.baseRevision?.commitId;
+      if (!baseRevision) {
+        return yield* workspaceError({
+          operation: "ensure-thread-workspace",
+          kind: "jj",
+          detail: "Persisted Jujutsu workspace metadata has no base revision.",
+          recoverable: true,
+        });
+      }
+      const handle = yield* registry.resolve({ cwd: input.cwd, requestedKind: "jj" });
+      const ensured = yield* createJjWorkspace(
+        {
+          cwd: input.cwd,
+          threadId: input.threadId,
+          baseRevision,
+          ...(input.workspace.publishRef ? { publishRef: input.workspace.publishRef.name } : {}),
+          path: input.workspace.rootPath,
+        },
+        handle.driver,
+        handle.repository.rootPath,
+      );
+      if (
+        ensured.rootPath !== input.workspace.rootPath ||
+        ensured.name !== input.workspace.name ||
+        !sameRevision(ensured.workspaceRevision, input.workspace.workspaceRevision) ||
+        !sameRevision(ensured.baseRevision, input.workspace.baseRevision)
+      ) {
+        yield* Effect.logInfo("refreshed persisted Jujutsu thread workspace identity", {
+          threadId: input.threadId,
+          workspaceName: ensured.name,
+          workspacePath: ensured.rootPath,
+        });
+      }
+      return ensured;
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : workspaceError({
+            operation: "ensure-thread-workspace",
+            kind: "jj",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  const removeThreadWorkspace: VcsWorkspaceService["Service"]["removeThreadWorkspace"] = Effect.fn(
+    "VcsWorkspaceService.removeThreadWorkspace",
+  )(
+    function* (input) {
+      if (input.workspace.driverKind === "git") {
+        yield* gitWorkflow.removeWorktree({
+          cwd: input.cwd,
+          path: input.workspace.rootPath,
+          force: true,
+        });
+        return;
+      }
+      const name = input.workspace.name;
+      if (!name) {
+        return yield* workspaceError({
+          operation: "remove-thread-workspace",
+          kind: "jj",
+          detail: "Persisted Jujutsu workspace metadata has no workspace name.",
+        });
+      }
+      const handle = yield* registry.resolve({ cwd: input.cwd, requestedKind: "jj" });
+      const pathExists = yield* fileSystem.exists(input.workspace.rootPath);
+      if (pathExists) {
+        const revision = yield* readCurrentJjRevision(handle.driver, input.workspace.rootPath);
+        if (currentWorkspaceName(revision) !== name) {
+          return yield* workspaceError({
+            operation: "remove-thread-workspace",
+            kind: "jj",
+            detail: `Refusing to delete '${input.workspace.rootPath}' because it belongs to another workspace.`,
+          });
+        }
+      }
+      const workspaces = yield* listJjWorkspaces(handle.driver, input.cwd);
+      if (workspaces.some((workspace) => workspace.name === name)) {
+        yield* handle.driver.execute({
+          operation: "VcsWorkspaceService.forgetJjWorkspace",
+          cwd: input.cwd,
+          args: ["workspace", "forget", name],
+          timeoutMs: 10_000,
+          maxOutputBytes: 256 * 1024,
+        });
+      }
+      if (pathExists) {
+        yield* fileSystem.remove(input.workspace.rootPath, { recursive: true, force: true });
+      }
+    },
+    Effect.mapError((cause) =>
+      isVcsWorkflowError(cause)
+        ? cause
+        : workspaceError({
+            operation: "remove-thread-workspace",
+            kind: "unknown",
+            detail: errorDetail(cause),
+            recoverable: true,
+          }),
+    ),
+  );
+
+  return VcsWorkspaceService.of({
+    createThreadWorkspace,
+    ensureThreadWorkspace,
+    removeThreadWorkspace,
+  });
+});
+
+export const layer = Layer.effect(VcsWorkspaceService, make);

--- a/apps/server/src/vcs/testing/VcsDriverContractHarness.ts
+++ b/apps/server/src/vcs/testing/VcsDriverContractHarness.ts
@@ -143,6 +143,9 @@ export function runVcsDriverContractSuite<R, E>(input: VcsDriverContractSuiteInp
 
           yield* input.fixture.createRepo(cwd);
           yield* input.fixture.ignorePath(cwd, "*.log");
+          yield* input.fixture.writeFile(cwd, "keep.ts", "keep\n");
+          yield* input.fixture.writeFile(cwd, "debug.log", "ignore\n");
+          yield* input.fixture.writeFile(cwd, "nested/error.log", "ignore\n");
 
           const result = yield* driver.filterIgnoredPaths(cwd, [
             "keep.ts",

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -110,6 +110,7 @@ import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProjectConfig from "./vcs/VcsProjectConfig.ts";
 import * as VcsProcess from "./vcs/VcsProcess.ts";
+import * as VcsGitProviderCompatibility from "./vcs/VcsGitProviderCompatibility.ts";
 import * as PairingGrantStore from "./auth/PairingGrantStore.ts";
 import * as SessionStore from "./auth/SessionStore.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
@@ -320,6 +321,13 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.vcsCreateRef, AuthOrchestrationOperateScope],
   [WS_METHODS.vcsSwitchRef, AuthOrchestrationOperateScope],
   [WS_METHODS.vcsInit, AuthOrchestrationOperateScope],
+  [WS_METHODS.gitPullLegacy, AuthOrchestrationOperateScope],
+  [WS_METHODS.gitRefreshStatusLegacy, AuthOrchestrationReadScope],
+  [WS_METHODS.gitListRefsLegacy, AuthOrchestrationReadScope],
+  [WS_METHODS.gitCreateWorktreeLegacy, AuthOrchestrationOperateScope],
+  [WS_METHODS.gitRemoveWorktreeLegacy, AuthOrchestrationOperateScope],
+  [WS_METHODS.gitCreateRefLegacy, AuthOrchestrationOperateScope],
+  [WS_METHODS.gitSwitchRefLegacy, AuthOrchestrationOperateScope],
   [WS_METHODS.reviewGetDiffPreview, AuthReviewWriteScope],
   [WS_METHODS.terminalOpen, AuthTerminalOperateScope],
   [WS_METHODS.terminalAttach, AuthTerminalOperateScope],
@@ -1621,7 +1629,55 @@ const makeWsRpcLayer = (
             WS_METHODS.vcsInit,
             vcsProvisioning
               .initRepository(input)
-              .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+              .pipe(
+                Effect.tap(() => (input.kind === "jj" ? Effect.void : refreshGitStatus(input.cwd))),
+              ),
+            { "rpc.aggregate": "vcs" },
+          ),
+        [WS_METHODS.gitRefreshStatusLegacy]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitRefreshStatusLegacy,
+            vcsStatusBroadcaster.refreshStatus(input.cwd),
+            { "rpc.aggregate": "vcs" },
+          ),
+        [WS_METHODS.gitPullLegacy]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitPullLegacy,
+            gitWorkflow.pullCurrentBranch(input.cwd).pipe(
+              Effect.matchCauseEffect({
+                onFailure: (cause) => Effect.failCause(cause),
+                onSuccess: (result) =>
+                  refreshGitStatus(input.cwd).pipe(Effect.ignore({ log: true }), Effect.as(result)),
+              }),
+            ),
+            { "rpc.aggregate": "git" },
+          ),
+        [WS_METHODS.gitListRefsLegacy]: (input) =>
+          observeRpcEffect(WS_METHODS.gitListRefsLegacy, gitWorkflow.listRefs(input), {
+            "rpc.aggregate": "vcs",
+          }),
+        [WS_METHODS.gitCreateWorktreeLegacy]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitCreateWorktreeLegacy,
+            gitWorkflow.createWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "vcs" },
+          ),
+        [WS_METHODS.gitRemoveWorktreeLegacy]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitRemoveWorktreeLegacy,
+            gitWorkflow.removeWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "vcs" },
+          ),
+        [WS_METHODS.gitCreateRefLegacy]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitCreateRefLegacy,
+            gitWorkflow.createRef(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "vcs" },
+          ),
+        [WS_METHODS.gitSwitchRefLegacy]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitSwitchRefLegacy,
+            gitWorkflow.switchRef(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.reviewGetDiffPreview]: (input) =>
@@ -1897,6 +1953,9 @@ export const websocketRpcRouteLayer = Layer.unwrap(
                         ),
                       ),
                       Layer.provideMerge(GitVcsDriver.layer),
+                      Layer.provideMerge(
+                        VcsGitProviderCompatibility.layer.pipe(Layer.provide(GitVcsDriver.layer)),
+                      ),
                       Layer.provide(
                         VcsDriverRegistry.layer.pipe(Layer.provide(VcsProjectConfig.layer)),
                       ),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1629,9 +1629,7 @@ const makeWsRpcLayer = (
             WS_METHODS.vcsInit,
             vcsProvisioning
               .initRepository(input)
-              .pipe(
-                Effect.tap(() => (input.kind === "jj" ? Effect.void : refreshGitStatus(input.cwd))),
-              ),
+              .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.gitRefreshStatusLegacy]: (input) =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -26,6 +26,7 @@ import {
   EventId,
   type OrchestrationCommand,
   type GitActionProgressEvent,
+  GitCommandError,
   type GitManagerServiceError,
   OrchestrationDispatchCommandError,
   type OrchestrationEvent,
@@ -56,6 +57,7 @@ import {
   type TerminalError,
   type TerminalEvent,
   type TerminalMetadataStreamEvent,
+  type VcsCreateWorktreeResult,
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
@@ -90,6 +92,7 @@ import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
 import * as WorkspacePaths from "./workspace/WorkspacePaths.ts";
 import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
+import * as VcsWorkspaceService from "./vcs/VcsWorkspaceService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
@@ -409,6 +412,7 @@ const makeWsRpcLayer = (
       const keybindings = yield* Keybindings.Keybindings;
       const externalLauncher = yield* ExternalLauncher.ExternalLauncher;
       const gitWorkflow = yield* GitWorkflowService.GitWorkflowService;
+      const vcsWorkspaceService = yield* VcsWorkspaceService.VcsWorkspaceService;
       const review = yield* ReviewService.ReviewService;
       const vcsProvisioning = yield* VcsProvisioningService.VcsProvisioningService;
       const vcsStatusBroadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
@@ -695,20 +699,36 @@ const makeWsRpcLayer = (
           let targetProjectId = bootstrap?.createThread?.projectId;
           let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
           let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
+          let createdVcsWorkspace = bootstrap?.createThread?.vcsWorkspace ?? null;
+          let workspaceAttachedToThread = createdVcsWorkspace !== null;
+
+          const cleanupCreatedWorkspace = () =>
+            !workspaceAttachedToThread && createdVcsWorkspace && targetProjectCwd
+              ? vcsWorkspaceService
+                  .removeThreadWorkspace({
+                    cwd: targetProjectCwd,
+                    workspace: createdVcsWorkspace,
+                  })
+                  .pipe(Effect.ignoreCause({ log: true }))
+              : Effect.void;
 
           const cleanupCreatedThread = () =>
-            createdThread
-              ? serverCommandId("bootstrap-thread-delete").pipe(
-                  Effect.flatMap((commandId) =>
-                    orchestrationEngine.dispatch({
-                      type: "thread.delete",
-                      commandId,
-                      threadId: command.threadId,
-                    }),
-                  ),
-                  Effect.ignoreCause({ log: true }),
-                )
-              : Effect.void;
+            cleanupCreatedWorkspace().pipe(
+              Effect.andThen(
+                createdThread
+                  ? serverCommandId("bootstrap-thread-delete").pipe(
+                      Effect.flatMap((commandId) =>
+                        orchestrationEngine.dispatch({
+                          type: "thread.delete",
+                          commandId,
+                          threadId: command.threadId,
+                        }),
+                      ),
+                      Effect.ignoreCause({ log: true }),
+                    )
+                  : Effect.void,
+              ),
+            );
 
           const recordSetupScriptLaunchFailure = (input: {
             readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
@@ -838,40 +858,38 @@ const makeWsRpcLayer = (
                 interactionMode: bootstrap.createThread.interactionMode,
                 branch: bootstrap.createThread.branch,
                 worktreePath: bootstrap.createThread.worktreePath,
+                ...(bootstrap.createThread.vcsWorkspace !== undefined
+                  ? { vcsWorkspace: bootstrap.createThread.vcsWorkspace }
+                  : {}),
                 createdAt: bootstrap.createThread.createdAt,
               });
               createdThread = true;
             }
 
             if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
-              if (bootstrap.prepareWorktree.startFromOrigin) {
-                yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                });
-                const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  fallbackRemoteName: "origin",
-                });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
-              }
-              const worktree = yield* gitWorkflow.createWorktree({
+              createdVcsWorkspace = yield* vcsWorkspaceService.createThreadWorkspace({
                 cwd: bootstrap.prepareWorktree.projectCwd,
-                refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
+                threadId: command.threadId,
+                baseRevision: bootstrap.prepareWorktree.baseBranch,
                 baseRefName: bootstrap.prepareWorktree.baseBranch,
-                path: null,
+                ...(bootstrap.prepareWorktree.branch
+                  ? { publishRef: bootstrap.prepareWorktree.branch }
+                  : {}),
+                ...(bootstrap.prepareWorktree.startFromOrigin ? { startFromOrigin: true } : {}),
               });
-              targetWorktreePath = worktree.worktree.path;
+              targetWorktreePath = createdVcsWorkspace.rootPath;
               yield* orchestrationEngine.dispatch({
                 type: "thread.meta.update",
                 commandId: yield* serverCommandId("bootstrap-thread-meta-update"),
                 threadId: command.threadId,
-                branch: worktree.worktree.refName,
+                branch:
+                  createdVcsWorkspace.driverKind === "git"
+                    ? (createdVcsWorkspace.publishRef?.name ?? createdVcsWorkspace.name)
+                    : null,
                 worktreePath: targetWorktreePath,
+                vcsWorkspace: createdVcsWorkspace,
               });
+              workspaceAttachedToThread = true;
               yield* refreshGitStatus(targetWorktreePath);
             }
 
@@ -1603,7 +1621,39 @@ const makeWsRpcLayer = (
         [WS_METHODS.vcsCreateWorktree]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsCreateWorktree,
-            gitWorkflow.createWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            (input.threadId
+              ? vcsWorkspaceService
+                  .createThreadWorkspace({
+                    cwd: input.cwd,
+                    threadId: input.threadId,
+                    baseRevision: input.refName,
+                    ...(input.baseRefName ? { baseRefName: input.baseRefName } : {}),
+                    ...(input.newRefName ? { publishRef: input.newRefName } : {}),
+                    ...(input.path ? { path: input.path } : {}),
+                  })
+                  .pipe(
+                    Effect.map(
+                      (workspace): VcsCreateWorktreeResult => ({
+                        worktree: {
+                          path: workspace.rootPath,
+                          refName: workspace.publishRef?.name ?? workspace.name ?? input.refName,
+                        },
+                        workspace,
+                      }),
+                    ),
+                    Effect.mapError(
+                      (cause) =>
+                        new GitCommandError({
+                          operation: "vcs.createWorktree",
+                          command: "vcs-workspace",
+                          cwd: input.cwd,
+                          detail: cause.message,
+                          cause,
+                        }),
+                    ),
+                  )
+              : gitWorkflow.createWorktree(input)
+            ).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.vcsRemoveWorktree]: (input) =>

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -157,19 +157,29 @@ describe("when: repository uses jj", () => {
     refName: null,
     workspaceRevision: "change-id",
     publishRef: null,
+    hasWorkingTreeChanges: true,
   });
 
-  it("shows workspace-aware disabled finalization", () => {
+  it("enables workspace-aware finalization", () => {
     assert.deepEqual(resolveQuickAction(jjStatus, false), {
       label: "Finalize change",
-      disabled: true,
-      kind: "show_hint",
-      hint: "Jujutsu change finalization is not available yet.",
+      disabled: false,
+      kind: "run_action",
+      action: "commit",
     });
   });
 
-  it("does not expose Git actions", () => {
-    assert.deepEqual(buildMenuItems(jjStatus, false), []);
+  it("exposes only the finalize action", () => {
+    assert.deepEqual(buildMenuItems(jjStatus, false), [
+      {
+        id: "commit",
+        label: "Finalize change",
+        disabled: false,
+        icon: "commit",
+        kind: "open_dialog",
+        dialogAction: "commit",
+      },
+    ]);
   });
 });
 
@@ -1023,6 +1033,21 @@ describe("buildGitActionProgressStages", () => {
       "Preparing PR...",
       "Generating PR content...",
       "Creating pull request...",
+    ]);
+  });
+
+  it("uses jj-native finalization and bookmark labels", () => {
+    const stages = buildGitActionProgressStages({
+      action: "commit",
+      driverKind: "jj",
+      hasCustomCommitMessage: false,
+      hasWorkingTreeChanges: true,
+      featureBranch: true,
+    });
+    assert.deepEqual(stages, [
+      "Preparing feature bookmark...",
+      "Generating change message...",
+      "Finalizing change...",
     ]);
   });
 });

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -151,6 +151,28 @@ describe("when: git status is unavailable", () => {
   });
 });
 
+describe("when: repository uses jj", () => {
+  const jjStatus = status({
+    driverKind: "jj",
+    refName: null,
+    workspaceRevision: "change-id",
+    publishRef: null,
+  });
+
+  it("shows workspace-aware disabled finalization", () => {
+    assert.deepEqual(resolveQuickAction(jjStatus, false), {
+      label: "Finalize change",
+      disabled: true,
+      kind: "show_hint",
+      hint: "Jujutsu change finalization is not available yet.",
+    });
+  });
+
+  it("does not expose Git actions", () => {
+    assert.deepEqual(buildMenuItems(jjStatus, false), []);
+  });
+});
+
 describe("when: ref is clean, ahead, and has an open PR", () => {
   it("resolveQuickAction prefers push", () => {
     const quick = resolveQuickAction(

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -181,6 +181,83 @@ describe("when: repository uses jj", () => {
       },
     ]);
   });
+
+  it("publishes only through an explicit workspace bookmark", () => {
+    const publishRef = {
+      kind: "bookmark" as const,
+      name: "feature/phase-6",
+      target: { commitId: "finalized-commit", changeId: "finalized-change" },
+    };
+    assert.deepEqual(resolveQuickAction(jjStatus, false, false, true, publishRef), {
+      label: "Finalize & publish",
+      disabled: false,
+      kind: "run_action",
+      action: "commit_push",
+    });
+    const cleanStatus = { ...jjStatus, hasWorkingTreeChanges: false };
+    assert.deepEqual(resolveQuickAction(cleanStatus, false, false, true, publishRef), {
+      label: "Publish feature/phase-6",
+      disabled: false,
+      kind: "run_action",
+      action: "push",
+    });
+    assert.deepEqual(
+      resolveQuickAction(cleanStatus, false, false, true, {
+        ...publishRef,
+        remoteName: "origin",
+      }),
+      {
+        label: "Create change request",
+        disabled: false,
+        kind: "run_action",
+        action: "create_pr",
+      },
+    );
+  });
+
+  it("prefers an explicit safe fetch when the tracked remote is ahead", () => {
+    assert.deepEqual(resolveQuickAction({ ...jjStatus, behindCount: 1 }, false), {
+      label: "Fetch updates",
+      disabled: false,
+      kind: "run_pull",
+    });
+  });
+
+  it("opens an existing change request instead of offering to create another", () => {
+    const openPrStatus = {
+      ...jjStatus,
+      hasWorkingTreeChanges: false,
+      pr: {
+        number: 106,
+        title: "Phase 6 change request",
+        url: "https://example.com/pr/106",
+        baseRef: "main",
+        headRef: "feature/phase-6",
+        state: "open" as const,
+      },
+    };
+    const publishRef = {
+      kind: "bookmark" as const,
+      name: "feature/phase-6",
+      remoteName: "origin",
+      target: { commitId: "finalized-commit", changeId: "finalized-change" },
+    };
+
+    assert.deepEqual(buildMenuItems(openPrStatus, false, true, publishRef), [
+      {
+        id: "pr",
+        label: "View PR",
+        disabled: false,
+        icon: "pr",
+        kind: "open_pr",
+      },
+    ]);
+    assert.deepEqual(resolveQuickAction(openPrStatus, false, false, true, publishRef), {
+      label: "View PR",
+      disabled: false,
+      kind: "open_pr",
+    });
+  });
 });
 
 describe("when: ref is clean, ahead, and has an open PR", () => {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -1,6 +1,7 @@
 import type {
   GitRunStackedActionResult,
   GitStackedAction,
+  VcsNamedRef,
   VcsStatusResult,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
@@ -12,7 +13,7 @@ import {
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
-export type GitDialogAction = "commit" | "push" | "create_pr";
+export type GitDialogAction = "commit" | "commit_push" | "push" | "create_pr";
 
 export interface GitActionMenuItem {
   id: "commit" | "push" | "pr";
@@ -101,22 +102,55 @@ export function buildMenuItems(
   gitStatus: VcsStatusResult | null,
   isBusy: boolean,
   hasPrimaryRemote = true,
+  publishRef: VcsNamedRef | null = null,
 ): GitActionMenuItem[] {
   if (!gitStatus) return [];
+  const terminology = resolveChangeRequestTerminology(gitStatus);
   if (gitStatus.driverKind === "jj") {
+    const hasChanges = gitStatus.hasWorkingTreeChanges;
+    if (!hasChanges && gitStatus.pr?.state === "open") {
+      return [
+        {
+          id: "pr",
+          label: `View ${terminology.shortLabel}`,
+          disabled: isBusy,
+          icon: "pr",
+          kind: "open_pr",
+        },
+      ];
+    }
+    if (!hasChanges && publishRef) {
+      return [
+        publishRef.remoteName
+          ? {
+              id: "pr",
+              label: "Create change request",
+              disabled: isBusy,
+              icon: "pr",
+              kind: "open_dialog",
+              dialogAction: "create_pr",
+            }
+          : {
+              id: "push",
+              label: `Publish ${publishRef.name}`,
+              disabled: isBusy,
+              icon: "push",
+              kind: "open_dialog",
+              dialogAction: "push",
+            },
+      ];
+    }
     return [
       {
         id: "commit",
-        label: "Finalize change",
-        disabled: isBusy || !gitStatus.hasWorkingTreeChanges,
+        label: publishRef ? "Finalize & publish" : "Finalize change",
+        disabled: isBusy || !hasChanges,
         icon: "commit",
         kind: "open_dialog",
-        dialogAction: "commit",
+        dialogAction: publishRef ? "commit_push" : "commit",
       },
     ];
   }
-  const terminology = resolveChangeRequestTerminology(gitStatus);
-
   const hasBranch = gitStatus.refName !== null;
   const hasChanges = gitStatus.hasWorkingTreeChanges;
   const hasOpenPr = gitStatus.pr?.state === "open";
@@ -187,7 +221,69 @@ export function resolveQuickAction(
   isBusy: boolean,
   isDefaultRef = false,
   hasPrimaryRemote = true,
+  publishRef: VcsNamedRef | null = null,
 ): GitQuickAction {
+  if (gitStatus?.driverKind === "jj") {
+    if (isBusy) {
+      return {
+        label: "Source control action",
+        disabled: true,
+        kind: "show_hint",
+        hint: "Source control action in progress.",
+      };
+    }
+    if (gitStatus.behindCount > 0) {
+      return {
+        label: "Fetch updates",
+        disabled: false,
+        kind: "run_pull",
+      };
+    }
+    if (gitStatus.hasWorkingTreeChanges) {
+      return publishRef
+        ? {
+            label: "Finalize & publish",
+            disabled: false,
+            kind: "run_action",
+            action: "commit_push",
+          }
+        : {
+            label: "Finalize change",
+            disabled: false,
+            kind: "run_action",
+            action: "commit",
+          };
+    }
+    if (gitStatus.pr?.state === "open") {
+      const terminology = resolveChangeRequestTerminology(gitStatus);
+      return {
+        label: `View ${terminology.shortLabel}`,
+        disabled: false,
+        kind: "open_pr",
+      };
+    }
+    if (publishRef) {
+      return publishRef.remoteName
+        ? {
+            label: "Create change request",
+            disabled: false,
+            kind: "run_action",
+            action: "create_pr",
+          }
+        : {
+            label: `Publish ${publishRef.name}`,
+            disabled: false,
+            kind: "run_action",
+            action: "push",
+          };
+    }
+    return {
+      label: "Finalize change",
+      disabled: true,
+      kind: "show_hint",
+      hint: "The working-copy change is empty.",
+    };
+  }
   if (isBusy) {
     return { label: "Commit", disabled: true, kind: "show_hint", hint: "Git action in progress." };
   }
@@ -198,31 +294,6 @@ export function resolveQuickAction(
       disabled: true,
       kind: "show_hint",
       hint: "Git status is unavailable.",
-    };
-  }
-
-  if (gitStatus.driverKind === "jj") {
-    if (isBusy) {
-      return {
-        label: "Finalize change",
-        disabled: true,
-        kind: "show_hint",
-        hint: "Source control action in progress.",
-      };
-    }
-    if (!gitStatus.hasWorkingTreeChanges) {
-      return {
-        label: "Finalize change",
-        disabled: true,
-        kind: "show_hint",
-        hint: "The working-copy change is empty.",
-      };
-    }
-    return {
-      label: "Finalize change",
-      disabled: false,
-      kind: "run_action",
-      action: "commit",
     };
   }
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -97,6 +97,7 @@ export function buildMenuItems(
   hasPrimaryRemote = true,
 ): GitActionMenuItem[] {
   if (!gitStatus) return [];
+  if (gitStatus.driverKind === "jj") return [];
   const terminology = resolveChangeRequestTerminology(gitStatus);
 
   const hasBranch = gitStatus.refName !== null;
@@ -180,6 +181,15 @@ export function resolveQuickAction(
       disabled: true,
       kind: "show_hint",
       hint: "Git status is unavailable.",
+    };
+  }
+
+  if (gitStatus.driverKind === "jj") {
+    return {
+      label: "Finalize change",
+      disabled: true,
+      kind: "show_hint",
+      hint: "Jujutsu change finalization is not available yet.",
     };
   }
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -53,6 +53,7 @@ function resolveChangeRequestTerminology(
 
 export function buildGitActionProgressStages(input: {
   action: GitStackedAction;
+  driverKind?: VcsStatusResult["driverKind"];
   hasCustomCommitMessage: boolean;
   hasWorkingTreeChanges: boolean;
   pushTarget?: string;
@@ -61,7 +62,10 @@ export function buildGitActionProgressStages(input: {
   terminology?: ChangeRequestTerminology;
 }): string[] {
   const terminology = input.terminology ?? DEFAULT_CHANGE_REQUEST_TERMINOLOGY;
-  const branchStages = input.featureBranch ? ["Preparing feature ref..."] : [];
+  const isJj = input.driverKind === "jj";
+  const branchStages = input.featureBranch
+    ? [isJj ? "Preparing feature bookmark..." : "Preparing feature ref..."]
+    : [];
   const pushStage = input.pushTarget ? `Pushing to ${input.pushTarget}...` : "Pushing...";
   const prStages = [
     `Preparing ${terminology.shortLabel}...`,
@@ -80,8 +84,10 @@ export function buildGitActionProgressStages(input: {
   const commitStages = !shouldIncludeCommitStages
     ? []
     : input.hasCustomCommitMessage
-      ? ["Committing..."]
-      : ["Generating commit message...", "Committing..."];
+      ? [isJj ? "Finalizing change..." : "Committing..."]
+      : isJj
+        ? ["Generating change message...", "Finalizing change..."]
+        : ["Generating commit message...", "Committing..."];
   if (input.action === "commit") {
     return [...branchStages, ...commitStages];
   }
@@ -97,7 +103,18 @@ export function buildMenuItems(
   hasPrimaryRemote = true,
 ): GitActionMenuItem[] {
   if (!gitStatus) return [];
-  if (gitStatus.driverKind === "jj") return [];
+  if (gitStatus.driverKind === "jj") {
+    return [
+      {
+        id: "commit",
+        label: "Finalize change",
+        disabled: isBusy || !gitStatus.hasWorkingTreeChanges,
+        icon: "commit",
+        kind: "open_dialog",
+        dialogAction: "commit",
+      },
+    ];
+  }
   const terminology = resolveChangeRequestTerminology(gitStatus);
 
   const hasBranch = gitStatus.refName !== null;
@@ -185,11 +202,27 @@ export function resolveQuickAction(
   }
 
   if (gitStatus.driverKind === "jj") {
+    if (isBusy) {
+      return {
+        label: "Finalize change",
+        disabled: true,
+        kind: "show_hint",
+        hint: "Source control action in progress.",
+      };
+    }
+    if (!gitStatus.hasWorkingTreeChanges) {
+      return {
+        label: "Finalize change",
+        disabled: true,
+        kind: "show_hint",
+        hint: "The working-copy change is empty.",
+      };
+    }
     return {
       label: "Finalize change",
-      disabled: true,
-      kind: "show_hint",
-      hint: "Jujutsu change finalization is not available yet.",
+      disabled: false,
+      kind: "run_action",
+      action: "commit",
     };
   }
 

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -4,6 +4,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { getVcsPresentation } from "@t3tools/client-runtime/state/vcs";
 import type {
   GitActionProgressEvent,
   GitRunStackedActionResult,
@@ -1140,6 +1141,7 @@ export default function GitActionsControl({
   );
   const changeRequestTerminology = sourceControlPresentation.terminology;
   const isJjRepository = gitStatus?.driverKind === "jj";
+  const versionControlPresentation = getVcsPresentation(gitStatus?.driverKind);
   const jjPublishRef = isJjRepository
     ? (activeServerThread?.vcsWorkspace?.publishRef ?? null)
     : null;
@@ -1361,8 +1363,8 @@ export default function GitActionsControl({
         progressToastId ??
         toastManager.add({
           type: "loading",
-          title: progressStages[0] ?? "Running git action...",
-          description: "Waiting for Git...",
+          title: progressStages[0] ?? "Running source-control action...",
+          description: `Waiting for ${versionControlPresentation.systemLabel}...`,
           timeout: 0,
           data: scopedToastData,
         });
@@ -1371,19 +1373,19 @@ export default function GitActionsControl({
         toastId: resolvedProgressToastId,
         toastData: scopedToastData,
         actionId,
-        title: progressStages[0] ?? "Running git action...",
+        title: progressStages[0] ?? "Running source-control action...",
         phaseStartedAtMs: null,
         hookStartedAtMs: null,
         hookName: null,
         lastOutputLine: null,
-        currentPhaseLabel: progressStages[0] ?? "Running git action...",
+        currentPhaseLabel: progressStages[0] ?? "Running source-control action...",
       };
 
       if (progressToastId) {
         toastManager.update(progressToastId, {
           type: "loading",
-          title: progressStages[0] ?? "Running git action...",
-          description: "Waiting for Git...",
+          title: progressStages[0] ?? "Running source-control action...",
+          description: `Waiting for ${versionControlPresentation.systemLabel}...`,
           timeout: 0,
           data: scopedToastData,
         });

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -31,7 +31,13 @@ import {
   GlobeIcon,
 } from "lucide-react";
 import { Radio as RadioPrimitive } from "@base-ui/react/radio";
-import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "~/components/Icons";
+import {
+  AzureDevOpsIcon,
+  BitbucketIcon,
+  GitHubIcon,
+  GitLabIcon,
+  JujutsuIcon,
+} from "~/components/Icons";
 import { RadioGroup } from "~/components/ui/radio-group";
 import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
@@ -1007,6 +1013,18 @@ export default function GitActionsControl({
     () => ({ environmentId: activeEnvironmentId, cwd: gitCwd }),
     [activeEnvironmentId, gitCwd],
   );
+  const sourceControlDiscovery = useEnvironmentQuery(
+    activeEnvironmentId === null
+      ? null
+      : sourceControlEnvironment.discovery({
+          environmentId: activeEnvironmentId,
+          input: {},
+        }),
+  );
+  const jjAvailable =
+    sourceControlDiscovery.data?.versionControlSystems.some(
+      (item) => item.kind === "jj" && item.status === "available" && item.implemented,
+    ) ?? false;
   let runGitActionWithToast: (input: RunGitActionWithToastInput) => Promise<void>;
 
   const updateActiveProgressToast = useCallback(() => {
@@ -1093,7 +1111,8 @@ export default function GitActionsControl({
     [gitStatus?.sourceControlProvider],
   );
   const changeRequestTerminology = sourceControlPresentation.terminology;
-  const SourceControlIcon = sourceControlPresentation.Icon;
+  const isJjRepository = gitStatus?.driverKind === "jj";
+  const SourceControlIcon = isJjRepository ? JujutsuIcon : sourceControlPresentation.Icon;
   // Default to true while loading so we don't flash init controls.
   const isRepo = gitStatus?.isRepo ?? true;
   const hasPrimaryRemote = gitStatus?.hasPrimaryRemote ?? false;
@@ -1105,6 +1124,7 @@ export default function GitActionsControl({
   const noneSelected = selectedFiles.length === 0;
 
   const initAction = useVcsInitAction(sourceControlScope);
+  const initJjAction = useVcsInitAction(sourceControlScope, "jj");
   const runImmediateGitAction = useGitStackedAction(sourceControlScope);
   const pullAction = useVcsPullAction(sourceControlScope);
   const isGitActionRunning = useSourceControlActionRunning(
@@ -1117,7 +1137,7 @@ export default function GitActionsControl({
     activeDraftThread.worktreePath === null;
 
   useEffect(() => {
-    if (isGitActionRunning || isSelectingWorktreeBase) {
+    if (isJjRepository || isGitActionRunning || isSelectingWorktreeBase) {
       return;
     }
 
@@ -1135,6 +1155,7 @@ export default function GitActionsControl({
     activeDraftThread?.branch,
     gitStatusForActions,
     isGitActionRunning,
+    isJjRepository,
     isSelectingWorktreeBase,
     persistThreadBranchSync,
   ]);
@@ -1648,42 +1669,70 @@ export default function GitActionsControl({
     [gitCwd, openInPreferredEditor, threadToastData],
   );
 
-  const canPublishRepository = isRepo && gitStatusForActions !== null && !hasPrimaryRemote;
+  const canPublishRepository =
+    isRepo && !isJjRepository && gitStatusForActions !== null && !hasPrimaryRemote;
 
   if (!gitCwd) return null;
 
   return (
     <>
       {!isRepo ? (
-        <Button
-          variant="outline"
-          size="xs"
-          disabled={initAction.isPending}
-          onClick={() => {
-            void (async () => {
-              const result = await initAction.run();
-              if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-                return;
-              }
-              const error = squashAtomCommandFailure(result);
-              toastManager.add(
-                stackedThreadToast({
-                  type: "error",
-                  title: "Git initialization failed",
-                  description: error instanceof Error ? error.message : "An error occurred.",
-                  ...(threadToastData !== undefined ? { data: threadToastData } : {}),
-                }),
-              );
-            })();
-          }}
-        >
-          <GitBranchPlusIcon className="size-3.5" aria-hidden />
-          <span className="ml-0.5">
-            {initAction.isPending ? "Initializing..." : "Initialize Git"}
-          </span>
-        </Button>
+        <Group aria-label="Initialize source control" className="shrink-0">
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={initAction.isPending}
+            onClick={() => {
+              void (async () => {
+                const result = await initAction.run();
+                if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+                const error = squashAtomCommandFailure(result);
+                toastManager.add(
+                  stackedThreadToast({
+                    type: "error",
+                    title: "Git initialization failed",
+                    description: error instanceof Error ? error.message : "An error occurred.",
+                    ...(threadToastData !== undefined ? { data: threadToastData } : {}),
+                  }),
+                );
+              })();
+            }}
+          >
+            <GitBranchPlusIcon className="size-3.5" aria-hidden />
+            <span className="ml-0.5">
+              {initAction.isPending ? "Initializing..." : "Initialize Git"}
+            </span>
+          </Button>
+          {jjAvailable ? (
+            <Button
+              variant="outline"
+              size="xs"
+              disabled={initJjAction.isPending}
+              onClick={() => {
+                void (async () => {
+                  const result = await initJjAction.run();
+                  if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+                  const error = squashAtomCommandFailure(result);
+                  toastManager.add(
+                    stackedThreadToast({
+                      type: "error",
+                      title: "Jujutsu initialization failed",
+                      description: error instanceof Error ? error.message : "An error occurred.",
+                      ...(threadToastData !== undefined ? { data: threadToastData } : {}),
+                    }),
+                  );
+                })();
+              }}
+            >
+              <JujutsuIcon className="size-3.5" aria-hidden />
+              <span className="ml-0.5">
+                {initJjAction.isPending ? "Initializing..." : "Initialize Jujutsu"}
+              </span>
+            </Button>
+          ) : null}
+        </Group>
       ) : (
-        <Group aria-label="Git actions" className="shrink-0">
+        <Group aria-label="Source control actions" className="shrink-0">
           {quickActionDisabledReason ? (
             <Popover>
               <PopoverTrigger
@@ -1731,12 +1780,41 @@ export default function GitActionsControl({
             }}
           >
             <MenuTrigger
-              render={<Button aria-label="Git action options" size="icon-xs" variant="outline" />}
+              render={
+                <Button aria-label="Source control options" size="icon-xs" variant="outline" />
+              }
               disabled={isGitActionRunning}
             >
               <ChevronDownIcon aria-hidden="true" className="size-4" />
             </MenuTrigger>
             <MenuPopup align="end" className="w-full">
+              {isJjRepository && gitStatusForActions ? (
+                <div className="min-w-64 space-y-1 border-b px-2 py-2 text-xs">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-muted-foreground">Workspace change</span>
+                    <span
+                      className="max-w-40 truncate font-mono"
+                      title={gitStatusForActions.workspaceRevision ?? undefined}
+                    >
+                      {gitStatusForActions.workspaceRevision?.slice(0, 12) ?? "Unavailable"}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-muted-foreground">Publish bookmark</span>
+                    <span>{gitStatusForActions.publishRef ?? "None"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="text-muted-foreground">Changed files</span>
+                    <span>{gitStatusForActions.workingTree.files.length}</span>
+                  </div>
+                  {(gitStatusForActions.conflicts?.length ?? 0) > 0 ? (
+                    <p className="text-warning">
+                      {gitStatusForActions.conflicts?.length} conflict
+                      {gitStatusForActions.conflicts?.length === 1 ? "" : "s"}
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
               {gitActionMenuItems.map((item) => {
                 const disabledReason = getMenuActionDisabledReason({
                   item,
@@ -1791,7 +1869,7 @@ export default function GitActionsControl({
                   Publish repository...
                 </MenuItem>
               ) : null}
-              {gitStatusForActions?.refName === null && (
+              {!isJjRepository && gitStatusForActions?.refName === null && (
                 <p className="px-2 py-1.5 text-xs text-warning">
                   Detached HEAD: create and checkout a refName to enable push and pull request
                   actions.

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -332,8 +332,7 @@ function getMenuActionDisabledReason({
   return `Create ${terminology.singular} is currently unavailable.`;
 }
 
-const COMMIT_DIALOG_TITLE = "Commit changes";
-const COMMIT_DIALOG_DESCRIPTION =
+const GIT_COMMIT_DIALOG_DESCRIPTION =
   "Review and confirm your commit. Leave the message blank to auto-generate one.";
 
 function GitActionItemIcon({
@@ -1082,8 +1081,22 @@ export default function GitActionsControl({
     ],
   );
 
-  const syncThreadBranchAfterGitAction = useCallback(
+  const syncThreadAfterSourceControlAction = useCallback(
     (result: GitRunStackedActionResult) => {
+      if (result.commit.workspaceRevision && activeServerThread?.vcsWorkspace && activeThreadRef) {
+        void updateThreadMetadata({
+          environmentId: activeThreadRef.environmentId,
+          input: {
+            threadId: activeThreadRef.threadId,
+            vcsWorkspace: {
+              ...activeServerThread.vcsWorkspace,
+              workspaceRevision: result.commit.workspaceRevision,
+              ...(result.commit.publishRef ? { publishRef: result.commit.publishRef } : {}),
+            },
+          },
+        });
+        return;
+      }
       const branchUpdate = resolveThreadBranchUpdate(result);
       if (!branchUpdate) {
         return;
@@ -1091,7 +1104,7 @@ export default function GitActionsControl({
 
       persistThreadBranchSync(branchUpdate.branch);
     },
-    [persistThreadBranchSync],
+    [activeServerThread, activeThreadRef, persistThreadBranchSync, updateThreadMetadata],
   );
 
   const gitStatusQuery = useEnvironmentQuery(
@@ -1309,6 +1322,7 @@ export default function GitActionsControl({
 
       const progressStages = buildGitActionProgressStages({
         action,
+        driverKind: actionStatus?.driverKind,
         hasCustomCommitMessage: !!commitMessage?.trim(),
         hasWorkingTreeChanges: !!actionStatus?.hasWorkingTreeChanges,
         featureBranch,
@@ -1437,7 +1451,7 @@ export default function GitActionsControl({
       }
 
       const actionResult = result.value;
-      syncThreadBranchAfterGitAction(actionResult);
+      syncThreadAfterSourceControlAction(actionResult);
       const closeResultToast = () => {
         toastManager.close(resolvedProgressToastId);
       };
@@ -1905,18 +1919,26 @@ export default function GitActionsControl({
       >
         <DialogPopup>
           <DialogHeader>
-            <DialogTitle>{COMMIT_DIALOG_TITLE}</DialogTitle>
-            <DialogDescription>{COMMIT_DIALOG_DESCRIPTION}</DialogDescription>
+            <DialogTitle>{isJjRepository ? "Finalize change" : "Commit changes"}</DialogTitle>
+            <DialogDescription>
+              {isJjRepository
+                ? "Review and finalize the working-copy change. Leave the message blank to auto-generate one."
+                : GIT_COMMIT_DIALOG_DESCRIPTION}
+            </DialogDescription>
           </DialogHeader>
           <DialogPanel className="space-y-4">
             <div className="space-y-3 rounded-lg border border-input bg-muted/40 p-3 text-xs">
               <div className="grid grid-cols-[auto_1fr] items-center gap-x-2 gap-y-1">
-                <span className="text-muted-foreground">Branch</span>
+                <span className="text-muted-foreground">
+                  {isJjRepository ? "Workspace change" : "Branch"}
+                </span>
                 <span className="flex items-center justify-between gap-2">
                   <span className="font-medium">
-                    {gitStatusForActions?.refName ?? "(detached HEAD)"}
+                    {isJjRepository
+                      ? (gitStatusForActions?.workspaceRevision ?? "unknown")
+                      : (gitStatusForActions?.refName ?? "(detached HEAD)")}
                   </span>
-                  {isDefaultRef && (
+                  {!isJjRepository && isDefaultRef && (
                     <span className="text-right text-warning text-xs">
                       Warning: default refName
                     </span>
@@ -2024,7 +2046,9 @@ export default function GitActionsControl({
               </div>
             </div>
             <div className="space-y-1">
-              <p className="text-xs font-medium">Commit message (optional)</p>
+              <p className="text-xs font-medium">
+                {isJjRepository ? "Change message (optional)" : "Commit message (optional)"}
+              </p>
               <Textarea
                 value={dialogCommitMessage}
                 onChange={(event) => setDialogCommitMessage(event.target.value)}
@@ -2052,10 +2076,10 @@ export default function GitActionsControl({
               disabled={noneSelected}
               onClick={runDialogActionOnNewBranch}
             >
-              Commit on new refName
+              {isJjRepository ? "Finalize with new bookmark" : "Commit on new refName"}
             </Button>
             <Button size="sm" disabled={noneSelected} onClick={runDialogAction}>
-              Commit
+              {isJjRepository ? "Finalize change" : "Commit"}
             </Button>
           </DialogFooter>
         </DialogPopup>

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -13,6 +13,7 @@ import type {
   SourceControlProviderKind,
   SourceControlPublishRepositoryResult,
   SourceControlRepositoryVisibility,
+  VcsNamedRef,
   VcsStatusResult,
 } from "@t3tools/contracts";
 import { useNavigate } from "@tanstack/react-router";
@@ -374,6 +375,8 @@ interface PublishRepositoryDialogProps {
   readonly onOpenChange: (open: boolean) => void;
   readonly environmentId: ScopedThreadRef["environmentId"] | null;
   readonly gitCwd: string;
+  readonly publishRef: VcsNamedRef | null;
+  readonly onPublishRef: (publishRef: VcsNamedRef) => void;
 }
 
 function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
@@ -496,6 +499,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
         visibility: publishVisibility,
         remoteName: publishRemoteName.trim() || "origin",
         protocol: publishProtocol,
+        ...(props.publishRef ? { publishRef: props.publishRef } : {}),
       });
 
       if (result._tag === "Failure") {
@@ -510,11 +514,16 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
         setPublishResult(result.value);
         setPublishWizardStep(2);
       });
+      if (result.value.publishRef) {
+        props.onPublishRef(result.value.publishRef);
+      }
     })();
   }, [
     canSubmitPublishRepository,
     props.environmentId,
     props.gitCwd,
+    props.publishRef,
+    props.onPublishRef,
     publishProtocol,
     publishProvider,
     publishRemoteName,
@@ -1083,14 +1092,20 @@ export default function GitActionsControl({
 
   const syncThreadAfterSourceControlAction = useCallback(
     (result: GitRunStackedActionResult) => {
-      if (result.commit.workspaceRevision && activeServerThread?.vcsWorkspace && activeThreadRef) {
+      if (
+        (result.commit.workspaceRevision || result.commit.publishRef) &&
+        activeServerThread?.vcsWorkspace &&
+        activeThreadRef
+      ) {
         void updateThreadMetadata({
           environmentId: activeThreadRef.environmentId,
           input: {
             threadId: activeThreadRef.threadId,
             vcsWorkspace: {
               ...activeServerThread.vcsWorkspace,
-              workspaceRevision: result.commit.workspaceRevision,
+              workspaceRevision:
+                result.commit.workspaceRevision ??
+                activeServerThread.vcsWorkspace.workspaceRevision,
               ...(result.commit.publishRef ? { publishRef: result.commit.publishRef } : {}),
             },
           },
@@ -1125,6 +1140,9 @@ export default function GitActionsControl({
   );
   const changeRequestTerminology = sourceControlPresentation.terminology;
   const isJjRepository = gitStatus?.driverKind === "jj";
+  const jjPublishRef = isJjRepository
+    ? (activeServerThread?.vcsWorkspace?.publishRef ?? null)
+    : null;
   const SourceControlIcon = isJjRepository ? JujutsuIcon : sourceControlPresentation.Icon;
   // Default to true while loading so we don't flash init controls.
   const isRepo = gitStatus?.isRepo ?? true;
@@ -1178,13 +1196,19 @@ export default function GitActionsControl({
   }, [gitStatusForActions?.isDefaultRef]);
 
   const gitActionMenuItems = useMemo(
-    () => buildMenuItems(gitStatusForActions, isGitActionRunning, hasPrimaryRemote),
-    [gitStatusForActions, hasPrimaryRemote, isGitActionRunning],
+    () => buildMenuItems(gitStatusForActions, isGitActionRunning, hasPrimaryRemote, jjPublishRef),
+    [gitStatusForActions, hasPrimaryRemote, isGitActionRunning, jjPublishRef],
   );
   const quickAction = useMemo(
     () =>
-      resolveQuickAction(gitStatusForActions, isGitActionRunning, isDefaultRef, hasPrimaryRemote),
-    [gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning],
+      resolveQuickAction(
+        gitStatusForActions,
+        isGitActionRunning,
+        isDefaultRef,
+        hasPrimaryRemote,
+        jjPublishRef,
+      ),
+    [gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning, jjPublishRef],
   );
   const quickActionDisabledReason = quickAction.disabled
     ? (quickAction.hint ?? "This action is currently unavailable.")
@@ -1427,6 +1451,7 @@ export default function GitActionsControl({
         ...(commitMessage ? { commitMessage } : {}),
         ...(featureBranch ? { featureBranch } : {}),
         ...(filePaths ? { filePaths } : {}),
+        ...(!featureBranch && jjPublishRef ? { publishRef: jjPublishRef } : {}),
         onProgress: applyProgressEvent,
       });
 
@@ -1594,13 +1619,38 @@ export default function GitActionsControl({
         }
 
         const pullResult = result.value;
+        if (pullResult.workspaceRevision && activeServerThread?.vcsWorkspace && activeThreadRef) {
+          void updateThreadMetadata({
+            environmentId: activeThreadRef.environmentId,
+            input: {
+              threadId: activeThreadRef.threadId,
+              vcsWorkspace: {
+                ...activeServerThread.vcsWorkspace,
+                workspaceRevision: pullResult.workspaceRevision,
+              },
+            },
+          });
+        }
+        const needsRebase = pullResult.status === "fetched_needs_rebase";
+        const needsResolution = pullResult.status === "fetched_needs_resolution";
         toastManager.update(toastId, {
-          type: "success",
-          title: pullResult.status === "pulled" ? "Pulled" : "Already up to date",
-          description:
-            pullResult.status === "pulled"
-              ? `Updated ${pullResult.refName} from ${pullResult.upstreamRef ?? "upstream"}`
-              : `${pullResult.refName} is already synchronized.`,
+          type: needsRebase || needsResolution ? "info" : "success",
+          title: needsResolution
+            ? "Fetched; resolution needed"
+            : needsRebase
+              ? "Fetched; rebase needed"
+              : pullResult.status === "pulled"
+                ? isJjRepository
+                  ? "Fetched updates"
+                  : "Pulled"
+                : "Already up to date",
+          description: needsResolution
+            ? "Workspace or bookmark conflicts were left unchanged."
+            : needsRebase
+              ? "Local workspace changes were left unchanged."
+              : pullResult.status === "pulled"
+                ? `Updated ${pullResult.refName} from ${pullResult.upstreamRef ?? "upstream"}`
+                : `${pullResult.refName} is already synchronized.`,
           data: threadToastData,
         });
       })();
@@ -1647,7 +1697,7 @@ export default function GitActionsControl({
     setExcludedFiles(new Set());
     setIsEditingFiles(false);
     void runGitActionWithToast({
-      action: "commit",
+      action: isJjRepository && jjPublishRef ? "commit_push" : "commit",
       ...(commitMessage ? { commitMessage } : {}),
       ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
     });
@@ -1683,8 +1733,7 @@ export default function GitActionsControl({
     [gitCwd, openInPreferredEditor, threadToastData],
   );
 
-  const canPublishRepository =
-    isRepo && !isJjRepository && gitStatusForActions !== null && !hasPrimaryRemote;
+  const canPublishRepository = isRepo && gitStatusForActions !== null && !hasPrimaryRemote;
 
   if (!gitCwd) return null;
 
@@ -2079,7 +2128,11 @@ export default function GitActionsControl({
               {isJjRepository ? "Finalize with new bookmark" : "Commit on new refName"}
             </Button>
             <Button size="sm" disabled={noneSelected} onClick={runDialogAction}>
-              {isJjRepository ? "Finalize change" : "Commit"}
+              {isJjRepository
+                ? jjPublishRef
+                  ? "Finalize & publish"
+                  : "Finalize change"
+                : "Commit"}
             </Button>
           </DialogFooter>
         </DialogPopup>
@@ -2090,6 +2143,17 @@ export default function GitActionsControl({
         onOpenChange={setIsPublishDialogOpen}
         environmentId={activeEnvironmentId}
         gitCwd={gitCwd}
+        publishRef={jjPublishRef}
+        onPublishRef={(publishRef) => {
+          if (!activeServerThread?.vcsWorkspace || !activeThreadRef) return;
+          void updateThreadMetadata({
+            environmentId: activeThreadRef.environmentId,
+            input: {
+              threadId: activeThreadRef.threadId,
+              vcsWorkspace: { ...activeServerThread.vcsWorkspace, publishRef },
+            },
+          });
+        }}
       />
 
       <Dialog

--- a/apps/web/src/components/PullRequestThreadDialog.tsx
+++ b/apps/web/src/components/PullRequestThreadDialog.tsx
@@ -1,5 +1,6 @@
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
+import { capitalizeVcsTerm, getVcsPresentation } from "@t3tools/client-runtime/state/vcs";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -67,6 +68,8 @@ export function PullRequestThreadDialog({
     [gitStatus?.sourceControlProvider],
   );
   const terminology = sourceControlPresentation.terminology;
+  const vcsPresentation = getVcsPresentation(gitStatus?.driverKind);
+  const workspaceLabel = capitalizeVcsTerm(vcsPresentation.workspaceSingular);
   const SourceControlIcon = sourceControlPresentation.Icon;
 
   useEffect(() => {
@@ -202,7 +205,8 @@ export function PullRequestThreadDialog({
           </DialogTitle>
           <DialogDescription>
             Resolve a {sourceControlPresentation.providerName} {terminology.singular}, then create
-            the draft thread in the main repo or in a dedicated worktree.
+            the draft thread in the main repository or in a dedicated{" "}
+            {vcsPresentation.workspaceSingular}.
           </DialogDescription>
         </DialogHeader>
         <DialogPanel className="space-y-4">
@@ -295,7 +299,9 @@ export function PullRequestThreadDialog({
               preparePullRequestThreadAction.isPending
             }
           >
-            {preparingMode === "worktree" ? "Preparing worktree..." : "Worktree"}
+            {preparingMode === "worktree"
+              ? `Preparing ${vcsPresentation.workspaceSingular}...`
+              : workspaceLabel}
           </Button>
         </DialogFooter>
       </DialogPopup>

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -120,8 +120,8 @@ function RedactedAccount(props: { readonly account: string | null }) {
 }
 
 function itemStatusDot(item: VcsDiscoveryItem | SourceControlProviderDiscoveryItem): string {
-  if (isVcsNotReady(item)) return "bg-muted-foreground/35";
   if (item.status !== "available") return "bg-warning";
+  if (isVcsNotReady(item)) return "bg-muted-foreground/35";
   if (isProviderDiscoveryItem(item) && item.auth.status !== "authenticated") return "bg-warning";
   return "bg-success";
 }
@@ -163,6 +163,10 @@ function itemSummary({
   readonly auth: SourceControlProviderAuth | null;
   readonly authAccount: string | null;
 }) {
+  if (item.status === "unsupported") {
+    return <span>{optionLabel(item.detail) ?? item.installHint}</span>;
+  }
+
   if (isVcsNotReady(item)) {
     return <span>Support for {item.label} is coming soon.</span>;
   }

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -332,8 +332,8 @@ function GitFetchIntervalSettings() {
             </span>
           </div>
           <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">
-            Refresh remote branch status in the background. Set this to 0 seconds if Git credentials
-            or security keys should only be prompted by explicit Git actions.
+            Refresh remote version-control status in the background. Set this to 0 seconds if
+            credentials or security keys should only be prompted by explicit source-control actions.
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -351,7 +351,7 @@ function GitFetchIntervalSettings() {
           >
             <NumberFieldGroup>
               <NumberFieldDecrement aria-label="Decrease fetch interval" />
-              <NumberFieldInput aria-label="Automatic Git fetch interval in seconds" />
+              <NumberFieldInput aria-label="Automatic remote fetch interval in seconds" />
               <NumberFieldIncrement aria-label="Increase fetch interval" />
             </NumberFieldGroup>
           </NumberField>
@@ -423,7 +423,7 @@ function EmptySourceControlDiscovery({
           <EmptyDescription>
             {hasError
               ? error
-              : "Install Git on the server, add optional hosting integrations or credentials your workspace needs, then rescan."}
+              : "Install a supported version control system on the server, add optional hosting integrations or credentials your workspace needs, then rescan."}
           </EmptyDescription>
         </EmptyHeader>
         <EmptyContent>
@@ -476,7 +476,7 @@ export function SourceControlSettingsPanel() {
           </Button>
         }
       />
-      <TooltipPopup side="top">Rescan Git and hosting integrations</TooltipPopup>
+      <TooltipPopup side="top">Rescan version control and hosting integrations</TooltipPopup>
     </Tooltip>
   );
 

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -14,6 +14,7 @@ import type {
   GitResolvePullRequestResult,
   GitStackedAction,
   SourceControlCloneProtocol,
+  SourceControlPublishRepositoryInput,
   SourceControlRepositoryVisibility,
   ThreadId,
   VcsDriverKind,
@@ -278,6 +279,7 @@ export function useSourceControlPublishRepositoryAction(scope: SourceControlActi
       visibility: SourceControlRepositoryVisibility;
       remoteName: string;
       protocol: SourceControlCloneProtocol;
+      publishRef?: SourceControlPublishRepositoryInput["publishRef"];
     }) => {
       const target = resolveScope(scope);
       if (target === null) {

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -16,6 +16,7 @@ import type {
   SourceControlCloneProtocol,
   SourceControlRepositoryVisibility,
   ThreadId,
+  VcsDriverKind,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
@@ -138,7 +139,7 @@ export function useSourceControlActionRunning(
   );
 }
 
-export function useVcsInitAction(scope: SourceControlActionScope) {
+export function useVcsInitAction(scope: SourceControlActionScope, kind: VcsDriverKind = "git") {
   const init = useAtomCommand(vcsEnvironment.init, { reportFailure: false });
   const action = useCallback(async () => {
     const target = resolveScope(scope);
@@ -155,10 +156,15 @@ export function useVcsInitAction(scope: SourceControlActionScope) {
     }
     return init({
       environmentId: target.environmentId,
-      input: { cwd: target.cwd },
+      input: { cwd: target.cwd, kind },
     });
-  }, [init, scope]);
-  return useAction({ kind: "init", label: "Initializing repository", scope, action });
+  }, [init, kind, scope]);
+  return useAction({
+    kind: "init",
+    label: kind === "jj" ? "Initializing Jujutsu repository" : "Initializing Git repository",
+    scope,
+    action,
+  });
 }
 
 export function useVcsPullAction(scope: SourceControlActionScope) {

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -1,6 +1,6 @@
 # jj command contract
 
-Status: Phases 0-5 implemented; remote publishing begins in Phase 6.
+Status: Phases 0-6 implemented; pull-request checkout begins in Phase 7.
 
 ## Compatibility
 
@@ -95,7 +95,21 @@ Commands below omit the standard `--color=never --no-pager` prefix and repositor
 | List remotes               | `jj git remote list`                                       | Decode documented line format until jj provides template output     |
 | Add remote                 | `jj git remote add <name> <url>`                           | Exit status; redact URL credentials                                 |
 | Fetch                      | `jj git fetch --remote <remote>`                           | Exit status; then reread bookmarks                                  |
-| Push one bookmark          | `jj git push --remote <remote> --bookmark <name>`          | Exit status; never push all bookmarks                               |
+| Push one bookmark          | `jj git push --remote <remote> --bookmark exact:<name>`    | Exit status; never push all bookmarks                               |
+
+## Remote synchronization safety
+
+Fetch snapshots the workspace, records its current revision and remote bookmarks, runs
+`jj git fetch --remote <remote>`, then rereads structured state. It advances `@` only when the
+working-copy change is empty and its old parent is safely superseded by the fetched default remote
+bookmark. Dirty, divergent, or conflicted workspaces remain unchanged and return structured
+needs-rebase or needs-resolution results.
+
+Publish requires an explicit bookmark and target revision. T3 Code moves that bookmark to the
+target, then pushes only `exact:<bookmark>` to one named remote. It never pushes all bookmarks,
+never force-pushes automatically, and reports authentication or remote-safety rejection through
+the typed VCS error contract. Provider commands derive repository identity from the normalized
+remote, allowing change-request operations to use the published bookmark as their head.
 
 ## Thread workspace lifecycle
 

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -1,0 +1,158 @@
+# jj command contract
+
+Status: Phase 0 implemented; no production jj driver yet.
+
+## Compatibility
+
+T3 Code's minimum supported Jujutsu version is `0.42.0`.
+
+The floor is enforced by `inspectJjVersion()` in `packages/shared/src/jjCli.ts`. Source-control discovery reports older or unparseable versions as `unsupported` with an actionable minimum-version message.
+
+The real-CLI contract runs against:
+
+- `jj-cli@0.42.0`, the compatibility floor;
+- the latest `jj-cli` release available to the installer;
+- Ubuntu, macOS, and Windows.
+
+The matrix lives in `.github/workflows/jj-phase-zero.yml`. Run the same smoke test locally with:
+
+```sh
+pnpm test:jj-phase-zero
+```
+
+## Machine-output rules
+
+All data-producing commands must:
+
+- pass arguments as an argv array, never through a shell command string;
+- use `--color=never` and `--no-pager`;
+- provide an explicit template;
+- emit one JSON value per line;
+- decode every line with `JSON.parse`;
+- treat stdout as bounded untrusted input;
+- treat stderr as diagnostic input only, never as repository data.
+
+The canonical templates and argv builders live in `packages/shared/src/jjCli.ts`:
+
+- `JJ_REVISION_JSON_TEMPLATE` for status/revision data;
+- `JJ_CHANGED_FILE_JSON_TEMPLATE` for changed paths;
+- `JJ_BOOKMARK_JSON_TEMPLATE` for local and remote bookmarks;
+- `JJ_WORKSPACE_JSON_TEMPLATE` for workspace identity and targets;
+- `JJ_OPERATION_JSON_TEMPLATE` for operation IDs and metadata.
+
+`json()` performs escaping. Newlines, tabs, quotes, spaces, and Unicode therefore cannot break record boundaries. Do not replace these templates with parsing of default `jj status`, `jj log`, or graph output.
+
+## Command mapping
+
+Commands below omit the standard `--color=never --no-pager` prefix and repository path selection.
+
+| Product intent             | jj command                                                 | Data contract                                                       |
+| -------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| Discover version           | `jj --version`                                             | Parse with `inspectJjVersion()`                                     |
+| Detect workspace root      | `jj workspace root`                                        | One absolute path                                                   |
+| Initialize                 | `jj git init --colocate <destination>`                     | Exit status; verify `.jj` and `.git`                                |
+| Clone                      | `jj git clone --colocate <source> <destination>`           | Exit status; verify `.jj` and `.git`                                |
+| Snapshot filesystem        | `jj util snapshot`                                         | Exit status, followed by revision/operation query                   |
+| Read current revision      | `jj log --no-graph -r @ -T <revision-json>`                | One `JjRevisionRecord` JSON line                                    |
+| Read arbitrary revision    | `jj log --no-graph -r <revision> -T <revision-json>`       | Exactly one `JjRevisionRecord`                                      |
+| Read changed files         | `jj log --no-graph -r <revision> -T <changed-file-json>`   | Zero or more `JjChangedFileRecord` lines                            |
+| Read patch                 | `jj diff --git -r <revision>`                              | Bounded Git-format patch, not structured metadata                   |
+| Read range patch           | `jj diff --git --from <base> --to <target>`                | Bounded Git-format patch                                            |
+| List files                 | `jj file list -r <revision> -T 'json(self) ++ "\\n"'`      | One JSON tree entry per line                                        |
+| Filter files               | `jj file list -r @ -T <file-json> <root-file filesets...>` | Returned exact paths are tracked/non-ignored                        |
+| List bookmarks             | `jj bookmark list --all-remotes -T <bookmark-json>`        | One serialized `CommitRef` per line                                 |
+| Create bookmark            | `jj bookmark create <quoted-symbol> -r <revision>`         | Exit status plus invalid-ref warning check                          |
+| Move bookmark              | `jj bookmark set <quoted-symbol> -r <revision>`            | Exit status plus conflict/warning check                             |
+| Track remote bookmark      | `jj bookmark track <name> --remote <remote>`               | Exit status                                                         |
+| List workspaces            | `jj workspace list -T <workspace-json>`                    | One serialized `WorkspaceRef` per line                              |
+| Create workspace           | `jj workspace add <path> --name <name> -r <base>`          | Exit status; confirm through workspace list                         |
+| Repair stale workspace     | `jj workspace update-stale`                                | Exit status; then reread revision                                   |
+| Forget workspace           | `jj workspace forget <name>`                               | Exit status before directory removal                                |
+| Describe change            | `jj describe -m <message>`                                 | Exit status; then reread revision                                   |
+| Finalize all files         | `jj commit -m <message>`                                   | Record `@` before and `@-`/`@` after                                |
+| Finalize selected files    | `jj commit -m <message> <root-file filesets...>`           | Selected files remain in finalized revision; others move to new `@` |
+| Start change               | `jj new <base>`                                            | Exit status; then reread `@`                                        |
+| Edit existing change       | `jj edit <revision>`                                       | Explicit-only operation; never implicit checkout behavior           |
+| Restore checkpoint content | `jj restore --from <checkpoint-commit> --into @`           | Reread `@`; restore description separately                          |
+| Read current operation     | `jj op log --no-graph -n 1 -T <operation-json>`            | Exactly one serialized operation                                    |
+| Garbage collect            | `jj util gc --expire now`                                  | Used by retention tests, not normal workflow                        |
+| List remotes               | `jj git remote list`                                       | Decode documented line format until jj provides template output     |
+| Add remote                 | `jj git remote add <name> <url>`                           | Exit status; redact URL credentials                                 |
+| Fetch                      | `jj git fetch --remote <remote>`                           | Exit status; then reread bookmarks                                  |
+| Push one bookmark          | `jj git push --remote <remote> --bookmark <name>`          | Exit status; never push all bookmarks                               |
+
+Bookmark/revision names that enter revset positions must use `quoteJjSymbol()`. Exact file arguments must use `root-file:` filesets with template-language string quoting; this helper remains a Phase 5 implementation task.
+
+## Special-character results
+
+The executable smoke test covers:
+
+- repository and workspace paths containing spaces and Unicode;
+- file paths containing spaces and Unicode on every OS;
+- file paths containing tabs and newlines where the host filesystem permits them;
+- multiline descriptions containing tabs and Unicode;
+- Unicode bookmark names that export to the colocated Git repository;
+- spaces, tabs, and newlines in jj bookmark names.
+
+jj can represent quoted bookmark names containing spaces or control characters, but Git refs cannot. In a colocated repository, jj may return exit code `0` while warning that export failed. T3 Code therefore inspects stderr even on successful bookmark mutations and classifies this case as `invalid-ref`.
+
+## Error and condition classification
+
+| Condition                       | Source                           | Classification         |
+| ------------------------------- | -------------------------------- | ---------------------- |
+| Missing `jj` executable         | Process spawn failure            | `VcsProcessSpawnError` |
+| Directory outside jj repository | Non-zero stderr                  | `not-repository`       |
+| Stale workspace                 | Non-zero stderr                  | `stale-workspace`      |
+| Missing/ambiguous revision      | Non-zero stderr                  | `unresolved-revision`  |
+| Conflicted bookmark             | Non-zero stderr or bookmark JSON | `bookmark-conflict`    |
+| Content conflict                | `JjRevisionRecord.conflict`      | `content-conflict`     |
+| Authentication failure          | Non-zero stderr                  | `authentication`       |
+| Remote safety rejection         | Non-zero stderr                  | `push-rejected`        |
+| Git-incompatible bookmark       | Success or failure stderr        | `invalid-ref`          |
+| Unknown non-zero result         | Non-zero stderr                  | `command-failed`       |
+
+Content conflicts are repository state, not necessarily command failure. They must be decoded from the revision JSON rather than inferred from exit status.
+
+Classification is structural and redacted: errors retain kind, operation, command, exit code, stderr length, and truncation state. They do not retain stderr or argv secrets.
+
+## Checkpoint decision
+
+A jj checkpoint record contains:
+
+```ts
+interface JjCheckpointMetadata {
+  readonly operationId: string;
+  readonly workspaceName: string;
+  readonly commitId: string;
+  readonly changeId: string;
+  readonly description: string;
+}
+```
+
+Capture sequence:
+
+1. Run `jj util snapshot`.
+2. Read `@` with the revision JSON template.
+3. Read the current operation with the operation JSON template.
+4. Persist the metadata atomically with the T3 Code checkpoint.
+
+Restore sequence:
+
+1. Resolve the recorded commit ID after a fresh process start.
+2. Run `jj restore --from <commitId> --into @` in the recorded workspace.
+3. Restore the recorded description with `jj describe -m <description>`.
+4. Verify the resulting revision and files.
+
+Do not use `jj op restore`. It changes repository-wide operation state and can affect unrelated workspaces.
+
+The smoke test proves the recorded commit remains resolvable after process restart and `jj util gc --expire now`, then proves restore leaves a sibling workspace and publish bookmark unchanged.
+
+Retention promise: checkpoint revisions are retained while their operation remains in jj's operation log. T3 Code must not abandon checkpoint operations during the product checkpoint retention window. External `jj op abandon` can invalidate that promise and must produce an expired-checkpoint error, never a fallback repository-wide restore.
+
+## Implemented evidence
+
+- Pure contract tests: `packages/shared/src/jjCli.test.ts`
+- Process error tests: `apps/server/src/vcs/VcsProcess.test.ts`
+- Discovery version test: `apps/server/src/sourceControl/SourceControlDiscovery.test.ts`
+- Real CLI smoke: `scripts/jj-phase-zero-smoke.ts`
+- Platform/version matrix: `.github/workflows/jj-phase-zero.yml`

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -1,6 +1,6 @@
 # jj command contract
 
-Status: Phases 0-3 implemented; thread workspace workflows begin in Phase 4.
+Status: Phases 0-5 implemented; remote publishing begins in Phase 6.
 
 ## Compatibility
 
@@ -117,7 +117,9 @@ Removal validates ownership, runs `jj workspace forget <name>`, and only then re
 the workspace directory. Missing metadata and missing directories are idempotent; ownership
 mismatches fail without deleting files.
 
-Bookmark/revision names that enter revset positions must use `quoteJjSymbol()`. Exact file arguments must use `root-file:` filesets with template-language string quoting; this helper remains a Phase 5 implementation task.
+Bookmark/revision names that enter revset positions must use `quoteJjSymbol()`. Exact file arguments
+use `quoteJjRootFileFileset()`, which rejects absolute or parent-traversing paths and produces a
+`root-file:` fileset with template-language string quoting.
 
 ## Special-character results
 

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -97,6 +97,26 @@ Commands below omit the standard `--color=never --no-pager` prefix and repositor
 | Fetch                      | `jj git fetch --remote <remote>`                           | Exit status; then reread bookmarks                                  |
 | Push one bookmark          | `jj git push --remote <remote> --bookmark <name>`          | Exit status; never push all bookmarks                               |
 
+## Thread workspace lifecycle
+
+Thread workspace names are `t3code-` plus the first 20 hexadecimal characters of the SHA-256 digest
+of the thread ID. The mapping is deterministic, filesystem-safe, and independent of user-selected
+bookmark names.
+
+Creation resolves and stores the requested base revision before `jj workspace add`. A successful
+result is accepted only after workspace metadata and the new working-copy revision are reread. The
+persisted identity contains the workspace name and path, current commit/change IDs, base
+commit/change IDs, and the optional publish bookmark.
+
+Reconnect validates the path's current workspace name. A stale working copy is logged before
+`jj workspace update-stale` runs, then its revision is reread. A missing directory with retained jj
+metadata is repaired by forgetting the missing workspace and recreating it at the persisted base.
+Non-empty paths owned by another or unknown workspace are never replaced.
+
+Removal validates ownership, runs `jj workspace forget <name>`, and only then recursively removes
+the workspace directory. Missing metadata and missing directories are idempotent; ownership
+mismatches fail without deleting files.
+
 Bookmark/revision names that enter revset positions must use `quoteJjSymbol()`. Exact file arguments must use `root-file:` filesets with template-language string quoting; this helper remains a Phase 5 implementation task.
 
 ## Special-character results

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -1,6 +1,6 @@
 # jj command contract
 
-Status: Phase 0 implemented; no production jj driver yet.
+Status: Phases 0-3 implemented; thread workspace workflows begin in Phase 4.
 
 ## Compatibility
 
@@ -40,6 +40,15 @@ The canonical templates and argv builders live in `packages/shared/src/jjCli.ts`
 - `JJ_WORKSPACE_JSON_TEMPLATE` for workspace identity and targets;
 - `JJ_OPERATION_JSON_TEMPLATE` for operation IDs and metadata.
 
+Production process/repository support lives in `apps/server/src/vcs/JjProcess.ts` and
+`apps/server/src/vcs/JjVcsDriver.ts`. Automatic detection prefers `.jj` over `.git` in
+colocated repositories.
+
+Phase 3 status reads explicitly snapshot first, then expose workspace revision metadata, changed
+files, content conflicts, local/remote bookmarks, tracked-default divergence, and bounded
+Git-format review patches. jj status keeps `refName` and `publishRef` null: a bookmark pointing at
+`@` is not treated as current or selected for publishing.
+
 `json()` performs escaping. Newlines, tabs, quotes, spaces, and Unicode therefore cannot break record boundaries. Do not replace these templates with parsing of default `jj status`, `jj log`, or graph output.
 
 ## Command mapping
@@ -58,7 +67,7 @@ Commands below omit the standard `--color=never --no-pager` prefix and repositor
 | Read changed files         | `jj log --no-graph -r <revision> -T <changed-file-json>`   | Zero or more `JjChangedFileRecord` lines                            |
 | Read patch                 | `jj diff --git -r <revision>`                              | Bounded Git-format patch, not structured metadata                   |
 | Read range patch           | `jj diff --git --from <base> --to <target>`                | Bounded Git-format patch                                            |
-| List files                 | `jj file list -r <revision> -T 'json(self) ++ "\\n"'`      | One JSON tree entry per line                                        |
+| List files                 | `jj file list -r <revision> -T 'json(path) ++ "\\n"'`      | One JSON path per line                                              |
 | Filter files               | `jj file list -r @ -T <file-json> <root-file filesets...>` | Returned exact paths are tracked/non-ignored                        |
 | List bookmarks             | `jj bookmark list --all-remotes -T <bookmark-json>`        | One serialized `CommitRef` per line                                 |
 | Create bookmark            | `jj bookmark create <quoted-symbol> -r <revision>`         | Exit status plus invalid-ref warning check                          |

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -22,15 +22,22 @@ pnpm test:jj-phase-zero
 
 ## Machine-output rules
 
-All data-producing commands must:
+All commands must:
 
 - pass arguments as an argv array, never through a shell command string;
 - use `--color=never` and `--no-pager`;
-- provide an explicit template;
-- emit one JSON value per line;
-- decode every line with `JSON.parse`;
 - treat stdout as bounded untrusted input;
 - treat stderr as diagnostic input only, never as repository data.
+
+Commands returning machine metadata must additionally:
+
+- provide an explicit template;
+- emit one JSON value per line;
+- decode every metadata line with `JSON.parse`.
+
+Git-format patch commands and `jj git remote list` are not machine-metadata commands. Patch output
+remains bounded Git-format text, while remote-list output uses jj's documented non-template line
+format until jj provides structured template output.
 
 The canonical templates and argv builders live in `packages/shared/src/jjCli.ts`:
 

--- a/docs/architecture/jj-command-contract.md
+++ b/docs/architecture/jj-command-contract.md
@@ -1,6 +1,6 @@
 # jj command contract
 
-Status: Phases 0-6 implemented; pull-request checkout begins in Phase 7.
+Status: Phases 0-10 implemented for colocated Git-backed repositories.
 
 ## Compatibility
 
@@ -96,6 +96,9 @@ Commands below omit the standard `--color=never --no-pager` prefix and repositor
 | Add remote                 | `jj git remote add <name> <url>`                           | Exit status; redact URL credentials                                 |
 | Fetch                      | `jj git fetch --remote <remote>`                           | Exit status; then reread bookmarks                                  |
 | Push one bookmark          | `jj git push --remote <remote> --bookmark exact:<name>`    | Exit status; never push all bookmarks                               |
+| Prepare review bookmark    | `jj bookmark set t3code-review-<number> -r <head>`         | Deterministic local bookmark; published head remains unchanged      |
+| Start local review         | `jj new <review-head>`                                     | New empty change on the published review revision                   |
+| Retain checkpoint          | hidden `git update-ref` transaction                        | Commit anchor plus metadata blob ref; never pushed                  |
 
 ## Remote synchronization safety
 
@@ -174,10 +177,14 @@ A jj checkpoint record contains:
 ```ts
 interface JjCheckpointMetadata {
   readonly operationId: string;
-  readonly workspaceName: string;
-  readonly commitId: string;
-  readonly changeId: string;
-  readonly description: string;
+  readonly checkpointRef: string;
+  readonly revision: {
+    readonly commitId: string;
+    readonly changeId: string;
+    readonly parents: readonly string[];
+    readonly description: string;
+  };
+  readonly workingCopies: readonly unknown[];
 }
 ```
 
@@ -186,7 +193,8 @@ Capture sequence:
 1. Run `jj util snapshot`.
 2. Read `@` with the revision JSON template.
 3. Read the current operation with the operation JSON template.
-4. Persist the metadata atomically with the T3 Code checkpoint.
+4. Write the metadata as a Git object.
+5. Atomically update the hidden checkpoint commit ref and its hidden metadata ref.
 
 Restore sequence:
 
@@ -197,9 +205,21 @@ Restore sequence:
 
 Do not use `jj op restore`. It changes repository-wide operation state and can affect unrelated workspaces.
 
-The smoke test proves the recorded commit remains resolvable after process restart and `jj util gc --expire now`, then proves restore leaves a sibling workspace and publish bookmark unchanged.
+Hidden refs under `refs/t3code/` retain checkpoint commits and metadata in the colocated Git object
+store. They are local implementation refs, are not bookmarks, and are never included in jj publish
+commands. Deleting a checkpoint removes both refs together through the driver contract.
 
-Retention promise: checkpoint revisions are retained while their operation remains in jj's operation log. T3 Code must not abandon checkpoint operations during the product checkpoint retention window. External `jj op abandon` can invalidate that promise and must produce an expired-checkpoint error, never a fallback repository-wide restore.
+Retention follows the product checkpoint timeline: hidden commit and metadata refs remain until the
+checkpoint reactor expires or deletes that timeline entry. Restore ownership is still scoped by the
+thread/workspace orchestration layer. A missing ref produces an unavailable-checkpoint result, never
+a repository-wide fallback restore.
+
+## Colocation boundary
+
+T3 Code uses jj commands for repository semantics. Direct Git commands inside the jj driver are
+limited to hidden checkpoint retention refs in the shared Git object store. Provider compatibility
+may also invoke Git-aware hosting tools with explicit repository and bookmark context. Neither
+boundary may infer a current bookmark, push hidden refs, or mutate unrelated workspaces.
 
 ## Implemented evidence
 

--- a/docs/user/jujutsu.md
+++ b/docs/user/jujutsu.md
@@ -1,0 +1,94 @@
+# Jujutsu support
+
+T3 Code supports Jujutsu `0.42.0` or newer for Git-backed repositories using colocated `.jj` and
+`.git` metadata.
+
+## Setup
+
+Install `jj`, confirm `jj --version`, then initialize from T3 Code's source-control controls or run:
+
+```sh
+jj git init --colocate .
+```
+
+For an existing Git repository, run that command from its clean repository root. Colocation keeps
+the existing Git object store and remotes while adding Jujutsu workspace metadata.
+
+Automatic detection chooses jj when both `.jj` and `.git` exist. To make selection explicit, add
+`.t3code/vcs.json`:
+
+```json
+{
+  "vcs": {
+    "kind": "jj"
+  }
+}
+```
+
+Use `"git"` instead to force Git for that project.
+
+## Product concepts
+
+- Workspace change: mutable working-copy commit `@` edited by one local or isolated workspace.
+- Publish bookmark: explicit named ref moved to a finalized revision and pushed.
+- Thread workspace: `jj workspace` used where Git uses a worktree.
+- Finalize change: describes the selected work and creates a new empty working-copy change.
+
+T3 Code never treats a bookmark pointing at `@` as an automatically selected publish bookmark.
+Publishing always names one bookmark and one remote.
+
+## Supported workflows
+
+- detect, initialize, and clone colocated repositories;
+- status, bookmarks, conflicts, divergence, and Git-format diffs;
+- local and isolated thread workspaces;
+- finalize all or selected files while preserving excluded edits;
+- fetch updates without rewriting a non-empty workspace automatically;
+- push one explicit bookmark and create or view a hosted change request;
+- check out same-repository or fork change requests into a new empty change;
+- capture, preview, restore, retain, and delete thread-local checkpoints.
+
+## Colocation and Git tools
+
+Git-aware agents and provider CLIs can still see `.git`. Avoid running concurrent history-changing
+Git and jj commands in the same workspace. After an external tool changes Git refs, run `jj status`
+or use T3 Code's refresh action before continuing.
+
+T3 Code checkpoint refs live under `refs/t3code/`. They are local retention anchors, not branches or
+bookmarks, and T3 Code never pushes them.
+
+## Recovery
+
+Inspect state first:
+
+```sh
+jj status
+jj bookmark list --all-remotes
+jj workspace list
+jj operation log --limit 5
+```
+
+For a stale workspace, from that workspace run:
+
+```sh
+jj workspace update-stale
+```
+
+For remote divergence or conflicts, resolve the affected revision or bookmark explicitly. T3 Code
+does not force-push, auto-rebase dirty work, or auto-resolve conflicts. Authentication failures use
+the same Git remote credentials required by `jj git fetch` and `jj git push`.
+
+Do not use `jj op restore` to recover one T3 Code thread. It restores repository-wide operation
+state and can affect sibling workspaces. Use the thread checkpoint restore action, which restores
+only selected workspace content and description.
+
+## Intentional limitations
+
+- Pure jj and non-colocated Git-backed repositories are not supported yet.
+- T3 Code does not provide a general operation-log, revset, split, squash, absorb, or history-edit UI.
+- Git index and commit-hook behavior is not emulated for selected-file finalization.
+- Bookmark names published to Git must also be valid Git ref names.
+- Automatic conflict resolution and automatic force push are never attempted.
+
+Workflow telemetry records duration, cancellation/failure outcome, VCS kind, workflow, and operation.
+It excludes repository paths, messages, patches, remote URLs, and credentials.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:mobile": "node scripts/mobile-native-static-check.ts",
     "test": "vp run -r test",
     "test:desktop-smoke": "vp run --filter @t3tools/desktop smoke-test",
+    "test:jj-phase-zero": "node scripts/jj-phase-zero-smoke.ts",
     "fmt": "vp fmt",
     "fmt:check": "vp fmt --check",
     "build:contracts": "vp run --filter @t3tools/contracts build",

--- a/packages/client-runtime/src/state/gitActions.test.ts
+++ b/packages/client-runtime/src/state/gitActions.test.ts
@@ -1,0 +1,53 @@
+import type { VcsNamedRef, VcsStatusResult } from "@t3tools/contracts";
+import { assert, describe, it } from "vite-plus/test";
+
+import { buildMenuItems, resolveQuickAction } from "./gitActions.ts";
+
+const publishRef: VcsNamedRef = {
+  kind: "bookmark",
+  name: "feature/phase-6",
+  remoteName: "origin",
+  target: { commitId: "finalized-commit", changeId: "finalized-change" },
+};
+
+const status: VcsStatusResult = {
+  isRepo: true,
+  driverKind: "jj",
+  hasPrimaryRemote: true,
+  isDefaultRef: false,
+  refName: null,
+  workspaceRevision: "workspace-change",
+  publishRef: null,
+  hasWorkingTreeChanges: false,
+  workingTree: { files: [], insertions: 0, deletions: 0 },
+  hasUpstream: true,
+  aheadCount: 0,
+  behindCount: 0,
+  pr: {
+    number: 106,
+    title: "Phase 6 change request",
+    url: "https://example.com/pr/106",
+    baseRef: "main",
+    headRef: publishRef.name,
+    state: "open",
+  },
+};
+
+describe("jj git actions", () => {
+  it("opens an existing PR instead of offering to create another", () => {
+    assert.deepEqual(buildMenuItems(status, false, true, publishRef), [
+      {
+        id: "pr",
+        label: "View PR",
+        disabled: false,
+        icon: "pr",
+        kind: "open_pr",
+      },
+    ]);
+    assert.deepEqual(resolveQuickAction(status, false, false, true, publishRef), {
+      label: "View PR",
+      disabled: false,
+      kind: "open_pr",
+    });
+  });
+});

--- a/packages/client-runtime/src/state/gitActions.ts
+++ b/packages/client-runtime/src/state/gitActions.ts
@@ -2,13 +2,14 @@ import type {
   GitRunStackedActionInput,
   GitRunStackedActionResult,
   GitStackedAction,
+  VcsNamedRef,
   VcsStatusResult,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
-export type GitDialogAction = "commit" | "push" | "create_pr";
+export type GitDialogAction = "commit" | "commit_push" | "push" | "create_pr";
 
 export interface GitActionMenuItem {
   id: "commit" | "push" | "pr";
@@ -41,7 +42,7 @@ export type DefaultBranchConfirmableAction =
 
 export type GitActionRequestInput = Pick<
   GitRunStackedActionInput,
-  "action" | "commitMessage" | "featureBranch" | "filePaths"
+  "action" | "commitMessage" | "featureBranch" | "filePaths" | "publishRef"
 >;
 
 export function buildGitActionProgressStages(input: {
@@ -86,8 +87,54 @@ export function buildMenuItems(
   gitStatus: VcsStatusResult | null,
   isBusy: boolean,
   hasOriginRemote = true,
+  publishRef: VcsNamedRef | null = null,
 ): GitActionMenuItem[] {
   if (!gitStatus) return [];
+  if (gitStatus.driverKind === "jj") {
+    const hasChanges = gitStatus.hasWorkingTreeChanges;
+    if (!hasChanges && gitStatus.pr?.state === "open") {
+      return [
+        {
+          id: "pr",
+          label: "View PR",
+          disabled: isBusy,
+          icon: "pr",
+          kind: "open_pr",
+        },
+      ];
+    }
+    if (!hasChanges && publishRef) {
+      return [
+        publishRef.remoteName
+          ? {
+              id: "pr",
+              label: "Create change request",
+              disabled: isBusy,
+              icon: "pr",
+              kind: "open_dialog",
+              dialogAction: "create_pr",
+            }
+          : {
+              id: "push",
+              label: `Publish ${publishRef.name}`,
+              disabled: isBusy,
+              icon: "push",
+              kind: "open_dialog",
+              dialogAction: "push",
+            },
+      ];
+    }
+    return [
+      {
+        id: "commit",
+        label: publishRef ? "Finalize & publish" : "Finalize change",
+        disabled: isBusy || !hasChanges,
+        icon: "commit",
+        kind: "open_dialog",
+        dialogAction: publishRef ? "commit_push" : "commit",
+      },
+    ];
+  }
 
   const hasBranch = gitStatus.refName !== null;
   const hasChanges = gitStatus.hasWorkingTreeChanges;
@@ -153,7 +200,68 @@ export function resolveQuickAction(
   isBusy: boolean,
   isDefaultBranch = false,
   hasOriginRemote = true,
+  publishRef: VcsNamedRef | null = null,
 ): GitQuickAction {
+  if (gitStatus?.driverKind === "jj") {
+    if (isBusy) {
+      return {
+        label: "Source control action",
+        disabled: true,
+        kind: "show_hint",
+        hint: "Source control action in progress.",
+      };
+    }
+    if (gitStatus.behindCount > 0) {
+      return {
+        label: "Fetch updates",
+        disabled: false,
+        kind: "run_pull",
+      };
+    }
+    if (gitStatus.hasWorkingTreeChanges) {
+      return publishRef
+        ? {
+            label: "Finalize & publish",
+            disabled: false,
+            kind: "run_action",
+            action: "commit_push",
+          }
+        : {
+            label: "Finalize change",
+            disabled: false,
+            kind: "run_action",
+            action: "commit",
+          };
+    }
+    if (gitStatus.pr?.state === "open") {
+      return {
+        label: "View PR",
+        disabled: false,
+        kind: "open_pr",
+      };
+    }
+    if (publishRef) {
+      return publishRef.remoteName
+        ? {
+            label: "Create change request",
+            disabled: false,
+            kind: "run_action",
+            action: "create_pr",
+          }
+        : {
+            label: `Publish ${publishRef.name}`,
+            disabled: false,
+            kind: "run_action",
+            action: "push",
+          };
+    }
+    return {
+      label: "Finalize change",
+      disabled: true,
+      kind: "show_hint",
+      hint: "The working-copy change is empty.",
+    };
+  }
   if (isBusy) {
     return { label: "Commit", disabled: true, kind: "show_hint", hint: "Git action in progress." };
   }

--- a/packages/client-runtime/src/state/vcs.ts
+++ b/packages/client-runtime/src/state/vcs.ts
@@ -225,3 +225,4 @@ export * from "./gitActions.ts";
 export * from "./vcsAction.ts";
 export * from "./vcsRef.ts";
 export * from "./vcsStatus.ts";
+export * from "./vcsPresentation.ts";

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -74,6 +74,7 @@ export interface RunVcsStackedActionInput {
   readonly commitMessage?: string;
   readonly featureBranch?: boolean;
   readonly filePaths?: ReadonlyArray<string>;
+  readonly publishRef?: GitRunStackedActionInput["publishRef"];
   readonly onProgress?: (event: GitActionProgressEvent) => void;
 }
 
@@ -461,6 +462,7 @@ export function createVcsActionManager<R, E>(
           ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
           ...(input.featureBranch ? { featureBranch: true } : {}),
           ...(input.filePaths?.length ? { filePaths: [...input.filePaths] } : {}),
+          ...(input.publishRef ? { publishRef: input.publishRef } : {}),
         };
         return consumeVcsActionProgress(
           runStreamInEnvironment(

--- a/packages/client-runtime/src/state/vcsPresentation.test.ts
+++ b/packages/client-runtime/src/state/vcsPresentation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { capitalizeVcsTerm, getVcsPresentation } from "./vcsPresentation.ts";
+
+describe("VCS presentation", () => {
+  it("uses branch and worktree terms for Git", () => {
+    expect(getVcsPresentation("git")).toMatchObject({
+      refSingular: "branch",
+      workspaceSingular: "worktree",
+      currentRefFallback: "Detached HEAD",
+    });
+  });
+
+  it("uses bookmark and workspace terms for Jujutsu", () => {
+    expect(getVcsPresentation("jj")).toMatchObject({
+      refSingular: "bookmark",
+      workspaceSingular: "workspace",
+      currentRefFallback: "Unbookmarked change",
+    });
+  });
+
+  it("falls back to generic version control terms", () => {
+    expect(getVcsPresentation(undefined).systemLabel).toBe("Version control");
+    expect(capitalizeVcsTerm("workspace")).toBe("Workspace");
+  });
+});

--- a/packages/client-runtime/src/state/vcsPresentation.ts
+++ b/packages/client-runtime/src/state/vcsPresentation.ts
@@ -1,0 +1,45 @@
+import type { VcsDriverKind } from "@t3tools/contracts";
+
+export interface VcsPresentation {
+  readonly systemLabel: string;
+  readonly refSingular: string;
+  readonly refPlural: string;
+  readonly workspaceSingular: string;
+  readonly workspacePlural: string;
+  readonly currentRefFallback: string;
+}
+
+const PRESENTATION_BY_KIND = {
+  git: {
+    systemLabel: "Git",
+    refSingular: "branch",
+    refPlural: "branches",
+    workspaceSingular: "worktree",
+    workspacePlural: "worktrees",
+    currentRefFallback: "Detached HEAD",
+  },
+  jj: {
+    systemLabel: "Jujutsu",
+    refSingular: "bookmark",
+    refPlural: "bookmarks",
+    workspaceSingular: "workspace",
+    workspacePlural: "workspaces",
+    currentRefFallback: "Unbookmarked change",
+  },
+  unknown: {
+    systemLabel: "Version control",
+    refSingular: "named ref",
+    refPlural: "named refs",
+    workspaceSingular: "workspace",
+    workspacePlural: "workspaces",
+    currentRefFallback: "Unnamed revision",
+  },
+} satisfies Record<VcsDriverKind, VcsPresentation>;
+
+export function getVcsPresentation(kind: VcsDriverKind | null | undefined): VcsPresentation {
+  return PRESENTATION_BY_KIND[kind ?? "unknown"];
+}
+
+export function capitalizeVcsTerm(term: string): string {
+  return term.length === 0 ? term : `${term[0]?.toUpperCase()}${term.slice(1)}`;
+}

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -138,6 +138,31 @@ describe("GitRunStackedActionResult", () => {
       expect(parsed.toast.cta.action.kind).toBe("create_pr");
     }
   });
+
+  it("decodes jj finalized and new workspace revisions", () => {
+    const parsed = decodeRunStackedActionResult({
+      action: "commit",
+      branch: { status: "created", name: "feature/jj-change" },
+      commit: {
+        status: "created",
+        commitSha: "finalized-commit",
+        subject: "Finalize jj change",
+        finalizedRevision: { commitId: "finalized-commit", changeId: "finalized-change" },
+        workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+        publishRef: {
+          kind: "bookmark",
+          name: "feature/jj-change",
+          target: { commitId: "finalized-commit", changeId: "finalized-change" },
+        },
+      },
+      push: { status: "skipped_not_requested" },
+      pr: { status: "skipped_not_requested" },
+      toast: { title: "Finalized finaliz", cta: { kind: "none" } },
+    });
+
+    expect(parsed.commit.workspaceRevision?.changeId).toBe("workspace-change");
+    expect(parsed.commit.publishRef?.kind).toBe("bookmark");
+  });
 });
 
 describe("VcsStatusLocalResult", () => {

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -8,6 +8,7 @@ import {
   GitRunStackedActionInput,
   GitResolvePullRequestResult,
   VcsStatusLocalResult,
+  VcsPullResult,
 } from "./git.ts";
 
 const decodeCreateWorktreeInput = Schema.decodeUnknownSync(VcsCreateWorktreeInput);
@@ -18,6 +19,7 @@ const decodeRunStackedActionInput = Schema.decodeUnknownSync(GitRunStackedAction
 const decodeRunStackedActionResult = Schema.decodeUnknownSync(GitRunStackedActionResult);
 const decodeResolvePullRequestResult = Schema.decodeUnknownSync(GitResolvePullRequestResult);
 const decodeStatusLocalResult = Schema.decodeUnknownSync(VcsStatusLocalResult);
+const decodePullResult = Schema.decodeUnknownSync(VcsPullResult);
 
 describe("VcsCreateWorktreeInput", () => {
   it("accepts omitted newRefName for existing-refName worktrees", () => {
@@ -96,6 +98,36 @@ describe("GitRunStackedActionInput", () => {
 
     expect(parsed.actionId).toBe("action-1");
     expect(parsed.action).toBe("create_pr");
+  });
+
+  it("accepts an explicit jj publish bookmark", () => {
+    const parsed = decodeRunStackedActionInput({
+      actionId: "action-jj-publish",
+      cwd: "/repo",
+      action: "push",
+      publishRef: {
+        kind: "bookmark",
+        name: "feature/phase-6",
+        target: { commitId: "published-commit", changeId: "published-change" },
+      },
+    });
+
+    expect(parsed.publishRef?.name).toBe("feature/phase-6");
+  });
+});
+
+describe("VcsPullResult", () => {
+  it("preserves structured jj fetch recovery state", () => {
+    const parsed = decodePullResult({
+      status: "fetched_needs_rebase",
+      refName: "main",
+      upstreamRef: "main@origin",
+      workspaceRevision: { commitId: "workspace-commit", changeId: "workspace-change" },
+      conflicts: [],
+    });
+
+    expect(parsed.status).toBe("fetched_needs_rebase");
+    expect(parsed.workspaceRevision?.changeId).toBe("workspace-change");
   });
 });
 

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -7,6 +7,7 @@ import {
   GitRunStackedActionResult,
   GitRunStackedActionInput,
   GitResolvePullRequestResult,
+  VcsStatusLocalResult,
 } from "./git.ts";
 
 const decodeCreateWorktreeInput = Schema.decodeUnknownSync(VcsCreateWorktreeInput);
@@ -16,6 +17,7 @@ const decodePreparePullRequestThreadInput = Schema.decodeUnknownSync(
 const decodeRunStackedActionInput = Schema.decodeUnknownSync(GitRunStackedActionInput);
 const decodeRunStackedActionResult = Schema.decodeUnknownSync(GitRunStackedActionResult);
 const decodeResolvePullRequestResult = Schema.decodeUnknownSync(GitResolvePullRequestResult);
+const decodeStatusLocalResult = Schema.decodeUnknownSync(VcsStatusLocalResult);
 
 describe("VcsCreateWorktreeInput", () => {
   it("accepts omitted newRefName for existing-refName worktrees", () => {
@@ -124,5 +126,37 @@ describe("GitRunStackedActionResult", () => {
     if (parsed.toast.cta.kind === "run_action") {
       expect(parsed.toast.cta.action.kind).toBe("create_pr");
     }
+  });
+});
+
+describe("VcsStatusLocalResult", () => {
+  const baseStatus = {
+    isRepo: true,
+    hasPrimaryRemote: true,
+    isDefaultRef: true,
+    refName: "main",
+    hasWorkingTreeChanges: false,
+    workingTree: { files: [], insertions: 0, deletions: 0 },
+  };
+
+  it("requires variant-specific conflict details", () => {
+    expect(
+      decodeStatusLocalResult({
+        ...baseStatus,
+        conflicts: [
+          { kind: "content", path: "conflicted.txt" },
+          { kind: "named-ref", refName: "feature" },
+        ],
+      }).conflicts,
+    ).toEqual([
+      { kind: "content", path: "conflicted.txt" },
+      { kind: "named-ref", refName: "feature" },
+    ]);
+    expect(() =>
+      decodeStatusLocalResult({ ...baseStatus, conflicts: [{ kind: "content" }] }),
+    ).toThrow();
+    expect(() =>
+      decodeStatusLocalResult({ ...baseStatus, conflicts: [{ kind: "named-ref" }] }),
+    ).toThrow();
   });
 });

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -42,6 +42,17 @@ describe("VcsCreateWorktreeInput", () => {
 
     expect(parsed.baseRefName).toBe("origin/main");
   });
+
+  it("accepts a thread id for VCS-neutral workspace creation", () => {
+    const parsed = decodeCreateWorktreeInput({
+      cwd: "/repo",
+      threadId: "thread-workspace",
+      refName: "main",
+      path: null,
+    });
+
+    expect(parsed.threadId).toBe("thread-workspace");
+  });
 });
 
 describe("GitPreparePullRequestThreadInput", () => {

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,7 +1,13 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
-import { VcsDriverKind, VcsNamedRef, VcsRevision, VcsWorkspaceIdentity } from "./vcs.ts";
+import {
+  VcsConflict,
+  VcsDriverKind,
+  VcsNamedRef,
+  VcsRevision,
+  VcsWorkspaceIdentity,
+} from "./vcs.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const GIT_LIST_BRANCHES_MAX_LIMIT = 200;
@@ -124,6 +130,7 @@ export const GitRunStackedActionInput = Schema.Struct({
   filePaths: Schema.optional(
     Schema.Array(TrimmedNonEmptyStringSchema).check(Schema.isMinLength(1)),
   ),
+  publishRef: Schema.optional(VcsNamedRef),
 });
 export type GitRunStackedActionInput = typeof GitRunStackedActionInput.Type;
 
@@ -361,9 +368,16 @@ export const GitRunStackedActionResult = Schema.Struct({
 export type GitRunStackedActionResult = typeof GitRunStackedActionResult.Type;
 
 export const VcsPullResult = Schema.Struct({
-  status: Schema.Literals(["pulled", "skipped_up_to_date"]),
+  status: Schema.Literals([
+    "pulled",
+    "skipped_up_to_date",
+    "fetched_needs_rebase",
+    "fetched_needs_resolution",
+  ]),
   refName: TrimmedNonEmptyStringSchema,
   upstreamRef: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
+  workspaceRevision: Schema.optional(VcsRevision),
+  conflicts: Schema.optional(Schema.Array(VcsConflict)),
 });
 export type VcsPullResult = typeof VcsPullResult.Type;
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
-import { VcsDriverKind } from "./vcs.ts";
+import { VcsDriverKind, VcsWorkspaceIdentity } from "./vcs.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const GIT_LIST_BRANCHES_MAX_LIMIT = 200;
@@ -141,6 +141,7 @@ export type VcsListRefsInput = typeof VcsListRefsInput.Type;
 
 export const VcsCreateWorktreeInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
+  threadId: Schema.optional(ThreadId),
   refName: TrimmedNonEmptyStringSchema,
   newRefName: Schema.optional(TrimmedNonEmptyStringSchema),
   baseRefName: Schema.optional(TrimmedNonEmptyStringSchema),
@@ -306,6 +307,7 @@ export type VcsListRefsResult = typeof VcsListRefsResult.Type;
 
 export const VcsCreateWorktreeResult = Schema.Struct({
   worktree: VcsWorktree,
+  workspace: Schema.optional(VcsWorkspaceIdentity),
 });
 export type VcsCreateWorktreeResult = typeof VcsCreateWorktreeResult.Type;
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -74,9 +74,15 @@ const GitRunStackedActionToast = Schema.Struct({
 export type GitRunStackedActionToast = typeof GitRunStackedActionToast.Type;
 
 export const VcsRef = Schema.Struct({
+  kind: Schema.optional(Schema.Literals(["branch", "bookmark"])),
   name: TrimmedNonEmptyStringSchema,
   isRemote: Schema.optional(Schema.Boolean),
   remoteName: Schema.optional(TrimmedNonEmptyStringSchema),
+  tracked: Schema.optional(Schema.Boolean),
+  conflicted: Schema.optional(Schema.Boolean),
+  targetRevision: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
+  aheadCount: Schema.optional(NonNegativeInt),
+  behindCount: Schema.optional(NonNegativeInt),
   current: Schema.Boolean,
   isDefault: Schema.Boolean,
   worktreePath: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
@@ -200,6 +206,30 @@ const VcsStatusChangeRequest = Schema.Struct({
 
 const VcsStatusLocalShape = {
   isRepo: Schema.Boolean,
+  driverKind: Schema.optional(VcsDriverKind),
+  workspaceRevision: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
+  workspaceRevisionDetails: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        commitId: TrimmedNonEmptyStringSchema,
+        changeId: Schema.optional(TrimmedNonEmptyStringSchema),
+        description: Schema.String,
+        parents: Schema.Array(TrimmedNonEmptyStringSchema),
+        empty: Schema.Boolean,
+      }),
+    ),
+  ),
+  publishRef: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
+  defaultRef: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
+  conflicts: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        kind: Schema.Literals(["content", "named-ref"]),
+        path: Schema.optional(TrimmedNonEmptyStringSchema),
+        refName: Schema.optional(TrimmedNonEmptyStringSchema),
+      }),
+    ),
+  ),
   sourceControlProvider: Schema.optional(SourceControlProviderInfo),
   hasPrimaryRemote: Schema.Boolean,
   isDefaultRef: Schema.Boolean,
@@ -219,6 +249,14 @@ const VcsStatusLocalShape = {
 };
 
 const VcsStatusRemoteShape = {
+  trackedRemote: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        remoteName: TrimmedNonEmptyStringSchema,
+        refName: TrimmedNonEmptyStringSchema,
+      }),
+    ),
+  ),
   hasUpstream: Schema.Boolean,
   aheadCount: NonNegativeInt,
   behindCount: NonNegativeInt,

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -223,11 +223,16 @@ const VcsStatusLocalShape = {
   defaultRef: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
   conflicts: Schema.optional(
     Schema.Array(
-      Schema.Struct({
-        kind: Schema.Literals(["content", "named-ref"]),
-        path: Schema.optional(TrimmedNonEmptyStringSchema),
-        refName: Schema.optional(TrimmedNonEmptyStringSchema),
-      }),
+      Schema.Union([
+        Schema.Struct({
+          kind: Schema.Literal("content"),
+          path: TrimmedNonEmptyStringSchema,
+        }),
+        Schema.Struct({
+          kind: Schema.Literal("named-ref"),
+          refName: TrimmedNonEmptyStringSchema,
+        }),
+      ]),
     ),
   ),
   sourceControlProvider: Schema.optional(SourceControlProviderInfo),

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
-import { VcsDriverKind, VcsWorkspaceIdentity } from "./vcs.ts";
+import { VcsDriverKind, VcsNamedRef, VcsRevision, VcsWorkspaceIdentity } from "./vcs.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const GIT_LIST_BRANCHES_MAX_LIMIT = 200;
@@ -338,6 +338,9 @@ export const GitRunStackedActionResult = Schema.Struct({
     status: GitCommitStepStatus,
     commitSha: Schema.optional(TrimmedNonEmptyStringSchema),
     subject: Schema.optional(TrimmedNonEmptyStringSchema),
+    finalizedRevision: Schema.optional(VcsRevision),
+    workspaceRevision: Schema.optional(VcsRevision),
+    publishRef: Schema.optional(VcsNamedRef),
   }),
   push: Schema.Struct({
     status: GitPushStepStatus,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -21,6 +21,7 @@ import {
   TurnId,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
+import { VcsWorkspaceIdentity } from "./vcs.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -352,6 +353,7 @@ export const OrchestrationThread = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
@@ -398,6 +400,7 @@ export const OrchestrationThreadShell = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
@@ -524,6 +527,7 @@ const ThreadCreateCommand = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
   createdAt: IsoDateTime,
 });
 
@@ -554,6 +558,7 @@ const ThreadMetaUpdateCommand = Schema.Struct({
   branch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   expectedBranch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   worktreePath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
 });
 
 const ThreadRuntimeModeSetCommand = Schema.Struct({
@@ -580,6 +585,7 @@ const ThreadTurnStartBootstrapCreateThread = Schema.Struct({
   interactionMode: ProviderInteractionMode,
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
   createdAt: IsoDateTime,
 });
 
@@ -869,6 +875,7 @@ export const ThreadCreatedPayload = Schema.Struct({
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });
@@ -895,6 +902,7 @@ export const ThreadMetaUpdatedPayload = Schema.Struct({
   modelSelection: Schema.optional(ModelSelection),
   branch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   worktreePath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
   updatedAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -882,6 +882,8 @@ export const ThreadCreatedPayload = Schema.Struct({
 
 export const ThreadDeletedPayload = Schema.Struct({
   threadId: ThreadId,
+  vcsWorkspace: Schema.optional(Schema.NullOr(VcsWorkspaceIdentity)),
+  workspaceRoot: Schema.optional(TrimmedNonEmptyString),
   deletedAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -171,6 +171,15 @@ export const WS_METHODS = {
   vcsSwitchRef: "vcs.switchRef",
   vcsInit: "vcs.init",
 
+  // Temporary aliases for clients from before VCS-neutral RPC names shipped.
+  gitPullLegacy: "git.pull",
+  gitRefreshStatusLegacy: "git.refreshStatus",
+  gitListRefsLegacy: "git.listRefs",
+  gitCreateWorktreeLegacy: "git.createWorktree",
+  gitRemoveWorktreeLegacy: "git.removeWorktree",
+  gitCreateRefLegacy: "git.createRef",
+  gitSwitchRefLegacy: "git.switchRef",
+
   // Git workflow methods
   gitRunStackedAction: "git.runStackedAction",
   gitResolvePullRequest: "git.resolvePullRequest",
@@ -467,6 +476,47 @@ export const WsVcsInitRpc = Rpc.make(WS_METHODS.vcsInit, {
   error: Schema.Union([VcsError, EnvironmentAuthorizationError]),
 });
 
+export const WsGitPullLegacyRpc = Rpc.make(WS_METHODS.gitPullLegacy, {
+  payload: VcsPullInput,
+  success: VcsPullResult,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitRefreshStatusLegacyRpc = Rpc.make(WS_METHODS.gitRefreshStatusLegacy, {
+  payload: VcsStatusInput,
+  success: VcsStatusResult,
+  error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitListRefsLegacyRpc = Rpc.make(WS_METHODS.gitListRefsLegacy, {
+  payload: VcsListRefsInput,
+  success: VcsListRefsResult,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitCreateWorktreeLegacyRpc = Rpc.make(WS_METHODS.gitCreateWorktreeLegacy, {
+  payload: VcsCreateWorktreeInput,
+  success: VcsCreateWorktreeResult,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitRemoveWorktreeLegacyRpc = Rpc.make(WS_METHODS.gitRemoveWorktreeLegacy, {
+  payload: VcsRemoveWorktreeInput,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitCreateRefLegacyRpc = Rpc.make(WS_METHODS.gitCreateRefLegacy, {
+  payload: VcsCreateRefInput,
+  success: VcsCreateRefResult,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitSwitchRefLegacyRpc = Rpc.make(WS_METHODS.gitSwitchRefLegacy, {
+  payload: VcsSwitchRefInput,
+  success: VcsSwitchRefResult,
+  error: Schema.Union([GitCommandError, EnvironmentAuthorizationError]),
+});
+
 /**
  * Ephemeral live diff preview for compact/mobile surfaces.
  * Not the persisted T3 Review model. Future review sessions should use
@@ -718,6 +768,13 @@ export const WsRpcGroup = RpcGroup.make(
   WsVcsCreateRefRpc,
   WsVcsSwitchRefRpc,
   WsVcsInitRpc,
+  WsGitPullLegacyRpc,
+  WsGitRefreshStatusLegacyRpc,
+  WsGitListRefsLegacyRpc,
+  WsGitCreateWorktreeLegacyRpc,
+  WsGitRemoveWorktreeLegacyRpc,
+  WsGitCreateRefLegacyRpc,
+  WsGitSwitchRefLegacyRpc,
   WsReviewGetDiffPreviewRpc,
   WsTerminalOpenRpc,
   WsTerminalAttachRpc,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -103,7 +103,11 @@ export const SourceControlPublishRepositoryResult = Schema.Struct({
 });
 export type SourceControlPublishRepositoryResult = typeof SourceControlPublishRepositoryResult.Type;
 
-export const SourceControlDiscoveryStatus = Schema.Literals(["available", "missing"]);
+export const SourceControlDiscoveryStatus = Schema.Literals([
+  "available",
+  "missing",
+  "unsupported",
+]);
 export type SourceControlDiscoveryStatus = typeof SourceControlDiscoveryStatus.Type;
 
 export const SourceControlProviderAuthStatus = Schema.Literals([

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -1,6 +1,6 @@
 import * as Schema from "effect/Schema";
 import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
-import { VcsDriverKind } from "./vcs.ts";
+import { VcsDriverKind, VcsNamedRef } from "./vcs.ts";
 
 export const SourceControlProviderKind = Schema.Literals([
   "github",
@@ -87,6 +87,7 @@ export const SourceControlPublishRepositoryInput = Schema.Struct({
   visibility: SourceControlRepositoryVisibility,
   remoteName: Schema.optional(TrimmedNonEmptyString),
   protocol: Schema.optional(SourceControlCloneProtocol),
+  publishRef: Schema.optional(VcsNamedRef),
 });
 export type SourceControlPublishRepositoryInput = typeof SourceControlPublishRepositoryInput.Type;
 
@@ -100,6 +101,7 @@ export const SourceControlPublishRepositoryResult = Schema.Struct({
   branch: TrimmedNonEmptyString,
   upstreamBranch: Schema.optional(TrimmedNonEmptyString),
   status: SourceControlPublishStatus,
+  publishRef: Schema.optional(VcsNamedRef),
 });
 export type SourceControlPublishRepositoryResult = typeof SourceControlPublishRepositoryResult.Type;
 

--- a/packages/contracts/src/vcs.test.ts
+++ b/packages/contracts/src/vcs.test.ts
@@ -37,6 +37,7 @@ describe("VCS-neutral persistence contracts", () => {
       name: "thread-demo",
       rootPath: "/tmp/jj-workspace",
       workspaceRevision: { commitId: "abc123", changeId: "change123" },
+      baseRevision: { commitId: "base123", changeId: "base-change123" },
       publishRef: { kind: "bookmark", name: "feature/demo" },
     });
     const encoded = encodeThreadWorkspace({ version: 2, workspace });

--- a/packages/contracts/src/vcs.test.ts
+++ b/packages/contracts/src/vcs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
+
+import { VcsNamedRef, VcsThreadWorkspace, VcsWorkspaceIdentity } from "./vcs.ts";
+
+const decodeThreadWorkspace = Schema.decodeUnknownSync(VcsThreadWorkspace);
+const encodeThreadWorkspace = Schema.encodeSync(VcsThreadWorkspace);
+const decodeWorkspaceIdentity = Schema.decodeUnknownSync(VcsWorkspaceIdentity);
+const decodeNamedRef = Schema.decodeUnknownSync(VcsNamedRef);
+
+describe("VCS-neutral persistence contracts", () => {
+  it("reads legacy Git thread workspace metadata", () => {
+    expect(
+      decodeThreadWorkspace({
+        version: 1,
+        branch: "feature/legacy",
+        worktreePath: "/tmp/legacy-worktree",
+      }),
+    ).toEqual({
+      version: 1,
+      branch: "feature/legacy",
+      worktreePath: "/tmp/legacy-worktree",
+    });
+  });
+
+  it("round-trips generic jj workspace metadata", () => {
+    const workspace = decodeWorkspaceIdentity({
+      driverKind: "jj",
+      name: "thread-demo",
+      rootPath: "/tmp/jj-workspace",
+      workspaceRevision: { commitId: "abc123", changeId: "change123" },
+      publishRef: { kind: "bookmark", name: "feature/demo" },
+    });
+    const encoded = encodeThreadWorkspace({ version: 2, workspace });
+
+    expect(decodeThreadWorkspace(encoded)).toEqual({
+      version: 2,
+      workspace,
+    });
+  });
+
+  it("keeps named-ref kind separate from its name", () => {
+    expect(
+      decodeNamedRef({
+        kind: "bookmark",
+        name: "main",
+      }),
+    ).toEqual({ kind: "bookmark", name: "main" });
+  });
+});

--- a/packages/contracts/src/vcs.test.ts
+++ b/packages/contracts/src/vcs.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as Schema from "effect/Schema";
 
-import { VcsNamedRef, VcsThreadWorkspace, VcsWorkspaceIdentity } from "./vcs.ts";
+import {
+  VcsActionProgressEvent,
+  VcsConflict,
+  VcsNamedRef,
+  VcsThreadWorkspace,
+  VcsWorkspaceIdentity,
+} from "./vcs.ts";
 
 const decodeThreadWorkspace = Schema.decodeUnknownSync(VcsThreadWorkspace);
 const encodeThreadWorkspace = Schema.encodeSync(VcsThreadWorkspace);
 const decodeWorkspaceIdentity = Schema.decodeUnknownSync(VcsWorkspaceIdentity);
 const decodeNamedRef = Schema.decodeUnknownSync(VcsNamedRef);
+const decodeConflict = Schema.decodeUnknownSync(VcsConflict);
+const decodeActionProgressEvent = Schema.decodeUnknownSync(VcsActionProgressEvent);
 
 describe("VCS-neutral persistence contracts", () => {
   it("reads legacy Git thread workspace metadata", () => {
@@ -46,5 +54,37 @@ describe("VCS-neutral persistence contracts", () => {
         name: "main",
       }),
     ).toEqual({ kind: "bookmark", name: "main" });
+  });
+
+  it("requires variant-specific conflict details", () => {
+    expect(decodeConflict({ kind: "content", path: "conflicted.txt" })).toEqual({
+      kind: "content",
+      path: "conflicted.txt",
+    });
+    expect(decodeConflict({ kind: "named-ref", ref: { kind: "bookmark", name: "main" } })).toEqual({
+      kind: "named-ref",
+      ref: { kind: "bookmark", name: "main" },
+    });
+    expect(() => decodeConflict({ kind: "content" })).toThrow();
+    expect(() => decodeConflict({ kind: "named-ref" })).toThrow();
+  });
+
+  it("preserves raw action output text", () => {
+    const text = "  indented\n\n";
+    expect(
+      decodeActionProgressEvent({
+        _tag: "output",
+        actionId: "action-1",
+        phase: "sync",
+        stream: "stdout",
+        text,
+      }),
+    ).toEqual({
+      _tag: "output",
+      actionId: "action-1",
+      phase: "sync",
+      stream: "stdout",
+      text,
+    });
   });
 });

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -76,6 +76,12 @@ export interface VcsProcessTimeoutFailure {
 export const VcsProcessExitFailureKind = Schema.Literals([
   "authentication",
   "not-found",
+  "not-repository",
+  "stale-workspace",
+  "unresolved-revision",
+  "bookmark-conflict",
+  "push-rejected",
+  "invalid-ref",
   "command-failed",
 ]);
 export type VcsProcessExitFailureKind = typeof VcsProcessExitFailureKind.Type;
@@ -131,16 +137,32 @@ export class VcsProcessExitError extends Schema.TaggedErrorClass<VcsProcessExitE
     error: VcsProcessExitFailure,
     failureKind: VcsProcessExitFailureKind,
   ) {
-    const detail =
-      failureKind === "authentication"
-        ? "Authentication failed."
-        : failureKind === "not-found"
-          ? context.command === "glab"
+    const detail = (() => {
+      switch (failureKind) {
+        case "authentication":
+          return "Authentication failed.";
+        case "not-found":
+          return context.command === "glab"
             ? "Merge request not found."
             : context.command === "gh" || context.command === "az"
               ? "Pull request not found."
-              : "VCS resource not found."
-          : "Process exited with a non-zero status.";
+              : "VCS resource not found.";
+        case "not-repository":
+          return "The directory is not inside a Jujutsu repository.";
+        case "stale-workspace":
+          return "The Jujutsu workspace is stale and must be updated.";
+        case "unresolved-revision":
+          return "The Jujutsu revision could not be resolved.";
+        case "bookmark-conflict":
+          return "The Jujutsu bookmark is conflicted.";
+        case "push-rejected":
+          return "Jujutsu rejected the push to protect remote work.";
+        case "invalid-ref":
+          return "The Jujutsu bookmark cannot be represented by the Git remote.";
+        case "command-failed":
+          return "Process exited with a non-zero status.";
+      }
+    })();
 
     return new VcsProcessExitError({
       ...context,

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -136,6 +136,7 @@ export const VcsWorkspaceIdentity = Schema.Struct({
   name: Schema.NullOr(TrimmedNonEmptyString),
   rootPath: TrimmedNonEmptyString,
   workspaceRevision: Schema.NullOr(VcsRevision),
+  baseRevision: Schema.optional(Schema.NullOr(VcsRevision)),
   publishRef: Schema.NullOr(VcsNamedRef),
 });
 export type VcsWorkspaceIdentity = typeof VcsWorkspaceIdentity.Type;

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -112,11 +112,16 @@ export type VcsDivergence = typeof VcsDivergence.Type;
 export const VcsConflictKind = Schema.Literals(["content", "named-ref"]);
 export type VcsConflictKind = typeof VcsConflictKind.Type;
 
-export const VcsConflict = Schema.Struct({
-  kind: VcsConflictKind,
-  path: Schema.optional(TrimmedNonEmptyString),
-  ref: Schema.optional(VcsNamedRef),
-});
+export const VcsConflict = Schema.Union([
+  Schema.Struct({
+    kind: Schema.Literal("content"),
+    path: TrimmedNonEmptyString,
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("named-ref"),
+    ref: VcsNamedRef,
+  }),
+]);
 export type VcsConflict = typeof VcsConflict.Type;
 
 export const VcsTrackedRemoteState = Schema.Struct({
@@ -190,7 +195,7 @@ export const VcsActionProgressEvent = Schema.Union([
     actionId: TrimmedNonEmptyString,
     phase: VcsActionProgressPhase,
     stream: Schema.Literals(["stdout", "stderr"]),
-    text: TrimmedNonEmptyString,
+    text: Schema.String,
   }),
   Schema.TaggedStruct("action-finished", {
     actionId: TrimmedNonEmptyString,

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -25,6 +25,12 @@ export const VcsDriverCapabilities = Schema.Struct({
   supportsBookmarks: Schema.Boolean,
   supportsAtomicSnapshot: Schema.Boolean,
   supportsPushDefaultRemote: Schema.Boolean,
+  supportsWorkspaces: Schema.optional(Schema.Boolean),
+  supportsNamedPublishRefs: Schema.optional(Schema.Boolean),
+  supportsSelectedFileFinalize: Schema.optional(Schema.Boolean),
+  supportsThreadLocalRestore: Schema.optional(Schema.Boolean),
+  supportsDefaultRemotePush: Schema.optional(Schema.Boolean),
+  supportsGitProviderCompatibility: Schema.optional(Schema.Boolean),
   ignoreClassifier: Schema.Literals(["native", "git-compatible-fallback"]),
 });
 export type VcsDriverCapabilities = typeof VcsDriverCapabilities.Type;
@@ -33,6 +39,7 @@ export const VcsRepositoryIdentity = Schema.Struct({
   kind: VcsDriverKind,
   rootPath: TrimmedNonEmptyString,
   metadataPath: Schema.NullOr(TrimmedNonEmptyString),
+  colocated: Schema.optional(Schema.Boolean),
   freshness: VcsFreshness,
 });
 export type VcsRepositoryIdentity = typeof VcsRepositoryIdentity.Type;
@@ -57,6 +64,144 @@ export const VcsListRemotesResult = Schema.Struct({
   freshness: VcsFreshness,
 });
 export type VcsListRemotesResult = typeof VcsListRemotesResult.Type;
+
+export const VcsAddRemoteInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  name: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+});
+export type VcsAddRemoteInput = typeof VcsAddRemoteInput.Type;
+
+export const VcsRemoveRemoteInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  name: TrimmedNonEmptyString,
+});
+export type VcsRemoveRemoteInput = typeof VcsRemoveRemoteInput.Type;
+
+export const VcsCloneRepositoryInput = Schema.Struct({
+  kind: Schema.optional(VcsDriverKind),
+  source: TrimmedNonEmptyString,
+  destination: TrimmedNonEmptyString,
+});
+export type VcsCloneRepositoryInput = typeof VcsCloneRepositoryInput.Type;
+
+export const VcsNamedRefKind = Schema.Literals(["branch", "bookmark"]);
+export type VcsNamedRefKind = typeof VcsNamedRefKind.Type;
+
+export const VcsRevision = Schema.Struct({
+  commitId: TrimmedNonEmptyString,
+  changeId: Schema.optional(TrimmedNonEmptyString),
+});
+export type VcsRevision = typeof VcsRevision.Type;
+
+export const VcsNamedRef = Schema.Struct({
+  kind: VcsNamedRefKind,
+  name: TrimmedNonEmptyString,
+  remoteName: Schema.optional(TrimmedNonEmptyString),
+  target: Schema.optional(VcsRevision),
+});
+export type VcsNamedRef = typeof VcsNamedRef.Type;
+
+export const VcsDivergence = Schema.Struct({
+  ahead: NonNegativeInt,
+  behind: NonNegativeInt,
+  divergent: Schema.Boolean,
+});
+export type VcsDivergence = typeof VcsDivergence.Type;
+
+export const VcsConflictKind = Schema.Literals(["content", "named-ref"]);
+export type VcsConflictKind = typeof VcsConflictKind.Type;
+
+export const VcsConflict = Schema.Struct({
+  kind: VcsConflictKind,
+  path: Schema.optional(TrimmedNonEmptyString),
+  ref: Schema.optional(VcsNamedRef),
+});
+export type VcsConflict = typeof VcsConflict.Type;
+
+export const VcsTrackedRemoteState = Schema.Struct({
+  remoteName: TrimmedNonEmptyString,
+  remoteRef: VcsNamedRef,
+  divergence: VcsDivergence,
+});
+export type VcsTrackedRemoteState = typeof VcsTrackedRemoteState.Type;
+
+export const VcsWorkspaceIdentity = Schema.Struct({
+  driverKind: VcsDriverKind,
+  name: Schema.NullOr(TrimmedNonEmptyString),
+  rootPath: TrimmedNonEmptyString,
+  workspaceRevision: Schema.NullOr(VcsRevision),
+  publishRef: Schema.NullOr(VcsNamedRef),
+});
+export type VcsWorkspaceIdentity = typeof VcsWorkspaceIdentity.Type;
+
+/** Compatibility shape used while persisted Git thread fields are migrated. */
+export const VcsThreadWorkspace = Schema.Union([
+  Schema.Struct({
+    version: Schema.Literal(2),
+    workspace: VcsWorkspaceIdentity,
+  }),
+  Schema.Struct({
+    version: Schema.Literal(1),
+    branch: Schema.NullOr(TrimmedNonEmptyString),
+    worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  }),
+]);
+export type VcsThreadWorkspace = typeof VcsThreadWorkspace.Type;
+
+export const VcsWorkflowKind = Schema.Literals(["change", "workspace", "sync", "checkpoint"]);
+export type VcsWorkflowKind = typeof VcsWorkflowKind.Type;
+
+export class VcsWorkflowError extends Schema.TaggedErrorClass<VcsWorkflowError>()(
+  "VcsWorkflowError",
+  {
+    workflow: VcsWorkflowKind,
+    operation: TrimmedNonEmptyString,
+    kind: VcsDriverKind,
+    detail: TrimmedNonEmptyString,
+    recoverable: Schema.Boolean,
+  },
+) {
+  override get message(): string {
+    return `VCS ${this.workflow} workflow failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export const VcsActionProgressPhase = Schema.Literals([
+  "prepare-ref",
+  "finalize-change",
+  "sync",
+  "publish",
+  "change-request",
+]);
+export type VcsActionProgressPhase = typeof VcsActionProgressPhase.Type;
+
+export const VcsActionProgressEvent = Schema.Union([
+  Schema.TaggedStruct("action-started", {
+    actionId: TrimmedNonEmptyString,
+    phases: Schema.Array(VcsActionProgressPhase),
+  }),
+  Schema.TaggedStruct("phase-started", {
+    actionId: TrimmedNonEmptyString,
+    phase: VcsActionProgressPhase,
+    label: TrimmedNonEmptyString,
+  }),
+  Schema.TaggedStruct("output", {
+    actionId: TrimmedNonEmptyString,
+    phase: VcsActionProgressPhase,
+    stream: Schema.Literals(["stdout", "stderr"]),
+    text: TrimmedNonEmptyString,
+  }),
+  Schema.TaggedStruct("action-finished", {
+    actionId: TrimmedNonEmptyString,
+  }),
+  Schema.TaggedStruct("action-failed", {
+    actionId: TrimmedNonEmptyString,
+    phase: Schema.NullOr(VcsActionProgressPhase),
+    message: TrimmedNonEmptyString,
+  }),
+]);
+export type VcsActionProgressEvent = typeof VcsActionProgressEvent.Type;
 
 export interface VcsProcessErrorContext {
   readonly operation: string;
@@ -298,5 +443,6 @@ export const VcsError = Schema.Union([
   VcsProcessMissingExitCodeError,
   VcsRepositoryDetectionError,
   VcsUnsupportedOperationError,
+  VcsWorkflowError,
 ]);
 export type VcsError = typeof VcsError.Type;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,10 @@
       "types": "./src/git.ts",
       "import": "./src/git.ts"
     },
+    "./jjCli": {
+      "types": "./src/jjCli.ts",
+      "import": "./src/jjCli.ts"
+    },
     "./sourceControl": {
       "types": "./src/sourceControl.ts",
       "import": "./src/sourceControl.ts"

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -104,6 +104,18 @@ describe("applyGitStatusStreamEvent", () => {
   it("preserves local-only fields when applying a remote update", () => {
     const current: VcsStatusResult = {
       isRepo: true,
+      driverKind: "jj",
+      workspaceRevision: "change-id",
+      workspaceRevisionDetails: {
+        commitId: "commit-id",
+        changeId: "change-id",
+        description: "demo",
+        parents: ["parent-id"],
+        empty: false,
+      },
+      publishRef: null,
+      defaultRef: "main@origin",
+      conflicts: [{ kind: "content", path: "src/demo.ts" }],
       sourceControlProvider: {
         kind: "github",
         name: "GitHub",
@@ -111,7 +123,7 @@ describe("applyGitStatusStreamEvent", () => {
       },
       hasPrimaryRemote: true,
       isDefaultRef: false,
-      refName: "feature/demo",
+      refName: null,
       hasWorkingTreeChanges: true,
       workingTree: {
         files: [{ path: "src/demo.ts", insertions: 1, deletions: 0 }],
@@ -125,6 +137,7 @@ describe("applyGitStatusStreamEvent", () => {
     };
 
     const remote: VcsStatusRemoteResult = {
+      trackedRemote: { remoteName: "origin", refName: "main" },
       hasUpstream: true,
       aheadCount: 2,
       behindCount: 1,
@@ -133,6 +146,7 @@ describe("applyGitStatusStreamEvent", () => {
 
     expect(applyGitStatusStreamEvent(current, { _tag: "remoteUpdated", remote })).toEqual({
       ...current,
+      trackedRemote: { remoteName: "origin", refName: "main" },
       hasUpstream: true,
       aheadCount: 2,
       behindCount: 1,

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -220,8 +220,9 @@ export function mergeGitStatusParts(
   };
 }
 
-function toRemoteStatusPart(status: VcsStatusResult): VcsStatusRemoteResult {
+export function toRemoteStatusPart(status: VcsStatusResult): VcsStatusRemoteResult {
   return {
+    ...(status.trackedRemote === undefined ? {} : { trackedRemote: status.trackedRemote }),
     hasUpstream: status.hasUpstream,
     aheadCount: status.aheadCount,
     behindCount: status.behindCount,
@@ -232,9 +233,19 @@ function toRemoteStatusPart(status: VcsStatusResult): VcsStatusRemoteResult {
   };
 }
 
-function toLocalStatusPart(status: VcsStatusResult): VcsStatusLocalResult {
+export function toLocalStatusPart(status: VcsStatusResult): VcsStatusLocalResult {
   return {
     isRepo: status.isRepo,
+    ...(status.driverKind === undefined ? {} : { driverKind: status.driverKind }),
+    ...(status.workspaceRevision === undefined
+      ? {}
+      : { workspaceRevision: status.workspaceRevision }),
+    ...(status.workspaceRevisionDetails === undefined
+      ? {}
+      : { workspaceRevisionDetails: status.workspaceRevisionDetails }),
+    ...(status.publishRef === undefined ? {} : { publishRef: status.publishRef }),
+    ...(status.defaultRef === undefined ? {} : { defaultRef: status.defaultRef }),
+    ...(status.conflicts === undefined ? {} : { conflicts: status.conflicts }),
     ...(status.sourceControlProvider
       ? { sourceControlProvider: status.sourceControlProvider }
       : {}),

--- a/packages/shared/src/jjCli.test.ts
+++ b/packages/shared/src/jjCli.test.ts
@@ -5,6 +5,9 @@ import {
   classifyJjCommandFailure,
   classifyJjRevisionCondition,
   inspectJjVersion,
+  isJjBookmarkRecord,
+  isJjChangedFileRecord,
+  isJjRevisionRecord,
   parseJjJsonLines,
   parseJjVersionOutput,
   quoteJjSymbol,
@@ -29,6 +32,17 @@ describe("jj CLI contract", () => {
       status: "supported",
       version: JJ_MINIMUM_SUPPORTED_VERSION,
     });
+  });
+
+  it("treats jj source revision suffixes as packaging metadata", () => {
+    const sourceRevision = "b8f7c455170e3273897aaf94431f8ccfb1afa7ad";
+
+    expect(inspectJjVersion(`jj 0.42.0-${sourceRevision}`)).toEqual({
+      status: "supported",
+      version: `0.42.0-${sourceRevision}`,
+    });
+    expect(inspectJjVersion(`jj 0.41.0-${sourceRevision}`).status).toBe("unsupported");
+    expect(inspectJjVersion("jj 0.42.0-rc.1").status).toBe("unsupported");
   });
 
   it("round-trips JSON lines containing control characters and Unicode", () => {
@@ -65,5 +79,31 @@ describe("jj CLI contract", () => {
   it("classifies content conflicts from structured revision data", () => {
     expect(classifyJjRevisionCondition({ conflict: true })).toBe("content-conflict");
     expect(classifyJjRevisionCondition({ conflict: false })).toBeNull();
+  });
+
+  it("validates revision, file, and bookmark machine records", () => {
+    expect(
+      isJjRevisionRecord({
+        commitId: "abc",
+        changeId: "change",
+        description: "message",
+        conflict: false,
+        empty: true,
+        parents: ["parent"],
+        workingCopies: [],
+      }),
+    ).toBe(true);
+    expect(isJjChangedFileRecord({ path: "file.txt", status: "renamed", conflict: true })).toBe(
+      true,
+    );
+    expect(
+      isJjBookmarkRecord({
+        name: "main",
+        remote: "origin",
+        target: ["abc"],
+        tracking_target: ["def"],
+      }),
+    ).toBe(true);
+    expect(isJjBookmarkRecord({ name: "broken", target: "abc" })).toBe(false);
   });
 });

--- a/packages/shared/src/jjCli.test.ts
+++ b/packages/shared/src/jjCli.test.ts
@@ -10,6 +10,7 @@ import {
   isJjRevisionRecord,
   parseJjJsonLines,
   parseJjVersionOutput,
+  quoteJjRootFileFileset,
   quoteJjSymbol,
 } from "./jjCli.ts";
 
@@ -60,6 +61,24 @@ describe("jj CLI contract", () => {
       expect(JSON.parse(quoteJjSymbol(name))).toBe(name);
     }
     expect(() => quoteJjSymbol("nul\0name")).toThrow("NUL");
+  });
+
+  it("quotes exact workspace-relative file paths as root-file filesets", () => {
+    for (const filePath of [
+      "src/file.ts",
+      "space snow-雪.txt",
+      "tab\tname.txt",
+      "line\nbreak.txt",
+      'quote"name.txt',
+    ]) {
+      const fileset = quoteJjRootFileFileset(filePath);
+      expect(fileset.startsWith("root-file:")).toBe(true);
+      expect(JSON.parse(fileset.slice("root-file:".length))).toBe(filePath);
+    }
+
+    for (const invalidPath of ["", "/tmp/file", "../file", "src/../file", "C:\\tmp\\file"]) {
+      expect(() => quoteJjRootFileFileset(invalidPath)).toThrow();
+    }
   });
 
   it.each([

--- a/packages/shared/src/jjCli.test.ts
+++ b/packages/shared/src/jjCli.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  JJ_MINIMUM_SUPPORTED_VERSION,
+  classifyJjCommandFailure,
+  classifyJjRevisionCondition,
+  inspectJjVersion,
+  parseJjJsonLines,
+  parseJjVersionOutput,
+  quoteJjSymbol,
+} from "./jjCli.ts";
+
+describe("jj CLI contract", () => {
+  it("parses release and prerelease version output", () => {
+    expect(parseJjVersionOutput("jj 0.42.0\n")).toBe("0.42.0");
+    expect(parseJjVersionOutput("jj v0.43.0-rc.1\n")).toBe("0.43.0-rc.1");
+    expect(parseJjVersionOutput("jj 0.43.0+build.7\n")).toBe("0.43.0");
+    expect(parseJjVersionOutput("unexpected")).toBeNull();
+  });
+
+  it("rejects versions below the supported floor with an actionable detail", () => {
+    expect(inspectJjVersion("jj 0.41.0")).toEqual({
+      status: "unsupported",
+      version: "0.41.0",
+      minimumVersion: JJ_MINIMUM_SUPPORTED_VERSION,
+      detail: `Jujutsu 0.41.0 is unsupported. T3 Code requires jj ${JJ_MINIMUM_SUPPORTED_VERSION} or newer.`,
+    });
+    expect(inspectJjVersion(`jj ${JJ_MINIMUM_SUPPORTED_VERSION}`)).toEqual({
+      status: "supported",
+      version: JJ_MINIMUM_SUPPORTED_VERSION,
+    });
+  });
+
+  it("round-trips JSON lines containing control characters and Unicode", () => {
+    const records = [
+      { path: "space snow-雪.txt", description: "line one\nline\ttwo" },
+      { path: "line\nbreak.txt", description: 'quote: "' },
+    ];
+    const output = `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+
+    expect(parseJjJsonLines(output)).toEqual(records);
+  });
+
+  it("quotes revset symbols without shell interpolation", () => {
+    for (const name of ["feature space", "unicode-雪", "tab\tname", "line\nname", 'quote"name']) {
+      expect(JSON.parse(quoteJjSymbol(name))).toBe(name);
+    }
+    expect(() => quoteJjSymbol("nul\0name")).toThrow("NUL");
+  });
+
+  it.each([
+    ["Error: There is no jj repo in .", 1, "not-repository"],
+    ["Working copy is stale. Run `jj workspace update-stale`.", 1, "stale-workspace"],
+    ["Error: Revision doesn't exist: missing", 1, "unresolved-revision"],
+    ["Error: Bookmark main is conflicted", 1, "bookmark-conflict"],
+    ["fatal: Authentication failed", 1, "authentication"],
+    ["Error: Refusing to push bookmark because it unexpectedly moved", 1, "push-rejected"],
+    ["Warning: Failed to export some bookmarks: not a valid ref name", 0, "invalid-ref"],
+    ["unknown failure", 2, "command-failed"],
+    ["", 0, null],
+  ] as const)("classifies %s", (stderr, exitCode, expected) => {
+    expect(classifyJjCommandFailure({ stderr, exitCode })).toBe(expected);
+  });
+
+  it("classifies content conflicts from structured revision data", () => {
+    expect(classifyJjRevisionCondition({ conflict: true })).toBe("content-conflict");
+    expect(classifyJjRevisionCondition({ conflict: false })).toBeNull();
+  });
+});

--- a/packages/shared/src/jjCli.test.ts
+++ b/packages/shared/src/jjCli.test.ts
@@ -96,6 +96,9 @@ describe("jj CLI contract", () => {
     expect(isJjChangedFileRecord({ path: "file.txt", status: "renamed", conflict: true })).toBe(
       true,
     );
+    expect(isJjChangedFileRecord({ path: "file.txt", status: ["renamed"], conflict: true })).toBe(
+      false,
+    );
     expect(
       isJjBookmarkRecord({
         name: "main",

--- a/packages/shared/src/jjCli.ts
+++ b/packages/shared/src/jjCli.ts
@@ -1,0 +1,248 @@
+import { compareSemverVersions } from "./semver.ts";
+
+export const JJ_MINIMUM_SUPPORTED_VERSION = "0.42.0";
+
+export type JjVersionSupport =
+  | {
+      readonly status: "supported";
+      readonly version: string;
+    }
+  | {
+      readonly status: "unsupported";
+      readonly version: string;
+      readonly minimumVersion: string;
+      readonly detail: string;
+    }
+  | {
+      readonly status: "invalid";
+      readonly detail: string;
+    };
+
+export type JjCommandFailureKind =
+  | "not-repository"
+  | "stale-workspace"
+  | "unresolved-revision"
+  | "bookmark-conflict"
+  | "authentication"
+  | "push-rejected"
+  | "invalid-ref"
+  | "command-failed";
+
+export type JjRevisionConditionKind = "content-conflict";
+
+export interface JjRevisionRecord {
+  readonly commitId: string;
+  readonly changeId: string;
+  readonly description: string;
+  readonly conflict: boolean;
+  readonly empty: boolean;
+  readonly parents: ReadonlyArray<string>;
+  readonly workingCopies: ReadonlyArray<unknown>;
+}
+
+export interface JjChangedFileRecord {
+  readonly path: string;
+  readonly status: "modified" | "added" | "removed" | "copied" | "renamed";
+  readonly conflict: boolean;
+}
+
+const JJ_VERSION_PATTERN =
+  /(?:^|\s)(?:jj\s+)?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\+[0-9A-Za-z.-]+)?(?:\s|$)/i;
+
+export function parseJjVersionOutput(output: string): string | null {
+  return output.match(JJ_VERSION_PATTERN)?.[1] ?? null;
+}
+
+export function inspectJjVersion(output: string): JjVersionSupport {
+  const version = parseJjVersionOutput(output);
+  if (version === null) {
+    return {
+      status: "invalid",
+      detail: `Could not parse the Jujutsu version from: ${JSON.stringify(output.trim())}`,
+    };
+  }
+
+  if (compareSemverVersions(version, JJ_MINIMUM_SUPPORTED_VERSION) < 0) {
+    return {
+      status: "unsupported",
+      version,
+      minimumVersion: JJ_MINIMUM_SUPPORTED_VERSION,
+      detail: `Jujutsu ${version} is unsupported. T3 Code requires jj ${JJ_MINIMUM_SUPPORTED_VERSION} or newer.`,
+    };
+  }
+
+  return { status: "supported", version };
+}
+
+export const JJ_REVISION_JSON_TEMPLATE = [
+  'concat("{\\"commitId\\":", json(commit_id),',
+  '",\\"changeId\\":", json(change_id),',
+  '",\\"description\\":", json(description),',
+  '",\\"conflict\\":", json(conflict),',
+  '",\\"empty\\":", json(empty),',
+  '",\\"parents\\":", json(parents.map(|parent| parent.commit_id())),',
+  '",\\"workingCopies\\":", json(working_copies), "}\\n")',
+].join(" ");
+
+export const JJ_CHANGED_FILE_JSON_TEMPLATE = [
+  "diff.files().map(|entry|",
+  'concat("{\\"path\\":", json(entry.path()),',
+  '",\\"status\\":", json(entry.status()),',
+  '",\\"conflict\\":", json(entry.target().conflict()), "}\\n"))',
+  '.join("")',
+].join(" ");
+
+export const JJ_BOOKMARK_JSON_TEMPLATE = 'json(self) ++ "\\n"';
+export const JJ_WORKSPACE_JSON_TEMPLATE = 'json(self) ++ "\\n"';
+export const JJ_OPERATION_JSON_TEMPLATE = 'json(self) ++ "\\n"';
+
+const JJ_MACHINE_GLOBAL_ARGS = ["--color=never", "--no-pager"] as const;
+
+export const jjMachineCommand = {
+  revision(revision = "@"): ReadonlyArray<string> {
+    return [
+      ...JJ_MACHINE_GLOBAL_ARGS,
+      "log",
+      "--no-graph",
+      "--revisions",
+      revision,
+      "--template",
+      JJ_REVISION_JSON_TEMPLATE,
+    ];
+  },
+  changedFiles(revision = "@"): ReadonlyArray<string> {
+    return [
+      ...JJ_MACHINE_GLOBAL_ARGS,
+      "log",
+      "--no-graph",
+      "--revisions",
+      revision,
+      "--template",
+      JJ_CHANGED_FILE_JSON_TEMPLATE,
+    ];
+  },
+  bookmarks(): ReadonlyArray<string> {
+    return [
+      ...JJ_MACHINE_GLOBAL_ARGS,
+      "bookmark",
+      "list",
+      "--all-remotes",
+      "--template",
+      JJ_BOOKMARK_JSON_TEMPLATE,
+    ];
+  },
+  workspaces(): ReadonlyArray<string> {
+    return [
+      ...JJ_MACHINE_GLOBAL_ARGS,
+      "workspace",
+      "list",
+      "--template",
+      JJ_WORKSPACE_JSON_TEMPLATE,
+    ];
+  },
+  currentOperation(): ReadonlyArray<string> {
+    return [
+      ...JJ_MACHINE_GLOBAL_ARGS,
+      "operation",
+      "log",
+      "--no-graph",
+      "--limit",
+      "1",
+      "--template",
+      JJ_OPERATION_JSON_TEMPLATE,
+    ];
+  },
+} as const;
+
+export function parseJjJsonLines(output: string): ReadonlyArray<unknown> {
+  return output
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+export function quoteJjSymbol(value: string): string {
+  if (value.includes("\0")) {
+    throw new Error("jj symbols cannot contain NUL bytes");
+  }
+  return JSON.stringify(value);
+}
+
+export function classifyJjRevisionCondition(
+  revision: Pick<JjRevisionRecord, "conflict">,
+): JjRevisionConditionKind | null {
+  return revision.conflict ? "content-conflict" : null;
+}
+
+export function classifyJjCommandFailure(input: {
+  readonly exitCode: number;
+  readonly stderr: string;
+}): JjCommandFailureKind | null {
+  const normalized = input.stderr.toLowerCase();
+
+  if (
+    normalized.includes("failed to export some bookmarks") ||
+    normalized.includes("not a valid ref name") ||
+    normalized.includes("invalid bookmark name") ||
+    normalized.includes("invalid ref name")
+  ) {
+    return "invalid-ref";
+  }
+
+  if (
+    normalized.includes("authentication failed") ||
+    normalized.includes("permission denied (publickey)") ||
+    normalized.includes("terminal prompts disabled") ||
+    normalized.includes("could not read username") ||
+    normalized.includes("unauthorized")
+  ) {
+    return "authentication";
+  }
+
+  if (
+    normalized.includes("refusing to push") ||
+    normalized.includes("unexpectedly moved") ||
+    normalized.includes("failed to push") ||
+    normalized.includes("push was rejected") ||
+    normalized.includes("non-fast-forward")
+  ) {
+    return "push-rejected";
+  }
+
+  if (
+    normalized.includes("working copy is stale") ||
+    normalized.includes("workspace is stale") ||
+    normalized.includes("run `jj workspace update-stale`")
+  ) {
+    return "stale-workspace";
+  }
+
+  if (
+    (normalized.includes("bookmark") && normalized.includes("conflict")) ||
+    normalized.includes("conflicted bookmark") ||
+    normalized.includes("resolved to more than one revision")
+  ) {
+    return "bookmark-conflict";
+  }
+
+  if (
+    normalized.includes("there is no jj repo") ||
+    normalized.includes("not a jj repository") ||
+    normalized.includes("no repository found")
+  ) {
+    return "not-repository";
+  }
+
+  if (
+    normalized.includes("revision doesn't exist") ||
+    normalized.includes("revision does not exist") ||
+    (normalized.includes("revision") && normalized.includes("doesn't exist")) ||
+    normalized.includes("no such revision") ||
+    normalized.includes("resolved to no revisions") ||
+    (normalized.includes("revset") && normalized.includes("doesn't exist"))
+  ) {
+    return "unresolved-revision";
+  }
+
+  return input.exitCode === 0 ? null : "command-failed";
+}

--- a/packages/shared/src/jjCli.ts
+++ b/packages/shared/src/jjCli.ts
@@ -76,7 +76,8 @@ export function isJjChangedFileRecord(value: unknown): value is JjChangedFileRec
   const record = value as Record<string, unknown>;
   return (
     typeof record.path === "string" &&
-    ["modified", "added", "removed", "copied", "renamed"].includes(String(record.status)) &&
+    typeof record.status === "string" &&
+    ["modified", "added", "removed", "copied", "renamed"].includes(record.status) &&
     typeof record.conflict === "boolean"
   );
 }

--- a/packages/shared/src/jjCli.ts
+++ b/packages/shared/src/jjCli.ts
@@ -46,11 +46,62 @@ export interface JjChangedFileRecord {
   readonly conflict: boolean;
 }
 
+export interface JjBookmarkRecord {
+  readonly name: string;
+  readonly remote?: string;
+  readonly target: ReadonlyArray<string>;
+  readonly tracking_target?: ReadonlyArray<string>;
+}
+
+function isStringArray(value: unknown): value is ReadonlyArray<string> {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+export function isJjRevisionRecord(value: unknown): value is JjRevisionRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.commitId === "string" &&
+    typeof record.changeId === "string" &&
+    typeof record.description === "string" &&
+    typeof record.conflict === "boolean" &&
+    typeof record.empty === "boolean" &&
+    isStringArray(record.parents) &&
+    Array.isArray(record.workingCopies)
+  );
+}
+
+export function isJjChangedFileRecord(value: unknown): value is JjChangedFileRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.path === "string" &&
+    ["modified", "added", "removed", "copied", "renamed"].includes(String(record.status)) &&
+    typeof record.conflict === "boolean"
+  );
+}
+
+export function isJjBookmarkRecord(value: unknown): value is JjBookmarkRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.name === "string" &&
+    (record.remote === undefined || typeof record.remote === "string") &&
+    isStringArray(record.target) &&
+    (record.tracking_target === undefined || isStringArray(record.tracking_target))
+  );
+}
+
 const JJ_VERSION_PATTERN =
   /(?:^|\s)(?:jj\s+)?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\+[0-9A-Za-z.-]+)?(?:\s|$)/i;
+const JJ_SOURCE_REVISION_SUFFIX_PATTERN = /-[0-9a-f]{40}$/i;
 
 export function parseJjVersionOutput(output: string): string | null {
   return output.match(JJ_VERSION_PATTERN)?.[1] ?? null;
+}
+
+function getComparableJjVersion(version: string): string {
+  return version.replace(JJ_SOURCE_REVISION_SUFFIX_PATTERN, "");
 }
 
 export function inspectJjVersion(output: string): JjVersionSupport {
@@ -62,7 +113,7 @@ export function inspectJjVersion(output: string): JjVersionSupport {
     };
   }
 
-  if (compareSemverVersions(version, JJ_MINIMUM_SUPPORTED_VERSION) < 0) {
+  if (compareSemverVersions(getComparableJjVersion(version), JJ_MINIMUM_SUPPORTED_VERSION) < 0) {
     return {
       status: "unsupported",
       version,

--- a/packages/shared/src/jjCli.ts
+++ b/packages/shared/src/jjCli.ts
@@ -247,6 +247,22 @@ export function quoteJjSymbol(value: string): string {
   return JSON.stringify(value);
 }
 
+export function quoteJjRootFileFileset(value: string): string {
+  if (value.length === 0) {
+    throw new Error("jj file paths cannot be empty");
+  }
+  if (value.includes("\0")) {
+    throw new Error("jj file paths cannot contain NUL bytes");
+  }
+  if (/^(?:[/\\]|[A-Za-z]:[/\\])/.test(value)) {
+    throw new Error("jj file paths must be workspace-relative");
+  }
+  if (value.split(/[\\/]/).some((segment) => segment === "." || segment === "..")) {
+    throw new Error("jj file paths cannot contain relative traversal segments");
+  }
+  return `root-file:${quoteJjSymbol(value)}`;
+}
+
 export function classifyJjRevisionCondition(
   revision: Pick<JjRevisionRecord, "conflict">,
 ): JjRevisionConditionKind | null {

--- a/packages/shared/src/jjCli.ts
+++ b/packages/shared/src/jjCli.ts
@@ -53,6 +53,15 @@ export interface JjBookmarkRecord {
   readonly tracking_target?: ReadonlyArray<string>;
 }
 
+export interface JjWorkspaceRecord {
+  readonly name: string;
+  readonly target: {
+    readonly commit_id: string;
+    readonly parents: ReadonlyArray<string>;
+    readonly change_id: string;
+  };
+}
+
 function isStringArray(value: unknown): value is ReadonlyArray<string> {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
@@ -90,6 +99,24 @@ export function isJjBookmarkRecord(value: unknown): value is JjBookmarkRecord {
     (record.remote === undefined || typeof record.remote === "string") &&
     isStringArray(record.target) &&
     (record.tracking_target === undefined || isStringArray(record.tracking_target))
+  );
+}
+
+export function isJjWorkspaceRecord(value: unknown): value is JjWorkspaceRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.name !== "string" ||
+    typeof record.target !== "object" ||
+    record.target === null
+  ) {
+    return false;
+  }
+  const target = record.target as Record<string, unknown>;
+  return (
+    typeof target.commit_id === "string" &&
+    typeof target.change_id === "string" &&
+    isStringArray(target.parents)
   );
 }
 

--- a/scripts/jj-phase-zero-smoke.ts
+++ b/scripts/jj-phase-zero-smoke.ts
@@ -1,0 +1,279 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeAssert from "node:assert/strict";
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import {
+  JJ_MINIMUM_SUPPORTED_VERSION,
+  classifyJjCommandFailure,
+  classifyJjRevisionCondition,
+  inspectJjVersion,
+  jjMachineCommand,
+  parseJjJsonLines,
+  quoteJjSymbol,
+  type JjChangedFileRecord,
+  type JjRevisionRecord,
+} from "@t3tools/shared/jjCli";
+
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface CheckpointMetadata {
+  readonly operationId: string;
+  readonly workspaceName: string;
+  readonly commitId: string;
+  readonly changeId: string;
+  readonly description: string;
+}
+
+const JJ_TEST_CONFIG = [
+  "--config",
+  'user.name="T3 Code jj contract"',
+  "--config",
+  'user.email="jj-contract@example.invalid"',
+] as const;
+
+function run(
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string,
+  options?: { readonly allowFailure?: boolean },
+): CommandResult {
+  const result = NodeChildProcess.spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+    },
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const exitCode = result.status ?? 1;
+  const output = {
+    exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+
+  if (exitCode !== 0 && options?.allowFailure !== true) {
+    throw new Error(
+      `${command} failed with ${exitCode}\nstdout:\n${output.stdout}\nstderr:\n${output.stderr}`,
+    );
+  }
+
+  return output;
+}
+
+function runJj(
+  cwd: string,
+  args: ReadonlyArray<string>,
+  options?: { readonly allowFailure?: boolean },
+): CommandResult {
+  return run("jj", [...JJ_TEST_CONFIG, ...args], cwd, options);
+}
+
+function parseSingleRecord<T>(output: string): T {
+  const records = parseJjJsonLines(output);
+  NodeAssert.equal(records.length, 1);
+  return records[0] as T;
+}
+
+function revision(cwd: string, revisionId = "@"): JjRevisionRecord {
+  return parseSingleRecord<JjRevisionRecord>(
+    runJj(cwd, jjMachineCommand.revision(revisionId)).stdout,
+  );
+}
+
+function currentOperation(cwd: string): Record<string, unknown> {
+  return parseSingleRecord<Record<string, unknown>>(
+    runJj(cwd, jjMachineCommand.currentOperation()).stdout,
+  );
+}
+
+function bookmarkTarget(cwd: string, name: string): ReadonlyArray<string> {
+  const records = parseJjJsonLines(runJj(cwd, jjMachineCommand.bookmarks()).stdout);
+  const record = records.find(
+    (candidate) =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      "name" in candidate &&
+      candidate.name === name &&
+      !("remote" in candidate),
+  );
+  NodeAssert.ok(typeof record === "object" && record !== null);
+  const target = "target" in record ? record.target : undefined;
+  NodeAssert.ok(Array.isArray(target));
+  return target as ReadonlyArray<string>;
+}
+
+const versionOutput = run("jj", ["--version"], process.cwd()).stdout;
+const versionSupport = inspectJjVersion(versionOutput);
+NodeAssert.equal(
+  versionSupport.status,
+  "supported",
+  versionSupport.status === "supported" ? undefined : versionSupport.detail,
+);
+
+const testRoot = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-jj-phase-zero-"));
+
+try {
+  const sourcePath = NodePath.join(testRoot, "source space-雪");
+  const clonePath = NodePath.join(testRoot, "clone space-雪");
+  const secondWorkspacePath = NodePath.join(testRoot, "workspace space-雪");
+  NodeFS.mkdirSync(sourcePath);
+
+  runJj(testRoot, ["git", "init", "--colocate", sourcePath]);
+  NodeAssert.ok(NodeFS.existsSync(NodePath.join(sourcePath, ".jj")));
+  NodeAssert.ok(NodeFS.existsSync(NodePath.join(sourcePath, ".git")));
+
+  const fileNames =
+    process.env.OS === "Windows_NT"
+      ? ["space snow-雪.txt"]
+      : ["space snow-雪.txt", "tab\tname.txt", "line\nbreak.txt"];
+  for (const fileName of fileNames) {
+    NodeFS.writeFileSync(NodePath.join(sourcePath, fileName), `checkpoint:${fileName}\n`);
+  }
+
+  runJj(sourcePath, ["util", "snapshot"]);
+  const initialDescription = "phase zero\nUnicode 雪 and tab\tcontent";
+  runJj(sourcePath, ["describe", "--message", initialDescription]);
+
+  const initialRevision = revision(sourcePath);
+  NodeAssert.equal(initialRevision.description, `${initialDescription}\n`);
+  NodeAssert.equal(classifyJjRevisionCondition(initialRevision), null);
+
+  const changedFiles = parseJjJsonLines(
+    runJj(sourcePath, jjMachineCommand.changedFiles()).stdout,
+  ) as ReadonlyArray<JjChangedFileRecord>;
+  NodeAssert.deepEqual(new Set(changedFiles.map((file) => file.path)), new Set(fileNames));
+
+  runJj(sourcePath, ["commit", "--message", "baseline"]);
+  for (const bookmark of ["main", "feature-雪"]) {
+    runJj(sourcePath, ["bookmark", "create", quoteJjSymbol(bookmark), "--revision", "@-"]);
+  }
+
+  for (const invalidBookmark of ["feature space", "tab\tname", "line\nname"]) {
+    const result = runJj(
+      sourcePath,
+      ["bookmark", "create", quoteJjSymbol(invalidBookmark), "--revision", "@-"],
+      { allowFailure: true },
+    );
+    NodeAssert.equal(
+      classifyJjCommandFailure({ exitCode: result.exitCode, stderr: result.stderr }),
+      "invalid-ref",
+    );
+    runJj(sourcePath, ["bookmark", "delete", quoteJjSymbol(invalidBookmark)], {
+      allowFailure: true,
+    });
+  }
+
+  NodeFS.writeFileSync(NodePath.join(sourcePath, fileNames[0] as string), "checkpoint version\n");
+  runJj(sourcePath, ["util", "snapshot"]);
+  const checkpointDescription = "checkpoint description\nwith tab\tand 雪";
+  runJj(sourcePath, ["describe", "--message", checkpointDescription]);
+  const checkpointRevision = revision(sourcePath);
+  const checkpointOperation = currentOperation(sourcePath);
+  NodeAssert.equal(typeof checkpointOperation.id, "string");
+
+  const checkpoint: CheckpointMetadata = {
+    operationId: checkpointOperation.id as string,
+    workspaceName: "default",
+    commitId: checkpointRevision.commitId,
+    changeId: checkpointRevision.changeId,
+    description: checkpointRevision.description,
+  };
+  const checkpointPath = NodePath.join(testRoot, "checkpoint.json");
+  NodeFS.writeFileSync(checkpointPath, JSON.stringify(checkpoint));
+
+  runJj(sourcePath, [
+    "workspace",
+    "add",
+    secondWorkspacePath,
+    "--name",
+    "contract-雪",
+    "--revision",
+    quoteJjSymbol("feature-雪"),
+  ]);
+  const workspaces = parseJjJsonLines(runJj(sourcePath, jjMachineCommand.workspaces()).stdout);
+  NodeAssert.ok(
+    workspaces.some(
+      (workspace) =>
+        typeof workspace === "object" &&
+        workspace !== null &&
+        "name" in workspace &&
+        workspace.name === "contract-雪",
+    ),
+  );
+
+  const secondWorkspaceFile = NodePath.join(secondWorkspacePath, fileNames[0] as string);
+  NodeFS.writeFileSync(secondWorkspaceFile, "second workspace version\n");
+  runJj(secondWorkspacePath, ["util", "snapshot"]);
+  const secondWorkspaceRevision = revision(secondWorkspacePath);
+
+  NodeFS.writeFileSync(NodePath.join(sourcePath, fileNames[0] as string), "after checkpoint\n");
+  runJj(sourcePath, ["util", "snapshot"]);
+  NodeAssert.notEqual(revision(sourcePath).commitId, checkpoint.commitId);
+
+  const featureTargetBeforeRestore = bookmarkTarget(sourcePath, "feature-雪");
+  runJj(sourcePath, ["util", "gc", "--expire", "now"]);
+
+  // New file read plus new jj processes model a server restart before restore.
+  const restartedCheckpoint = JSON.parse(
+    NodeFS.readFileSync(checkpointPath, "utf8"),
+  ) as CheckpointMetadata;
+  NodeAssert.equal(
+    revision(sourcePath, restartedCheckpoint.commitId).changeId,
+    restartedCheckpoint.changeId,
+  );
+
+  runJj(sourcePath, ["restore", "--from", restartedCheckpoint.commitId, "--into", "@"]);
+  runJj(sourcePath, ["describe", "--message", restartedCheckpoint.description.trimEnd()]);
+
+  NodeAssert.equal(
+    NodeFS.readFileSync(NodePath.join(sourcePath, fileNames[0] as string), "utf8"),
+    "checkpoint version\n",
+  );
+  NodeAssert.equal(NodeFS.readFileSync(secondWorkspaceFile, "utf8"), "second workspace version\n");
+  NodeAssert.equal(revision(secondWorkspacePath).commitId, secondWorkspaceRevision.commitId);
+  NodeAssert.deepEqual(bookmarkTarget(sourcePath, "feature-雪"), featureTargetBeforeRestore);
+  NodeAssert.notEqual(currentOperation(sourcePath).id, restartedCheckpoint.operationId);
+
+  runJj(testRoot, ["git", "clone", "--colocate", sourcePath, clonePath]);
+  NodeAssert.ok(NodeFS.existsSync(NodePath.join(clonePath, ".jj")));
+  NodeAssert.ok(NodeFS.existsSync(NodePath.join(clonePath, ".git")));
+
+  const nonRepository = runJj(testRoot, ["status"], { allowFailure: true });
+  NodeAssert.equal(
+    classifyJjCommandFailure({
+      exitCode: nonRepository.exitCode,
+      stderr: nonRepository.stderr,
+    }),
+    "not-repository",
+  );
+
+  const unresolvedRevision = runJj(sourcePath, ["log", "--revisions", "t3code_missing_revision"], {
+    allowFailure: true,
+  });
+  NodeAssert.equal(
+    classifyJjCommandFailure({
+      exitCode: unresolvedRevision.exitCode,
+      stderr: unresolvedRevision.stderr,
+    }),
+    "unresolved-revision",
+  );
+
+  process.stdout.write(
+    `jj Phase 0 contract passed with jj ${versionSupport.version} (minimum ${JJ_MINIMUM_SUPPORTED_VERSION})\n`,
+  );
+} finally {
+  NodeFS.rmSync(testRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large changes to source control, orchestration persistence, and provider PR/publish paths; incorrect jj/Git routing could corrupt workspace state or remote refs.
> 
> **Overview**
> **Colocated Jujutsu (jj)** is wired through the same product flows as Git: status/refs, fetch with rebase/conflict outcomes, finalize/publish via explicit bookmarks, stacked actions, and PR checkout through `VcsReviewService`, with **GitManager** delegating jj repos to `VcsChangeService` / `VcsSyncService` instead of raw git commands.
> 
> **Thread lifecycle** now persists **`vcsWorkspace`** (migration `033`, orchestration events/projection), refreshes workspaces on turn start, removes them on thread delete, and syncs publish refs / workspace revisions from mobile git actions after pull and stacked actions.
> 
> **Mobile** source-control sheets use driver-aware labels (bookmark vs branch, finalize vs commit) and pass **`publishRef`** into quick actions and commit flows (e.g. finalize & publish when a bookmark exists).
> 
> **CI** moves jobs off Blacksmith to `ubuntu-24.04` / `macos-26`, pins **jj-cli@0.42.0** in the main test job, and adds a cross-platform **`jj-phase-zero`** workflow plus planning docs and a security-policy fork notice for **michft/t3code**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91babca405fdaaca73b280a714f571dc0bdf7c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Jujutsu (jj) VCS support with workspace management, finalize/publish flows, and jj-aware UI
> - Introduces full Jujutsu repository support alongside Git, including a `JjVcsDriver`, `JjProcess` service, `VcsWorkspaceService` for per-thread workspace lifecycle, `VcsSyncService` for fetch/publish, `VcsChangeService` for finalizing changes, and `VcsReviewService` for PR preparation.
> - Extends `GitWorkflowService` and `GitManager` to detect jj repositories via `VcsDriverRegistry` and delegate status, pull, stacked actions, worktree creation, and PR preparation to jj-specific paths.
> - UI (web and mobile) adapts labels, icons, quick actions, and menus to jj terminology ("Finalize change", "Finalize & publish", bookmarks, workspace revision) based on `driverKind` from status.
> - Adds `VcsWorkspaceIdentity` and `VcsNamedRef` to contracts and propagates them through orchestration events, thread projection, DB schema (migration 033), and thread metadata.
> - Adds legacy RPC aliases (`gitPullLegacy`, etc.) for backward compatibility and exposes `VcsGitProviderCompatibility` to isolate git-specific provider interactions in colocated repos.
> - Adds a CI jj installation step, a `jj-phase-zero` smoke test workflow, and a `scripts/jj-phase-zero-smoke.ts` script that validates jj machine-output contract end-to-end.
> - Risk: jj workspace creation replaces direct git worktree calls in the WebSocket bootstrap path; unattached workspaces are cleaned up on failure, but this changes how thread workspace state is initialized for all new threads.
>
> <!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 91babca. 69 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->