### PR TITLE
feat(web): add Tab completion to path browser

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -85,6 +85,17 @@ describe("resolveBrowseTabCompletion", () => {
     ).toBeNull();
   });
 
+  it("does not enter the first child when the completed path has no leaf filter", () => {
+    expect(
+      resolveBrowseTabCompletion({
+        allowFirstEntryFallback: false,
+        exactEntry: null,
+        filteredEntries: entries,
+        highlightedItemValue: null,
+      }),
+    ).toBeNull();
+  });
+
   it("uses the case-sensitive exact entry before the first prefix match", () => {
     const caseVariants = [
       { name: "Docs", fullPath: "/workspace/Docs" },
@@ -113,6 +124,21 @@ describe("resolveBrowseTabCompletion", () => {
         highlightedItemValue: "browse:/workspace/Docs",
       }),
     ).toEqual({ kind: "entry", entry: caseVariants[0] });
+  });
+
+  it("uses an exact entry when a stored highlight no longer resolves", () => {
+    const caseVariants = [
+      { name: "Docs", fullPath: "/workspace/Docs" },
+      { name: "docs", fullPath: "/workspace/docs" },
+    ];
+
+    expect(
+      resolveBrowseTabCompletion({
+        exactEntry: caseVariants[1] ?? null,
+        filteredEntries: caseVariants,
+        highlightedItemValue: "browse:/workspace/removed",
+      }),
+    ).toEqual({ kind: "entry", entry: caseVariants[1] });
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -48,6 +48,7 @@ describe("resolveBrowseTabCompletion", () => {
   it("uses the highlighted directory", () => {
     expect(
       resolveBrowseTabCompletion({
+        exactEntry: null,
         filteredEntries: entries,
         highlightedItemValue: "browse:/workspace/alpine",
       }),
@@ -57,6 +58,7 @@ describe("resolveBrowseTabCompletion", () => {
   it("uses the first directory when none is highlighted", () => {
     expect(
       resolveBrowseTabCompletion({
+        exactEntry: null,
         filteredEntries: entries,
         highlightedItemValue: null,
       }),
@@ -66,6 +68,7 @@ describe("resolveBrowseTabCompletion", () => {
   it("preserves the highlighted parent-directory action", () => {
     expect(
       resolveBrowseTabCompletion({
+        exactEntry: null,
         filteredEntries: entries,
         highlightedItemValue: "browse:up",
       }),
@@ -75,10 +78,41 @@ describe("resolveBrowseTabCompletion", () => {
   it("returns null when there are no matching directories", () => {
     expect(
       resolveBrowseTabCompletion({
+        exactEntry: null,
         filteredEntries: [],
         highlightedItemValue: null,
       }),
     ).toBeNull();
+  });
+
+  it("uses the case-sensitive exact entry before the first prefix match", () => {
+    const caseVariants = [
+      { name: "Docs", fullPath: "/workspace/Docs" },
+      { name: "docs", fullPath: "/workspace/docs" },
+    ];
+
+    expect(
+      resolveBrowseTabCompletion({
+        exactEntry: caseVariants[1] ?? null,
+        filteredEntries: caseVariants,
+        highlightedItemValue: null,
+      }),
+    ).toEqual({ kind: "entry", entry: caseVariants[1] });
+  });
+
+  it("keeps a highlighted row ahead of a different exact entry", () => {
+    const caseVariants = [
+      { name: "Docs", fullPath: "/workspace/Docs" },
+      { name: "docs", fullPath: "/workspace/docs" },
+    ];
+
+    expect(
+      resolveBrowseTabCompletion({
+        exactEntry: caseVariants[1] ?? null,
+        filteredEntries: caseVariants,
+        highlightedItemValue: "browse:/workspace/Docs",
+      }),
+    ).toEqual({ kind: "entry", entry: caseVariants[0] });
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -5,6 +5,7 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  resolveBrowseTabCompletion,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -37,6 +38,49 @@ describe("enumerateCommandPaletteItems", () => {
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
 const PROJECT_ID = ProjectId.make("project-1");
+
+describe("resolveBrowseTabCompletion", () => {
+  const entries = [
+    { name: "alpha", fullPath: "/workspace/alpha" },
+    { name: "alpine", fullPath: "/workspace/alpine" },
+  ];
+
+  it("uses the highlighted directory", () => {
+    expect(
+      resolveBrowseTabCompletion({
+        filteredEntries: entries,
+        highlightedItemValue: "browse:/workspace/alpine",
+      }),
+    ).toEqual({ kind: "entry", entry: entries[1] });
+  });
+
+  it("uses the first directory when none is highlighted", () => {
+    expect(
+      resolveBrowseTabCompletion({
+        filteredEntries: entries,
+        highlightedItemValue: null,
+      }),
+    ).toEqual({ kind: "entry", entry: entries[0] });
+  });
+
+  it("preserves the highlighted parent-directory action", () => {
+    expect(
+      resolveBrowseTabCompletion({
+        filteredEntries: entries,
+        highlightedItemValue: "browse:up",
+      }),
+    ).toEqual({ kind: "up" });
+  });
+
+  it("returns null when there are no matching directories", () => {
+    expect(
+      resolveBrowseTabCompletion({
+        filteredEntries: [],
+        highlightedItemValue: null,
+      }),
+    ).toBeNull();
+  });
+});
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -102,6 +102,32 @@ export function filterBrowseEntries(input: {
   return { filteredEntries, highlightedEntry, exactEntry };
 }
 
+export type BrowseTabCompletion =
+  | { readonly kind: "up" }
+  | { readonly kind: "entry"; readonly entry: FilesystemBrowseEntry };
+
+export function resolveBrowseTabCompletion(input: {
+  filteredEntries: ReadonlyArray<FilesystemBrowseEntry>;
+  highlightedItemValue: string | null;
+}): BrowseTabCompletion | null {
+  if (input.highlightedItemValue === "browse:up") {
+    return { kind: "up" };
+  }
+
+  if (input.highlightedItemValue?.startsWith("browse:")) {
+    const highlightedPath = input.highlightedItemValue.slice("browse:".length);
+    const highlightedEntry = input.filteredEntries.find(
+      (entry) => entry.fullPath === highlightedPath,
+    );
+    if (highlightedEntry) {
+      return { kind: "entry", entry: highlightedEntry };
+    }
+  }
+
+  const firstEntry = input.filteredEntries[0];
+  return firstEntry ? { kind: "entry", entry: firstEntry } : null;
+}
+
 export function normalizeSearchText(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
 }

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -107,6 +107,7 @@ export type BrowseTabCompletion =
   | { readonly kind: "entry"; readonly entry: FilesystemBrowseEntry };
 
 export function resolveBrowseTabCompletion(input: {
+  allowFirstEntryFallback?: boolean;
   exactEntry: FilesystemBrowseEntry | null;
   filteredEntries: ReadonlyArray<FilesystemBrowseEntry>;
   highlightedItemValue: string | null;
@@ -125,11 +126,11 @@ export function resolveBrowseTabCompletion(input: {
     }
   }
 
-  if (input.highlightedItemValue === null && input.exactEntry) {
+  if (input.exactEntry) {
     return { kind: "entry", entry: input.exactEntry };
   }
 
-  const firstEntry = input.filteredEntries[0];
+  const firstEntry = input.allowFirstEntryFallback === false ? undefined : input.filteredEntries[0];
   return firstEntry ? { kind: "entry", entry: firstEntry } : null;
 }
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -107,6 +107,7 @@ export type BrowseTabCompletion =
   | { readonly kind: "entry"; readonly entry: FilesystemBrowseEntry };
 
 export function resolveBrowseTabCompletion(input: {
+  exactEntry: FilesystemBrowseEntry | null;
   filteredEntries: ReadonlyArray<FilesystemBrowseEntry>;
   highlightedItemValue: string | null;
 }): BrowseTabCompletion | null {
@@ -122,6 +123,10 @@ export function resolveBrowseTabCompletion(input: {
     if (highlightedEntry) {
       return { kind: "entry", entry: highlightedEntry };
     }
+  }
+
+  if (input.highlightedItemValue === null && input.exactEntry) {
+    return { kind: "entry", entry: input.exactEntry };
   }
 
   const firstEntry = input.filteredEntries[0];

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -102,6 +102,7 @@ import {
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
+  resolveBrowseTabCompletion,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -1697,6 +1698,28 @@ function OpenCommandPaletteDialog(props: {
         executeItem(matchingItem);
         return;
       }
+    }
+
+    const isPlainTab =
+      event.key === "Tab" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+
+    if (isBrowsing && isPlainTab) {
+      event.preventDefault();
+
+      if (relativePathNeedsActiveProject || isBrowsePending) {
+        return;
+      }
+
+      const completion = resolveBrowseTabCompletion({
+        filteredEntries: filteredBrowseEntries,
+        highlightedItemValue,
+      });
+      if (completion?.kind === "up") {
+        browseUp();
+      } else if (completion?.kind === "entry") {
+        browseTo(completion.entry.name);
+      }
+      return;
     }
 
     if (addProjectCloneFlow?.step === "repository" && event.key === "Enter") {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1706,7 +1706,7 @@ function OpenCommandPaletteDialog(props: {
     if (isBrowsing && isPlainTab) {
       event.preventDefault();
 
-      if (relativePathNeedsActiveProject || isBrowsePending) {
+      if (relativePathNeedsActiveProject || (isBrowsePending && browseResult === null)) {
         return;
       }
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1711,6 +1711,7 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const completion = resolveBrowseTabCompletion({
+        exactEntry: exactBrowseEntry,
         filteredEntries: filteredBrowseEntries,
         highlightedItemValue,
       });

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1711,6 +1711,7 @@ function OpenCommandPaletteDialog(props: {
       }
 
       const completion = resolveBrowseTabCompletion({
+        allowFirstEntryFallback: browseFilterQuery.length > 0,
         exactEntry: exactBrowseEntry,
         filteredEntries: filteredBrowseEntries,
         highlightedItemValue,


### PR DESCRIPTION
## Summary

- complete the highlighted directory when Tab is pressed in the path browser
- fall back to the first matching directory when no result is highlighted
- keep focus in the path input while matches are loading or unavailable
- preserve Tab navigation to the highlighted parent-directory entry

## Why

The add-project and clone-destination path inputs already display matching directories, but Tab moved focus out of the input instead of accepting a suggestion. This makes the picker behave like a directory autocomplete and addresses #2160.

## Validation

- `pnpm exec vp test run apps/web/src/components/CommandPalette.logic.test.ts`
- `pnpm --filter @t3tools/web typecheck`
- focused `vp fmt --check` and `vp lint` on the three changed files
- isolated exact-head browser verification of Tab completion against a disposable project (see evidence below)

Closes #2160

## Exact-head evidence

Revalidated at 83ce1aa790b2 on current main (9a0a07167f06): focused tests, vp check, and vp run typecheck passed. The capture uses only disposable local projects.

![Tab completes the entered folder path](https://github.com/user-attachments/assets/6763f265-b66e-4e45-b5a2-deb211e02e82)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard handling and pure selection logic in the command palette browse flow; no auth, data, or API changes.
> 
> **Overview**
> **Tab in the command palette path browser** now accepts directory suggestions instead of inserting a tab character or moving focus away.
> 
> A new **`resolveBrowseTabCompletion`** helper picks the Tab action: parent (`..`) when that row is highlighted, otherwise the highlighted folder, then a case-sensitive exact name match, and only when the user has typed a leaf filter—the first filtered directory. With no leaf filter, Tab does nothing so browsing an open directory does not auto-enter the first child.
> 
> **`CommandPalette`** intercepts plain **Tab** in browse mode (after blocking default behavior), skips completion while browse results are loading or a relative path needs an active project, then calls **`browseUp`** or **`browseTo`** from the resolver result. Unit tests cover highlight priority, exact vs. prefix matches, and stale highlights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47dac3db2cdd70cd96cfd4ea929306f2046a8c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Tab key completion to path browser in Command Palette
> - Adds `resolveBrowseTabCompletion` in [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/4257/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) to determine the Tab action while browsing: goes up when the parent-directory item is highlighted, enters the highlighted directory, falls back to an exact match, or enters the first filtered entry when a leaf filter is present.
> - Wires Tab key handling into [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/4257/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) so pressing Tab (no modifiers) in browse mode triggers path navigation instead of inserting a tab character.
> - Behavioral Change: Tab is now prevented by default in browse mode; existing keyboard behavior in non-browse modes is unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47dac3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->