### PR TITLE
feat(web): copy branch name via right-click in the branch selector

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -3,7 +3,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import type { EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
+import type { ContextMenuItem, EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { ChevronDownIcon, GitBranchIcon, RefreshCwIcon, SearchIcon } from "lucide-react";
 import {
@@ -17,9 +17,12 @@ import {
   useRef,
   useState,
   useTransition,
+  type MouseEvent as ReactMouseEvent,
 } from "react";
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
+import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
+import { readLocalApi } from "../localApi";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { usePaginatedBranches } from "../state/queries";
 import { useProject, useThread } from "../state/entities";
@@ -317,6 +320,45 @@ export function BranchToolbarBranchSelector({
   // ---------------------------------------------------------------------------
   // Branch actions
   // ---------------------------------------------------------------------------
+  const copyBranchName = useCallback((branchName: string) => {
+    void writeTextToClipboard(branchName, "branch name").then(
+      (didCopy) => {
+        if (!didCopy) return;
+        toastManager.add({
+          type: "success",
+          title: "Branch name copied",
+          description: branchName,
+        });
+      },
+      (error: unknown) => {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to copy branch name",
+            description: toBranchActionErrorMessage(error),
+          }),
+        );
+      },
+    );
+  }, []);
+
+  const handleBranchContextMenu = useCallback(
+    (event: ReactMouseEvent, branchName: string | null) => {
+      if (!branchName) return;
+      const api = readLocalApi();
+      if (!api) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const items: ContextMenuItem<"copy-branch-name">[] = [
+        { id: "copy-branch-name", label: "Copy branch name", icon: "copy" },
+      ];
+      void api.contextMenu.show(items, { x: event.clientX, y: event.clientY }).then((action) => {
+        if (action === "copy-branch-name") copyBranchName(branchName);
+      });
+    },
+    [copyBranchName],
+  );
+
   const runBranchAction = (action: () => Promise<void>) => {
     startBranchActionTransition(async () => {
       await action();
@@ -624,6 +666,7 @@ export function BranchToolbarBranchSelector({
         value={itemValue}
         className="pe-1.5"
         onClick={() => selectBranch(refName)}
+        onContextMenu={(event) => handleBranchContextMenu(event, itemValue)}
       >
         <div className="flex w-full min-w-0 items-center justify-between gap-2">
           <span className="min-w-0 flex-1 truncate">{itemValue}</span>
@@ -678,6 +721,7 @@ export function BranchToolbarBranchSelector({
           render={<Button variant="ghost" size="xs" />}
           className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
           disabled={isInitialBranchesLoadPending || isBranchActionPending}
+          onContextMenu={(event) => handleBranchContextMenu(event, resolvedActiveBranch)}
         >
           <GitBranchIcon className="size-3 shrink-0 opacity-70" />
           <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -717,16 +717,23 @@ export function BranchToolbarBranchSelector({
             <TooltipPopup side="top">{branchPrTooltip}</TooltipPopup>
           </Tooltip>
         ) : null}
-        <ComboboxTrigger
-          render={<Button variant="ghost" size="xs" />}
-          className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
-          disabled={isInitialBranchesLoadPending || isBranchActionPending}
+        {/* Context menu lives on the wrapper: the disabled Button has
+            pointer-events-none, so the trigger itself never sees right-clicks
+            while refs are loading or a branch action is pending. */}
+        <span
+          className="flex min-w-0"
           onContextMenu={(event) => handleBranchContextMenu(event, resolvedActiveBranch)}
         >
-          <GitBranchIcon className="size-3 shrink-0 opacity-70" />
-          <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
-          <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
-        </ComboboxTrigger>
+          <ComboboxTrigger
+            render={<Button variant="ghost" size="xs" />}
+            className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
+            disabled={isInitialBranchesLoadPending || isBranchActionPending}
+          >
+            <GitBranchIcon className="size-3 shrink-0 opacity-70" />
+            <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
+            <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
+          </ComboboxTrigger>
+        </span>
       </div>
       <ComboboxPopup align="end" side="top" className="flex w-80 flex-col">
         <div className="shrink-0 px-3 pt-2.5">


### PR DESCRIPTION
## Problem

Right-clicking the branch name below the composer (or any ref in the branch picker) showed the browser's default Cut/Copy/Paste menu with everything disabled, so there was no way to copy a branch name for cloning or checking out elsewhere.

## Fix

Right-clicking the branch selector trigger or any branch row in the ref picker now opens a **Copy branch name** context menu, using the existing `localApi.contextMenu.show` plumbing (native menu on desktop, DOM fallback on web — same as tab and sidebar context menus). Copying uses the shared `writeTextToClipboard` helper and reports success/failure via toast, matching the "Copy path" behavior on right-panel tabs.

- Trigger button: copies the currently resolved active branch.
- Picker rows: copies that row's ref name (works for local, remote, worktree, and default refs). The "create new ref" and "checkout PR" rows are unaffected.

## Verification

- `pnpm typecheck` (apps/web) passes.
- `pnpm lint` clean for the touched file (remaining warnings are pre-existing elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated UI in the branch selector; reuses established context-menu and clipboard patterns with no auth, data, or VCS checkout logic changes.
> 
> **Overview**
> Right-click on the **active branch trigger** or any **ref row** in the branch picker now opens a **Copy branch name** context menu (via `localApi.contextMenu.show`, same as sidebar and right-panel tabs). The chosen ref is copied with `writeTextToClipboard`, with success and error toasts aligned with existing copy-path behavior.
> 
> The combobox trigger is wrapped in a `span` that owns `onContextMenu` so copy still works while the trigger button is disabled during ref load or pending branch actions (`pointer-events-none` on the button would otherwise block right-clicks). Create-ref and checkout-PR rows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9749bf76de2d43a2799674fb45e57df8e9cfc1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add right-click context menu to copy branch name in the branch selector
> - Adds `onContextMenu` handlers to each branch `ComboboxItem` and to a wrapper around the `ComboboxTrigger` in [`BranchToolbarBranchSelector.tsx`](https://github.com/pingdotgg/t3code/pull/4275/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734).
> - Right-clicking opens a native context menu with a 'Copy branch name' option; selecting it writes the branch name to the clipboard via `writeTextToClipboard` and shows a success or error toast.
> - The wrapper around the trigger captures right-clicks even when the button is disabled (which sets `pointer-events-none`).
> - Requires a local API to be available; the context menu is skipped otherwise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9749bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->