### PR TITLE
Add shortcut to settle the open thread

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -195,7 +195,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
-      assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+enter");
+      assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+x");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -195,6 +195,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
+      assert.equal(defaultsByCommand.get("thread.settle"), "mod+shift+enter");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -819,6 +819,7 @@ describe("shouldDismissThreadSettleConfirmation", () => {
         routeThreadKey: "thread-2",
         targetExists: true,
         targetExplicitlySettled: false,
+        targetCanSettle: true,
       }),
     ).toBe(true);
   });
@@ -830,6 +831,7 @@ describe("shouldDismissThreadSettleConfirmation", () => {
         routeThreadKey: "thread-1",
         targetExists: true,
         targetExplicitlySettled: false,
+        targetCanSettle: true,
       }),
     ).toBe(false);
   });
@@ -855,6 +857,7 @@ describe("shouldDismissThreadSettleConfirmation", () => {
         routeThreadKey: "thread-1",
         targetExists: true,
         targetExplicitlySettled: target.settledOverride === "settled",
+        targetCanSettle: true,
       }),
     ).toBe(false);
   });
@@ -866,6 +869,19 @@ describe("shouldDismissThreadSettleConfirmation", () => {
         routeThreadKey: "thread-1",
         targetExists: true,
         targetExplicitlySettled: true,
+        targetCanSettle: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("dismisses a confirmation when live work makes the target unsettleable", () => {
+    expect(
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: "thread-1",
+        routeThreadKey: "thread-1",
+        targetExists: true,
+        targetExplicitlySettled: false,
+        targetCanSettle: false,
       }),
     ).toBe(true);
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -15,6 +15,7 @@ import {
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  registerMountedThreadChangeRequestState,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -584,6 +585,22 @@ describe("resolveNextActiveThreadIdAfterSettle", () => {
     ).toBe("logical-next-active");
   });
 
+  it("finds an active full-list target when V2's scoped order excludes the current route", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["scoped-settled"],
+        fallbackThreadIds: [
+          "full-list-before",
+          "hidden-current",
+          "hidden-settled",
+          "hidden-active",
+        ],
+        settledThreadId: "hidden-current",
+        isActive: (threadId) => threadId === "hidden-active",
+      }),
+    ).toBe("hidden-active");
+  });
+
   it("rotates hidden fallbacks after exhausting visible active threads", () => {
     expect(
       resolveNextActiveThreadIdAfterSettle({
@@ -677,7 +694,7 @@ describe("shouldDismissThreadSettleConfirmation", () => {
         confirmationThreadKey: "thread-1",
         routeThreadKey: "thread-2",
         targetExists: true,
-        targetSettled: false,
+        targetExplicitlySettled: false,
       }),
     ).toBe(true);
   });
@@ -688,9 +705,66 @@ describe("shouldDismissThreadSettleConfirmation", () => {
         confirmationThreadKey: "thread-1",
         routeThreadKey: "thread-1",
         targetExists: true,
-        targetSettled: false,
+        targetExplicitlySettled: false,
       }),
     ).toBe(false);
+  });
+
+  it("keeps a confirmation open when inactivity only makes the target effectively settled", () => {
+    const target = makeThreadShell({
+      latestUserMessageAt: "2026-03-01T12:00:00.000Z",
+      updatedAt: "2026-03-01T12:00:00.000Z",
+      settledOverride: null,
+    });
+
+    expect(
+      isSidebarThreadEffectivelySettled({
+        thread: target,
+        settlementSupported: true,
+        now: "2026-03-15T12:00:00.000Z",
+        autoSettleAfterDays: 3,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: "thread-1",
+        routeThreadKey: "thread-1",
+        targetExists: true,
+        targetExplicitlySettled: target.settledOverride === "settled",
+      }),
+    ).toBe(false);
+  });
+
+  it("dismisses a confirmation after the server explicitly settles its target", () => {
+    expect(
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: "thread-1",
+        routeThreadKey: "thread-1",
+        targetExists: true,
+        targetExplicitlySettled: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("registerMountedThreadChangeRequestState", () => {
+  it("removes a row's PR state when the row unmounts", () => {
+    const states = new Map<string, "open" | "closed" | "merged">();
+    const unregister = registerMountedThreadChangeRequestState({
+      threadKey: "thread-1",
+      state: "merged" as const,
+      onChange: (threadKey, state) => {
+        if (state === null) {
+          states.delete(threadKey);
+        } else {
+          states.set(threadKey, state);
+        }
+      },
+    });
+
+    expect(states.get("thread-1")).toBe("merged");
+    unregister();
+    expect(states.has("thread-1")).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -773,6 +773,16 @@ describe("canSettleLegacySidebarRouteThread", () => {
     }
   });
 
+  it("does not reopen settlement for an explicitly settled thread", () => {
+    expect(
+      canSettleLegacySidebarRouteThread({
+        thread: makeThreadShell({ settledOverride: "settled" }),
+        settlementSupported: true,
+        now,
+      }),
+    ).toBe(false);
+  });
+
   it("uses the settle operation's capability and live-work guards", () => {
     expect(
       canSettleLegacySidebarRouteThread({

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -31,6 +31,7 @@ import {
   sortSettledThreadsForSidebarV2,
   shouldDismissThreadSettleConfirmation,
   shouldQuerySidebarThreadGitStatus,
+  shouldPublishSidebarChangeRequestState,
   sortThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
@@ -80,6 +81,16 @@ describe("shouldQuerySidebarThreadGitStatus", () => {
         gitCwd: "/repo",
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldPublishSidebarChangeRequestState", () => {
+  it("preserves the last known state while git status is pending", () => {
+    expect(shouldPublishSidebarChangeRequestState(true)).toBe(false);
+  });
+
+  it("publishes the resolved state after git status settles", () => {
+    expect(shouldPublishSidebarChangeRequestState(false)).toBe(true);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,6 +14,7 @@ import {
   getSidebarThreadKeysNeedingChangeRequestReporter,
   hasUnseenCompletion,
   isContextMenuPointerDown,
+  isSidebarThreadEffectivelySnoozed,
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
@@ -723,6 +724,75 @@ describe("isSidebarThreadEffectivelySettled", () => {
               settlementSupported: true,
               now,
               autoSettleAfterDays: 3,
+            })
+          );
+        },
+      }),
+    ).toBe("active");
+  });
+});
+
+describe("isSidebarThreadEffectivelySnoozed", () => {
+  const now = "2026-04-10T12:00:00.000Z";
+
+  it("requires server snooze support and a future wake time", () => {
+    const snoozedThread = makeThreadShell({
+      snoozedAt: "2026-04-10T09:00:00.000Z",
+      snoozedUntil: "2026-04-11T09:00:00.000Z",
+    });
+
+    expect(
+      isSidebarThreadEffectivelySnoozed({
+        thread: snoozedThread,
+        snoozeSupported: true,
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      isSidebarThreadEffectivelySnoozed({
+        thread: snoozedThread,
+        snoozeSupported: false,
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      isSidebarThreadEffectivelySnoozed({
+        thread: makeThreadShell({
+          snoozedAt: "2026-04-09T09:00:00.000Z",
+          snoozedUntil: "2026-04-10T09:00:00.000Z",
+        }),
+        snoozeSupported: true,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps snoozed threads out of post-settle navigation targets", () => {
+    const threads = new Map([
+      ["current", makeThreadShell({ id: ThreadId.make("current") })],
+      [
+        "snoozed",
+        makeThreadShell({
+          id: ThreadId.make("snoozed"),
+          snoozedAt: "2026-04-10T09:00:00.000Z",
+          snoozedUntil: "2026-04-11T09:00:00.000Z",
+        }),
+      ],
+      ["active", makeThreadShell({ id: ThreadId.make("active") })],
+    ]);
+
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["current", "snoozed", "active"],
+        settledThreadId: "current",
+        isActive: (threadId) => {
+          const thread = threads.get(threadId);
+          return (
+            thread !== undefined &&
+            !isSidebarThreadEffectivelySnoozed({
+              thread,
+              snoozeSupported: true,
+              now,
             })
           );
         },

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -6,6 +6,7 @@ import {
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
+  resolveNextActiveThreadIdAfterSettle,
   getFallbackThreadIdAfterDelete,
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
@@ -509,6 +510,35 @@ describe("resolveAdjacentThreadId", () => {
         threadIds: threads,
         currentThreadId: threads[0] ?? null,
         direction: "previous",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveNextActiveThreadIdAfterSettle", () => {
+  it("wraps to the next active thread while skipping settled threads", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["thread-1", "thread-2", "thread-3"],
+        settledThreadId: "thread-1",
+        isActive: (threadId) => threadId === "thread-3",
+      }),
+    ).toBe("thread-3");
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["thread-1", "thread-2", "thread-3"],
+        settledThreadId: "thread-3",
+        isActive: (threadId) => threadId === "thread-1",
+      }),
+    ).toBe("thread-1");
+  });
+
+  it("returns null when settling leaves no active thread", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["thread-1", "thread-2"],
+        settledThreadId: "thread-1",
+        isActive: () => false,
       }),
     ).toBeNull();
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -754,8 +754,19 @@ describe("getSidebarThreadKeysNeedingChangeRequestReporter", () => {
       getSidebarThreadKeysNeedingChangeRequestReporter(
         ["visible", "preview-hidden", "collapsed"],
         new Set(["visible"]),
+        true,
       ),
     ).toEqual(["preview-hidden", "collapsed"]);
+  });
+
+  it("reports every thread when settings replaces the sidebar thread rows", () => {
+    expect(
+      getSidebarThreadKeysNeedingChangeRequestReporter(
+        ["would-be-visible", "preview-hidden", "collapsed"],
+        new Set(["would-be-visible"]),
+        false,
+      ),
+    ).toEqual(["would-be-visible", "preview-hidden", "collapsed"]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -542,6 +542,28 @@ describe("resolveNextActiveThreadIdAfterSettle", () => {
       }),
     ).toBeNull();
   });
+
+  it("falls back to an active thread hidden outside the visible keyboard order", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["visible-current", "visible-settled"],
+        fallbackThreadIds: ["visible-current", "preview-hidden-active", "collapsed-project-active"],
+        settledThreadId: "visible-current",
+        isActive: (threadId) => threadId.endsWith("active"),
+      }),
+    ).toBe("preview-hidden-active");
+  });
+
+  it("prefers the next visible active thread before hidden fallbacks", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["visible-current", "visible-next"],
+        fallbackThreadIds: ["visible-current", "hidden-active"],
+        settledThreadId: "visible-current",
+        isActive: (threadId) => threadId !== "visible-current",
+      }),
+    ).toBe("visible-next");
+  });
 });
 
 describe("getVisibleSidebarThreadIds", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -12,6 +12,7 @@ import {
   getProjectSortTimestamp,
   hasUnseenCompletion,
   isContextMenuPointerDown,
+  isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
@@ -25,6 +26,7 @@ import {
   shouldClearThreadSelectionOnMouseDown,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
+  shouldDismissThreadSettleConfirmation,
   sortThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
@@ -42,6 +44,7 @@ import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   type Project,
+  type SidebarThreadSummary,
   type Thread,
 } from "../types";
 
@@ -590,6 +593,104 @@ describe("resolveNextActiveThreadIdAfterSettle", () => {
         isActive: (threadId) => threadId.endsWith("active"),
       }),
     ).toBe("hidden-next-active");
+  });
+});
+
+describe("isSidebarThreadEffectivelySettled", () => {
+  const now = "2026-03-15T12:00:00.000Z";
+
+  it("classifies inactivity and closed change requests as settled", () => {
+    const thread = makeThreadShell({
+      latestUserMessageAt: "2026-03-01T12:00:00.000Z",
+      updatedAt: "2026-03-01T12:00:00.000Z",
+    });
+
+    expect(
+      isSidebarThreadEffectivelySettled({
+        thread,
+        settlementSupported: true,
+        now,
+        autoSettleAfterDays: 3,
+      }),
+    ).toBe(true);
+    expect(
+      isSidebarThreadEffectivelySettled({
+        thread: makeThreadShell(),
+        settlementSupported: true,
+        now,
+        autoSettleAfterDays: null,
+        changeRequestState: "closed",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps auto-settlement disabled on servers without lifecycle support", () => {
+    expect(
+      isSidebarThreadEffectivelySettled({
+        thread: makeThreadShell(),
+        settlementSupported: false,
+        now,
+        autoSettleAfterDays: null,
+        changeRequestState: "merged",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps auto-settled threads out of post-settle navigation targets", () => {
+    const threads = new Map([
+      ["current", makeThreadShell({ id: ThreadId.make("current") })],
+      [
+        "inactive",
+        makeThreadShell({
+          id: ThreadId.make("inactive"),
+          latestUserMessageAt: "2026-03-01T12:00:00.000Z",
+        }),
+      ],
+      ["active", makeThreadShell({ id: ThreadId.make("active") })],
+    ]);
+
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["current", "inactive", "active"],
+        settledThreadId: "current",
+        isActive: (threadId) => {
+          const thread = threads.get(threadId);
+          return (
+            thread !== undefined &&
+            !isSidebarThreadEffectivelySettled({
+              thread,
+              settlementSupported: true,
+              now,
+              autoSettleAfterDays: 3,
+            })
+          );
+        },
+      }),
+    ).toBe("active");
+  });
+});
+
+describe("shouldDismissThreadSettleConfirmation", () => {
+  it("dismisses a confirmation when the route changes away from its target", () => {
+    expect(
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: "thread-1",
+        routeThreadKey: "thread-2",
+        targetExists: true,
+        targetSettled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a confirmation open while its unsettled target remains the route", () => {
+    expect(
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: "thread-1",
+        routeThreadKey: "thread-1",
+        targetExists: true,
+        targetSettled: false,
+      }),
+    ).toBe(false);
   });
 });
 
@@ -1167,6 +1268,17 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     worktreePath: null,
     checkpoints: [],
     activities: [],
+    ...overrides,
+  };
+}
+
+function makeThreadShell(overrides: Partial<SidebarThreadSummary> = {}): SidebarThreadSummary {
+  return {
+    ...makeThread(),
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
     ...overrides,
   };
 }

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -10,12 +10,12 @@ import {
   getFallbackThreadIdAfterDelete,
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
+  getSidebarThreadKeysNeedingChangeRequestReporter,
   hasUnseenCompletion,
   isContextMenuPointerDown,
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
-  registerMountedThreadChangeRequestState,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -747,24 +747,14 @@ describe("shouldDismissThreadSettleConfirmation", () => {
   });
 });
 
-describe("registerMountedThreadChangeRequestState", () => {
-  it("removes a row's PR state when the row unmounts", () => {
-    const states = new Map<string, "open" | "closed" | "merged">();
-    const unregister = registerMountedThreadChangeRequestState({
-      threadKey: "thread-1",
-      state: "merged" as const,
-      onChange: (threadKey, state) => {
-        if (state === null) {
-          states.delete(threadKey);
-        } else {
-          states.set(threadKey, state);
-        }
-      },
-    });
-
-    expect(states.get("thread-1")).toBe("merged");
-    unregister();
-    expect(states.has("thread-1")).toBe(false);
+describe("getSidebarThreadKeysNeedingChangeRequestReporter", () => {
+  it("keeps live PR-state reporters for collapsed and preview-hidden rows", () => {
+    expect(
+      getSidebarThreadKeysNeedingChangeRequestReporter(
+        ["visible", "preview-hidden", "collapsed"],
+        new Set(["visible"]),
+      ),
+    ).toEqual(["preview-hidden", "collapsed"]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -17,6 +17,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  pruneSidebarChangeRequestStates,
   resolveSidebarThreadGitCwd,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -793,6 +794,26 @@ describe("resolveSidebarThreadGitCwd", () => {
         sidebarProjectCwd: "/sidebar-project",
       }),
     ).toBe("/sidebar-project");
+  });
+});
+
+describe("pruneSidebarChangeRequestStates", () => {
+  it("drops state for removed and archived threads", () => {
+    expect(
+      pruneSidebarChangeRequestStates(
+        new Map([
+          ["active", "open"],
+          ["removed", "closed"],
+          ["archived", "merged"],
+        ]),
+        new Set(["active"]),
+      ),
+    ).toEqual(new Map([["active", "open"]]));
+  });
+
+  it("preserves map identity when every state still belongs to a live thread", () => {
+    const current = new Map([["active", "open"]]);
+    expect(pruneSidebarChangeRequestStates(current, new Set(["active"]))).toBe(current);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  canSettleLegacySidebarRouteThread,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -727,6 +728,76 @@ describe("isSidebarThreadEffectivelySettled", () => {
         },
       }),
     ).toBe("active");
+  });
+});
+
+describe("canSettleLegacySidebarRouteThread", () => {
+  const now = "2026-03-15T12:00:00.000Z";
+
+  it("keeps inactive and pull-request-idle threads eligible for explicit settlement", () => {
+    const inactiveThread = makeThreadShell({
+      latestUserMessageAt: "2026-03-01T12:00:00.000Z",
+      updatedAt: "2026-03-01T12:00:00.000Z",
+    });
+    const pullRequestIdleThread = makeThreadShell({
+      latestUserMessageAt: "2026-03-15T10:00:00.000Z",
+      updatedAt: "2026-03-15T10:00:00.000Z",
+    });
+
+    expect(
+      isSidebarThreadEffectivelySettled({
+        thread: inactiveThread,
+        settlementSupported: true,
+        now,
+        autoSettleAfterDays: 3,
+      }),
+    ).toBe(true);
+    expect(
+      isSidebarThreadEffectivelySettled({
+        thread: pullRequestIdleThread,
+        settlementSupported: true,
+        now,
+        autoSettleAfterDays: null,
+        changeRequestState: "closed",
+      }),
+    ).toBe(true);
+
+    for (const thread of [inactiveThread, pullRequestIdleThread]) {
+      expect(
+        canSettleLegacySidebarRouteThread({
+          thread,
+          settlementSupported: true,
+          now,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("uses the settle operation's capability and live-work guards", () => {
+    expect(
+      canSettleLegacySidebarRouteThread({
+        thread: makeThreadShell(),
+        settlementSupported: false,
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      canSettleLegacySidebarRouteThread({
+        thread: makeThreadShell({
+          session: {
+            threadId: ThreadId.make("thread-running"),
+            status: "running",
+            providerName: "Codex",
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            activeTurnId: "turn-running" as never,
+            lastError: null,
+            updatedAt: now,
+          },
+        }),
+        settlementSupported: true,
+        now,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -30,6 +30,7 @@ import {
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
   shouldDismissThreadSettleConfirmation,
+  shouldQuerySidebarThreadGitStatus,
   sortThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
@@ -52,6 +53,35 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("shouldQuerySidebarThreadGitStatus", () => {
+  it("queries worktree-only threads so their pull request state can be reported", () => {
+    expect(
+      shouldQuerySidebarThreadGitStatus({
+        branch: null,
+        worktreePath: "/repo/.t3/worktrees/feature",
+        gitCwd: "/repo/.t3/worktrees/feature",
+      }),
+    ).toBe(true);
+  });
+
+  it("requires a cwd and either a branch or worktree", () => {
+    expect(
+      shouldQuerySidebarThreadGitStatus({
+        branch: "feature",
+        worktreePath: null,
+        gitCwd: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldQuerySidebarThreadGitStatus({
+        branch: null,
+        worktreePath: null,
+        gitCwd: "/repo",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -564,6 +564,33 @@ describe("resolveNextActiveThreadIdAfterSettle", () => {
       }),
     ).toBe("visible-next");
   });
+
+  it("rotates the full logical order when the settled thread is hidden", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["visible-earlier", "visible-later"],
+        fallbackThreadIds: [
+          "visible-earlier",
+          "hidden-current",
+          "logical-next-active",
+          "earlier-active",
+        ],
+        settledThreadId: "hidden-current",
+        isActive: (threadId) => threadId.endsWith("active"),
+      }),
+    ).toBe("logical-next-active");
+  });
+
+  it("rotates hidden fallbacks after exhausting visible active threads", () => {
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["visible-current", "visible-settled"],
+        fallbackThreadIds: ["earlier-active", "visible-current", "hidden-next-active"],
+        settledThreadId: "visible-current",
+        isActive: (threadId) => threadId.endsWith("active"),
+      }),
+    ).toBe("hidden-next-active");
+  });
 });
 
 describe("getVisibleSidebarThreadIds", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -17,6 +17,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolveSidebarThreadGitCwd,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
@@ -755,6 +756,32 @@ describe("getSidebarThreadKeysNeedingChangeRequestReporter", () => {
         new Set(["visible"]),
       ),
     ).toEqual(["preview-hidden", "collapsed"]);
+  });
+});
+
+describe("resolveSidebarThreadGitCwd", () => {
+  it("uses the same fallback order for visible and hidden thread reporters", () => {
+    expect(
+      resolveSidebarThreadGitCwd({
+        worktreePath: "/worktree",
+        threadProjectCwd: "/thread-project",
+        sidebarProjectCwd: "/sidebar-project",
+      }),
+    ).toBe("/worktree");
+    expect(
+      resolveSidebarThreadGitCwd({
+        worktreePath: null,
+        threadProjectCwd: "/thread-project",
+        sidebarProjectCwd: "/sidebar-project",
+      }),
+    ).toBe("/thread-project");
+    expect(
+      resolveSidebarThreadGitCwd({
+        worktreePath: null,
+        threadProjectCwd: null,
+        sidebarProjectCwd: "/sidebar-project",
+      }),
+    ).toBe("/sidebar-project");
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,6 +14,7 @@ import {
   getSidebarThreadKeysNeedingChangeRequestReporter,
   hasUnseenCompletion,
   isContextMenuPointerDown,
+  isSidebarThreadActiveForPostSettleNavigation,
   isSidebarThreadEffectivelySnoozed,
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
@@ -791,6 +792,40 @@ describe("isSidebarThreadEffectivelySnoozed", () => {
             thread !== undefined &&
             !isSidebarThreadEffectivelySnoozed({
               thread,
+              snoozeSupported: true,
+              now,
+            })
+          );
+        },
+      }),
+    ).toBe("active");
+  });
+
+  it("skips snoozed legacy targets even when they are not effectively settled", () => {
+    const threads = new Map([
+      ["current", makeThreadShell({ id: ThreadId.make("current") })],
+      [
+        "snoozed",
+        makeThreadShell({
+          id: ThreadId.make("snoozed"),
+          snoozedAt: "2026-04-10T09:00:00.000Z",
+          snoozedUntil: "2026-04-11T09:00:00.000Z",
+        }),
+      ],
+      ["active", makeThreadShell({ id: ThreadId.make("active") })],
+    ]);
+
+    expect(
+      resolveNextActiveThreadIdAfterSettle({
+        threadIds: ["current", "snoozed", "active"],
+        settledThreadId: "current",
+        isActive: (threadId) => {
+          const thread = threads.get(threadId);
+          return (
+            thread !== undefined &&
+            isSidebarThreadActiveForPostSettleNavigation({
+              thread,
+              effectivelySettled: false,
               snoozeSupported: true,
               now,
             })

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -53,14 +53,25 @@ export function shouldDismissThreadSettleConfirmation<T>(input: {
   readonly confirmationThreadKey: T | null;
   readonly routeThreadKey: T | null;
   readonly targetExists: boolean;
-  readonly targetSettled: boolean;
+  readonly targetExplicitlySettled: boolean;
 }): boolean {
   return (
     input.confirmationThreadKey !== null &&
     (input.confirmationThreadKey !== input.routeThreadKey ||
       !input.targetExists ||
-      input.targetSettled)
+      input.targetExplicitlySettled)
   );
+}
+
+export function registerMountedThreadChangeRequestState<TState>(input: {
+  readonly threadKey: string;
+  readonly state: TState | null;
+  readonly onChange: (threadKey: string, state: TState | null) => void;
+}): () => void {
+  input.onChange(input.threadKey, input.state);
+  return () => {
+    input.onChange(input.threadKey, null);
+  };
 }
 
 export function isSidebarThreadEffectivelySettled(input: {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -134,6 +134,7 @@ export function canSettleLegacySidebarRouteThread(input: {
   return (
     input.thread !== null &&
     input.settlementSupported &&
+    input.thread.settledOverride !== "settled" &&
     canSettle(input.thread, { now: input.now })
   );
 }

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -63,15 +63,11 @@ export function shouldDismissThreadSettleConfirmation<T>(input: {
   );
 }
 
-export function registerMountedThreadChangeRequestState<TState>(input: {
-  readonly threadKey: string;
-  readonly state: TState | null;
-  readonly onChange: (threadKey: string, state: TState | null) => void;
-}): () => void {
-  input.onChange(input.threadKey, input.state);
-  return () => {
-    input.onChange(input.threadKey, null);
-  };
+export function getSidebarThreadKeysNeedingChangeRequestReporter<T>(
+  allThreadKeys: readonly T[],
+  visibleThreadKeys: ReadonlySet<T>,
+): T[] {
+  return allThreadKeys.filter((threadKey) => !visibleThreadKeys.has(threadKey));
 }
 
 export function isSidebarThreadEffectivelySettled(input: {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -89,6 +89,10 @@ export function shouldQuerySidebarThreadGitStatus(input: {
   return (input.branch !== null || input.worktreePath !== null) && input.gitCwd !== null;
 }
 
+export function shouldPublishSidebarChangeRequestState(isGitStatusPending: boolean): boolean {
+  return !isGitStatusPending;
+}
+
 export function pruneSidebarChangeRequestStates<T>(
   current: ReadonlyMap<string, T>,
   liveThreadKeys: ReadonlySet<string>,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -70,6 +70,14 @@ export function getSidebarThreadKeysNeedingChangeRequestReporter<T>(
   return allThreadKeys.filter((threadKey) => !visibleThreadKeys.has(threadKey));
 }
 
+export function resolveSidebarThreadGitCwd(input: {
+  readonly worktreePath: string | null;
+  readonly threadProjectCwd: string | null;
+  readonly sidebarProjectCwd: string | null;
+}): string | null {
+  return input.worktreePath ?? input.threadProjectCwd ?? input.sidebarProjectCwd;
+}
+
 export function isSidebarThreadEffectivelySettled(input: {
   readonly thread: SidebarThreadSummary;
   readonly settlementSupported: boolean;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -353,16 +353,24 @@ export function shouldNavigateAfterProjectRemoval(input: {
 
 export function resolveNextActiveThreadIdAfterSettle<T>(input: {
   threadIds: readonly T[];
+  fallbackThreadIds?: readonly T[];
   settledThreadId: T;
   isActive: (threadId: T) => boolean;
 }): T | null {
   const currentIndex = input.threadIds.indexOf(input.settledThreadId);
-  if (currentIndex === -1) return null;
-  return (
-    [...input.threadIds.slice(currentIndex + 1), ...input.threadIds.slice(0, currentIndex)].find(
-      input.isActive,
-    ) ?? null
-  );
+  const preferredThreadIds =
+    currentIndex === -1
+      ? []
+      : [...input.threadIds.slice(currentIndex + 1), ...input.threadIds.slice(0, currentIndex)];
+  const seen = new Set<T>([input.settledThreadId]);
+
+  for (const threadId of [...preferredThreadIds, ...(input.fallbackThreadIds ?? [])]) {
+    if (seen.has(threadId)) continue;
+    seen.add(threadId);
+    if (input.isActive(threadId)) return threadId;
+  }
+
+  return null;
 }
 
 export function isContextMenuPointerDown(input: {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -357,14 +357,19 @@ export function resolveNextActiveThreadIdAfterSettle<T>(input: {
   settledThreadId: T;
   isActive: (threadId: T) => boolean;
 }): T | null {
-  const currentIndex = input.threadIds.indexOf(input.settledThreadId);
-  const preferredThreadIds =
-    currentIndex === -1
-      ? []
-      : [...input.threadIds.slice(currentIndex + 1), ...input.threadIds.slice(0, currentIndex)];
+  const rotateAfterSettledThread = (threadIds: readonly T[]): readonly T[] => {
+    const currentIndex = threadIds.indexOf(input.settledThreadId);
+    return currentIndex === -1
+      ? threadIds
+      : [...threadIds.slice(currentIndex + 1), ...threadIds.slice(0, currentIndex)];
+  };
+  const preferredThreadIds = input.threadIds.includes(input.settledThreadId)
+    ? rotateAfterSettledThread(input.threadIds)
+    : [];
+  const fallbackThreadIds = rotateAfterSettledThread(input.fallbackThreadIds ?? []);
   const seen = new Set<T>([input.settledThreadId]);
 
-  for (const threadId of [...preferredThreadIds, ...(input.fallbackThreadIds ?? [])]) {
+  for (const threadId of [...preferredThreadIds, ...fallbackThreadIds]) {
     if (seen.has(threadId)) continue;
     seen.add(threadId);
     if (input.isActive(threadId)) return threadId;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -81,6 +81,19 @@ export function resolveSidebarThreadGitCwd(input: {
   return input.worktreePath ?? input.threadProjectCwd ?? input.sidebarProjectCwd;
 }
 
+export function pruneSidebarChangeRequestStates<T>(
+  current: ReadonlyMap<string, T>,
+  liveThreadKeys: ReadonlySet<string>,
+): ReadonlyMap<string, T> {
+  let next: Map<string, T> | null = null;
+  for (const threadKey of current.keys()) {
+    if (liveThreadKeys.has(threadKey)) continue;
+    next ??= new Map(current);
+    next.delete(threadKey);
+  }
+  return next ?? current;
+}
+
 export function isSidebarThreadEffectivelySettled(input: {
   readonly thread: SidebarThreadSummary;
   readonly settlementSupported: boolean;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,5 +1,9 @@
 import * as React from "react";
 import type { ContextMenuItem } from "@t3tools/contracts";
+import {
+  effectiveSettled,
+  type ChangeRequestStateLike,
+} from "@t3tools/client-runtime/state/thread-settled";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
@@ -44,6 +48,39 @@ type LogicalSidebarProject = SidebarProject & {
 };
 
 export type ThreadTraversalDirection = "previous" | "next";
+
+export function shouldDismissThreadSettleConfirmation<T>(input: {
+  readonly confirmationThreadKey: T | null;
+  readonly routeThreadKey: T | null;
+  readonly targetExists: boolean;
+  readonly targetSettled: boolean;
+}): boolean {
+  return (
+    input.confirmationThreadKey !== null &&
+    (input.confirmationThreadKey !== input.routeThreadKey ||
+      !input.targetExists ||
+      input.targetSettled)
+  );
+}
+
+export function isSidebarThreadEffectivelySettled(input: {
+  readonly thread: SidebarThreadSummary;
+  readonly settlementSupported: boolean;
+  readonly now: string;
+  readonly autoSettleAfterDays: number | null;
+  readonly changeRequestState?: ChangeRequestStateLike | null;
+}): boolean {
+  return (
+    input.settlementSupported &&
+    effectiveSettled(input.thread, {
+      now: input.now,
+      autoSettleAfterDays: input.autoSettleAfterDays,
+      ...(input.changeRequestState !== undefined
+        ? { changeRequestState: input.changeRequestState }
+        : {}),
+    })
+  );
+}
 
 export async function archiveSelectedThreadEntries<
   TEntry extends { readonly threadKey: string },

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -351,6 +351,20 @@ export function shouldNavigateAfterProjectRemoval(input: {
   );
 }
 
+export function resolveNextActiveThreadIdAfterSettle<T>(input: {
+  threadIds: readonly T[];
+  settledThreadId: T;
+  isActive: (threadId: T) => boolean;
+}): T | null {
+  const currentIndex = input.threadIds.indexOf(input.settledThreadId);
+  if (currentIndex === -1) return null;
+  return (
+    [...input.threadIds.slice(currentIndex + 1), ...input.threadIds.slice(0, currentIndex)].find(
+      input.isActive,
+    ) ?? null
+  );
+}
+
 export function isContextMenuPointerDown(input: {
   button: number;
   ctrlKey: boolean;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import type { ContextMenuItem } from "@t3tools/contracts";
 import {
   canSettle,
+  effectiveSnoozed,
   effectiveSettled,
   type ChangeRequestStateLike,
 } from "@t3tools/client-runtime/state/thread-settled";
@@ -126,6 +127,14 @@ export function isSidebarThreadEffectivelySettled(input: {
         : {}),
     })
   );
+}
+
+export function isSidebarThreadEffectivelySnoozed(input: {
+  readonly thread: SidebarThreadSummary;
+  readonly snoozeSupported: boolean;
+  readonly now: string;
+}): boolean {
+  return input.snoozeSupported && effectiveSnoozed(input.thread, { now: input.now });
 }
 
 export function canSettleLegacySidebarRouteThread(input: {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -66,8 +66,11 @@ export function shouldDismissThreadSettleConfirmation<T>(input: {
 export function getSidebarThreadKeysNeedingChangeRequestReporter<T>(
   allThreadKeys: readonly T[],
   visibleThreadKeys: ReadonlySet<T>,
+  sidebarThreadRowsMounted: boolean,
 ): T[] {
-  return allThreadKeys.filter((threadKey) => !visibleThreadKeys.has(threadKey));
+  return allThreadKeys.filter(
+    (threadKey) => !sidebarThreadRowsMounted || !visibleThreadKeys.has(threadKey),
+  );
 }
 
 export function resolveSidebarThreadGitCwd(input: {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -55,12 +55,14 @@ export function shouldDismissThreadSettleConfirmation<T>(input: {
   readonly routeThreadKey: T | null;
   readonly targetExists: boolean;
   readonly targetExplicitlySettled: boolean;
+  readonly targetCanSettle: boolean;
 }): boolean {
   return (
     input.confirmationThreadKey !== null &&
     (input.confirmationThreadKey !== input.routeThreadKey ||
       !input.targetExists ||
-      input.targetExplicitlySettled)
+      input.targetExplicitlySettled ||
+      !input.targetCanSettle)
   );
 }
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -81,6 +81,14 @@ export function resolveSidebarThreadGitCwd(input: {
   return input.worktreePath ?? input.threadProjectCwd ?? input.sidebarProjectCwd;
 }
 
+export function shouldQuerySidebarThreadGitStatus(input: {
+  readonly branch: string | null;
+  readonly worktreePath: string | null;
+  readonly gitCwd: string | null;
+}): boolean {
+  return (input.branch !== null || input.worktreePath !== null) && input.gitCwd !== null;
+}
+
 export function pruneSidebarChangeRequestStates<T>(
   current: ReadonlyMap<string, T>,
   liveThreadKeys: ReadonlySet<string>,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { ContextMenuItem } from "@t3tools/contracts";
 import {
+  canSettle,
   effectiveSettled,
   type ChangeRequestStateLike,
 } from "@t3tools/client-runtime/state/thread-settled";
@@ -122,6 +123,18 @@ export function isSidebarThreadEffectivelySettled(input: {
         ? { changeRequestState: input.changeRequestState }
         : {}),
     })
+  );
+}
+
+export function canSettleLegacySidebarRouteThread(input: {
+  readonly thread: SidebarThreadSummary | null;
+  readonly settlementSupported: boolean;
+  readonly now: string;
+}): boolean {
+  return (
+    input.thread !== null &&
+    input.settlementSupported &&
+    canSettle(input.thread, { now: input.now })
   );
 }
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -137,6 +137,22 @@ export function isSidebarThreadEffectivelySnoozed(input: {
   return input.snoozeSupported && effectiveSnoozed(input.thread, { now: input.now });
 }
 
+export function isSidebarThreadActiveForPostSettleNavigation(input: {
+  readonly thread: SidebarThreadSummary;
+  readonly effectivelySettled: boolean;
+  readonly snoozeSupported: boolean;
+  readonly now: string;
+}): boolean {
+  return (
+    !input.effectivelySettled &&
+    !isSidebarThreadEffectivelySnoozed({
+      thread: input.thread,
+      snoozeSupported: input.snoozeSupported,
+      now: input.now,
+    })
+  );
+}
+
 export function canSettleLegacySidebarRouteThread(input: {
   readonly thread: SidebarThreadSummary | null;
   readonly settlementSupported: boolean;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -343,7 +343,12 @@ function SidebarHiddenThreadChangeRequestStateReporter(props: {
         })
       : null,
   );
-  const prState = resolveThreadPr(thread.branch, gitStatus.data)?.state ?? null;
+  const prState =
+    resolveThreadPr({
+      threadBranch: thread.branch,
+      gitStatus: gitStatus.data,
+      hasDedicatedWorktree: thread.worktreePath !== null,
+    })?.state ?? null;
 
   useEffect(() => {
     onChangeRequestState(threadKey, prState);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -196,6 +196,7 @@ import {
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
+  shouldQuerySidebarThreadGitStatus,
   shouldClearThreadSelectionOnMouseDown,
   shouldDismissThreadSettleConfirmation,
   sortProjectsForSidebar,
@@ -337,7 +338,11 @@ function SidebarHiddenThreadChangeRequestStateReporter(props: {
     sidebarProjectCwd: projectCwd,
   });
   const gitStatus = useEnvironmentQuery(
-    thread.branch != null && gitCwd !== null
+    shouldQuerySidebarThreadGitStatus({
+      branch: thread.branch,
+      worktreePath: thread.worktreePath,
+      gitCwd,
+    })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -471,7 +476,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     sidebarProjectCwd: props.projectCwd,
   });
   const gitStatus = useEnvironmentQuery(
-    thread.branch != null && gitCwd !== null
+    shouldQuerySidebarThreadGitStatus({
+      branch: thread.branch,
+      worktreePath: thread.worktreePath,
+      gitCwd,
+    })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -338,11 +338,12 @@ function SidebarHiddenThreadChangeRequestStateReporter(props: {
     sidebarProjectCwd: projectCwd,
   });
   const gitStatus = useEnvironmentQuery(
-    shouldQuerySidebarThreadGitStatus({
-      branch: thread.branch,
-      worktreePath: thread.worktreePath,
-      gitCwd,
-    })
+    gitCwd !== null &&
+      shouldQuerySidebarThreadGitStatus({
+        branch: thread.branch,
+        worktreePath: thread.worktreePath,
+        gitCwd,
+      })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -476,11 +477,12 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     sidebarProjectCwd: props.projectCwd,
   });
   const gitStatus = useEnvironmentQuery(
-    shouldQuerySidebarThreadGitStatus({
-      branch: thread.branch,
-      worktreePath: thread.worktreePath,
-      gitCwd,
-    })
+    gitCwd !== null &&
+      shouldQuerySidebarThreadGitStatus({
+        branch: thread.branch,
+        worktreePath: thread.worktreePath,
+        gitCwd,
+      })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -84,6 +84,7 @@ import {
   readThreadShell,
   useProject,
   useProjects,
+  useServerConfigs,
   useThreadShells,
   useThreadShellsForProjectRefs,
 } from "../state/entities";

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3542,8 +3542,9 @@ export default function Sidebar() {
       getSidebarThreadKeysNeedingChangeRequestReporter(
         allUnarchivedSidebarThreadKeys,
         visibleSidebarThreadKeySet,
+        !isOnSettings,
       ),
-    [allUnarchivedSidebarThreadKeys, visibleSidebarThreadKeySet],
+    [allUnarchivedSidebarThreadKeys, isOnSettings, visibleSidebarThreadKeySet],
   );
   useEffect(() => {
     const liveThreadKeys = new Set(allUnarchivedSidebarThreadKeys);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -193,6 +193,7 @@ import {
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
+  registerMountedThreadChangeRequestState,
   shouldClearThreadSelectionOnMouseDown,
   shouldDismissThreadSettleConfirmation,
   sortProjectsForSidebar,
@@ -471,9 +472,15 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const prState = pr?.state ?? null;
-  useEffect(() => {
-    onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+  useEffect(
+    () =>
+      registerMountedThreadChangeRequestState({
+        threadKey,
+        state: prState,
+        onChange: onChangeRequestState,
+      }),
+    [onChangeRequestState, prState, threadKey],
+  );
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
   const threadMetaClassName = isConfirmingArchive
@@ -3632,18 +3639,12 @@ export default function Sidebar() {
         confirmationThreadKey: settleConfirmationThreadKey,
         routeThreadKey,
         targetExists: settleConfirmationThread !== null,
-        targetSettled:
-          settleConfirmationThread !== null && isThreadEffectivelySettled(settleConfirmationThread),
+        targetExplicitlySettled: settleConfirmationThread?.settledOverride === "settled",
       })
     ) {
       setSettleConfirmationThreadKey(null);
     }
-  }, [
-    isThreadEffectivelySettled,
-    routeThreadKey,
-    settleConfirmationThread,
-    settleConfirmationThreadKey,
-  ]);
+  }, [routeThreadKey, settleConfirmationThread, settleConfirmationThreadKey]);
 
   useEffect(() => {
     const onMouseDown = (event: globalThis.MouseEvent) => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -62,6 +62,7 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { canSettle } from "@t3tools/client-runtime/state/thread-settled";
 import { useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
@@ -3508,7 +3509,8 @@ export default function Sidebar() {
           routeThread != null &&
           serverConfigs.get(routeThread.environmentId)?.environment.capabilities
             .threadSettlement === true &&
-          routeThread.settledOverride !== "settled",
+          routeThread.settledOverride !== "settled" &&
+          canSettle(routeThread, { now: new Date().toISOString() }),
         isRouteThreadSettling:
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
       });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3398,6 +3398,18 @@ export default function Sidebar() {
     ? threadJumpLabelByKey
     : EMPTY_THREAD_JUMP_LABELS;
   const orderedSidebarThreadKeys = visibleSidebarThreadKeys;
+  const allUnarchivedSidebarThreadKeys = useMemo(
+    () =>
+      sortedProjects.flatMap((project) =>
+        sortThreads(
+          (threadsByProjectKey.get(project.projectKey) ?? []).filter(
+            (thread) => thread.archivedAt === null,
+          ),
+          sidebarThreadSortOrder,
+        ).map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
+      ),
+    [sidebarThreadSortOrder, sortedProjects, threadsByProjectKey],
+  );
   const prewarmedSidebarThreadKeys = useMemo(
     () => getSidebarThreadIdsToPrewarm(visibleSidebarThreadKeys),
     [visibleSidebarThreadKeys],
@@ -3421,6 +3433,7 @@ export default function Sidebar() {
 
       const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
         threadIds: orderedSidebarThreadKeys,
+        fallbackThreadIds: allUnarchivedSidebarThreadKeys,
         settledThreadId: threadKey,
         isActive: (candidateKey) => {
           const candidate = sidebarThreadByKey.get(candidateKey);
@@ -3457,7 +3470,14 @@ export default function Sidebar() {
         }
       })();
     },
-    [handleNewThread, navigateToThread, orderedSidebarThreadKeys, settleThread, sidebarThreadByKey],
+    [
+      allUnarchivedSidebarThreadKeys,
+      handleNewThread,
+      navigateToThread,
+      orderedSidebarThreadKeys,
+      settleThread,
+      sidebarThreadByKey,
+    ],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -191,6 +191,7 @@ import {
   isTrailingDoubleClick,
   resolveNextActiveThreadIdAfterSettle,
   resolveProjectStatusIndicator,
+  resolveSidebarThreadGitCwd,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
@@ -318,9 +319,10 @@ function buildThreadJumpLabelMap(input: {
 
 function SidebarHiddenThreadChangeRequestStateReporter(props: {
   thread: SidebarThreadSummary;
+  projectCwd: string | null;
   onChangeRequestState: (threadKey: string, state: ChangeRequestStateLike | null) => void;
 }) {
-  const { thread, onChangeRequestState } = props;
+  const { thread, projectCwd, onChangeRequestState } = props;
   const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
   const threadProject = useProject(
     useMemo(
@@ -328,7 +330,11 @@ function SidebarHiddenThreadChangeRequestStateReporter(props: {
       [thread.environmentId, thread.projectId],
     ),
   );
-  const gitCwd = thread.worktreePath ?? threadProject?.workspaceRoot ?? null;
+  const gitCwd = resolveSidebarThreadGitCwd({
+    worktreePath: thread.worktreePath,
+    threadProjectCwd: threadProject?.workspaceRoot ?? null,
+    sidebarProjectCwd: projectCwd,
+  });
   const gitStatus = useEnvironmentQuery(
     thread.branch != null && gitCwd !== null
       ? vcsEnvironment.status({
@@ -453,7 +459,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     ),
   );
   const threadProjectCwd = threadProject?.workspaceRoot ?? null;
-  const gitCwd = thread.worktreePath ?? threadProjectCwd ?? props.projectCwd;
+  const gitCwd = resolveSidebarThreadGitCwd({
+    worktreePath: thread.worktreePath,
+    threadProjectCwd,
+    sidebarProjectCwd: props.projectCwd,
+  });
   const gitStatus = useEnvironmentQuery(
     thread.branch != null && gitCwd !== null
       ? vcsEnvironment.status({
@@ -3263,6 +3273,21 @@ export default function Sidebar() {
     }
     return next;
   }, [sidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
+  const sidebarProjectCwdByThreadKey = useMemo(
+    () =>
+      new Map(
+        sidebarThreads.map((thread) => {
+          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+          const scopedProject = scopedProjectKey(
+            scopeProjectRef(thread.environmentId, thread.projectId),
+          );
+          const physicalKey = projectPhysicalKeyByScopedRef.get(scopedProject) ?? scopedProject;
+          const logicalKey = physicalToLogicalKey.get(physicalKey) ?? physicalKey;
+          return [threadKey, sidebarProjectByKey.get(logicalKey)?.workspaceRoot ?? null] as const;
+        }),
+      ),
+    [physicalToLogicalKey, projectPhysicalKeyByScopedRef, sidebarProjectByKey, sidebarThreads],
+  );
   const getCurrentSidebarShortcutContext = useCallback(
     () => ({
       terminalFocus: isTerminalFocused(),
@@ -3814,6 +3839,7 @@ export default function Sidebar() {
           <SidebarHiddenThreadChangeRequestStateReporter
             key={threadKey}
             thread={thread}
+            projectCwd={sidebarProjectCwdByThreadKey.get(threadKey) ?? null}
             onChangeRequestState={handleChangeRequestState}
           />
         ) : null;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -96,11 +96,10 @@ import {
 } from "../uiStateStore";
 import {
   resolveShortcutCommand,
+  resolveThreadSidebarShortcutAction,
   shortcutLabelForCommand,
   shouldShowThreadJumpHintsForModifiers,
   threadJumpCommandForIndex,
-  threadJumpIndexFromCommand,
-  threadTraversalDirectionFromCommand,
 } from "../keybindings";
 import { isModelPickerOpen } from "../modelPickerVisibility";
 import { useShortcutModifierState } from "../shortcutModifierState";
@@ -134,6 +133,15 @@ import {
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
 import { Button } from "./ui/button";
 import {
   Dialog,
@@ -168,12 +176,11 @@ import {
   useSidebar,
 } from "./ui/sidebar";
 import { useThreadSelectionStore } from "../threadSelectionStore";
-import { openCommandPalette } from "../commandPaletteBus";
+import { isCommandPaletteOpen, openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
   getSidebarThreadIdsToPrewarm,
-  resolveAdjacentThreadId,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   resolveProjectStatusIndicator,
@@ -2999,7 +3006,8 @@ export default function Sidebar() {
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
-  const { archiveThread, deleteThread } = useThreadActions();
+  const { archiveThread, deleteThread, settleThread } = useThreadActions();
+  const serverConfigs = useServerConfigs();
   const { isMobile, setOpenMobile } = useSidebar();
   const routeTarget = useParams({
     strict: false,
@@ -3013,6 +3021,12 @@ export default function Sidebar() {
     [routeDraftThread, routeTarget],
   );
   const routeThreadKey = routeThreadRef ? scopedThreadKey(routeThreadRef) : null;
+  const routeThreadKeyRef = useRef(routeThreadKey);
+  routeThreadKeyRef.current = routeThreadKey;
+  const [settleConfirmationThreadKey, setSettleConfirmationThreadKey] = useState<string | null>(
+    null,
+  );
+  const settleConfirmationButtonRef = useRef<HTMLButtonElement>(null);
   const routeTerminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
@@ -3395,6 +3409,51 @@ export default function Sidebar() {
       }),
     [prewarmedSidebarThreadKeys],
   );
+  const settlingThreadKeysRef = useRef(new Set<string>());
+
+  const attemptShortcutSettle = useCallback(
+    (threadKey: string) => {
+      const thread = sidebarThreadByKey.get(threadKey);
+      if (!thread || settlingThreadKeysRef.current.has(threadKey)) return;
+      settlingThreadKeysRef.current.add(threadKey);
+      setSettleConfirmationThreadKey((current) => (current === threadKey ? null : current));
+
+      const currentIndex = orderedSidebarThreadKeys.indexOf(threadKey);
+      const nextThreadKey =
+        currentIndex === -1
+          ? null
+          : ([
+              ...orderedSidebarThreadKeys.slice(currentIndex + 1),
+              ...orderedSidebarThreadKeys.slice(0, currentIndex),
+            ][0] ?? null);
+      const nextThread = nextThreadKey ? sidebarThreadByKey.get(nextThreadKey) : null;
+
+      void (async () => {
+        try {
+          const result = await settleThread(scopeThreadRef(thread.environmentId, thread.id));
+          if (result._tag === "Failure") {
+            if (!isAtomCommandInterrupted(result)) {
+              const error = squashAtomCommandFailure(result);
+              toastManager.add(
+                stackedThreadToast({
+                  type: "error",
+                  title: "Failed to settle thread",
+                  description: error instanceof Error ? error.message : "An error occurred.",
+                }),
+              );
+            }
+            return;
+          }
+          if (routeThreadKeyRef.current === threadKey && nextThread) {
+            navigateToThread(scopeThreadRef(nextThread.environmentId, nextThread.id));
+          }
+        } finally {
+          settlingThreadKeysRef.current.delete(threadKey);
+        }
+      })();
+    },
+    [navigateToThread, orderedSidebarThreadKeys, settleThread, sidebarThreadByKey],
+  );
 
   useEffect(() => {
     updateThreadJumpHintsVisibility(shouldShowThreadJumpHintsNow);
@@ -3407,48 +3466,37 @@ export default function Sidebar() {
       if (event.defaultPrevented || event.repeat) {
         return;
       }
+      if (isCommandPaletteOpen() || isModelPickerOpen()) return;
 
       const command = resolveShortcutCommand(event, keybindings, {
         platform,
         context: shortcutContext,
       });
-      const traversalDirection = threadTraversalDirectionFromCommand(command);
-      if (traversalDirection !== null) {
-        const targetThreadKey = resolveAdjacentThreadId({
-          threadIds: orderedSidebarThreadKeys,
-          currentThreadId: routeThreadKey,
-          direction: traversalDirection,
-        });
-        if (!targetThreadKey) {
-          return;
-        }
-        const targetThread = sidebarThreadByKey.get(targetThreadKey);
-        if (!targetThread) {
-          return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-        navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
-        return;
-      }
-
-      const jumpIndex = threadJumpIndexFromCommand(command ?? "");
-      if (jumpIndex === null) {
-        return;
-      }
-
-      const targetThreadKey = threadJumpThreadKeys[jumpIndex];
-      if (!targetThreadKey) {
-        return;
-      }
-      const targetThread = sidebarThreadByKey.get(targetThreadKey);
-      if (!targetThread) {
-        return;
-      }
-
+      const routeThread = routeThreadKey ? sidebarThreadByKey.get(routeThreadKey) : null;
+      const action = resolveThreadSidebarShortcutAction({
+        command,
+        orderedThreadKeys: orderedSidebarThreadKeys,
+        jumpThreadKeys: threadJumpThreadKeys,
+        routeThreadKey,
+        settleConfirmationThreadKey,
+        canSettleRouteThread:
+          routeThread != null &&
+          serverConfigs.get(routeThread.environmentId)?.environment.capabilities
+            .threadSettlement === true &&
+          routeThread.settledOverride !== "settled",
+        isRouteThreadSettling:
+          routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
+      });
+      if (action.type === "none") return;
       event.preventDefault();
       event.stopPropagation();
+      if (action.type === "consume") return;
+      if (action.type === "confirm-settle") {
+        setSettleConfirmationThreadKey(action.threadKey);
+        return;
+      }
+      const targetThread = sidebarThreadByKey.get(action.threadKey);
+      if (!targetThread) return;
       navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
     };
 
@@ -3464,9 +3512,28 @@ export default function Sidebar() {
     orderedSidebarThreadKeys,
     platform,
     routeThreadKey,
+    serverConfigs,
+    settleConfirmationThreadKey,
     sidebarThreadByKey,
     threadJumpThreadKeys,
   ]);
+
+  const settleConfirmationThread = settleConfirmationThreadKey
+    ? (sidebarThreadByKey.get(settleConfirmationThreadKey) ?? null)
+    : null;
+  const confirmShortcutSettle = useCallback(() => {
+    if (!settleConfirmationThreadKey) return;
+    attemptShortcutSettle(settleConfirmationThreadKey);
+  }, [attemptShortcutSettle, settleConfirmationThreadKey]);
+
+  useEffect(() => {
+    if (
+      settleConfirmationThreadKey !== null &&
+      (settleConfirmationThread === null || settleConfirmationThread.settledOverride === "settled")
+    ) {
+      setSettleConfirmationThreadKey(null);
+    }
+  }, [settleConfirmationThread, settleConfirmationThreadKey]);
 
   useEffect(() => {
     const onMouseDown = (event: globalThis.MouseEvent) => {
@@ -3637,6 +3704,30 @@ export default function Sidebar() {
           <SidebarChromeFooter />
         </>
       )}
+      <AlertDialog
+        open={settleConfirmationThread !== null}
+        onOpenChange={(open) => {
+          if (!open) setSettleConfirmationThreadKey(null);
+        }}
+      >
+        <AlertDialogPopup initialFocus={settleConfirmationButtonRef}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Settle this thread?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {settleConfirmationThread
+                ? `“${settleConfirmationThread.title}” will move out of active work. You can un-settle it later.`
+                : "This thread will move out of active work. You can un-settle it later."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button ref={settleConfirmationButtonRef} onClick={confirmShortcutSettle}>
+              Settle thread
+              <Kbd className="ml-1 h-5 px-1.5">Enter</Kbd>
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
     </>
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -186,6 +186,7 @@ import {
   getSidebarThreadKeysNeedingChangeRequestReporter,
   getSidebarThreadIdsToPrewarm,
   isContextMenuPointerDown,
+  isSidebarThreadActiveForPostSettleNavigation,
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   resolveNextActiveThreadIdAfterSettle,
@@ -3584,13 +3585,24 @@ export default function Sidebar() {
       settlingThreadKeysRef.current.add(threadKey);
       setSettleConfirmationThreadKey((current) => (current === threadKey ? null : current));
 
+      const navigationNow = new Date().toISOString();
       const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
         threadIds: orderedSidebarThreadKeys,
         fallbackThreadIds: allUnarchivedSidebarThreadKeys,
         settledThreadId: threadKey,
         isActive: (candidateKey) => {
           const candidate = sidebarThreadByKey.get(candidateKey);
-          return candidate != null && !isThreadEffectivelySettled(candidate);
+          return (
+            candidate != null &&
+            isSidebarThreadActiveForPostSettleNavigation({
+              thread: candidate,
+              effectivelySettled: isThreadEffectivelySettled(candidate),
+              snoozeSupported:
+                serverConfigs.get(candidate.environmentId)?.environment.capabilities
+                  .threadSnooze === true,
+              now: navigationNow,
+            })
+          );
         },
       });
       const nextThread = nextThreadKey ? sidebarThreadByKey.get(nextThreadKey) : null;
@@ -3629,6 +3641,7 @@ export default function Sidebar() {
       isThreadEffectivelySettled,
       navigateToThread,
       orderedSidebarThreadKeys,
+      serverConfigs,
       settleThread,
       sidebarThreadByKey,
     ],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -62,10 +62,7 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import {
-  canSettle,
-  type ChangeRequestStateLike,
-} from "@t3tools/client-runtime/state/thread-settled";
+import { type ChangeRequestStateLike } from "@t3tools/client-runtime/state/thread-settled";
 import { useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
@@ -185,6 +182,7 @@ import { isCommandPaletteOpen, openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  canSettleLegacySidebarRouteThread,
   getSidebarThreadKeysNeedingChangeRequestReporter,
   getSidebarThreadIdsToPrewarm,
   isContextMenuPointerDown,
@@ -3668,12 +3666,14 @@ export default function Sidebar() {
         jumpThreadKeys: threadJumpThreadKeys,
         routeThreadKey,
         settleConfirmationThreadKey,
-        canSettleRouteThread:
-          routeThread != null &&
-          serverConfigs.get(routeThread.environmentId)?.environment.capabilities
-            .threadSettlement === true &&
-          !isThreadEffectivelySettled(routeThread) &&
-          canSettle(routeThread, { now: new Date().toISOString() }),
+        canSettleRouteThread: canSettleLegacySidebarRouteThread({
+          thread: routeThread ?? null,
+          settlementSupported:
+            routeThread != null &&
+            serverConfigs.get(routeThread.environmentId)?.environment.capabilities
+              .threadSettlement === true,
+          now: new Date().toISOString(),
+        }),
         isRouteThreadSettling:
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
       });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -62,7 +62,10 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { canSettle } from "@t3tools/client-runtime/state/thread-settled";
+import {
+  canSettle,
+  type ChangeRequestStateLike,
+} from "@t3tools/client-runtime/state/thread-settled";
 import { useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
@@ -183,6 +186,7 @@ import {
   buildMultiSelectThreadContextMenuItems,
   getSidebarThreadIdsToPrewarm,
   isContextMenuPointerDown,
+  isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   resolveNextActiveThreadIdAfterSettle,
   resolveProjectStatusIndicator,
@@ -190,6 +194,7 @@ import {
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
+  shouldDismissThreadSettleConfirmation,
   sortProjectsForSidebar,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
@@ -346,6 +351,7 @@ interface SidebarThreadRowProps {
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
+  onChangeRequestState: (threadKey: string, state: ChangeRequestStateLike | null) => void;
 }
 
 export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowProps) {
@@ -372,6 +378,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     cancelRename,
     attemptArchiveThread,
     openPrLink,
+    onChangeRequestState,
     thread,
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
@@ -463,6 +470,10 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     gitStatus: gitStatus.data,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prState = pr?.state ?? null;
+  useEffect(() => {
+    onChangeRequestState(threadKey, prState);
+  }, [onChangeRequestState, prState, threadKey]);
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
   const threadMetaClassName = isConfirmingArchive
@@ -929,6 +940,7 @@ interface SidebarProjectThreadListProps {
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
+  onChangeRequestState: (threadKey: string, state: ChangeRequestStateLike | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
 }
@@ -969,6 +981,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     cancelRename,
     attemptArchiveThread,
     openPrLink,
+    onChangeRequestState,
     expandThreadListForProject,
     collapseThreadListForProject,
   } = props;
@@ -1020,6 +1033,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
               cancelRename={cancelRename}
               attemptArchiveThread={attemptArchiveThread}
               openPrLink={openPrLink}
+              onChangeRequestState={onChangeRequestState}
             />
           );
         })}
@@ -1070,6 +1084,7 @@ interface SidebarProjectItemProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
+  onChangeRequestState: (threadKey: string, state: ChangeRequestStateLike | null) => void;
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
@@ -1090,6 +1105,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     archiveThread,
     deleteThread,
     threadJumpLabelByKey,
+    onChangeRequestState,
     attachThreadListAutoAnimateRef,
     expandThreadListForProject,
     collapseThreadListForProject,
@@ -2363,6 +2379,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         cancelRename={cancelRename}
         attemptArchiveThread={attemptArchiveThread}
         openPrLink={openPrLink}
+        onChangeRequestState={onChangeRequestState}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
       />
@@ -2761,6 +2778,7 @@ interface SidebarProjectsContentProps {
   newThreadShortcutLabel: string | null;
   commandPaletteShortcutLabel: string | null;
   threadJumpLabelByKey: ReadonlyMap<string, string>;
+  onChangeRequestState: (threadKey: string, state: ChangeRequestStateLike | null) => void;
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
@@ -2801,6 +2819,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     newThreadShortcutLabel,
     commandPaletteShortcutLabel,
     threadJumpLabelByKey,
+    onChangeRequestState,
     attachThreadListAutoAnimateRef,
     expandThreadListForProject,
     collapseThreadListForProject,
@@ -2938,6 +2957,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         archiveThread={archiveThread}
                         deleteThread={deleteThread}
                         threadJumpLabelByKey={threadJumpLabelByKey}
+                        onChangeRequestState={onChangeRequestState}
                         attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
                         expandThreadListForProject={expandThreadListForProject}
                         collapseThreadListForProject={collapseThreadListForProject}
@@ -2970,6 +2990,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 archiveThread={archiveThread}
                 deleteThread={deleteThread}
                 threadJumpLabelByKey={threadJumpLabelByKey}
+                onChangeRequestState={onChangeRequestState}
                 attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
                 expandThreadListForProject={expandThreadListForProject}
                 collapseThreadListForProject={collapseThreadListForProject}
@@ -3006,6 +3027,7 @@ export default function Sidebar() {
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
+  const sidebarAutoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
   const { archiveThread, deleteThread, settleThread } = useThreadActions();
@@ -3029,6 +3051,50 @@ export default function Sidebar() {
     null,
   );
   const settleConfirmationButtonRef = useRef<HTMLButtonElement>(null);
+  const [settlementNowMinute, setSettlementNowMinute] = useState(() =>
+    new Date().toISOString().slice(0, 16),
+  );
+  useEffect(() => {
+    const id = window.setInterval(
+      () => setSettlementNowMinute(new Date().toISOString().slice(0, 16)),
+      60_000,
+    );
+    return () => window.clearInterval(id);
+  }, []);
+  const settlementNow = `${settlementNowMinute}:00.000Z`;
+  const [changeRequestStateByThreadKey, setChangeRequestStateByThreadKey] = useState<
+    ReadonlyMap<string, ChangeRequestStateLike>
+  >(() => new Map());
+  const handleChangeRequestState = useCallback(
+    (threadKey: string, state: ChangeRequestStateLike | null) => {
+      setChangeRequestStateByThreadKey((current) => {
+        if ((current.get(threadKey) ?? null) === state) return current;
+        const next = new Map(current);
+        if (state === null) {
+          next.delete(threadKey);
+        } else {
+          next.set(threadKey, state);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+  const isThreadEffectivelySettled = useCallback(
+    (thread: SidebarThreadSummary) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      return isSidebarThreadEffectivelySettled({
+        thread,
+        settlementSupported:
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement ===
+          true,
+        now: settlementNow,
+        autoSettleAfterDays: sidebarAutoSettleAfterDays,
+        changeRequestState: changeRequestStateByThreadKey.get(threadKey) ?? null,
+      });
+    },
+    [changeRequestStateByThreadKey, serverConfigs, settlementNow, sidebarAutoSettleAfterDays],
+  );
   const routeTerminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
@@ -3438,7 +3504,7 @@ export default function Sidebar() {
         settledThreadId: threadKey,
         isActive: (candidateKey) => {
           const candidate = sidebarThreadByKey.get(candidateKey);
-          return candidate != null && candidate.settledOverride !== "settled";
+          return candidate != null && !isThreadEffectivelySettled(candidate);
         },
       });
       const nextThread = nextThreadKey ? sidebarThreadByKey.get(nextThreadKey) : null;
@@ -3474,6 +3540,7 @@ export default function Sidebar() {
     [
       allUnarchivedSidebarThreadKeys,
       handleNewThread,
+      isThreadEffectivelySettled,
       navigateToThread,
       orderedSidebarThreadKeys,
       settleThread,
@@ -3509,7 +3576,7 @@ export default function Sidebar() {
           routeThread != null &&
           serverConfigs.get(routeThread.environmentId)?.environment.capabilities
             .threadSettlement === true &&
-          routeThread.settledOverride !== "settled" &&
+          !isThreadEffectivelySettled(routeThread) &&
           canSettle(routeThread, { now: new Date().toISOString() }),
         isRouteThreadSettling:
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
@@ -3536,6 +3603,7 @@ export default function Sidebar() {
     };
   }, [
     getCurrentSidebarShortcutContext,
+    isThreadEffectivelySettled,
     keybindings,
     navigateToThread,
     orderedSidebarThreadKeys,
@@ -3551,18 +3619,31 @@ export default function Sidebar() {
     ? (sidebarThreadByKey.get(settleConfirmationThreadKey) ?? null)
     : null;
   const confirmShortcutSettle = useCallback(() => {
-    if (!settleConfirmationThreadKey) return;
+    if (!settleConfirmationThreadKey || settleConfirmationThreadKey !== routeThreadKeyRef.current) {
+      setSettleConfirmationThreadKey(null);
+      return;
+    }
     attemptShortcutSettle(settleConfirmationThreadKey);
   }, [attemptShortcutSettle, settleConfirmationThreadKey]);
 
   useEffect(() => {
     if (
-      settleConfirmationThreadKey !== null &&
-      (settleConfirmationThread === null || settleConfirmationThread.settledOverride === "settled")
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: settleConfirmationThreadKey,
+        routeThreadKey,
+        targetExists: settleConfirmationThread !== null,
+        targetSettled:
+          settleConfirmationThread !== null && isThreadEffectivelySettled(settleConfirmationThread),
+      })
     ) {
       setSettleConfirmationThreadKey(null);
     }
-  }, [settleConfirmationThread, settleConfirmationThreadKey]);
+  }, [
+    isThreadEffectivelySettled,
+    routeThreadKey,
+    settleConfirmationThread,
+    settleConfirmationThreadKey,
+  ]);
 
   useEffect(() => {
     const onMouseDown = (event: globalThis.MouseEvent) => {
@@ -3719,6 +3800,7 @@ export default function Sidebar() {
             newThreadShortcutLabel={newThreadShortcutLabel}
             commandPaletteShortcutLabel={commandPaletteShortcutLabel}
             threadJumpLabelByKey={visibleThreadJumpLabelByKey}
+            onChangeRequestState={handleChangeRequestState}
             attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
             expandThreadListForProject={expandThreadListForProject}
             collapseThreadListForProject={collapseThreadListForProject}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -184,6 +184,7 @@ import { isCommandPaletteOpen, openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  getSidebarThreadKeysNeedingChangeRequestReporter,
   getSidebarThreadIdsToPrewarm,
   isContextMenuPointerDown,
   isSidebarThreadEffectivelySettled,
@@ -193,7 +194,6 @@ import {
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
-  registerMountedThreadChangeRequestState,
   shouldClearThreadSelectionOnMouseDown,
   shouldDismissThreadSettleConfirmation,
   sortProjectsForSidebar,
@@ -314,6 +314,36 @@ function buildThreadJumpLabelMap(input: {
     }
   }
   return mapping.size > 0 ? mapping : EMPTY_THREAD_JUMP_LABELS;
+}
+
+function SidebarHiddenThreadChangeRequestStateReporter(props: {
+  thread: SidebarThreadSummary;
+  onChangeRequestState: (threadKey: string, state: ChangeRequestStateLike | null) => void;
+}) {
+  const { thread, onChangeRequestState } = props;
+  const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+  const threadProject = useProject(
+    useMemo(
+      () => scopeProjectRef(thread.environmentId, thread.projectId),
+      [thread.environmentId, thread.projectId],
+    ),
+  );
+  const gitCwd = thread.worktreePath ?? threadProject?.workspaceRoot ?? null;
+  const gitStatus = useEnvironmentQuery(
+    thread.branch != null && gitCwd !== null
+      ? vcsEnvironment.status({
+          environmentId: thread.environmentId,
+          input: { cwd: gitCwd },
+        })
+      : null,
+  );
+  const prState = resolveThreadPr(thread.branch, gitStatus.data)?.state ?? null;
+
+  useEffect(() => {
+    onChangeRequestState(threadKey, prState);
+  }, [onChangeRequestState, prState, threadKey]);
+
+  return null;
 }
 
 interface SidebarThreadRowProps {
@@ -472,15 +502,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const prState = pr?.state ?? null;
-  useEffect(
-    () =>
-      registerMountedThreadChangeRequestState({
-        threadKey,
-        state: prState,
-        onChange: onChangeRequestState,
-      }),
-    [onChangeRequestState, prState, threadKey],
-  );
+  useEffect(() => {
+    onChangeRequestState(threadKey, prState);
+  }, [onChangeRequestState, prState, threadKey]);
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
   const threadMetaClassName = isConfirmingArchive
@@ -3484,6 +3508,25 @@ export default function Sidebar() {
       ),
     [sidebarThreadSortOrder, sortedProjects, threadsByProjectKey],
   );
+  const visibleSidebarThreadKeySet = useMemo(
+    () => new Set(visibleSidebarThreadKeys),
+    [visibleSidebarThreadKeys],
+  );
+  const changeRequestReporterThreadKeys = useMemo(
+    () =>
+      getSidebarThreadKeysNeedingChangeRequestReporter(
+        allUnarchivedSidebarThreadKeys,
+        visibleSidebarThreadKeySet,
+      ),
+    [allUnarchivedSidebarThreadKeys, visibleSidebarThreadKeySet],
+  );
+  useEffect(() => {
+    const liveThreadKeys = new Set(allUnarchivedSidebarThreadKeys);
+    setChangeRequestStateByThreadKey((current) => {
+      if ([...current.keys()].every((threadKey) => liveThreadKeys.has(threadKey))) return current;
+      return new Map([...current].filter(([threadKey]) => liveThreadKeys.has(threadKey)));
+    });
+  }, [allUnarchivedSidebarThreadKeys]);
   const prewarmedSidebarThreadKeys = useMemo(
     () => getSidebarThreadIdsToPrewarm(visibleSidebarThreadKeys),
     [visibleSidebarThreadKeys],
@@ -3765,6 +3808,16 @@ export default function Sidebar() {
 
   return (
     <>
+      {changeRequestReporterThreadKeys.map((threadKey) => {
+        const thread = sidebarThreadByKey.get(threadKey);
+        return thread ? (
+          <SidebarHiddenThreadChangeRequestStateReporter
+            key={threadKey}
+            thread={thread}
+            onChangeRequestState={handleChangeRequestState}
+          />
+        ) : null;
+      })}
       {prewarmedSidebarThreadRefs.map((threadRef) => (
         <SidebarThreadDetailPrewarmer key={scopedThreadKey(threadRef)} threadRef={threadRef} />
       ))}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -183,6 +183,7 @@ import {
   getSidebarThreadIdsToPrewarm,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
+  resolveNextActiveThreadIdAfterSettle,
   resolveProjectStatusIndicator,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
@@ -3418,14 +3419,14 @@ export default function Sidebar() {
       settlingThreadKeysRef.current.add(threadKey);
       setSettleConfirmationThreadKey((current) => (current === threadKey ? null : current));
 
-      const currentIndex = orderedSidebarThreadKeys.indexOf(threadKey);
-      const nextThreadKey =
-        currentIndex === -1
-          ? null
-          : ([
-              ...orderedSidebarThreadKeys.slice(currentIndex + 1),
-              ...orderedSidebarThreadKeys.slice(0, currentIndex),
-            ][0] ?? null);
+      const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
+        threadIds: orderedSidebarThreadKeys,
+        settledThreadId: threadKey,
+        isActive: (candidateKey) => {
+          const candidate = sidebarThreadByKey.get(candidateKey);
+          return candidate != null && candidate.settledOverride !== "settled";
+        },
+      });
       const nextThread = nextThreadKey ? sidebarThreadByKey.get(nextThreadKey) : null;
 
       void (async () => {
@@ -3444,15 +3445,19 @@ export default function Sidebar() {
             }
             return;
           }
-          if (routeThreadKeyRef.current === threadKey && nextThread) {
-            navigateToThread(scopeThreadRef(nextThread.environmentId, nextThread.id));
+          if (routeThreadKeyRef.current === threadKey) {
+            if (nextThread) {
+              navigateToThread(scopeThreadRef(nextThread.environmentId, nextThread.id));
+            } else {
+              void handleNewThread(scopeProjectRef(thread.environmentId, thread.projectId));
+            }
           }
         } finally {
           settlingThreadKeysRef.current.delete(threadKey);
         }
       })();
     },
-    [navigateToThread, orderedSidebarThreadKeys, settleThread, sidebarThreadByKey],
+    [handleNewThread, navigateToThread, orderedSidebarThreadKeys, settleThread, sidebarThreadByKey],
   );
 
   useEffect(() => {
@@ -3488,16 +3493,18 @@ export default function Sidebar() {
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
       });
       if (action.type === "none") return;
+      if (action.type === "navigate") {
+        const targetThread = sidebarThreadByKey.get(action.threadKey);
+        if (!targetThread) return;
+        event.preventDefault();
+        event.stopPropagation();
+        navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       if (action.type === "consume") return;
-      if (action.type === "confirm-settle") {
-        setSettleConfirmationThreadKey(action.threadKey);
-        return;
-      }
-      const targetThread = sidebarThreadByKey.get(action.threadKey);
-      if (!targetThread) return;
-      navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
+      setSettleConfirmationThreadKey(action.threadKey);
     };
 
     window.addEventListener("keydown", onWindowKeyDown);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -196,6 +196,7 @@ import {
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
+  shouldPublishSidebarChangeRequestState,
   shouldQuerySidebarThreadGitStatus,
   shouldClearThreadSelectionOnMouseDown,
   shouldDismissThreadSettleConfirmation,
@@ -358,8 +359,9 @@ function SidebarHiddenThreadChangeRequestStateReporter(props: {
     })?.state ?? null;
 
   useEffect(() => {
+    if (!shouldPublishSidebarChangeRequestState(gitStatus.isPending)) return;
     onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+  }, [gitStatus.isPending, onChangeRequestState, prState, threadKey]);
 
   return null;
 }
@@ -530,8 +532,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const prState = pr?.state ?? null;
   useEffect(() => {
+    if (!shouldPublishSidebarChangeRequestState(gitStatus.isPending)) return;
     onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+  }, [gitStatus.isPending, onChangeRequestState, prState, threadKey]);
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
   const threadMetaClassName = isConfirmingArchive

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -206,6 +206,7 @@ import { sortThreads } from "../lib/threadSort";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
+import { useNowMinute } from "~/hooks/useNowMinute";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
 import { primaryServerKeybindingsAtom } from "../state/server";
@@ -3110,16 +3111,7 @@ export default function Sidebar() {
     null,
   );
   const settleConfirmationButtonRef = useRef<HTMLButtonElement>(null);
-  const [settlementNowMinute, setSettlementNowMinute] = useState(() =>
-    new Date().toISOString().slice(0, 16),
-  );
-  useEffect(() => {
-    const id = window.setInterval(
-      () => setSettlementNowMinute(new Date().toISOString().slice(0, 16)),
-      60_000,
-    );
-    return () => window.clearInterval(id);
-  }, []);
+  const settlementNowMinute = useNowMinute();
   const settlementNow = `${settlementNowMinute}:00.000Z`;
   const [changeRequestStateByThreadKey, setChangeRequestStateByThreadKey] = useState<
     ReadonlyMap<string, ChangeRequestStateLike>
@@ -3714,13 +3706,26 @@ export default function Sidebar() {
   const settleConfirmationThread = settleConfirmationThreadKey
     ? (sidebarThreadByKey.get(settleConfirmationThreadKey) ?? null)
     : null;
+  const settleConfirmationCanSettle =
+    settleConfirmationThread !== null &&
+    serverConfigs.get(settleConfirmationThread.environmentId)?.environment.capabilities
+      .threadSettlement === true &&
+    canSettleLegacySidebarRouteThread({
+      thread: settleConfirmationThread,
+      settlementSupported: true,
+      now: new Date().toISOString(),
+    });
   const confirmShortcutSettle = useCallback(() => {
-    if (!settleConfirmationThreadKey || settleConfirmationThreadKey !== routeThreadKeyRef.current) {
+    if (
+      !settleConfirmationThreadKey ||
+      settleConfirmationThreadKey !== routeThreadKeyRef.current ||
+      !settleConfirmationCanSettle
+    ) {
       setSettleConfirmationThreadKey(null);
       return;
     }
     attemptShortcutSettle(settleConfirmationThreadKey);
-  }, [attemptShortcutSettle, settleConfirmationThreadKey]);
+  }, [attemptShortcutSettle, settleConfirmationCanSettle, settleConfirmationThreadKey]);
 
   useEffect(() => {
     if (
@@ -3729,11 +3734,17 @@ export default function Sidebar() {
         routeThreadKey,
         targetExists: settleConfirmationThread !== null,
         targetExplicitlySettled: settleConfirmationThread?.settledOverride === "settled",
+        targetCanSettle: settleConfirmationCanSettle,
       })
     ) {
       setSettleConfirmationThreadKey(null);
     }
-  }, [routeThreadKey, settleConfirmationThread, settleConfirmationThreadKey]);
+  }, [
+    routeThreadKey,
+    settleConfirmationCanSettle,
+    settleConfirmationThread,
+    settleConfirmationThreadKey,
+  ]);
 
   useEffect(() => {
     const onMouseDown = (event: globalThis.MouseEvent) => {
@@ -3917,7 +3928,7 @@ export default function Sidebar() {
         </>
       )}
       <AlertDialog
-        open={settleConfirmationThread !== null}
+        open={settleConfirmationThread !== null && settleConfirmationCanSettle}
         onOpenChange={(open) => {
           if (!open) setSettleConfirmationThreadKey(null);
         }}
@@ -3933,7 +3944,11 @@ export default function Sidebar() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
-            <Button ref={settleConfirmationButtonRef} onClick={confirmShortcutSettle}>
+            <Button
+              ref={settleConfirmationButtonRef}
+              disabled={!settleConfirmationCanSettle}
+              onClick={confirmShortcutSettle}
+            >
               Settle thread
               <Kbd className="ml-1 h-5 px-1.5">Enter</Kbd>
             </Button>

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -126,6 +126,7 @@ import {
   resolveSidebarThreadGitCwd,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
+  shouldPublishSidebarChangeRequestState,
   shouldQuerySidebarThreadGitStatus,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
@@ -209,8 +210,9 @@ function SidebarV2HiddenThreadChangeRequestStateReporter(props: {
     })?.state ?? null;
 
   useEffect(() => {
+    if (!shouldPublishSidebarChangeRequestState(gitStatus.isPending)) return;
     onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+  }, [gitStatus.isPending, onChangeRequestState, prState, threadKey]);
 
   return null;
 }
@@ -572,8 +574,9 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // and a merged/closed PR auto-settles a thread — data only rows have.
   const prState = pr?.state ?? null;
   useEffect(() => {
+    if (!shouldPublishSidebarChangeRequestState(gitStatus.isPending)) return;
     onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+  }, [gitStatus.isPending, onChangeRequestState, prState, threadKey]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -83,11 +83,21 @@ import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore"
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { openCommandPalette } from "../commandPaletteBus";
+import { isCommandPaletteOpen, openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Button } from "./ui/button";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
@@ -2127,9 +2137,14 @@ export default function SidebarV2() {
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
       : false,
   );
+  const [settleConfirmationThreadKey, setSettleConfirmationThreadKey] = useState<string | null>(
+    null,
+  );
+  const settleConfirmationButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat) return;
+      if (isCommandPaletteOpen() || isModelPickerOpen()) return;
       const command = resolveShortcutCommand(event, keybindings, {
         platform: navigator.platform,
         context: {
@@ -2147,6 +2162,19 @@ export default function SidebarV2() {
         navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
         return true;
       };
+      if (command === "thread.settle") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!routeThreadKey) return;
+        const thread = threadByKey.get(routeThreadKey);
+        const supportsSettlement =
+          thread &&
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement ===
+            true;
+        if (!thread || !supportsSettlement || settledThreadKeys.has(routeThreadKey)) return;
+        setSettleConfirmationThreadKey(routeThreadKey);
+        return;
+      }
       const traversalDirection = threadTraversalDirectionFromCommand(command);
       if (traversalDirection !== null) {
         navigateToThreadKey(
@@ -2170,8 +2198,21 @@ export default function SidebarV2() {
     orderedThreadKeys,
     routeTerminalOpen,
     routeThreadKey,
+    serverConfigs,
+    settledThreadKeys,
     threadByKey,
   ]);
+
+  const settleConfirmationThread = settleConfirmationThreadKey
+    ? (threadByKey.get(settleConfirmationThreadKey) ?? null)
+    : null;
+  const confirmShortcutSettle = useCallback(() => {
+    if (!settleConfirmationThread) return;
+    setSettleConfirmationThreadKey(null);
+    attemptSettle(
+      scopeThreadRef(settleConfirmationThread.environmentId, settleConfirmationThread.id),
+    );
+  }, [attemptSettle, settleConfirmationThread]);
 
   // Same predicate as v1: hints show only while the held modifiers exactly
   // match a thread-jump binding. Adding Shift (screenshots) or Alt no
@@ -2733,6 +2774,30 @@ export default function SidebarV2() {
         </DialogPopup>
       </Dialog>
       <SidebarChromeFooter />
+      <AlertDialog
+        open={settleConfirmationThread !== null}
+        onOpenChange={(open) => {
+          if (!open) setSettleConfirmationThreadKey(null);
+        }}
+      >
+        <AlertDialogPopup initialFocus={settleConfirmationButtonRef}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Settle this thread?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {settleConfirmationThread
+                ? `“${settleConfirmationThread.title}” will move out of active work. You can un-settle it later.`
+                : "This thread will move out of active work. You can un-settle it later."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button ref={settleConfirmationButtonRef} onClick={confirmShortcutSettle}>
+              Settle thread
+              <Kbd className="ml-1 h-5 px-1.5">Enter</Kbd>
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
     </>
   );
 }

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1797,17 +1797,22 @@ export default function SidebarV2() {
     (threadKey: string, coParkingKeys?: ReadonlySet<string>): (() => void) | null => {
       if (routeThreadKeyRef.current !== threadKey) return null;
       const shell = allThreadByKeyRef.current.get(threadKey);
-      const orderedKeys = orderedThreadKeysRef.current;
-      const settledKeys = settledThreadKeysRef.current;
-      const snoozedKeys = snoozedThreadKeysRef.current;
-      const currentIndex = orderedKeys.indexOf(threadKey);
-      const nextCardKey =
-        currentIndex === -1
-          ? null
-          : ([...orderedKeys.slice(currentIndex + 1), ...orderedKeys.slice(0, currentIndex)].find(
-              (key) => !settledKeys.has(key) && !snoozedKeys.has(key) && !coParkingKeys?.has(key),
-            ) ?? null);
-      const nextThread = nextCardKey ? threadByKeyRef.current.get(nextCardKey) : null;
+      const navigationNow = new Date().toISOString();
+      const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
+        threadIds: orderedThreadKeysRef.current,
+        fallbackThreadIds: allUnarchivedThreadKeysRef.current,
+        settledThreadId: threadKey,
+        isActive: (candidateKey) => {
+          const candidate = allThreadByKeyRef.current.get(candidateKey);
+          return (
+            candidate !== undefined &&
+            !coParkingKeys?.has(candidateKey) &&
+            !isThreadEffectivelySnoozedRef.current(candidate, navigationNow) &&
+            !isThreadEffectivelySettledRef.current(candidate)
+          );
+        },
+      });
+      const nextThread = nextThreadKey ? allThreadByKeyRef.current.get(nextThreadKey) : null;
       return nextThread
         ? () => navigateToThread(scopeThreadRef(nextThread.environmentId, nextThread.id))
         : shell

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -56,11 +56,10 @@ import {
 import { isElectron } from "../env";
 import {
   resolveShortcutCommand,
+  resolveThreadSidebarShortcutAction,
   shortcutLabelForCommand,
   shouldShowThreadJumpHintsForModifiers,
   threadJumpCommandForIndex,
-  threadJumpIndexFromCommand,
-  threadTraversalDirectionFromCommand,
 } from "../keybindings";
 import { useShortcutModifierState } from "../shortcutModifierState";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -120,7 +119,6 @@ import {
   hasUnseenCompletion,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
-  resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
@@ -1578,6 +1576,10 @@ export default function SidebarV2() {
   );
   const snoozedThreadKeysRef = useRef(snoozedThreadKeys);
   snoozedThreadKeysRef.current = snoozedThreadKeys;
+  const [settleConfirmationThreadKey, setSettleConfirmationThreadKey] = useState<string | null>(
+    null,
+  );
+  const settleConfirmationButtonRef = useRef<HTMLButtonElement>(null);
 
   const jumpLabelByKey = useMemo(() => {
     const mapping = new Map<string, string>();
@@ -1709,6 +1711,7 @@ export default function SidebarV2() {
         const threadKey = scopedThreadKey(threadRef);
         if (settlingThreadKeysRef.current.has(threadKey)) return;
         settlingThreadKeysRef.current.add(threadKey);
+        setSettleConfirmationThreadKey((current) => (current === threadKey ? null : current));
         try {
           const navigateAfterSettle = planForwardNavigation(threadKey, opts.coSettlingKeys);
           const result = await settleThread(threadRef);
@@ -2137,10 +2140,6 @@ export default function SidebarV2() {
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
       : false,
   );
-  const [settleConfirmationThreadKey, setSettleConfirmationThreadKey] = useState<string | null>(
-    null,
-  );
-  const settleConfirmationButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat) return;
@@ -2153,42 +2152,31 @@ export default function SidebarV2() {
           modelPickerOpen: isModelPickerOpen(),
         },
       });
-      const navigateToThreadKey = (targetThreadKey: string | null) => {
-        if (!targetThreadKey) return false;
-        const targetThread = threadByKey.get(targetThreadKey);
-        if (!targetThread) return false;
-        event.preventDefault();
-        event.stopPropagation();
-        navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
-        return true;
-      };
-      if (command === "thread.settle") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!routeThreadKey) return;
-        const thread = threadByKey.get(routeThreadKey);
-        const supportsSettlement =
-          thread &&
-          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement ===
-            true;
-        if (!thread || !supportsSettlement || settledThreadKeys.has(routeThreadKey)) return;
-        setSettleConfirmationThreadKey(routeThreadKey);
+      const routeThread = routeThreadKey ? threadByKey.get(routeThreadKey) : null;
+      const action = resolveThreadSidebarShortcutAction({
+        command,
+        orderedThreadKeys,
+        routeThreadKey,
+        settleConfirmationThreadKey,
+        canSettleRouteThread:
+          routeThread != null &&
+          serverConfigs.get(routeThread.environmentId)?.environment.capabilities
+            .threadSettlement === true &&
+          !settledThreadKeys.has(routeThreadKey ?? ""),
+        isRouteThreadSettling:
+          routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
+      });
+      if (action.type === "none") return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (action.type === "consume") return;
+      if (action.type === "confirm-settle") {
+        setSettleConfirmationThreadKey(action.threadKey);
         return;
       }
-      const traversalDirection = threadTraversalDirectionFromCommand(command);
-      if (traversalDirection !== null) {
-        navigateToThreadKey(
-          resolveAdjacentThreadId({
-            threadIds: orderedThreadKeys,
-            currentThreadId: routeThreadKey,
-            direction: traversalDirection,
-          }),
-        );
-        return;
-      }
-      const jumpIndex = threadJumpIndexFromCommand(command ?? "");
-      if (jumpIndex === null) return;
-      navigateToThreadKey(orderedThreadKeys[jumpIndex] ?? null);
+      const targetThread = threadByKey.get(action.threadKey);
+      if (!targetThread) return;
+      navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
     };
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);
@@ -2199,6 +2187,7 @@ export default function SidebarV2() {
     routeTerminalOpen,
     routeThreadKey,
     serverConfigs,
+    settleConfirmationThreadKey,
     settledThreadKeys,
     threadByKey,
   ]);
@@ -2208,11 +2197,20 @@ export default function SidebarV2() {
     : null;
   const confirmShortcutSettle = useCallback(() => {
     if (!settleConfirmationThread) return;
-    setSettleConfirmationThreadKey(null);
     attemptSettle(
       scopeThreadRef(settleConfirmationThread.environmentId, settleConfirmationThread.id),
     );
   }, [attemptSettle, settleConfirmationThread]);
+
+  useEffect(() => {
+    if (
+      settleConfirmationThreadKey !== null &&
+      (settledThreadKeys.has(settleConfirmationThreadKey) ||
+        !threadByKey.has(settleConfirmationThreadKey))
+    ) {
+      setSettleConfirmationThreadKey(null);
+    }
+  }, [settleConfirmationThreadKey, settledThreadKeys, threadByKey]);
 
   // Same predicate as v1: hints show only while the held modifiers exactly
   // match a thread-jump binding. Adding Shift (screenshots) or Alt no

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -189,11 +189,12 @@ function SidebarV2HiddenThreadChangeRequestStateReporter(props: {
     sidebarProjectCwd: null,
   });
   const gitStatus = useEnvironmentQuery(
-    shouldQuerySidebarThreadGitStatus({
-      branch: thread.branch,
-      worktreePath: thread.worktreePath,
-      gitCwd,
-    })
+    gitCwd !== null &&
+      shouldQuerySidebarThreadGitStatus({
+        branch: thread.branch,
+        worktreePath: thread.worktreePath,
+        gitCwd,
+      })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -543,11 +544,12 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     sidebarProjectCwd: null,
   });
   const gitStatus = useEnvironmentQuery(
-    shouldQuerySidebarThreadGitStatus({
-      branch: thread.branch,
-      worktreePath: thread.worktreePath,
-      gitCwd,
-    })
+    gitCwd !== null &&
+      shouldQuerySidebarThreadGitStatus({
+        branch: thread.branch,
+        worktreePath: thread.worktreePath,
+        gitCwd,
+      })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -126,6 +126,7 @@ import {
   resolveSidebarThreadGitCwd,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
+  shouldQuerySidebarThreadGitStatus,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
@@ -188,7 +189,11 @@ function SidebarV2HiddenThreadChangeRequestStateReporter(props: {
     sidebarProjectCwd: null,
   });
   const gitStatus = useEnvironmentQuery(
-    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
+    shouldQuerySidebarThreadGitStatus({
+      branch: thread.branch,
+      worktreePath: thread.worktreePath,
+      gitCwd,
+    })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
@@ -538,7 +543,11 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     sidebarProjectCwd: null,
   });
   const gitStatus = useEnvironmentQuery(
-    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
+    shouldQuerySidebarThreadGitStatus({
+      branch: thread.branch,
+      worktreePath: thread.worktreePath,
+      gitCwd,
+    })
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -121,7 +121,9 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveSettledTimestamp,
+  pruneSidebarChangeRequestStates,
   resolveNextActiveThreadIdAfterSettle,
+  resolveSidebarThreadGitCwd,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
@@ -175,12 +177,16 @@ const SETTLED_TAIL_INITIAL_COUNT = 10;
 
 function SidebarV2HiddenThreadChangeRequestStateReporter(props: {
   thread: SidebarThreadSummary;
-  projectCwd: string | null;
+  threadProjectCwd: string | null;
   onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
 }) {
-  const { thread, projectCwd, onChangeRequestState } = props;
+  const { thread, threadProjectCwd, onChangeRequestState } = props;
   const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-  const gitCwd = thread.worktreePath ?? projectCwd;
+  const gitCwd = resolveSidebarThreadGitCwd({
+    worktreePath: thread.worktreePath,
+    threadProjectCwd,
+    sidebarProjectCwd: null,
+  });
   const gitStatus = useEnvironmentQuery(
     (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
@@ -526,7 +532,11 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                   }
                 : null;
 
-  const gitCwd = thread.worktreePath ?? props.projectCwd;
+  const gitCwd = resolveSidebarThreadGitCwd({
+    worktreePath: thread.worktreePath,
+    threadProjectCwd: props.projectCwd,
+    sidebarProjectCwd: null,
+  });
   const gitStatus = useEnvironmentQuery(
     (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
@@ -1585,6 +1595,15 @@ export default function SidebarV2() {
       ),
     [allUnarchivedThreads],
   );
+  const allUnarchivedThreadKeySet = useMemo(
+    () => new Set(allUnarchivedThreadKeys),
+    [allUnarchivedThreadKeys],
+  );
+  useEffect(() => {
+    setChangeRequestStateByKey((current) =>
+      pruneSidebarChangeRequestStates(current, allUnarchivedThreadKeySet),
+    );
+  }, [allUnarchivedThreadKeySet]);
   const allUnarchivedThreadKeysRef = useRef(allUnarchivedThreadKeys);
   allUnarchivedThreadKeysRef.current = allUnarchivedThreadKeys;
   const allThreadByKey = useMemo(
@@ -2378,7 +2397,9 @@ export default function SidebarV2() {
           <SidebarV2HiddenThreadChangeRequestStateReporter
             key={threadKey}
             thread={thread}
-            projectCwd={projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null}
+            threadProjectCwd={
+              projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
+            }
             onChangeRequestState={handleChangeRequestState}
           />
         ) : null;

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1488,13 +1488,7 @@ export default function SidebarV2() {
       settledThreads: sortSettledThreadsForSidebarV2(settled),
       snoozeNow: preciseNow,
     };
-  }, [
-    isThreadEffectivelySettled,
-    scopedProjectKeys,
-    serverConfigs,
-    snoozeWakeTick,
-    threads,
-  ]);
+  }, [isThreadEffectivelySettled, scopedProjectKeys, serverConfigs, snoozeWakeTick, threads]);
 
   // Arm a timeout for the earliest upcoming wake so the shelf empties the
   // moment a snooze expires instead of on the next minute tick. Sorted
@@ -2336,15 +2330,29 @@ export default function SidebarV2() {
   const settleConfirmationThread = settleConfirmationThreadKey
     ? (allThreadByKey.get(settleConfirmationThreadKey) ?? null)
     : null;
+  const settleConfirmationCanSettle =
+    settleConfirmationThread !== null &&
+    serverConfigs.get(settleConfirmationThread.environmentId)?.environment.capabilities
+      .threadSettlement === true &&
+    canSettle(settleConfirmationThread, { now: new Date().toISOString() });
   const confirmShortcutSettle = useCallback(() => {
-    if (!settleConfirmationThread || settleConfirmationThreadKey !== routeThreadKeyRef.current) {
+    if (
+      !settleConfirmationThread ||
+      settleConfirmationThreadKey !== routeThreadKeyRef.current ||
+      !settleConfirmationCanSettle
+    ) {
       setSettleConfirmationThreadKey(null);
       return;
     }
     attemptSettle(
       scopeThreadRef(settleConfirmationThread.environmentId, settleConfirmationThread.id),
     );
-  }, [attemptSettle, settleConfirmationThread, settleConfirmationThreadKey]);
+  }, [
+    attemptSettle,
+    settleConfirmationCanSettle,
+    settleConfirmationThread,
+    settleConfirmationThreadKey,
+  ]);
 
   useEffect(() => {
     if (
@@ -2353,11 +2361,17 @@ export default function SidebarV2() {
         routeThreadKey,
         targetExists: settleConfirmationThread !== null,
         targetExplicitlySettled: settleConfirmationThread?.settledOverride === "settled",
+        targetCanSettle: settleConfirmationCanSettle,
       })
     ) {
       setSettleConfirmationThreadKey(null);
     }
-  }, [routeThreadKey, settleConfirmationThread, settleConfirmationThreadKey]);
+  }, [
+    routeThreadKey,
+    settleConfirmationCanSettle,
+    settleConfirmationThread,
+    settleConfirmationThreadKey,
+  ]);
 
   // Same predicate as v1: hints show only while the held modifiers exactly
   // match a thread-jump binding. Adding Shift (screenshots) or Alt no
@@ -2933,7 +2947,7 @@ export default function SidebarV2() {
       </Dialog>
       <SidebarChromeFooter />
       <AlertDialog
-        open={settleConfirmationThread !== null}
+        open={settleConfirmationThread !== null && settleConfirmationCanSettle}
         onOpenChange={(open) => {
           if (!open) setSettleConfirmationThreadKey(null);
         }}
@@ -2949,7 +2963,11 @@ export default function SidebarV2() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
-            <Button ref={settleConfirmationButtonRef} onClick={confirmShortcutSettle}>
+            <Button
+              ref={settleConfirmationButtonRef}
+              disabled={!settleConfirmationCanSettle}
+              onClick={confirmShortcutSettle}
+            >
               Settle thread
               <Kbd className="ml-1 h-5 px-1.5">Enter</Kbd>
             </Button>

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1,6 +1,7 @@
 import { autoAnimate } from "@formkit/auto-animate";
 import { useAtomValue } from "@effect/atom-react";
 import {
+  canSettle,
   canSnooze,
   effectiveSettled,
   effectiveSnoozed,
@@ -2162,6 +2163,7 @@ export default function SidebarV2() {
           routeThread != null &&
           serverConfigs.get(routeThread.environmentId)?.environment.capabilities
             .threadSettlement === true &&
+          canSettle(routeThread, { now: new Date().toISOString() }) &&
           !settledThreadKeys.has(routeThreadKey ?? ""),
         isRouteThreadSettling:
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -183,7 +183,7 @@ function SidebarV2HiddenThreadChangeRequestStateReporter(props: {
   const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
   const gitCwd = thread.worktreePath ?? projectCwd;
   const gitStatus = useEnvironmentQuery(
-    thread.branch != null && gitCwd !== null
+    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -96,7 +96,6 @@ import {
   AlertDialogPopup,
   AlertDialogTitle,
 } from "./ui/alert-dialog";
-import { Button } from "./ui/button";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1,11 +1,6 @@
 import { autoAnimate } from "@formkit/auto-animate";
 import { useAtomValue } from "@effect/atom-react";
-import {
-  canSettle,
-  canSnooze,
-  effectiveSnoozed,
-  threadWokeAt,
-} from "@t3tools/client-runtime/state/thread-settled";
+import { canSettle, canSnooze, threadWokeAt } from "@t3tools/client-runtime/state/thread-settled";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
@@ -117,6 +112,7 @@ import {
   firstValidTimestampMs,
   getSidebarThreadKeysNeedingChangeRequestReporter,
   hasUnseenCompletion,
+  isSidebarThreadEffectivelySnoozed,
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
@@ -1447,6 +1443,18 @@ export default function SidebarV2() {
   );
   const isThreadEffectivelySettledRef = useRef(isThreadEffectivelySettled);
   isThreadEffectivelySettledRef.current = isThreadEffectivelySettled;
+  const isThreadEffectivelySnoozed = useCallback(
+    (thread: SidebarThreadSummary, now: string) =>
+      isSidebarThreadEffectivelySnoozed({
+        thread,
+        snoozeSupported:
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true,
+        now,
+      }),
+    [serverConfigs],
+  );
+  const isThreadEffectivelySnoozedRef = useRef(isThreadEffectivelySnoozed);
+  isThreadEffectivelySnoozedRef.current = isThreadEffectivelySnoozed;
   const { activeThreads, snoozedThreads, settledThreads, snoozeNow } = useMemo(() => {
     // Snooze classification uses a REAL clock, not the quantized minute:
     // wake times are second-precise and a woken thread must not linger on
@@ -1464,12 +1472,10 @@ export default function SidebarV2() {
     const snoozed: EnvironmentThreadShell[] = [];
     const settled: EnvironmentThreadShell[] = [];
     for (const thread of visible) {
-      const supportsSnooze =
-        serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
       // Snooze outranks settled classification: an explicitly snoozed thread
       // belongs to the shelf even if it would also auto-settle (the shelf's
       // wake time is a stronger statement about when it matters again).
-      if (supportsSnooze && effectiveSnoozed(thread, { now: preciseNow })) {
+      if (isThreadEffectivelySnoozed(thread, preciseNow)) {
         snoozed.push(thread);
       } else if (isThreadEffectivelySettled(thread)) {
         settled.push(thread);
@@ -1488,7 +1494,13 @@ export default function SidebarV2() {
       settledThreads: sortSettledThreadsForSidebarV2(settled),
       snoozeNow: preciseNow,
     };
-  }, [isThreadEffectivelySettled, scopedProjectKeys, serverConfigs, snoozeWakeTick, threads]);
+  }, [
+    isThreadEffectivelySettled,
+    isThreadEffectivelySnoozed,
+    scopedProjectKeys,
+    snoozeWakeTick,
+    threads,
+  ]);
 
   // Arm a timeout for the earliest upcoming wake so the shelf empties the
   // moment a snooze expires instead of on the next minute tick. Sorted
@@ -1822,6 +1834,7 @@ export default function SidebarV2() {
           const shell = allThreadByKeyRef.current.get(threadKey);
           let navigateAfterSettle: (() => void) | null = null;
           if (routeThreadKeyRef.current === threadKey) {
+            const navigationNow = new Date().toISOString();
             const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
               threadIds: orderedThreadKeysRef.current,
               fallbackThreadIds: allUnarchivedThreadKeysRef.current,
@@ -1831,6 +1844,7 @@ export default function SidebarV2() {
                 return (
                   candidate !== undefined &&
                   !opts.coSettlingKeys?.has(candidateKey) &&
+                  !isThreadEffectivelySnoozedRef.current(candidate, navigationNow) &&
                   !isThreadEffectivelySettledRef.current(candidate)
                 );
               },

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -121,6 +121,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveSettledTimestamp,
+  resolveNextActiveThreadIdAfterSettle,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
@@ -1390,6 +1391,8 @@ export default function SidebarV2() {
     },
     [autoSettleAfterDays, changeRequestStateByKey, nowMinute, serverConfigs],
   );
+  const isThreadEffectivelySettledRef = useRef(isThreadEffectivelySettled);
+  isThreadEffectivelySettledRef.current = isThreadEffectivelySettled;
   const { activeThreads, snoozedThreads, settledThreads, snoozeNow } = useMemo(() => {
     // Snooze classification uses a REAL clock, not the quantized minute:
     // wake times are second-precise and a woken thread must not linger on
@@ -1538,20 +1541,31 @@ export default function SidebarV2() {
   // rendered at click time.
   const orderedThreadKeysRef = useRef(orderedThreadKeys);
   orderedThreadKeysRef.current = orderedThreadKeys;
-  // Route actions are independent of the selected project chip. Keep a map
-  // of every live shell for eligibility and confirmation; rendered traversal
-  // continues to use the scoped map below.
+  // Route actions are independent of the selected project chip. Keep every
+  // live shell in stable creation order for eligibility, confirmation, and
+  // post-settle fallback; rendered keyboard traversal stays scoped below.
+  const allUnarchivedThreads = useMemo(
+    () => sortThreadsForSidebarV2(threads.filter((thread) => thread.archivedAt === null)),
+    [threads],
+  );
+  const allUnarchivedThreadKeys = useMemo(
+    () =>
+      allUnarchivedThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+    [allUnarchivedThreads],
+  );
+  const allUnarchivedThreadKeysRef = useRef(allUnarchivedThreadKeys);
+  allUnarchivedThreadKeysRef.current = allUnarchivedThreadKeys;
   const allThreadByKey = useMemo(
     () =>
       new Map(
-        threads
-          .filter((thread) => thread.archivedAt === null)
-          .map(
-            (thread) =>
-              [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
-          ),
+        allUnarchivedThreads.map(
+          (thread) =>
+            [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+        ),
       ),
-    [threads],
+    [allUnarchivedThreads],
   );
   const allThreadByKeyRef = useRef(allThreadByKey);
   allThreadByKeyRef.current = allThreadByKey;
@@ -1733,7 +1747,37 @@ export default function SidebarV2() {
         settlingThreadKeysRef.current.add(threadKey);
         setSettleConfirmationThreadKey((current) => (current === threadKey ? null : current));
         try {
-          const navigateAfterSettle = planForwardNavigation(threadKey, opts.coSettlingKeys);
+          // Settling the thread you're looking at moves you forward: the next
+          // remaining card (never a settled row, never one settling in the
+          // same batch), or a fresh draft in this project when it was the
+          // last active one. Snapshot the target before the settle mutates
+          // the partition. Background settles never navigate.
+          const shell = allThreadByKeyRef.current.get(threadKey);
+          let navigateAfterSettle: (() => void) | null = null;
+          if (routeThreadKey === threadKey) {
+            const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
+              threadIds: orderedThreadKeysRef.current,
+              fallbackThreadIds: allUnarchivedThreadKeysRef.current,
+              settledThreadId: threadKey,
+              isActive: (candidateKey) => {
+                const candidate = allThreadByKeyRef.current.get(candidateKey);
+                return (
+                  candidate !== undefined &&
+                  !opts.coSettlingKeys?.has(candidateKey) &&
+                  !isThreadEffectivelySettledRef.current(candidate)
+                );
+              },
+            });
+            const nextThread = nextThreadKey ? allThreadByKeyRef.current.get(nextThreadKey) : null;
+            navigateAfterSettle = nextThread
+              ? () => navigateToThread(scopeThreadRef(nextThread.environmentId, nextThread.id))
+              : shell
+                ? () =>
+                    void handleNewThreadRef.current(
+                      scopeProjectRef(shell.environmentId, shell.projectId),
+                    )
+                : () => void router.navigate({ to: "/" });
+          }
           const result = await settleThread(threadRef);
           if (result._tag === "Failure") {
             // Never navigate away from a thread that did not settle.
@@ -2235,18 +2279,12 @@ export default function SidebarV2() {
         confirmationThreadKey: settleConfirmationThreadKey,
         routeThreadKey,
         targetExists: settleConfirmationThread !== null,
-        targetSettled:
-          settleConfirmationThread !== null && isThreadEffectivelySettled(settleConfirmationThread),
+        targetExplicitlySettled: settleConfirmationThread?.settledOverride === "settled",
       })
     ) {
       setSettleConfirmationThreadKey(null);
     }
-  }, [
-    isThreadEffectivelySettled,
-    routeThreadKey,
-    settleConfirmationThread,
-    settleConfirmationThreadKey,
-  ]);
+  }, [routeThreadKey, settleConfirmationThread, settleConfirmationThreadKey]);
 
   // Same predicate as v1: hints show only while the held modifiers exactly
   // match a thread-jump binding. Adding Shift (screenshots) or Alt no

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1827,7 +1827,7 @@ export default function SidebarV2() {
           // the partition. Background settles never navigate.
           const shell = allThreadByKeyRef.current.get(threadKey);
           let navigateAfterSettle: (() => void) | null = null;
-          if (routeThreadKey === threadKey) {
+          if (routeThreadKeyRef.current === threadKey) {
             const nextThreadKey = resolveNextActiveThreadIdAfterSettle({
               threadIds: orderedThreadKeysRef.current,
               fallbackThreadIds: allUnarchivedThreadKeysRef.current,
@@ -1876,7 +1876,7 @@ export default function SidebarV2() {
         }
       })();
     },
-    [planForwardNavigation, settleThread],
+    [navigateToThread, router, settleThread],
   );
   const attemptUnsettle = useCallback(
     (threadRef: ScopedThreadRef) => {

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -116,6 +116,7 @@ import { cn } from "~/lib/utils";
 import {
   formatWorkingDurationLabel,
   firstValidTimestampMs,
+  getSidebarThreadKeysNeedingChangeRequestReporter,
   hasUnseenCompletion,
   isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
@@ -172,6 +173,36 @@ import { useComposerDraftStore } from "../composerDraftStore";
 // Settled-tail paging: recent history is the common lookup; the deep tail
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
+
+function SidebarV2HiddenThreadChangeRequestStateReporter(props: {
+  thread: SidebarThreadSummary;
+  projectCwd: string | null;
+  onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
+}) {
+  const { thread, projectCwd, onChangeRequestState } = props;
+  const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+  const gitCwd = thread.worktreePath ?? projectCwd;
+  const gitStatus = useEnvironmentQuery(
+    thread.branch != null && gitCwd !== null
+      ? vcsEnvironment.status({
+          environmentId: thread.environmentId,
+          input: { cwd: gitCwd },
+        })
+      : null,
+  );
+  const prState =
+    resolveThreadPr({
+      threadBranch: thread.branch,
+      gitStatus: gitStatus.data,
+      hasDedicatedWorktree: thread.worktreePath !== null,
+    })?.state ?? null;
+
+  useEffect(() => {
+    onChangeRequestState(threadKey, prState);
+  }, [onChangeRequestState, prState, threadKey]);
+
+  return null;
+}
 const SETTLED_TAIL_PAGE_COUNT = 25;
 const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
   repository: "Group by repository",
@@ -1579,6 +1610,16 @@ export default function SidebarV2() {
       ),
     [orderedThreads],
   );
+  const visibleThreadKeySet = useMemo(() => new Set(orderedThreadKeys), [orderedThreadKeys]);
+  const hiddenChangeRequestReporterThreadKeys = useMemo(
+    () =>
+      getSidebarThreadKeysNeedingChangeRequestReporter(
+        allUnarchivedThreadKeys,
+        visibleThreadKeySet,
+        true,
+      ),
+    [allUnarchivedThreadKeys, visibleThreadKeySet],
+  );
   // Handlers read these through refs: depending on per-update Map/Set
   // identities would give every row a fresh callback prop on each shell
   // event and defeat row memoization during streaming.
@@ -2332,6 +2373,17 @@ export default function SidebarV2() {
     shortcutLabelForCommand(keybindings, "chat.new");
   return (
     <>
+      {hiddenChangeRequestReporterThreadKeys.map((threadKey) => {
+        const thread = allThreadByKey.get(threadKey);
+        return thread ? (
+          <SidebarV2HiddenThreadChangeRequestStateReporter
+            key={threadKey}
+            thread={thread}
+            projectCwd={projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null}
+            onChangeRequestState={handleChangeRequestState}
+          />
+        ) : null;
+      })}
       <SidebarChromeHeader isElectron={isElectron} />
       <SidebarContent className="gap-0">
         <SidebarGroup className="px-2 pb-2 pt-3">

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -3,7 +3,6 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   canSettle,
   canSnooze,
-  effectiveSettled,
   effectiveSnoozed,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
@@ -118,6 +117,7 @@ import {
   formatWorkingDurationLabel,
   firstValidTimestampMs,
   hasUnseenCompletion,
+  isSidebarThreadEffectivelySettled,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveSettledTimestamp,
@@ -127,6 +127,7 @@ import {
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
   sortThreadsForSidebarV2,
+  shouldDismissThreadSettleConfirmation,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
@@ -1374,8 +1375,22 @@ export default function SidebarV2() {
   // merging, no optimistic holds. Archived threads remain hidden here —
   // archive keeps its original "remove from sidebar" meaning.
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
+  const isThreadEffectivelySettled = useCallback(
+    (thread: SidebarThreadSummary) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      return isSidebarThreadEffectivelySettled({
+        thread,
+        settlementSupported:
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement ===
+          true,
+        now: `${nowMinute}:00.000Z`,
+        autoSettleAfterDays,
+        changeRequestState: changeRequestStateByKey.get(threadKey) ?? null,
+      });
+    },
+    [autoSettleAfterDays, changeRequestStateByKey, nowMinute, serverConfigs],
+  );
   const { activeThreads, snoozedThreads, settledThreads, snoozeNow } = useMemo(() => {
-    const now = `${nowMinute}:00.000Z`;
     // Snooze classification uses a REAL clock, not the quantized minute:
     // wake times are second-precise and a woken thread must not linger on
     // the shelf for the rest of the minute. snoozeWakeTick re-runs this
@@ -1392,25 +1407,14 @@ export default function SidebarV2() {
     const snoozed: EnvironmentThreadShell[] = [];
     const settled: EnvironmentThreadShell[] = [];
     for (const thread of visible) {
-      // Threads on servers without the settlement capability (old server,
-      // or descriptor not loaded yet) never classify as settled: the user
-      // could neither un-settle nor pin them, so auto-settling them would
-      // strand rows in a tail with no working affordances.
-      const supportsSettlement =
-        serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement === true;
       const supportsSnooze =
         serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
-      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-      const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
       // Snooze outranks settled classification: an explicitly snoozed thread
       // belongs to the shelf even if it would also auto-settle (the shelf's
       // wake time is a stronger statement about when it matters again).
       if (supportsSnooze && effectiveSnoozed(thread, { now: preciseNow })) {
         snoozed.push(thread);
-      } else if (
-        supportsSettlement &&
-        effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
-      ) {
+      } else if (isThreadEffectivelySettled(thread)) {
         settled.push(thread);
       } else {
         active.push(thread);
@@ -1428,9 +1432,7 @@ export default function SidebarV2() {
       snoozeNow: preciseNow,
     };
   }, [
-    autoSettleAfterDays,
-    changeRequestStateByKey,
-    nowMinute,
+    isThreadEffectivelySettled,
     scopedProjectKeys,
     serverConfigs,
     snoozeWakeTick,
@@ -1536,6 +1538,23 @@ export default function SidebarV2() {
   // rendered at click time.
   const orderedThreadKeysRef = useRef(orderedThreadKeys);
   orderedThreadKeysRef.current = orderedThreadKeys;
+  // Route actions are independent of the selected project chip. Keep a map
+  // of every live shell for eligibility and confirmation; rendered traversal
+  // continues to use the scoped map below.
+  const allThreadByKey = useMemo(
+    () =>
+      new Map(
+        threads
+          .filter((thread) => thread.archivedAt === null)
+          .map(
+            (thread) =>
+              [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+          ),
+      ),
+    [threads],
+  );
+  const allThreadByKeyRef = useRef(allThreadByKey);
+  allThreadByKeyRef.current = allThreadByKey;
   const threadByKey = useMemo(
     () =>
       new Map(
@@ -1684,7 +1703,7 @@ export default function SidebarV2() {
   const planForwardNavigation = useCallback(
     (threadKey: string, coParkingKeys?: ReadonlySet<string>): (() => void) | null => {
       if (routeThreadKeyRef.current !== threadKey) return null;
-      const shell = threadByKeyRef.current.get(threadKey);
+      const shell = allThreadByKeyRef.current.get(threadKey);
       const orderedKeys = orderedThreadKeysRef.current;
       const settledKeys = settledThreadKeysRef.current;
       const snoozedKeys = snoozedThreadKeysRef.current;
@@ -2153,7 +2172,7 @@ export default function SidebarV2() {
           modelPickerOpen: isModelPickerOpen(),
         },
       });
-      const routeThread = routeThreadKey ? threadByKey.get(routeThreadKey) : null;
+      const routeThread = routeThreadKey ? allThreadByKey.get(routeThreadKey) : null;
       const action = resolveThreadSidebarShortcutAction({
         command,
         orderedThreadKeys,
@@ -2164,7 +2183,7 @@ export default function SidebarV2() {
           serverConfigs.get(routeThread.environmentId)?.environment.capabilities
             .threadSettlement === true &&
           canSettle(routeThread, { now: new Date().toISOString() }) &&
-          !settledThreadKeys.has(routeThreadKey ?? ""),
+          !isThreadEffectivelySettled(routeThread),
         isRouteThreadSettling:
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
       });
@@ -2185,6 +2204,8 @@ export default function SidebarV2() {
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);
   }, [
+    allThreadByKey,
+    isThreadEffectivelySettled,
     keybindings,
     navigateToThread,
     orderedThreadKeys,
@@ -2192,29 +2213,40 @@ export default function SidebarV2() {
     routeThreadKey,
     serverConfigs,
     settleConfirmationThreadKey,
-    settledThreadKeys,
     threadByKey,
   ]);
 
   const settleConfirmationThread = settleConfirmationThreadKey
-    ? (threadByKey.get(settleConfirmationThreadKey) ?? null)
+    ? (allThreadByKey.get(settleConfirmationThreadKey) ?? null)
     : null;
   const confirmShortcutSettle = useCallback(() => {
-    if (!settleConfirmationThread) return;
+    if (!settleConfirmationThread || settleConfirmationThreadKey !== routeThreadKeyRef.current) {
+      setSettleConfirmationThreadKey(null);
+      return;
+    }
     attemptSettle(
       scopeThreadRef(settleConfirmationThread.environmentId, settleConfirmationThread.id),
     );
-  }, [attemptSettle, settleConfirmationThread]);
+  }, [attemptSettle, settleConfirmationThread, settleConfirmationThreadKey]);
 
   useEffect(() => {
     if (
-      settleConfirmationThreadKey !== null &&
-      (settledThreadKeys.has(settleConfirmationThreadKey) ||
-        !threadByKey.has(settleConfirmationThreadKey))
+      shouldDismissThreadSettleConfirmation({
+        confirmationThreadKey: settleConfirmationThreadKey,
+        routeThreadKey,
+        targetExists: settleConfirmationThread !== null,
+        targetSettled:
+          settleConfirmationThread !== null && isThreadEffectivelySettled(settleConfirmationThread),
+      })
     ) {
       setSettleConfirmationThreadKey(null);
     }
-  }, [settleConfirmationThreadKey, settledThreadKeys, threadByKey]);
+  }, [
+    isThreadEffectivelySettled,
+    routeThreadKey,
+    settleConfirmationThread,
+    settleConfirmationThreadKey,
+  ]);
 
   // Same predicate as v1: hints show only while the held modifiers exactly
   // match a thread-jump binding. Adding Shift (screenshots) or Alt no

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -2167,16 +2167,18 @@ export default function SidebarV2() {
           routeThreadKey !== null && settlingThreadKeysRef.current.has(routeThreadKey),
       });
       if (action.type === "none") return;
+      if (action.type === "navigate") {
+        const targetThread = threadByKey.get(action.threadKey);
+        if (!targetThread) return;
+        event.preventDefault();
+        event.stopPropagation();
+        navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       if (action.type === "consume") return;
-      if (action.type === "confirm-settle") {
-        setSettleConfirmationThreadKey(action.threadKey);
-        return;
-      }
-      const targetThread = threadByKey.get(action.threadKey);
-      if (!targetThread) return;
-      navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
+      setSettleConfirmationThreadKey(action.threadKey);
     };
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -126,6 +126,11 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
+  {
+    shortcut: modShortcut("enter", { shiftKey: true }),
+    command: "thread.settle",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
   { shortcut: modShortcut("1"), command: "thread.jump.1" },
@@ -147,6 +152,29 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenIdentifier("modelPickerOpen"),
   },
 ]);
+
+describe("thread settle shortcut", () => {
+  it("resolves Mod+Shift+Enter outside the terminal", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "Enter", metaKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "MacIntel" },
+      ),
+      "thread.settle",
+    );
+  });
+
+  it("does not resolve while the terminal owns focus", () => {
+    assert.isNull(
+      resolveShortcutCommand(
+        event({ key: "Enter", ctrlKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        { platform: "Linux", context: { terminalFocus: true } },
+      ),
+    );
+  });
+});
 
 describe("isTerminalToggleShortcut", () => {
   it("matches Cmd+J on macOS", () => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "vite-plus/test";
+import { assert, describe, expect, it } from "vite-plus/test";
 
 import {
   type KeybindingCommand,
@@ -21,6 +21,7 @@ import {
   isTerminalSplitVerticalShortcut,
   isTerminalToggleShortcut,
   resolveShortcutCommand,
+  resolveThreadSidebarShortcutAction,
   shouldShowModelPickerJumpHints,
   shouldShowThreadJumpHints,
   shortcutLabelForCommand,
@@ -173,6 +174,55 @@ describe("thread settle shortcut", () => {
         { platform: "Linux", context: { terminalFocus: true } },
       ),
     );
+  });
+
+  it("routes an eligible settle command to the shared confirmation flow", () => {
+    expect(
+      resolveThreadSidebarShortcutAction({
+        command: "thread.settle",
+        orderedThreadKeys: ["thread-1", "thread-2"],
+        routeThreadKey: "thread-1",
+        settleConfirmationThreadKey: null,
+        canSettleRouteThread: true,
+        isRouteThreadSettling: false,
+      }),
+    ).toEqual({ type: "confirm-settle", threadKey: "thread-1" });
+  });
+
+  it("consumes thread navigation while settle confirmation is open", () => {
+    expect(
+      resolveThreadSidebarShortcutAction({
+        command: "thread.next",
+        orderedThreadKeys: ["thread-1", "thread-2"],
+        routeThreadKey: "thread-1",
+        settleConfirmationThreadKey: "thread-1",
+        canSettleRouteThread: true,
+        isRouteThreadSettling: false,
+      }),
+    ).toEqual({ type: "consume" });
+    expect(
+      resolveThreadSidebarShortcutAction({
+        command: "thread.jump.2",
+        orderedThreadKeys: ["thread-1", "thread-2"],
+        routeThreadKey: "thread-1",
+        settleConfirmationThreadKey: "thread-1",
+        canSettleRouteThread: true,
+        isRouteThreadSettling: false,
+      }),
+    ).toEqual({ type: "consume" });
+  });
+
+  it("consumes settle without reopening confirmation while the route thread is settling", () => {
+    expect(
+      resolveThreadSidebarShortcutAction({
+        command: "thread.settle",
+        orderedThreadKeys: ["thread-1"],
+        routeThreadKey: "thread-1",
+        settleConfirmationThreadKey: null,
+        canSettleRouteThread: true,
+        isRouteThreadSettling: true,
+      }),
+    ).toEqual({ type: "consume" });
   });
 });
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -128,7 +128,7 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
   {
-    shortcut: modShortcut("enter", { shiftKey: true }),
+    shortcut: modShortcut("x", { shiftKey: true }),
     command: "thread.settle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
@@ -155,24 +155,21 @@ const DEFAULT_BINDINGS = compile([
 ]);
 
 describe("thread settle shortcut", () => {
-  it("resolves Mod+Shift+Enter outside the terminal", () => {
+  it("resolves Mod+Shift+X outside the terminal", () => {
     assert.strictEqual(
-      resolveShortcutCommand(
-        event({ key: "Enter", metaKey: true, shiftKey: true }),
-        DEFAULT_BINDINGS,
-        { platform: "MacIntel" },
-      ),
+      resolveShortcutCommand(event({ key: "x", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
       "thread.settle",
     );
   });
 
   it("does not resolve while the terminal owns focus", () => {
     assert.isNull(
-      resolveShortcutCommand(
-        event({ key: "Enter", ctrlKey: true, shiftKey: true }),
-        DEFAULT_BINDINGS,
-        { platform: "Linux", context: { terminalFocus: true } },
-      ),
+      resolveShortcutCommand(event({ key: "x", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: true },
+      }),
     );
   });
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -189,6 +189,19 @@ describe("thread settle shortcut", () => {
     ).toEqual({ type: "confirm-settle", threadKey: "thread-1" });
   });
 
+  it("consumes settle when live work makes the route thread ineligible", () => {
+    expect(
+      resolveThreadSidebarShortcutAction({
+        command: "thread.settle",
+        orderedThreadKeys: ["thread-1"],
+        routeThreadKey: "thread-1",
+        settleConfirmationThreadKey: null,
+        canSettleRouteThread: false,
+        isRouteThreadSettling: false,
+      }),
+    ).toEqual({ type: "consume" });
+  });
+
   it("consumes thread navigation while settle confirmation is open", () => {
     expect(
       resolveThreadSidebarShortcutAction({

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -282,6 +282,74 @@ export function threadTraversalDirectionFromCommand(
   return null;
 }
 
+export type ThreadSidebarShortcutAction<TThreadKey> =
+  | { readonly type: "none" }
+  | { readonly type: "consume" }
+  | { readonly type: "navigate"; readonly threadKey: TThreadKey }
+  | { readonly type: "confirm-settle"; readonly threadKey: TThreadKey };
+
+/**
+ * Resolves the thread commands shared by both sidebar implementations.
+ * A settle confirmation is modal with respect to thread shortcuts: navigation
+ * must not change the route behind it, and a second settle shortcut must not
+ * replace or reopen it.
+ */
+export function resolveThreadSidebarShortcutAction<TThreadKey>(input: {
+  readonly command: KeybindingCommand | null;
+  readonly orderedThreadKeys: readonly TThreadKey[];
+  readonly jumpThreadKeys?: readonly TThreadKey[];
+  readonly routeThreadKey: TThreadKey | null;
+  readonly settleConfirmationThreadKey: TThreadKey | null;
+  readonly canSettleRouteThread: boolean;
+  readonly isRouteThreadSettling: boolean;
+}): ThreadSidebarShortcutAction<TThreadKey> {
+  const traversalDirection = threadTraversalDirectionFromCommand(input.command);
+  const jumpIndex = threadJumpIndexFromCommand(input.command ?? "");
+  const isThreadCommand =
+    input.command === "thread.settle" || traversalDirection !== null || jumpIndex !== null;
+
+  if (!isThreadCommand) return { type: "none" };
+  if (input.settleConfirmationThreadKey !== null) return { type: "consume" };
+
+  if (input.command === "thread.settle") {
+    if (
+      input.routeThreadKey === null ||
+      !input.canSettleRouteThread ||
+      input.isRouteThreadSettling
+    ) {
+      return { type: "consume" };
+    }
+    return { type: "confirm-settle", threadKey: input.routeThreadKey };
+  }
+
+  if (traversalDirection !== null) {
+    const threadKey = resolveAdjacentItem({
+      items: input.orderedThreadKeys,
+      current: input.routeThreadKey,
+      direction: traversalDirection,
+    });
+    return threadKey === null ? { type: "none" } : { type: "navigate", threadKey };
+  }
+
+  const threadKey = (input.jumpThreadKeys ?? input.orderedThreadKeys)[jumpIndex ?? -1];
+  return threadKey === undefined ? { type: "none" } : { type: "navigate", threadKey };
+}
+
+function resolveAdjacentItem<T>(input: {
+  readonly items: readonly T[];
+  readonly current: T | null;
+  readonly direction: "previous" | "next";
+}): T | null {
+  if (input.items.length === 0) return null;
+  if (input.current === null) {
+    return input.direction === "previous" ? (input.items.at(-1) ?? null) : (input.items[0] ?? null);
+  }
+  const currentIndex = input.items.indexOf(input.current);
+  if (currentIndex === -1) return null;
+  const targetIndex = input.direction === "previous" ? currentIndex - 1 : currentIndex + 1;
+  return input.items[targetIndex] ?? null;
+}
+
 export function shouldShowThreadJumpHints(
   event: ShortcutEventLike,
   keybindings: ResolvedKeybindingsConfig,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -33,7 +33,8 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+n", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+o", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
-  { "key": "mod+o", "command": "editor.openFavorite" }
+  { "key": "mod+o", "command": "editor.openFavorite" },
+  { "key": "mod+shift+enter", "command": "thread.settle", "when": "!terminalFocus" }
 ]
 ```
 
@@ -67,6 +68,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
 - `editor.openFavorite`: open current project/worktree in the last-used editor
+- `thread.settle`: confirm and settle the open thread, then move to the next active thread
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)
 
 ### Key Syntax

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -34,7 +34,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+shift+o", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
   { "key": "mod+o", "command": "editor.openFavorite" },
-  { "key": "mod+shift+enter", "command": "thread.settle", "when": "!terminalFocus" }
+  { "key": "mod+shift+x", "command": "thread.settle", "when": "!terminalFocus" }
 ]
 ```
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -35,6 +35,7 @@ export type ModelPickerJumpKeybindingCommand =
   (typeof MODEL_PICKER_JUMP_KEYBINDING_COMMANDS)[number];
 
 export const THREAD_KEYBINDING_COMMANDS = [
+  "thread.settle",
   "thread.previous",
   "thread.next",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -41,7 +41,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
-  { key: "mod+shift+enter", command: "thread.settle", when: "!terminalFocus" },
+  { key: "mod+shift+x", command: "thread.settle", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -41,6 +41,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  { key: "mod+shift+enter", command: "thread.settle", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({


### PR DESCRIPTION
## What Changed

- add `thread.settle` as a configurable keybinding command with `Mod+Shift+X` as the default
- show a confirmation dialog for the open thread before settling
- focus the primary action so Enter confirms, while Escape cancels
- preserve Sidebar V2's existing move-to-next-thread behavior after a successful settle
- document the command and cover default/resolution behavior with tests

## Why

Settling the thread currently requires targeting a hover-only sidebar action. A global shortcut makes this frequent lifecycle action available without leaving the keyboard, while the focused confirmation prevents accidental settles and makes the confirmation keystroke explicit.

## UI Changes

The shortcut opens an in-app alert dialog naming the thread and explaining that it moves out of active work. The `Settle thread` button is the initial focus target and displays an `Enter` key hint; Escape cancels.

Exact-head browser verification completed in an isolated environment against a disposable thread; the focused confirmation state is shown below.

## Checklist

- [x] `vp check`
- [x] `vp run typecheck`
- [x] `vp test apps/web/src/keybindings.test.ts apps/server/src/keybindings.test.ts`
- [x] `vp run --filter @t3tools/web build`

## Exact-head evidence

Revalidated at 2d4990a04b59: focused tests, vp check, and vp run typecheck passed. Integrated browser verification confirmed Mod+Shift+X opens the settle dialog from the focused composer while preserving draft text, and Mod+Shift+Enter no longer triggers settlement. The capture uses only disposable local projects.

![Settle-thread confirmation with focused primary action](https://github.com/user-attachments/assets/fc84b6af-404a-4662-81d7-d586e73cf6ce)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread lifecycle navigation and keyboard handling in both sidebars; mistakes could mis-route after settle or settle ineligible threads, though confirmation and extensive unit tests mitigate this.
> 
> **Overview**
> Adds **`thread.settle`** (`Mod+Shift+X`, `!terminalFocus`) to contracts, shared defaults, server bootstrap tests, and user keybinding docs.
> 
> **`resolveThreadSidebarShortcutAction`** centralizes thread shortcut handling for both sidebars: navigate, open settle confirmation, consume (ineligible route, in-flight settle, or modal open), or ignore. While a settle dialog is open, other thread shortcuts are consumed so the route does not change behind it.
> 
> **Legacy and V2 sidebars** wire the shortcut to an **AlertDialog** (Enter on the focused “Settle thread” action, Escape cancels). On confirm they call **`settleThread`** and, if you are still on that thread, advance via **`resolveNextActiveThreadIdAfterSettle`** (visible order first, full unarchived list as fallback), skipping effectively settled and snoozed threads—or start a new thread when none remain. Shortcut handling is skipped when the command palette or model picker is open.
> 
> Supporting changes in **`Sidebar.logic`**: PR/change-request state for hidden or collapsed rows (git cwd resolution, worktree-only git queries, pending-state publish rules), shared effective settled/snooze helpers, and confirmation dismiss rules. Visible rows report PR state upward for auto-settle classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b2132142edf7b5e2ce992c0d239f5098d5cbc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `thread.settle` keyboard shortcut (Mod+Shift+X) to settle the open thread from the sidebar
> - Adds `thread.settle` to the keybinding system, bound to `Mod+Shift+X` with `!terminalFocus`, in both [shared keybindings](https://github.com/pingdotgg/t3code/pull/4277/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06) and [contracts](https://github.com/pingdotgg/t3code/pull/4277/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6).
> - Introduces `resolveThreadSidebarShortcutAction` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/4277/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) to classify thread shortcuts into `none`, `consume`, `navigate`, or `confirm-settle` outcomes, replacing direct traversal/jump index logic.
> - Both [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4277/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4277/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) now show an `AlertDialog` confirmation before settling; on confirm, the thread is settled and the sidebar navigates to the next active thread or opens a new one.
> - Adds hidden `SidebarHiddenThreadChangeRequestStateReporter` components to track per-thread PR/change-request state for threads not currently visible in the sidebar, used to determine effective settlement state.
> - Keyboard shortcut handling is suppressed when the command palette or model picker is open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b21321.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->