### PR TITLE
fix(server): bound editor discovery latency

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -186,7 +186,7 @@ it.effect("bounds slow editor probes concurrently and keeps partial results", ()
     yield* TestClock.adjust(discoveryTimeout);
 
     const editors = yield* Fiber.join(discoveryFiber);
-    assert.deepEqual(editors, ["cursor", "vscode"]);
+    assert.deepEqual(editors, ["cursor", "vscode", "zed"]);
   }).pipe(
     Effect.scoped,
     Effect.provide(
@@ -200,7 +200,9 @@ it.effect("bounds slow editor probes concurrently and keeps partial results", ()
             if (command === "cursor") {
               return Effect.sleep(Duration.seconds(1)).pipe(Effect.as(true));
             }
-            return command === "code" ? Effect.succeed(true) : Effect.never;
+            return command === "code" || command === "zeditor"
+              ? Effect.succeed(true)
+              : Effect.never;
           },
         }),
       ),

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -150,6 +150,31 @@ it.effect("launches an installed editor with platform-safe arguments", () =>
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 
+it.effect("launches an editor through a responsive fallback alias", () => {
+  let spawned: ChildProcess.StandardCommand | undefined;
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    yield* launcher.launchEditor({ editor: "zed", cwd: "/workspace" });
+
+    assert.ok(spawned);
+    assert.equal(spawned.command, "zeditor");
+    assert.deepEqual(spawned.args, ["/workspace"]);
+  }).pipe(
+    Effect.provide(
+      testLayer({
+        platform: "linux",
+        env: { PATH: "/bin" },
+        editorCommandAvailability: (command) =>
+          command === "zeditor" ? Effect.succeed(true) : Effect.never,
+        onSpawn: (command) => {
+          spawned = command;
+        },
+      }),
+    ),
+  );
+});
+
 it.effect("discovers editors through the service API", () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -1,12 +1,15 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
@@ -38,6 +41,11 @@ const testLayer = (input: {
   readonly resolveExecutable?: (command: string) => string | undefined;
   readonly onSpawn?: (command: ChildProcess.StandardCommand) => void;
   readonly onUnref?: () => void;
+  readonly editorCommandAvailability?: (
+    command: string,
+    env: NodeJS.ProcessEnv,
+  ) => Effect.Effect<boolean>;
+  readonly editorDiscoveryTimeout?: Duration.Input;
 }) => {
   const spawnerLayer = Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
@@ -53,8 +61,20 @@ const testLayer = (input: {
     ),
   );
 
+  const externalLauncherLayer = Layer.effect(
+    ExternalLauncher.ExternalLauncher,
+    ExternalLauncher.makeWithOptions({
+      ...(input.editorCommandAvailability === undefined
+        ? {}
+        : { editorCommandAvailability: input.editorCommandAvailability }),
+      ...(input.editorDiscoveryTimeout === undefined
+        ? {}
+        : { editorDiscoveryTimeout: input.editorDiscoveryTimeout }),
+    }),
+  );
+
   return Layer.mergeAll(
-    ExternalLauncher.layer.pipe(Layer.provide(Layer.merge(NodeServices.layer, spawnerLayer))),
+    externalLauncherLayer.pipe(Layer.provide(Layer.merge(NodeServices.layer, spawnerLayer))),
     Layer.succeed(HostProcessPlatform, input.platform),
     Layer.succeed(
       SpawnExecutableResolution,
@@ -154,6 +174,39 @@ it.effect("discovers editors through the service API", () =>
     assert.equal(editors.includes("file-manager"), true);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
+
+it.effect("bounds slow editor probes concurrently and keeps partial results", () => {
+  const discoveryTimeout = Duration.seconds(3);
+
+  return Effect.gen(function* () {
+    const launcher = yield* ExternalLauncher.ExternalLauncher;
+    const discoveryFiber = yield* launcher.resolveAvailableEditors().pipe(Effect.forkScoped);
+
+    yield* Effect.yieldNow;
+    yield* TestClock.adjust(discoveryTimeout);
+
+    const editors = yield* Fiber.join(discoveryFiber);
+    assert.deepEqual(editors, ["cursor", "vscode"]);
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(
+      Layer.merge(
+        TestClock.layer(),
+        testLayer({
+          platform: "win32",
+          env: { PATH: "C:\\bin", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+          editorDiscoveryTimeout: discoveryTimeout,
+          editorCommandAvailability: (command) => {
+            if (command === "cursor") {
+              return Effect.sleep(Duration.seconds(1)).pipe(Effect.as(true));
+            }
+            return command === "code" ? Effect.succeed(true) : Effect.never;
+          },
+        }),
+      ),
+    ),
+  );
+});
 
 it.effect("rejects unknown editors through the service API", () =>
   Effect.gen(function* () {

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -285,12 +285,13 @@ const buildAvailableEditors = Effect.fn("externalLauncher.buildAvailableEditors"
       const probe =
         editor.commands === null
           ? commandAvailability(fileManagerCommandForPlatform(platform), env)
-          : Effect.gen(function* () {
-              for (const command of editor.commands) {
-                if (yield* commandAvailability(command, env)) return true;
-              }
-              return false;
-            });
+          : Effect.raceAll(
+              editor.commands.map((command) =>
+                commandAvailability(command, env).pipe(
+                  Effect.filterOrFail((available) => available),
+                ),
+              ),
+            ).pipe(Effect.orElseSucceed(() => false));
 
       return probe.pipe(
         Effect.timeoutOption(timeout),

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -173,13 +173,20 @@ function resolveEditorArgs(
 const resolveAvailableCommand = Effect.fn("externalLauncher.resolveAvailableCommand")(function* (
   commands: ReadonlyArray<string>,
   env: NodeJS.ProcessEnv,
-): Effect.fn.Return<Option.Option<string>, never, FileSystem.FileSystem | Path.Path> {
-  for (const command of commands) {
-    if (yield* isCommandAvailable(command, { env })) {
-      return Option.some(command);
-    }
+  commandAvailability: EditorCommandAvailability,
+): Effect.fn.Return<Option.Option<string>> {
+  if (commands.length === 0) {
+    return Option.none();
   }
-  return Option.none();
+
+  return yield* Effect.raceAll(
+    commands.map((command) =>
+      commandAvailability(command, env).pipe(
+        Effect.filterOrFail((available) => available),
+        Effect.as(command),
+      ),
+    ),
+  ).pipe(Effect.option);
 });
 
 function encodeUtf16LeBase64(input: string): string {
@@ -346,6 +353,7 @@ export class ExternalLauncher extends Context.Service<
 
 const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
   input: LaunchEditorInput,
+  commandAvailability: EditorCommandAvailability,
 ): Effect.fn.Return<EditorLaunch, ExternalLauncherError, FileSystem.FileSystem | Path.Path> {
   const platform = yield* HostProcessPlatform;
   const env = yield* readCommandLookupEnv;
@@ -361,7 +369,7 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
 
   if (editorDef.commands) {
     const command = Option.getOrElse(
-      yield* resolveAvailableCommand(editorDef.commands, env),
+      yield* resolveAvailableCommand(editorDef.commands, env, commandAvailability),
       () => editorDef.commands[0],
     );
     return {
@@ -417,13 +425,14 @@ const launchBrowser = Effect.fn("externalLauncher.launchBrowser")(function* (
 
 const launchEditorProcess = Effect.fn("externalLauncher.launchEditorProcess")(function* (
   launch: EditorLaunch,
+  commandAvailability: EditorCommandAvailability,
 ): Effect.fn.Return<
   void,
   ExternalLauncherError,
   ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > {
   const env = yield* readCommandLookupEnv;
-  if (!(yield* isCommandAvailable(launch.command, { env }))) {
+  if (!(yield* commandAvailability(launch.command, env))) {
     return yield* new ExternalLauncherCommandNotFoundError({
       editor: launch.editor,
       command: launch.command,
@@ -484,8 +493,8 @@ export const makeWithOptions = Effect.fn("ExternalLauncher.makeWithOptions")(fun
       ),
     launchEditor: (input) =>
       provideCommandResolutionServices(
-        Effect.flatMap(resolveEditorLaunch(input), (launch) =>
-          launchEditorProcess(launch).pipe(
+        Effect.flatMap(resolveEditorLaunch(input, editorCommandAvailability), (launch) =>
+          launchEditorProcess(launch, editorCommandAvailability).pipe(
             Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
           ),
         ),

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -21,6 +21,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
@@ -78,6 +79,18 @@ const DETACHED_IGNORE_STDIO_OPTIONS = {
   stdout: "ignore",
   stderr: "ignore",
 } as const satisfies ChildProcess.CommandOptions;
+
+const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(3);
+
+type EditorCommandAvailability = (
+  command: string,
+  env: NodeJS.ProcessEnv,
+) => Effect.Effect<boolean>;
+
+interface ExternalLauncherOptions {
+  readonly editorCommandAvailability?: EditorCommandAvailability;
+  readonly editorDiscoveryTimeout?: Duration.Input;
+}
 
 const compactEnv = (input: Record<string, Option.Option<string>>): NodeJS.ProcessEnv =>
   Object.fromEntries(
@@ -263,25 +276,32 @@ function buildBrowserLaunch(
 const buildAvailableEditors = Effect.fn("externalLauncher.buildAvailableEditors")(function* (
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
-): Effect.fn.Return<ReadonlyArray<EditorId>, never, FileSystem.FileSystem | Path.Path> {
-  const available: EditorId[] = [];
+  commandAvailability: EditorCommandAvailability,
+  timeout: Duration.Input,
+): Effect.fn.Return<ReadonlyArray<EditorId>> {
+  const results = yield* Effect.forEach(
+    EDITORS,
+    (editor) => {
+      const probe =
+        editor.commands === null
+          ? commandAvailability(fileManagerCommandForPlatform(platform), env)
+          : Effect.gen(function* () {
+              for (const command of editor.commands) {
+                if (yield* commandAvailability(command, env)) return true;
+              }
+              return false;
+            });
 
-  for (const editor of EDITORS) {
-    if (editor.commands === null) {
-      const command = fileManagerCommandForPlatform(platform);
-      if (yield* isCommandAvailable(command, { env })) {
-        available.push(editor.id);
-      }
-      continue;
-    }
+      return probe.pipe(
+        Effect.timeoutOption(timeout),
+        Effect.map(Option.getOrElse(() => false)),
+        Effect.map((available) => (available ? Option.some(editor.id) : Option.none<EditorId>())),
+      );
+    },
+    { concurrency: "unbounded" },
+  );
 
-    const command = yield* resolveAvailableCommand(editor.commands, env);
-    if (Option.isSome(command)) {
-      available.push(editor.id);
-    }
-  }
-
-  return available;
+  return results.flatMap(Option.toArray);
 });
 
 const resolveBrowserLaunch = Effect.fn("externalLauncher.resolveBrowserLaunch")(function* (
@@ -292,10 +312,13 @@ const resolveBrowserLaunch = Effect.fn("externalLauncher.resolveBrowserLaunch")(
   return buildBrowserLaunch(target, platform, env);
 });
 
-const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEditors")(function* () {
+const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEditors")(function* (
+  commandAvailability: EditorCommandAvailability,
+  timeout: Duration.Input,
+) {
   const platform = yield* HostProcessPlatform;
   const env = yield* readCommandLookupEnv;
-  return yield* buildAvailableEditors(platform, env);
+  return yield* buildAvailableEditors(platform, env, commandAvailability, timeout);
 });
 
 /**
@@ -430,7 +453,9 @@ const launchEditorProcess = Effect.fn("externalLauncher.launchEditorProcess")(fu
   );
 });
 
-export const make = Effect.gen(function* () {
+export const makeWithOptions = Effect.fn("ExternalLauncher.makeWithOptions")(function* (
+  options: ExternalLauncherOptions = {},
+) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -443,8 +468,15 @@ export const make = Effect.gen(function* () {
       Effect.provideService(Path.Path, path),
     );
 
+  const editorCommandAvailability =
+    options.editorCommandAvailability ??
+    ((command: string, env: NodeJS.ProcessEnv) =>
+      provideCommandResolutionServices(isCommandAvailable(command, { env })));
+  const editorDiscoveryTimeout = options.editorDiscoveryTimeout ?? EDITOR_DISCOVERY_TIMEOUT;
+
   return ExternalLauncher.of({
-    resolveAvailableEditors: () => provideCommandResolutionServices(resolveAvailableEditors()),
+    resolveAvailableEditors: () =>
+      resolveAvailableEditors(editorCommandAvailability, editorDiscoveryTimeout),
     launchBrowser: (target) =>
       launchBrowser(target).pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
@@ -459,5 +491,7 @@ export const make = Effect.gen(function* () {
       ),
   });
 });
+
+export const make = makeWithOptions();
 
 export const layer = Layer.effect(ExternalLauncher, make);


### PR DESCRIPTION
## Summary

- run editor availability probes concurrently instead of serializing every command lookup
- cap each editor probe at three seconds and keep successful partial results when another probe stalls
- preserve the configured editor order and add deterministic virtual-clock regression coverage

## Root cause

`server.getConfig` waits for external editor discovery before returning its configuration snapshot. Editor discovery checked every configured editor sequentially, and every missing Windows command could traverse the full inherited `PATH` across all `PATHEXT` variants. Slow filesystem lookups therefore accumulated across the entire editor catalog and blocked provider statuses from reaching the client.

## Impact

Optional editor detection can no longer block configuration indefinitely. Fast probes remain visible even when another editor lookup times out, allowing the Providers page and other configuration consumers to resolve within a bounded interval.

## Validation

- `pnpm exec vp test run apps/server/src/process/externalLauncher.test.ts` (5 tests passed)
- `pnpm exec vp lint --report-unused-disable-directives apps/server/src/process/externalLauncher.ts apps/server/src/process/externalLauncher.test.ts`
- `pnpm exec vp run --filter t3 typecheck`
- `pnpm exec vp fmt --check apps/server/src/process/externalLauncher.ts apps/server/src/process/externalLauncher.test.ts`
- isolated authenticated web verification: the Providers page rendered completed provider states; on Windows the editor discovery span completed in about 1.62 seconds while individual missing-command probes took about 1.5 seconds

Closes #4210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and completeness of editor lists (timeouts may hide slow-but-valid editors) and affects config paths that wait on discovery; behavior is bounded and covered by new tests.
> 
> **Overview**
> **Editor discovery** in `ExternalLauncher` no longer runs serial PATH probes that could block `getConfig` indefinitely on slow Windows lookups.
> 
> Probes for each configured editor now run **in parallel**, with a **3-second cap per editor** (`EDITOR_DISCOVERY_TIMEOUT`). Editors that finish in time are included; timed-out or hanging probes are dropped while faster ones still appear in the list. **Command alias resolution** for launch uses `Effect.raceAll` so the first responsive alias wins instead of checking aliases one-by-one.
> 
> `makeWithOptions` exposes injectable `editorCommandAvailability` and `editorDiscoveryTimeout` for tests; production still defaults to `isCommandAvailable`. New tests cover Zed fallback alias racing and virtual-clock behavior that partial results survive when some probes never complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce82e3f6dd06c62d38bfebdff6156e4814cf950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound editor discovery latency by probing aliases concurrently with a 3-second timeout
> - Editor discovery in [`externalLauncher.ts`](https://github.com/pingdotgg/t3code/pull/4221/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56) now probes all editors concurrently instead of sequentially, applying a per-editor timeout (default 3 seconds) and returning partial results for editors that resolved in time.
> - For multi-alias editors (e.g. `zed`/`zeditor`), the selected command is now the first alias whose availability check resolves, rather than using a fixed order.
> - A new `makeWithOptions` factory allows injecting a custom `editorCommandAvailability` function and `editorDiscoveryTimeout`, used by tests to control probe timing.
> - Behavioral Change: editors whose availability probes never complete (e.g. hung filesystem checks) are now silently dropped from results after the timeout rather than blocking discovery indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ce82e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->