### PR TITLE
fix(server): bound editor discovery during config loading

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -73,6 +73,7 @@ const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 
 import * as ServerConfig from "./config.ts";
 import { makeRoutesLayer } from "./server.ts";
+import { resolveAvailableEditorsForConfig } from "./ws.ts";
 import * as CheckpointDiffQuery from "./checkpointing/CheckpointDiffQuery.ts";
 import * as GitManager from "./git/GitManager.ts";
 import * as Keybindings from "./keybindings.ts";
@@ -3726,6 +3727,23 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(response.shellResumeCompletionMarker, true);
       assert.equal(response.threadResumeCompletionMarker, true);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("does not block server config when editor discovery never resolves", () =>
+    Effect.gen(function* () {
+      const discoveryInterrupted = yield* Deferred.make<void>();
+      const responseFiber = yield* resolveAvailableEditorsForConfig(
+        Effect.never.pipe(
+          Effect.onInterrupt(() => Deferred.succeed(discoveryInterrupted, undefined)),
+        ),
+      ).pipe(Effect.forkChild);
+
+      yield* TestClock.adjust(Duration.seconds(5));
+
+      const availableEditors = yield* Fiber.join(responseFiber);
+      yield* Deferred.await(discoveryInterrupted);
+      assert.deepEqual(availableEditors, []);
+    }),
   );
 
   it.effect(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -118,6 +118,15 @@ import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+const EDITOR_DISCOVERY_TIMEOUT = Duration.seconds(5);
+
+export const resolveAvailableEditorsForConfig = <A, E, R>(
+  discovery: Effect.Effect<ReadonlyArray<A>, E, R>,
+) =>
+  discovery.pipe(
+    Effect.timeoutOption(EDITOR_DISCOVERY_TIMEOUT),
+    Effect.map(Option.getOrElse(() => [])),
+  );
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
@@ -1080,7 +1089,9 @@ const makeWsRpcLayer = (
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
           providers,
-          availableEditors: yield* externalLauncher.resolveAvailableEditors(),
+          availableEditors: yield* resolveAvailableEditorsForConfig(
+            externalLauncher.resolveAvailableEditors(),
+          ),
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,


### PR DESCRIPTION
## What Changed

- Bound optional editor discovery during server config loading to five seconds.
- Return an empty `availableEditors` list when discovery times out.
- Added regression coverage proving config loading completes and interrupts discovery when it never resolves.

## Why

`server.getConfig` waits for optional editor discovery. On affected machines, discovery consumed almost the entire 15-second connection setup window, so the client timed out and entered a reconnect loop even though the server was running.

This keeps the fix at the config-loading seam and avoids the process-diagnostics and platform-specific changes proposed in #3911. Related symptom report: #3746.

Closes #3610

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable; there are no UI changes
- [x] Video is not applicable; there are no animation or interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound editor discovery in `makeWsRpcLayer` to a 5-second timeout
> - Introduces `resolveAvailableEditorsForConfig` in [ws.ts](https://github.com/pingdotgg/t3code/pull/4291/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125), which wraps editor discovery with a 5-second timeout using `Effect.timeoutOption`.
> - The `availableEditors` field in the server config response now returns an empty array on timeout instead of blocking indefinitely.
> - Adds a test verifying that the discovery fiber is interrupted and an empty array is returned when discovery never resolves.
> - Behavioral Change: clients that previously waited for slow editor discovery will now receive an empty `availableEditors` list after 5 seconds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bd5bcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to optional config metadata with graceful degradation; no auth or persistence impact.
> 
> **Overview**
> **`server.getConfig` no longer waits indefinitely on optional editor discovery.** Discovery is capped at **5 seconds** via new `resolveAvailableEditorsForConfig` (`Effect.timeoutOption`); on timeout **`availableEditors` is `[]`** instead of holding the response.
> 
> This addresses clients timing out during connection setup when slow discovery consumed most of the setup window. A regression test asserts that after 5s the result is empty and the stuck discovery fiber is interrupted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd5bcfa380941c5a7102b169e6195e744c97bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->