### PR TITLE
Add search to new-thread project picker

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,7 +1,10 @@
 import type { ScopedProjectRef } from "@t3tools/contracts";
-import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
-import { FolderPlusIcon } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import {
+  scopedProjectKey,
+  scopeProjectRef,
+} from "@t3tools/client-runtime/environment";
+import { FolderPlusIcon, SearchIcon } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 
 import { openCommandPalette } from "~/commandPaletteBus";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
@@ -15,14 +18,15 @@ import { useProjects, useThreadShells } from "~/state/entities";
 import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuRadioGroup,
-  MenuRadioItem,
-  MenuSeparator,
-  MenuTrigger,
-} from "../ui/menu";
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+  ComboboxTrigger,
+} from "../ui/combobox";
+import { filterDraftHeroProjects } from "./draftHeroProjectSearch";
 
 interface DraftHeroHeadlineProps {
   readonly activeProjectRef: ScopedProjectRef | null;
@@ -37,15 +41,27 @@ export function DraftHeroHeadline({
   const threads = useThreadShells();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const projectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
+  const projectGroupingSettings = useClientSettings(
+    selectProjectGroupingSettings,
+  );
+  const projectSortOrder = useClientSettings(
+    (settings) => settings.sidebarProjectSortOrder,
+  );
   const handleNewThread = useNewThreadHandler();
-  const openAddProject = useCallback(() => openCommandPalette({ open: "add-project" }), []);
+  const openAddProject = useCallback(
+    () => openCommandPalette({ open: "add-project" }),
+    [],
+  );
+  const [isProjectPickerOpen, setIsProjectPickerOpen] = useState(false);
+  const [projectQuery, setProjectQuery] = useState("");
 
   const environmentLabelById = useMemo(
     () =>
       new Map(
-        environments.map((environment) => [environment.environmentId, environment.label] as const),
+        environments.map(
+          (environment) =>
+            [environment.environmentId, environment.label] as const,
+        ),
       ),
     [environments],
   );
@@ -80,60 +96,128 @@ export function DraftHeroHeadline({
     [activeProjectRef, projectGroups],
   );
   const projectEntryByKey = useMemo(
-    () => new Map(projectPickerEntries.map((entry) => [entry.group.projectKey, entry] as const)),
+    () =>
+      new Map(
+        projectPickerEntries.map(
+          (entry) => [entry.group.projectKey, entry] as const,
+        ),
+      ),
     [projectPickerEntries],
+  );
+  const filteredProjectEntries = useMemo(
+    () =>
+      filterDraftHeroProjects(
+        projectPickerEntries.map((entry) => ({
+          entry,
+          title: entry.group.displayName,
+          workspaceRoot: entry.targetProject.workspaceRoot,
+        })),
+        projectQuery,
+      ).map(({ entry }) => entry),
+    [projectPickerEntries, projectQuery],
   );
   const activeProjectGroup =
     activeProjectRef === null
       ? null
       : (projectGroups.find((group) =>
           group.memberProjectRefs.some(
-            (projectRef) => scopedProjectKey(projectRef) === scopedProjectKey(activeProjectRef),
+            (projectRef) =>
+              scopedProjectKey(projectRef) ===
+              scopedProjectKey(activeProjectRef),
           ),
         ) ?? null);
   const activeProjectKey = activeProjectGroup?.projectKey ?? "";
-  const activeProjectDisplayName = activeProjectGroup?.displayName ?? activeProjectTitle;
+  const activeProjectDisplayName =
+    activeProjectGroup?.displayName ?? activeProjectTitle;
   const hasResolvedProject = activeProjectTitle !== null;
   const canChooseProject = projectPickerEntries.length > 0;
   const shouldShowProjectMenu = canChooseProject;
 
   const projectSelector = shouldShowProjectMenu ? (
-    <Menu>
-      <MenuTrigger
+    <Combobox
+      autoHighlight
+      items={projectPickerEntries.map(({ group }) => group.projectKey)}
+      filteredItems={filteredProjectEntries.map(
+        ({ group }) => group.projectKey,
+      )}
+      open={isProjectPickerOpen}
+      value={activeProjectKey}
+      onOpenChange={(open) => {
+        setIsProjectPickerOpen(open);
+        if (!open) {
+          setProjectQuery("");
+        }
+      }}
+      onValueChange={(value) => {
+        if (!value || value === activeProjectKey) {
+          setIsProjectPickerOpen(false);
+          return;
+        }
+        const entry = projectEntryByKey.get(value);
+        if (!entry) {
+          return;
+        }
+        setIsProjectPickerOpen(false);
+        const project = entry.targetProject;
+        void handleNewThread(
+          scopeProjectRef(project.environmentId, project.id),
+          {
+            replace: true,
+          },
+        );
+      }}
+    >
+      <ComboboxTrigger
         aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
         className="pointer-events-auto inline cursor-pointer border-current border-b border-dotted text-foreground underline-offset-8 transition-opacity hover:opacity-75 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
       >
         {activeProjectDisplayName ?? "Choose a project"}
-      </MenuTrigger>
-      <MenuPopup align="center" className="max-h-80 w-64 overflow-y-auto">
-        <MenuRadioGroup
-          value={activeProjectKey}
-          onValueChange={(value) => {
-            const entry = projectEntryByKey.get(value as string);
-            if (!entry || value === activeProjectKey) {
-              return;
-            }
-            const project = entry.targetProject;
-            void handleNewThread(scopeProjectRef(project.environmentId, project.id), {
-              replace: true,
-            });
-          }}
-        >
-          {projectPickerEntries.map(({ group }) => {
+      </ComboboxTrigger>
+      <ComboboxPopup align="center" className="w-72 max-w-[calc(100vw-1rem)]">
+        <div className="shrink-0 px-3 pt-2.5">
+          <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
+            <SearchIcon
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1.5 left-0 size-4 text-muted-foreground/55"
+            />
+            <ComboboxInput
+              autoFocus
+              className="[&_input]:h-6.5 [&_input]:ps-5 [&_input]:font-sans [&_input]:leading-6.5"
+              inputClassName="rounded-none bg-transparent text-sm"
+              placeholder="Search projects..."
+              showTrigger={false}
+              size="sm"
+              unstyled
+              value={projectQuery}
+              onChange={(event) => setProjectQuery(event.target.value)}
+            />
+          </div>
+        </div>
+        <ComboboxEmpty>No matching projects.</ComboboxEmpty>
+        <ComboboxList className="max-h-64">
+          {filteredProjectEntries.map(({ group }) => {
             return (
-              <MenuRadioItem key={group.projectKey} value={group.projectKey} closeOnClick>
+              <ComboboxItem key={group.projectKey} value={group.projectKey}>
                 <span className="min-w-0 truncate">{group.displayName}</span>
-              </MenuRadioItem>
+              </ComboboxItem>
             );
           })}
-        </MenuRadioGroup>
-        <MenuSeparator />
-        <MenuItem onClick={openAddProject}>
-          <FolderPlusIcon />
-          New project
-        </MenuItem>
-      </MenuPopup>
-    </Menu>
+        </ComboboxList>
+        <div className="border-t border-border/70 p-1">
+          <button
+            type="button"
+            className="flex min-h-8 w-full cursor-default items-center gap-2 rounded-sm px-2 py-1 text-left text-base text-foreground outline-none hover:bg-accent focus-visible:bg-accent sm:min-h-7 sm:text-sm"
+            onClick={() => {
+              setIsProjectPickerOpen(false);
+              openAddProject();
+            }}
+          >
+            <FolderPlusIcon />
+            New project
+          </button>
+        </div>
+      </ComboboxPopup>
+    </Combobox>
   ) : (
     <button
       type="button"

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,8 +1,5 @@
 import type { ScopedProjectRef } from "@t3tools/contracts";
-import {
-  scopedProjectKey,
-  scopeProjectRef,
-} from "@t3tools/client-runtime/environment";
+import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { FolderPlusIcon, SearchIcon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
@@ -26,7 +23,7 @@ import {
   ComboboxPopup,
   ComboboxTrigger,
 } from "../ui/combobox";
-import { filterDraftHeroProjects } from "./draftHeroProjectSearch";
+import { filterDraftHeroProjects, isImeCommitKey } from "./draftHeroProjectSearch";
 
 interface DraftHeroHeadlineProps {
   readonly activeProjectRef: ScopedProjectRef | null;
@@ -41,27 +38,17 @@ export function DraftHeroHeadline({
   const threads = useThreadShells();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const projectGroupingSettings = useClientSettings(
-    selectProjectGroupingSettings,
-  );
-  const projectSortOrder = useClientSettings(
-    (settings) => settings.sidebarProjectSortOrder,
-  );
+  const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const projectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const handleNewThread = useNewThreadHandler();
-  const openAddProject = useCallback(
-    () => openCommandPalette({ open: "add-project" }),
-    [],
-  );
+  const openAddProject = useCallback(() => openCommandPalette({ open: "add-project" }), []);
   const [isProjectPickerOpen, setIsProjectPickerOpen] = useState(false);
   const [projectQuery, setProjectQuery] = useState("");
 
   const environmentLabelById = useMemo(
     () =>
       new Map(
-        environments.map(
-          (environment) =>
-            [environment.environmentId, environment.label] as const,
-        ),
+        environments.map((environment) => [environment.environmentId, environment.label] as const),
       ),
     [environments],
   );
@@ -96,12 +83,7 @@ export function DraftHeroHeadline({
     [activeProjectRef, projectGroups],
   );
   const projectEntryByKey = useMemo(
-    () =>
-      new Map(
-        projectPickerEntries.map(
-          (entry) => [entry.group.projectKey, entry] as const,
-        ),
-      ),
+    () => new Map(projectPickerEntries.map((entry) => [entry.group.projectKey, entry] as const)),
     [projectPickerEntries],
   );
   const filteredProjectEntries = useMemo(
@@ -111,6 +93,10 @@ export function DraftHeroHeadline({
           entry,
           title: entry.group.displayName,
           workspaceRoot: entry.targetProject.workspaceRoot,
+          searchTerms: entry.group.memberProjects.flatMap((project) => [
+            project.title,
+            project.workspaceRoot,
+          ]),
         })),
         projectQuery,
       ).map(({ entry }) => entry),
@@ -121,14 +107,11 @@ export function DraftHeroHeadline({
       ? null
       : (projectGroups.find((group) =>
           group.memberProjectRefs.some(
-            (projectRef) =>
-              scopedProjectKey(projectRef) ===
-              scopedProjectKey(activeProjectRef),
+            (projectRef) => scopedProjectKey(projectRef) === scopedProjectKey(activeProjectRef),
           ),
         ) ?? null);
   const activeProjectKey = activeProjectGroup?.projectKey ?? "";
-  const activeProjectDisplayName =
-    activeProjectGroup?.displayName ?? activeProjectTitle;
+  const activeProjectDisplayName = activeProjectGroup?.displayName ?? activeProjectTitle;
   const hasResolvedProject = activeProjectTitle !== null;
   const canChooseProject = projectPickerEntries.length > 0;
   const shouldShowProjectMenu = canChooseProject;
@@ -137,9 +120,7 @@ export function DraftHeroHeadline({
     <Combobox
       autoHighlight
       items={projectPickerEntries.map(({ group }) => group.projectKey)}
-      filteredItems={filteredProjectEntries.map(
-        ({ group }) => group.projectKey,
-      )}
+      filteredItems={filteredProjectEntries.map(({ group }) => group.projectKey)}
       open={isProjectPickerOpen}
       value={activeProjectKey}
       onOpenChange={(open) => {
@@ -159,12 +140,9 @@ export function DraftHeroHeadline({
         }
         setIsProjectPickerOpen(false);
         const project = entry.targetProject;
-        void handleNewThread(
-          scopeProjectRef(project.environmentId, project.id),
-          {
-            replace: true,
-          },
-        );
+        void handleNewThread(scopeProjectRef(project.environmentId, project.id), {
+          replace: true,
+        });
       }}
     >
       <ComboboxTrigger
@@ -190,6 +168,18 @@ export function DraftHeroHeadline({
               unstyled
               value={projectQuery}
               onChange={(event) => setProjectQuery(event.target.value)}
+              onKeyDownCapture={(event) => {
+                if (
+                  isImeCommitKey({
+                    key: event.key,
+                    isComposing: event.nativeEvent.isComposing,
+                    keyCode: event.nativeEvent.keyCode,
+                  })
+                ) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              }}
             />
           </div>
         </div>

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -176,7 +176,8 @@ export function DraftHeroHeadline({
                     keyCode: event.nativeEvent.keyCode,
                   })
                 ) {
-                  event.preventDefault();
+                  // Keep the browser's default so Enter can commit the IME
+                  // text; stopping propagation only blocks Combobox selection.
                   event.stopPropagation();
                 }
               }}

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,7 +1,7 @@
 import type { ScopedProjectRef } from "@t3tools/contracts";
 import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { FolderPlusIcon, SearchIcon } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useReducer } from "react";
 
 import { openCommandPalette } from "~/commandPaletteBus";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
@@ -27,6 +27,7 @@ import {
   filterDraftHeroProjects,
   isImeCommitKey,
   isVisibleDraftHeroProjectSelection,
+  reduceDraftHeroProjectPickerState,
 } from "./draftHeroProjectSearch";
 
 interface DraftHeroHeadlineProps {
@@ -46,8 +47,11 @@ export function DraftHeroHeadline({
   const projectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const handleNewThread = useNewThreadHandler();
   const openAddProject = useCallback(() => openCommandPalette({ open: "add-project" }), []);
-  const [isProjectPickerOpen, setIsProjectPickerOpen] = useState(false);
-  const [projectQuery, setProjectQuery] = useState("");
+  const [projectPickerState, dispatchProjectPicker] = useReducer(
+    reduceDraftHeroProjectPickerState,
+    { open: false, query: "" },
+  );
+  const { open: isProjectPickerOpen, query: projectQuery } = projectPickerState;
 
   const environmentLabelById = useMemo(
     () =>
@@ -128,14 +132,11 @@ export function DraftHeroHeadline({
       open={isProjectPickerOpen}
       value={activeProjectKey}
       onOpenChange={(open) => {
-        setIsProjectPickerOpen(open);
-        if (!open) {
-          setProjectQuery("");
-        }
+        dispatchProjectPicker({ type: "set-open", open });
       }}
       onValueChange={(value) => {
         if (!value || value === activeProjectKey) {
-          setIsProjectPickerOpen(false);
+          dispatchProjectPicker({ type: "set-open", open: false });
           return;
         }
         if (
@@ -150,7 +151,7 @@ export function DraftHeroHeadline({
         if (!entry) {
           return;
         }
-        setIsProjectPickerOpen(false);
+        dispatchProjectPicker({ type: "set-open", open: false });
         const project = entry.targetProject;
         void handleNewThread(scopeProjectRef(project.environmentId, project.id), {
           replace: true,
@@ -179,7 +180,9 @@ export function DraftHeroHeadline({
               size="sm"
               unstyled
               value={projectQuery}
-              onChange={(event) => setProjectQuery(event.target.value)}
+              onChange={(event) =>
+                dispatchProjectPicker({ type: "set-query", query: event.target.value })
+              }
               onKeyDownCapture={(event) => {
                 if (
                   isImeCommitKey({
@@ -211,7 +214,7 @@ export function DraftHeroHeadline({
             type="button"
             className="flex min-h-8 w-full cursor-default items-center gap-2 rounded-sm px-2 py-1 text-left text-base text-foreground outline-none hover:bg-accent focus-visible:bg-accent sm:min-h-7 sm:text-sm"
             onClick={() => {
-              setIsProjectPickerOpen(false);
+              dispatchProjectPicker({ type: "set-open", open: false });
               openAddProject();
             }}
           >

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,7 +1,7 @@
 import type { ScopedProjectRef } from "@t3tools/contracts";
 import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { FolderPlusIcon, SearchIcon } from "lucide-react";
-import { useCallback, useMemo, useReducer } from "react";
+import { useCallback, useMemo, useReducer, useRef } from "react";
 
 import { openCommandPalette } from "~/commandPaletteBus";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
@@ -16,7 +16,6 @@ import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
   Combobox,
-  ComboboxEmpty,
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
@@ -35,6 +34,8 @@ interface DraftHeroHeadlineProps {
   readonly activeProjectTitle: string | null;
 }
 
+const NEW_PROJECT_ITEM_KEY_BASE = "__draft-hero-new-project__";
+
 export function DraftHeroHeadline({
   activeProjectRef,
   activeProjectTitle,
@@ -52,6 +53,7 @@ export function DraftHeroHeadline({
     { open: false, query: "" },
   );
   const { open: isProjectPickerOpen, query: projectQuery } = projectPickerState;
+  const newProjectSelectionIntentRef = useRef(false);
 
   const environmentLabelById = useMemo(
     () =>
@@ -110,6 +112,30 @@ export function DraftHeroHeadline({
       ).map(({ entry }) => entry),
     [projectPickerEntries, projectQuery],
   );
+  const projectPickerItemKeys = useMemo(
+    () => projectPickerEntries.map(({ group }) => group.projectKey),
+    [projectPickerEntries],
+  );
+  const filteredProjectItemKeys = useMemo(
+    () => filteredProjectEntries.map(({ group }) => group.projectKey),
+    [filteredProjectEntries],
+  );
+  const newProjectItemKey = useMemo(() => {
+    const projectKeys = new Set(projectPickerItemKeys);
+    let key = NEW_PROJECT_ITEM_KEY_BASE;
+    while (projectKeys.has(key)) {
+      key += "_";
+    }
+    return key;
+  }, [projectPickerItemKeys]);
+  const projectPickerComboboxItems = useMemo(
+    () => [...projectPickerItemKeys, newProjectItemKey],
+    [newProjectItemKey, projectPickerItemKeys],
+  );
+  const filteredProjectComboboxItems = useMemo(
+    () => [...filteredProjectItemKeys, newProjectItemKey],
+    [filteredProjectItemKeys, newProjectItemKey],
+  );
   const activeProjectGroup =
     activeProjectRef === null
       ? null
@@ -126,25 +152,31 @@ export function DraftHeroHeadline({
 
   const projectSelector = shouldShowProjectMenu ? (
     <Combobox
-      autoHighlight
-      items={projectPickerEntries.map(({ group }) => group.projectKey)}
-      filteredItems={filteredProjectEntries.map(({ group }) => group.projectKey)}
+      autoHighlight={filteredProjectEntries.length > 0}
+      filter={null}
+      items={projectPickerComboboxItems}
+      filteredItems={filteredProjectComboboxItems}
       open={isProjectPickerOpen}
       value={activeProjectKey}
       onOpenChange={(open) => {
+        newProjectSelectionIntentRef.current = false;
         dispatchProjectPicker({ type: "set-open", open });
       }}
       onValueChange={(value) => {
+        if (value === newProjectItemKey) {
+          if (!newProjectSelectionIntentRef.current) {
+            return;
+          }
+          newProjectSelectionIntentRef.current = false;
+          dispatchProjectPicker({ type: "set-open", open: false });
+          openAddProject();
+          return;
+        }
         if (!value || value === activeProjectKey) {
           dispatchProjectPicker({ type: "set-open", open: false });
           return;
         }
-        if (
-          !isVisibleDraftHeroProjectSelection(
-            value,
-            filteredProjectEntries.map(({ group }) => group.projectKey),
-          )
-        ) {
+        if (!isVisibleDraftHeroProjectSelection(value, filteredProjectItemKeys)) {
           return;
         }
         const entry = projectEntryByKey.get(value);
@@ -180,27 +212,39 @@ export function DraftHeroHeadline({
               size="sm"
               unstyled
               value={projectQuery}
-              onChange={(event) =>
-                dispatchProjectPicker({ type: "set-query", query: event.target.value })
-              }
+              onChange={(event) => {
+                newProjectSelectionIntentRef.current = false;
+                dispatchProjectPicker({ type: "set-query", query: event.target.value });
+              }}
               onKeyDownCapture={(event) => {
-                if (
-                  isImeCommitKey({
-                    key: event.key,
-                    isComposing: event.nativeEvent.isComposing,
-                    keyCode: event.nativeEvent.keyCode,
-                  })
-                ) {
+                const keyboardEvent = {
+                  key: event.key,
+                  isComposing: event.nativeEvent.isComposing,
+                  keyCode: event.nativeEvent.keyCode,
+                };
+                if (isImeCommitKey(keyboardEvent)) {
                   // Keep the browser's default so Enter can commit the IME
                   // text; stopping propagation only blocks Combobox selection.
                   event.stopPropagation();
+                  return;
+                }
+                if (
+                  !keyboardEvent.isComposing &&
+                  keyboardEvent.keyCode !== 229 &&
+                  (event.key === "ArrowDown" || event.key === "ArrowUp")
+                ) {
+                  newProjectSelectionIntentRef.current = true;
                 }
               }}
             />
           </div>
         </div>
-        <ComboboxEmpty>No matching projects.</ComboboxEmpty>
         <ComboboxList className="max-h-64">
+          {filteredProjectEntries.length === 0 && (
+            <div className="p-2 text-center text-base text-muted-foreground sm:text-sm">
+              No matching projects.
+            </div>
+          )}
           {filteredProjectEntries.map(({ group }) => {
             return (
               <ComboboxItem key={group.projectKey} value={group.projectKey}>
@@ -208,20 +252,17 @@ export function DraftHeroHeadline({
               </ComboboxItem>
             );
           })}
-        </ComboboxList>
-        <div className="border-t border-border/70 p-1">
-          <button
-            type="button"
-            className="flex min-h-8 w-full cursor-default items-center gap-2 rounded-sm px-2 py-1 text-left text-base text-foreground outline-none hover:bg-accent focus-visible:bg-accent sm:min-h-7 sm:text-sm"
-            onClick={() => {
-              dispatchProjectPicker({ type: "set-open", open: false });
-              openAddProject();
+          <ComboboxItem
+            className="sticky bottom-0 z-10 mt-1 gap-2 border-t border-border/70 bg-popover"
+            value={newProjectItemKey}
+            onPointerDown={() => {
+              newProjectSelectionIntentRef.current = true;
             }}
           >
             <FolderPlusIcon />
             New project
-          </button>
-        </div>
+          </ComboboxItem>
+        </ComboboxList>
       </ComboboxPopup>
     </Combobox>
   ) : (

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -23,7 +23,11 @@ import {
   ComboboxPopup,
   ComboboxTrigger,
 } from "../ui/combobox";
-import { filterDraftHeroProjects, isImeCommitKey } from "./draftHeroProjectSearch";
+import {
+  filterDraftHeroProjects,
+  isImeCommitKey,
+  isVisibleDraftHeroProjectSelection,
+} from "./draftHeroProjectSearch";
 
 interface DraftHeroHeadlineProps {
   readonly activeProjectRef: ScopedProjectRef | null;
@@ -132,6 +136,14 @@ export function DraftHeroHeadline({
       onValueChange={(value) => {
         if (!value || value === activeProjectKey) {
           setIsProjectPickerOpen(false);
+          return;
+        }
+        if (
+          !isVisibleDraftHeroProjectSelection(
+            value,
+            filteredProjectEntries.map(({ group }) => group.projectKey),
+          )
+        ) {
           return;
         }
         const entry = projectEntryByKey.get(value);

--- a/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
-import { filterDraftHeroProjects } from "./draftHeroProjectSearch";
+import { filterDraftHeroProjects, isImeCommitKey } from "./draftHeroProjectSearch";
 
 const projects = [
   { title: "T3 Code", workspaceRoot: "/work/t3code" },
@@ -25,7 +25,50 @@ describe("filterDraftHeroProjects", () => {
     ).toEqual(["Marketing Site"]);
   });
 
+  it("uses locale-independent case folding", () => {
+    const localeFold = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(() => {
+      throw new Error("locale-sensitive folding must not be used");
+    });
+
+    try {
+      expect(
+        filterDraftHeroProjects([{ title: "Internal", workspaceRoot: "/work/internal" }], "i"),
+      ).toHaveLength(1);
+    } finally {
+      localeFold.mockRestore();
+    }
+  });
+
+  it("matches titles and paths from every grouped project member", () => {
+    const groupedProjects = [
+      {
+        title: "T3 Code",
+        workspaceRoot: "/work/t3code",
+        searchTerms: ["T3 Code Remote", "/home/remote/t3code", "T3 Code WSL", "/mnt/c/code/t3code"],
+      },
+    ];
+
+    expect(
+      filterDraftHeroProjects(groupedProjects, "remote").map((project) => project.title),
+    ).toEqual(["T3 Code"]);
+    expect(
+      filterDraftHeroProjects(groupedProjects, "/mnt/c").map((project) => project.title),
+    ).toEqual(["T3 Code"]);
+  });
+
   it("preserves candidate order for an empty query", () => {
     expect(filterDraftHeroProjects(projects, "   ")).toEqual(projects);
+  });
+});
+
+describe("isImeCommitKey", () => {
+  it("recognizes Enter during composition, including the legacy keyCode signal", () => {
+    expect(isImeCommitKey({ key: "Enter", isComposing: true, keyCode: 13 })).toBe(true);
+    expect(isImeCommitKey({ key: "Enter", isComposing: false, keyCode: 229 })).toBe(true);
+  });
+
+  it("does not block ordinary Enter or other composing keys", () => {
+    expect(isImeCommitKey({ key: "Enter", isComposing: false, keyCode: 13 })).toBe(false);
+    expect(isImeCommitKey({ key: "a", isComposing: true, keyCode: 229 })).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { filterDraftHeroProjects } from "./draftHeroProjectSearch";
+
+const projects = [
+  { title: "T3 Code", workspaceRoot: "/work/t3code" },
+  { title: "Mobile App", workspaceRoot: "/work/products/mobile" },
+  { title: "Marketing Site", workspaceRoot: "/work/products/marketing" },
+];
+
+describe("filterDraftHeroProjects", () => {
+  it("narrows candidates as the title query becomes more specific", () => {
+    expect(filterDraftHeroProjects(projects, "m").map((project) => project.title)).toEqual([
+      "Mobile App",
+      "Marketing Site",
+    ]);
+    expect(filterDraftHeroProjects(projects, "mob").map((project) => project.title)).toEqual([
+      "Mobile App",
+    ]);
+  });
+
+  it("matches project paths and multiple query tokens", () => {
+    expect(
+      filterDraftHeroProjects(projects, "products market").map((project) => project.title),
+    ).toEqual(["Marketing Site"]);
+  });
+
+  it("preserves candidate order for an empty query", () => {
+    expect(filterDraftHeroProjects(projects, "   ")).toEqual(projects);
+  });
+});

--- a/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { filterDraftHeroProjects, isImeCommitKey } from "./draftHeroProjectSearch";
+import {
+  filterDraftHeroProjects,
+  isImeCommitKey,
+  isVisibleDraftHeroProjectSelection,
+} from "./draftHeroProjectSearch";
 
 const projects = [
   { title: "T3 Code", workspaceRoot: "/work/t3code" },
@@ -70,5 +74,17 @@ describe("isImeCommitKey", () => {
   it("does not block ordinary Enter or other composing keys", () => {
     expect(isImeCommitKey({ key: "Enter", isComposing: false, keyCode: 13 })).toBe(false);
     expect(isImeCommitKey({ key: "a", isComposing: true, keyCode: 229 })).toBe(false);
+  });
+});
+
+describe("isVisibleDraftHeroProjectSelection", () => {
+  it("rejects a stale highlighted project when filtering has no results", () => {
+    expect(isVisibleDraftHeroProjectSelection("project:t3code", [])).toBe(false);
+  });
+
+  it("allows a project that remains in the filtered results", () => {
+    expect(
+      isVisibleDraftHeroProjectSelection("project:t3code", ["project:mobile", "project:t3code"]),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.test.ts
@@ -4,6 +4,7 @@ import {
   filterDraftHeroProjects,
   isImeCommitKey,
   isVisibleDraftHeroProjectSelection,
+  reduceDraftHeroProjectPickerState,
 } from "./draftHeroProjectSearch";
 
 const projects = [
@@ -11,6 +12,17 @@ const projects = [
   { title: "Mobile App", workspaceRoot: "/work/products/mobile" },
   { title: "Marketing Site", workspaceRoot: "/work/products/marketing" },
 ];
+
+describe("reduceDraftHeroProjectPickerState", () => {
+  it("clears the search query whenever the picker closes", () => {
+    expect(
+      reduceDraftHeroProjectPickerState(
+        { open: true, query: "mobile" },
+        { type: "set-open", open: false },
+      ),
+    ).toEqual({ open: false, query: "" });
+  });
+});
 
 describe("filterDraftHeroProjects", () => {
   it("narrows candidates as the title query becomes more specific", () => {

--- a/apps/web/src/components/chat/draftHeroProjectSearch.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.ts
@@ -1,20 +1,31 @@
 type SearchableProject = {
   readonly title: string;
   readonly workspaceRoot: string;
+  readonly searchTerms?: ReadonlyArray<string>;
 };
+
+export function isImeCommitKey(input: {
+  readonly key: string;
+  readonly isComposing: boolean;
+  readonly keyCode: number;
+}): boolean {
+  return input.key === "Enter" && (input.isComposing || input.keyCode === 229);
+}
 
 export function filterDraftHeroProjects<T extends SearchableProject>(
   projects: ReadonlyArray<T>,
   query: string,
 ): T[] {
-  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
 
   if (tokens.length === 0) {
     return [...projects];
   }
 
   return projects.filter((project) => {
-    const searchText = `${project.title}\n${project.workspaceRoot}`.toLocaleLowerCase();
+    const searchText = [project.title, project.workspaceRoot, ...(project.searchTerms ?? [])]
+      .join("\n")
+      .toLowerCase();
     return tokens.every((token) => searchText.includes(token));
   });
 }

--- a/apps/web/src/components/chat/draftHeroProjectSearch.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.ts
@@ -1,0 +1,20 @@
+type SearchableProject = {
+  readonly title: string;
+  readonly workspaceRoot: string;
+};
+
+export function filterDraftHeroProjects<T extends SearchableProject>(
+  projects: ReadonlyArray<T>,
+  query: string,
+): T[] {
+  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+
+  if (tokens.length === 0) {
+    return [...projects];
+  }
+
+  return projects.filter((project) => {
+    const searchText = `${project.title}\n${project.workspaceRoot}`.toLocaleLowerCase();
+    return tokens.every((token) => searchText.includes(token));
+  });
+}

--- a/apps/web/src/components/chat/draftHeroProjectSearch.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.ts
@@ -29,3 +29,10 @@ export function filterDraftHeroProjects<T extends SearchableProject>(
     return tokens.every((token) => searchText.includes(token));
   });
 }
+
+export function isVisibleDraftHeroProjectSelection(
+  value: string,
+  filteredProjectKeys: ReadonlyArray<string>,
+): boolean {
+  return filteredProjectKeys.includes(value);
+}

--- a/apps/web/src/components/chat/draftHeroProjectSearch.ts
+++ b/apps/web/src/components/chat/draftHeroProjectSearch.ts
@@ -4,6 +4,29 @@ type SearchableProject = {
   readonly searchTerms?: ReadonlyArray<string>;
 };
 
+export type DraftHeroProjectPickerState = {
+  readonly open: boolean;
+  readonly query: string;
+};
+
+export type DraftHeroProjectPickerAction =
+  | { readonly type: "set-open"; readonly open: boolean }
+  | { readonly type: "set-query"; readonly query: string };
+
+export function reduceDraftHeroProjectPickerState(
+  state: DraftHeroProjectPickerState,
+  action: DraftHeroProjectPickerAction,
+): DraftHeroProjectPickerState {
+  if (action.type === "set-query") {
+    return { ...state, query: action.query };
+  }
+
+  return {
+    open: action.open,
+    query: action.open ? state.query : "",
+  };
+}
+
 export function isImeCommitKey(input: {
   readonly key: string;
   readonly isComposing: boolean;


### PR DESCRIPTION
## Summary

- replace the new-thread project menu with a searchable picker
- narrow candidates incrementally by project name or workspace path as the user types
- auto-highlight the first remaining candidate so Enter selects it
- preserve the existing New project action

## Verification

- `vp test run src/components/chat/draftHeroProjectSearch.test.ts --project unit`
- `vp lint` and `vp fmt` on the changed files
- `pnpm run typecheck` in `apps/web`

Isolated exact-head browser verification of incremental search completed against disposable projects; the server and test data were stopped and removed afterward.

## Exact-head evidence

Revalidated at 064fa4bb9fc2 on current main (9a0a07167f06): focused tests, vp check, and vp run typecheck passed. The capture uses only disposable local projects.

![Searchable new-thread project picker filtered to Cedar Docs](https://github.com/user-attachments/assets/897ad9d9-5cc6-4ef9-9fa2-df7ac7e6b628)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to project selection on the new-thread draft hero, with logic covered by unit tests and no auth or data-path changes.
> 
> **Overview**
> Replaces the draft hero **project menu** with a **searchable combobox** so users can narrow projects by name or workspace path while starting a new thread.
> 
> Filtering is **client-side** via new `draftHeroProjectSearch` helpers: multi-token matching (including grouped member titles/paths), picker state that **clears the query on close**, guards so stale highlights cannot switch projects after filtering, and **IME-safe Enter** handling in the search field. The combobox uses **auto-highlight** on the first match for keyboard selection; **New project** stays as a sticky footer action and only fires after explicit keyboard or pointer intent so it does not steal focus from search.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3408bb2266fe1021d5e97fb984a402728c024fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add search to the new-thread project picker in `DraftHeroHeadline`
> - Replaces the menu-based project selector with a searchable combobox in [`DraftHeroHeadline.tsx`](https://github.com/pingdotgg/t3code/pull/4259/files#diff-59395eb8416aacb935e49426b6445ebb8ce3ab54f9d16bd99ed27d0e85a60ec7), filtering projects by title, workspace root, and group member search terms.
> - Adds [`draftHeroProjectSearch.ts`](https://github.com/pingdotgg/t3code/pull/4259/files#diff-f77b7b0d23ce0a36f7da51e66128836f834cfc44b5ad07c3144303d53c475d0d) with a reducer for `{open, query}` state (query clears on close), a multi-token case-insensitive filter, an IME Enter detection util, and a visibility guard to prevent acting on selections no longer in filtered results.
> - The "New project" action is a sticky item at the bottom of the list with collision-safe key generation; it requires keyboard navigation intent before it can be selected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3408bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- exact-stack-evidence-20260724 -->
## Current combined-stack UI evidence (2026-07-24)

Captured from PR head `a1e3bc69a67caa3ffe6e2afa1fad5bbd65097782` on upstream main `ece05087a70e94efcd57441337fa1249559362ba`, using combined integration `4dd4cef40` and package `/nix/store/pf7fjqw8ykkdgayf3ywsbgxxp6wi1m42-t3code-0.0.29-patched-main-20260724`.

The animation shows the draft project picker filtering incrementally to Canvas Components and Enter selecting the only visible result. All names and paths are disposable seed data.

![Searchable draft project picker interaction](https://raw.githubusercontent.com/colonelpanic8/t3code/7611b3e06348aa5e4314c5ea5d8a563469fdf2c9/pr-4259/search-interaction.gif)

![Searchable draft project picker filtered to Cedar Docs](https://raw.githubusercontent.com/colonelpanic8/t3code/7611b3e06348aa5e4314c5ea5d8a563469fdf2c9/pr-4259/search-cedar.png)
<!-- /exact-stack-evidence-20260724 -->
