### PR TITLE
Fix clone destination initialization

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -6,6 +6,7 @@ import {
   buildProjectCreateCommand,
   findExistingAddProject,
   getAddProjectInitialQuery,
+  getCloneDestinationInitialQuery,
   resolveAddProjectPath,
   sortAddProjectProviderSources,
   type AddProjectRemoteSource,
@@ -757,15 +758,15 @@ export function AddProjectDestinationScreen(props: {
   const remoteUrl = stringParam(props.remoteUrl);
   const repositoryTitle = stringParam(props.repositoryTitle);
   const [pathInput, setPathInput] = useState(() =>
-    getAddProjectInitialQuery(environment?.baseDirectory),
+    getCloneDestinationInitialQuery(environment?.baseDirectory, remoteUrl),
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!environment) return;
-    setPathInput(getAddProjectInitialQuery(environment.baseDirectory));
-  }, [environment]);
+    setPathInput(getCloneDestinationInitialQuery(environment.baseDirectory, remoteUrl));
+  }, [environment, remoteUrl]);
 
   const submitPath = useCallback(async () => {
     if (!environment || !remoteUrl || isSubmitting) return;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { getCloneDestinationInitialQuery } from "@t3tools/client-runtime/operations/projects";
 import {
   isAtomCommandInterrupted,
   settlePromise,
@@ -1221,8 +1222,11 @@ function OpenCommandPaletteDialog(props: {
     ],
   );
 
-  function getDefaultCloneParentPath(environmentId: EnvironmentId): string {
-    return getAddProjectInitialQueryForEnvironment(environmentId);
+  function getDefaultCloneDestinationPath(environmentId: EnvironmentId, remoteUrl: string): string {
+    return getCloneDestinationInitialQuery(
+      getAddProjectInitialQueryForEnvironment(environmentId),
+      remoteUrl,
+    );
   }
 
   async function submitAddProjectCloneFlow(destinationPathInput?: string): Promise<void> {
@@ -1238,7 +1242,10 @@ function OpenCommandPaletteDialog(props: {
 
       const provider = remoteProjectSourceProvider(addProjectCloneFlow.source);
       if (!provider) {
-        const destinationPath = getDefaultCloneParentPath(addProjectCloneFlow.environmentId);
+        const destinationPath = getDefaultCloneDestinationPath(
+          addProjectCloneFlow.environmentId,
+          rawRepository,
+        );
         setAddProjectCloneFlow({
           step: "confirm",
           environmentId: addProjectCloneFlow.environmentId,
@@ -1275,7 +1282,10 @@ function OpenCommandPaletteDialog(props: {
         return;
       }
       const repository = lookupResult.value;
-      const destinationPath = getDefaultCloneParentPath(addProjectCloneFlow.environmentId);
+      const destinationPath = getDefaultCloneDestinationPath(
+        addProjectCloneFlow.environmentId,
+        repository.sshUrl,
+      );
       setAddProjectCloneFlow({
         step: "confirm",
         environmentId: addProjectCloneFlow.environmentId,

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -12,6 +12,7 @@ import {
   buildProjectCreateCommand,
   findExistingAddProject,
   getAddProjectInitialQuery,
+  getCloneDestinationInitialQuery,
   resolveAddProjectPath,
   sortAddProjectProviderSources,
 } from "./projects.ts";
@@ -22,6 +23,24 @@ describe("add project shared logic", () => {
     expect(getAddProjectInitialQuery("")).toBe("~/");
     expect(getAddProjectInitialQuery("/work")).toBe("/work/");
     expect(getAddProjectInitialQuery("C:\\work")).toBe("C:\\work\\");
+  });
+
+  it("initializes clone destinations with the inferred repository directory", () => {
+    expect(
+      getCloneDestinationInitialQuery("/work/projects", "git@github.com:openai/codex.git"),
+    ).toBe("/work/projects/codex");
+    expect(getCloneDestinationInitialQuery("C:\\work", "https://github.com/openai/codex.git")).toBe(
+      "C:\\work\\codex",
+    );
+    expect(getCloneDestinationInitialQuery(null, "https://github.com/openai/codex.git")).toBe(
+      "~/codex",
+    );
+  });
+
+  it("falls back to the clone base directory when the remote has no repository name", () => {
+    expect(getCloneDestinationInitialQuery("/work/projects", "https://github.com")).toBe(
+      "/work/projects/",
+    );
   });
 
   it("rejects unsupported windows paths on non-windows environments", () => {

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -8,6 +8,7 @@ import type {
   SourceControlRepositoryInfo,
 } from "@t3tools/contracts";
 import { DEFAULT_MODEL, ProviderInstanceId } from "@t3tools/contracts";
+import { inferGitCloneDirectoryName } from "@t3tools/shared/git";
 import * as Arr from "effect/Array";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
@@ -168,6 +169,15 @@ export function buildAddProjectRemoteSourceReadiness(
 export function getAddProjectInitialQuery(baseDirectory: string | null | undefined): string {
   const trimmed = baseDirectory?.trim() ?? "";
   return trimmed.length === 0 ? "~/" : ensureBrowseDirectoryPath(trimmed);
+}
+
+export function getCloneDestinationInitialQuery(
+  baseDirectory: string | null | undefined,
+  remoteUrl: string | null | undefined,
+): string {
+  const basePath = getAddProjectInitialQuery(baseDirectory);
+  const directoryName = inferGitCloneDirectoryName(remoteUrl ?? "");
+  return directoryName ? `${basePath}${directoryName}` : basePath;
 }
 
 export function resolveAddProjectPath(input: {

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -4,11 +4,40 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   applyGitStatusStreamEvent,
   buildTemporaryWorktreeBranchName,
+  inferGitCloneDirectoryName,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
   WORKTREE_BRANCH_PREFIX,
 } from "./git.ts";
+
+describe("inferGitCloneDirectoryName", () => {
+  it("infers checkout names from common remote URL shapes", () => {
+    expect(inferGitCloneDirectoryName("https://github.com/openai/codex.git")).toBe("codex");
+    expect(inferGitCloneDirectoryName("org-14957082@github.com:openai/codex.git")).toBe("codex");
+    expect(inferGitCloneDirectoryName("ssh://git@gitlab.com/group/nested/project.git")).toBe(
+      "project",
+    );
+    expect(inferGitCloneDirectoryName("https://dev.azure.com/acme/team/_git/platform")).toBe(
+      "platform",
+    );
+  });
+
+  it("handles escaped names and Git's special suffixes", () => {
+    expect(inferGitCloneDirectoryName("https://example.com/acme/my%20project.git?ref=main")).toBe(
+      "my project",
+    );
+    expect(inferGitCloneDirectoryName("/srv/git/project.bundle")).toBe("project");
+    expect(inferGitCloneDirectoryName("https://example.com/acme/project/.git/")).toBe("project");
+  });
+
+  it("returns null when a checkout name cannot be inferred", () => {
+    expect(inferGitCloneDirectoryName("  ")).toBeNull();
+    expect(inferGitCloneDirectoryName("https://github.com")).toBeNull();
+    expect(inferGitCloneDirectoryName("git@github.com:")).toBeNull();
+    expect(inferGitCloneDirectoryName("https://example.com/acme/project%2Fnested.git")).toBeNull();
+  });
+});
 
 describe("normalizeGitRemoteUrl", () => {
   it("canonicalizes equivalent GitHub remotes across protocol variants", () => {

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -131,6 +131,50 @@ export function normalizeGitRemoteUrl(value: string): string {
 }
 
 /**
+ * Infer the checkout directory Git would normally derive from a clone URL.
+ * Supports URL-shaped, SCP-style, and local-path remotes.
+ */
+export function inferGitCloneDirectoryName(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  let repositoryPath = trimmed;
+  if (/^(?:ssh|https?|git|file):\/\//i.test(trimmed)) {
+    try {
+      repositoryPath = new URL(trimmed).pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  const withoutTrailingSeparators = repositoryPath.replace(/[\\/]+$/g, "");
+  const withoutDotGitDirectory = withoutTrailingSeparators.replace(/[\\/]\.git$/i, "");
+  const lastSeparatorIndex = Math.max(
+    withoutDotGitDirectory.lastIndexOf("/"),
+    withoutDotGitDirectory.lastIndexOf("\\"),
+    withoutDotGitDirectory.lastIndexOf(":"),
+  );
+  const encodedName = withoutDotGitDirectory
+    .slice(lastSeparatorIndex + 1)
+    .replace(/\.(?:git|bundle)$/i, "");
+
+  if (encodedName.length === 0) {
+    return null;
+  }
+
+  let name = encodedName;
+  try {
+    name = decodeURIComponent(encodedName);
+  } catch {
+    // Keep the original segment when the remote contains malformed URL escapes.
+  }
+
+  return name === "." || name === ".." || /[\\/]/.test(name) ? null : name;
+}
+
+/**
  * Best-effort parse of a GitHub `owner/repo` identifier from common remote URL shapes.
  */
 export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | null): string | null {


### PR DESCRIPTION
## Summary

- infer the checkout directory from HTTPS, SSH, SCP-style, and local Git remotes
- initialize web and mobile clone flows with the full destination path instead of the non-empty parent directory
- add regression coverage for the reported GitHub SSH URL and cross-platform paths

## Testing

- `vp test packages/shared/src/git.test.ts packages/client-runtime/src/operations/projects.test.ts`
- `vp test apps/server/src/sourceControl/SourceControlRepositoryService.test.ts`
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only default path initialization with shared parsing logic and unit tests; no changes to clone or auth behavior.
> 
> **Overview**
> Clone flows on **web** and **mobile** now prefill the destination path with the inferred repo folder (e.g. `~/projects/codex`) instead of only the add-project base directory.
> 
> A new shared helper **`inferGitCloneDirectoryName`** parses HTTPS, SSH/SCP, Azure DevOps, local paths, and `.git`/`.bundle` suffixes; **`getCloneDestinationInitialQuery`** appends that name to the configured base path and falls back to the base alone when inference fails. Regression tests cover cross-platform paths and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32dbcbc5de34680cc053d8e8092ce47082e242e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clone destination path to include inferred repository directory name from remote URL
> - Adds `inferGitCloneDirectoryName` in [`packages/shared/src/git.ts`](https://github.com/pingdotgg/t3code/pull/4236/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) to extract a checkout directory name from URL-shaped, SCP-style, and local-path remotes, stripping `.git`/`.bundle` suffixes and decoding percent-encoding.
> - Adds `getCloneDestinationInitialQuery` in [`packages/client-runtime/src/operations/projects.ts`](https://github.com/pingdotgg/t3code/pull/4236/files#diff-50bc4917fdd160661572e739c44cc80d565982b40d14cc5ce0a41cff3302c032) that composes the base directory with the inferred directory name to produce a full destination path.
> - Updates the mobile `AddProjectDestinationScreen` and the web `OpenCommandPaletteDialog` clone flow to use `getCloneDestinationInitialQuery`, so the suggested destination now includes the inferred repo name and updates when `remoteUrl` changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32dbcbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->