### PR TITLE
Preserve draft thread highlighting during promotion

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -118,7 +118,7 @@ import { vcsEnvironment } from "../state/vcs";
 import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import {
   buildThreadRouteParams,
-  resolveThreadRouteRef,
+  resolveActiveThreadRouteRef,
   resolveThreadRouteTarget,
 } from "../threadRoutes";
 import { stackedThreadToast, toastManager } from "./ui/toast";
@@ -3068,10 +3068,17 @@ export default function Sidebar() {
   const handleNewThread = useNewThreadHandler();
   const { archiveThread, deleteThread } = useThreadActions();
   const { isMobile, setOpenMobile } = useSidebar();
-  const routeThreadRef = useParams({
+  const routeTarget = useParams({
     strict: false,
-    select: (params) => resolveThreadRouteRef(params),
+    select: (params) => resolveThreadRouteTarget(params),
   });
+  const routeDraftThread = useComposerDraftStore((store) =>
+    routeTarget?.kind === "draft" ? store.getDraftSession(routeTarget.draftId) : null,
+  );
+  const routeThreadRef = useMemo(
+    () => resolveActiveThreadRouteRef(routeTarget, routeDraftThread),
+    [routeDraftThread, routeTarget],
+  );
   const routeThreadKey = routeThreadRef ? scopedThreadKey(routeThreadRef) : null;
   const routeTerminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -81,7 +81,7 @@ describe("threadRoutes", () => {
     });
   });
 
-  it("uses a draft's reserved thread ref before promotion is recorded", () => {
+  it("does not treat a draft's reserved thread ref as an active sidebar thread", () => {
     const target = resolveThreadRouteTarget({ draftId: "draft-1" });
 
     expect(
@@ -90,9 +90,6 @@ describe("threadRoutes", () => {
         threadId: ThreadId.make("draft-thread"),
         promotedTo: null,
       }),
-    ).toEqual({
-      environmentId: "env-1",
-      threadId: "draft-thread",
-    });
+    ).toBeNull();
   });
 });

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -6,6 +6,7 @@ import { DraftId } from "./composerDraftStore";
 import {
   buildDraftThreadRouteParams,
   buildThreadRouteParams,
+  resolveActiveThreadRouteRef,
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
 } from "./threadRoutes";
@@ -62,6 +63,36 @@ describe("threadRoutes", () => {
     ).toEqual({
       kind: "draft",
       draftId: "draft-1",
+    });
+  });
+
+  it("resolves the backing thread while a draft route is being promoted", () => {
+    const target = resolveThreadRouteTarget({ draftId: "draft-1" });
+
+    expect(
+      resolveActiveThreadRouteRef(target, {
+        environmentId: "env-1" as never,
+        threadId: ThreadId.make("draft-thread"),
+        promotedTo: scopeThreadRef("env-2" as never, ThreadId.make("server-thread")),
+      }),
+    ).toEqual({
+      environmentId: "env-2",
+      threadId: "server-thread",
+    });
+  });
+
+  it("uses a draft's reserved thread ref before promotion is recorded", () => {
+    const target = resolveThreadRouteTarget({ draftId: "draft-1" });
+
+    expect(
+      resolveActiveThreadRouteRef(target, {
+        environmentId: "env-1" as never,
+        threadId: ThreadId.make("draft-thread"),
+        promotedTo: null,
+      }),
+    ).toEqual({
+      environmentId: "env-1",
+      threadId: "draft-thread",
     });
   });
 });

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -65,9 +65,8 @@ export function resolveThreadRouteTarget(
 }
 
 /**
- * Resolves the thread represented by either a canonical thread route or the
- * draft route that temporarily remains mounted while its first send is being
- * promoted to a server thread.
+ * Resolves the thread represented by either a canonical thread route or a
+ * draft route whose promotion to a server thread has been recorded.
  */
 export function resolveActiveThreadRouteRef(
   target: ThreadRouteTarget | null,
@@ -76,8 +75,8 @@ export function resolveActiveThreadRouteRef(
   if (target?.kind === "server") {
     return target.threadRef;
   }
-  if (target?.kind !== "draft" || !draftThread) {
+  if (target?.kind !== "draft" || !draftThread?.promotedTo) {
     return null;
   }
-  return draftThread.promotedTo ?? scopeThreadRef(draftThread.environmentId, draftThread.threadId);
+  return draftThread.promotedTo;
 }

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -12,6 +12,12 @@ export type ThreadRouteTarget =
       draftId: DraftId;
     };
 
+type DraftThreadRouteState = {
+  environmentId: EnvironmentId;
+  threadId: ThreadId;
+  promotedTo?: ScopedThreadRef | null;
+};
+
 export function buildThreadRouteParams(ref: ScopedThreadRef): {
   environmentId: EnvironmentId;
   threadId: ThreadId;
@@ -56,4 +62,22 @@ export function resolveThreadRouteTarget(
     kind: "draft",
     draftId: params.draftId as DraftId,
   };
+}
+
+/**
+ * Resolves the thread represented by either a canonical thread route or the
+ * draft route that temporarily remains mounted while its first send is being
+ * promoted to a server thread.
+ */
+export function resolveActiveThreadRouteRef(
+  target: ThreadRouteTarget | null,
+  draftThread: DraftThreadRouteState | null,
+): ScopedThreadRef | null {
+  if (target?.kind === "server") {
+    return target.threadRef;
+  }
+  if (target?.kind !== "draft" || !draftThread) {
+    return null;
+  }
+  return draftThread.promotedTo ?? scopeThreadRef(draftThread.environmentId, draftThread.threadId);
 }


### PR DESCRIPTION
## Summary

- Resolve the active thread from draft route state during promotion.
- Keep highlighting on the promoted server thread when available.
- Add coverage for pre- and post-promotion route resolution.

## Testing

- `vp test run apps/web/src/threadRoutes.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing/highlighting change in the web UI with unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes sidebar active-thread highlighting when the URL is still on a **draft** route while a draft is being promoted to a server thread.
> 
> **`resolveActiveThreadRouteRef`** in `threadRoutes.ts` maps route targets to the thread that should count as “active”: server routes use the scoped ref directly; draft routes use **`promotedTo`** from the composer draft session when present, and return **null** otherwise so the draft’s reserved local thread id is not highlighted as a real sidebar thread.
> 
> The **sidebar** now resolves `resolveThreadRouteTarget` from URL params, loads the matching draft session from `useComposerDraftStore`, and derives `routeThreadKey` from that helper (replacing a single `resolveThreadRouteRef` on params). Tests cover promoted vs pre-promotion draft routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b2676ada4cd86ba1918f7a5ab04702d4ce200da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve draft thread highlighting in sidebar after promotion to server thread
> - Introduces `resolveActiveThreadRouteRef` in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/4283/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3), which resolves a `ScopedThreadRef` for server routes directly, or for draft routes only when the draft session has a non-null `promotedTo` reference.
> - Updates [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4283/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to derive the active thread ref via a two-step process: resolve a `ThreadRouteTarget`, look up the draft session from `useComposerDraftStore` if it's a draft route, then compute the active ref with `resolveActiveThreadRouteRef`.
> - Draft routes with no promotion no longer resolve to an active thread ref in the sidebar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b2676a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->