### PR TITLE
Show working status for new threads

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1,4 +1,5 @@
 import {
+  ApprovalRequestId,
   CheckpointRef,
   CommandId,
   CorrelationId,
@@ -2463,7 +2464,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
-  it.effect("clears a pending turn start when provider startup fails", () =>
+  it.effect("only clears the pending turn start that failed", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;
       const eventStore = yield* OrchestrationEventStore;
@@ -2486,44 +2487,95 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         metadata: {},
         payload: {
           threadId,
-          messageId: MessageId.make("message-start-failed"),
+          messageId: MessageId.make("message-start-old"),
           runtimeMode: "full-access",
           createdAt: "2026-02-26T13:00:00.000Z",
         },
       });
 
       yield* appendAndProject({
-        type: "thread.session-set",
+        type: "thread.turn-start-requested",
         eventId: EventId.make("evt-start-failed-2"),
         aggregateKind: "thread",
         aggregateId: threadId,
-        occurredAt: "2026-02-26T13:00:01.000Z",
+        occurredAt: "2026-02-26T13:00:00.100Z",
         commandId: CommandId.make("cmd-start-failed-2"),
         causationEventId: null,
         correlationId: CorrelationId.make("cmd-start-failed-2"),
         metadata: {},
         payload: {
           threadId,
-          session: {
-            threadId,
-            status: "ready",
-            providerName: "codex",
-            runtimeMode: "full-access",
-            activeTurnId: null,
-            lastError: "Provider startup failed",
-            updatedAt: "2026-02-26T13:00:01.000Z",
+          messageId: MessageId.make("message-start-new"),
+          runtimeMode: "full-access",
+          createdAt: "2026-02-26T13:00:00.100Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-start-failed-3"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:00.200Z",
+        commandId: CommandId.make("cmd-start-failed-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-3"),
+        metadata: { requestId: ApprovalRequestId.make("message-start-old") },
+        payload: {
+          threadId,
+          activity: {
+            id: EventId.make("activity-start-failed-old"),
+            tone: "error",
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start failed",
+            payload: { requestId: "message-start-old", detail: "Provider startup failed" },
+            turnId: null,
+            createdAt: "2026-02-26T13:00:00.200Z",
           },
         },
       });
 
-      const pendingRows = yield* sql<{ readonly threadId: string }>`
-        SELECT thread_id AS "threadId"
+      const pendingRows = yield* sql<{ readonly messageId: string }>`
+        SELECT pending_message_id AS "messageId"
         FROM projection_turns
         WHERE thread_id = ${threadId}
           AND turn_id IS NULL
           AND state = 'pending'
       `;
-      assert.deepEqual(pendingRows, []);
+      assert.deepEqual(pendingRows, [{ messageId: "message-start-new" }]);
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-start-failed-4"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:00.300Z",
+        commandId: CommandId.make("cmd-start-failed-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-4"),
+        metadata: { requestId: ApprovalRequestId.make("message-start-new") },
+        payload: {
+          threadId,
+          activity: {
+            id: EventId.make("activity-start-failed-new"),
+            tone: "error",
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start failed",
+            payload: { requestId: "message-start-new", detail: "Provider startup failed" },
+            turnId: null,
+            createdAt: "2026-02-26T13:00:00.300Z",
+          },
+        },
+      });
+
+      const clearedRows = yield* sql<{ readonly messageId: string }>`
+        SELECT pending_message_id AS "messageId"
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'pending'
+      `;
+      assert.deepEqual(clearedRows, []);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2462,6 +2462,70 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       ]);
     }),
   );
+
+  it.effect("clears a pending turn start when provider startup fails", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const threadId = ThreadId.make("thread-start-failed");
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "thread.turn-start-requested",
+        eventId: EventId.make("evt-start-failed-1"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:00.000Z",
+        commandId: CommandId.make("cmd-start-failed-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-1"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("message-start-failed"),
+          runtimeMode: "full-access",
+          createdAt: "2026-02-26T13:00:00.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.session-set",
+        eventId: EventId.make("evt-start-failed-2"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:01.000Z",
+        commandId: CommandId.make("cmd-start-failed-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-2"),
+        metadata: {},
+        payload: {
+          threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: "Provider startup failed",
+            updatedAt: "2026-02-26T13:00:01.000Z",
+          },
+        },
+      });
+
+      const pendingRows = yield* sql<{ readonly threadId: string }>`
+        SELECT thread_id AS "threadId"
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'pending'
+      `;
+      assert.deepEqual(pendingRows, []);
+    }),
+  );
 });
 
 it.effect("restores pending turn-start metadata across projection pipeline restart", () =>

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2464,7 +2464,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
-  it.effect("only clears the pending turn start that failed", () =>
+  it.effect("only clears pending turn starts targeted by failure signals", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;
       const eventStore = yield* OrchestrationEventStore;
@@ -2474,6 +2474,13 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         eventStore
           .append(event)
           .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+      const listPendingStarts = () => sql<{ readonly messageId: string }>`
+        SELECT pending_message_id AS "messageId"
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'pending'
+      `;
 
       yield* appendAndProject({
         type: "thread.turn-start-requested",
@@ -2535,13 +2542,7 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         },
       });
 
-      const pendingRows = yield* sql<{ readonly messageId: string }>`
-        SELECT pending_message_id AS "messageId"
-        FROM projection_turns
-        WHERE thread_id = ${threadId}
-          AND turn_id IS NULL
-          AND state = 'pending'
-      `;
+      const pendingRows = yield* listPendingStarts();
       assert.deepEqual(pendingRows, [{ messageId: "message-start-new" }]);
 
       yield* appendAndProject({
@@ -2568,14 +2569,80 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         },
       });
 
-      const clearedRows = yield* sql<{ readonly messageId: string }>`
-        SELECT pending_message_id AS "messageId"
-        FROM projection_turns
-        WHERE thread_id = ${threadId}
-          AND turn_id IS NULL
-          AND state = 'pending'
-      `;
+      const clearedRows = yield* listPendingStarts();
       assert.deepEqual(clearedRows, []);
+
+      yield* appendAndProject({
+        type: "thread.turn-start-requested",
+        eventId: EventId.make("evt-start-failed-5"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:00.500Z",
+        commandId: CommandId.make("cmd-start-failed-5"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-5"),
+        metadata: {},
+        payload: {
+          threadId,
+          messageId: MessageId.make("message-start-terminal"),
+          runtimeMode: "full-access",
+          createdAt: "2026-02-26T13:00:00.500Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.session-set",
+        eventId: EventId.make("evt-start-failed-6"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:00.600Z",
+        commandId: CommandId.make("cmd-start-failed-6"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-6"),
+        metadata: {},
+        payload: {
+          threadId,
+          session: {
+            threadId,
+            status: "error",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: "Earlier session failed",
+            updatedAt: "2026-02-26T13:00:00.400Z",
+          },
+        },
+      });
+
+      const rowsAfterStaleSession = yield* listPendingStarts();
+      assert.deepEqual(rowsAfterStaleSession, [{ messageId: "message-start-terminal" }]);
+
+      yield* appendAndProject({
+        type: "thread.session-set",
+        eventId: EventId.make("evt-start-failed-7"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: "2026-02-26T13:00:00.700Z",
+        commandId: CommandId.make("cmd-start-failed-7"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-start-failed-7"),
+        metadata: {},
+        payload: {
+          threadId,
+          session: {
+            threadId,
+            status: "stopped",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: "2026-02-26T13:00:00.700Z",
+          },
+        },
+      });
+
+      const rowsAfterCurrentSession = yield* listPendingStarts();
+      assert.deepEqual(rowsAfterCurrentSession, []);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1082,6 +1082,26 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         case "thread.session-set": {
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
+            if (
+              event.payload.session.lastError !== null ||
+              event.payload.session.status === "error" ||
+              event.payload.session.status === "interrupted" ||
+              event.payload.session.status === "stopped"
+            ) {
+              const pendingTurnStart =
+                yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+                  threadId: event.payload.threadId,
+                });
+              if (
+                Option.isSome(pendingTurnStart) &&
+                pendingTurnStart.value.requestedAt <= event.payload.session.updatedAt
+              ) {
+                yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
+                  threadId: event.payload.threadId,
+                });
+              }
+            }
+
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
             // turn rather than the last assistant message.

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1056,20 +1056,32 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
+        case "thread.activity-appended": {
+          if (event.payload.activity.kind !== "provider.turn.start.failed") {
+            return;
+          }
+          const requestId = event.metadata.requestId;
+          if (requestId === undefined) {
+            return;
+          }
+          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+            threadId: event.payload.threadId,
+          });
+          if (
+            Option.isNone(pendingTurnStart) ||
+            String(requestId) !== pendingTurnStart.value.messageId
+          ) {
+            return;
+          }
+          yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
+        }
+
         case "thread.session-set": {
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
-            if (
-              event.payload.session.lastError !== null ||
-              event.payload.session.status === "error" ||
-              event.payload.session.status === "interrupted" ||
-              event.payload.session.status === "stopped"
-            ) {
-              yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
-                threadId: event.payload.threadId,
-              });
-            }
-
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
             // turn rather than the last assistant message.

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1059,6 +1059,17 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         case "thread.session-set": {
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
+            if (
+              event.payload.session.lastError !== null ||
+              event.payload.session.status === "error" ||
+              event.payload.session.status === "interrupted" ||
+              event.payload.session.status === "stopped"
+            ) {
+              yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
+                threadId: event.payload.threadId,
+              });
+            }
+
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
             // turn rather than the last assistant message.

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -217,22 +217,39 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           checkpoint_status,
           checkpoint_files_json
         )
-        VALUES (
-          'thread-1',
-          'turn-1',
-          NULL,
-          'thread-1',
-          'plan-1',
-          'message-1',
-          'completed',
-          '2026-02-24T00:00:08.000Z',
-          '2026-02-24T00:00:08.000Z',
-          '2026-02-24T00:00:08.000Z',
-          1,
-          'checkpoint-1',
-          'ready',
-          '[{"path":"README.md","kind":"modified","additions":2,"deletions":1}]'
-        )
+        VALUES
+          (
+            'thread-1',
+            'turn-1',
+            NULL,
+            'thread-1',
+            'plan-1',
+            'message-1',
+            'completed',
+            '2026-02-24T00:00:08.000Z',
+            '2026-02-24T00:00:08.000Z',
+            '2026-02-24T00:00:08.000Z',
+            1,
+            'checkpoint-1',
+            'ready',
+            '[{"path":"README.md","kind":"modified","additions":2,"deletions":1}]'
+          ),
+          (
+            'thread-1',
+            NULL,
+            'message-pending',
+            NULL,
+            NULL,
+            NULL,
+            'pending',
+            '2026-02-24T00:00:09.000Z',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            '[]'
+          )
       `;
 
       let sequence = 5;
@@ -432,11 +449,16 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             updatedAt: "2026-02-24T00:00:07.000Z",
           },
           latestUserMessageAt: "2026-02-24T00:00:04.000Z",
+          hasPendingTurnStart: true,
           hasPendingApprovals: true,
           hasPendingUserInput: false,
           hasActionableProposedPlan: false,
         },
       ]);
+
+      const threadShell = yield* snapshotQuery.getThreadShellById(ThreadId.make("thread-1"));
+      assert.equal(threadShell._tag, "Some");
+      assert.equal(threadShell._tag === "Some" && threadShell.value.hasPendingTurnStart, true);
 
       const threadDetail = yield* snapshotQuery.getThreadDetailById(ThreadId.make("thread-1"));
       assert.equal(threadDetail._tag, "Some");

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -103,6 +103,9 @@ const ProjectionLatestTurnDbRowSchema = Schema.Struct({
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
 });
+const ProjectionPendingTurnStartDbRowSchema = Schema.Struct({
+  threadId: ThreadId,
+});
 const ProjectionStateDbRowSchema = ProjectionState;
 const ProjectionCountsRowSchema = Schema.Struct({
   projectCount: Schema.Number,
@@ -614,6 +617,23 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
+  const listActivePendingTurnStartRows = SqlSchema.findAll({
+    Request: Schema.Void,
+    Result: ProjectionPendingTurnStartDbRowSchema,
+    execute: () =>
+      sql`
+        SELECT turns.thread_id AS "threadId"
+        FROM projection_turns turns
+        INNER JOIN projection_threads threads
+          ON threads.thread_id = turns.thread_id
+        WHERE threads.deleted_at IS NULL
+          AND threads.archived_at IS NULL
+          AND turns.turn_id IS NULL
+          AND turns.state = 'pending'
+        ORDER BY turns.thread_id ASC
+      `,
+  });
+
   const listArchivedLatestTurnRows = SqlSchema.findAll({
     Request: Schema.Void,
     Result: ProjectionLatestTurnDbRowSchema,
@@ -882,6 +902,20 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         WHERE threads.thread_id = ${threadId}
           AND threads.deleted_at IS NULL
           AND threads.archived_at IS NULL
+        LIMIT 1
+      `,
+  });
+
+  const getPendingTurnStartRowByThread = SqlSchema.findOneOption({
+    Request: ThreadIdLookupInput,
+    Result: ProjectionPendingTurnStartDbRowSchema,
+    execute: ({ threadId }) =>
+      sql`
+        SELECT thread_id AS "threadId"
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'pending'
         LIMIT 1
       `,
   });
@@ -1449,14 +1483,24 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               ),
             ),
           ),
-          listActiveLatestTurnRows(undefined).pipe(
-            Effect.mapError(
-              toPersistenceSqlOrDecodeError(
-                "ProjectionSnapshotQuery.getShellSnapshot:listLatestTurns:query",
-                "ProjectionSnapshotQuery.getShellSnapshot:listLatestTurns:decodeRows",
+          Effect.all({
+            latestTurnRows: listActiveLatestTurnRows(undefined).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getShellSnapshot:listLatestTurns:query",
+                  "ProjectionSnapshotQuery.getShellSnapshot:listLatestTurns:decodeRows",
+                ),
               ),
             ),
-          ),
+            pendingTurnStartRows: listActivePendingTurnStartRows(undefined).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getShellSnapshot:listPendingTurnStarts:query",
+                  "ProjectionSnapshotQuery.getShellSnapshot:listPendingTurnStarts:decodeRows",
+                ),
+              ),
+            ),
+          }),
           listProjectionStateRows(undefined).pipe(
             Effect.mapError(
               toPersistenceSqlOrDecodeError(
@@ -1468,8 +1512,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         ]),
       )
       .pipe(
-        Effect.flatMap(([projectRows, threadRows, sessionRows, latestTurnRows, stateRows]) =>
+        Effect.flatMap(([projectRows, threadRows, sessionRows, turnRows, stateRows]) =>
           Effect.gen(function* () {
+            const { latestTurnRows, pendingTurnStartRows } = turnRows;
             let updatedAt: string | null = null;
             for (const row of projectRows) {
               updatedAt = maxIso(updatedAt, row.updatedAt);
@@ -1500,6 +1545,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             const sessionByThread = new Map(
               sessionRows.map((row) => [row.threadId, mapSessionRow(row)] as const),
             );
+            const pendingTurnStartThreadIds = new Set(
+              pendingTurnStartRows.map((row) => row.threadId),
+            );
 
             const snapshot = {
               snapshotSequence: computeSnapshotSequence(stateRows),
@@ -1529,6 +1577,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                       settledAt: row.settledAt,
                       session: sessionByThread.get(row.threadId) ?? null,
                       latestUserMessageAt: row.latestUserMessageAt,
+                      hasPendingTurnStart: pendingTurnStartThreadIds.has(row.threadId),
                       hasPendingApprovals: row.pendingApprovalCount > 0,
                       hasPendingUserInput: row.pendingUserInputCount > 0,
                       hasActionableProposedPlan: row.hasActionableProposedPlan > 0,
@@ -1859,7 +1908,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
 
   const getThreadShellById: ProjectionSnapshotQueryShape["getThreadShellById"] = (threadId) =>
     Effect.gen(function* () {
-      const [threadRow, latestTurnRow, sessionRow] = yield* Effect.all([
+      const [threadRow, latestTurnRow, sessionRow, pendingTurnStartRow] = yield* Effect.all([
         getActiveThreadRowById({ threadId }).pipe(
           Effect.mapError(
             toPersistenceSqlOrDecodeError(
@@ -1881,6 +1930,14 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             toPersistenceSqlOrDecodeError(
               "ProjectionSnapshotQuery.getThreadShellById:getSession:query",
               "ProjectionSnapshotQuery.getThreadShellById:getSession:decodeRow",
+            ),
+          ),
+        ),
+        getPendingTurnStartRowByThread({ threadId }).pipe(
+          Effect.mapError(
+            toPersistenceSqlOrDecodeError(
+              "ProjectionSnapshotQuery.getThreadShellById:getPendingTurnStart:query",
+              "ProjectionSnapshotQuery.getThreadShellById:getPendingTurnStart:decodeRow",
             ),
           ),
         ),
@@ -1907,6 +1964,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         settledAt: threadRow.value.settledAt,
         session: Option.isSome(sessionRow) ? mapSessionRow(sessionRow.value) : null,
         latestUserMessageAt: threadRow.value.latestUserMessageAt,
+        hasPendingTurnStart: Option.isSome(pendingTurnStartRow),
         hasPendingApprovals: threadRow.value.pendingApprovalCount > 0,
         hasPendingUserInput: threadRow.value.pendingUserInputCount > 0,
         hasActionableProposedPlan: threadRow.value.hasActionableProposedPlan > 0,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1907,69 +1907,81 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
     });
 
   const getThreadShellById: ProjectionSnapshotQueryShape["getThreadShellById"] = (threadId) =>
-    Effect.gen(function* () {
-      const [threadRow, latestTurnRow, sessionRow, pendingTurnStartRow] = yield* Effect.all([
-        getActiveThreadRowById({ threadId }).pipe(
-          Effect.mapError(
-            toPersistenceSqlOrDecodeError(
-              "ProjectionSnapshotQuery.getThreadShellById:getThread:query",
-              "ProjectionSnapshotQuery.getThreadShellById:getThread:decodeRow",
+    sql
+      .withTransaction(
+        Effect.gen(function* () {
+          const [threadRow, latestTurnRow, sessionRow, pendingTurnStartRow] = yield* Effect.all([
+            getActiveThreadRowById({ threadId }).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getThreadShellById:getThread:query",
+                  "ProjectionSnapshotQuery.getThreadShellById:getThread:decodeRow",
+                ),
+              ),
             ),
-          ),
-        ),
-        getLatestTurnRowByThread({ threadId }).pipe(
-          Effect.mapError(
-            toPersistenceSqlOrDecodeError(
-              "ProjectionSnapshotQuery.getThreadShellById:getLatestTurn:query",
-              "ProjectionSnapshotQuery.getThreadShellById:getLatestTurn:decodeRow",
+            getLatestTurnRowByThread({ threadId }).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getThreadShellById:getLatestTurn:query",
+                  "ProjectionSnapshotQuery.getThreadShellById:getLatestTurn:decodeRow",
+                ),
+              ),
             ),
-          ),
-        ),
-        getThreadSessionRowByThread({ threadId }).pipe(
-          Effect.mapError(
-            toPersistenceSqlOrDecodeError(
-              "ProjectionSnapshotQuery.getThreadShellById:getSession:query",
-              "ProjectionSnapshotQuery.getThreadShellById:getSession:decodeRow",
+            getThreadSessionRowByThread({ threadId }).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getThreadShellById:getSession:query",
+                  "ProjectionSnapshotQuery.getThreadShellById:getSession:decodeRow",
+                ),
+              ),
             ),
-          ),
-        ),
-        getPendingTurnStartRowByThread({ threadId }).pipe(
-          Effect.mapError(
-            toPersistenceSqlOrDecodeError(
-              "ProjectionSnapshotQuery.getThreadShellById:getPendingTurnStart:query",
-              "ProjectionSnapshotQuery.getThreadShellById:getPendingTurnStart:decodeRow",
+            getPendingTurnStartRowByThread({ threadId }).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getThreadShellById:getPendingTurnStart:query",
+                  "ProjectionSnapshotQuery.getThreadShellById:getPendingTurnStart:decodeRow",
+                ),
+              ),
             ),
-          ),
-        ),
-      ]);
+          ]);
 
-      if (Option.isNone(threadRow)) {
-        return Option.none<OrchestrationThreadShell>();
-      }
+          if (Option.isNone(threadRow)) {
+            return Option.none<OrchestrationThreadShell>();
+          }
 
-      return Option.some({
-        id: threadRow.value.threadId,
-        projectId: threadRow.value.projectId,
-        title: threadRow.value.title,
-        modelSelection: threadRow.value.modelSelection,
-        runtimeMode: threadRow.value.runtimeMode,
-        interactionMode: threadRow.value.interactionMode,
-        branch: threadRow.value.branch,
-        worktreePath: threadRow.value.worktreePath,
-        latestTurn: Option.isSome(latestTurnRow) ? mapLatestTurn(latestTurnRow.value) : null,
-        createdAt: threadRow.value.createdAt,
-        updatedAt: threadRow.value.updatedAt,
-        archivedAt: threadRow.value.archivedAt,
-        settledOverride: threadRow.value.settledOverride,
-        settledAt: threadRow.value.settledAt,
-        session: Option.isSome(sessionRow) ? mapSessionRow(sessionRow.value) : null,
-        latestUserMessageAt: threadRow.value.latestUserMessageAt,
-        hasPendingTurnStart: Option.isSome(pendingTurnStartRow),
-        hasPendingApprovals: threadRow.value.pendingApprovalCount > 0,
-        hasPendingUserInput: threadRow.value.pendingUserInputCount > 0,
-        hasActionableProposedPlan: threadRow.value.hasActionableProposedPlan > 0,
-      } satisfies OrchestrationThreadShell);
-    });
+          return Option.some({
+            id: threadRow.value.threadId,
+            projectId: threadRow.value.projectId,
+            title: threadRow.value.title,
+            modelSelection: threadRow.value.modelSelection,
+            runtimeMode: threadRow.value.runtimeMode,
+            interactionMode: threadRow.value.interactionMode,
+            branch: threadRow.value.branch,
+            worktreePath: threadRow.value.worktreePath,
+            latestTurn: Option.isSome(latestTurnRow) ? mapLatestTurn(latestTurnRow.value) : null,
+            createdAt: threadRow.value.createdAt,
+            updatedAt: threadRow.value.updatedAt,
+            archivedAt: threadRow.value.archivedAt,
+            settledOverride: threadRow.value.settledOverride,
+            settledAt: threadRow.value.settledAt,
+            session: Option.isSome(sessionRow) ? mapSessionRow(sessionRow.value) : null,
+            latestUserMessageAt: threadRow.value.latestUserMessageAt,
+            hasPendingTurnStart: Option.isSome(pendingTurnStartRow),
+            hasPendingApprovals: threadRow.value.pendingApprovalCount > 0,
+            hasPendingUserInput: threadRow.value.pendingUserInputCount > 0,
+            hasActionableProposedPlan: threadRow.value.hasActionableProposedPlan > 0,
+          } satisfies OrchestrationThreadShell);
+        }),
+      )
+      .pipe(
+        Effect.mapError((error) =>
+          isPersistenceError(error)
+            ? error
+            : toPersistenceSqlError("ProjectionSnapshotQuery.getThreadShellById:transaction")(
+                error,
+              ),
+        ),
+      );
 
   const getThreadDetailById: ProjectionSnapshotQueryShape["getThreadDetailById"] = (threadId) =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -411,6 +411,7 @@ describe("ProviderCommandReactor", () => {
     return {
       engine,
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
+      snapshotQuery,
       startSession,
       sendTurn,
       interruptTurn,
@@ -465,6 +466,53 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
   });
+
+  effectIt.effect("clears pending work when session startup fails before binding", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
+      const messageId = asMessageId("user-message-start-failed");
+      harness.startSession.mockImplementationOnce(
+        (_: unknown, __: unknown) => Effect.fail("simulated startup failure") as never,
+      );
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-failed"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId,
+          role: "user",
+          text: "hello reactor",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const readModel = await harness.readModel();
+          return (
+            readModel.threads[0]?.activities.some(
+              (activity) => activity.kind === "provider.turn.start.failed",
+            ) ?? false
+          );
+        }),
+      );
+
+      const readModel = yield* harness.snapshotQuery.getSnapshot();
+      expect(readModel.threads[0]?.session).toBeNull();
+      expect(
+        readModel.threads[0]?.activities.find(
+          (activity) => activity.kind === "provider.turn.start.failed",
+        ),
+      ).toMatchObject({ payload: { requestId: messageId } });
+      const shellSnapshot = yield* harness.snapshotQuery.getShellSnapshot();
+      expect(shellSnapshot.threads[0]?.hasPendingTurnStart).toBe(false);
+    }),
+  );
 
   it("generates a thread title on the first turn", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -371,6 +371,7 @@ describe("ProviderCommandReactor", () => {
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
+      Layer.provide(SqlitePersistenceMemory),
     );
     runtime = ManagedRuntime.make(layer);
 
@@ -547,6 +548,12 @@ describe("ProviderCommandReactor", () => {
         }),
       );
 
+      const readModel = yield* harness.snapshotQuery.getSnapshot();
+      expect(
+        readModel.threads[0]?.activities.find(
+          (activity) => activity.kind === "provider.turn.start.failed",
+        ),
+      ).toMatchObject({ payload: { requestId: messageId } });
       const shellSnapshot = yield* harness.snapshotQuery.getShellSnapshot();
       expect(shellSnapshot.threads[0]?.hasPendingTurnStart).toBe(false);
     }),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -514,6 +514,44 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
+  effectIt.effect("clears pending work when turn startup is interrupted", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
+      const messageId = asMessageId("user-message-start-interrupted");
+      harness.sendTurn.mockImplementationOnce(() => Effect.interrupt);
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-interrupted"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId,
+          role: "user",
+          text: "hello reactor",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const readModel = await harness.readModel();
+          return (
+            readModel.threads[0]?.activities.some(
+              (activity) => activity.kind === "provider.turn.start.failed",
+            ) ?? false
+          );
+        }),
+      );
+
+      const shellSnapshot = yield* harness.snapshotQuery.getShellSnapshot();
+      expect(shellSnapshot.threads[0]?.hasPendingTurnStart).toBe(false);
+    }),
+  );
+
   it("generates a thread title on the first turn", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -29,6 +29,8 @@ import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
+import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
+import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
@@ -190,6 +192,7 @@ const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const orchestrationEngine = yield* OrchestrationEngineService;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+  const projectionTurnRepository = yield* ProjectionTurnRepository;
   const providerService = yield* ProviderService;
   const providerRegistry = yield* ProviderRegistry;
   const gitWorkflow = yield* GitWorkflowService;
@@ -805,10 +808,13 @@ const make = Effect.gen(function* () {
     const handleTurnStartFailure = Effect.fnUntraced(function* (cause: Cause.Cause<unknown>) {
       const interrupted = Cause.hasInterruptsOnly(cause);
       if (interrupted) {
-        const threadShell = yield* projectionSnapshotQuery.getThreadShellById(
-          event.payload.threadId,
-        );
-        if (Option.isNone(threadShell) || threadShell.value.hasPendingTurnStart !== true) {
+        const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+          threadId: event.payload.threadId,
+        });
+        if (
+          Option.isNone(pendingTurnStart) ||
+          pendingTurnStart.value.messageId !== event.payload.messageId
+        ) {
           return;
         }
       }
@@ -1094,4 +1100,6 @@ const make = Effect.gen(function* () {
   } satisfies ProviderCommandReactorShape;
 });
 
-export const ProviderCommandReactorLive = Layer.effect(ProviderCommandReactor, make);
+export const ProviderCommandReactorLive = Layer.effect(ProviderCommandReactor, make).pipe(
+  Layer.provide(ProjectionTurnRepositoryLive),
+);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -766,6 +766,7 @@ const make = Effect.gen(function* () {
         detail: `User message '${event.payload.messageId}' was not found for turn start request.`,
         turnId: null,
         createdAt: event.payload.createdAt,
+        requestId: event.payload.messageId,
       });
       return;
     }
@@ -819,6 +820,7 @@ const make = Effect.gen(function* () {
             detail,
             turnId: null,
             createdAt: event.payload.createdAt,
+            requestId: event.payload.messageId,
           }),
         ),
         Effect.asVoid,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -802,30 +802,37 @@ const make = Effect.gen(function* () {
       }
     }
 
-    const handleTurnStartFailure = (cause: Cause.Cause<unknown>) => {
-      if (Cause.hasInterruptsOnly(cause)) {
-        return Effect.void;
+    const handleTurnStartFailure = Effect.fnUntraced(function* (cause: Cause.Cause<unknown>) {
+      const interrupted = Cause.hasInterruptsOnly(cause);
+      if (interrupted) {
+        const threadShell = yield* projectionSnapshotQuery.getThreadShellById(
+          event.payload.threadId,
+        );
+        if (Option.isNone(threadShell) || threadShell.value.hasPendingTurnStart !== true) {
+          return;
+        }
       }
-      const detail = formatFailureDetail(cause);
-      return setThreadSessionErrorOnTurnStartFailure({
+
+      const detail = interrupted
+        ? "Provider turn start was interrupted before it began."
+        : formatFailureDetail(cause);
+      if (!interrupted) {
+        yield* setThreadSessionErrorOnTurnStartFailure({
+          threadId: event.payload.threadId,
+          detail,
+          createdAt: event.payload.createdAt,
+        });
+      }
+      yield* appendProviderFailureActivity({
         threadId: event.payload.threadId,
+        kind: "provider.turn.start.failed",
+        summary: "Provider turn start failed",
         detail,
+        turnId: null,
         createdAt: event.payload.createdAt,
-      }).pipe(
-        Effect.flatMap(() =>
-          appendProviderFailureActivity({
-            threadId: event.payload.threadId,
-            kind: "provider.turn.start.failed",
-            summary: "Provider turn start failed",
-            detail,
-            turnId: null,
-            createdAt: event.payload.createdAt,
-            requestId: event.payload.messageId,
-          }),
-        ),
-        Effect.asVoid,
-      );
-    };
+        requestId: event.payload.messageId,
+      });
+    });
 
     const recoverTurnStartFailure = (cause: Cause.Cause<unknown>) =>
       handleTurnStartFailure(cause).pipe(

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -648,7 +648,11 @@ describe("resolveSidebarV2Status", () => {
     updatedAt: "2026-03-09T10:00:00.000Z",
   };
 
-  const idle = { hasPendingApprovals: false, hasPendingUserInput: false };
+  const idle = {
+    hasPendingApprovals: false,
+    hasPendingTurnStart: false,
+    hasPendingUserInput: false,
+  };
 
   it("prioritizes approval over a running session", () => {
     expect(resolveSidebarV2Status({ ...idle, hasPendingApprovals: true, session })).toBe(
@@ -674,6 +678,16 @@ describe("resolveSidebarV2Status", () => {
       resolveSidebarV2Status({
         ...idle,
         session: { ...session, status: "starting" as const },
+      }),
+    ).toBe("working");
+  });
+
+  it("reports working while a turn start is pending without a session", () => {
+    expect(
+      resolveSidebarV2Status({
+        ...idle,
+        hasPendingTurnStart: true,
+        session: null,
       }),
     ).toBe("working");
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -170,6 +170,7 @@ describe("hasUnseenCompletion", () => {
         hasPendingUserInput: false,
         interactionMode: "default",
         latestTurn: makeLatestTurn(),
+        latestUserMessageAt: null,
         lastVisitedAt: "2026-03-09T10:04:00.000Z",
         session: null,
       }),
@@ -184,6 +185,7 @@ describe("hasUnseenCompletion", () => {
         hasPendingUserInput: false,
         interactionMode: "default",
         latestTurn: makeLatestTurn(),
+        latestUserMessageAt: null,
         lastVisitedAt: undefined,
         session: null,
       }),
@@ -737,6 +739,7 @@ describe("resolveThreadStatusPill", () => {
     hasPendingUserInput: false,
     interactionMode: "plan" as const,
     latestTurn: null,
+    latestUserMessageAt: null,
     lastVisitedAt: undefined,
     session: {
       threadId: ThreadId.make("thread-1"),
@@ -779,6 +782,56 @@ describe("resolveThreadStatusPill", () => {
         thread: baseThread,
       }),
     ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("shows working while a new thread turn is waiting for its first session update", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          latestUserMessageAt: "2026-03-09T10:00:01.000Z",
+          session: null,
+        },
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("keeps showing working through a ready session before the turn starts", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          latestUserMessageAt: "2026-03-09T10:00:01.000Z",
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            activeTurnId: null,
+            updatedAt: "2026-03-09T10:00:02.000Z",
+          },
+        },
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("does not show stale pending work after the turn acknowledges the message", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          latestUserMessageAt: "2026-03-09T10:00:01.000Z",
+          latestTurn: {
+            ...makeLatestTurn(),
+            requestedAt: "2026-03-09T10:00:02.000Z",
+          },
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            activeTurnId: null,
+            updatedAt: "2026-03-09T10:05:00.000Z",
+          },
+        },
+      }),
+    ).toBeNull();
   });
 
   it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -170,7 +170,6 @@ describe("hasUnseenCompletion", () => {
         hasPendingUserInput: false,
         interactionMode: "default",
         latestTurn: makeLatestTurn(),
-        latestUserMessageAt: null,
         lastVisitedAt: "2026-03-09T10:04:00.000Z",
         session: null,
       }),
@@ -185,7 +184,6 @@ describe("hasUnseenCompletion", () => {
         hasPendingUserInput: false,
         interactionMode: "default",
         latestTurn: makeLatestTurn(),
-        latestUserMessageAt: null,
         lastVisitedAt: undefined,
         session: null,
       }),
@@ -736,10 +734,10 @@ describe("resolveThreadStatusPill", () => {
   const baseThread = {
     hasActionableProposedPlan: false,
     hasPendingApprovals: false,
+    hasPendingTurnStart: false,
     hasPendingUserInput: false,
     interactionMode: "plan" as const,
     latestTurn: null,
-    latestUserMessageAt: null,
     lastVisitedAt: undefined,
     session: {
       threadId: ThreadId.make("thread-1"),
@@ -789,7 +787,7 @@ describe("resolveThreadStatusPill", () => {
       resolveThreadStatusPill({
         thread: {
           ...baseThread,
-          latestUserMessageAt: "2026-03-09T10:00:01.000Z",
+          hasPendingTurnStart: true,
           session: null,
         },
       }),
@@ -801,7 +799,7 @@ describe("resolveThreadStatusPill", () => {
       resolveThreadStatusPill({
         thread: {
           ...baseThread,
-          latestUserMessageAt: "2026-03-09T10:00:01.000Z",
+          hasPendingTurnStart: true,
           session: {
             ...baseThread.session,
             status: "ready",
@@ -811,27 +809,6 @@ describe("resolveThreadStatusPill", () => {
         },
       }),
     ).toMatchObject({ label: "Working", pulse: true });
-  });
-
-  it("does not show stale pending work after the turn acknowledges the message", () => {
-    expect(
-      resolveThreadStatusPill({
-        thread: {
-          ...baseThread,
-          latestUserMessageAt: "2026-03-09T10:00:01.000Z",
-          latestTurn: {
-            ...makeLatestTurn(),
-            requestedAt: "2026-03-09T10:00:02.000Z",
-          },
-          session: {
-            ...baseThread.session,
-            status: "ready",
-            activeTurnId: null,
-            updatedAt: "2026-03-09T10:05:00.000Z",
-          },
-        },
-      }),
-    ).toBeNull();
   });
 
   it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -115,6 +115,7 @@ type ThreadStatusInput = Pick<
   | "hasPendingUserInput"
   | "interactionMode"
   | "latestTurn"
+  | "latestUserMessageAt"
   | "session"
 > & {
   lastVisitedAt?: string | undefined;
@@ -221,6 +222,32 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   const lastVisitedAt = Date.parse(thread.lastVisitedAt);
   if (Number.isNaN(lastVisitedAt)) return true;
   return completedAt > lastVisitedAt;
+}
+
+function hasPendingTurnStart(thread: ThreadStatusInput): boolean {
+  if (!thread.latestUserMessageAt) return false;
+  const latestUserMessageAt = Date.parse(thread.latestUserMessageAt);
+  if (Number.isNaN(latestUserMessageAt)) return false;
+
+  const latestTurnRequestedAt = thread.latestTurn
+    ? Date.parse(thread.latestTurn.requestedAt)
+    : Number.NaN;
+  if (!Number.isNaN(latestTurnRequestedAt) && latestTurnRequestedAt >= latestUserMessageAt) {
+    return false;
+  }
+
+  // Session bootstrap may pass through starting/ready before the provider
+  // creates the turn; only terminal states can acknowledge a failed start.
+  const session = thread.session;
+  if (
+    !session ||
+    (session.status !== "error" && session.status !== "interrupted" && session.status !== "stopped")
+  ) {
+    return true;
+  }
+
+  const sessionUpdatedAt = Date.parse(session.updatedAt);
+  return Number.isNaN(sessionUpdatedAt) || sessionUpdatedAt < latestUserMessageAt;
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
@@ -505,7 +532,7 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.session?.status === "running") {
+  if (thread.session?.status === "running" || hasPendingTurnStart(thread)) {
     return {
       label: "Working",
       colorClass: "text-sky-600 dark:text-sky-300/80",

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -429,7 +429,7 @@ export type SidebarV2Status = "approval" | "input" | "working" | "failed" | "rea
 
 type SidebarV2StatusInput = Pick<
   SidebarThreadSummary,
-  "hasPendingApprovals" | "hasPendingUserInput" | "session"
+  "hasPendingApprovals" | "hasPendingTurnStart" | "hasPendingUserInput" | "session"
 >;
 
 export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2Status {
@@ -439,7 +439,11 @@ export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2S
   if (thread.hasPendingUserInput) {
     return "input";
   }
-  if (thread.session?.status === "running" || thread.session?.status === "starting") {
+  if (
+    thread.session?.status === "running" ||
+    thread.session?.status === "starting" ||
+    thread.hasPendingTurnStart === true
+  ) {
     return "working";
   }
   if (thread.session?.status === "error") {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -112,10 +112,10 @@ type ThreadStatusInput = Pick<
   SidebarThreadSummary,
   | "hasActionableProposedPlan"
   | "hasPendingApprovals"
+  | "hasPendingTurnStart"
   | "hasPendingUserInput"
   | "interactionMode"
   | "latestTurn"
-  | "latestUserMessageAt"
   | "session"
 > & {
   lastVisitedAt?: string | undefined;
@@ -222,32 +222,6 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   const lastVisitedAt = Date.parse(thread.lastVisitedAt);
   if (Number.isNaN(lastVisitedAt)) return true;
   return completedAt > lastVisitedAt;
-}
-
-function hasPendingTurnStart(thread: ThreadStatusInput): boolean {
-  if (!thread.latestUserMessageAt) return false;
-  const latestUserMessageAt = Date.parse(thread.latestUserMessageAt);
-  if (Number.isNaN(latestUserMessageAt)) return false;
-
-  const latestTurnRequestedAt = thread.latestTurn
-    ? Date.parse(thread.latestTurn.requestedAt)
-    : Number.NaN;
-  if (!Number.isNaN(latestTurnRequestedAt) && latestTurnRequestedAt >= latestUserMessageAt) {
-    return false;
-  }
-
-  // Session bootstrap may pass through starting/ready before the provider
-  // creates the turn; only terminal states can acknowledge a failed start.
-  const session = thread.session;
-  if (
-    !session ||
-    (session.status !== "error" && session.status !== "interrupted" && session.status !== "stopped")
-  ) {
-    return true;
-  }
-
-  const sessionUpdatedAt = Date.parse(session.updatedAt);
-  return Number.isNaN(sessionUpdatedAt) || sessionUpdatedAt < latestUserMessageAt;
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
@@ -532,7 +506,7 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.session?.status === "running" || hasPendingTurnStart(thread)) {
+  if (thread.session?.status === "running" || thread.hasPendingTurnStart === true) {
     return {
       label: "Working",
       colorClass: "text-sky-600 dark:text-sky-300/80",

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -412,6 +412,7 @@ export const OrchestrationThreadShell = Schema.Struct({
   settledAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
   session: Schema.NullOr(OrchestrationSession),
   latestUserMessageAt: Schema.NullOr(IsoDateTime),
+  hasPendingTurnStart: Schema.optional(Schema.Boolean),
   hasPendingApprovals: Schema.Boolean,
   hasPendingUserInput: Schema.Boolean,
   hasActionableProposedPlan: Schema.Boolean,


### PR DESCRIPTION
Shows “Working” while a new thread waits for its first provider turn, with safe cleanup for failed or ended starts.

Works in both sidebar versions. Validated with focused tests, typechecks, lint, and an isolated browser run.