### PR TITLE
fix(server): respect inherited OPENCODE_CONFIG_CONTENT

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.environment.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.environment.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveOpenCodeConfigContent } from "./opencodeRuntime.ts";
+
+describe("resolveOpenCodeConfigContent", () => {
+  it("prefers the caller environment over the inherited environment", () => {
+    expect(
+      resolveOpenCodeConfigContent(
+        { OPENCODE_CONFIG_CONTENT: '{"source":"caller"}' },
+        { OPENCODE_CONFIG_CONTENT: '{"source":"process"}' },
+      ),
+    ).toBe('{"source":"caller"}');
+  });
+
+  it("falls back to the inherited environment and then an empty config", () => {
+    expect(
+      resolveOpenCodeConfigContent(undefined, {
+        OPENCODE_CONFIG_CONTENT: '{"source":"process"}',
+      }),
+    ).toBe('{"source":"process"}');
+    expect(resolveOpenCodeConfigContent(undefined, {})).toBe("{}");
+  });
+});

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -461,7 +461,17 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
             shell: spawnCommand.shell,
             env: {
               ...input.environment,
-              OPENCODE_CONFIG_CONTENT: OPENCODE_EMPTY_CONFIG_CONTENT,
+              // Respect an OPENCODE_CONFIG_CONTENT provided by the caller or
+              // the inherited process environment, only falling back to the
+              // empty config when neither is set. Setting it unconditionally
+              // previously clobbered the user's opencode config, hiding their
+              // providers/models. The value is set explicitly (rather than
+              // relying on inheritance) because `extendEnv` is false whenever
+              // `input.environment` is provided.
+              OPENCODE_CONFIG_CONTENT:
+                input.environment?.OPENCODE_CONFIG_CONTENT ??
+                process.env.OPENCODE_CONFIG_CONTENT ??
+                OPENCODE_EMPTY_CONFIG_CONTENT,
             },
             extendEnv: input.environment === undefined,
           }),

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -37,6 +37,17 @@ import { resolveSpawnCommand } from "@t3tools/shared/shell";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
+export function resolveOpenCodeConfigContent(
+  inputEnvironment: Readonly<Record<string, string | undefined>> | undefined,
+  inheritedEnvironment: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  return (
+    inputEnvironment?.OPENCODE_CONFIG_CONTENT ??
+    inheritedEnvironment.OPENCODE_CONFIG_CONTENT ??
+    OPENCODE_EMPTY_CONFIG_CONTENT
+  );
+}
+
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
 const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 30_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
@@ -474,10 +485,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
               // providers/models. The value is set explicitly (rather than
               // relying on inheritance) because `extendEnv` is false whenever
               // `input.environment` is provided.
-              OPENCODE_CONFIG_CONTENT:
-                input.environment?.OPENCODE_CONFIG_CONTENT ??
-                process.env.OPENCODE_CONFIG_CONTENT ??
-                OPENCODE_EMPTY_CONFIG_CONTENT,
+              OPENCODE_CONFIG_CONTENT: resolveOpenCodeConfigContent(input.environment),
             },
             extendEnv: input.environment === undefined,
           }),

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -467,7 +467,17 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
             shell: spawnCommand.shell,
             env: {
               ...input.environment,
-              OPENCODE_CONFIG_CONTENT: OPENCODE_EMPTY_CONFIG_CONTENT,
+              // Respect an OPENCODE_CONFIG_CONTENT provided by the caller or
+              // the inherited process environment, only falling back to the
+              // empty config when neither is set. Setting it unconditionally
+              // previously clobbered the user's opencode config, hiding their
+              // providers/models. The value is set explicitly (rather than
+              // relying on inheritance) because `extendEnv` is false whenever
+              // `input.environment` is provided.
+              OPENCODE_CONFIG_CONTENT:
+                input.environment?.OPENCODE_CONFIG_CONTENT ??
+                process.env.OPENCODE_CONFIG_CONTENT ??
+                OPENCODE_EMPTY_CONFIG_CONTENT,
             },
             extendEnv: input.environment === undefined,
           }),


### PR DESCRIPTION
## What Changed

`opencodeRuntime.ts` no longer sets `OPENCODE_CONFIG_CONTENT="{}"` on the
opencode subprocess unconditionally. It now only injects that empty default
when neither the caller-provided environment nor the inherited process
environment already sets `OPENCODE_CONFIG_CONTENT`.

## Why

The key was written *after* `...input.environment`, so it clobbered any
inherited value. Users who configure providers/models via `opencode.json`
(or an inherited `OPENCODE_CONFIG_CONTENT`, e.g. from a systemd service) saw
opencode run with an empty config — no providers or models in the t3code UI.
Full root cause and reproduction in #4239.

This is a small, focused behavioural fix (a guard variable + conditional
spread); it preserves the existing default when nothing is provided.

Fixes #4239

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] N/A — no UI changes
- [x] N/A — no animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subprocess environment for OpenCode startup, which affects provider/model discovery, but scope is narrow with tests and restores intended config inheritance.
> 
> **Overview**
> **Fixes OpenCode config being wiped on server spawn** (#4239). Spawning `opencode serve` no longer always forces `OPENCODE_CONFIG_CONTENT` to `{}`, which had overridden caller or process env and left the UI without providers/models.
> 
> `startOpenCodeServerProcess` now sets `OPENCODE_CONFIG_CONTENT` via **`resolveOpenCodeConfigContent`**: caller `input.environment` first, then inherited `process.env`, then `{}`. The value is still set explicitly on the child env because `extendEnv` is off when a caller env object is passed.
> 
> Unit tests in `opencodeRuntime.environment.test.ts` cover precedence and the empty-config fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11635eba3d83b9c957326cbbddd245d0fe77a6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OPENCODE_CONFIG_CONTENT` to respect inherited environment variables in server process
> Previously, `makeOpenCodeRuntime` always overwrote `OPENCODE_CONFIG_CONTENT` with an empty config string (`"{}"`), ignoring any value set in the caller or process environment. The new `resolveOpenCodeConfigContent` helper checks the caller-provided environment first, then `process.env`, and falls back to `"{}"` only when neither has the value set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11635eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->