### PR TITLE
fix(web): keep composer editable while disconnected

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1892,8 +1892,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       isConnecting ||
       isComposerApprovalState ||
       pendingUserInputs.length > 0 ||
-      projectSelectionRequired ||
-      (environmentUnavailable !== null && activePendingProgress === null)
+      projectSelectionRequired
     ) {
       return false;
     }
@@ -2101,8 +2100,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       isComposerApprovalState,
       pendingUserInputs.length,
       projectSelectionRequired,
-      environmentUnavailable,
-      activePendingProgress,
       applyPromptReplacement,
       isComposerModelPickerOpen,
       readComposerSnapshot,
@@ -2144,7 +2141,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           className={cn(
             "chat-composer-glass rounded-[20px] border transition-[background-color] duration-200 has-focus-visible:border-ring/45",
             isDragOverComposer ? "border-primary/70 bg-accent/45" : "border-border",
-            environmentUnavailable || projectSelectionRequired ? "opacity-75" : null,
+            projectSelectionRequired ? "opacity-75" : null,
             composerProviderState.composerSurfaceClassName,
           )}
           onFocusCapture={(event) => {
@@ -2502,12 +2499,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                               ? "Ask for follow-up changes or attach images"
                               : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
-                disabled={
-                  isConnecting ||
-                  isComposerApprovalState ||
-                  projectSelectionRequired ||
-                  (environmentUnavailable !== null && activePendingProgress === null)
-                }
+                disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}
               />
               {showMobilePendingAnswerActions ? (
                 <div

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1159,6 +1159,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     isSendBusy ||
     isConnecting ||
     projectSelectionRequired ||
+    environmentUnavailable !== null ||
     !composerSendState.hasSendableContent;
   const collapsedComposerPrimaryActionLabel = "Send message";
   const showMobilePendingAnswerActions =
@@ -1697,7 +1698,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   const shouldBlurMobileComposerOnSubmit = useCallback(() => {
     if (!isMobileViewport) return false;
-    if (isSendBusy || isConnecting || phase === "running") return false;
+    if (isSendBusy || isConnecting || environmentUnavailable !== null || phase === "running") {
+      return false;
+    }
     if (activePendingProgress) {
       return activePendingProgress.isLastQuestion && Boolean(activePendingResolvedAnswers);
     }
@@ -1706,6 +1709,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activePendingProgress,
     activePendingResolvedAnswers,
     composerSendState.hasSendableContent,
+    environmentUnavailable,
     isConnecting,
     isMobileViewport,
     isSendBusy,


### PR DESCRIPTION
## What Changed

Removed `environmentUnavailable` from the composer textarea's `disabled` condition (and from `insertComposerTextAtEnd` + the surface dimming), so the prompt box stays typable while an environment is reconnecting. Sending is still blocked until the connection is back.

## Why

When a connection drops mid-prompt, the text box goes fully disabled and you can't keep typing or paste. There's no reason drafting has to wait for the reconnect — only submitting does.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change in chat composer gating with send paths still honoring `environmentUnavailable`.
> 
> **Overview**
> **Keeps the chat composer editable when the environment is unavailable** (e.g. reconnecting), so users can keep typing and pasting instead of losing the prompt field mid-draft.
> 
> In `ChatComposer.tsx`, `environmentUnavailable` is no longer used to disable `ComposerPromptEditor`, block `insertComposerTextAtEnd` / mention inserts, or dim the composer surface. The placeholder still shows the connection status when unavailable.
> 
> **Send stays gated:** collapsed mobile send, `ComposerPrimaryActions`, and footer actions still pass `isEnvironmentUnavailable`, and `shouldBlurMobileComposerOnSubmit` now also skips blur when the environment is unavailable so mobile focus behavior matches blocked submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa76075dfa0757cdc438df0b73e5f7fb83a05c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep chat composer input editable and undimmed while environment is disconnected
> - The composer text input is no longer disabled or visually dimmed when the environment is unavailable; only `isConnecting`, approval state, and `projectSelectionRequired` block input.
> - The send button is disabled when the environment is unavailable, preventing submission without re-enabling typing.
> - On mobile, the composer no longer blurs on submit when the environment is unavailable.
> - Text insertion via `insertComposerTextAtEnd` is now allowed during disconnection, as long as other blocking conditions (connecting, approval state, pending inputs, project selection) are false.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fa7607.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->