### PR TITLE
fix(server): don't drop sticky PR fallback when remote URL can't be resolved

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1514,6 +1514,54 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("status keeps the last known PR when the current remote URL can't be resolved", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/pr-config-hiccup"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/pr-config-hiccup"]);
+
+      const existingPr = {
+        number: 217,
+        title: "Config hiccup PR",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/217",
+        baseRefName: "main",
+        headRefName: "feature/pr-config-hiccup",
+      };
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
+          prListSequence: [JSON.stringify([existingPr])],
+          failWith: new GitHubCli.GitHubCliUnavailableError({
+            command: "gh",
+            cwd: repoDir,
+            cause: new Error("rate limited"),
+          }),
+          failAfterCalls: 1,
+        },
+      });
+
+      const first = yield* manager.status({ cwd: repoDir });
+      expect(first.pr?.number).toBe(217);
+
+      // `remote.origin.url` reads go through readConfigValueNullable, which
+      // maps ANY failed read (a real "no remote configured" state or a
+      // transient git-config hiccup) to null the same way. Unsetting the
+      // key here reproduces that ambiguity without touching branch
+      // tracking (refs/remotes/origin/* and branch.<b>.remote are
+      // untouched) — the remote identity has not actually changed, so the
+      // sticky PR must survive even though the current lookup can no
+      // longer resolve a remote URL to compare against.
+      yield* runGit(repoDir, ["config", "--unset", "remote.origin.url"]);
+      yield* manager.invalidateStatus(repoDir);
+
+      const second = yield* manager.status({ cwd: repoDir });
+      expect(second.pr?.number).toBe(217);
+    }),
+  );
+
   it.effect("creates a commit when working tree is dirty", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -846,16 +846,25 @@ export const make = Effect.gen(function* () {
     }
 
     // The normalized URL catches both remote-alias changes and an existing
-    // alias being repointed. It also lets an upstream appear after `push -u`
-    // without invalidating the fallback when it still targets the same repo.
-    if (lastKnown.headRemoteUrlKey !== null || current.headRemoteUrlKey !== null) {
+    // alias being repointed. Both sides must be resolved before treating a
+    // mismatch as real: `readConfigValueNullable` swallows any git-config
+    // read failure into `null`, so a transient failure to resolve the
+    // *current* remote URL must read as "unknown", not as "no remote" — the
+    // latter would otherwise drop an already-known PR badge on every hiccup.
+    if (lastKnown.headRemoteUrlKey !== null && current.headRemoteUrlKey !== null) {
       return lastKnown.headRemoteUrlKey === current.headRemoteUrlKey ? lastKnown.pr : null;
     }
 
-    // If neither remote URL is available, fall back to the remote identity
-    // encoded by tracked branches. A null-to-non-null transition is allowed
-    // because that is the expected first-push case.
-    if (lastKnown.upstreamRef !== null && current.upstreamRef !== null) {
+    // If the remote URL can't be compared, fall back to the remote identity
+    // encoded by tracked branches — same "both sides known" requirement, for
+    // the same reason. A null-to-non-null transition (upstream/remoteName)
+    // is allowed because that is the expected first-push case.
+    if (
+      lastKnown.upstreamRef !== null &&
+      current.upstreamRef !== null &&
+      lastKnown.remoteName !== null &&
+      current.remoteName !== null
+    ) {
       return lastKnown.remoteName === current.remoteName ? lastKnown.pr : null;
     }
     return lastKnown.pr;


### PR DESCRIPTION
## Summary
- Follow-up to #4281 (merged): Bugbot flagged that the sticky-PR fallback's remote-URL comparison treated a `null` on either side as a hard mismatch, dropping an already-known PR badge whenever the *current* lookup transiently failed to read `remote.<name>.url` — indistinguishable from a genuine "no remote configured" state.
- `resolveLastKnownPr` now only invalidates the fallback when both the cached and current remote-URL keys (and, one level down, `remoteName`) are known and disagree; a null on either side is treated as inconclusive rather than as proof the remote changed.
- Added a regression test that unsets `remote.origin.url` between two status calls (reproducing the ambiguous-null case via real git config, without touching branch tracking) and asserts the sticky PR survives.

## Test plan
- [x] `pnpm typecheck` (apps/server) — clean
- [x] `pnpm vp lint` on changed files — clean
- [x] `apps/server/src/git/GitManager.test.ts` full suite — 64/64 passed, including the new regression test and the existing sticky-PR/retarget/repoint tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to PR badge fallback validation in git status; regression test added; genuine remote repoint/retarget behavior still covered by existing tests.
> 
> **Overview**
> Fixes **sticky PR** fallback logic in `resolveLastKnownPr` so a transient or ambiguous missing `remote.<name>.url` no longer clears an already-known PR badge.
> 
> **Remote URL comparison** now only treats a mismatch as real when **both** the cached and current normalized remote URL keys are non-null and differ. A `null` from `readConfigValueNullable` (real “no remote” vs config read failure) is **inconclusive**, not proof the remote changed.
> 
> The **upstream / `remoteName` fallback** uses the same rule: both sides must be known before disagreement invalidates the cache; otherwise the last known PR is kept (including first-push null→non-null transitions).
> 
> Adds a regression test that unsets `remote.origin.url` between status calls (with `gh` failing on the second lookup) and expects PR **#217** to remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3572fed3d28886a6b07dc4199505724123b5e54f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve cached PR when remote URL or upstream identity can't be resolved
> When reconciling a last-known PR with the current repo state in [GitManager.ts](https://github.com/pingdotgg/t3code/pull/4289/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337), null checks are now required on both sides of each comparison before treating a mismatch as invalidating the cached PR. Previously, a transient failure to read `remote.origin.url` or the upstream/remote identity would produce a null value that caused the cached PR to be dropped silently. A new integration test in [GitManager.test.ts](https://github.com/pingdotgg/t3code/pull/4289/files#diff-913ade748b9dbddd4912c2fd2d736a754c232ed342415f121860f38508455eb1) covers this scenario by unsetting the remote URL mid-session and asserting the last-known PR is preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3572fed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->