### PR TITLE
Unify the new thread project picker

### DIFF
--- a/apps/web/src/commandPaletteBus.ts
+++ b/apps/web/src/commandPaletteBus.ts
@@ -1,9 +1,13 @@
+import type { ScopedProjectRef } from "@t3tools/contracts";
+
 // Tiny event bus allowing components to programmatically open the command palette
 // without owning its React state.
 const COMMAND_PALETTE_OPEN_EVENT = "t3code:open-command-palette";
+const COMMAND_PALETTE_CLOSE_EVENT = "t3code:close-command-palette";
 
 export interface CommandPaletteOpenDetail {
   readonly open?: "add-project" | "new-thread-in";
+  readonly preferredProjectRef?: ScopedProjectRef | null;
 }
 
 export function openCommandPalette(detail?: CommandPaletteOpenDetail): void {
@@ -20,6 +24,15 @@ export function onOpenCommandPalette(
   };
   window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, handler);
   return () => window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, handler);
+}
+
+export function closeCommandPalette(): void {
+  window.dispatchEvent(new Event(COMMAND_PALETTE_CLOSE_EVENT));
+}
+
+export function onCloseCommandPalette(listener: () => void): () => void {
+  window.addEventListener(COMMAND_PALETTE_CLOSE_EVENT, listener);
+  return () => window.removeEventListener(COMMAND_PALETTE_CLOSE_EVENT, listener);
 }
 
 /** Read at event time so consumers do not subscribe to transient dialog state. */

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
+  buildNewThreadPickerGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  prioritizeCommandPaletteItem,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -31,6 +33,110 @@ describe("enumerateCommandPaletteItems", () => {
       "thread.jump.8",
       "thread.jump.9",
       undefined,
+    ]);
+  });
+});
+
+const makeActionItem = (value: string) => ({
+  kind: "action" as const,
+  value,
+  searchTerms: [],
+  title: value,
+  icon: null,
+  run: async () => undefined,
+});
+
+describe("prioritizeCommandPaletteItem", () => {
+  it("moves the preferred item to the front without disturbing the remaining order", () => {
+    const items = [makeActionItem("first"), makeActionItem("second"), makeActionItem("third")];
+
+    expect(prioritizeCommandPaletteItem(items, "third").map((item) => item.value)).toEqual([
+      "third",
+      "first",
+      "second",
+    ]);
+    expect(prioritizeCommandPaletteItem(items, "missing")).toEqual(items);
+  });
+});
+
+describe("buildNewThreadPickerGroups", () => {
+  const addProjectItem = makeActionItem("action:add-project");
+
+  it("waits for projects before showing an empty picker", () => {
+    expect(
+      buildNewThreadPickerGroups({
+        projectItems: [],
+        addProjectItem,
+        areProjectsLoading: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps Add project keyboard-addressable after project choices", () => {
+    const projectItem = makeActionItem("new-thread-in:environment-local:project-1");
+
+    expect(
+      buildNewThreadPickerGroups({
+        projectItems: [projectItem],
+        addProjectItem,
+        areProjectsLoading: false,
+      }).map((group) => ({
+        value: group.value,
+        items: group.items.map((item) => item.value),
+      })),
+    ).toEqual([
+      {
+        value: "new-thread-projects",
+        items: ["new-thread-in:environment-local:project-1"],
+      },
+      { value: "new-thread-actions", items: ["action:add-project"] },
+    ]);
+  });
+
+  it("offers Add project when loading completes without projects", () => {
+    expect(
+      buildNewThreadPickerGroups({
+        projectItems: [],
+        addProjectItem,
+        areProjectsLoading: false,
+      }),
+    ).toEqual([
+      {
+        value: "new-thread-actions",
+        label: "Actions",
+        items: [addProjectItem],
+      },
+    ]);
+  });
+});
+
+describe("filterCommandPaletteGroups", () => {
+  it("keeps dedicated picker actions visible for the actions-only filter", () => {
+    const addProjectItem = {
+      ...makeActionItem("action:add-project"),
+      searchTerms: ["add project"],
+    };
+
+    expect(
+      filterCommandPaletteGroups({
+        activeGroups: [
+          {
+            value: "new-thread-actions",
+            label: "Actions",
+            items: [addProjectItem],
+          },
+        ],
+        query: ">",
+        isInSubmenu: true,
+        projectSearchItems: [],
+        threadSearchItems: [],
+      }),
+    ).toEqual([
+      {
+        value: "new-thread-actions",
+        label: "Actions",
+        items: [addProjectItem],
+      },
     ]);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -6,7 +6,6 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
-  prioritizeCommandPaletteItem,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -44,19 +43,6 @@ const makeActionItem = (value: string) => ({
   title: value,
   icon: null,
   run: async () => undefined,
-});
-
-describe("prioritizeCommandPaletteItem", () => {
-  it("moves the preferred item to the front without disturbing the remaining order", () => {
-    const items = [makeActionItem("first"), makeActionItem("second"), makeActionItem("third")];
-
-    expect(prioritizeCommandPaletteItem(items, "third").map((item) => item.value)).toEqual([
-      "third",
-      "first",
-      "second",
-    ]);
-    expect(prioritizeCommandPaletteItem(items, "missing")).toEqual(items);
-  });
 });
 
 describe("buildNewThreadPickerGroups", () => {

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -6,6 +6,7 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  shouldClearAddProjectEnvironmentOnPop,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -93,6 +94,28 @@ describe("buildNewThreadPickerGroups", () => {
         items: [addProjectItem],
       },
     ]);
+  });
+});
+
+describe("shouldClearAddProjectEnvironmentOnPop", () => {
+  it("clears the selected environment when returning from source selection", () => {
+    expect(
+      shouldClearAddProjectEnvironmentOnPop({
+        viewStackDepth: 2,
+        currentGroupValue: "sources:environment-local",
+        addProjectEnvironmentId: "environment-local",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the selected environment while returning to source selection", () => {
+    expect(
+      shouldClearAddProjectEnvironmentOnPop({
+        viewStackDepth: 3,
+        currentGroupValue: undefined,
+        addProjectEnvironmentId: "environment-local",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -6,6 +6,7 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  resolveCommandPaletteEmptyStateMessage,
   shouldClearAddProjectEnvironmentOnPop,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
@@ -94,6 +95,39 @@ describe("buildNewThreadPickerGroups", () => {
         items: [addProjectItem],
       },
     ]);
+  });
+});
+
+describe("resolveCommandPaletteEmptyStateMessage", () => {
+  it("keeps browse/create guidance when the new-thread picker has no projects", () => {
+    expect(
+      resolveCommandPaletteEmptyStateMessage({
+        contextualMessage: "Press Enter to create this folder and add it as a project.",
+        isNewThreadProjectPickerView: true,
+        projectCount: 0,
+        allEnvironmentShellsBootstrapped: true,
+        query: "/work/new-project",
+      }),
+    ).toBe("Press Enter to create this folder and add it as a project.");
+  });
+
+  it("uses zero-project guidance only when no more specific state applies", () => {
+    expect(
+      resolveCommandPaletteEmptyStateMessage({
+        isNewThreadProjectPickerView: true,
+        projectCount: 0,
+        allEnvironmentShellsBootstrapped: true,
+        query: "",
+      }),
+    ).toBe("No projects yet. Add a project to start a thread.");
+    expect(
+      resolveCommandPaletteEmptyStateMessage({
+        isNewThreadProjectPickerView: true,
+        projectCount: 0,
+        allEnvironmentShellsBootstrapped: false,
+        query: "",
+      }),
+    ).toBe("Loading projects…");
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -92,6 +92,18 @@ export function buildNewThreadPickerGroups(input: {
   return groups;
 }
 
+export function shouldClearAddProjectEnvironmentOnPop(input: {
+  viewStackDepth: number;
+  currentGroupValue: string | undefined;
+  addProjectEnvironmentId: string | null;
+}): boolean {
+  return (
+    input.viewStackDepth <= 1 ||
+    (input.addProjectEnvironmentId !== null &&
+      input.currentGroupValue === `sources:${input.addProjectEnvironmentId}`)
+  );
+}
+
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
 export function filterBrowseEntries(input: {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -92,6 +92,27 @@ export function buildNewThreadPickerGroups(input: {
   return groups;
 }
 
+export function resolveCommandPaletteEmptyStateMessage(input: {
+  readonly contextualMessage?: string;
+  readonly isNewThreadProjectPickerView: boolean;
+  readonly projectCount: number;
+  readonly allEnvironmentShellsBootstrapped: boolean;
+  readonly query: string;
+}): string | undefined {
+  if (input.contextualMessage) {
+    return input.contextualMessage;
+  }
+  if (!input.isNewThreadProjectPickerView || input.projectCount > 0) {
+    return undefined;
+  }
+  if (!input.allEnvironmentShellsBootstrapped) {
+    return "Loading projects…";
+  }
+  return input.query.trim().length === 0
+    ? "No projects yet. Add a project to start a thread."
+    : undefined;
+}
+
 export function shouldClearAddProjectEnvironmentOnPop(input: {
   viewStackDepth: number;
   currentGroupValue: string | undefined;

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -14,6 +14,7 @@ import { type Project, type SidebarThreadSummary, type Thread } from "../types";
 export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-muted-foreground/80";
 export const ADDON_ICON_CLASS = "size-4";
+export const NEW_THREAD_PROJECT_VIEW_GROUP = "new-thread-projects";
 
 export interface CommandPaletteItem {
   readonly kind: "action" | "submenu";
@@ -66,6 +67,43 @@ export function enumerateCommandPaletteItems(
     const { shortcutCommand: _shortcutCommand, ...itemWithoutShortcut } = item;
     return itemWithoutShortcut;
   });
+}
+
+export function prioritizeCommandPaletteItem(
+  items: ReadonlyArray<CommandPaletteActionItem>,
+  preferredValue: string | null,
+): CommandPaletteActionItem[] {
+  if (preferredValue === null) return [...items];
+
+  const preferredIndex = items.findIndex((item) => item.value === preferredValue);
+  if (preferredIndex <= 0) return [...items];
+
+  const preferredItem = items[preferredIndex];
+  if (preferredItem === undefined) return [...items];
+  return [preferredItem, ...items.slice(0, preferredIndex), ...items.slice(preferredIndex + 1)];
+}
+
+export function buildNewThreadPickerGroups(input: {
+  projectItems: ReadonlyArray<CommandPaletteActionItem>;
+  addProjectItem: CommandPaletteActionItem;
+  areProjectsLoading: boolean;
+}): CommandPaletteGroup[] {
+  if (input.areProjectsLoading && input.projectItems.length === 0) return [];
+
+  const groups: CommandPaletteGroup[] = [];
+  if (input.projectItems.length > 0) {
+    groups.push({
+      value: NEW_THREAD_PROJECT_VIEW_GROUP,
+      label: "Projects",
+      items: input.projectItems,
+    });
+  }
+  groups.push({
+    value: "new-thread-actions",
+    label: "Actions",
+    items: [input.addProjectItem],
+  });
+  return groups;
 }
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
@@ -229,6 +267,10 @@ function rankCommandPaletteItemMatch(
   return 0;
 }
 
+function isCommandPaletteActionGroup(group: CommandPaletteGroup): boolean {
+  return group.value === "actions" || group.value === "new-thread-actions";
+}
+
 export function filterCommandPaletteGroups(input: {
   activeGroups: ReadonlyArray<CommandPaletteGroup>;
   query: string;
@@ -242,14 +284,14 @@ export function filterCommandPaletteGroups(input: {
 
   if (normalizedQuery.length === 0) {
     if (isActionsFilter) {
-      return input.activeGroups.filter((group) => group.value === "actions");
+      return input.activeGroups.filter(isCommandPaletteActionGroup);
     }
     return [...input.activeGroups];
   }
 
   let baseGroups = [...input.activeGroups];
   if (isActionsFilter) {
-    baseGroups = baseGroups.filter((group) => group.value === "actions");
+    baseGroups = baseGroups.filter(isCommandPaletteActionGroup);
   } else if (!input.isInSubmenu) {
     baseGroups = baseGroups.filter((group) => group.value !== "recent-threads");
   }

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -69,20 +69,6 @@ export function enumerateCommandPaletteItems(
   });
 }
 
-export function prioritizeCommandPaletteItem(
-  items: ReadonlyArray<CommandPaletteActionItem>,
-  preferredValue: string | null,
-): CommandPaletteActionItem[] {
-  if (preferredValue === null) return [...items];
-
-  const preferredIndex = items.findIndex((item) => item.value === preferredValue);
-  if (preferredIndex <= 0) return [...items];
-
-  const preferredItem = items[preferredIndex];
-  if (preferredItem === undefined) return [...items];
-  return [preferredItem, ...items.slice(0, preferredIndex), ...items.slice(preferredIndex + 1)];
-}
-
 export function buildNewThreadPickerGroups(input: {
   projectItems: ReadonlyArray<CommandPaletteActionItem>;
   addProjectItem: CommandPaletteActionItem;

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -334,6 +334,10 @@ export function filterCommandPaletteGroups(input: {
   }
 
   return searchableGroups.flatMap((group) => {
+    if (!isActionsFilter && group.value === "new-thread-actions") {
+      return [{ value: group.value, label: group.label, items: [...group.items] }];
+    }
+
     const items = Arr.filterMap(group.items, (item, index) => {
       const haystack = normalizeSearchText(item.searchTerms.join(" "));
       if (!haystack.includes(normalizedQuery)) {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -11,6 +11,7 @@ import {
   type EnvironmentId,
   type FilesystemBrowseResult,
   type ProjectId,
+  type ScopedProjectRef,
   type SourceControlDiscoveryResult,
   type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
@@ -57,7 +58,11 @@ import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import {
+  useAllEnvironmentShellsBootstrapped,
+  useProjects,
+  useThreadShells,
+} from "../state/entities";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
@@ -74,7 +79,7 @@ import {
   isUnsupportedWindowsProjectPath,
   resolveProjectPathForDispatch,
 } from "../lib/projectPaths";
-import { onOpenCommandPalette } from "../commandPaletteBus";
+import { onCloseCommandPalette, onOpenCommandPalette } from "../commandPaletteBus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { getLatestThreadForProject, sortThreads } from "../lib/threadSort";
 import { cn, isMacPlatform, isWindowsPlatform, newProjectId } from "../lib/utils";
@@ -89,6 +94,7 @@ import {
 import {
   ADDON_ICON_CLASS,
   buildBrowseGroups,
+  buildNewThreadPickerGroups,
   buildProjectActionItems,
   buildRootGroups,
   buildThreadActionItems,
@@ -101,6 +107,8 @@ import {
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
+  NEW_THREAD_PROJECT_VIEW_GROUP,
+  prioritizeCommandPaletteItem,
   RECENT_THREAD_LIMIT,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
@@ -339,9 +347,12 @@ function errorMessage(error: unknown): string {
   return "An error occurred.";
 }
 
-interface CommandPaletteOpenIntent {
-  readonly kind: "add-project" | "new-thread-in";
-}
+type CommandPaletteOpenIntent =
+  | { readonly kind: "add-project" }
+  | {
+      readonly kind: "new-thread-in";
+      readonly preferredProjectRef: ScopedProjectRef | null;
+    };
 
 interface CommandPaletteUiState {
   readonly open: boolean;
@@ -352,7 +363,10 @@ type CommandPaletteUiAction =
   | { readonly _tag: "SetOpen"; readonly open: boolean }
   | { readonly _tag: "Toggle" }
   | { readonly _tag: "OpenAddProject" }
-  | { readonly _tag: "OpenNewThreadIn" }
+  | {
+      readonly _tag: "OpenNewThreadIn";
+      readonly preferredProjectRef: ScopedProjectRef | null;
+    }
   | { readonly _tag: "ClearOpenIntent" };
 
 function reduceCommandPaletteUiState(
@@ -370,7 +384,13 @@ function reduceCommandPaletteUiState(
     case "OpenAddProject":
       return { open: true, openIntent: { kind: "add-project" } };
     case "OpenNewThreadIn":
-      return { open: true, openIntent: { kind: "new-thread-in" } };
+      return {
+        open: true,
+        openIntent: {
+          kind: "new-thread-in",
+          preferredProjectRef: action.preferredProjectRef,
+        },
+      };
     case "ClearOpenIntent":
       return state.openIntent ? { ...state, openIntent: null } : state;
   }
@@ -384,7 +404,14 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   const setOpen = useCallback((open: boolean) => dispatch({ _tag: "SetOpen", open }), []);
   const toggleOpen = useCallback(() => dispatch({ _tag: "Toggle" }), []);
   const openAddProject = useCallback(() => dispatch({ _tag: "OpenAddProject" }), []);
-  const openNewThreadIn = useCallback(() => dispatch({ _tag: "OpenNewThreadIn" }), []);
+  const openNewThreadIn = useCallback(
+    (preferredProjectRef?: ScopedProjectRef | null) =>
+      dispatch({
+        _tag: "OpenNewThreadIn",
+        preferredProjectRef: preferredProjectRef ?? null,
+      }),
+    [],
+  );
   const clearOpenIntent = useCallback(() => dispatch({ _tag: "ClearOpenIntent" }), []);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const composerHandleRef = useRef<ChatComposerHandle | null>(null);
@@ -423,7 +450,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
     () =>
       onOpenCommandPalette((detail) => {
         if (detail.open === "new-thread-in") {
-          openNewThreadIn();
+          openNewThreadIn(detail.preferredProjectRef);
         } else if (detail.open === "add-project") {
           openAddProject();
         } else {
@@ -432,6 +459,8 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       }),
     [openAddProject, openNewThreadIn, setOpen],
   );
+
+  useEffect(() => onCloseCommandPalette(() => setOpen(false)), [setOpen]);
 
   return (
     <ComposerHandleContext value={composerHandleRef}>
@@ -495,12 +524,18 @@ function OpenCommandPaletteDialog(props: {
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
+  const allEnvironmentShellsBootstrapped = useAllEnvironmentShellsBootstrapped();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const providers = useAtomValue(primaryServerProvidersAtom);
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
+  const isNewThreadProjectPickerView =
+    currentView?.groups[0]?.value === NEW_THREAD_PROJECT_VIEW_GROUP;
+  const [newThreadPreferredProjectRef, setNewThreadPreferredProjectRef] =
+    useState<ScopedProjectRef | null>(null);
+  const [newThreadPickerGeneration, setNewThreadPickerGeneration] = useState(0);
   const [browseGeneration, setBrowseGeneration] = useState(0);
   const [addProjectEnvironmentId, setAddProjectEnvironmentId] = useState<EnvironmentId | null>(
     null,
@@ -570,6 +605,7 @@ function OpenCommandPaletteDialog(props: {
       }),
     [activeDraftThread, activeThread, defaultProjectRef, handleNewThread],
   );
+  const effectiveNewThreadProjectRef = newThreadPreferredProjectRef ?? contextualProjectRef;
   const projectPickerEntries = useMemo(
     () =>
       buildSidebarProjectPickerEntries({
@@ -578,6 +614,14 @@ function OpenCommandPaletteDialog(props: {
       }),
     [contextualProjectRef, projectGroups],
   );
+  const newThreadProjectPickerEntries = useMemo(
+    () =>
+      buildSidebarProjectPickerEntries({
+        groups: projectGroups,
+        preferredProjectRef: effectiveNewThreadProjectRef,
+      }),
+    [effectiveNewThreadProjectRef, projectGroups],
+  );
   const pickerProjects = useMemo(
     () =>
       projectPickerEntries.map(({ group, targetProject }) => ({
@@ -585,6 +629,14 @@ function OpenCommandPaletteDialog(props: {
         title: group.displayName,
       })),
     [projectPickerEntries],
+  );
+  const newThreadPickerProjects = useMemo(
+    () =>
+      newThreadProjectPickerEntries.map(({ group, targetProject }) => ({
+        ...targetProject,
+        title: group.displayName,
+      })),
+    [newThreadProjectPickerEntries],
   );
   const projectGroupByTargetKey = useMemo(
     () =>
@@ -595,6 +647,16 @@ function OpenCommandPaletteDialog(props: {
         ]),
       ),
     [projectPickerEntries],
+  );
+  const newThreadProjectGroupByTargetKey = useMemo(
+    () =>
+      new Map(
+        newThreadProjectPickerEntries.map(({ group, targetProject }) => [
+          `${targetProject.environmentId}:${targetProject.id}`,
+          group,
+        ]),
+      ),
+    [newThreadProjectPickerEntries],
   );
 
   const addProjectEnvironmentOptions = useMemo(() => {
@@ -805,43 +867,72 @@ function OpenCommandPaletteDialog(props: {
     [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
   );
 
+  const preferredNewThreadItemValue = useMemo(() => {
+    if (newThreadPreferredProjectRef === null) return null;
+
+    const preferredEntry = newThreadProjectPickerEntries.find(({ group }) =>
+      group.memberProjectRefs.some(
+        (projectRef) =>
+          projectRef.environmentId === newThreadPreferredProjectRef.environmentId &&
+          projectRef.projectId === newThreadPreferredProjectRef.projectId,
+      ),
+    );
+    return preferredEntry
+      ? `new-thread-in:${preferredEntry.targetProject.environmentId}:${preferredEntry.targetProject.id}`
+      : null;
+  }, [newThreadPreferredProjectRef, newThreadProjectPickerEntries]);
+
   const projectThreadItems = useMemo(
     () =>
       enumerateCommandPaletteItems(
-        buildProjectActionItems({
-          projects: pickerProjects,
-          valuePrefix: "new-thread-in",
-          searchTerms: (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            return (
-              group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
-            );
-          },
-          icon: (project) => (
-            <ProjectFavicon
-              environmentId={project.environmentId}
-              cwd={project.workspaceRoot}
-              className={ITEM_ICON_CLASS}
-            />
-          ),
-          runProject: async (project) => {
-            const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
-            const contextualRefBelongsToGroup =
-              contextualProjectRef !== null &&
-              group?.memberProjectRefs.some(
-                (projectRef) =>
-                  projectRef.environmentId === contextualProjectRef.environmentId &&
-                  projectRef.projectId === contextualProjectRef.projectId,
+        prioritizeCommandPaletteItem(
+          buildProjectActionItems({
+            projects: newThreadPickerProjects,
+            valuePrefix: "new-thread-in",
+            searchTerms: (project) => {
+              const group = newThreadProjectGroupByTargetKey.get(
+                `${project.environmentId}:${project.id}`,
               );
-            await handleNewThread(
-              contextualRefBelongsToGroup
-                ? contextualProjectRef
-                : scopeProjectRef(project.environmentId, project.id),
-            );
-          },
-        }),
+              return (
+                group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ??
+                []
+              );
+            },
+            icon: (project) => (
+              <ProjectFavicon
+                environmentId={project.environmentId}
+                cwd={project.workspaceRoot}
+                className={ITEM_ICON_CLASS}
+              />
+            ),
+            runProject: async (project) => {
+              const group = newThreadProjectGroupByTargetKey.get(
+                `${project.environmentId}:${project.id}`,
+              );
+              const preferredRefBelongsToGroup =
+                effectiveNewThreadProjectRef !== null &&
+                group?.memberProjectRefs.some(
+                  (projectRef) =>
+                    projectRef.environmentId === effectiveNewThreadProjectRef.environmentId &&
+                    projectRef.projectId === effectiveNewThreadProjectRef.projectId,
+                );
+              await handleNewThread(
+                preferredRefBelongsToGroup
+                  ? effectiveNewThreadProjectRef
+                  : scopeProjectRef(project.environmentId, project.id),
+              );
+            },
+          }),
+          preferredNewThreadItemValue,
+        ),
       ),
-    [contextualProjectRef, handleNewThread, pickerProjects, projectGroupByTargetKey],
+    [
+      effectiveNewThreadProjectRef,
+      handleNewThread,
+      newThreadPickerProjects,
+      newThreadProjectGroupByTargetKey,
+      preferredNewThreadItemValue,
+    ],
   );
 
   const allThreadItems = useMemo(
@@ -879,6 +970,9 @@ function OpenCommandPaletteDialog(props: {
   }
 
   function pushView(item: CommandPaletteSubmenuItem): void {
+    if (item.groups[0]?.value === NEW_THREAD_PROJECT_VIEW_GROUP) {
+      setNewThreadPreferredProjectRef(null);
+    }
     pushPaletteView({
       addonIcon: item.addonIcon,
       groups: item.groups,
@@ -888,6 +982,9 @@ function OpenCommandPaletteDialog(props: {
 
   function popView(): void {
     setAddProjectCloneFlow(null);
+    if (isNewThreadProjectPickerView) {
+      setNewThreadPreferredProjectRef(null);
+    }
     if (viewStack.length <= 1) {
       setAddProjectEnvironmentId(null);
     }
@@ -1101,92 +1198,7 @@ function OpenCommandPaletteDialog(props: {
     startAddProjectSourceSelection,
   ]);
 
-  useLayoutEffect(() => {
-    if (openIntent?.kind !== "add-project") {
-      return;
-    }
-    clearOpenIntent();
-    openAddProjectFlow();
-  }, [clearOpenIntent, openAddProjectFlow, openIntent]);
-
-  useLayoutEffect(() => {
-    if (openIntent?.kind !== "new-thread-in" || projectThreadItems.length === 0) {
-      return;
-    }
-    clearOpenIntent();
-    setAddProjectCloneFlow(null);
-    setViewStack([]);
-    setQuery("");
-    const currentPrefix =
-      currentProjectEnvironmentId && currentProjectId
-        ? `new-thread-in:${currentProjectEnvironmentId}:${currentProjectId}`
-        : null;
-    const prioritized = currentPrefix
-      ? [
-          ...projectThreadItems.filter((item) => item.value === currentPrefix),
-          ...projectThreadItems.filter((item) => item.value !== currentPrefix),
-        ]
-      : projectThreadItems;
-    pushPaletteView({
-      addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [
-        {
-          value: "projects",
-          label: "Projects",
-          items: enumerateCommandPaletteItems(prioritized),
-        },
-      ],
-    });
-  }, [
-    clearOpenIntent,
-    currentProjectEnvironmentId,
-    currentProjectId,
-    openIntent,
-    projectThreadItems,
-  ]);
-
-  const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
-
-  if (projects.length > 0) {
-    const activeProjectTitle =
-      projectPickerEntries.find((entry) => entry.isPreferred)?.group.displayName ??
-      (currentProjectId ? (projectTitleById.get(currentProjectId) ?? null) : null);
-
-    if (activeProjectTitle) {
-      actionItems.push({
-        kind: "action",
-        value: "action:new-thread",
-        searchTerms: ["new thread", "chat", "create", "draft"],
-        title: (
-          <>
-            New thread in <span className="font-semibold">{activeProjectTitle}</span>
-          </>
-        ),
-        icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
-        shortcutCommand: "chat.new",
-        run: async () => {
-          await startNewThreadFromContext({
-            activeDraftThread,
-            activeThread: activeThread ?? undefined,
-            defaultProjectRef,
-            handleNewThread,
-          });
-        },
-      });
-    }
-
-    actionItems.push({
-      kind: "submenu",
-      value: "action:new-thread-in",
-      searchTerms: ["new thread", "project", "pick", "choose", "select"],
-      title: "New thread in...",
-      icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
-      addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
-    });
-  }
-
-  actionItems.push({
+  const addProjectActionItem: CommandPaletteActionItem = {
     kind: "action",
     value: "action:add-project",
     searchTerms: [
@@ -1213,7 +1225,91 @@ function OpenCommandPaletteDialog(props: {
     run: async () => {
       openAddProjectFlow();
     },
+  };
+  const newThreadPickerGroups = buildNewThreadPickerGroups({
+    projectItems: projectThreadItems,
+    addProjectItem: addProjectActionItem,
+    areProjectsLoading: !allEnvironmentShellsBootstrapped,
   });
+  const newThreadPickerView = useMemo<CommandPaletteView>(
+    () => ({
+      addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
+      groups: [
+        {
+          value: NEW_THREAD_PROJECT_VIEW_GROUP,
+          label: "Projects",
+          items: [],
+        },
+      ],
+    }),
+    [],
+  );
+
+  useLayoutEffect(() => {
+    if (openIntent?.kind !== "add-project") {
+      return;
+    }
+    clearOpenIntent();
+    openAddProjectFlow();
+  }, [clearOpenIntent, openAddProjectFlow, openIntent]);
+
+  useLayoutEffect(() => {
+    if (openIntent?.kind !== "new-thread-in") {
+      return;
+    }
+    setNewThreadPreferredProjectRef(openIntent.preferredProjectRef);
+    clearOpenIntent();
+    setAddProjectEnvironmentId(null);
+    setAddProjectCloneFlow(null);
+    setIsRemoteProjectLookingUp(false);
+    setIsRemoteProjectCloning(false);
+    setViewStack([newThreadPickerView]);
+    setHighlightedItemValue(null);
+    setQuery("");
+    setNewThreadPickerGeneration((generation) => generation + 1);
+  }, [clearOpenIntent, newThreadPickerView, openIntent]);
+
+  const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
+
+  if (projects.length > 0) {
+    const activeProjectTitle =
+      projectPickerEntries.find((entry) => entry.isPreferred)?.group.displayName ??
+      (currentProjectId ? (projectTitleById.get(currentProjectId) ?? null) : null);
+
+    if (activeProjectTitle) {
+      actionItems.push({
+        kind: "action",
+        value: "action:new-thread",
+        searchTerms: ["new thread", "chat", "create", "draft"],
+        title: (
+          <>
+            New thread in <span className="font-semibold">{activeProjectTitle}</span>
+          </>
+        ),
+        icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
+        run: async () => {
+          await startNewThreadFromContext({
+            activeDraftThread,
+            activeThread: activeThread ?? undefined,
+            defaultProjectRef,
+            handleNewThread,
+          });
+        },
+      });
+    }
+
+    actionItems.push({
+      kind: "submenu",
+      value: "action:new-thread-in",
+      searchTerms: ["new thread", "project", "pick", "choose", "select"],
+      title: "New thread in...",
+      icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
+      addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
+      groups: newThreadPickerView.groups,
+    });
+  }
+
+  actionItems.push(addProjectActionItem);
 
   if (wslAddProjectEnvironmentOption) {
     actionItems.push({
@@ -1244,10 +1340,11 @@ function OpenCommandPaletteDialog(props: {
   const rootGroups = buildRootGroups({ actionItems, recentThreadItems });
   const sourceSelectionViewValue =
     addProjectEnvironmentId === null ? null : `sources:${addProjectEnvironmentId}`;
-  const activeGroups =
-    addProjectEnvironmentId !== null &&
-    currentView !== null &&
-    currentView.groups[0]?.value === sourceSelectionViewValue
+  const activeGroups = isNewThreadProjectPickerView
+    ? newThreadPickerGroups
+    : addProjectEnvironmentId !== null &&
+        currentView !== null &&
+        currentView.groups[0]?.value === sourceSelectionViewValue
       ? buildAddProjectSourceGroups(
           addProjectEnvironmentId,
           buildAddProjectRemoteSourceReadiness(sourceControlDiscovery.data),
@@ -1877,7 +1974,7 @@ function OpenCommandPaletteDialog(props: {
       }}
     >
       <Command
-        key={`${viewStack.length}-${browseGeneration}-${isBrowsing}-${addProjectCloneFlow?.step ?? "none"}`}
+        key={`${viewStack.length}-${browseGeneration}-${newThreadPickerGeneration}-${isBrowsing}-${addProjectCloneFlow?.step ?? "none"}`}
         aria-label="Command palette"
         autoHighlight={isBrowsing || isRemoteProjectCloneFlow ? false : "always"}
         mode="none"
@@ -2022,23 +2119,35 @@ function OpenCommandPaletteDialog(props: {
             isActionsOnly={isActionsOnly}
             keybindings={keybindings}
             onExecuteItem={executeItem}
-            {...(addProjectCloneFlow?.step === "repository"
-              ? {
-                  emptyStateMessage:
-                    addProjectCloneFlow.source === "url"
-                      ? "Enter a Git clone URL and press Enter to continue."
-                      : "Enter a repository path and press Enter to look it up.",
-                }
-              : addProjectCloneFlow?.step === "confirm"
-                ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
-                : relativePathNeedsActiveProject
-                  ? { emptyStateMessage: "Relative paths require an active project." }
-                  : willCreateProjectPath
-                    ? {
-                        emptyStateMessage:
-                          "Press Enter to create this folder and add it as a project.",
-                      }
-                    : {})}
+            {...(isNewThreadProjectPickerView &&
+            allEnvironmentShellsBootstrapped &&
+            projects.length === 0 &&
+            query.trim().length === 0
+              ? { leadingMessage: "No projects yet. Add a project to start a thread." }
+              : {})}
+            {...(isNewThreadProjectPickerView && projects.length === 0
+              ? allEnvironmentShellsBootstrapped
+                ? query.trim().length === 0
+                  ? { emptyStateMessage: "No projects yet. Add a project to start a thread." }
+                  : {}
+                : { emptyStateMessage: "Loading projects…" }
+              : addProjectCloneFlow?.step === "repository"
+                ? {
+                    emptyStateMessage:
+                      addProjectCloneFlow.source === "url"
+                        ? "Enter a Git clone URL and press Enter to continue."
+                        : "Enter a repository path and press Enter to look it up.",
+                  }
+                : addProjectCloneFlow?.step === "confirm"
+                  ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
+                  : relativePathNeedsActiveProject
+                    ? { emptyStateMessage: "Relative paths require an active project." }
+                    : willCreateProjectPath
+                      ? {
+                          emptyStateMessage:
+                            "Press Enter to create this folder and add it as a project.",
+                        }
+                      : {})}
           />
         </CommandPanel>
         <CommandFooter className="gap-3 max-sm:flex-col max-sm:items-start">

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -109,6 +109,7 @@ import {
   ITEM_ICON_CLASS,
   NEW_THREAD_PROJECT_VIEW_GROUP,
   RECENT_THREAD_LIMIT,
+  shouldClearAddProjectEnvironmentOnPop,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -964,7 +965,13 @@ function OpenCommandPaletteDialog(props: {
     if (isNewThreadProjectPickerView) {
       setNewThreadPreferredProjectRef(null);
     }
-    if (viewStack.length <= 1) {
+    if (
+      shouldClearAddProjectEnvironmentOnPop({
+        viewStackDepth: viewStack.length,
+        currentGroupValue: currentView?.groups[0]?.value,
+        addProjectEnvironmentId,
+      })
+    ) {
       setAddProjectEnvironmentId(null);
     }
     setViewStack((previousViews) => previousViews.slice(0, -1));

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -108,7 +108,6 @@ import {
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   NEW_THREAD_PROJECT_VIEW_GROUP,
-  prioritizeCommandPaletteItem,
   RECENT_THREAD_LIMIT,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
@@ -867,71 +866,51 @@ function OpenCommandPaletteDialog(props: {
     [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
   );
 
-  const preferredNewThreadItemValue = useMemo(() => {
-    if (newThreadPreferredProjectRef === null) return null;
-
-    const preferredEntry = newThreadProjectPickerEntries.find(({ group }) =>
-      group.memberProjectRefs.some(
-        (projectRef) =>
-          projectRef.environmentId === newThreadPreferredProjectRef.environmentId &&
-          projectRef.projectId === newThreadPreferredProjectRef.projectId,
-      ),
-    );
-    return preferredEntry
-      ? `new-thread-in:${preferredEntry.targetProject.environmentId}:${preferredEntry.targetProject.id}`
-      : null;
-  }, [newThreadPreferredProjectRef, newThreadProjectPickerEntries]);
-
   const projectThreadItems = useMemo(
     () =>
       enumerateCommandPaletteItems(
-        prioritizeCommandPaletteItem(
-          buildProjectActionItems({
-            projects: newThreadPickerProjects,
-            valuePrefix: "new-thread-in",
-            searchTerms: (project) => {
-              const group = newThreadProjectGroupByTargetKey.get(
-                `${project.environmentId}:${project.id}`,
+        buildProjectActionItems({
+          projects: newThreadPickerProjects,
+          valuePrefix: "new-thread-in",
+          searchTerms: (project) => {
+            const group = newThreadProjectGroupByTargetKey.get(
+              `${project.environmentId}:${project.id}`,
+            );
+            return (
+              group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+            );
+          },
+          icon: (project) => (
+            <ProjectFavicon
+              environmentId={project.environmentId}
+              cwd={project.workspaceRoot}
+              className={ITEM_ICON_CLASS}
+            />
+          ),
+          runProject: async (project) => {
+            const group = newThreadProjectGroupByTargetKey.get(
+              `${project.environmentId}:${project.id}`,
+            );
+            const preferredRefBelongsToGroup =
+              effectiveNewThreadProjectRef !== null &&
+              group?.memberProjectRefs.some(
+                (projectRef) =>
+                  projectRef.environmentId === effectiveNewThreadProjectRef.environmentId &&
+                  projectRef.projectId === effectiveNewThreadProjectRef.projectId,
               );
-              return (
-                group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ??
-                []
-              );
-            },
-            icon: (project) => (
-              <ProjectFavicon
-                environmentId={project.environmentId}
-                cwd={project.workspaceRoot}
-                className={ITEM_ICON_CLASS}
-              />
-            ),
-            runProject: async (project) => {
-              const group = newThreadProjectGroupByTargetKey.get(
-                `${project.environmentId}:${project.id}`,
-              );
-              const preferredRefBelongsToGroup =
-                effectiveNewThreadProjectRef !== null &&
-                group?.memberProjectRefs.some(
-                  (projectRef) =>
-                    projectRef.environmentId === effectiveNewThreadProjectRef.environmentId &&
-                    projectRef.projectId === effectiveNewThreadProjectRef.projectId,
-                );
-              await handleNewThread(
-                preferredRefBelongsToGroup
-                  ? effectiveNewThreadProjectRef
-                  : scopeProjectRef(project.environmentId, project.id),
-              );
-            },
-          }),
-          preferredNewThreadItemValue,
-        ),
+            await handleNewThread(
+              preferredRefBelongsToGroup
+                ? effectiveNewThreadProjectRef
+                : scopeProjectRef(project.environmentId, project.id),
+            );
+          },
+        }),
       ),
     [
       effectiveNewThreadProjectRef,
       handleNewThread,
       newThreadPickerProjects,
       newThreadProjectGroupByTargetKey,
-      preferredNewThreadItemValue,
     ],
   );
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -109,6 +109,7 @@ import {
   ITEM_ICON_CLASS,
   NEW_THREAD_PROJECT_VIEW_GROUP,
   RECENT_THREAD_LIMIT,
+  resolveCommandPaletteEmptyStateMessage,
   shouldClearAddProjectEnvironmentOnPop,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
@@ -1945,6 +1946,26 @@ function OpenCommandPaletteDialog(props: {
     primaryEnvironmentId,
   ]);
 
+  const contextualEmptyStateMessage =
+    addProjectCloneFlow?.step === "repository"
+      ? addProjectCloneFlow.source === "url"
+        ? "Enter a Git clone URL and press Enter to continue."
+        : "Enter a repository path and press Enter to look it up."
+      : addProjectCloneFlow?.step === "confirm"
+        ? "Choose a destination path and press Enter to clone."
+        : relativePathNeedsActiveProject
+          ? "Relative paths require an active project."
+          : willCreateProjectPath
+            ? "Press Enter to create this folder and add it as a project."
+            : undefined;
+  const emptyStateMessage = resolveCommandPaletteEmptyStateMessage({
+    ...(contextualEmptyStateMessage ? { contextualMessage: contextualEmptyStateMessage } : {}),
+    isNewThreadProjectPickerView,
+    projectCount: projects.length,
+    allEnvironmentShellsBootstrapped,
+    query,
+  });
+
   return (
     <CommandDialogPopup
       aria-label="Command palette"
@@ -2111,29 +2132,7 @@ function OpenCommandPaletteDialog(props: {
             query.trim().length === 0
               ? { leadingMessage: "No projects yet. Add a project to start a thread." }
               : {})}
-            {...(isNewThreadProjectPickerView && projects.length === 0
-              ? allEnvironmentShellsBootstrapped
-                ? query.trim().length === 0
-                  ? { emptyStateMessage: "No projects yet. Add a project to start a thread." }
-                  : {}
-                : { emptyStateMessage: "Loading projects…" }
-              : addProjectCloneFlow?.step === "repository"
-                ? {
-                    emptyStateMessage:
-                      addProjectCloneFlow.source === "url"
-                        ? "Enter a Git clone URL and press Enter to continue."
-                        : "Enter a repository path and press Enter to look it up.",
-                  }
-                : addProjectCloneFlow?.step === "confirm"
-                  ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
-                  : relativePathNeedsActiveProject
-                    ? { emptyStateMessage: "Relative paths require an active project." }
-                    : willCreateProjectPath
-                      ? {
-                          emptyStateMessage:
-                            "Press Enter to create this folder and add it as a project.",
-                        }
-                      : {})}
+            {...(emptyStateMessage ? { emptyStateMessage } : {})}
           />
         </CommandPanel>
         <CommandFooter className="gap-3 max-sm:flex-col max-sm:items-start">

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -749,7 +749,9 @@ function OpenCommandPaletteDialog(props: {
   const isRemoteProjectCloneFlow = addProjectCloneFlow !== null;
   const isRemoteProjectRepositoryStep = addProjectCloneFlow?.step === "repository";
   const isBrowsing =
-    !isRemoteProjectRepositoryStep && isFilesystemBrowseQuery(query, browseEnvironmentPlatform);
+    !isNewThreadProjectPickerView &&
+    !isRemoteProjectRepositoryStep &&
+    isFilesystemBrowseQuery(query, browseEnvironmentPlatform);
   const paletteMode = getCommandPaletteMode({ currentView, isBrowsing });
   const getAddProjectInitialQueryForEnvironment = useCallback(
     (environmentId: EnvironmentId | null): string => {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -538,6 +538,7 @@ function OpenCommandPaletteDialog(props: {
     currentView?.groups[0]?.value === NEW_THREAD_PROJECT_VIEW_GROUP;
   const [newThreadPreferredProjectRef, setNewThreadPreferredProjectRef] =
     useState<ScopedProjectRef | null>(null);
+  const newThreadPreferredProjectScopeKeyRef = useRef<string | null>(null);
   const [newThreadPickerGeneration, setNewThreadPickerGeneration] = useState(0);
   const [browseGeneration, setBrowseGeneration] = useState(0);
   const [addProjectEnvironmentId, setAddProjectEnvironmentId] = useState<EnvironmentId | null>(
@@ -1260,6 +1261,7 @@ function OpenCommandPaletteDialog(props: {
     if (openIntent?.kind !== "new-thread-in") {
       return;
     }
+    newThreadPreferredProjectScopeKeyRef.current = projectScopeKey;
     setNewThreadPreferredProjectRef(openIntent.preferredProjectRef);
     clearOpenIntent();
     setAddProjectEnvironmentId(null);
@@ -1270,7 +1272,18 @@ function OpenCommandPaletteDialog(props: {
     setHighlightedItemValue(null);
     setQuery("");
     setNewThreadPickerGeneration((generation) => generation + 1);
-  }, [clearOpenIntent, newThreadPickerView, openIntent]);
+  }, [clearOpenIntent, newThreadPickerView, openIntent, projectScopeKey]);
+
+  useLayoutEffect(() => {
+    if (
+      newThreadPreferredProjectRef === null ||
+      newThreadPreferredProjectScopeKeyRef.current === projectScopeKey
+    ) {
+      return;
+    }
+    newThreadPreferredProjectScopeKeyRef.current = projectScopeKey;
+    setNewThreadPreferredProjectRef(null);
+  }, [newThreadPreferredProjectRef, projectScopeKey]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -140,7 +140,9 @@ import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore"
 import {
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  resolveNewThreadPickerProjectRef,
 } from "../sidebarProjectGrouping";
+import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
 
@@ -596,6 +598,14 @@ function OpenCommandPaletteDialog(props: {
       ),
     [clientSettings.sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
+  const projectScopeKey = useSidebarProjectScopeStore((state) => state.projectScopeKey);
+  const scopedProjectGroup = useMemo(
+    () =>
+      projectScopeKey === null
+        ? null
+        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+    [projectGroups, projectScopeKey],
+  );
   const contextualProjectRef = useMemo(
     () =>
       resolveThreadActionProjectRef({
@@ -606,7 +616,11 @@ function OpenCommandPaletteDialog(props: {
       }),
     [activeDraftThread, activeThread, defaultProjectRef, handleNewThread],
   );
-  const effectiveNewThreadProjectRef = newThreadPreferredProjectRef ?? contextualProjectRef;
+  const effectiveNewThreadProjectRef = resolveNewThreadPickerProjectRef({
+    preferredProjectRef: newThreadPreferredProjectRef,
+    scopedProjectGroup,
+    contextualProjectRef,
+  });
   const projectPickerEntries = useMemo(
     () =>
       buildSidebarProjectPickerEntries({

--- a/apps/web/src/components/CommandPaletteResults.tsx
+++ b/apps/web/src/components/CommandPaletteResults.tsx
@@ -18,6 +18,7 @@ import { cn } from "~/lib/utils";
 
 interface CommandPaletteResultsProps {
   emptyStateMessage?: string;
+  leadingMessage?: string;
   groups: ReadonlyArray<CommandPaletteGroup>;
   highlightedItemValue?: string | null;
   isActionsOnly: boolean;
@@ -39,6 +40,9 @@ export function CommandPaletteResults(props: CommandPaletteResultsProps) {
 
   return (
     <CommandList>
+      {props.leadingMessage ? (
+        <div className="px-4 py-3 text-sm text-muted-foreground">{props.leadingMessage}</div>
+      ) : null}
       {props.groups.map((group) => (
         <CommandGroup items={group.items} key={group.value}>
           <CommandGroupLabel>{group.label}</CommandGroupLabel>

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -2197,7 +2197,7 @@ export default function SidebarV2() {
   // for multi-project setups.
   const handleNewThreadClick = useCallback(() => {
     // One project: nothing to pick, create immediately.
-    if (projectGroups.length <= 1) {
+    if (projectGroups.length === 1) {
       if (isMobile) setOpenMobile(false);
       void startNewThreadFromContext({
         activeDraftThread: newThreadContext.activeDraftThread,
@@ -2208,8 +2208,13 @@ export default function SidebarV2() {
       return;
     }
     if (isMobile) setOpenMobile(false);
-    openCommandPalette({ open: "new-thread-in" });
-  }, [isMobile, newThreadContext, projectGroups.length, setOpenMobile]);
+    openCommandPalette({
+      open: "new-thread-in",
+      preferredProjectRef: scopedProjectGroup
+        ? scopeProjectRef(scopedProjectGroup.environmentId, scopedProjectGroup.id)
+        : null,
+    });
+  }, [isMobile, newThreadContext, projectGroups.length, scopedProjectGroup, setOpenMobile]);
 
   const commandPaletteShortcutLabel = shortcutLabelForCommand(keybindings, "commandPalette.toggle");
   // Same resolution as v1: prefer the local-thread binding, fall back to
@@ -2253,7 +2258,6 @@ export default function SidebarV2() {
                       type="button"
                       className="relative size-8 justify-center rounded-md border-0 bg-transparent p-0 text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                       onClick={handleNewThreadClick}
-                      disabled={projects.length === 0}
                       aria-label="New thread"
                     />
                   }

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -76,6 +76,7 @@ import {
 } from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
+  resolveScopedNewThreadProjectRef,
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
@@ -84,7 +85,7 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -2208,11 +2209,18 @@ export default function SidebarV2() {
       return;
     }
     if (isMobile) setOpenMobile(false);
+    const contextualProjectRef = resolveThreadActionProjectRef({
+      activeDraftThread: newThreadContext.activeDraftThread,
+      activeThread: newThreadContext.activeThread ?? undefined,
+      defaultProjectRef: newThreadContext.defaultProjectRef,
+      handleNewThread: newThreadContext.handleNewThread,
+    });
     openCommandPalette({
       open: "new-thread-in",
-      preferredProjectRef: scopedProjectGroup
-        ? scopeProjectRef(scopedProjectGroup.environmentId, scopedProjectGroup.id)
-        : null,
+      preferredProjectRef: resolveScopedNewThreadProjectRef({
+        scopedProjectGroup,
+        contextualProjectRef,
+      }),
     });
   }, [isMobile, newThreadContext, projectGroups.length, scopedProjectGroup, setOpenMobile]);
 

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1205,12 +1205,6 @@ export default function SidebarV2() {
       setProjectScopeKey(null);
     }
   }, [projectScopeKey, scopedProjectGroup]);
-  useEffect(
-    () => () => {
-      setProjectScopeKey(null);
-    },
-    [setProjectScopeKey],
-  );
   // Scope flips drop the selection: rows selected under the old scope may be
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -85,8 +85,13 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { openCommandPalette } from "../commandPaletteBus";
+import {
+  closeCommandPalette,
+  isCommandPaletteOpen,
+  openCommandPalette,
+} from "../commandPaletteBus";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveChatNewShortcutBehavior } from "../lib/chatRouteShortcuts";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
@@ -2199,9 +2204,16 @@ export default function SidebarV2() {
   // uses. The command palette already offers a "New thread in..." submenu
   // for multi-project setups.
   const handleNewThreadClick = useCallback(() => {
-    // One project: nothing to pick, create immediately.
-    if (projectGroups.length === 1) {
+    const behavior = resolveChatNewShortcutBehavior({
+      sidebarV2Enabled: true,
+      projectCount: projectGroups.length,
+      commandPaletteOpen: isCommandPaletteOpen(),
+    });
+    if (behavior !== "open-project-picker") {
       if (isMobile) setOpenMobile(false);
+      if (behavior === "dismiss-and-create") {
+        closeCommandPalette();
+      }
       void startNewThreadFromContext({
         activeDraftThread: newThreadContext.activeDraftThread,
         activeThread: newThreadContext.activeThread ?? undefined,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -82,6 +82,7 @@ import {
 } from "../sidebarProjectGrouping";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
@@ -1179,7 +1180,8 @@ export default function SidebarV2() {
 
   // Project scope: one menu above the list. Scoping filters the list without
   // making the header width depend on the number or length of project names.
-  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
+  const projectScopeKey = useSidebarProjectScopeStore((state) => state.projectScopeKey);
+  const setProjectScopeKey = useSidebarProjectScopeStore((state) => state.setProjectScopeKey);
   const scopedProjectGroup = useMemo(
     () =>
       projectScopeKey === null
@@ -1203,6 +1205,12 @@ export default function SidebarV2() {
       setProjectScopeKey(null);
     }
   }, [projectScopeKey, scopedProjectGroup]);
+  useEffect(
+    () => () => {
+      setProjectScopeKey(null);
+    },
+    [setProjectScopeKey],
+  );
   // Scope flips drop the selection: rows selected under the old scope may be
   // hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -12,6 +12,7 @@ import {
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  resolveScopedNewThreadProjectRef,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
 import { legacyProjectCwdPreferenceKey } from "./uiStateStore";
@@ -316,6 +317,65 @@ describe("environment grouping", () => {
     });
     expect(entries[0]?.isPreferred).toBe(true);
     expect(entries[1]?.group.displayName).toBe("separate");
+  });
+
+  it("preserves an exact contextual project when opening a picker from its logical scope", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [primary, remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    const contextualProjectRef = {
+      environmentId: remote.environmentId,
+      projectId: remote.id,
+    };
+    expect(
+      resolveScopedNewThreadProjectRef({
+        scopedProjectGroup: group ?? null,
+        contextualProjectRef,
+      }),
+    ).toEqual(contextualProjectRef);
+  });
+
+  it("uses the scoped representative when the contextual project is outside the scope", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const separate = makeProject({
+      id: ProjectId.make("project-separate"),
+      title: "separate",
+      workspaceRoot: "/tmp/separate",
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [primary, remote, separate],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    expect(
+      resolveScopedNewThreadProjectRef({
+        scopedProjectGroup: group ?? null,
+        contextualProjectRef: {
+          environmentId: separate.environmentId,
+          projectId: separate.id,
+        },
+      }),
+    ).toEqual({
+      environmentId: primary.environmentId,
+      projectId: primary.id,
+    });
   });
 
   it("keeps manual project order when building grouped sidebar entries", () => {

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -12,6 +12,7 @@ import {
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  resolveNewThreadPickerProjectRef,
   resolveScopedNewThreadProjectRef,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
@@ -366,6 +367,40 @@ describe("environment grouping", () => {
 
     expect(
       resolveScopedNewThreadProjectRef({
+        scopedProjectGroup: group ?? null,
+        contextualProjectRef: {
+          environmentId: separate.environmentId,
+          projectId: separate.id,
+        },
+      }),
+    ).toEqual({
+      environmentId: primary.environmentId,
+      projectId: primary.id,
+    });
+  });
+
+  it("uses the sidebar scope when the command palette has no explicit project preference", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const separate = makeProject({
+      id: ProjectId.make("project-separate"),
+      title: "separate",
+      workspaceRoot: "/tmp/separate",
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [primary, remote, separate],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    expect(
+      resolveNewThreadPickerProjectRef({
+        preferredProjectRef: null,
         scopedProjectGroup: group ?? null,
         contextualProjectRef: {
           environmentId: separate.environmentId,

--- a/apps/web/src/lib/chatRouteShortcuts.test.ts
+++ b/apps/web/src/lib/chatRouteShortcuts.test.ts
@@ -72,5 +72,12 @@ describe("resolveChatNewShortcutBehavior", () => {
         commandPaletteOpen: true,
       }),
     ).toBe("dismiss-and-create");
+    expect(
+      resolveChatNewShortcutBehavior({
+        sidebarV2Enabled: true,
+        projectCount: 1,
+        commandPaletteOpen: true,
+      }),
+    ).toBe("dismiss-and-create");
   });
 });

--- a/apps/web/src/lib/chatRouteShortcuts.test.ts
+++ b/apps/web/src/lib/chatRouteShortcuts.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  resolveChatNewShortcutBehavior,
+  shouldHandleChatRouteShortcut,
+} from "./chatRouteShortcuts";
+
+describe("shouldHandleChatRouteShortcut", () => {
+  it("lets chat.new refresh an already-open command palette", () => {
+    expect(shouldHandleChatRouteShortcut({ command: "chat.new", commandPaletteOpen: true })).toBe(
+      true,
+    );
+  });
+
+  it("continues to suppress unrelated chat shortcuts while the palette is open", () => {
+    expect(
+      shouldHandleChatRouteShortcut({ command: "chat.newLocal", commandPaletteOpen: true }),
+    ).toBe(false);
+    expect(shouldHandleChatRouteShortcut({ command: null, commandPaletteOpen: true })).toBe(false);
+  });
+
+  it("handles shortcuts normally while the palette is closed", () => {
+    expect(
+      shouldHandleChatRouteShortcut({ command: "chat.newLocal", commandPaletteOpen: false }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveChatNewShortcutBehavior", () => {
+  it("opens the project picker when Sidebar V2 has multiple projects", () => {
+    expect(
+      resolveChatNewShortcutBehavior({
+        sidebarV2Enabled: true,
+        projectCount: 2,
+        commandPaletteOpen: true,
+      }),
+    ).toBe("open-project-picker");
+  });
+
+  it("opens the picker empty state when Sidebar V2 has no projects", () => {
+    expect(
+      resolveChatNewShortcutBehavior({
+        sidebarV2Enabled: true,
+        projectCount: 0,
+        commandPaletteOpen: false,
+      }),
+    ).toBe("open-project-picker");
+  });
+
+  it("creates immediately for Sidebar V1 and single-project setups", () => {
+    expect(
+      resolveChatNewShortcutBehavior({
+        sidebarV2Enabled: false,
+        projectCount: 2,
+        commandPaletteOpen: false,
+      }),
+    ).toBe("create-immediately");
+    expect(
+      resolveChatNewShortcutBehavior({
+        sidebarV2Enabled: true,
+        projectCount: 1,
+        commandPaletteOpen: false,
+      }),
+    ).toBe("create-immediately");
+  });
+
+  it("dismisses an open palette before immediate creation", () => {
+    expect(
+      resolveChatNewShortcutBehavior({
+        sidebarV2Enabled: false,
+        projectCount: 1,
+        commandPaletteOpen: true,
+      }),
+    ).toBe("dismiss-and-create");
+  });
+});

--- a/apps/web/src/lib/chatRouteShortcuts.ts
+++ b/apps/web/src/lib/chatRouteShortcuts.ts
@@ -1,0 +1,19 @@
+import type { KeybindingCommand } from "@t3tools/contracts";
+
+export function shouldHandleChatRouteShortcut(input: {
+  readonly command: KeybindingCommand | null;
+  readonly commandPaletteOpen: boolean;
+}): boolean {
+  return !input.commandPaletteOpen || input.command === "chat.new";
+}
+
+export function resolveChatNewShortcutBehavior(input: {
+  readonly sidebarV2Enabled: boolean;
+  readonly projectCount: number;
+  readonly commandPaletteOpen: boolean;
+}): "open-project-picker" | "create-immediately" | "dismiss-and-create" {
+  if (input.sidebarV2Enabled && input.projectCount !== 1) {
+    return "open-project-picker";
+  }
+  return input.commandPaletteOpen ? "dismiss-and-create" : "create-immediately";
+}

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -2,16 +2,26 @@ import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
 import { useEffect, useMemo } from "react";
 
-import { isCommandPaletteOpen } from "../commandPaletteBus";
+import {
+  closeCommandPalette,
+  isCommandPaletteOpen,
+  openCommandPalette,
+} from "../commandPaletteBus";
 import { useClientSettings } from "../hooks/useSettings";
-import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import {
+  resolveThreadActionProjectRef,
+  startNewThreadFromContext,
+} from "../lib/chatThreadActions";
+import {
+  resolveChatNewShortcutBehavior,
+  shouldHandleChatRouteShortcut,
+} from "../lib/chatRouteShortcuts";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
@@ -67,7 +77,8 @@ function ChatRouteGlobalShortcuts() {
         },
       });
 
-      if (isCommandPaletteOpen()) {
+      const commandPaletteOpen = isCommandPaletteOpen();
+      if (!shouldHandleChatRouteShortcut({ command, commandPaletteOpen })) {
         return;
       }
 
@@ -95,9 +106,25 @@ function ChatRouteGlobalShortcuts() {
         // Sidebar v2 routes creation through the command palette whenever
         // there is a real choice to make; v1 (and single-project setups)
         // keep the immediate contextual create.
-        if (sidebarV2Enabled && projectGroupCount > 1) {
-          openCommandPalette({ open: "new-thread-in" });
+        const behavior = resolveChatNewShortcutBehavior({
+          sidebarV2Enabled,
+          projectCount: projectGroupCount,
+          commandPaletteOpen,
+        });
+        if (behavior === "open-project-picker") {
+          openCommandPalette({
+            open: "new-thread-in",
+            preferredProjectRef: resolveThreadActionProjectRef({
+              activeDraftThread,
+              activeThread: activeThread ?? undefined,
+              defaultProjectRef,
+              handleNewThread,
+            }),
+          });
           return;
+        }
+        if (behavior === "dismiss-and-create") {
+          closeCommandPalette();
         }
         void startNewThreadFromContext({
           activeDraftThread,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -11,7 +11,11 @@ import { useClientSettings } from "../hooks/useSettings";
 import { useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
-import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
+import {
+  buildSidebarProjectSnapshots,
+  resolveScopedNewThreadProjectRef,
+} from "../sidebarProjectGrouping";
+import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
@@ -42,15 +46,23 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const projectGroupCount = useMemo(
+  const projectGroups = useMemo(
     () =>
       buildSidebarProjectSnapshots({
         projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
         resolveEnvironmentLabel: () => null,
-      }).length,
+      }),
     [primaryEnvironmentId, projectGroupingSettings, projects],
+  );
+  const projectScopeKey = useSidebarProjectScopeStore((state) => state.projectScopeKey);
+  const scopedProjectGroup = useMemo(
+    () =>
+      projectScopeKey === null
+        ? null
+        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+    [projectGroups, projectScopeKey],
   );
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
@@ -108,17 +120,20 @@ function ChatRouteGlobalShortcuts() {
         // keep the immediate contextual create.
         const behavior = resolveChatNewShortcutBehavior({
           sidebarV2Enabled,
-          projectCount: projectGroupCount,
+          projectCount: projectGroups.length,
           commandPaletteOpen,
         });
         if (behavior === "open-project-picker") {
           openCommandPalette({
             open: "new-thread-in",
-            preferredProjectRef: resolveThreadActionProjectRef({
-              activeDraftThread,
-              activeThread: activeThread ?? undefined,
-              defaultProjectRef,
-              handleNewThread,
+            preferredProjectRef: resolveScopedNewThreadProjectRef({
+              scopedProjectGroup,
+              contextualProjectRef: resolveThreadActionProjectRef({
+                activeDraftThread,
+                activeThread: activeThread ?? undefined,
+                defaultProjectRef,
+                handleNewThread,
+              }),
             }),
           });
           return;
@@ -191,7 +206,8 @@ function ChatRouteGlobalShortcuts() {
     keybindings,
     defaultProjectRef,
     previewOpen,
-    projectGroupCount,
+    projectGroups.length,
+    scopedProjectGroup,
     routeThreadRef,
     selectedThreadKeysSize,
     sidebarV2Enabled,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -9,13 +9,15 @@ import {
 } from "../commandPaletteBus";
 import { useClientSettings } from "../hooks/useSettings";
 import { useProjects } from "../state/entities";
-import { usePrimaryEnvironmentId } from "../state/environments";
-import { selectProjectGroupingSettings } from "../logicalProject";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { getProjectOrderKey, selectProjectGroupingSettings } from "../logicalProject";
+import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
 import {
   buildSidebarProjectSnapshots,
   resolveScopedNewThreadProjectRef,
 } from "../sidebarProjectGrouping";
 import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
+import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
@@ -43,18 +45,48 @@ function ChatRouteGlobalShortcuts() {
     useHandleNewThread();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const sidebarV2Enabled = useClientSettings((settings) => settings.sidebarV2Enabled);
+  const sidebarProjectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
+  const projectOrder = useUiStateStore((state) => state.projectOrder);
+  const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const environmentLabelById = useMemo(
+    () =>
+      new Map(
+        environments.map((environment) => [environment.environmentId, environment.label] as const),
+      ),
+    [environments],
+  );
+  const orderedProjects = useMemo(
+    () =>
+      orderItemsByPreferredIds({
+        items: projects,
+        preferredIds: projectOrder,
+        getId: getProjectOrderKey,
+        getPreferenceIds: (project) => [
+          getProjectOrderKey(project),
+          legacyProjectCwdPreferenceKey(project.workspaceRoot),
+        ],
+      }),
+    [projectOrder, projects],
+  );
   const projectGroups = useMemo(
     () =>
       buildSidebarProjectSnapshots({
-        projects,
+        projects: sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
-        resolveEnvironmentLabel: () => null,
+        resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
-    [primaryEnvironmentId, projectGroupingSettings, projects],
+    [
+      environmentLabelById,
+      orderedProjects,
+      primaryEnvironmentId,
+      projectGroupingSettings,
+      projects,
+      sidebarProjectSortOrder,
+    ],
   );
   const projectScopeKey = useSidebarProjectScopeStore((state) => state.projectScopeKey);
   const scopedProjectGroup = useMemo(

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -20,10 +20,7 @@ import { useSidebarProjectScopeStore } from "../sidebarProjectScopeStore";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import {
-  resolveThreadActionProjectRef,
-  startNewThreadFromContext,
-} from "../lib/chatThreadActions";
+import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
   resolveChatNewShortcutBehavior,
   shouldHandleChatRouteShortcut,

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -260,3 +260,25 @@ export function buildSidebarProjectPickerEntries(input: {
     ...entries.slice(preferredIndex + 1),
   ];
 }
+
+export function resolveScopedNewThreadProjectRef(input: {
+  scopedProjectGroup: SidebarProjectSnapshot | null;
+  contextualProjectRef: ScopedProjectRef | null;
+}): ScopedProjectRef | null {
+  if (input.scopedProjectGroup === null) {
+    return input.contextualProjectRef;
+  }
+
+  const contextualProjectIsInScope =
+    input.contextualProjectRef !== null &&
+    input.scopedProjectGroup.memberProjectRefs.some(
+      (projectRef) =>
+        projectRef.environmentId === input.contextualProjectRef?.environmentId &&
+        projectRef.projectId === input.contextualProjectRef.projectId,
+    );
+  if (contextualProjectIsInScope) {
+    return input.contextualProjectRef;
+  }
+
+  return scopeProjectRef(input.scopedProjectGroup.environmentId, input.scopedProjectGroup.id);
+}

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -282,3 +282,17 @@ export function resolveScopedNewThreadProjectRef(input: {
 
   return scopeProjectRef(input.scopedProjectGroup.environmentId, input.scopedProjectGroup.id);
 }
+
+export function resolveNewThreadPickerProjectRef(input: {
+  preferredProjectRef: ScopedProjectRef | null;
+  scopedProjectGroup: SidebarProjectSnapshot | null;
+  contextualProjectRef: ScopedProjectRef | null;
+}): ScopedProjectRef | null {
+  return (
+    input.preferredProjectRef ??
+    resolveScopedNewThreadProjectRef({
+      scopedProjectGroup: input.scopedProjectGroup,
+      contextualProjectRef: input.contextualProjectRef,
+    })
+  );
+}

--- a/apps/web/src/sidebarProjectScopeStore.ts
+++ b/apps/web/src/sidebarProjectScopeStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface SidebarProjectScopeStore {
+  readonly projectScopeKey: string | null;
+  readonly setProjectScopeKey: (projectScopeKey: string | null) => void;
+}
+
+export const useSidebarProjectScopeStore = create<SidebarProjectScopeStore>((set) => ({
+  projectScopeKey: null,
+  setProjectScopeKey: (projectScopeKey) => set({ projectScopeKey }),
+}));


### PR DESCRIPTION
## Summary

- route every new-thread entry point through one command-palette project picker
- prioritize the project from the current route or thread context
- preserve loading and empty states, Add project, and repeat-shortcut refresh behavior
- remove the duplicate Sidebar V2 picker and its separate keyboard-navigation path

## Why

T3 Code originally had two project-picker experiences for starting a thread. The command-palette picker was searchable and already served the Ctrl+K flow, while Ctrl+N and the Sidebar V2 button used a separate sidebar-owned modal. Consolidating them gives every entry point the same interaction and removes duplicate UI and keyboard-navigation code.

PR [#4269](https://github.com/pingdotgg/t3code/pull/4269) landed the basic route into the command palette after this PR opened. That means the current `main` screenshot below is an intermediate state, while the first screenshot is the real product before-state of the consolidation this PR proposed.

## UI comparison

### Before: standalone Sidebar V2 dialog

The original new-thread flow used a separate project dialog. It duplicated the Ctrl+K picker and did not support incremental filtering.

![Original Sidebar V2 new-thread dialog](https://github.com/user-attachments/assets/9ba07b32-49ff-4efa-8126-eff210999f2d)

### Current `main` after #4269

`main` now routes into the command palette, but the intermediate picker still shows the new-thread shortcut on every project row and does not include Add project in the same result set.

![Current main new-thread picker](https://github.com/user-attachments/assets/01f55e4a-3bbf-4535-9c2b-038c0dec1fb3)

### This PR

This PR keeps the command-palette picker, prioritizes the contextual project, and includes Add project as a keyboard-addressable action.

![New-thread picker on this PR](https://github.com/user-attachments/assets/dd05d7de-724d-4925-bb3b-0b6c8ad62a54)

It also uses the same incremental search behavior as Ctrl+K → New thread in…:

![New-thread picker filtered to Canvas Components](https://github.com/user-attachments/assets/cad00ad9-4596-46f8-a26d-9ce382ff074c)

## Validation

- web package typecheck
- targeted lint on changed files
- `CommandPalette.logic.test.ts` and `keybindings.test.ts` (56 tests)
- isolated end-to-end web verification: Ctrl+N opens the Projects command-palette submenu and selecting a project creates a fresh draft
- compared against Ctrl+K → New thread in… to confirm both entry points render the same picker

## Exact-head evidence

Revalidated at 9fb451def031 on current main (9a0a07167f06): focused tests, vp check, and vp run typecheck passed. The capture uses only disposable local projects.

![Unified new-thread picker filtered to Cedar Docs](https://github.com/user-attachments/assets/873ca3eb-8e06-40bc-83a1-c20b5976347f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread-creation entry points, global shortcuts, and command-palette navigation across Sidebar V2 and chat routes; behavior changes for zero-project and multi-project cases but logic is largely extracted and unit-tested.
> 
> **Overview**
> **Unifies** starting a new thread behind a single **command-palette project picker** instead of mixed sidebar and palette flows.
> 
> The palette gains a dedicated **`new-thread-in`** view: grouped project rows, **Add project** always in an Actions group (including the `>` actions filter), and empty/loading copy via new logic helpers. Opening can pass **`preferredProjectRef`** on the event bus; resolution combines that with **sidebar project scope** and thread/route context through **`resolveNewThreadPickerProjectRef`** / **`resolveScopedNewThreadProjectRef`**, with scope lifted to a shared **`sidebarProjectScopeStore`**.
> 
> **Sidebar V2** and **chat route shortcuts** (`Ctrl+N` / `chat.new`) use **`resolveChatNewShortcutBehavior`**: multi-project or zero-project Sidebar V2 opens the picker (with preference); single-project still creates immediately and can **close** an open palette first. **`chat.new`** may refresh while the palette is open; other chat shortcuts stay suppressed. The sidebar **New thread** control is no longer disabled when there are no projects.
> 
> Supporting changes: **`closeCommandPalette`** on the bus, add-project back-navigation fix when popping views, and removal of per-row **`chat.new`** shortcut on picker projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13906adafc1a195fd1a8c55621375786199654de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify the new thread project picker in the command palette with scoped project resolution
> - Adds a dedicated 'New thread in…' project picker view to the command palette, replacing inline project embedding with a structured group built by `buildNewThreadPickerGroups`
> - The picker resolves an effective preferred project from explicit preference, sidebar scope, or contextual project via `resolveNewThreadPickerProjectRef` and `resolveScopedNewThreadProjectRef`
> - Clicking 'New thread' in SidebarV2 now opens the project picker when multiple or zero projects exist, passing a `preferredProjectRef`; the button is no longer disabled with zero projects
> - Global chat shortcuts (`ChatRouteGlobalShortcuts`) suppress unrelated shortcuts while the palette is open and close the palette before immediate thread creation
> - Adds `closeCommandPalette`/`onCloseCommandPalette` event utilities and a shared `sidebarProjectScopeStore` for cross-component scope sharing
> - Behavioral Change: `resolveChatNewShortcutBehavior` replaces a simple project-count check with a three-way decision (`open-project-picker`, `create-immediately`, `dismiss-and-create`) affecting keyboard shortcut behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2550fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- exact-stack-evidence-20260724 -->
## Current combined-stack UI evidence (2026-07-24)

Captured from PR head `a5e53a9ce55272a331c6ba6443d3601c82363020` on upstream main `ece05087a70e94efcd57441337fa1249559362ba`, using combined integration `4dd4cef40` and package `/nix/store/pf7fjqw8ykkdgayf3ywsbgxxp6wi1m42-t3code-0.0.29-patched-main-20260724`.

The animation shows the Sidebar V2 New thread control opening the shared Projects picker, filtering to Atlas API, and Enter creating the new draft in that project. The picker retains Add project and keyboard hints. All names and paths are disposable seed data.

![Unified Sidebar V2 new-thread interaction](https://raw.githubusercontent.com/colonelpanic8/t3code/7611b3e06348aa5e4314c5ea5d8a563469fdf2c9/pr-4263/unified-new-thread-interaction.gif)

![Unified new-thread picker with projects and Add project](https://raw.githubusercontent.com/colonelpanic8/t3code/7611b3e06348aa5e4314c5ea5d8a563469fdf2c9/pr-4263/sidebar-v2-picker.png)
<!-- /exact-stack-evidence-20260724 -->
