### PR TITLE
fix(claude): handle all SDK stream messages; stop spurious work-log warning rows

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1705,24 +1705,78 @@ describe("ClaudeAdapterLive", () => {
         );
         assert.equal(progressEvent.payload.description, "Running background teammate");
       }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 
-      // The undeclared background_tasks_changed roster snapshot is consumed
-      // silently — it must not surface as an unknown-subtype warning row.
+  it.effect("consumes undeclared and UX-internal system subtypes without warning rows", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEvents: Array<ProviderRuntimeEvent> = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => runtimeEvents.push(event)),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      // Undeclared wire-only roster snapshot + typed UX-internal subtypes:
+      // all consumed silently, none may surface as unknown-subtype warnings.
+      for (const message of [
+        {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "t1", task_type: "local_agent", description: "Say hi" }],
+          session_id: "session",
+          uuid: "roster",
+        },
+        { type: "system", subtype: "commands_changed", session_id: "session", uuid: "cc" },
+        {
+          type: "system",
+          subtype: "notification",
+          key: "context",
+          text: "low priority note",
+          priority: "low",
+          session_id: "session",
+          uuid: "notif",
+        },
+      ]) {
+        harness.query.emit(message as unknown as SDKMessage);
+      }
+      // api_retry maps to a session heartbeat, not a warning row.
       harness.query.emit({
         type: "system",
-        subtype: "background_tasks_changed",
-        tasks: [{ task_id: "workflow-1", task_type: "local_workflow", description: "Run checks" }],
+        subtype: "api_retry",
+        attempt: 3,
+        max_retries: 10,
+        retry_delay_ms: 1000,
+        error_status: 502,
+        error: { type: "api_error" },
         session_id: "session",
-        uuid: "roster",
+        uuid: "retry",
       } as unknown as SDKMessage);
       yield* Effect.yieldNow;
-      const rosterWarnings = runtimeEvents.filter(
-        (event) =>
-          event.type === "runtime.warning" &&
-          typeof event.payload.message === "string" &&
-          event.payload.message.includes("background_tasks_changed"),
+      yield* Effect.yieldNow;
+
+      const warnings = runtimeEvents.filter((event) => event.type === "runtime.warning");
+      assert.deepEqual(
+        warnings.map((event) => event.payload.message),
+        [],
       );
-      assert.equal(rosterWarnings.length, 0);
+      const heartbeat = runtimeEvents.find(
+        (event) =>
+          event.type === "session.state.changed" &&
+          typeof event.payload.reason === "string" &&
+          event.payload.reason.startsWith("api_retry:"),
+      );
+      assert.equal(heartbeat?.type, "session.state.changed");
+      runtimeEventsFiber.interruptUnsafe();
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1705,6 +1705,24 @@ describe("ClaudeAdapterLive", () => {
         );
         assert.equal(progressEvent.payload.description, "Running background teammate");
       }
+
+      // The undeclared background_tasks_changed roster snapshot is consumed
+      // silently — it must not surface as an unknown-subtype warning row.
+      harness.query.emit({
+        type: "system",
+        subtype: "background_tasks_changed",
+        tasks: [{ task_id: "workflow-1", task_type: "local_workflow", description: "Run checks" }],
+        session_id: "session",
+        uuid: "roster",
+      } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+      const rosterWarnings = runtimeEvents.filter(
+        (event) =>
+          event.type === "runtime.warning" &&
+          typeof event.payload.message === "string" &&
+          event.payload.message.includes("background_tasks_changed"),
+      );
+      assert.equal(rosterWarnings.length, 0);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1726,8 +1726,9 @@ describe("ClaudeAdapterLive", () => {
         runtimeMode: "full-access",
       });
 
-      // Undeclared wire-only roster snapshot + typed UX-internal subtypes:
-      // all consumed silently, none may surface as unknown-subtype warnings.
+      // Undeclared wire-only roster snapshot + every typed UX-internal
+      // subtype and top-level type consumed silently: none may surface as
+      // unknown-subtype warnings.
       for (const message of [
         {
           type: "system",
@@ -1736,7 +1737,21 @@ describe("ClaudeAdapterLive", () => {
           session_id: "session",
           uuid: "roster",
         },
+        {
+          type: "system",
+          subtype: "task_updated",
+          task_id: "t1",
+          patch: { status: "running" },
+          session_id: "session",
+          uuid: "tu",
+        },
         { type: "system", subtype: "commands_changed", session_id: "session", uuid: "cc" },
+        { type: "system", subtype: "model_refusal_fallback", session_id: "session", uuid: "mrf" },
+        { type: "system", subtype: "local_command_output", session_id: "session", uuid: "lco" },
+        { type: "system", subtype: "plugin_install", session_id: "session", uuid: "pi" },
+        { type: "system", subtype: "memory_recall", session_id: "session", uuid: "mr" },
+        { type: "system", subtype: "elicitation_complete", session_id: "session", uuid: "ec" },
+        { type: "prompt_suggestion", suggestion: "try this", session_id: "session", uuid: "ps" },
         {
           type: "system",
           subtype: "notification",
@@ -1748,6 +1763,30 @@ describe("ClaudeAdapterLive", () => {
         },
       ]) {
         harness.query.emit(message as unknown as SDKMessage);
+      }
+      // High-priority notifications DO surface as a warning row.
+      harness.query.emit({
+        type: "system",
+        subtype: "notification",
+        key: "limit",
+        text: "context window nearly full",
+        priority: "high",
+        session_id: "session",
+        uuid: "notif-high",
+      } as unknown as SDKMessage);
+      // session_state_changed maps to the matching session states.
+      for (const [state, uuid] of [
+        ["running", "ssc-run"],
+        ["requires_action", "ssc-req"],
+        ["idle", "ssc-idle"],
+      ]) {
+        harness.query.emit({
+          type: "system",
+          subtype: "session_state_changed",
+          state,
+          session_id: "session",
+          uuid,
+        } as unknown as SDKMessage);
       }
       // api_retry maps to a session heartbeat, not a warning row.
       harness.query.emit({
@@ -1765,10 +1804,26 @@ describe("ClaudeAdapterLive", () => {
       yield* Effect.yieldNow;
 
       const warnings = runtimeEvents.filter((event) => event.type === "runtime.warning");
+      // Exactly one warning: the high-priority notification. Nothing else.
       assert.deepEqual(
         warnings.map((event) => event.payload.message),
-        [],
+        ["context window nearly full"],
       );
+      const sessionStates = runtimeEvents
+        .filter((event) => event.type === "session.state.changed")
+        .map((event) =>
+          event.type === "session.state.changed"
+            ? `${event.payload.state}:${event.payload.reason ?? ""}`
+            : "",
+        )
+        .filter(
+          (entry) => entry.startsWith("running:session_state") || entry.includes("session_state"),
+        );
+      assert.deepEqual(sessionStates, [
+        "running:session_state:running",
+        "waiting:session_state:requires_action",
+        "ready:session_state:idle",
+      ]);
       const heartbeat = runtimeEvents.find(
         (event) =>
           event.type === "session.state.changed" &&

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2708,6 +2708,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           },
         });
         return;
+      // Task state patch (status/backgrounded/end_time). No runtime mapping
+      // yet — the terminal task_notification reports the outcome — but it
+      // must not surface as an unknown-subtype warning row.
+      case "task_updated":
+        return;
       case "task_notification":
         yield* emitThreadTokenUsage(
           context,
@@ -2752,6 +2757,52 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         return;
       case "thinking_tokens":
         return;
+      case "api_retry":
+        // Transport-level retry heartbeat. Surfacing each attempt as a
+        // warning row spammed the work log (10 rows during a 502 storm);
+        // the terminal result/error path reports the actual failure. Keep
+        // the session visibly alive instead.
+        yield* offerRuntimeEvent({
+          ...base,
+          type: "session.state.changed",
+          payload: {
+            state: "running",
+            reason: `api_retry:${message.attempt}/${message.max_retries}`,
+          },
+        });
+        return;
+      case "session_state_changed":
+        // Authoritative turn-over signal from the CLI.
+        yield* offerRuntimeEvent({
+          ...base,
+          type: "session.state.changed",
+          payload: {
+            state:
+              message.state === "running"
+                ? "running"
+                : message.state === "requires_action"
+                  ? "waiting"
+                  : "ready",
+            reason: `session_state:${message.state}`,
+          },
+        });
+        return;
+      case "notification":
+        // User-facing CLI notification (e.g. context-limit warnings). Only
+        // high-priority ones warrant a work-log row.
+        if (message.priority === "high" || message.priority === "immediate") {
+          yield* emitRuntimeWarning(context, message.text, message);
+        }
+        return;
+      // Inner protocol/UX details with no T3 surface today — consumed
+      // deliberately so they don't masquerade as unknown-subtype warnings.
+      case "model_refusal_fallback":
+      case "local_command_output":
+      case "plugin_install":
+      case "commands_changed":
+      case "memory_recall":
+      case "elicitation_complete":
+        return;
       case "permission_denied":
         yield* offerRuntimeEvent({
           ...base,
@@ -2771,13 +2822,20 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           message,
         );
         return;
-      default:
+      default: {
+        // Exhaustiveness guard: every subtype in the SDK's typed union is
+        // handled above, so `message` narrows to never here — a new SDK
+        // release adding a subtype fails this typecheck instead of silently
+        // warning at runtime. The runtime fallback still catches undeclared
+        // wire-only subtypes (like background_tasks_changed used to be).
+        const unknownMessage: { subtype: string } = message satisfies never;
         yield* emitRuntimeWarning(
           context,
-          describeUnknownSdkMessage(`Claude system message '${message.subtype}'`, message),
+          describeUnknownSdkMessage(`Claude system message '${unknownMessage.subtype}'`, message),
           message,
         );
         return;
+      }
     }
   });
 
@@ -2885,13 +2943,20 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       case "rate_limit_event":
         yield* handleSdkTelemetryMessage(context, message);
         return;
-      default:
+      // Composer prompt suggestions have no T3 surface; consumed deliberately.
+      case "prompt_suggestion":
+        return;
+      default: {
+        // Exhaustiveness guard (see handleSystemMessage): new SDK top-level
+        // message types fail typecheck here instead of warning at runtime.
+        const unknownMessage: { type: string } = message satisfies never;
         yield* emitRuntimeWarning(
           context,
-          describeUnknownSdkMessage(`Claude SDK message '${message.type}'`, message),
+          describeUnknownSdkMessage(`Claude SDK message '${unknownMessage.type}'`, message),
           message,
         );
         return;
+      }
     }
   });
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2585,6 +2585,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       },
     };
 
+    // Undeclared-but-real subtypes (absent from the SDK's union, so they can't
+    // be switch cases): consumed intentionally without emitting, otherwise
+    // they fall through to the unknown-subtype warning and surface as spurious
+    // error rows in client work logs. `background_tasks_changed` is a roster
+    // snapshot ({tasks: [...]}) — the task_* lifecycle events carry the
+    // authoritative per-agent data and the typed background_tasks control
+    // request is the reconciliation source.
+    if ((message.subtype as string) === "background_tasks_changed") {
+      return;
+    }
+
     switch (message.subtype) {
       case "init":
         yield* offerRuntimeEvent({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2828,7 +2828,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         // release adding a subtype fails this typecheck instead of silently
         // warning at runtime. The runtime fallback still catches undeclared
         // wire-only subtypes (like background_tasks_changed used to be).
-        const unknownMessage: { subtype: string } = message satisfies never;
+        message satisfies never;
+        const unknownMessage = message as never as { subtype: string };
         yield* emitRuntimeWarning(
           context,
           describeUnknownSdkMessage(`Claude system message '${unknownMessage.subtype}'`, message),
@@ -2949,7 +2950,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       default: {
         // Exhaustiveness guard (see handleSystemMessage): new SDK top-level
         // message types fail typecheck here instead of warning at runtime.
-        const unknownMessage: { type: string } = message satisfies never;
+        message satisfies never;
+        const unknownMessage = message as never as { type: string };
         yield* emitRuntimeWarning(
           context,
           describeUnknownSdkMessage(`Claude SDK message '${unknownMessage.type}'`, message),


### PR DESCRIPTION
## What

Every Claude SDK stream message type is now explicitly handled in the ClaudeAdapter, with type-level exhaustiveness guards so future SDK additions fail typecheck instead of silently degrading.

## Why now (split out of #4220)

Users on main see spurious error-toned rows in the work log today:

- **`api_retry` storms**: a 502 burst renders as *ten* orange "Claude system message 'api_retry'" rows (one per attempt). Now maps to a `session.state.changed` heartbeat (`reason: api_retry:3/10`); the terminal error path already reports the real failure once.
- **`background_tasks_changed`**: an undeclared-but-real wire subtype (absent from the SDK's typed union) that rendered as "Claude system message 'background_tasks_changed' (no displayable text content)". Now consumed silently.

Found via a log-driven audit: censused every native SDK message in captured provider NDJSON logs from real sessions, cross-referenced against the SDK 0.3.170 union (33 message types / 24 system subtypes).

## Changes

- `api_retry` → session heartbeat, not N warning rows
- `session_state_changed` → authoritative `session.state.changed` mapping (idle/running/requires_action)
- `notification` → warning row only for `high`/`immediate` priority
- `background_tasks_changed` (undeclared), `task_updated`, `model_refusal_fallback`, `local_command_output`, `plugin_install`, `commands_changed`, `memory_recall`, `elicitation_complete`, `prompt_suggestion` → deliberately consumed, no spurious rows
- Both `default` branches now narrow to `never` (`message satisfies never`): a new SDK message type or subtype is a **typecheck failure** at upgrade time; the runtime fallback still catches undeclared wire-only subtypes

## Verification

- New test: emits undeclared + UX-internal subtypes and an `api_retry`, asserts zero warning rows and the heartbeat event
- 60 ClaudeAdapter tests pass; `tsgo --noEmit` clean for apps/server

Note for #4220: that branch carries a richer `task_updated` mapping (agent status patches); this PR only stops it warning. #4220 will absorb this cleanly on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime event mapping for live Claude sessions (session state, warnings, retries); behavior is well-covered by tests but affects user-visible work logs during provider outages.
> 
> **Overview**
> Stops **false error-toned work-log rows** by explicitly handling Claude SDK system and top-level messages that previously fell through to unknown-subtype warnings.
> 
> **`api_retry`** now emits a **`session.state.changed`** heartbeat (`reason: api_retry:n/m`) instead of one warning per retry during 502 storms. **`session_state_changed`** maps to **`session.state.changed`** (`running` / `waiting` / `ready`). **`notification`** only surfaces as **`runtime.warning`** when priority is **`high`** or **`immediate`**.
> 
> Wire-only or UX-internal traffic (**`background_tasks_changed`**, **`task_updated`**, **`commands_changed`**, **`memory_recall`**, **`prompt_suggestion`**, and similar) is **consumed silently**. Router **`default`** branches use **`message satisfies never`** so new SDK union members fail typecheck at upgrade; undeclared wire subtypes still hit the runtime fallback.
> 
> Adds an integration test that asserts a single high-priority notification warning, correct session-state mapping, and an **`api_retry`** heartbeat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5718d55cdf3a633e6937c77a0beb9692a782f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude SDK stream handling to suppress spurious work-log warning rows
> - Adds silent handling in `handleSystemMessage` for several SDK system subtypes (`background_tasks_changed`, `task_updated`, `commands_changed`, `model_refusal_fallback`, `local_command_output`, `plugin_install`, `memory_recall`, `elicitation_complete`) that previously generated spurious warning rows.
> - Maps `session_state_changed` messages to `session.state.changed` events with normalized states (`running`, `waiting`, `ready`) and emits a heartbeat `session.state.changed` for `api_retry` messages.
> - Limits `notification`-driven warnings to `high` or `immediate` priority only; lower-priority notifications are silently consumed.
> - Adds top-level handling for `prompt_suggestion` in `handleSdkMessage` so it no longer surfaces as an unknown-type warning.
> - Unknown declared subtypes and top-level types still emit a runtime warning via a TypeScript exhaustiveness guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a5718d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning messages for internal and unsupported Claude system events.
  * Improved session status updates for retries and session state changes.
  * High- and immediate-priority notifications continue to surface as warnings, while lower-priority notifications remain unobtrusive.
  * Added support for safely handling prompt suggestions and task-related events without disrupting sessions.

* **Tests**
  * Added coverage confirming internal events do not generate warning rows and retry activity updates session state correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->