### PR TITLE
Add configurable add-project shortcut

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -200,7 +200,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");
       assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
       assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
-      assert.equal(defaultsByCommand.get("project.add"), "mod+alt+a");
+      assert.equal(defaultsByCommand.get("project.add"), "alt+a");
       assert.equal(defaultsByCommand.get("terminal.splitVertical"), "mod+shift+d");
       assert.equal(defaultsByCommand.get("modelPicker.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("modelPicker.jump.9"), "mod+9");

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -200,6 +200,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");
       assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
       assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
+      assert.equal(defaultsByCommand.get("project.add"), "mod+alt+a");
       assert.equal(defaultsByCommand.get("terminal.splitVertical"), "mod+shift+d");
       assert.equal(defaultsByCommand.get("modelPicker.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("modelPicker.jump.9"), "mod+9");

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -5,8 +5,35 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  shouldHandleCommandPaletteShortcut,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
+
+describe("shouldHandleCommandPaletteShortcut", () => {
+  it("does not capture the add-project shortcut from an editable target", () => {
+    expect(
+      shouldHandleCommandPaletteShortcut({
+        command: "project.add",
+        editableTarget: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still handles add-project outside editors and the palette toggle everywhere", () => {
+    expect(
+      shouldHandleCommandPaletteShortcut({
+        command: "project.add",
+        editableTarget: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandleCommandPaletteShortcut({
+        command: "commandPalette.toggle",
+        editableTarget: true,
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("enumerateCommandPaletteItems", () => {
   it("assigns positional jump shortcuts to the first nine displayed items", () => {

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
+  buildNewThreadInGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  resetAddProjectFlowState,
   shouldHandleCommandPaletteShortcut,
   shouldResetPaletteFlowOnPop,
+  type CommandPaletteActionItem,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -73,6 +76,56 @@ describe("shouldResetPaletteFlowOnPop", () => {
 
   it("keeps a flow active while popping between its own nested views", () => {
     expect(shouldResetPaletteFlowOnPop(1, 3)).toBe(false);
+  });
+});
+
+describe("resetAddProjectFlowState", () => {
+  it("clears every piece of add-project state before opening another palette flow", () => {
+    const flowBaseDepthRef = { current: 2 as number | null };
+    const clearEnvironment = vi.fn();
+    const clearCloneFlow = vi.fn();
+
+    resetAddProjectFlowState({
+      flowBaseDepthRef,
+      clearEnvironment,
+      clearCloneFlow,
+    });
+
+    expect(clearEnvironment).toHaveBeenCalledOnce();
+    expect(clearCloneFlow).toHaveBeenCalledOnce();
+    expect(flowBaseDepthRef.current).toBeNull();
+  });
+});
+
+describe("buildNewThreadInGroups", () => {
+  it("includes Add project alongside projects for every new-thread picker entry point", () => {
+    const projectItem: CommandPaletteActionItem = {
+      kind: "action",
+      value: "new-thread-in:environment-1:project-1",
+      searchTerms: ["Project"],
+      title: "Project",
+      icon: null,
+      run: async () => undefined,
+    };
+    const addProjectAction: CommandPaletteActionItem = {
+      kind: "action",
+      value: "action:add-project",
+      searchTerms: ["Add project"],
+      title: "Add project",
+      icon: null,
+      shortcutCommand: "project.add",
+      run: async () => undefined,
+    };
+
+    const groups = buildNewThreadInGroups({
+      projectItems: [projectItem],
+      addProjectAction,
+    });
+
+    expect(groups.map((group) => group.value)).toEqual(["projects", "actions"]);
+    expect(groups[0]?.items).toEqual([projectItem]);
+    expect(groups[1]?.items).toEqual([addProjectAction]);
+    expect(groups[1]?.items[0]?.shortcutCommand).toBe("project.add");
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -6,6 +6,7 @@ import {
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
   shouldHandleCommandPaletteShortcut,
+  shouldResetPaletteFlowOnPop,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -64,6 +65,16 @@ describe("enumerateCommandPaletteItems", () => {
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
 const PROJECT_ID = ProjectId.make("project-1");
+
+describe("shouldResetPaletteFlowOnPop", () => {
+  it("resets a flow opened from a nested parent when its first view is popped", () => {
+    expect(shouldResetPaletteFlowOnPop(1, 2)).toBe(true);
+  });
+
+  it("keeps a flow active while popping between its own nested views", () => {
+    expect(shouldResetPaletteFlowOnPop(1, 3)).toBe(false);
+  });
+});
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -18,6 +18,7 @@ describe("shouldHandleCommandPaletteShortcut", () => {
     expect(
       shouldHandleCommandPaletteShortcut({
         command: "project.add",
+        paletteOpen: false,
         editableTarget: true,
       }),
     ).toBe(false);
@@ -27,12 +28,14 @@ describe("shouldHandleCommandPaletteShortcut", () => {
     expect(
       shouldHandleCommandPaletteShortcut({
         command: "project.add",
+        paletteOpen: false,
         editableTarget: false,
       }),
     ).toBe(true);
     expect(
       shouldHandleCommandPaletteShortcut({
         command: "commandPalette.toggle",
+        paletteOpen: false,
         editableTarget: true,
       }),
     ).toBe(true);
@@ -68,6 +71,28 @@ describe("enumerateCommandPaletteItems", () => {
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
 const PROJECT_ID = ProjectId.make("project-1");
+
+describe("shouldHandleCommandPaletteShortcut in an open palette", () => {
+  it("allows Alt+A from the editable search input while the new-task palette is open", () => {
+    expect(
+      shouldHandleCommandPaletteShortcut({
+        command: "project.add",
+        paletteOpen: true,
+        editableTarget: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("continues to ignore Alt+A from editors outside the palette", () => {
+    expect(
+      shouldHandleCommandPaletteShortcut({
+        command: "project.add",
+        paletteOpen: false,
+        editableTarget: true,
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("shouldResetPaletteFlowOnPop", () => {
   it("resets a flow opened from a nested parent when its first view is popped", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -15,6 +15,16 @@ export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-muted-foreground/80";
 export const ADDON_ICON_CLASS = "size-4";
 
+export function shouldHandleCommandPaletteShortcut(input: {
+  command: KeybindingCommand | null;
+  editableTarget: boolean;
+}): boolean {
+  if (input.command === "commandPalette.toggle") {
+    return true;
+  }
+  return input.command === "project.add" && !input.editableTarget;
+}
+
 export interface CommandPaletteItem {
   readonly kind: "action" | "submenu";
   readonly value: string;

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -78,6 +78,13 @@ export function enumerateCommandPaletteItems(
   });
 }
 
+export function shouldResetPaletteFlowOnPop(
+  flowBaseDepth: number | null,
+  currentDepth: number,
+): boolean {
+  return flowBaseDepth !== null && Math.max(0, currentDepth - 1) <= flowBaseDepth;
+}
+
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
 export function filterBrowseEntries(input: {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -17,12 +17,13 @@ export const ADDON_ICON_CLASS = "size-4";
 
 export function shouldHandleCommandPaletteShortcut(input: {
   command: KeybindingCommand | null;
+  paletteOpen: boolean;
   editableTarget: boolean;
 }): boolean {
   if (input.command === "commandPalette.toggle") {
     return true;
   }
-  return input.command === "project.add" && !input.editableTarget;
+  return input.command === "project.add" && (!input.editableTarget || input.paletteOpen);
 }
 
 export interface CommandPaletteItem {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -85,6 +85,26 @@ export function shouldResetPaletteFlowOnPop(
   return flowBaseDepth !== null && Math.max(0, currentDepth - 1) <= flowBaseDepth;
 }
 
+export function resetAddProjectFlowState(input: {
+  flowBaseDepthRef: { current: number | null };
+  clearEnvironment: () => void;
+  clearCloneFlow: () => void;
+}): void {
+  input.clearCloneFlow();
+  input.clearEnvironment();
+  input.flowBaseDepthRef.current = null;
+}
+
+export function buildNewThreadInGroups(input: {
+  projectItems: ReadonlyArray<CommandPaletteActionItem>;
+  addProjectAction: CommandPaletteActionItem;
+}): CommandPaletteGroup[] {
+  return [
+    { value: "projects", label: "Projects", items: input.projectItems },
+    { value: "actions", label: "Actions", items: [input.addProjectAction] },
+  ];
+}
+
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
 export function filterBrowseEntries(input: {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -102,6 +102,7 @@ import {
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
+  shouldHandleCommandPaletteShortcut,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -408,7 +409,18 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           terminalOpen,
         },
       });
-      if (command !== "commandPalette.toggle" && command !== "project.add") {
+      const target =
+        event.target instanceof Element
+          ? event.target.closest(
+              'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
+            )
+          : null;
+      if (
+        !shouldHandleCommandPaletteShortcut({
+          command,
+          editableTarget: target !== null,
+        })
+      ) {
         return;
       }
       event.preventDefault();

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -408,16 +408,20 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           terminalOpen,
         },
       });
-      if (command !== "commandPalette.toggle") {
+      if (command !== "commandPalette.toggle" && command !== "project.add") {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
-      toggleOpen();
+      if (command === "project.add") {
+        openAddProject();
+      } else {
+        toggleOpen();
+      }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, terminalOpen, toggleOpen]);
+  }, [keybindings, openAddProject, terminalOpen, toggleOpen]);
 
   useEffect(
     () =>
@@ -1146,6 +1150,35 @@ function OpenCommandPaletteDialog(props: {
   ]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
+  const addProjectAction: CommandPaletteActionItem = {
+    kind: "action",
+    value: "action:add-project",
+    searchTerms: [
+      "add project",
+      "folder",
+      "directory",
+      "browse",
+      "clone",
+      "remote",
+      "repository",
+      "repo",
+      "git",
+      "github",
+      "gitlab",
+      "bitbucket",
+      "azure",
+      "devops",
+      "url",
+      "environment",
+    ],
+    title: "Add project",
+    icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
+    shortcutCommand: "project.add",
+    keepOpen: true,
+    run: async () => {
+      openAddProjectFlow();
+    },
+  };
 
   if (projects.length > 0) {
     const activeProjectTitle =
@@ -1182,38 +1215,14 @@ function OpenCommandPaletteDialog(props: {
       title: "New thread in...",
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+      groups: [
+        { value: "projects", label: "Projects", items: projectThreadItems },
+        { value: "actions", label: "Actions", items: [addProjectAction] },
+      ],
     });
   }
 
-  actionItems.push({
-    kind: "action",
-    value: "action:add-project",
-    searchTerms: [
-      "add project",
-      "folder",
-      "directory",
-      "browse",
-      "clone",
-      "remote",
-      "repository",
-      "repo",
-      "git",
-      "github",
-      "gitlab",
-      "bitbucket",
-      "azure",
-      "devops",
-      "url",
-      "environment",
-    ],
-    title: "Add project",
-    icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
-    keepOpen: true,
-    run: async () => {
-      openAddProjectFlow();
-    },
-  });
+  actionItems.push(addProjectAction);
 
   if (wslAddProjectEnvironmentOption) {
     actionItems.push({

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -103,6 +103,7 @@ import {
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
   shouldHandleCommandPaletteShortcut,
+  shouldResetPaletteFlowOnPop,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -532,7 +533,9 @@ function OpenCommandPaletteDialog(props: {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const providers = useAtomValue(primaryServerProvidersAtom);
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
-  const addProjectFlowOpenRef = useRef(false);
+  const viewStackDepthRef = useRef(0);
+  viewStackDepthRef.current = viewStack.length;
+  const addProjectFlowBaseDepthRef = useRef<number | null>(null);
   const currentView = viewStack.at(-1) ?? null;
   const [browseGeneration, setBrowseGeneration] = useState(0);
   const [addProjectEnvironmentId, setAddProjectEnvironmentId] = useState<EnvironmentId | null>(
@@ -921,9 +924,12 @@ function OpenCommandPaletteDialog(props: {
 
   function popView(): void {
     setAddProjectCloneFlow(null);
-    if (viewStack.length <= 1) {
+    if (
+      viewStack.length <= 1 ||
+      shouldResetPaletteFlowOnPop(addProjectFlowBaseDepthRef.current, viewStack.length)
+    ) {
       setAddProjectEnvironmentId(null);
-      addProjectFlowOpenRef.current = false;
+      addProjectFlowBaseDepthRef.current = null;
     }
     setViewStack((previousViews) => previousViews.slice(0, -1));
     setHighlightedItemValue(null);
@@ -938,9 +944,13 @@ function OpenCommandPaletteDialog(props: {
     }
   }
 
+  const markAddProjectFlowOpen = useCallback((): void => {
+    addProjectFlowBaseDepthRef.current ??= viewStackDepthRef.current;
+  }, []);
+
   const startAddProjectBrowse = useCallback(
     (environmentId: EnvironmentId): void => {
-      addProjectFlowOpenRef.current = true;
+      markAddProjectFlowOpen();
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
       pushPaletteView({
@@ -949,12 +959,12 @@ function OpenCommandPaletteDialog(props: {
         initialQuery: getAddProjectInitialQueryForEnvironment(environmentId),
       });
     },
-    [getAddProjectInitialQueryForEnvironment],
+    [getAddProjectInitialQueryForEnvironment, markAddProjectFlowOpen],
   );
 
   const startAddProjectClone = useCallback(
     (environmentId: EnvironmentId, source: AddProjectRemoteSource): void => {
-      addProjectFlowOpenRef.current = true;
+      markAddProjectFlowOpen();
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow({ step: "repository", environmentId, source });
       pushPaletteView({
@@ -963,7 +973,7 @@ function OpenCommandPaletteDialog(props: {
         initialQuery: "",
       });
     },
-    [],
+    [markAddProjectFlowOpen],
   );
 
   const openSourceControlSettings = useCallback(() => {
@@ -1067,7 +1077,7 @@ function OpenCommandPaletteDialog(props: {
 
   const startAddProjectSourceSelection = useCallback(
     (environmentId: EnvironmentId): void => {
-      addProjectFlowOpenRef.current = true;
+      markAddProjectFlowOpen();
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
       pushPaletteView({
@@ -1080,7 +1090,12 @@ function OpenCommandPaletteDialog(props: {
         ),
       });
     },
-    [browseEnvironmentId, buildAddProjectSourceGroups, sourceControlDiscovery.data],
+    [
+      browseEnvironmentId,
+      buildAddProjectSourceGroups,
+      markAddProjectFlowOpen,
+      sourceControlDiscovery.data,
+    ],
   );
 
   const addProjectEnvironmentItems: CommandPaletteActionItem[] = addProjectEnvironmentOptions.map(
@@ -1110,11 +1125,11 @@ function OpenCommandPaletteDialog(props: {
   );
 
   const openAddProjectFlow = useCallback(() => {
-    if (addProjectFlowOpenRef.current) {
+    if (addProjectFlowBaseDepthRef.current !== null) {
       return;
     }
     if (addProjectEnvironmentOptions.length > 1) {
-      addProjectFlowOpenRef.current = true;
+      markAddProjectFlowOpen();
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: addProjectEnvironmentGroups,
@@ -1134,12 +1149,13 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
 
-    addProjectFlowOpenRef.current = true;
+    markAddProjectFlowOpen();
     void startAddProjectSourceSelection(environmentId);
   }, [
     addProjectEnvironmentGroups,
     addProjectEnvironmentOptions.length,
     defaultAddProjectEnvironmentId,
+    markAddProjectFlowOpen,
     startAddProjectSourceSelection,
   ]);
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -940,6 +940,7 @@ function OpenCommandPaletteDialog(props: {
 
   const startAddProjectBrowse = useCallback(
     (environmentId: EnvironmentId): void => {
+      addProjectFlowOpenRef.current = true;
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
       pushPaletteView({
@@ -953,6 +954,7 @@ function OpenCommandPaletteDialog(props: {
 
   const startAddProjectClone = useCallback(
     (environmentId: EnvironmentId, source: AddProjectRemoteSource): void => {
+      addProjectFlowOpenRef.current = true;
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow({ step: "repository", environmentId, source });
       pushPaletteView({
@@ -1065,6 +1067,7 @@ function OpenCommandPaletteDialog(props: {
 
   const startAddProjectSourceSelection = useCallback(
     (environmentId: EnvironmentId): void => {
+      addProjectFlowOpenRef.current = true;
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
       pushPaletteView({

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -74,7 +74,7 @@ import {
   isUnsupportedWindowsProjectPath,
   resolveProjectPathForDispatch,
 } from "../lib/projectPaths";
-import { onOpenCommandPalette } from "../commandPaletteBus";
+import { isCommandPaletteOpen, onOpenCommandPalette } from "../commandPaletteBus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { getLatestThreadForProject, sortThreads } from "../lib/threadSort";
 import { cn, isMacPlatform, isWindowsPlatform, newProjectId } from "../lib/utils";
@@ -421,7 +421,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       if (
         !shouldHandleCommandPaletteShortcut({
           command,
-          paletteOpen: state.open,
+          paletteOpen: isCommandPaletteOpen(),
           editableTarget: target !== null,
         })
       ) {
@@ -437,7 +437,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, openAddProject, state.open, terminalOpen, toggleOpen]);
+  }, [keybindings, openAddProject, terminalOpen, toggleOpen]);
 
   useEffect(
     () =>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -89,6 +89,7 @@ import {
 import {
   ADDON_ICON_CLASS,
   buildBrowseGroups,
+  buildNewThreadInGroups,
   buildProjectActionItems,
   buildRootGroups,
   buildThreadActionItems,
@@ -102,6 +103,7 @@ import {
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
+  resetAddProjectFlowState,
   shouldHandleCommandPaletteShortcut,
   shouldResetPaletteFlowOnPop,
 } from "./CommandPalette.logic";
@@ -901,6 +903,18 @@ function OpenCommandPaletteDialog(props: {
   );
   const recentThreadItems = allThreadItems.slice(0, RECENT_THREAD_LIMIT);
 
+  const resetAddProjectFlow = useCallback((): void => {
+    resetAddProjectFlowState({
+      flowBaseDepthRef: addProjectFlowBaseDepthRef,
+      clearEnvironment: () => {
+        setAddProjectEnvironmentId(null);
+      },
+      clearCloneFlow: () => {
+        setAddProjectCloneFlow(null);
+      },
+    });
+  }, []);
+
   function pushPaletteView(view: CommandPaletteView): void {
     setViewStack((previousViews) => [
       ...previousViews,
@@ -923,13 +937,13 @@ function OpenCommandPaletteDialog(props: {
   }
 
   function popView(): void {
-    setAddProjectCloneFlow(null);
     if (
       viewStack.length <= 1 ||
       shouldResetPaletteFlowOnPop(addProjectFlowBaseDepthRef.current, viewStack.length)
     ) {
-      setAddProjectEnvironmentId(null);
-      addProjectFlowBaseDepthRef.current = null;
+      resetAddProjectFlow();
+    } else {
+      setAddProjectCloneFlow(null);
     }
     setViewStack((previousViews) => previousViews.slice(0, -1));
     setHighlightedItemValue(null);
@@ -1159,6 +1173,39 @@ function OpenCommandPaletteDialog(props: {
     startAddProjectSourceSelection,
   ]);
 
+  const addProjectAction = useMemo<CommandPaletteActionItem>(
+    () => ({
+      kind: "action",
+      value: "action:add-project",
+      searchTerms: [
+        "add project",
+        "folder",
+        "directory",
+        "browse",
+        "clone",
+        "remote",
+        "repository",
+        "repo",
+        "git",
+        "github",
+        "gitlab",
+        "bitbucket",
+        "azure",
+        "devops",
+        "url",
+        "environment",
+      ],
+      title: "Add project",
+      icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
+      shortcutCommand: "project.add",
+      keepOpen: true,
+      run: async () => {
+        openAddProjectFlow();
+      },
+    }),
+    [openAddProjectFlow],
+  );
+
   useLayoutEffect(() => {
     if (openIntent?.kind !== "add-project") {
       return;
@@ -1172,7 +1219,7 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
     clearOpenIntent();
-    setAddProjectCloneFlow(null);
+    resetAddProjectFlow();
     setViewStack([]);
     setQuery("");
     const currentPrefix =
@@ -1187,52 +1234,22 @@ function OpenCommandPaletteDialog(props: {
       : projectThreadItems;
     pushPaletteView({
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [
-        {
-          value: "projects",
-          label: "Projects",
-          items: enumerateCommandPaletteItems(prioritized),
-        },
-      ],
+      groups: buildNewThreadInGroups({
+        projectItems: enumerateCommandPaletteItems(prioritized),
+        addProjectAction,
+      }),
     });
   }, [
+    addProjectAction,
     clearOpenIntent,
     currentProjectEnvironmentId,
     currentProjectId,
     openIntent,
     projectThreadItems,
+    resetAddProjectFlow,
   ]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
-  const addProjectAction: CommandPaletteActionItem = {
-    kind: "action",
-    value: "action:add-project",
-    searchTerms: [
-      "add project",
-      "folder",
-      "directory",
-      "browse",
-      "clone",
-      "remote",
-      "repository",
-      "repo",
-      "git",
-      "github",
-      "gitlab",
-      "bitbucket",
-      "azure",
-      "devops",
-      "url",
-      "environment",
-    ],
-    title: "Add project",
-    icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
-    shortcutCommand: "project.add",
-    keepOpen: true,
-    run: async () => {
-      openAddProjectFlow();
-    },
-  };
 
   if (projects.length > 0) {
     const activeProjectTitle =
@@ -1269,10 +1286,7 @@ function OpenCommandPaletteDialog(props: {
       title: "New thread in...",
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [
-        { value: "projects", label: "Projects", items: projectThreadItems },
-        { value: "actions", label: "Actions", items: [addProjectAction] },
-      ],
+      groups: buildNewThreadInGroups({ projectItems: projectThreadItems, addProjectAction }),
     });
   }
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -380,19 +380,6 @@ function reduceCommandPaletteUiState(
   }
 }
 
-function isEditableKeyboardTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  return (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    target instanceof HTMLSelectElement ||
-    target.isContentEditable ||
-    target.closest('[contenteditable]:not([contenteditable="false"])') !== null
-  );
-}
-
 export function CommandPalette({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reduceCommandPaletteUiState, {
     open: false,
@@ -434,12 +421,10 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       if (
         !shouldHandleCommandPaletteShortcut({
           command,
+          paletteOpen: state.open,
           editableTarget: target !== null,
         })
       ) {
-        return;
-      }
-      if (command === "project.add" && isEditableKeyboardTarget(event.target)) {
         return;
       }
       event.preventDefault();
@@ -452,7 +437,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keybindings, openAddProject, terminalOpen, toggleOpen]);
+  }, [keybindings, openAddProject, state.open, terminalOpen, toggleOpen]);
 
   useEffect(
     () =>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -377,6 +377,19 @@ function reduceCommandPaletteUiState(
   }
 }
 
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    target.isContentEditable ||
+    target.closest('[contenteditable]:not([contenteditable="false"])') !== null
+  );
+}
+
 export function CommandPalette({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reduceCommandPaletteUiState, {
     open: false,
@@ -402,7 +415,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.defaultPrevented) return;
+      if (event.defaultPrevented || event.repeat) return;
       const command = resolveShortcutCommand(event, keybindings, {
         context: {
           terminalFocus: isTerminalFocused(),
@@ -421,6 +434,9 @@ export function CommandPalette({ children }: { children: ReactNode }) {
           editableTarget: target !== null,
         })
       ) {
+        return;
+      }
+      if (command === "project.add" && isEditableKeyboardTarget(event.target)) {
         return;
       }
       event.preventDefault();
@@ -516,6 +532,7 @@ function OpenCommandPaletteDialog(props: {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const providers = useAtomValue(primaryServerProvidersAtom);
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
+  const addProjectFlowOpenRef = useRef(false);
   const currentView = viewStack.at(-1) ?? null;
   const [browseGeneration, setBrowseGeneration] = useState(0);
   const [addProjectEnvironmentId, setAddProjectEnvironmentId] = useState<EnvironmentId | null>(
@@ -906,6 +923,7 @@ function OpenCommandPaletteDialog(props: {
     setAddProjectCloneFlow(null);
     if (viewStack.length <= 1) {
       setAddProjectEnvironmentId(null);
+      addProjectFlowOpenRef.current = false;
     }
     setViewStack((previousViews) => previousViews.slice(0, -1));
     setHighlightedItemValue(null);
@@ -1089,7 +1107,11 @@ function OpenCommandPaletteDialog(props: {
   );
 
   const openAddProjectFlow = useCallback(() => {
+    if (addProjectFlowOpenRef.current) {
+      return;
+    }
     if (addProjectEnvironmentOptions.length > 1) {
+      addProjectFlowOpenRef.current = true;
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: addProjectEnvironmentGroups,
@@ -1109,6 +1131,7 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
 
+    addProjectFlowOpenRef.current = true;
     void startAddProjectSourceSelection(environmentId);
   }, [
     addProjectEnvironmentGroups,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -126,7 +126,14 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
   {
-    shortcut: modShortcut("a", { altKey: true }),
+    shortcut: {
+      key: "a",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+      modKey: false,
+    },
     command: "project.add",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
@@ -332,7 +339,7 @@ describe("shortcutLabelForCommand", () => {
       shortcutLabelForCommand(DEFAULT_BINDINGS, "commandPalette.toggle", "MacIntel"),
       "⌘K",
     );
-    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "project.add", "MacIntel"), "⌥⌘A");
+    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "project.add", "MacIntel"), "⌥A");
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "modelPicker.toggle", "Linux"),
       "Ctrl+Shift+M",
@@ -522,14 +529,14 @@ describe("chat/editor shortcuts", () => {
 
   it("matches project.add shortcut outside terminal focus", () => {
     assert.strictEqual(
-      resolveShortcutCommand(event({ key: "a", metaKey: true, altKey: true }), DEFAULT_BINDINGS, {
+      resolveShortcutCommand(event({ key: "å", code: "KeyA", altKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
         context: { terminalFocus: false },
       }),
       "project.add",
     );
     assert.notStrictEqual(
-      resolveShortcutCommand(event({ key: "a", metaKey: true, altKey: true }), DEFAULT_BINDINGS, {
+      resolveShortcutCommand(event({ key: "å", code: "KeyA", altKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",
         context: { terminalFocus: true },
       }),

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -125,6 +125,11 @@ const DEFAULT_BINDINGS = compile([
   },
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
+  {
+    shortcut: modShortcut("a", { altKey: true }),
+    command: "project.add",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
@@ -327,6 +332,7 @@ describe("shortcutLabelForCommand", () => {
       shortcutLabelForCommand(DEFAULT_BINDINGS, "commandPalette.toggle", "MacIntel"),
       "⌘K",
     );
+    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "project.add", "MacIntel"), "⌥⌘A");
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "modelPicker.toggle", "Linux"),
       "Ctrl+Shift+M",
@@ -511,6 +517,23 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
       "commandPalette.toggle",
+    );
+  });
+
+  it("matches project.add shortcut outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "a", metaKey: true, altKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "project.add",
+    );
+    assert.notStrictEqual(
+      resolveShortcutCommand(event({ key: "a", metaKey: true, altKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+      "project.add",
     );
   });
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -65,6 +65,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
 
+    const parsedAddProject = yield* decode(KeybindingRule, {
+      key: "mod+alt+a",
+      command: "project.add",
+    });
+    assert.strictEqual(parsedAddProject.command, "project.add");
+
     const parsedModelPickerToggle = yield* decode(KeybindingRule, {
       key: "mod+shift+m",
       command: "modelPicker.toggle",

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -66,7 +66,7 @@ it.effect("parses keybinding rules", () =>
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
 
     const parsedAddProject = yield* decode(KeybindingRule, {
-      key: "mod+alt+a",
+      key: "alt+a",
       command: "project.add",
     });
     assert.strictEqual(parsedAddProject.command, "project.add");

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -66,6 +66,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "composer.stash",
   "chat.new",
   "chat.newLocal",
+  "project.add",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -39,7 +39,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
-  { key: "mod+alt+a", command: "project.add", when: "!terminalFocus" },
+  { key: "alt+a", command: "project.add", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -39,6 +39,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  { key: "mod+alt+a", command: "project.add", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },


### PR DESCRIPTION
## Summary

- add **Add project** to the **New thread in…** view
- introduce the configurable `project.add` keybinding with a default of `alt+a`
- route the shortcut through the existing command-palette add-project flow and show the effective binding beside the action

## Why

T3 Code already models user-facing shortcuts as named, configurable commands. Using that same system keeps shortcut conflict resolution, per-user overrides, and the Keybindings settings UI consistent instead of hard-coding a palette-only key. Plain `Alt+A` is unused by the app; `Ctrl+A` remains available for standard Select All behavior.

## Validation

- `vp test packages/contracts/src/keybindings.test.ts apps/web/src/keybindings.test.ts apps/server/src/keybindings.test.ts`
- `vp check`
- `vp run typecheck`

## Exact-head evidence

Revalidated at ac10e74ae628 on current main (9a0a07167f06): focused tests, vp check, and vp run typecheck passed. The capture uses only disposable local projects.

![Alt+A opens the Add project flow](https://github.com/user-attachments/assets/d275380a-1a34-4d34-8388-5d4ffe378063)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and keybinding changes only; no auth or data-layer changes. Main risk is Alt+A conflicting with typing in the palette search when open, which is intentional.
> 
> **Overview**
> Adds a new **`project.add`** keybinding command (default **`alt+a`**, disabled in terminal focus) across contracts, shared defaults, and server config, so users can rebind it like other shortcuts.
> 
> The command palette’s global key handler now routes **`project.add`** into the existing add-project flow (not only **`commandPalette.toggle`**), with **`shouldHandleCommandPaletteShortcut`** so **Alt+A** does not steal focus from editors unless the palette is already open; key repeat is ignored.
> 
> **Add project** is surfaced in **New thread in…** via **`buildNewThreadInGroups`** with the binding shown on the action. The add-project wizard tracks stack depth to avoid reopening while active and fully resets clone/environment state when backing out to the parent view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad869d760054e86debf115ed5ced676f9b56e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `project.add` shortcut (Alt+A) to open the add-project flow
> - Registers `project.add` as a new static keybinding command with a default `alt+a` binding (outside terminal focus) in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/4258/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06) and [keybindings.ts](https://github.com/pingdotgg/t3code/pull/4258/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6).
> - The global keydown handler in [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/4258/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) now opens the add-project flow when `project.add` fires, skipping editable targets unless the palette is already open.
> - The `New thread in...` submenu now includes an `Add project` action with the shortcut displayed alongside the project list.
> - Add-project flow tracks its stack depth via `addProjectFlowBaseDepthRef` to prevent duplicate openings and resets state when the user pops back to or above that depth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dad869d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->