### PR TITLE
fix(web): align and space file search

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -36,6 +36,7 @@ const TREE_UNSAFE_CSS = `
     --trees-font-size-override: 12px;
     --trees-padding-inline-override: 12px;
   }
+  [data-file-tree-search-container] { padding-block-start: 4px; }
   button[data-type='item'] { border-radius: 5px; }
 `;
 

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -34,6 +34,7 @@ const TREE_UNSAFE_CSS = `
     --trees-border-color-override: color-mix(in srgb, currentColor 14%, transparent);
     --trees-font-family-override: var(--font-sans);
     --trees-font-size-override: 12px;
+    --trees-padding-inline-override: 12px;
   }
   button[data-type='item'] { border-radius: 5px; }
 `;


### PR DESCRIPTION
## Summary

- add a small top inset above the workspace file search so it is not flush with the file-tree boundary
- align the search field and tree with the Files panel 12px horizontal inset

## Root cause

The tree search container had no top padding, while `@pierre/trees` also defaulted to a 16px inline inset rather than the Files panel header spacing.

## Validation

- integrated web preview: search container has 4px top padding; the input begins 5px below the tree boundary including its existing 1px margin
- integrated web preview: search input and Files content share the same 12px horizontal inset
- `vp fmt --check apps/web/src/components/files/FileBrowserPanel.tsx`
- `vp lint apps/web/src/components/files/FileBrowserPanel.tsx`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

This is a CSS-only layout change; file search behavior is unchanged.

Before:
<img width="534" height="95" alt="image" src="https://github.com/user-attachments/assets/9df0e079-c4ed-413d-85d5-09f876134391" />

After:
<img width="343" height="128" alt="image" src="https://github.com/user-attachments/assets/af218cec-3db4-4f89-9cd4-f17f69a6c91c" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout overrides in the file browser; no logic, API, or data-handling changes.
> 
> **Overview**
> **Visual alignment** in the workspace Files panel: the `@pierre/trees` search field and tree no longer sit 4px inward relative to the header.
> 
> `TREE_UNSAFE_CSS` now sets `--trees-padding-inline-override: 12px` so the tree matches the header’s `px-3` inset, and adds `padding-block-start: 4px` on `[data-file-tree-search-container]` for the search row spacing. Search behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b326014b61fbb11de08eef8607f1a1e59e95f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix alignment and spacing of file search in FileBrowserPanel
> Adds 12px inline padding to the file tree via a CSS custom property and 4px top padding to the search container in [FileBrowserPanel.tsx](https://github.com/pingdotgg/t3code/pull/4256/files#diff-aeb8bbbac738f422eace5ad6cee4745362f7559fdd5668df4eb1be558f4b5fb3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b32601.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->