### PR TITLE
fix(web): use message-square icon for settled icon-less project threads in sidebar v2

### DIFF
--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -1,6 +1,7 @@
 import type { EnvironmentId } from "@t3tools/contracts";
 import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
 import { FolderIcon } from "lucide-react";
+import type { ComponentType } from "react";
 import { useState } from "react";
 import { useAssetUrl } from "../assets/assetUrls";
 
@@ -10,29 +11,46 @@ export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
   cwd: string;
   className?: string | undefined;
+  fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
   const src = useAssetUrl(input.environmentId, {
     _tag: "project-favicon",
     cwd: input.cwd,
   });
+  const FallbackIcon = input.fallbackIcon ?? FolderIcon;
 
   if (!src || isProjectFaviconFallbackUrl(src)) {
-    return <ProjectFaviconFallback className={input.className} />;
+    return <ProjectFaviconFallback className={input.className} icon={FallbackIcon} />;
   }
 
-  return <ProjectFaviconImage key={src} src={src} className={input.className} />;
+  return (
+    <ProjectFaviconImage
+      key={src}
+      src={src}
+      className={input.className}
+      fallbackIcon={FallbackIcon}
+    />
+  );
 }
 
-function ProjectFaviconFallback({ className }: { readonly className?: string | undefined }) {
-  return <FolderIcon className={`size-3.5 shrink-0 text-muted-foreground/50 ${className ?? ""}`} />;
+function ProjectFaviconFallback({
+  className,
+  icon: Icon,
+}: {
+  readonly className?: string | undefined;
+  readonly icon: ComponentType<{ className?: string }>;
+}) {
+  return <Icon className={`size-3.5 shrink-0 text-muted-foreground/50 ${className ?? ""}`} />;
 }
 
 function ProjectFaviconImage({
   src,
   className,
+  fallbackIcon: FallbackIcon,
 }: {
   readonly src: string;
   readonly className?: string | undefined;
+  readonly fallbackIcon: ComponentType<{ className?: string }>;
 }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
     loadedProjectFaviconSrcs.has(src) ? "loaded" : "loading",
@@ -40,7 +58,9 @@ function ProjectFaviconImage({
 
   return (
     <>
-      {status !== "loaded" ? <ProjectFaviconFallback className={className} /> : null}
+      {status !== "loaded" ? (
+        <ProjectFaviconFallback className={className} icon={FallbackIcon} />
+      ) : null}
       <img
         src={src}
         alt=""

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -14,6 +14,7 @@ import {
   CircleDashedIcon,
   CloudIcon,
   FolderPlusIcon,
+  MessageSquareIcon,
   PlusIcon,
   SearchIcon,
   SquarePenIcon,
@@ -426,6 +427,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               environmentId={thread.environmentId}
               cwd={props.projectCwd ?? ""}
               className="size-3.5"
+              fallbackIcon={MessageSquareIcon}
             />
           </span>
           {title}


### PR DESCRIPTION
## What Changed

- `ProjectFavicon` gained an optional `fallbackIcon` prop (defaults to `FolderIcon`)
- Settled threads (slim rows) in sidebar v2 now pass `MessageSquareIcon` as the fallback
- Card variant (active threads) unchanged. `FolderIcon` beside the project name stays correct

## Why

Settled threads show the project favicon beside the thread title. When a project has no favicon, `FolderIcon` was shown, which is misleading next to a thread name (it implies the thread is a folder). `MessageSquareIcon` was already used elsewhere in the codebase for thread-related commands, so is a natural fit and visually matches the small icon size.

## UI Changes

Before:
<img width="111" height="198" alt="image" src="https://github.com/user-attachments/assets/05c2a93b-c9d0-4833-acad-b85993d4e1ab" />

After:
<img width="319" height="247" alt="image" src="https://github.com/user-attachments/assets/8bcbbcbe-0e07-47ad-8ee0-d9c74abd18a6" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational change with a backward-compatible optional prop; no auth, data, or API impact.
> 
> **Overview**
> **`ProjectFavicon`** now accepts an optional **`fallbackIcon`** prop (still defaults to **`FolderIcon`**) and uses it whenever there is no favicon URL, including while an image is loading or after load errors.
> 
> In **sidebar v2**, **slim (settled) thread rows** pass **`MessageSquareIcon`** as that fallback so icon-less projects show a chat glyph next to the thread title instead of a folder. **Card rows** and other **`ProjectFavicon`** call sites are unchanged and keep the folder fallback beside project names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154821ac96e8dc678d376a6a7e0a48a52aa8aa96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use message-square icon for icon-less project threads in sidebar v2
> Adds a `fallbackIcon` prop to `ProjectFavicon`, `ProjectFaviconFallback`, and `ProjectFaviconImage` in [ProjectFavicon.tsx](https://github.com/pingdotgg/t3code/pull/4279/files#diff-ba3b3091a902090e72f9ecf4b437466f7adea984de7f3827b82726cae0f7e604) so callers can supply a custom icon instead of the default `FolderIcon`. In [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4279/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c), thread rows now pass `MessageSquareIcon` as the fallback, so a chat bubble appears when a thread has no favicon rather than a folder.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 154821a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->