### PR TITLE
fix(grok): show Grok plan-mode plans and handle plan approvals over ACP

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -21,6 +21,7 @@ const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
 const emitXAiExitPlanMode = process.env.T3_ACP_EMIT_XAI_EXIT_PLAN_MODE === "1";
 const xAiExitPlanFile = process.env.T3_ACP_XAI_EXIT_PLAN_FILE;
+const xAiExitPlanRepeat = process.env.T3_ACP_XAI_EXIT_PLAN_REPEAT === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
@@ -795,15 +796,20 @@ const program = Effect.gen(function* () {
             },
           });
         }
-        const result = yield* agent.client.extRequest("_x.ai/exit_plan_mode", {
-          sessionId: requestedSessionId,
-          toolCallId: "exit-plan-mode-tool-call-1",
-          ...(xAiExitPlanFile
-            ? { planContent: null }
-            : { planContent: "# Plan\n\n- Add the endpoint\n- Add the test" }),
-        });
-        if (typeof result !== "object" || result === null || !("outcome" in result)) {
-          throw new Error("Expected _x.ai/exit_plan_mode response outcome.");
+        // Optionally re-present within the same prompt, mimicking the model
+        // revising the plan right after receiving the revise feedback.
+        const presentations = xAiExitPlanRepeat ? 2 : 1;
+        for (let index = 0; index < presentations; index += 1) {
+          const result = yield* agent.client.extRequest("_x.ai/exit_plan_mode", {
+            sessionId: requestedSessionId,
+            toolCallId: `exit-plan-mode-tool-call-${index + 1}`,
+            ...(xAiExitPlanFile
+              ? { planContent: null }
+              : { planContent: `# Plan v${index + 1}\n\n- Add the endpoint\n- Add the test` }),
+          });
+          if (typeof result !== "object" || result === null || !("outcome" in result)) {
+            throw new Error("Expected _x.ai/exit_plan_mode response outcome.");
+          }
         }
         return { stopReason: "end_turn" };
       }

--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -19,6 +19,8 @@ const emitInterleavedAssistantToolCalls =
 const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHOLDERS === "1";
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
+const emitXAiExitPlanMode = process.env.T3_ACP_EMIT_XAI_EXIT_PLAN_MODE === "1";
+const xAiExitPlanFile = process.env.T3_ACP_XAI_EXIT_PLAN_FILE;
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
@@ -770,6 +772,39 @@ const program = Effect.gen(function* () {
           ],
         });
 
+        return { stopReason: "end_turn" };
+      }
+
+      if (emitXAiExitPlanMode) {
+        if (xAiExitPlanFile) {
+          // Mimic Grok reporting the plan-file path on plan-mode entry, then
+          // racing its own plan write: exit_plan_mode carries no planContent.
+          yield* agent.client.sessionUpdate({
+            sessionId: requestedSessionId,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: "enter-plan-mode-tool-call-1",
+              status: "completed",
+              rawOutput: {
+                type: "EnterPlanMode",
+                Entered: {
+                  message: "You have entered plan mode.",
+                  plan_file_path: xAiExitPlanFile,
+                },
+              },
+            },
+          });
+        }
+        const result = yield* agent.client.extRequest("_x.ai/exit_plan_mode", {
+          sessionId: requestedSessionId,
+          toolCallId: "exit-plan-mode-tool-call-1",
+          ...(xAiExitPlanFile
+            ? { planContent: null }
+            : { planContent: "# Plan\n\n- Add the endpoint\n- Add the test" }),
+        });
+        if (typeof result !== "object" || result === null || !("outcome" in result)) {
+          throw new Error("Expected _x.ai/exit_plan_mode response outcome.");
+        }
         return { stopReason: "end_turn" };
       }
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -1204,7 +1204,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       assert.equal(proposedPlans.length, 1);
       assert.equal(
         proposedPlans[0]?.payload.planMarkdown,
-        "# Plan\n\n- Add the endpoint\n- Add the test",
+        "# Plan v1\n\n- Add the endpoint\n- Add the test",
       );
       assert.equal(proposedPlans[0]?.raw?.method, "_x.ai/exit_plan_mode");
 
@@ -1242,7 +1242,73 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
 
       yield* Fiber.interrupt(eventsFiber);
       yield* adapter.stopSession(threadId);
-    }),
+    }).pipe(TestClock.withLive),
+  );
+
+  it.effect("captures a plan re-presented within the capturing turn instead of approving it", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-xai-exit-plan-same-turn");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-plan-repeat-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_XAI_EXIT_PLAN_MODE: "1",
+          T3_ACP_XAI_EXIT_PLAN_REPEAT: "1",
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const proposedPlans: Array<
+        Extract<ProviderRuntimeEvent, { type: "turn.proposed.completed" }>
+      > = [];
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
+        if (
+          String(event.threadId) === String(threadId) &&
+          event.type === "turn.proposed.completed"
+        ) {
+          proposedPlans.push(event);
+        }
+        return Effect.void;
+      }).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      // Both presentations happen inside this single default-mode turn, so
+      // neither may be auto-approved on the user's behalf.
+      yield* adapter.sendTurn({
+        threadId,
+        input: "make a plan",
+        attachments: [],
+        interactionMode: "default",
+      });
+
+      assert.equal(proposedPlans.length, 2);
+      assert.equal(
+        proposedPlans[1]?.payload.planMarkdown,
+        "# Plan v2\n\n- Add the endpoint\n- Add the test",
+      );
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const planResponses = requests.flatMap((entry) =>
+        !("method" in entry) &&
+        typeof entry.result === "object" &&
+        entry.result !== null &&
+        "outcome" in entry.result &&
+        typeof entry.result.outcome === "string"
+          ? [entry.result.outcome]
+          : [],
+      );
+      assert.deepEqual(planResponses, ["rejected", "rejected"]);
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }).pipe(TestClock.withLive),
   );
 
   it.effect("recovers the Grok plan from the plan file when planContent is empty", () =>
@@ -1293,7 +1359,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
 
       yield* Fiber.interrupt(eventsFiber);
       yield* adapter.stopSession(threadId);
-    }),
+    }).pipe(TestClock.withLive),
   );
 
   it.effect("continues streaming events when native notification logging fails", () =>

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -26,7 +26,11 @@ import {
 } from "@t3tools/contracts";
 
 import { ServerConfig } from "../../config.ts";
-import { grokPromptSettlementBelongsToContext, makeGrokAdapter } from "./GrokAdapter.ts";
+import {
+  grokPromptSettlementBelongsToContext,
+  makeGrokAdapter,
+  shouldAutoApproveGrokPlan,
+} from "./GrokAdapter.ts";
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
@@ -118,6 +122,49 @@ it("requires a settlement to match the live Grok turn", () => {
       liveActiveTurnId: staleTurnId,
       liveSessionActiveTurnId: staleTurnId,
       turnId: staleTurnId,
+    }),
+  );
+});
+
+it("approves a captured Grok plan only after a fresh non-plan user prompt", () => {
+  // No capture yet: never approve.
+  assert.isFalse(
+    shouldAutoApproveGrokPlan({
+      planCapture: undefined,
+      activeInteractionMode: "default",
+      promptSerial: 3,
+    }),
+  );
+  // Same prompt re-presentation (no new user input): capture again.
+  assert.isFalse(
+    shouldAutoApproveGrokPlan({
+      planCapture: { promptSerial: 3 },
+      activeInteractionMode: "default",
+      promptSerial: 3,
+    }),
+  );
+  // Plan-mode refinement prompt: capture the revised plan, do not approve.
+  assert.isFalse(
+    shouldAutoApproveGrokPlan({
+      planCapture: { promptSerial: 3 },
+      activeInteractionMode: "plan",
+      promptSerial: 4,
+    }),
+  );
+  // Fresh default-mode prompt after capture — a new turn or an implement
+  // click steered into the still-running capturing turn: approve.
+  assert.isTrue(
+    shouldAutoApproveGrokPlan({
+      planCapture: { promptSerial: 3 },
+      activeInteractionMode: "default",
+      promptSerial: 4,
+    }),
+  );
+  assert.isTrue(
+    shouldAutoApproveGrokPlan({
+      planCapture: { promptSerial: 3 },
+      activeInteractionMode: undefined,
+      promptSerial: 4,
     }),
   );
 });

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -1159,6 +1159,143 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("captures Grok plan approvals and approves them on implementation turns", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-xai-exit-plan-mode");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-plan-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_XAI_EXIT_PLAN_MODE: "1",
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const proposedPlans: Array<
+        Extract<ProviderRuntimeEvent, { type: "turn.proposed.completed" }>
+      > = [];
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
+        if (String(event.threadId) !== String(threadId)) {
+          return Effect.void;
+        }
+        if (event.type === "turn.proposed.completed") {
+          proposedPlans.push(event);
+        }
+        return Effect.void;
+      }).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      // First presentation (agent-initiated planning in a default-mode
+      // thread): the plan is captured and Grok is told to stop and wait.
+      yield* adapter.sendTurn({
+        threadId,
+        input: "make a plan",
+        attachments: [],
+        interactionMode: "default",
+      });
+      assert.equal(proposedPlans.length, 1);
+      assert.equal(
+        proposedPlans[0]?.payload.planMarkdown,
+        "# Plan\n\n- Add the endpoint\n- Add the test",
+      );
+      assert.equal(proposedPlans[0]?.raw?.method, "_x.ai/exit_plan_mode");
+
+      // Refinement turn (thread in plan mode): the revised plan is captured
+      // again instead of being approved.
+      yield* adapter.sendTurn({
+        threadId,
+        input: "add a rollout step",
+        attachments: [],
+        interactionMode: "plan",
+      });
+      assert.equal(proposedPlans.length, 2);
+
+      // Implementation turn: the pending plan approval is granted so Grok can
+      // exit plan mode and build.
+      yield* adapter.sendTurn({
+        threadId,
+        input: "implement the plan",
+        attachments: [],
+        interactionMode: "default",
+      });
+      assert.equal(proposedPlans.length, 2);
+
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      const planResponses = requests.flatMap((entry) =>
+        !("method" in entry) &&
+        typeof entry.result === "object" &&
+        entry.result !== null &&
+        "outcome" in entry.result &&
+        typeof entry.result.outcome === "string"
+          ? [entry.result.outcome]
+          : [],
+      );
+      assert.deepEqual(planResponses, ["rejected", "rejected", "approved"]);
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("recovers the Grok plan from the plan file when planContent is empty", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-xai-exit-plan-empty-content");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-plan-file-")),
+      );
+      const planFilePath = NodePath.join(tempDir, "plan.md");
+      yield* Effect.promise(() =>
+        NodeFSP.writeFile(planFilePath, "# Recovered plan\n\n- Read from disk\n", "utf8"),
+      );
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_XAI_EXIT_PLAN_MODE: "1",
+          T3_ACP_XAI_EXIT_PLAN_FILE: planFilePath,
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const proposedPlans: Array<
+        Extract<ProviderRuntimeEvent, { type: "turn.proposed.completed" }>
+      > = [];
+      const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
+        if (
+          String(event.threadId) === String(threadId) &&
+          event.type === "turn.proposed.completed"
+        ) {
+          proposedPlans.push(event);
+        }
+        return Effect.void;
+      }).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "make a plan",
+        attachments: [],
+        interactionMode: "default",
+      });
+
+      assert.equal(proposedPlans.length, 1);
+      assert.equal(proposedPlans[0]?.payload.planMarkdown, "# Recovered plan\n\n- Read from disk");
+
+      yield* Fiber.interrupt(eventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("continues streaming events when native notification logging fails", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-native-log-failure");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -118,10 +118,13 @@ interface GrokSessionContext {
    * plan-approval request is captured as a proposed plan or auto-approved. */
   activeInteractionMode: ProviderInteractionMode | undefined;
   /** Set once a Grok plan has been captured as a proposed plan and is
-   * awaiting the user's decision on the plan card. Records the turn that
-   * captured it so a re-presentation within the same turn is captured again
-   * instead of auto-approved; only a later non-plan turn approves. */
-  planCapture: { readonly turnId: TurnId | undefined } | undefined;
+   * awaiting the user's decision on the plan card. Records the prompt serial
+   * at capture time so a re-presentation without any new user prompt is
+   * captured again instead of auto-approved; only a request preceded by a
+   * fresh non-plan user prompt (a new turn or a steer) approves. */
+  planCapture: { readonly promptSerial: number } | undefined;
+  /** Monotonic count of user prompts sent to this session, including steers. */
+  promptSerial: number;
   /** Grok's current ACP session mode (from current_mode_update), e.g. "plan". */
   currentAcpModeId: string | undefined;
   /** Plan file path reported by enter_plan_mode; used to recover the plan
@@ -179,6 +182,26 @@ function appendPromptResultToTurn(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Decides whether an incoming exit_plan_mode request is the user-driven
+ * implementation of an already-captured plan (approve) or another plan
+ * presentation to capture. Approval requires a plan captured earlier AND at
+ * least one new non-plan user prompt since the capture — a new turn or a
+ * steer into the still-running capturing turn both qualify, while Grok
+ * re-presenting on its own within the same prompt does not.
+ */
+export function shouldAutoApproveGrokPlan(input: {
+  readonly planCapture: { readonly promptSerial: number } | undefined;
+  readonly activeInteractionMode: ProviderInteractionMode | undefined;
+  readonly promptSerial: number;
+}): boolean {
+  return (
+    input.planCapture !== undefined &&
+    input.activeInteractionMode !== "plan" &&
+    input.promptSerial > input.planCapture.promptSerial
+  );
 }
 
 /**
@@ -727,18 +750,21 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       yield* logNative(input.threadId, method, params);
                       const ctx = sessions.get(input.threadId);
                       const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
-                      // A plan was captured on an earlier turn and the user
-                      // came back in a non-plan turn: that is the
-                      // implementation turn, so let Grok exit plan mode and
-                      // build. The captured plan must come from a *previous*
-                      // turn — Grok may re-present a revised plan within the
-                      // capturing turn itself, which must be captured again,
-                      // not approved on the user's behalf.
+                      // A plan was captured earlier and the user has since
+                      // sent a non-plan prompt (a new turn, or an implement
+                      // click steered into the still-running capturing turn):
+                      // let Grok exit plan mode and build. Without a fresh
+                      // user prompt — e.g. Grok re-presenting a revised plan
+                      // on its own right after the revise feedback — the plan
+                      // is captured again, never approved on the user's
+                      // behalf.
                       if (
-                        ctx?.planCapture !== undefined &&
-                        ctx.activeInteractionMode !== "plan" &&
-                        turnId !== undefined &&
-                        turnId !== ctx.planCapture.turnId
+                        ctx !== undefined &&
+                        shouldAutoApproveGrokPlan({
+                          planCapture: ctx.planCapture,
+                          activeInteractionMode: ctx.activeInteractionMode,
+                          promptSerial: ctx.promptSerial,
+                        })
                       ) {
                         ctx.planCapture = undefined;
                         return makeXAiExitPlanModeApprovedResponse();
@@ -790,7 +816,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         planMarkdown ??= unchangedContents;
                       }
                       if (ctx) {
-                        ctx.planCapture = { turnId };
+                        ctx.planCapture = { promptSerial: ctx.promptSerial };
                         ctx.lastCapturedPlanMarkdown = planMarkdown;
                       }
                       yield* offerRuntimeEvent({
@@ -931,6 +957,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             lastPlanFingerprint: undefined,
             activeInteractionMode: undefined,
             planCapture: undefined,
+            promptSerial: 0,
             currentAcpModeId: undefined,
             planFilePath: undefined,
             lastCapturedPlanMarkdown: undefined,
@@ -1094,6 +1121,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             // settle this prompt even if stop arrives during preparation.
             ctx.activeTurnId = turnId;
             ctx.activeInteractionMode = input.interactionMode;
+            ctx.promptSerial += 1;
             ctx.session = {
               ...ctx.session,
               status: steeringTurnId === undefined ? "connecting" : "running",

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -3,6 +3,7 @@ import {
   type GrokSettings,
   EventId,
   type ProviderApprovalDecision,
+  type ProviderInteractionMode,
   type ProviderRuntimeEvent,
   type ProviderSession,
   type ProviderUserInputAnswers,
@@ -61,10 +62,14 @@ import {
 } from "../acp/GrokAcpSupport.ts";
 import {
   extractXAiAskUserQuestions,
+  extractXAiExitPlanModePlan,
   makeXAiAskUserQuestionCancelledResponse,
   makeXAiAskUserQuestionResponse,
+  makeXAiExitPlanModeApprovedResponse,
+  makeXAiExitPlanModeCapturedResponse,
   promptResponseHasMissingXAiStopReason,
   XAiAskUserQuestionRequest,
+  XAiExitPlanModeRequest,
 } from "../acp/XAiAcpExtension.ts";
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
@@ -109,6 +114,17 @@ interface GrokSessionContext {
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
   turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
+  /** Interaction mode of the most recent sendTurn; decides whether a Grok
+   * plan-approval request is captured as a proposed plan or auto-approved. */
+  activeInteractionMode: ProviderInteractionMode | undefined;
+  /** True once a Grok plan has been captured as a proposed plan and is
+   * awaiting the user's decision on the plan card. */
+  planCaptured: boolean;
+  /** Grok's current ACP session mode (from current_mode_update), e.g. "plan". */
+  currentAcpModeId: string | undefined;
+  /** Plan file path reported by enter_plan_mode; used to recover the plan
+   * when exit_plan_mode arrives with empty planContent (write/read race). */
+  planFilePath: string | undefined;
   activeTurnId: TurnId | undefined;
   /** Turns already interrupted; late prompt RPCs must not resurrect them. */
   interruptedTurnIds: Set<TurnId>;
@@ -158,6 +174,32 @@ function appendPromptResultToTurn(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Pulls the plan-file path out of an enter_plan_mode tool-call update. Grok
+ * may batch the plan-file write and exit_plan_mode in one model response, in
+ * which case the CLI's plan-file read races its own write and the
+ * exit_plan_mode request arrives with an empty planContent — the adapter then
+ * reads the plan file directly using this path.
+ */
+export function extractGrokPlanFilePath(rawPayload: unknown): string | undefined {
+  if (!isRecord(rawPayload)) return undefined;
+  const params = isRecord(rawPayload.params) ? rawPayload.params : rawPayload;
+  const update = params.update;
+  if (!isRecord(update)) return undefined;
+  const rawOutput = update.rawOutput;
+  if (!isRecord(rawOutput) || rawOutput.type !== "EnterPlanMode") return undefined;
+  for (const value of Object.values(rawOutput)) {
+    if (
+      isRecord(value) &&
+      typeof value.plan_file_path === "string" &&
+      value.plan_file_path.trim()
+    ) {
+      return value.plan_file_path.trim();
+    }
+  }
+  return undefined;
 }
 
 const resolveNotificationTurnId = (ctx: GrokSessionContext): TurnId | undefined => ctx.activeTurnId;
@@ -663,6 +705,77 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 ),
               { discard: true },
             );
+            yield* Effect.forEach(
+              ["x.ai/exit_plan_mode", "_x.ai/exit_plan_mode"] as const,
+              (method) =>
+                acp.handleExtRequest(method, XAiExitPlanModeRequest, (params) =>
+                  mapAcpCallbackFailure(
+                    Effect.gen(function* () {
+                      yield* logNative(input.threadId, method, params);
+                      const ctx = sessions.get(input.threadId);
+                      const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
+                      // A plan was already captured and the user came back in a
+                      // non-plan turn: that is the implementation turn, so let
+                      // Grok exit plan mode and build.
+                      if (ctx?.planCaptured === true && ctx.activeInteractionMode !== "plan") {
+                        ctx.planCaptured = false;
+                        return makeXAiExitPlanModeApprovedResponse();
+                      }
+                      let planMarkdown = extractXAiExitPlanModePlan(params);
+                      // Grok can batch the plan-file write and exit_plan_mode
+                      // in one model response; its own plan read then races
+                      // the write and planContent arrives empty. Recover by
+                      // reading the plan file the CLI reported on entry.
+                      if (planMarkdown === undefined && ctx !== undefined) {
+                        for (
+                          let attempt = 0;
+                          attempt < 20 && planMarkdown === undefined;
+                          attempt += 1
+                        ) {
+                          // Re-read per attempt: the enter_plan_mode update that
+                          // carries the path is processed on a concurrent fiber.
+                          const planFilePath = ctx.planFilePath;
+                          if (planFilePath) {
+                            const contents = yield* fileSystem
+                              .readFileString(planFilePath)
+                              .pipe(Effect.orElseSucceed(() => ""));
+                            const trimmedContents = contents.trim();
+                            if (trimmedContents.length > 0) {
+                              planMarkdown = trimmedContents;
+                              break;
+                            }
+                          }
+                          yield* Effect.sleep("100 millis");
+                        }
+                      }
+                      if (ctx) {
+                        ctx.planCaptured = true;
+                      }
+                      yield* offerRuntimeEvent({
+                        type: "turn.proposed.completed",
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: {
+                          planMarkdown:
+                            planMarkdown ?? "# Plan\n\n(Grok did not supply plan text.)",
+                        },
+                        raw: {
+                          source: "acp.grok.extension",
+                          method,
+                          payload: params,
+                        },
+                      });
+                      // Answer immediately: Grok treats this as "revise", ends
+                      // the turn, and keeps plan mode active until the user
+                      // acts on the plan card.
+                      return makeXAiExitPlanModeCapturedResponse();
+                    }),
+                  ),
+                ),
+              { discard: true },
+            );
             yield* acp.handleRequestPermission((params) =>
               mapAcpCallbackFailure(
                 Effect.gen(function* () {
@@ -774,6 +887,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             pendingUserInputs,
             turns: [],
             lastPlanFingerprint: undefined,
+            activeInteractionMode: undefined,
+            planCaptured: false,
+            currentAcpModeId: undefined,
+            planFilePath: undefined,
             activeTurnId: undefined,
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
@@ -797,6 +914,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 }
 
                 if (event._tag === "ModeChanged") {
+                  ctx.currentAcpModeId = event.modeId;
                   return;
                 }
 
@@ -844,7 +962,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       "session/update",
                     );
                     return;
-                  case "ToolCallUpdated":
+                  case "ToolCallUpdated": {
+                    const planFilePath = extractGrokPlanFilePath(event.rawPayload);
+                    if (planFilePath) {
+                      ctx.planFilePath = planFilePath;
+                    }
                     yield* offerRuntimeEvent(
                       makeAcpToolCallEvent({
                         stamp,
@@ -856,6 +978,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       }),
                     );
                     return;
+                  }
                   case "ContentDelta":
                     yield* offerRuntimeEvent(
                       makeAcpContentDeltaEvent({
@@ -927,6 +1050,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             // Bind the turn id before cooperative yields so interruptTurn can
             // settle this prompt even if stop arrives during preparation.
             ctx.activeTurnId = turnId;
+            ctx.activeInteractionMode = input.interactionMode;
             ctx.session = {
               ...ctx.session,
               status: steeringTurnId === undefined ? "connecting" : "running",
@@ -984,7 +1108,16 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                     } satisfies EffectAcpSchema.ContentBlock;
                   }),
               );
+              // Grok has no client-togglable plan mode over ACP; plan mode is
+              // entered by the agent's own enter_plan_mode tool. When the
+              // thread is in plan mode but the Grok session is not, steer the
+              // agent into it with a leading instruction.
+              const planModeNudge =
+                input.interactionMode === "plan" && ctx.currentAcpModeId !== "plan"
+                  ? "[T3 Code] Plan mode is enabled for this message. Call the enter_plan_mode tool before doing anything else, and do not modify any files other than the plan file."
+                  : undefined;
               const promptParts: Array<EffectAcpSchema.ContentBlock> = [
+                ...(planModeNudge ? [{ type: "text" as const, text: planModeNudge }] : []),
                 ...(text ? [{ type: "text" as const, text }] : []),
                 ...imagePromptParts,
               ];

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -201,11 +201,13 @@ export function extractGrokPlanFilePath(rawPayload: unknown): string | undefined
     }
     const planFilePath = value.plan_file_path.trim();
     // The path is agent-supplied: accept only absolute, NUL-free paths so a
-    // malformed value cannot resolve somewhere surprising.
+    // malformed value cannot resolve somewhere surprising. Roots are limited
+    // to a Windows drive letter or a POSIX "/" — a bare leading backslash is
+    // relative on POSIX and rejected.
     if (
       planFilePath.length > 0 &&
       !planFilePath.includes("\0") &&
-      /^(?:[A-Za-z]:[\\/]|[\\/])/.test(planFilePath)
+      /^(?:[A-Za-z]:[\\/]|\/)/.test(planFilePath)
     ) {
       return planFilePath;
     }

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -750,6 +750,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       yield* logNative(input.threadId, method, params);
                       const ctx = sessions.get(input.threadId);
                       const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
+                      // Snapshot before the (possibly slow) capture work: a
+                      // steer that lands while this request is being handled
+                      // must count as arriving *after* the capture, so it can
+                      // still approve the plan.
+                      const requestPromptSerial = ctx?.promptSerial ?? 0;
                       // A plan was captured earlier and the user has since
                       // sent a non-plan prompt (a new turn, or an implement
                       // click steered into the still-running capturing turn):
@@ -816,7 +821,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         planMarkdown ??= unchangedContents;
                       }
                       if (ctx) {
-                        ctx.planCapture = { promptSerial: ctx.promptSerial };
+                        ctx.planCapture = { promptSerial: requestPromptSerial };
                         ctx.lastCapturedPlanMarkdown = planMarkdown;
                       }
                       yield* offerRuntimeEvent({
@@ -1121,7 +1126,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             // settle this prompt even if stop arrives during preparation.
             ctx.activeTurnId = turnId;
             ctx.activeInteractionMode = input.interactionMode;
-            ctx.promptSerial += 1;
             ctx.session = {
               ...ctx.session,
               status: steeringTurnId === undefined ? "connecting" : "running",
@@ -1241,6 +1245,12 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   payload: displayModel ? { model: displayModel } : {},
                 });
               }
+
+              // Count the prompt only once preparation has succeeded and the
+              // RPC is about to dispatch: a prompt that failed or was
+              // interrupted before reaching Grok must not count as the fresh
+              // user prompt that unlocks plan auto-approval.
+              ctx.promptSerial += 1;
 
               return {
                 acp: ctx.acp,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -117,14 +117,19 @@ interface GrokSessionContext {
   /** Interaction mode of the most recent sendTurn; decides whether a Grok
    * plan-approval request is captured as a proposed plan or auto-approved. */
   activeInteractionMode: ProviderInteractionMode | undefined;
-  /** True once a Grok plan has been captured as a proposed plan and is
-   * awaiting the user's decision on the plan card. */
-  planCaptured: boolean;
+  /** Set once a Grok plan has been captured as a proposed plan and is
+   * awaiting the user's decision on the plan card. Records the turn that
+   * captured it so a re-presentation within the same turn is captured again
+   * instead of auto-approved; only a later non-plan turn approves. */
+  planCapture: { readonly turnId: TurnId | undefined } | undefined;
   /** Grok's current ACP session mode (from current_mode_update), e.g. "plan". */
   currentAcpModeId: string | undefined;
   /** Plan file path reported by enter_plan_mode; used to recover the plan
    * when exit_plan_mode arrives with empty planContent (write/read race). */
   planFilePath: string | undefined;
+  /** Markdown of the most recently captured plan; recovery reads that treat
+   * matching plan-file contents as possibly stale (rewrite in flight). */
+  lastCapturedPlanMarkdown: string | undefined;
   activeTurnId: TurnId | undefined;
   /** Turns already interrupted; late prompt RPCs must not resurrect them. */
   interruptedTurnIds: Set<TurnId>;
@@ -191,12 +196,18 @@ export function extractGrokPlanFilePath(rawPayload: unknown): string | undefined
   const rawOutput = update.rawOutput;
   if (!isRecord(rawOutput) || rawOutput.type !== "EnterPlanMode") return undefined;
   for (const value of Object.values(rawOutput)) {
+    if (!isRecord(value) || typeof value.plan_file_path !== "string") {
+      continue;
+    }
+    const planFilePath = value.plan_file_path.trim();
+    // The path is agent-supplied: accept only absolute, NUL-free paths so a
+    // malformed value cannot resolve somewhere surprising.
     if (
-      isRecord(value) &&
-      typeof value.plan_file_path === "string" &&
-      value.plan_file_path.trim()
+      planFilePath.length > 0 &&
+      !planFilePath.includes("\0") &&
+      /^(?:[A-Za-z]:[\\/]|[\\/])/.test(planFilePath)
     ) {
-      return value.plan_file_path.trim();
+      return planFilePath;
     }
   }
   return undefined;
@@ -714,11 +725,20 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       yield* logNative(input.threadId, method, params);
                       const ctx = sessions.get(input.threadId);
                       const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
-                      // A plan was already captured and the user came back in a
-                      // non-plan turn: that is the implementation turn, so let
-                      // Grok exit plan mode and build.
-                      if (ctx?.planCaptured === true && ctx.activeInteractionMode !== "plan") {
-                        ctx.planCaptured = false;
+                      // A plan was captured on an earlier turn and the user
+                      // came back in a non-plan turn: that is the
+                      // implementation turn, so let Grok exit plan mode and
+                      // build. The captured plan must come from a *previous*
+                      // turn — Grok may re-present a revised plan within the
+                      // capturing turn itself, which must be captured again,
+                      // not approved on the user's behalf.
+                      if (
+                        ctx?.planCapture !== undefined &&
+                        ctx.activeInteractionMode !== "plan" &&
+                        turnId !== undefined &&
+                        turnId !== ctx.planCapture.turnId
+                      ) {
+                        ctx.planCapture = undefined;
                         return makeXAiExitPlanModeApprovedResponse();
                       }
                       let planMarkdown = extractXAiExitPlanModePlan(params);
@@ -727,6 +747,8 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       // the write and planContent arrives empty. Recover by
                       // reading the plan file the CLI reported on entry.
                       if (planMarkdown === undefined && ctx !== undefined) {
+                        const previousPlanMarkdown = ctx.lastCapturedPlanMarkdown;
+                        let unchangedContents: string | undefined;
                         for (
                           let attempt = 0;
                           attempt < 20 && planMarkdown === undefined;
@@ -735,21 +757,39 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                           // Re-read per attempt: the enter_plan_mode update that
                           // carries the path is processed on a concurrent fiber.
                           const planFilePath = ctx.planFilePath;
-                          if (planFilePath) {
+                          if (planFilePath === undefined) {
+                            // Nothing to read; give the concurrent fiber a
+                            // short grace period, then answer immediately.
+                            if (attempt >= 5) {
+                              break;
+                            }
+                          } else {
                             const contents = yield* fileSystem
                               .readFileString(planFilePath)
                               .pipe(Effect.orElseSucceed(() => ""));
                             const trimmedContents = contents.trim();
-                            if (trimmedContents.length > 0) {
+                            if (
+                              trimmedContents.length > 0 &&
+                              trimmedContents !== previousPlanMarkdown
+                            ) {
                               planMarkdown = trimmedContents;
                               break;
+                            }
+                            if (trimmedContents.length > 0) {
+                              // The file still holds the previously captured
+                              // plan; Grok may be rewriting it, so keep
+                              // polling but fall back to this if nothing new
+                              // shows up.
+                              unchangedContents = trimmedContents;
                             }
                           }
                           yield* Effect.sleep("100 millis");
                         }
+                        planMarkdown ??= unchangedContents;
                       }
                       if (ctx) {
-                        ctx.planCaptured = true;
+                        ctx.planCapture = { turnId };
+                        ctx.lastCapturedPlanMarkdown = planMarkdown;
                       }
                       yield* offerRuntimeEvent({
                         type: "turn.proposed.completed",
@@ -888,9 +928,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             turns: [],
             lastPlanFingerprint: undefined,
             activeInteractionMode: undefined,
-            planCaptured: false,
+            planCapture: undefined,
             currentAcpModeId: undefined,
             planFilePath: undefined,
+            lastCapturedPlanMarkdown: undefined,
             activeTurnId: undefined,
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -55,7 +55,7 @@ describe("XAiAcpExtension", () => {
 
   it("extracts the plan from wrapped _x.ai exit_plan_mode payloads", () => {
     const decoded = decodeXAiExitPlanModeRequest({
-      method: "x.ai/exit_plan_mode",
+      method: "_x.ai/exit_plan_mode",
       params: {
         sessionId: "session-1",
         toolCallId: "tool-call-1",

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -10,10 +10,14 @@ import { describe, expect } from "vite-plus/test";
 
 import {
   extractXAiAskUserQuestions,
+  extractXAiExitPlanModePlan,
   makeXAiAskUserQuestionCancelledResponse,
   makeXAiAskUserQuestionResponse,
+  makeXAiExitPlanModeApprovedResponse,
+  makeXAiExitPlanModeCapturedResponse,
   makeXAiPromptCompletionRuntime,
   XAiAskUserQuestionRequest,
+  XAiExitPlanModeRequest,
 } from "./XAiAcpExtension.ts";
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
@@ -36,8 +40,55 @@ const makePromptCompletionRuntime = (env: NodeJS.ProcessEnv) =>
   });
 
 const decodeXAiAskUserQuestionRequest = Schema.decodeUnknownSync(XAiAskUserQuestionRequest);
+const decodeXAiExitPlanModeRequest = Schema.decodeUnknownSync(XAiExitPlanModeRequest);
 
 describe("XAiAcpExtension", () => {
+  it("extracts the plan from the real xAI exit_plan_mode payload shape", () => {
+    const decoded = decodeXAiExitPlanModeRequest({
+      sessionId: "session-1",
+      toolCallId: "tool-call-1",
+      planContent: "# Plan\n\n- Step one\n",
+    });
+
+    expect(extractXAiExitPlanModePlan(decoded)).toEqual("# Plan\n\n- Step one");
+  });
+
+  it("extracts the plan from wrapped _x.ai exit_plan_mode payloads", () => {
+    const decoded = decodeXAiExitPlanModeRequest({
+      method: "x.ai/exit_plan_mode",
+      params: {
+        sessionId: "session-1",
+        toolCallId: "tool-call-1",
+        planContent: "# Wrapped plan",
+      },
+    });
+
+    expect(extractXAiExitPlanModePlan(decoded)).toEqual("# Wrapped plan");
+  });
+
+  it("treats missing or blank exit_plan_mode plan content as absent", () => {
+    expect(
+      extractXAiExitPlanModePlan(decodeXAiExitPlanModeRequest({ sessionId: "session-1" })),
+    ).toBeUndefined();
+    expect(
+      extractXAiExitPlanModePlan(
+        decodeXAiExitPlanModeRequest({ sessionId: "session-1", planContent: "   " }),
+      ),
+    ).toBeUndefined();
+    expect(
+      extractXAiExitPlanModePlan(
+        decodeXAiExitPlanModeRequest({ sessionId: "session-1", planContent: null }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("builds exit_plan_mode responses Grok understands", () => {
+    expect(makeXAiExitPlanModeApprovedResponse()).toEqual({ outcome: "approved" });
+
+    const captured = makeXAiExitPlanModeCapturedResponse();
+    expect(captured.outcome).toEqual("rejected");
+    expect(captured.feedback).toContain("End your turn");
+  });
   it("extracts questions from the real xAI ask_user_question payload shape", () => {
     const questions = extractXAiAskUserQuestions({
       sessionId: "session-1",

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -232,10 +232,11 @@ export function extractXAiExitPlanModePlan(params: XAiExitPlanModeRequest): stri
 
 /**
  * Grok interprets the response outcome as: `approved` exits plan mode and
- * tells the agent to implement the plan; `abandoned` keeps plan mode active
- * and tells the agent the user does not want to exit; any other outcome is
- * treated as "revise" — the tool completes with "The user wants to revise the
- * plan." plus the feedback text, and plan mode stays active.
+ * tells the agent to implement the plan; any other outcome is treated as
+ * "revise" — the tool completes with "The user wants to revise the plan."
+ * plus the feedback text, and plan mode stays active. (Grok's protocol also
+ * accepts `abandoned` to quit the plan entirely; T3 Code never sends it, so
+ * this type only models the outcomes T3 Code produces.)
  */
 export interface XAiExitPlanModeResponse {
   readonly outcome: "approved" | "rejected";

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -196,6 +196,69 @@ export function makeXAiAskUserQuestionCancelledResponse(): XAiAskUserQuestionCan
   return { outcome: "cancelled" };
 }
 
+const XAiExitPlanModeParams = Schema.Struct({
+  sessionId: Schema.String,
+  toolCallId: Schema.optional(Schema.String),
+  planContent: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const XAiWrappedExitPlanModeParams = Schema.Struct({
+  method: Schema.Literals(["x.ai/exit_plan_mode", "_x.ai/exit_plan_mode"]),
+  params: XAiExitPlanModeParams,
+});
+
+/**
+ * Grok's plan-approval reverse request. When the agent finishes planning it
+ * calls its `exit_plan_mode` tool, which the CLI intercepts and forwards to
+ * the ACP client as `_x.ai/exit_plan_mode` with the plan-file contents. If the
+ * client cannot answer, the tool fails with "client disconnected mid-approval"
+ * and plan mode stays active.
+ */
+export const XAiExitPlanModeRequest = Schema.Union([
+  XAiExitPlanModeParams,
+  XAiWrappedExitPlanModeParams,
+]);
+
+type XAiExitPlanModeRequestParams = typeof XAiExitPlanModeParams.Type;
+export type XAiExitPlanModeRequest = typeof XAiExitPlanModeRequest.Type;
+
+function unwrapExitPlanModeParams(params: XAiExitPlanModeRequest): XAiExitPlanModeRequestParams {
+  return "params" in params ? params.params : params;
+}
+
+export function extractXAiExitPlanModePlan(params: XAiExitPlanModeRequest): string | undefined {
+  return trimmed(unwrapExitPlanModeParams(params).planContent ?? undefined);
+}
+
+/**
+ * Grok interprets the response outcome as: `approved` exits plan mode and
+ * tells the agent to implement the plan; `abandoned` keeps plan mode active
+ * and tells the agent the user does not want to exit; any other outcome is
+ * treated as "revise" — the tool completes with "The user wants to revise the
+ * plan." plus the feedback text, and plan mode stays active.
+ */
+export interface XAiExitPlanModeResponse {
+  readonly outcome: "approved" | "rejected";
+  readonly feedback?: string;
+}
+
+export function makeXAiExitPlanModeApprovedResponse(): XAiExitPlanModeResponse {
+  return { outcome: "approved" };
+}
+
+/**
+ * Response sent after T3 Code captures the plan as a proposed plan. The
+ * feedback is surfaced to the agent as a user message, so it is phrased to
+ * end the turn until the user acts on the plan card.
+ */
+export function makeXAiExitPlanModeCapturedResponse(): XAiExitPlanModeResponse {
+  return {
+    outcome: "rejected",
+    feedback:
+      "The plan is now displayed for review. Do not present it again and do not ask follow-up questions. End your turn; I will reply with feedback or ask you to implement the plan.",
+  };
+}
+
 /**
  * Adds Grok's private prompt-completion fallback around a standards-only ACP runtime.
  * The underlying runtime remains unaware of xAI methods and metadata.


### PR DESCRIPTION
## Problem

Grok's plan mode was broken in T3 Code. When the Grok CLI finishes planning it intercepts its `exit_plan_mode` tool and sends a reverse request **`_x.ai/exit_plan_mode`** (`{sessionId, toolCallId, planContent}`) to the ACP client for approval. T3 Code had no handler for it, so the request failed with method-not-found, which Grok surfaces as:

> Plan approval could not be completed because the client disconnected. Plan mode remains active; the approval will reappear on reconnect.

The plan never displayed in the UI and the Grok session stayed stuck in plan mode.

## Wire protocol (discovered by live-probing `grok agent stdio`)

- `{outcome: "approved"}` → Grok exits plan mode (`current_mode_update` → `default`) and implements the plan.
- Any unrecognized outcome (e.g. `"rejected"`) with a `feedback` string → "The user wants to revise the plan." + feedback; the turn ends and plan mode stays active.
- There is no client-side way to toggle plan mode over ACP (no session modes advertised; `_x.ai/toggle_plan_mode` is rejected). Plan mode is only entered via the agent's own `enter_plan_mode` tool.

## Fix

- `XAiAcpExtension.ts`: schema for the request (plain + wrapped forms) and response builders.
- `GrokAdapter.ts`:
  - Registers handlers for `x.ai/exit_plan_mode` / `_x.ai/exit_plan_mode`.
  - First presentation: emits `turn.proposed.completed` with the plan markdown (same proposed-plan card flow as Claude/Cursor) and answers with a revise-and-wait response so Grok ends its turn cleanly.
  - Once a plan is captured, the next turn whose `interactionMode` is not `"plan"` (the implementation turn started from the plan card) answers `approved`, so Grok exits plan mode and builds. Plan-mode refinement turns capture the revised plan again.
  - Tracks `current_mode_update` and, when a turn arrives with `interactionMode: "plan"` while the Grok session is not in plan mode, prepends an instruction steering Grok into `enter_plan_mode` - previously T3 Code's plan toggle silently did nothing for Grok.
  - **Race recovery:** grok-4.5 sometimes emits the plan-file write and `exit_plan_mode` in one batched response; the CLI's plan-file read then races its own write and `planContent` arrives null. The adapter remembers the plan-file path from the `enter_plan_mode` tool output (`rawOutput.Entered.plan_file_path`) and poll-reads the file when `planContent` is empty.
- `acp-mock-agent.ts` + tests: mock support for the ext request (including the empty-`planContent` recovery path), adapter tests for capture → refine → approve, and schema unit tests.

## Verification

- Drove the **real Grok CLI** through the adapter in a temporary integration test: plan captured as a proposed plan on turn 1, "Implement the plan." on turn 2 auto-approved the parked approval, `current_mode_update` flipped `plan` → `default`, and Grok edited the target file. (Test removed before commit - it requires an authenticated local Grok install.)
- `vp test run src/provider/acp/XAiAcpExtension.test.ts` - 14/14 pass.
- New GrokAdapter mock tests follow the existing wrapper pattern (they cannot run on this Windows dev machine - the `.sh` mock wrapper fails to spawn for all pre-existing GrokAdapter tests too - so they rely on CI).
- `tsgo --noEmit` and `vp check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Grok session lifecycle and auto-approval of plan exit over ACP; incorrect gating could approve or block plans wrongly, though logic is covered by new tests and path validation limits file-read abuse.
> 
> **Overview**
> Fixes broken Grok plan mode where unhandled `_x.ai/exit_plan_mode` reverse requests left sessions stuck and plans invisible in the UI.
> 
> **ACP extension and adapter:** Adds `XAiExitPlanModeRequest` parsing and approved/rejected response builders in `XAiAcpExtension.ts`. `GrokAdapter` registers handlers for `x.ai/exit_plan_mode` and `_x.ai/exit_plan_mode`, emits `turn.proposed.completed` with plan markdown (same card flow as Claude/Cursor), and answers with a revise-and-wait response so Grok ends the turn cleanly. **`shouldAutoApproveGrokPlan`** gates auto-approval on a captured plan plus a newer non-plan user prompt (`promptSerial` / `planCapture`), so same-turn re-presentations and plan-mode refinement turns capture again instead of approving on the user's behalf.
> 
> **Plan recovery and steering:** Session state tracks `planFilePath` from `EnterPlanMode` tool updates and poll-reads the plan file when `planContent` is empty (CLI write/read race). When the thread is in plan mode but the Grok session is not, prompts get a leading instruction to call `enter_plan_mode`. `extractGrokPlanFilePath` only accepts absolute, NUL-free paths.
> 
> **Tests:** Mock agent env flags for exit-plan-mode scenarios; adapter tests for capture → refine → approve, same-turn double presentation, and file recovery; unit tests for extension helpers and approval logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f927f2d09003103aed40ae528b61cf63a04f7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Grok plan-mode plan capture and approval handling over ACP
> - The `GrokAdapter` now intercepts `_x.ai/exit_plan_mode` extension requests and captures the proposed plan markdown, emitting a `turn.proposed.completed` event and responding with a rejected outcome to keep Grok in plan mode until the user acts.
> - Plans are auto-approved only after a fresh non-plan user prompt has occurred since the plan was captured, determined by the new `shouldAutoApproveGrokPlan` helper.
> - If `planContent` is missing from the request, the adapter recovers the plan by reading the file path previously reported via `EnterPlanMode` tool call updates.
> - New helpers in [`XAiAcpExtension.ts`](https://github.com/pingdotgg/t3code/pull/4233/files#diff-facfffc25c57123d8d9a118e55dc2c9856d28b4ed93f1c10cc9dbf6f6f5c360a) parse both bare and wrapped `exit_plan_mode` requests and construct approval or capture responses.
> - The ACP mock agent gains `T3_ACP_EMIT_XAI_EXIT_PLAN_MODE` and related flags to simulate Grok plan-mode exit flows for local testing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f927f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->