### PR TITLE
feat(web): add project removal context menu

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  buildProjectRemovalConfirmation,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -41,6 +42,36 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("buildProjectRemovalConfirmation", () => {
+  it("describes removing an empty project without implying its files are deleted", () => {
+    expect(
+      buildProjectRemovalConfirmation({
+        title: "Workbench",
+        workspaceRoot: "/work/workbench",
+        threadCount: 0,
+      }),
+    ).toBe(
+      [
+        'Remove project "Workbench"?',
+        "Path: /work/workbench",
+        "This removes only this project entry.",
+      ].join("\n"),
+    );
+  });
+
+  it("warns that removing a non-empty project permanently deletes its threads", () => {
+    const message = buildProjectRemovalConfirmation({
+      title: "Workbench",
+      workspaceRoot: "/work/workbench",
+      environmentLabel: "Remote",
+      threadCount: 2,
+    });
+    expect(message).toContain('Remove project "Workbench" and delete its 2 threads?');
+    expect(message).toContain("Environment: Remote");
+    expect(message).toContain("This action cannot be undone.");
+  });
+});
 
 describe("archiveSelectedThreadEntries", () => {
   const entries = [{ threadKey: "one" }, { threadKey: "two" }, { threadKey: "three" }] as const;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -37,6 +37,35 @@ type ScopedSidebarThread = ThreadSortInput & {
 
 export type ThreadTraversalDirection = "previous" | "next";
 
+export function buildProjectRemovalConfirmation(input: {
+  title: string;
+  workspaceRoot: string;
+  environmentLabel?: string | undefined;
+  threadCount: number;
+}): string {
+  const details = [
+    `Path: ${input.workspaceRoot}`,
+    ...(input.environmentLabel ? [`Environment: ${input.environmentLabel}`] : []),
+  ];
+  if (input.threadCount > 0) {
+    return [
+      `Remove project "${input.title}" and delete its ${input.threadCount} thread${
+        input.threadCount === 1 ? "" : "s"
+      }?`,
+      ...details,
+      "This permanently clears conversation history for those threads.",
+      "This removes only this project entry.",
+      "This action cannot be undone.",
+    ].join("\n");
+  }
+
+  return [
+    `Remove project "${input.title}"?`,
+    ...details,
+    "This removes only this project entry.",
+  ].join("\n");
+}
+
 export async function archiveSelectedThreadEntries<
   TEntry extends { readonly threadKey: string },
   TResult extends { readonly _tag: "Success" | "Failure" },

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -55,6 +55,7 @@ import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { readLocalApi } from "../localApi";
 import { useUiStateStore } from "../uiStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { useComposerDraftStore } from "../composerDraftStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
@@ -65,13 +66,15 @@ import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
+import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { formatRelativeTimeLabel } from "../timestampFormat";
-import type { SidebarThreadSummary } from "../types";
+import type { Project, SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import {
+  buildProjectRemovalConfirmation,
   firstValidTimestampMs,
   hasUnseenCompletion,
   isTrailingDoubleClick,
@@ -98,6 +101,7 @@ import {
 } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { ContextMenu, ContextMenuItem, ContextMenuPopup, ContextMenuTrigger } from "./ui/menu";
 
 // Settled-tail paging: recent history is the common lookup; the deep tail
 // stays behind an explicit Show more.
@@ -623,6 +627,9 @@ export default function SidebarV2() {
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
+  const deleteProject = useAtomCommand(projectEnvironment.delete, {
+    reportFailure: false,
+  });
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
@@ -737,6 +744,62 @@ export default function SidebarV2() {
   useEffect(() => {
     clearSelection();
   }, [clearSelection, projectScopeKey]);
+
+  const handleRemoveProject = useCallback(
+    (project: Project) => {
+      void (async () => {
+        const api = readLocalApi();
+        if (!api) return;
+
+        const projectThreads = threads.filter(
+          (thread) =>
+            thread.environmentId === project.environmentId && thread.projectId === project.id,
+        );
+        const confirmed = await settlePromise(() =>
+          api.dialogs.confirm(
+            buildProjectRemovalConfirmation({
+              title: project.title,
+              workspaceRoot: project.workspaceRoot,
+              environmentLabel: environmentLabelById.get(project.environmentId),
+              threadCount: projectThreads.length,
+            }),
+          ),
+        );
+        if (confirmed._tag === "Failure" || !confirmed.value) return;
+
+        const result = await deleteProject({
+          environmentId: project.environmentId,
+          input: {
+            projectId: project.id,
+            ...(projectThreads.length > 0 ? { force: true } : {}),
+          },
+        });
+        if (result._tag === "Failure") {
+          if (!isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: `Failed to remove "${project.title}"`,
+                description:
+                  error instanceof Error ? error.message : "Unknown error removing project.",
+              }),
+            );
+          }
+          return;
+        }
+
+        const projectRef = scopeProjectRef(project.environmentId, project.id);
+        const draftStore = useComposerDraftStore.getState();
+        const projectDraftThread = draftStore.getDraftThreadByProjectRef(projectRef);
+        if (projectDraftThread) {
+          draftStore.clearDraftThread(projectDraftThread.draftId);
+        }
+        draftStore.clearProjectDraftThreadId(projectRef);
+      })();
+    },
+    [deleteProject, environmentLabelById, threads],
+  );
 
   // Settled threads stay in the live shell stream (settled ≠ archived), so
   // the partition works directly off live shells: no archived-snapshot
@@ -1419,26 +1482,39 @@ export default function SidebarV2() {
                   const scopeKey = `${project.environmentId}:${project.id}`;
                   const isScoped = projectScopeKey === scopeKey;
                   return (
-                    <button
-                      key={scopeKey}
-                      type="button"
-                      role="tab"
-                      aria-selected={isScoped}
-                      onClick={() => setProjectScopeKey(isScoped ? null : scopeKey)}
-                      className={cn(
-                        "flex shrink-0 items-center gap-1.5 rounded-md border py-1 pl-1.5 pr-2.5 text-[11px] font-medium transition-colors",
-                        isScoped
-                          ? "border-foreground/15 bg-accent text-foreground"
-                          : "border-black/15 text-muted-foreground hover:border-black/40 hover:text-foreground dark:border-white/15 dark:hover:border-white/40",
-                      )}
-                    >
-                      <ProjectFavicon
-                        environmentId={project.environmentId}
-                        cwd={project.workspaceRoot}
-                        className="size-3.5"
-                      />
-                      <span className="max-w-28 truncate">{project.title}</span>
-                    </button>
+                    <ContextMenu key={scopeKey}>
+                      <ContextMenuTrigger
+                        render={
+                          <button
+                            type="button"
+                            role="tab"
+                            aria-selected={isScoped}
+                            onClick={() => setProjectScopeKey(isScoped ? null : scopeKey)}
+                            className={cn(
+                              "flex shrink-0 items-center gap-1.5 rounded-md border py-1 pl-1.5 pr-2.5 text-[11px] font-medium transition-colors",
+                              isScoped
+                                ? "border-foreground/15 bg-accent text-foreground"
+                                : "border-black/15 text-muted-foreground hover:border-black/40 hover:text-foreground dark:border-white/15 dark:hover:border-white/40",
+                            )}
+                          />
+                        }
+                      >
+                        <ProjectFavicon
+                          environmentId={project.environmentId}
+                          cwd={project.workspaceRoot}
+                          className="size-3.5"
+                        />
+                        <span className="max-w-28 truncate">{project.title}</span>
+                      </ContextMenuTrigger>
+                      <ContextMenuPopup align="start" className="min-w-40">
+                        <ContextMenuItem
+                          variant="destructive"
+                          onClick={() => handleRemoveProject(project)}
+                        >
+                          Remove project
+                        </ContextMenuItem>
+                      </ContextMenuPopup>
+                    </ContextMenu>
                   );
                 })}
               </div>

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
 import { ChevronRightIcon } from "lucide-react";
 import type * as React from "react";
 
@@ -10,6 +11,8 @@ const MenuCreateHandle = MenuPrimitive.createHandle;
 
 const Menu = MenuPrimitive.Root;
 
+const ContextMenu = ContextMenuPrimitive.Root;
+
 const MenuPortal = MenuPrimitive.Portal;
 
 function MenuTrigger({ className, children, ...props }: MenuPrimitive.Trigger.Props) {
@@ -17,6 +20,14 @@ function MenuTrigger({ className, children, ...props }: MenuPrimitive.Trigger.Pr
     <MenuPrimitive.Trigger className={className} data-slot="menu-trigger" {...props}>
       {children}
     </MenuPrimitive.Trigger>
+  );
+}
+
+function ContextMenuTrigger({ className, children, ...props }: ContextMenuPrimitive.Trigger.Props) {
+  return (
+    <ContextMenuPrimitive.Trigger className={className} data-slot="context-menu-trigger" {...props}>
+      {children}
+    </ContextMenuPrimitive.Trigger>
   );
 }
 
@@ -288,16 +299,20 @@ export {
   MenuCreateHandle,
   MenuCreateHandle as DropdownMenuCreateHandle,
   Menu,
+  ContextMenu,
   Menu as DropdownMenu,
   MenuPortal,
   MenuPortal as DropdownMenuPortal,
   MenuTrigger,
+  ContextMenuTrigger,
   MenuTrigger as DropdownMenuTrigger,
   MenuPopup,
+  MenuPopup as ContextMenuPopup,
   MenuPopup as DropdownMenuContent,
   MenuGroup,
   MenuGroup as DropdownMenuGroup,
   MenuItem,
+  MenuItem as ContextMenuItem,
   MenuItem as DropdownMenuItem,
   MenuCheckboxItem,
   MenuCheckboxItem as DropdownMenuCheckboxItem,


### PR DESCRIPTION
## What Changed

- Add a web-native context menu to project chips in the project selector.
- Add a destructive **Remove project** action with clear confirmation copy for empty and non-empty projects.
- Remove projects through the existing project command and clear any associated composer draft state after successful removal.
- Add shared context-menu styling primitives and focused tests for the removal confirmation copy.

## Why

The existing native context-menu bridge is not available in the plain web development client. Using Base UI's context-menu primitive keeps the project chips visually unchanged while supporting right-click on desktop and long-press on touch devices.

## UI Changes

Project chips remain visually unchanged. Right-clicking or long-pressing a project chip opens a context menu with **Remove project**.

<img width="223" height="82" alt="image" src="https://github.com/user-attachments/assets/69afa82d-704b-4460-a699-dc15dee87f9b" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Issues Closed

Closes #as12341
closes #10231

## Validation

- `vp test run apps/web/src/components/Sidebar.logic.test.ts` — 73 tests passed
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context menu with 'Remove project' action to sidebar projects tab
> - Wraps each project tab in `SidebarV2` with a context menu that exposes a destructive 'Remove project' option.
> - On confirmation, calls `deleteProject` (with `force` when the project has threads) and clears any associated composer drafts; failures surface an error toast.
> - Adds `buildProjectRemovalConfirmation` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/4293/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to generate a confirmation message including the workspace path, optional environment label, and thread-count warnings with correct pluralization.
> - Exposes `ContextMenu` primitives (`Root`, `Trigger`, `Popup`, `Item`) in [menu.tsx](https://github.com/pingdotgg/t3code/pull/4293/files#diff-e0c9f33f4f308eae4b7e310785187bc81767e547539de6fcd955fa42aaccc621) using Base UI's context menu package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bdb859.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive project removal can permanently delete thread history when `force` is used; mitigated by confirmation copy and the existing delete command, but still user-data impact.
> 
> **Overview**
> Adds **Remove project** to sidebar project filter chips via a Base UI **context menu** (right-click / long-press), so the plain web client can remove projects without the Electron native menu bridge.
> 
> Each chip is wrapped in `ContextMenu` with a destructive item that runs `handleRemoveProject`: confirm with `buildProjectRemovalConfirmation` (path, optional environment, thread-count warnings), then `projectEnvironment.delete` with `force: true` when the project has threads. On success, associated **composer draft** state for that project is cleared; failures show an error toast.
> 
> `menu.tsx` exports `ContextMenu`, `ContextMenuTrigger`, and reuses existing popup/item styling as `ContextMenuPopup` / `ContextMenuItem`. Unit tests cover empty vs non-empty confirmation copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bdb85931ac169350cd14c6e37ad1ee0131c3fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->