### PR TITLE
Add Android APK server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.repos
+node_modules
+**/node_modules
+**/.expo
+apps/mobile/android
+apps/mobile/ios
+**/build
+**/.gradle

--- a/compose.android.yml
+++ b/compose.android.yml
@@ -1,0 +1,9 @@
+services:
+  apk-server:
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: docker/android/Dockerfile
+    ports:
+      - "8088:80"
+    restart: unless-stopped

--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -1,0 +1,47 @@
+FROM --platform=linux/amd64 node:24.13.1-bookworm AS builder
+
+ARG ANDROID_CMDLINE_TOOLS=11076708
+ENV ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
+    PATH=/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/root/.bun/bin:$PATH \
+    APP_VARIANT=preview \
+    EXPO_NO_GIT_STATUS=1 \
+    NODE_OPTIONS=--max-old-space-size=4096 \
+    GRADLE_OPTS=-Dorg.gradle.jvmargs=-Xmx6144m
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-17-jdk-headless curl unzip git ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /opt/android-sdk/cmdline-tools \
+    && curl -fsSL "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_TOOLS}_latest.zip" -o /tmp/android-tools.zip \
+    && unzip -q /tmp/android-tools.zip -d /opt/android-sdk/cmdline-tools \
+    && mv /opt/android-sdk/cmdline-tools/cmdline-tools /opt/android-sdk/cmdline-tools/latest \
+    && rm /tmp/android-tools.zip \
+    && yes | sdkmanager --licenses >/dev/null \
+    && sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;27.1.12297006" "cmake;3.22.1" \
+    && curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.11
+
+WORKDIR /src
+COPY . .
+
+RUN corepack enable \
+    && corepack prepare pnpm@11.10.0 --activate \
+    && pnpm config set network-concurrency 8 \
+    && pnpm config set child-concurrency 2 \
+    && pnpm install --filter @t3tools/mobile... --frozen-lockfile
+RUN cd apps/mobile \
+    && npx expo prebuild --clean --platform android \
+    && cd android \
+    && ./gradlew --no-daemon --max-workers=3 :app:assembleRelease \
+      -Pkotlin.compiler.execution.strategy=in-process \
+      -Dorg.gradle.internal.instrumentation.agent=false \
+      -PreactNativeArchitectures=arm64-v8a \
+    && mkdir -p /artifact \
+    && cp app/build/outputs/apk/release/app-release.apk /artifact/t3-code-preview.apk
+
+FROM nginx:1.29-alpine
+COPY docker/android/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/android/index.html /usr/share/nginx/html/index.html
+COPY --from=builder /artifact/t3-code-preview.apk /usr/share/nginx/html/t3-code-preview.apk
+EXPOSE 80

--- a/docker/android/index.html
+++ b/docker/android/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>T3 Code Android</title>
+    <style>
+      :root { color-scheme: dark; font-family: system-ui, sans-serif; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #111; color: #eee; }
+      main { width: min(32rem, calc(100% - 3rem)); text-align: center; }
+      a { display: inline-block; margin-top: 1rem; padding: .9rem 1.25rem; border-radius: .7rem; background: #eee; color: #111; font-weight: 700; text-decoration: none; }
+      p { color: #aaa; line-height: 1.5; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>T3 Code Preview</h1>
+      <p>Unofficial local Android build from the official open-source T3 Code repository.</p>
+      <a href="/t3-code-preview.apk">Download Android APK</a>
+    </main>
+  </body>
+</html>

--- a/docker/android/nginx.conf
+++ b/docker/android/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  location = / {
+    try_files /index.html =404;
+  }
+
+  location = /t3-code-preview.apk {
+    default_type application/vnd.android.package-archive;
+    add_header Content-Disposition 'attachment; filename="t3-code-preview.apk"';
+    try_files $uri =404;
+  }
+}


### PR DESCRIPTION
## What

Add a Docker Compose service that builds the Android preview APK and serves it through Nginx.

## Why

Provide a reproducible way to build and download the Android preview from a local web endpoint.

## Impact

Run `docker compose -f compose.android.yml up --build`, then download the APK from port 8088.

## Validation

- `docker compose -f compose.android.yml config`
- `git diff --cached --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Android APK build server serving the T3 Code app over HTTP
> - Adds a multi-stage [Dockerfile](https://github.com/pingdotgg/t3code/pull/4237/files#diff-4d2a727e99874bd8771cd7b90401e878e51bd30f0f2c90ea8a2d804876f9a839) that compiles the Android app using Node 24, Android SDK, and Gradle, producing a release APK for arm64-v8a.
> - The runtime stage uses nginx to serve the APK at `/t3-code-preview.apk` with a download `Content-Disposition` header, alongside a minimal landing page.
> - A new [compose.android.yml](https://github.com/pingdotgg/t3code/pull/4237/files#diff-f68fd5c28120b511956cede324ddb2152d49fda251eb30a7cc135a76e25c1333) defines the `apk-server` service, exposing port 8088 on the host.
> - A [.dockerignore](https://github.com/pingdotgg/t3code/pull/4237/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) excludes build artifacts, native dirs, and node_modules to reduce Docker build context size.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 154219a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->