### PR TITLE
feat(web): group new-thread project picker by connection

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
-import type { Thread } from "../types";
+import type { Project, Thread } from "../types";
 import {
+  buildProjectActionGroups,
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  prioritizeProjectGroupItem,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -163,5 +165,150 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("environment-remote");
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: PROJECT_ID,
+    environmentId: LOCAL_ENVIRONMENT_ID,
+    title: "Project",
+    workspaceRoot: "/home/user/project",
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function buildGroups(projects: Project[], environmentLabels = defaultEnvironmentLabels()) {
+  return buildProjectActionGroups({
+    projects,
+    environmentLabels,
+    valuePrefix: "new-thread-in",
+    icon: () => null,
+    runProject: async (_project) => undefined,
+  });
+}
+
+function defaultEnvironmentLabels() {
+  return [
+    { environmentId: LOCAL_ENVIRONMENT_ID, label: "This device" },
+    { environmentId: REMOTE_ENVIRONMENT_ID, label: "Work laptop" },
+  ];
+}
+
+describe("buildProjectActionGroups", () => {
+  it("groups projects by environment in catalog order with environment labels", () => {
+    const groups = buildGroups([
+      makeProject({
+        id: ProjectId.make("project-remote"),
+        environmentId: REMOTE_ENVIRONMENT_ID,
+        title: "support-hub",
+      }),
+      makeProject({ id: ProjectId.make("project-local"), title: "t3code" }),
+    ]);
+
+    expect(groups.map((group) => group.label)).toEqual(["This device", "Work laptop"]);
+    expect(groups[0]?.items.map((item) => item.value)).toEqual([
+      `new-thread-in:${LOCAL_ENVIRONMENT_ID}:project-local`,
+    ]);
+    expect(groups[1]?.items.map((item) => item.value)).toEqual([
+      `new-thread-in:${REMOTE_ENVIRONMENT_ID}:project-remote`,
+    ]);
+  });
+
+  it("labels the list as Projects when only one environment is known", () => {
+    const groups = buildGroups(
+      [makeProject()],
+      [{ environmentId: LOCAL_ENVIRONMENT_ID, label: "This device" }],
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe("Projects");
+  });
+
+  it("keeps the environment label when multiple environments are known but only one has projects", () => {
+    const groups = buildGroups([makeProject()]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe("This device");
+  });
+
+  it("makes group items searchable by their environment label", () => {
+    const groups = buildGroups([
+      makeProject({ id: ProjectId.make("project-local"), title: "t3code" }),
+      makeProject({
+        id: ProjectId.make("project-remote"),
+        environmentId: REMOTE_ENVIRONMENT_ID,
+        title: "support-hub",
+      }),
+    ]);
+
+    const filtered = filterCommandPaletteGroups({
+      activeGroups: groups,
+      query: "work laptop",
+      isInSubmenu: true,
+      projectSearchItems: [],
+      threadSearchItems: [],
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.label).toBe("Work laptop");
+    expect(filtered[0]?.items.map((item) => item.value)).toEqual([
+      `new-thread-in:${REMOTE_ENVIRONMENT_ID}:project-remote`,
+    ]);
+  });
+
+  it("keeps projects whose environment is missing from the catalog, labeled by id", () => {
+    const unknownEnvironmentId = EnvironmentId.make("environment-unknown");
+    const groups = buildGroups([
+      makeProject(),
+      makeProject({
+        id: ProjectId.make("project-unknown"),
+        environmentId: unknownEnvironmentId,
+      }),
+    ]);
+
+    expect(groups.map((group) => group.label)).toEqual(["This device", unknownEnvironmentId]);
+  });
+});
+
+describe("prioritizeProjectGroupItem", () => {
+  it("moves the current project's group first and its item to the top of that group", () => {
+    const groups = buildGroups([
+      makeProject({ id: ProjectId.make("project-local"), title: "t3code" }),
+      makeProject({
+        id: ProjectId.make("project-remote-a"),
+        environmentId: REMOTE_ENVIRONMENT_ID,
+        title: "bolt",
+      }),
+      makeProject({
+        id: ProjectId.make("project-remote-b"),
+        environmentId: REMOTE_ENVIRONMENT_ID,
+        title: "support-hub",
+      }),
+    ]);
+
+    const prioritized = prioritizeProjectGroupItem(
+      groups,
+      `new-thread-in:${REMOTE_ENVIRONMENT_ID}:project-remote-b`,
+    );
+
+    expect(prioritized.map((group) => group.label)).toEqual(["Work laptop", "This device"]);
+    expect(prioritized[0]?.items.map((item) => item.value)).toEqual([
+      `new-thread-in:${REMOTE_ENVIRONMENT_ID}:project-remote-b`,
+      `new-thread-in:${REMOTE_ENVIRONMENT_ID}:project-remote-a`,
+    ]);
+  });
+
+  it("returns groups unchanged when there is no current project", () => {
+    const groups = buildGroups([makeProject()]);
+
+    expect(prioritizeProjectGroupItem(groups, null)).toEqual(groups);
+    expect(prioritizeProjectGroupItem(groups, "new-thread-in:missing:missing")).toEqual(groups);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,4 +1,8 @@
-import { type KeybindingCommand, type FilesystemBrowseEntry } from "@t3tools/contracts";
+import {
+  type EnvironmentId,
+  type KeybindingCommand,
+  type FilesystemBrowseEntry,
+} from "@t3tools/contracts";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
@@ -109,6 +113,95 @@ export function buildProjectActionItems(input: {
       await input.runProject(project);
     },
   }));
+}
+
+export interface ProjectEnvironmentGroupLabel {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}
+
+export function buildProjectActionGroups(input: {
+  projects: ReadonlyArray<Project>;
+  environmentLabels: ReadonlyArray<ProjectEnvironmentGroupLabel>;
+  valuePrefix: string;
+  icon: (project: Project) => ReactNode;
+  runProject: (project: Project) => Promise<void>;
+  shortcutCommand?: KeybindingCommand;
+}): CommandPaletteGroup[] {
+  const labelByEnvironmentId = new Map(
+    input.environmentLabels.map((environment) => [environment.environmentId, environment.label]),
+  );
+  const projectsByEnvironmentId = new Map<EnvironmentId, Project[]>();
+  for (const project of input.projects) {
+    const environmentProjects = projectsByEnvironmentId.get(project.environmentId);
+    if (environmentProjects) {
+      environmentProjects.push(project);
+    } else {
+      projectsByEnvironmentId.set(project.environmentId, [project]);
+    }
+  }
+
+  // Environments in catalog order first, then any environment that only
+  // appears on a project (e.g. a machine removed from the catalog).
+  const orderedEnvironmentIds = [
+    ...input.environmentLabels.map((environment) => environment.environmentId),
+    ...projectsByEnvironmentId.keys(),
+  ];
+  const seenEnvironmentIds = new Set<EnvironmentId>();
+  const groups: CommandPaletteGroup[] = [];
+  for (const environmentId of orderedEnvironmentIds) {
+    if (seenEnvironmentIds.has(environmentId)) {
+      continue;
+    }
+    seenEnvironmentIds.add(environmentId);
+    const environmentProjects = projectsByEnvironmentId.get(environmentId);
+    if (!environmentProjects) {
+      continue;
+    }
+    const label = labelByEnvironmentId.get(environmentId) ?? environmentId;
+    groups.push({
+      value: `${input.valuePrefix}-environment:${environmentId}`,
+      label,
+      items: buildProjectActionItems({
+        projects: environmentProjects,
+        valuePrefix: input.valuePrefix,
+        icon: input.icon,
+        runProject: input.runProject,
+        ...(input.shortcutCommand !== undefined ? { shortcutCommand: input.shortcutCommand } : {}),
+      }).map((item) => ({ ...item, searchTerms: [...item.searchTerms, label] })),
+    });
+  }
+
+  // With a single known environment there is no machine to disambiguate, so
+  // keep the familiar flat "Projects" heading.
+  if (input.environmentLabels.length <= 1 && groups.length === 1 && groups[0]) {
+    return [{ ...groups[0], label: "Projects" }];
+  }
+  return groups;
+}
+
+export function prioritizeProjectGroupItem(
+  groups: ReadonlyArray<CommandPaletteGroup>,
+  currentItemValue: string | null,
+): CommandPaletteGroup[] {
+  if (currentItemValue === null) {
+    return [...groups];
+  }
+  const groupIndex = groups.findIndex((group) =>
+    group.items.some((item) => item.value === currentItemValue),
+  );
+  const currentGroup = groupIndex === -1 ? undefined : groups[groupIndex];
+  if (!currentGroup) {
+    return [...groups];
+  }
+  const reorderedGroup: CommandPaletteGroup = {
+    ...currentGroup,
+    items: [
+      ...currentGroup.items.filter((item) => item.value === currentItemValue),
+      ...currentGroup.items.filter((item) => item.value !== currentItemValue),
+    ],
+  };
+  return [reorderedGroup, ...groups.filter((_, index) => index !== groupIndex)];
 }
 
 export type BuildThreadActionItemsThread = Pick<

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -92,6 +92,7 @@ import {
 import {
   ADDON_ICON_CLASS,
   buildBrowseGroups,
+  buildProjectActionGroups,
   buildProjectActionItems,
   buildRootGroups,
   buildThreadActionItems,
@@ -103,6 +104,7 @@ import {
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
+  prioritizeProjectGroupItem,
   RECENT_THREAD_LIMIT,
 } from "./CommandPalette.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -684,10 +686,11 @@ function OpenCommandPaletteDialog(props: {
     [openProjectFromSearch, projects],
   );
 
-  const projectThreadItems = useMemo(
+  const projectThreadGroups = useMemo(
     () =>
-      buildProjectActionItems({
+      buildProjectActionGroups({
         projects,
+        environmentLabels: addProjectEnvironmentOptions,
         valuePrefix: "new-thread-in",
         shortcutCommand: "chat.new",
         icon: (project) => (
@@ -709,7 +712,14 @@ function OpenCommandPaletteDialog(props: {
           );
         },
       }),
-    [activeDraftThread, activeThread, defaultProjectRef, handleNewThread, projects],
+    [
+      activeDraftThread,
+      activeThread,
+      addProjectEnvironmentOptions,
+      defaultProjectRef,
+      handleNewThread,
+      projects,
+    ],
   );
 
   const allThreadItems = useMemo(
@@ -978,33 +988,27 @@ function OpenCommandPaletteDialog(props: {
   }, [clearOpenIntent, openAddProjectFlow, openIntent]);
 
   useLayoutEffect(() => {
-    if (openIntent?.kind !== "new-thread-in" || projectThreadItems.length === 0) {
+    if (openIntent?.kind !== "new-thread-in" || projectThreadGroups.length === 0) {
       return;
     }
     clearOpenIntent();
     setAddProjectCloneFlow(null);
     setViewStack([]);
     setQuery("");
-    const currentPrefix =
+    const currentItemValue =
       currentProjectEnvironmentId && currentProjectId
         ? `new-thread-in:${currentProjectEnvironmentId}:${currentProjectId}`
         : null;
-    const prioritized = currentPrefix
-      ? [
-          ...projectThreadItems.filter((item) => item.value === currentPrefix),
-          ...projectThreadItems.filter((item) => item.value !== currentPrefix),
-        ]
-      : projectThreadItems;
     pushPaletteView({
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [{ value: "projects", label: "Projects", items: prioritized }],
+      groups: prioritizeProjectGroupItem(projectThreadGroups, currentItemValue),
     });
   }, [
     clearOpenIntent,
     currentProjectEnvironmentId,
     currentProjectId,
     openIntent,
-    projectThreadItems,
+    projectThreadGroups,
   ]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
@@ -1044,7 +1048,7 @@ function OpenCommandPaletteDialog(props: {
       title: "New thread in...",
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+      groups: projectThreadGroups,
     });
   }
 


### PR DESCRIPTION
## What Changed

The command palette's "New thread in..." project picker now groups projects under one heading per connection (machine), instead of rendering a single flat list. Group headings use the same resolved environment labels as the add-project flow ("This device" / the machine's name), ordered primary-first. The group containing the active project moves to the top with that project as its first row (replacing the old flat-list bubble-to-top behavior). Machine names are added to each row's search terms, so filtering by a visible heading like "Work laptop" narrows to that machine instead of emptying the list.

Behavior is unchanged when only one connection is known: the picker keeps its flat "Projects" heading. Projects whose connection is gone from the catalog stay visible under a fallback heading rather than disappearing.

Scope: `CommandPalette.logic.ts` (two new pure functions), `CommandPalette.tsx` (wiring for the submenu and the sidebar-triggered open-intent view), and unit tests.

## Why

With the same repo checked out on several machines, the flat picker showed identical entries — three rows distinguishable only by truncated paths. Grouping by connection makes it obvious which machine each project lives on.

## UI Changes

Before: one flat "Projects" list where same-named projects from different machines repeat back-to-back.
After: one section per connection, machine name as the heading, active project's machine on top.

## Screenshots
<img width="1322" height="1190" alt="file-9d92d8afa54f824685315ca29b3e037f" src="https://github.com/user-attachments/assets/a674d20b-3211-4da6-b6b0-90a6b57c7ffc" />
<img width="1660" height="948" alt="image" src="https://github.com/user-attachments/assets/43e3c055-f491-473d-8825-ffd3c7277781" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes *(coming in a comment)*
- [ ] I included a video for animation/interaction changes *(n/a — no motion changes)*

## Verification

- `vp test run src/components/CommandPalette.logic.test.ts` — 11/11 passing (grouping, catalog ordering, single-connection collapse, removed-connection fallback, prioritization, heading search)
- `tsgo --noEmit` and `vp lint` clean (two pre-existing `no-unstable-nested-components` warnings unchanged from main)
- Integrated check via an isolated `vp run dev` environment in the in-app browser (single-connection collapse path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group projects by environment connection in the new-thread project picker
> - Adds `buildProjectActionGroups` to [CommandPalette.logic.ts](https://github.com/pingdotgg/t3code/pull/4295/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) to group projects by `environmentId`, ordered by a provided environment label catalog, with each item searchable by its environment label.
> - Adds `prioritizeProjectGroupItem` to sort groups so the current project's environment group appears first, with the current project at the top.
> - Updates [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/4295/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) to replace the flat `projectThreadItems` list with grouped output from these two functions in the 'New thread in...' submenu.
> - When only one environment is known and only one group exists, the group is labeled 'Projects' instead of the environment name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09a3483.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->