### PR TITLE
Add suggested draft task cards and issue triage flow

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -48,6 +48,7 @@ interface FakeGhScenario {
     headRepositoryNameWithOwner?: string | null;
     headRepositoryOwnerLogin?: string | null;
   };
+  issue?: GitHubCli.GitHubIssueSummary;
   repositoryCloneUrls?: Record<string, { url: string; sshUrl: string }>;
   failWith?: GitHubCli.GitHubCliError;
 }
@@ -476,6 +477,23 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
       });
     }
 
+    if (args[0] === "issue" && args[1] === "view") {
+      return Effect.succeed(
+        fakeGhOutput(
+          JSON.stringify(
+            scenario.issue ?? {
+              number: 84,
+              title: "Issue",
+              url: "https://github.com/pingdotgg/codething-mvp/issues/84",
+              state: "open",
+              labels: [],
+              assignees: [],
+            },
+          ) + "\n",
+        ),
+      );
+    }
+
     if (args[0] === "repo" && args[1] === "view") {
       const repository = args[2];
       if (typeof repository === "string" && args.includes("nameWithOwner,url,sshUrl")) {
@@ -576,6 +594,17 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         }).pipe(
           Effect.map((result) => JSON.parse(result.stdout) as GitHubCli.GitHubPullRequestSummary),
         ),
+      getIssue: (input) =>
+        execute({
+          cwd: input.cwd,
+          args: [
+            "issue",
+            "view",
+            input.reference,
+            "--json",
+            "number,title,url,state,labels,assignees",
+          ],
+        }).pipe(Effect.map((result) => JSON.parse(result.stdout) as GitHubCli.GitHubIssueSummary)),
       getRepositoryCloneUrls: (input) =>
         execute({
           cwd: input.cwd,
@@ -625,6 +654,13 @@ function resolvePullRequest(
   input: { cwd: string; reference: string },
 ) {
   return manager.resolvePullRequest(input);
+}
+
+function resolveIssue(
+  manager: GitManager.GitManager["Service"],
+  input: { cwd: string; reference: string },
+) {
+  return manager.resolveIssue(input);
 }
 
 function preparePullRequestThread(
@@ -2544,6 +2580,38 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         state: "open",
       });
       expect(ghCalls.some((call) => call.startsWith("pr view 42 "))).toBe(true);
+    }),
+  );
+
+  it.effect("resolves GitHub issues from #number references", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          issue: {
+            number: 84,
+            title: "Draft page suggestions",
+            url: "https://github.com/pingdotgg/codething-mvp/issues/84",
+            state: "open",
+            labels: ["enhancement"],
+            assignees: ["octocat"],
+          },
+        },
+      });
+
+      const result = yield* resolveIssue(manager, { cwd: repoDir, reference: "#84" });
+
+      expect(result.issue).toEqual({
+        number: 84,
+        title: "Draft page suggestions",
+        url: "https://github.com/pingdotgg/codething-mvp/issues/84",
+        state: "open",
+        labels: ["enhancement"],
+        assignees: ["octocat"],
+      });
+      expect(ghCalls.some((call) => call.startsWith("issue view 84 "))).toBe(true);
     }),
   );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -18,6 +18,8 @@ import {
   GitCommandError,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
+  GitIssueRefInput,
+  GitResolveIssueResult,
   GitPullRequestRefInput,
   GitResolvePullRequestResult,
   GitRunStackedActionInput,
@@ -41,7 +43,11 @@ import {
   type ChangeRequestTerminology,
 } from "@t3tools/shared/sourceControl";
 
-import { GitManagerError, GitPullRequestMaterializationError } from "@t3tools/contracts";
+import {
+  GitManagerError,
+  GitPullRequestMaterializationError,
+  SourceControlProviderError,
+} from "@t3tools/contracts";
 import * as TextGeneration from "../textGeneration/TextGeneration.ts";
 import * as ProjectSetupScriptRunner from "../project/ProjectSetupScriptRunner.ts";
 import { extractBranchNameFromRemoteRef } from "./remoteRefs.ts";
@@ -79,6 +85,9 @@ export class GitManager extends Context.Service<
     readonly resolvePullRequest: (
       input: GitPullRequestRefInput,
     ) => Effect.Effect<GitResolvePullRequestResult, GitManagerServiceError>;
+    readonly resolveIssue: (
+      input: GitIssueRefInput,
+    ) => Effect.Effect<GitResolveIssueResult, GitManagerServiceError>;
     readonly preparePullRequestThread: (
       input: GitPreparePullRequestThreadInput,
     ) => Effect.Effect<GitPreparePullRequestThreadResult, GitManagerServiceError>;
@@ -476,6 +485,10 @@ function normalizePullRequestReference(reference: string): string {
   const trimmed = reference.trim();
   const hashNumber = /^#(\d+)$/.exec(trimmed);
   return hashNumber?.[1] ?? trimmed;
+}
+
+function normalizeIssueReference(reference: string): string {
+  return normalizePullRequestReference(reference);
 }
 
 function toResolvedPullRequest(pr: {
@@ -1458,6 +1471,35 @@ export const make = Effect.gen(function* () {
     return { pullRequest };
   });
 
+  const resolveIssue: GitManager["Service"]["resolveIssue"] = Effect.fn("resolveIssue")(
+    function* (input) {
+      const provider = yield* sourceControlProvider(input.cwd);
+      if (!provider.getIssue) {
+        return yield* new SourceControlProviderError({
+          provider: provider.kind,
+          operation: "getIssue",
+          cwd: input.cwd,
+          reference: normalizeIssueReference(input.reference),
+          detail: "Issue lookup is currently available for GitHub repositories only.",
+        });
+      }
+      const issue = yield* provider.getIssue({
+        cwd: input.cwd,
+        reference: normalizeIssueReference(input.reference),
+      });
+      return {
+        issue: {
+          number: issue.number,
+          title: issue.title,
+          url: issue.url,
+          state: issue.state,
+          labels: [...issue.labels],
+          assignees: [...issue.assignees],
+        },
+      };
+    },
+  );
+
   const preparePullRequestThread: GitManager["Service"]["preparePullRequestThread"] = Effect.fn(
     "preparePullRequestThread",
   )(function* (input) {
@@ -1866,6 +1908,7 @@ export const make = Effect.gen(function* () {
     invalidateRemoteStatus,
     invalidateStatus,
     resolvePullRequest,
+    resolveIssue,
     preparePullRequestThread,
     runStackedAction,
   });

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -16,6 +16,8 @@ import {
   type GitManagerServiceError,
   type GitPreparePullRequestThreadInput,
   type GitPreparePullRequestThreadResult,
+  type GitIssueRefInput,
+  type GitResolveIssueResult,
   type GitPullRequestRefInput,
   type VcsPullResult,
   type VcsRemoveWorktreeInput,
@@ -56,6 +58,9 @@ export class GitWorkflowService extends Context.Service<
     readonly resolvePullRequest: (
       input: GitPullRequestRefInput,
     ) => Effect.Effect<GitResolvePullRequestResult, GitManagerServiceError>;
+    readonly resolveIssue: (
+      input: GitIssueRefInput,
+    ) => Effect.Effect<GitResolveIssueResult, GitManagerServiceError>;
     readonly preparePullRequestThread: (
       input: GitPreparePullRequestThreadInput,
     ) => Effect.Effect<GitPreparePullRequestThreadResult, GitManagerServiceError>;
@@ -285,6 +290,7 @@ export const make = Effect.gen(function* () {
       "GitWorkflowService.resolvePullRequest",
       gitManager.resolvePullRequest,
     ),
+    resolveIssue: routeGitManager("GitWorkflowService.resolveIssue", gitManager.resolveIssue),
     preparePullRequestThread: routeGitManager(
       "GitWorkflowService.preparePullRequestThread",
       gitManager.preparePullRequestThread,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4900,6 +4900,17 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
                   state: "open",
                 },
               }),
+            resolveIssue: () =>
+              Effect.succeed({
+                issue: {
+                  number: 2,
+                  title: "Demo issue",
+                  url: "https://example.com/issues/2",
+                  state: "open",
+                  labels: [],
+                  assignees: [],
+                },
+              }),
             preparePullRequestThread: () =>
               Effect.succeed({
                 pullRequest: {

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -111,6 +111,45 @@ describe("GitHubCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("parses issue view output", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              number: 84,
+              title: "Draft page suggestions",
+              url: "https://github.com/pingdotgg/codething-mvp/issues/84",
+              state: "OPEN",
+              labels: [{ name: "enhancement" }, { name: "web" }],
+              assignees: [{ login: "octocat" }],
+            }),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.getIssue({ cwd: "/repo", reference: "84" });
+
+      assert.deepStrictEqual(result, {
+        number: 84,
+        title: "Draft page suggestions",
+        url: "https://github.com/pingdotgg/codething-mvp/issues/84",
+        state: "open",
+        labels: ["enhancement", "web"],
+        assignees: ["octocat"],
+      });
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "GitHubCli.execute",
+        command: "gh",
+        args: ["issue", "view", "84", "--json", "number,title,url,state,labels,assignees"],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("trims pull request fields decoded from gh json", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -16,6 +16,7 @@ import {
   decodeGitHubPullRequestJson,
   decodeGitHubPullRequestListJson,
 } from "./gitHubPullRequests.ts";
+import { decodeGitHubIssueJson, type NormalizedGitHubIssueRecord } from "./gitHubIssues.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -57,6 +58,19 @@ export class GitHubPullRequestNotFoundError extends Schema.TaggedErrorClass<GitH
 ) {
   get detail(): string {
     return "Pull request not found. Check the PR number or URL and try again.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in execute: ${this.detail}`;
+  }
+}
+
+export class GitHubIssueNotFoundError extends Schema.TaggedErrorClass<GitHubIssueNotFoundError>()(
+  "GitHubIssueNotFoundError",
+  gitHubCliFailureFields,
+) {
+  get detail(): string {
+    return "Issue not found. Check the issue number or URL and try again.";
   }
 
   override get message(): string {
@@ -122,6 +136,19 @@ export class GitHubPullRequestDecodeError extends Schema.TaggedErrorClass<GitHub
   }
 }
 
+export class GitHubIssueDecodeError extends Schema.TaggedErrorClass<GitHubIssueDecodeError>()(
+  "GitHubIssueDecodeError",
+  gitHubCliDecodeFields,
+) {
+  get detail(): string {
+    return "GitHub CLI returned invalid issue JSON.";
+  }
+
+  override get message(): string {
+    return `GitHub CLI failed in getIssue: ${this.detail}`;
+  }
+}
+
 export class GitHubRepositoryDecodeError extends Schema.TaggedErrorClass<GitHubRepositoryDecodeError>()(
   "GitHubRepositoryDecodeError",
   gitHubCliDecodeFields,
@@ -139,10 +166,12 @@ export const GitHubCliError = Schema.Union([
   GitHubCliUnavailableError,
   GitHubCliAuthenticationError,
   GitHubPullRequestNotFoundError,
+  GitHubIssueNotFoundError,
   GitHubCliCommandError,
   GitHubPullRequestListDecodeError,
   GitHubChangeRequestListDecodeError,
   GitHubPullRequestDecodeError,
+  GitHubIssueDecodeError,
   GitHubRepositoryDecodeError,
 ]);
 export type GitHubCliError = typeof GitHubCliError.Type;
@@ -190,6 +219,8 @@ export interface GitHubPullRequestSummary {
   readonly headRepositoryOwnerLogin?: string | null;
 }
 
+export type GitHubIssueSummary = NormalizedGitHubIssueRecord;
+
 export interface GitHubRepositoryCloneUrls {
   readonly nameWithOwner: string;
   readonly url: string;
@@ -215,6 +246,11 @@ export class GitHubCli extends Context.Service<
       readonly cwd: string;
       readonly reference: string;
     }) => Effect.Effect<GitHubPullRequestSummary, GitHubCliError>;
+
+    readonly getIssue: (input: {
+      readonly cwd: string;
+      readonly reference: string;
+    }) => Effect.Effect<GitHubIssueSummary, GitHubCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
       readonly cwd: string;
@@ -388,6 +424,44 @@ export const make = Effect.gen(function* () {
               );
             }),
           ),
+        ),
+      ),
+    getIssue: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: [
+          "issue",
+          "view",
+          input.reference,
+          "--json",
+          "number,title,url,state,labels,assignees",
+        ],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          Effect.sync(() => decodeGitHubIssueJson(raw)).pipe(
+            Effect.flatMap((decoded) => {
+              if (!Result.isSuccess(decoded)) {
+                return Effect.fail(
+                  new GitHubIssueDecodeError({
+                    command: "gh",
+                    cwd: input.cwd,
+                    cause: decoded.failure,
+                  }),
+                );
+              }
+              return Effect.succeed(decoded.success);
+            }),
+          ),
+        ),
+        Effect.mapError((error) =>
+          error._tag === "GitHubPullRequestNotFoundError"
+            ? new GitHubIssueNotFoundError({
+                command: "gh",
+                cwd: input.cwd,
+                cause: error.cause,
+              })
+            : error,
         ),
       ),
     getRepositoryCloneUrls: (input) =>

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -68,6 +68,34 @@ it.effect("maps GitHub PR summaries into provider-neutral change requests", () =
   }),
 );
 
+it.effect("maps GitHub issues into provider-neutral issue metadata", () =>
+  Effect.gen(function* () {
+    const provider = yield* makeProvider({
+      getIssue: () =>
+        Effect.succeed({
+          number: 84,
+          title: "Draft page suggestions",
+          url: "https://github.com/pingdotgg/t3code/issues/84",
+          state: "open",
+          labels: ["enhancement"],
+          assignees: ["octocat"],
+        }),
+    });
+
+    const issue = yield* provider.getIssue!({ cwd: "/repo", reference: "84" });
+
+    assert.deepStrictEqual(issue, {
+      provider: "github",
+      number: 84,
+      title: "Draft page suggestions",
+      url: "https://github.com/pingdotgg/t3code/issues/84",
+      state: "open",
+      labels: ["enhancement"],
+      assignees: ["octocat"],
+    });
+  }),
+);
+
 it.effect("adds safe request context while retaining GitHub CLI causes", () =>
   Effect.gen(function* () {
     const cause = new GitHubCli.GitHubPullRequestNotFoundError({

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -6,6 +6,7 @@ import {
   SourceControlProviderError,
   type ChangeRequest,
   type ChangeRequestState,
+  type SourceControlIssue,
 } from "@t3tools/contracts";
 
 import * as GitHubCli from "./GitHubCli.ts";
@@ -39,6 +40,18 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
     ...(summary.headRepositoryOwnerLogin !== undefined
       ? { headRepositoryOwnerLogin: summary.headRepositoryOwnerLogin }
       : {}),
+  };
+}
+
+function toIssue(summary: GitHubCli.GitHubIssueSummary): SourceControlIssue {
+  return {
+    provider: "github",
+    number: summary.number,
+    title: summary.title,
+    url: summary.url,
+    state: summary.state,
+    labels: [...summary.labels],
+    assignees: [...summary.assignees],
   };
 }
 
@@ -195,6 +208,24 @@ export const make = Effect.gen(function* () {
             new SourceControlProviderError({
               provider: "github",
               operation: "getChangeRequest",
+              command: error.command,
+              cwd: input.cwd,
+              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                input.reference,
+              ),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
+    getIssue: (input) =>
+      github.getIssue(input).pipe(
+        Effect.map(toIssue),
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "github",
+              operation: "getIssue",
               command: error.command,
               cwd: input.cwd,
               reference: SourceControlProvider.transportSafeSourceControlErrorValue(

--- a/apps/server/src/sourceControl/SourceControlProvider.ts
+++ b/apps/server/src/sourceControl/SourceControlProvider.ts
@@ -6,6 +6,7 @@ import type {
   SourceControlProviderError,
   SourceControlProviderInfo,
   SourceControlProviderKind,
+  SourceControlIssue,
   SourceControlRepositoryCloneUrls,
   SourceControlRepositoryVisibility,
 } from "@t3tools/contracts";
@@ -96,6 +97,11 @@ export class SourceControlProvider extends Context.Service<
       readonly context?: SourceControlProviderContext;
       readonly reference: string;
     }) => Effect.Effect<ChangeRequest, SourceControlProviderError>;
+    readonly getIssue?: (input: {
+      readonly cwd: string;
+      readonly context?: SourceControlProviderContext;
+      readonly reference: string;
+    }) => Effect.Effect<SourceControlIssue, SourceControlProviderError>;
     readonly createChangeRequest: (input: {
       readonly cwd: string;
       readonly context?: SourceControlProviderContext;

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -169,6 +169,15 @@ function bindProviderContext(
         ...input,
         context: input.context ?? context,
       }),
+    ...(provider.getIssue
+      ? {
+          getIssue: (input: Parameters<NonNullable<typeof provider.getIssue>>[0]) =>
+            provider.getIssue!({
+              ...input,
+              context: input.context ?? context,
+            }),
+        }
+      : {}),
     createChangeRequest: (input) =>
       provider.createChangeRequest({
         ...input,

--- a/apps/server/src/sourceControl/gitHubIssues.ts
+++ b/apps/server/src/sourceControl/gitHubIssues.ts
@@ -1,0 +1,51 @@
+import * as Cause from "effect/Cause";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
+import { decodeJsonResult } from "@t3tools/shared/schemaJson";
+
+export interface NormalizedGitHubIssueRecord {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly state: "open" | "closed";
+  readonly labels: ReadonlyArray<string>;
+  readonly assignees: ReadonlyArray<string>;
+}
+
+const GitHubIssueSchema = Schema.Struct({
+  number: PositiveInt,
+  title: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+  state: Schema.String,
+  labels: Schema.Array(
+    Schema.Struct({
+      name: TrimmedNonEmptyString,
+    }),
+  ),
+  assignees: Schema.Array(
+    Schema.Struct({
+      login: TrimmedNonEmptyString,
+    }),
+  ),
+});
+
+const decodeGitHubIssue = decodeJsonResult(GitHubIssueSchema);
+
+export function decodeGitHubIssueJson(
+  raw: string,
+): Result.Result<NormalizedGitHubIssueRecord, Cause.Cause<Schema.SchemaError>> {
+  const result = decodeGitHubIssue(raw);
+  if (!Result.isSuccess(result)) {
+    return Result.fail(result.failure);
+  }
+
+  return Result.succeed({
+    number: result.success.number,
+    title: result.success.title,
+    url: result.success.url,
+    state: result.success.state.trim().toUpperCase() === "CLOSED" ? "closed" : "open",
+    labels: result.success.labels.map((label) => label.name),
+    assignees: result.success.assignees.map((assignee) => assignee.login),
+  });
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -322,6 +322,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.vcsPull, AuthOrchestrationOperateScope],
   [WS_METHODS.gitRunStackedAction, AuthOrchestrationOperateScope],
   [WS_METHODS.gitResolvePullRequest, AuthOrchestrationOperateScope],
+  [WS_METHODS.gitResolveIssue, AuthOrchestrationOperateScope],
   [WS_METHODS.gitPreparePullRequestThread, AuthOrchestrationOperateScope],
   [WS_METHODS.vcsListRefs, AuthOrchestrationReadScope],
   [WS_METHODS.vcsCreateWorktree, AuthOrchestrationOperateScope],
@@ -1797,6 +1798,10 @@ const makeWsRpcLayer = (
               "rpc.aggregate": "git",
             },
           ),
+        [WS_METHODS.gitResolveIssue]: (input) =>
+          observeRpcEffect(WS_METHODS.gitResolveIssue, gitWorkflow.resolveIssue(input), {
+            "rpc.aggregate": "git",
+          }),
         [WS_METHODS.gitPreparePullRequestThread]: (input) =>
           observeRpcEffect(
             WS_METHODS.gitPreparePullRequestThread,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3,6 +3,8 @@ import {
   DEFAULT_MODEL,
   defaultInstanceIdForDriver,
   type EnvironmentId,
+  type GitResolvedIssue,
+  type GitResolvedPullRequest,
   type MessageId,
   type ModelSelection,
   type ProjectScript,
@@ -150,7 +152,7 @@ import {
   nextProjectScriptId,
   projectScriptIdFromCommand,
 } from "~/projectScripts";
-import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
+import { newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
 import { useEnvironmentSettings } from "../hooks/useSettings";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
@@ -160,7 +162,6 @@ import {
   deriveLogicalProjectKeyFromSettings,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { buildDraftThreadRouteParams } from "../threadRoutes";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -204,7 +205,9 @@ import {
 import { environmentShell } from "../state/shell";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
+import { DraftSuggestedTasks } from "./chat/DraftSuggestedTasks";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
+import { IssueThreadDialog } from "./IssueThreadDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
@@ -260,6 +263,12 @@ import {
   resolveServerConfigVersionMismatch,
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
+import {
+  buildIssueTriageTask,
+  buildPullRequestTask,
+  FIX_FAILING_CHECKS_PROMPT,
+  REVIEW_CURRENT_CHANGES_PROMPT,
+} from "../suggestedTasks";
 
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
@@ -1175,13 +1184,6 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
-  const getDraftSessionByLogicalProjectKey = useComposerDraftStore(
-    (store) => store.getDraftSessionByLogicalProjectKey,
-  );
-  const getDraftSession = useComposerDraftStore((store) => store.getDraftSession);
-  const setLogicalProjectDraftThreadId = useComposerDraftStore(
-    (store) => store.setLogicalProjectDraftThreadId,
-  );
   const draftThread = useComposerDraftStore((store) =>
     routeKind === "server"
       ? store.getDraftSessionByRef(routeThreadRef)
@@ -1229,6 +1231,7 @@ function ChatViewContent(props: ChatViewProps) {
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
+  const [issueDialogOpen, setIssueDialogOpen] = useState(false);
   const [terminalUiLaunchContext, setTerminalUiLaunchContext] =
     useState<TerminalLaunchContext | null>(null);
   const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
@@ -1645,94 +1648,6 @@ function ChatViewContent(props: ChatViewProps) {
   const closePullRequestDialog = useCallback(() => {
     setPullRequestDialogState(null);
   }, []);
-
-  const openOrReuseProjectDraftThread = useCallback(
-    async (input: { branch: string; worktreePath: string | null; envMode: DraftThreadEnvMode }) => {
-      if (!activeProject) {
-        throw new Error("No active project is available for this pull request.");
-      }
-      const activeProjectRef = scopeProjectRef(activeProject.environmentId, activeProject.id);
-      const logicalProjectKey = deriveLogicalProjectKeyFromSettings(
-        activeProject,
-        projectGroupingSettings,
-      );
-      const storedDraftSession = getDraftSessionByLogicalProjectKey(logicalProjectKey);
-      if (storedDraftSession) {
-        setDraftThreadContext(storedDraftSession.draftId, input);
-        setLogicalProjectDraftThreadId(
-          logicalProjectKey,
-          activeProjectRef,
-          storedDraftSession.draftId,
-          {
-            threadId: storedDraftSession.threadId,
-            ...input,
-          },
-        );
-        if (routeKind !== "draft" || draftId !== storedDraftSession.draftId) {
-          await navigate({
-            to: "/draft/$draftId",
-            params: buildDraftThreadRouteParams(storedDraftSession.draftId),
-          });
-        }
-        return storedDraftSession.threadId;
-      }
-
-      const activeDraftSession = routeKind === "draft" && draftId ? getDraftSession(draftId) : null;
-      if (
-        !isServerThread &&
-        activeDraftSession?.logicalProjectKey === logicalProjectKey &&
-        draftId
-      ) {
-        setDraftThreadContext(draftId, input);
-        setLogicalProjectDraftThreadId(logicalProjectKey, activeProjectRef, draftId, {
-          threadId: activeDraftSession.threadId,
-          createdAt: activeDraftSession.createdAt,
-          runtimeMode: activeDraftSession.runtimeMode,
-          interactionMode: activeDraftSession.interactionMode,
-          ...input,
-        });
-        return activeDraftSession.threadId;
-      }
-
-      const nextDraftId = newDraftId();
-      const nextThreadId = newThreadId();
-      setLogicalProjectDraftThreadId(logicalProjectKey, activeProjectRef, nextDraftId, {
-        threadId: nextThreadId,
-        createdAt: new Date().toISOString(),
-        runtimeMode: DEFAULT_RUNTIME_MODE,
-        interactionMode: DEFAULT_INTERACTION_MODE,
-        ...input,
-      });
-      await navigate({
-        to: "/draft/$draftId",
-        params: buildDraftThreadRouteParams(nextDraftId),
-      });
-      return nextThreadId;
-    },
-    [
-      activeProject,
-      draftId,
-      getDraftSession,
-      getDraftSessionByLogicalProjectKey,
-      isServerThread,
-      navigate,
-      projectGroupingSettings,
-      routeKind,
-      setDraftThreadContext,
-      setLogicalProjectDraftThreadId,
-    ],
-  );
-
-  const handlePreparedPullRequestThread = useCallback(
-    async (input: { branch: string; worktreePath: string | null }) => {
-      await openOrReuseProjectDraftThread({
-        branch: input.branch,
-        worktreePath: input.worktreePath,
-        envMode: input.worktreePath ? "worktree" : "local",
-      });
-    },
-    [openOrReuseProjectDraftThread],
-  );
 
   useEffect(() => {
     if (!serverThread?.id) return;
@@ -2415,6 +2330,90 @@ function ChatViewContent(props: ChatViewProps) {
       focusComposer();
     });
   }, [focusComposer]);
+
+  const materializeSuggestedThread = async (input: {
+    title: string;
+    prompt: string;
+    branch: string | null;
+    worktreePath: string | null;
+  }): Promise<boolean> => {
+    if (!activeProject || !activeThread || !draftId || !isLocalDraftThread) {
+      return false;
+    }
+    const sendContext = composerRef.current?.getSendContext();
+    if (!sendContext) {
+      return false;
+    }
+
+    const createResult = await createThread({
+      environmentId,
+      input: {
+        threadId: activeThread.id,
+        projectId: activeProject.id,
+        title: truncate(input.title),
+        modelSelection: sendContext.selectedModelSelection,
+        runtimeMode,
+        interactionMode,
+        branch: input.branch,
+        worktreePath: input.worktreePath,
+        createdAt: activeThread.createdAt,
+      },
+    });
+    if (createResult._tag === "Failure") {
+      if (!isAtomCommandInterrupted(createResult)) {
+        const error = squashAtomCommandFailure(createResult);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not create suggested task thread",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An error occurred while creating the thread.",
+          }),
+        );
+      }
+      return false;
+    }
+
+    setDraftThreadContext(draftId, {
+      branch: input.branch,
+      worktreePath: input.worktreePath,
+      envMode: input.worktreePath ? "worktree" : "local",
+    });
+    setComposerDraftPrompt(draftId, input.prompt);
+    composerRef.current?.resetCursorState({ cursor: input.prompt.length, prompt: input.prompt });
+    scheduleComposerFocus();
+    return true;
+  };
+
+  const handlePreparedPullRequestThread = async (input: {
+    branch: string;
+    worktreePath: string | null;
+    pullRequest: GitResolvedPullRequest;
+  }) => {
+    const task = buildPullRequestTask(input.pullRequest);
+    return materializeSuggestedThread({
+      ...task,
+      branch: input.branch,
+      worktreePath: input.worktreePath,
+    });
+  };
+
+  const handleResolvedIssue = (issue: GitResolvedIssue) => {
+    const task = buildIssueTriageTask(issue);
+    return materializeSuggestedThread({
+      ...task,
+      branch: activeThread?.branch ?? null,
+      worktreePath: activeThread?.worktreePath ?? null,
+    });
+  };
+
+  const seedSuggestedPrompt = (prompt: string) => {
+    setComposerDraftPrompt(composerDraftTarget, prompt);
+    composerRef.current?.resetCursorState({ cursor: prompt.length, prompt });
+    scheduleComposerFocus();
+  };
   const addTerminalContextToDraft = useCallback(
     (selection: TerminalContextSelection) => {
       composerRef.current?.addTerminalContext(selection);
@@ -3612,6 +3611,7 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     setPullRequestDialogState(null);
+    setIssueDialogOpen(false);
     isAtEndRef.current = true;
     timelineScrollModeRef.current = "following-end";
     liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
@@ -5346,6 +5346,13 @@ function ChatViewContent(props: ChatViewProps) {
                           activeProjectRef={activeProjectRef}
                           activeProjectTitle={activeProject?.title ?? null}
                         />
+                        <DraftSuggestedTasks
+                          sourceControlAvailable={isGitRepo && activeProject !== null}
+                          onCheckoutPullRequest={() => openPullRequestDialog()}
+                          onTriageIssue={() => setIssueDialogOpen(true)}
+                          onReviewChanges={() => seedSuggestedPrompt(REVIEW_CURRENT_CHANGES_PROMPT)}
+                          onFixFailingChecks={() => seedSuggestedPrompt(FIX_FAILING_CHECKS_PROMPT)}
+                        />
                       </div>
                       <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
                     </div>
@@ -5502,6 +5509,16 @@ function ChatViewContent(props: ChatViewProps) {
                   }
                 }}
                 onPrepared={handlePreparedPullRequestThread}
+              />
+            ) : null}
+
+            {issueDialogOpen && activeThread ? (
+              <IssueThreadDialog
+                open
+                environmentId={activeThread.environmentId}
+                cwd={activeProject?.workspaceRoot ?? null}
+                onOpenChange={setIssueDialogOpen}
+                onResolved={handleResolvedIssue}
               />
             ) : null}
           </div>

--- a/apps/web/src/components/IssueThreadDialog.tsx
+++ b/apps/web/src/components/IssueThreadDialog.tsx
@@ -1,0 +1,196 @@
+import type { EnvironmentId, GitResolvedIssue } from "@t3tools/contracts";
+import { useDebouncedValue } from "@tanstack/react-pacer";
+import { CircleDotIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { readCachedIssueResolution, useIssueResolution } from "~/lib/sourceControlActions";
+import { parseIssueReference } from "~/issueReference";
+import { cn } from "~/lib/utils";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Spinner } from "./ui/spinner";
+
+interface IssueThreadDialogProps {
+  readonly open: boolean;
+  readonly environmentId: EnvironmentId;
+  readonly cwd: string | null;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onResolved: (issue: GitResolvedIssue) => Promise<boolean> | boolean;
+}
+
+export function IssueThreadDialog({
+  open,
+  environmentId,
+  cwd,
+  onOpenChange,
+  onResolved,
+}: IssueThreadDialogProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [reference, setReference] = useState("");
+  const [referenceDirty, setReferenceDirty] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [debouncedReference, referenceDebouncer] = useDebouncedValue(
+    reference,
+    { wait: 450 },
+    (state) => ({ isPending: state.isPending }),
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = window.requestAnimationFrame(() => inputRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [open]);
+
+  const parsedReference = parseIssueReference(reference);
+  const parsedDebouncedReference = parseIssueReference(debouncedReference);
+  const scope = useMemo(() => ({ environmentId, cwd }), [cwd, environmentId]);
+  const resolution = useIssueResolution({
+    ...scope,
+    reference: open ? parsedDebouncedReference : null,
+  });
+  const cachedIssue = useMemo(
+    () => readCachedIssueResolution({ ...scope, reference: parsedReference })?.issue ?? null,
+    [parsedReference, scope],
+  );
+  const liveIssue =
+    parsedReference !== null && parsedReference === parsedDebouncedReference
+      ? (resolution.data?.issue ?? null)
+      : null;
+  const issue = liveIssue ?? cachedIssue;
+  const isResolving =
+    open &&
+    parsedReference !== null &&
+    issue === null &&
+    (referenceDebouncer.state.isPending ||
+      parsedReference !== parsedDebouncedReference ||
+      resolution.isPending ||
+      resolution.isFetching);
+
+  const handleConfirm = async () => {
+    if (!parsedReference) {
+      setReferenceDirty(true);
+      return;
+    }
+    if (!issue || isResolving || isCreating) return;
+    setIsCreating(true);
+    const didCreateThread = await onResolved(issue);
+    setIsCreating(false);
+    if (didCreateThread) onOpenChange(false);
+  };
+
+  const validationMessage = !referenceDirty
+    ? null
+    : reference.trim().length === 0
+      ? "Paste a GitHub issue URL or enter 123 / #123."
+      : parsedReference === null
+        ? "Use a GitHub issue URL, 123, or #123."
+        : null;
+  const errorMessage =
+    validationMessage ??
+    (issue === null && resolution.error
+      ? typeof resolution.error === "string"
+        ? resolution.error
+        : "Unable to resolve this issue."
+      : null);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isCreating) onOpenChange(nextOpen);
+      }}
+    >
+      <DialogPopup className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CircleDotIcon className="size-4" />
+            Triage an issue
+          </DialogTitle>
+          <DialogDescription>
+            Resolve a GitHub issue, then create a focused triage thread without sending it yet.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="space-y-4">
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium text-foreground">Issue</span>
+            <Input
+              ref={inputRef}
+              placeholder="GitHub issue URL or #42"
+              value={reference}
+              onChange={(event) => {
+                setReferenceDirty(true);
+                setReference(event.target.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                void handleConfirm();
+              }}
+            />
+          </label>
+
+          {issue ? (
+            <div className="rounded-xl border border-border/70 bg-muted/24 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{issue.title}</p>
+                  <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                    #{issue.number}
+                    {issue.labels.length > 0 ? ` · ${issue.labels.join(", ")}` : ""}
+                  </p>
+                </div>
+                <span
+                  className={cn(
+                    "shrink-0 text-xs capitalize",
+                    issue.state === "open"
+                      ? "text-emerald-600 dark:text-emerald-300/90"
+                      : "text-zinc-500 dark:text-zinc-400/80",
+                  )}
+                >
+                  {issue.state}
+                </span>
+              </div>
+            </div>
+          ) : null}
+
+          {isResolving ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Spinner className="size-3.5" />
+              Resolving issue...
+            </div>
+          ) : null}
+
+          {errorMessage ? <p className="text-xs text-destructive">{errorMessage}</p> : null}
+        </DialogPanel>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={isCreating}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void handleConfirm()}
+            disabled={!issue || isResolving || isCreating}
+          >
+            {isCreating ? "Creating thread..." : "Create triage thread"}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/PullRequestThreadDialog.tsx
+++ b/apps/web/src/components/PullRequestThreadDialog.tsx
@@ -1,7 +1,7 @@
-import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import type { EnvironmentId, GitResolvedPullRequest, ThreadId } from "@t3tools/contracts";
 import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { useDebouncedValue } from "@tanstack/react-pacer";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   readCachedPullRequestResolution,
@@ -33,7 +33,11 @@ interface PullRequestThreadDialogProps {
   cwd: string | null;
   initialReference: string | null;
   onOpenChange: (open: boolean) => void;
-  onPrepared: (input: { branch: string; worktreePath: string | null }) => Promise<void> | void;
+  onPrepared: (input: {
+    branch: string;
+    worktreePath: string | null;
+    pullRequest: GitResolvedPullRequest;
+  }) => Promise<boolean> | boolean;
 }
 
 export function PullRequestThreadDialog({
@@ -129,44 +133,34 @@ export function PullRequestThreadDialog({
     }
   }, [resolvedPullRequest?.state]);
 
-  const handleConfirm = useCallback(
-    async (mode: "local" | "worktree") => {
-      if (!parsedReference) {
-        setReferenceDirty(true);
-        return;
+  const handleConfirm = async (mode: "local" | "worktree") => {
+    if (!parsedReference) {
+      setReferenceDirty(true);
+      return;
+    }
+    if (!parsedReference || !resolvedPullRequest || !cwd) {
+      return;
+    }
+    setPreparingMode(mode);
+    const result = await preparePullRequestThreadAction.run({
+      reference: parsedReference,
+      mode,
+      ...(mode === "worktree" ? { threadId } : {}),
+    });
+    setPreparingMode(null);
+    if (result._tag === "Failure") {
+      if (isAtomCommandInterrupted(result)) {
+        preparePullRequestThreadAction.resetError();
       }
-      if (!parsedReference || !resolvedPullRequest || !cwd) {
-        return;
-      }
-      setPreparingMode(mode);
-      const result = await preparePullRequestThreadAction.run({
-        reference: parsedReference,
-        mode,
-        ...(mode === "worktree" ? { threadId } : {}),
-      });
-      setPreparingMode(null);
-      if (result._tag === "Failure") {
-        if (isAtomCommandInterrupted(result)) {
-          preparePullRequestThreadAction.resetError();
-        }
-        return;
-      }
-      await onPrepared({
-        branch: result.value.branch,
-        worktreePath: result.value.worktreePath,
-      });
-      onOpenChange(false);
-    },
-    [
-      cwd,
-      onOpenChange,
-      onPrepared,
-      parsedReference,
-      preparePullRequestThreadAction,
-      resolvedPullRequest,
-      threadId,
-    ],
-  );
+      return;
+    }
+    const didCreateThread = await onPrepared({
+      branch: result.value.branch,
+      worktreePath: result.value.worktreePath,
+      pullRequest: result.value.pullRequest,
+    });
+    if (didCreateThread) onOpenChange(false);
+  };
 
   const validationMessage = !referenceDirty
     ? null
@@ -201,8 +195,8 @@ export function PullRequestThreadDialog({
             Checkout {terminology.singular}
           </DialogTitle>
           <DialogDescription>
-            Resolve a {sourceControlPresentation.providerName} {terminology.singular}, then create
-            the draft thread in the main repo or in a dedicated worktree.
+            Resolve a {sourceControlPresentation.providerName} {terminology.singular}, then open it
+            in the main repo or in a dedicated worktree.
           </DialogDescription>
         </DialogHeader>
         <DialogPanel className="space-y-4">
@@ -280,7 +274,7 @@ export function PullRequestThreadDialog({
               preparePullRequestThreadAction.isPending
             }
           >
-            {preparingMode === "local" ? "Preparing local..." : "Local"}
+            {preparingMode === "local" ? "Checking out..." : "Check out here"}
           </Button>
           <Button
             type="button"
@@ -295,7 +289,7 @@ export function PullRequestThreadDialog({
               preparePullRequestThreadAction.isPending
             }
           >
-            {preparingMode === "worktree" ? "Preparing worktree..." : "Worktree"}
+            {preparingMode === "worktree" ? "Preparing worktree..." : "Open in new worktree"}
           </Button>
         </DialogFooter>
       </DialogPopup>

--- a/apps/web/src/components/chat/DraftSuggestedTasks.tsx
+++ b/apps/web/src/components/chat/DraftSuggestedTasks.tsx
@@ -1,0 +1,92 @@
+import {
+  BugIcon,
+  GitPullRequestArrowIcon,
+  ScanSearchIcon,
+  TestTubeDiagonalIcon,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+interface SuggestedTask {
+  readonly title: string;
+  readonly description: string;
+  readonly icon: LucideIcon;
+  readonly tone: string;
+  readonly onSelect: () => void;
+  readonly disabled?: boolean;
+}
+
+interface DraftSuggestedTasksProps {
+  readonly sourceControlAvailable: boolean;
+  readonly onCheckoutPullRequest: () => void;
+  readonly onTriageIssue: () => void;
+  readonly onReviewChanges: () => void;
+  readonly onFixFailingChecks: () => void;
+}
+
+export function DraftSuggestedTasks(props: DraftSuggestedTasksProps) {
+  const tasks: ReadonlyArray<SuggestedTask> = [
+    {
+      title: "Check out a PR",
+      description: "Open it locally or in a worktree",
+      icon: GitPullRequestArrowIcon,
+      tone: "text-sky-500 dark:text-sky-400",
+      onSelect: props.onCheckoutPullRequest,
+      disabled: !props.sourceControlAvailable,
+    },
+    {
+      title: "Triage an issue",
+      description: "Investigate scope and likely cause",
+      icon: BugIcon,
+      tone: "text-amber-500 dark:text-amber-400",
+      onSelect: props.onTriageIssue,
+      disabled: !props.sourceControlAvailable,
+    },
+    {
+      title: "Review current changes",
+      description: "Inspect the diff and flag risks",
+      icon: ScanSearchIcon,
+      tone: "text-violet-500 dark:text-violet-400",
+      onSelect: props.onReviewChanges,
+    },
+    {
+      title: "Fix failing checks",
+      description: "Run focused checks and repair failures",
+      icon: TestTubeDiagonalIcon,
+      tone: "text-emerald-500 dark:text-emerald-400",
+      onSelect: props.onFixFailingChecks,
+    },
+  ];
+
+  return (
+    <div className="pointer-events-auto mx-auto mt-6 grid w-full max-w-3xl grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-2.5">
+      {tasks.map((task) => {
+        const Icon = task.icon;
+        return (
+          <button
+            key={task.title}
+            type="button"
+            onClick={task.onSelect}
+            disabled={task.disabled}
+            title={task.disabled ? "Available in Git repositories" : undefined}
+            className={cn(
+              "group min-h-20 rounded-xl border border-border/65 bg-card/45 p-3 text-left shadow-[0_1px_0_hsl(var(--border)/0.12)] backdrop-blur-sm transition-[border-color,background-color,transform,box-shadow] duration-150",
+              "hover:-translate-y-0.5 hover:border-border hover:bg-card/80 hover:shadow-sm",
+              "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              "disabled:pointer-events-none disabled:opacity-40 sm:min-h-24",
+            )}
+          >
+            <Icon className={cn("size-4", task.tone)} strokeWidth={1.8} />
+            <span className="mt-3 block text-[13px] font-medium leading-4 text-foreground">
+              {task.title}
+            </span>
+            <span className="mt-1 hidden text-[11px] leading-4 text-muted-foreground/75 sm:block">
+              {task.description}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/issueReference.test.ts
+++ b/apps/web/src/issueReference.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { parseIssueReference } from "./issueReference";
+
+describe("parseIssueReference", () => {
+  it("accepts GitHub issue URLs", () => {
+    expect(parseIssueReference("https://github.com/pingdotgg/t3code/issues/42")).toBe(
+      "https://github.com/pingdotgg/t3code/issues/42",
+    );
+  });
+
+  it("accepts numbers with or without a hash", () => {
+    expect(parseIssueReference("42")).toBe("42");
+    expect(parseIssueReference("#42")).toBe("42");
+  });
+
+  it("rejects unrelated input", () => {
+    expect(parseIssueReference("draft-page")).toBeNull();
+  });
+});

--- a/apps/web/src/issueReference.ts
+++ b/apps/web/src/issueReference.ts
@@ -1,0 +1,17 @@
+const GITHUB_ISSUE_URL_PATTERN =
+  /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)(?:[/?#].*)?$/i;
+const ISSUE_NUMBER_PATTERN = /^#?(\d+)$/;
+
+export function parseIssueReference(input: string): string | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (GITHUB_ISSUE_URL_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  const numberMatch = ISSUE_NUMBER_PATTERN.exec(trimmed);
+  return numberMatch?.[1] ?? null;
+}

--- a/apps/web/src/lib/sourceControlActions.ts
+++ b/apps/web/src/lib/sourceControlActions.ts
@@ -1,8 +1,10 @@
 export {
   readCachedPullRequestResolution,
+  readCachedIssueResolution,
   useGitStackedAction,
   usePreparePullRequestThreadAction,
   usePullRequestResolutionState as usePullRequestResolution,
+  useIssueResolutionState as useIssueResolution,
   useSourceControlActionRunning,
   useSourceControlPublishRepositoryAction,
   useVcsInitAction,

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -12,6 +12,7 @@ import type {
   EnvironmentId,
   GitActionProgressEvent,
   GitResolvePullRequestResult,
+  GitResolveIssueResult,
   GitStackedAction,
   SourceControlCloneProtocol,
   SourceControlRepositoryVisibility,
@@ -379,6 +380,50 @@ export function usePullRequestResolutionState(target: PullRequestResolutionTarge
       : null,
   );
   const cached = readCachedPullRequestResolution(target);
+
+  return {
+    data: query.data ?? cached,
+    error: query.error,
+    isPending: query.isPending && cached === null,
+    isFetching: query.isPending,
+    refresh: query.refresh,
+  };
+}
+
+export interface IssueResolutionTarget {
+  readonly environmentId: EnvironmentId | null;
+  readonly cwd: string | null;
+  readonly reference: string | null;
+}
+
+export function readCachedIssueResolution(
+  target: IssueResolutionTarget,
+): GitResolveIssueResult | null {
+  if (target.environmentId === null || target.cwd === null || target.reference === null) {
+    return null;
+  }
+  return Option.getOrNull(
+    AsyncResult.value(
+      appAtomRegistry.get(
+        gitEnvironment.issueResolution({
+          environmentId: target.environmentId,
+          input: { cwd: target.cwd, reference: target.reference },
+        }),
+      ),
+    ),
+  );
+}
+
+export function useIssueResolutionState(target: IssueResolutionTarget) {
+  const query = useEnvironmentQuery(
+    target.environmentId !== null && target.cwd !== null && target.reference !== null
+      ? gitEnvironment.issueResolution({
+          environmentId: target.environmentId,
+          input: { cwd: target.cwd, reference: target.reference },
+        })
+      : null,
+  );
+  const cached = readCachedIssueResolution(target);
 
   return {
     data: query.data ?? cached,

--- a/apps/web/src/suggestedTasks.test.ts
+++ b/apps/web/src/suggestedTasks.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildIssueTriageTask, buildPullRequestTask } from "./suggestedTasks";
+
+describe("suggested task builders", () => {
+  it("builds a PR-specific thread title and editable review prompt", () => {
+    const task = buildPullRequestTask({
+      number: 42,
+      title: "Improve the draft page",
+      url: "https://github.com/acme/app/pull/42",
+      baseBranch: "main",
+      headBranch: "feature/draft-page",
+      state: "open",
+    });
+
+    expect(task.title).toBe("PR #42 · Improve the draft page");
+    expect(task.prompt).toContain("Review PR #42");
+    expect(task.prompt).toContain("Do not make changes");
+  });
+
+  it("builds an analysis-only issue triage prompt", () => {
+    const task = buildIssueTriageTask({
+      number: 84,
+      title: "Sidebar freezes",
+      url: "https://github.com/acme/app/issues/84",
+      state: "open",
+      labels: ["bug"],
+      assignees: [],
+    });
+
+    expect(task.title).toBe("Triage #84 · Sidebar freezes");
+    expect(task.prompt).toContain("reproduction steps");
+    expect(task.prompt).toContain("Do not implement changes yet");
+  });
+});

--- a/apps/web/src/suggestedTasks.ts
+++ b/apps/web/src/suggestedTasks.ts
@@ -1,0 +1,27 @@
+import type { GitResolvedIssue, GitResolvedPullRequest } from "@t3tools/contracts";
+
+export const REVIEW_CURRENT_CHANGES_PROMPT =
+  "Review the current changes in this workspace. Inspect the diff, identify correctness, security, performance, and maintainability risks, and recommend focused improvements. Do not make changes until you have summarized what you found.";
+
+export const FIX_FAILING_CHECKS_PROMPT =
+  "Find the smallest relevant test, lint, formatting, and type-check commands for this project. Run the focused checks, diagnose any failures, implement fixes, and rerun the affected checks to verify them.";
+
+export function buildPullRequestTask(input: GitResolvedPullRequest): {
+  readonly title: string;
+  readonly prompt: string;
+} {
+  return {
+    title: `PR #${input.number} · ${input.title}`,
+    prompt: `Review PR #${input.number}, “${input.title}” (${input.url}). Understand the changes, run the relevant checks, identify correctness or maintainability issues, and suggest fixes. Do not make changes until you have summarized what you found.`,
+  };
+}
+
+export function buildIssueTriageTask(input: GitResolvedIssue): {
+  readonly title: string;
+  readonly prompt: string;
+} {
+  return {
+    title: `Triage #${input.number} · ${input.title}`,
+    prompt: `Triage issue #${input.number}, “${input.title}” (${input.url}). Read the issue and inspect the relevant code. Determine the likely cause, reproduction steps, scope, severity, and a concrete next action. Do not implement changes yet.`,
+  };
+}

--- a/packages/client-runtime/src/state/git.ts
+++ b/packages/client-runtime/src/state/git.ts
@@ -13,6 +13,10 @@ export function createGitEnvironmentAtoms<R, E>(
       label: "environment-data:git:resolve-pull-request",
       tag: WS_METHODS.gitResolvePullRequest,
     }),
+    issueResolution: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:git:resolve-issue",
+      tag: WS_METHODS.gitResolveIssue,
+    }),
     preparePullRequestThread: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:git:prepare-pull-request-thread",
       tag: WS_METHODS.gitPreparePullRequestThread,

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -7,6 +7,7 @@ import {
   GitRunStackedActionResult,
   GitRunStackedActionInput,
   GitResolvePullRequestResult,
+  GitResolveIssueResult,
 } from "./git.ts";
 
 const decodeCreateWorktreeInput = Schema.decodeUnknownSync(VcsCreateWorktreeInput);
@@ -16,6 +17,7 @@ const decodePreparePullRequestThreadInput = Schema.decodeUnknownSync(
 const decodeRunStackedActionInput = Schema.decodeUnknownSync(GitRunStackedActionInput);
 const decodeRunStackedActionResult = Schema.decodeUnknownSync(GitRunStackedActionResult);
 const decodeResolvePullRequestResult = Schema.decodeUnknownSync(GitResolvePullRequestResult);
+const decodeResolveIssueResult = Schema.decodeUnknownSync(GitResolveIssueResult);
 
 describe("VcsCreateWorktreeInput", () => {
   it("accepts omitted newRefName for existing-refName worktrees", () => {
@@ -70,6 +72,24 @@ describe("GitResolvePullRequestResult", () => {
 
     expect(parsed.pullRequest.number).toBe(42);
     expect(parsed.pullRequest.headBranch).toBe("feature/pr-threads");
+  });
+});
+
+describe("GitResolveIssueResult", () => {
+  it("decodes resolved issue metadata", () => {
+    const parsed = decodeResolveIssueResult({
+      issue: {
+        number: 84,
+        title: "Draft page suggestions",
+        url: "https://github.com/pingdotgg/codething-mvp/issues/84",
+        state: "open",
+        labels: ["enhancement", "web"],
+        assignees: ["octocat"],
+      },
+    });
+
+    expect(parsed.issue.number).toBe(84);
+    expect(parsed.issue.labels).toEqual(["enhancement", "web"]);
   });
 });
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -44,6 +44,7 @@ const GitBranchStepStatus = Schema.Literals(["created", "skipped_not_requested"]
 const GitPrStepStatus = Schema.Literals(["created", "opened_existing", "skipped_not_requested"]);
 const VcsStatusChangeRequestState = Schema.Literals(["open", "closed", "merged"]);
 const GitPullRequestReference = TrimmedNonEmptyStringSchema;
+const GitIssueReference = TrimmedNonEmptyStringSchema;
 const GitPullRequestState = Schema.Literals(["open", "closed", "merged"]);
 const GitPreparePullRequestThreadMode = Schema.Literals(["local", "worktree"]);
 export const GitRunStackedActionToastRunAction = Schema.Struct({
@@ -97,6 +98,16 @@ const GitResolvedPullRequest = Schema.Struct({
 });
 export type GitResolvedPullRequest = typeof GitResolvedPullRequest.Type;
 
+export const GitResolvedIssue = Schema.Struct({
+  number: PositiveInt,
+  title: TrimmedNonEmptyStringSchema,
+  url: Schema.String,
+  state: Schema.Literals(["open", "closed"]),
+  labels: Schema.Array(TrimmedNonEmptyStringSchema),
+  assignees: Schema.Array(TrimmedNonEmptyStringSchema),
+});
+export type GitResolvedIssue = typeof GitResolvedIssue.Type;
+
 // RPC Inputs
 
 export const VcsStatusInput = Schema.Struct({
@@ -147,6 +158,12 @@ export const GitPullRequestRefInput = Schema.Struct({
   reference: GitPullRequestReference,
 });
 export type GitPullRequestRefInput = typeof GitPullRequestRefInput.Type;
+
+export const GitIssueRefInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+  reference: GitIssueReference,
+});
+export type GitIssueRefInput = typeof GitIssueRefInput.Type;
 
 export const GitPreparePullRequestThreadInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
@@ -270,6 +287,11 @@ export const GitResolvePullRequestResult = Schema.Struct({
   pullRequest: GitResolvedPullRequest,
 });
 export type GitResolvePullRequestResult = typeof GitResolvePullRequestResult.Type;
+
+export const GitResolveIssueResult = Schema.Struct({
+  issue: GitResolvedIssue,
+});
+export type GitResolveIssueResult = typeof GitResolveIssueResult.Type;
 
 export const GitPreparePullRequestThreadResult = Schema.Struct({
   pullRequest: GitResolvedPullRequest,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -15,6 +15,8 @@ import type {
   GitPreparePullRequestThreadResult,
   GitPullRequestRefInput,
   GitResolvePullRequestResult,
+  GitIssueRefInput,
+  GitResolveIssueResult,
   VcsStatusInput,
   VcsStatusResult,
 } from "./git.ts";
@@ -1210,6 +1212,7 @@ export interface EnvironmentApi {
   };
   git: {
     resolvePullRequest: (input: GitPullRequestRefInput) => Promise<GitResolvePullRequestResult>;
+    resolveIssue: (input: GitIssueRefInput) => Promise<GitResolveIssueResult>;
     preparePullRequestThread: (
       input: GitPreparePullRequestThreadInput,
     ) => Promise<GitPreparePullRequestThreadResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -34,6 +34,8 @@ import {
   VcsPullResult,
   VcsRemoveWorktreeInput,
   GitResolvePullRequestResult,
+  GitIssueRefInput,
+  GitResolveIssueResult,
   GitRunStackedActionInput,
   VcsStatusInput,
   VcsStatusResult,
@@ -174,6 +176,7 @@ export const WS_METHODS = {
   // Git workflow methods
   gitRunStackedAction: "git.runStackedAction",
   gitResolvePullRequest: "git.resolvePullRequest",
+  gitResolveIssue: "git.resolveIssue",
   gitPreparePullRequestThread: "git.preparePullRequestThread",
 
   // Review methods
@@ -431,6 +434,12 @@ export const WsGitRunStackedActionRpc = Rpc.make(WS_METHODS.gitRunStackedAction,
 export const WsGitResolvePullRequestRpc = Rpc.make(WS_METHODS.gitResolvePullRequest, {
   payload: GitPullRequestRefInput,
   success: GitResolvePullRequestResult,
+  error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
+});
+
+export const WsGitResolveIssueRpc = Rpc.make(WS_METHODS.gitResolveIssue, {
+  payload: GitIssueRefInput,
+  success: GitResolveIssueResult,
   error: Schema.Union([GitManagerServiceError, EnvironmentAuthorizationError]),
 });
 
@@ -719,6 +728,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsVcsRefreshStatusRpc,
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,
+  WsGitResolveIssueRpc,
   WsGitPreparePullRequestThreadRpc,
   WsVcsListRefsRpc,
   WsVcsCreateWorktreeRpc,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -36,6 +36,20 @@ export const ChangeRequest = Schema.Struct({
 });
 export type ChangeRequest = typeof ChangeRequest.Type;
 
+export const SourceControlIssueState = Schema.Literals(["open", "closed"]);
+export type SourceControlIssueState = typeof SourceControlIssueState.Type;
+
+export const SourceControlIssue = Schema.Struct({
+  provider: SourceControlProviderKind,
+  number: PositiveInt,
+  title: TrimmedNonEmptyString,
+  url: Schema.String,
+  state: SourceControlIssueState,
+  labels: Schema.Array(TrimmedNonEmptyString),
+  assignees: Schema.Array(TrimmedNonEmptyString),
+});
+export type SourceControlIssue = typeof SourceControlIssue.Type;
+
 export const SourceControlRepositoryCloneUrls = Schema.Struct({
   nameWithOwner: TrimmedNonEmptyString,
   url: TrimmedNonEmptyString,


### PR DESCRIPTION
## Summary

- Add suggested draft task cards to the chat composer.
- Add GitHub issue reference parsing and issue triage thread flow.
- Add source-control issue APIs and GitHub CLI integration.
- Simplify thread list, provider, orchestration, and settings flows by removing settlement and legacy v2 behavior.

## Testing

- Not run (no test execution details provided).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git workflow RPCs, GitHub CLI parsing, and draft thread creation; changes are additive with tests but PR/issue flows now depend on the new materialization path.
> 
> **Overview**
> Adds **suggested task cards** on the draft chat hero for checking out a PR, triaging a GitHub issue, seeding a “review current changes” prompt, and seeding a “fix failing checks” prompt (git-backed actions disabled when the workspace isn’t a git repo).
> 
> **GitHub issue lookup** is wired end-to-end: optional `getIssue` on the source-control provider, `gh issue view` JSON decoding in `GitHubCli`, `GitManager.resolveIssue` / `git.resolveIssue` RPC, and client atoms (`issueResolution`) with caching like PR resolution.
> 
> **Issue triage UI** uses `IssueThreadDialog` (debounced resolve via `parseIssueReference`) and **`materializeSuggestedThread`** in `ChatView`, which creates the server thread, sets branch/worktree context, and pre-fills the composer **without auto-sending**. PR checkout follows the same pattern: `PullRequestThreadDialog` now returns resolved PR metadata to `buildPullRequestTask`, replacing the older draft-navigation/`openOrReuseProjectDraftThread` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4e10a7418447390ae82f929fdd2d901a86549f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add suggested draft task cards and issue triage flow to chat view
> - Adds a `DraftSuggestedTasks` component to the draft hero area with four actions: check out a PR, triage an issue, review current changes, and fix failing checks.
> - Adds `IssueThreadDialog` for resolving a GitHub issue reference (debounced, with validation), then prefilling the composer with a triage prompt.
> - Updates `PullRequestThreadDialog` to defer closing until the parent confirms successful thread creation via the `onPrepared` return value.
> - Introduces a `resolveIssue` RPC endpoint (`git.resolveIssue`) wired through contracts, WebSocket server, `GitWorkflowService`, `GitManager`, and `GitHubCli` to return normalized issue metadata.
> - Selecting a suggested task immediately creates a server thread using the current draft's model/runtime settings and seeds the composer prompt without sending.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4c4e10a. 20 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->