### PR TITLE
Unify temporary worktree branch naming

### DIFF
--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -83,6 +83,17 @@ describe("isTemporaryWorktreeBranch", () => {
     ).toBe(true);
   });
 
+  it("rejects UUID-shaped refs that are not RFC 4122 v4", () => {
+    // version nibble is not 4
+    expect(
+      isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-1d48-b4f2-9cf0aa54ab12`),
+    ).toBe(false);
+    // variant nibble is not [89ab]
+    expect(
+      isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-4d48-c4f2-9cf0aa54ab12`),
+    ).toBe(false);
+  });
+
   it("rejects non-temporary refName names", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -71,6 +71,18 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/DEADBEEF`)).toBe(true);
   });
 
+  it("normalizes a UUID-shaped random callback to the canonical 8-hex form", () => {
+    expect(buildTemporaryWorktreeBranchName(() => "f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12")).toBe(
+      `${WORKTREE_BRANCH_PREFIX}/f4ae4e0e`,
+    );
+  });
+
+  it("matches legacy UUID-shaped temporary worktree refs from older mobile builds", () => {
+    expect(
+      isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/f4ae4e0e-f971-4d48-b4f2-9cf0aa54ab12`),
+    ).toBe(true);
+  });
+
   it("rejects non-temporary refName names", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -11,10 +11,12 @@ import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
 export const WORKTREE_BRANCH_PREFIX = "t3code";
-// Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`,
-// so the matcher accepts both to keep those threads eligible for branch regeneration.
+// Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`
+// via Crypto.randomUUID() (always RFC 4122 v4), so the matcher also accepts exactly
+// that shape — version nibble `4`, variant nibble `[89ab]` — to keep those threads
+// eligible for branch regeneration without loosening beyond what was ever generated.
 const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(
-  `^${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`,
+  `^${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$`,
 );
 
 /**

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -11,7 +11,11 @@ import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
 export const WORKTREE_BRANCH_PREFIX = "t3code";
-const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(`^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}$`);
+// Canonical form is `t3code/<8 hex>`. Older mobile builds generated `t3code/<uuid>`,
+// so the matcher accepts both to keep those threads eligible for branch regeneration.
+const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(
+  `^${WORKTREE_BRANCH_PREFIX}\\/(?:[0-9a-f]{8}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`,
+);
 
 /**
  * Sanitize an arbitrary string into a valid, lowercase git refName fragment.
@@ -89,7 +93,12 @@ export function deriveLocalBranchNameFromRemoteRef(branchName: string): string {
 export function buildTemporaryWorktreeBranchName(
   randomHex: (byteLength: number) => string,
 ): string {
-  const token = randomHex(4).toLowerCase();
+  // Normalize to exactly 8 lowercase hex chars so a UUID-shaped callback
+  // still produces the canonical temporary branch form.
+  const token = randomHex(4)
+    .toLowerCase()
+    .replace(/[^0-9a-f]/g, "")
+    .slice(0, 8);
   return `${WORKTREE_BRANCH_PREFIX}/${token}`;
 }
 


### PR DESCRIPTION
- Normalize generated names to the canonical 8-hex format
- Accept legacy UUID-shaped mobile branch names
- Add regression coverage for both behaviors

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shared git helper changes with backward-compatible matching; no auth, data, or orchestration logic beyond branch-name detection.
> 
> **Overview**
> **Temporary worktree refs** now use a single canonical shape (`t3code/<8 hex>`) while still recognizing branch names older mobile clients created as `t3code/<full RFC 4122 v4 UUID>`.
> 
> `buildTemporaryWorktreeBranchName` strips non-hex from the random callback and keeps the first 8 hex digits, so a UUID-shaped generator still emits the short canonical name. `isTemporaryWorktreeBranch` matches both the 8-hex form and legacy v4 UUIDs (version `4`, variant `[89ab]`), but rejects other UUID-looking strings so the matcher is not broadly loosened.
> 
> Regression tests cover canonicalization, legacy acceptance, and invalid UUID-shaped refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a822dc054c1c9192b1a839cb15363008241b994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify temporary worktree branch naming to canonical `t3code/<8-hex>` form
> - Updates `TEMP_WORKTREE_BRANCH_PATTERN` in [git.ts](https://github.com/pingdotgg/t3code/pull/4278/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) to accept both the canonical `t3code/<8-hex>` format and legacy RFC 4122 v4 UUID-shaped refs (e.g. `t3code/<8-4-4-4-12>` with correct version/variant nibbles).
> - Updates `buildTemporaryWorktreeBranchName` to normalize its output by lowercasing, stripping non-hex characters, and truncating to 8 hex characters, so UUID-shaped random values are reduced to the canonical form.
> - Behavioral Change: branches built from UUID-shaped random callbacks now produce a shorter `t3code/<8-hex>` ref rather than a full UUID-shaped ref.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a822dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->