### PR TITLE
Stop running threads with Escape

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -26,6 +26,7 @@ import {
   KEY_ARROW_UP_COMMAND,
   KEY_DOWN_COMMAND,
   KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
@@ -57,6 +58,7 @@ import {
 import {
   clampCollapsedComposerCursor,
   collapseExpandedComposerCursor,
+  type ComposerCommandKey,
   expandCollapsedComposerCursor,
   isCollapsedCursorAdjacentToInlineToken,
 } from "~/composer-logic";
@@ -892,27 +894,18 @@ interface ComposerPromptEditorProps {
     cursorAdjacentToMention: boolean,
     terminalContextIds: string[],
   ) => void;
-  onCommandKeyDown?: (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-    event: KeyboardEvent,
-  ) => boolean;
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean;
   onPaste: React.ClipboardEventHandler<HTMLElement>;
   editorRef: React.RefObject<ComposerPromptEditorHandle | null>;
 }
 
 function ComposerCommandKeyPlugin(props: {
-  onCommandKeyDown?: (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-    event: KeyboardEvent,
-  ) => boolean;
+  onCommandKeyDown?: (key: ComposerCommandKey, event: KeyboardEvent) => boolean;
 }) {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    const handleCommand = (
-      key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-      event: KeyboardEvent | null,
-    ): boolean => {
+    const handleCommand = (key: ComposerCommandKey, event: KeyboardEvent | null): boolean => {
       if (!props.onCommandKeyDown || !event) {
         return false;
       }
@@ -945,6 +938,11 @@ function ComposerCommandKeyPlugin(props: {
       (event) => handleCommand("Enter", event),
       COMMAND_PRIORITY_HIGH,
     );
+    const unregisterEscape = editor.registerCommand(
+      KEY_ESCAPE_COMMAND,
+      (event) => handleCommand("Escape", event),
+      COMMAND_PRIORITY_HIGH,
+    );
     const unregisterTab = editor.registerCommand(
       KEY_TAB_COMMAND,
       (event) => handleCommand("Tab", event),
@@ -955,6 +953,7 @@ function ComposerCommandKeyPlugin(props: {
       unregisterArrowDown();
       unregisterArrowUp();
       unregisterEnter();
+      unregisterEscape();
       unregisterTab();
     };
   }, [editor, props]);

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -36,11 +36,13 @@ import {
 } from "react";
 import {
   clampCollapsedComposerCursor,
+  type ComposerCommandKey,
   type ComposerTrigger,
   collapseExpandedComposerCursor,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
   replaceTextRange,
+  shouldInterruptRunningThreadFromComposerKey,
   shouldSubmitComposerOnEnter,
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
@@ -1769,10 +1771,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Callbacks: command key
   // ------------------------------------------------------------------
-  const onComposerCommandKey = (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
-    event: KeyboardEvent,
-  ) => {
+  const onComposerCommandKey = (key: ComposerCommandKey, event: KeyboardEvent) => {
+    if (shouldInterruptRunningThreadFromComposerKey({ key, isRunning: phase === "running" })) {
+      onInterrupt();
+      return true;
+    }
     if (key === "Tab" && event.shiftKey) {
       toggleInteractionMode();
       return true;

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -8,6 +8,7 @@ import {
   isCollapsedCursorAdjacentToInlineToken,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
+  shouldInterruptRunningThreadFromComposerKey,
   shouldSubmitComposerOnEnter,
 } from "./composer-logic";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
@@ -23,6 +24,27 @@ describe("shouldSubmitComposerOnEnter", () => {
 
   it("inserts a newline for Shift+Enter", () => {
     expect(shouldSubmitComposerOnEnter({ isMobileViewport: false, shiftKey: true })).toBe(false);
+  });
+});
+
+describe("shouldInterruptRunningThreadFromComposerKey", () => {
+  it("interrupts a running thread on Escape", () => {
+    expect(shouldInterruptRunningThreadFromComposerKey({ key: "Escape", isRunning: true })).toBe(
+      true,
+    );
+  });
+
+  it.each(["ArrowDown", "ArrowUp", "Enter", "Tab"] as const)(
+    "does not interrupt a running thread on %s",
+    (key) => {
+      expect(shouldInterruptRunningThreadFromComposerKey({ key, isRunning: true })).toBe(false);
+    },
+  );
+
+  it("leaves Escape available when the thread is not running", () => {
+    expect(shouldInterruptRunningThreadFromComposerKey({ key: "Escape", isRunning: false })).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -3,6 +3,7 @@ import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "skill";
 export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerCommandKey = "ArrowDown" | "ArrowUp" | "Enter" | "Escape" | "Tab";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -16,6 +17,13 @@ export function shouldSubmitComposerOnEnter(input: {
   shiftKey: boolean;
 }): boolean {
   return !input.isMobileViewport && !input.shiftKey;
+}
+
+export function shouldInterruptRunningThreadFromComposerKey(input: {
+  key: ComposerCommandKey;
+  isRunning: boolean;
+}): boolean {
+  return input.key === "Escape" && input.isRunning;
 }
 
 const isInlineTokenSegment = (


### PR DESCRIPTION
## Summary

- register Escape as a composer command key
- interrupt the active turn when Escape is pressed while the chat input is focused and the thread is running
- preserve existing Escape behavior when the thread is idle
- cover the running and non-running keyboard rules

## Why

The chat composer did not forward Lexical's Escape command to the thread controls, so keyboard users had to move focus to the stop button to interrupt a running turn.

## User impact

Users can now stop a running thread by pressing Escape without leaving the chat input.

## Validation

- `vp check apps/web/src/composer-logic.ts apps/web/src/composer-logic.test.ts apps/web/src/components/ComposerPromptEditor.tsx apps/web/src/components/chat/ChatComposer.tsx`
- `vp test run apps/web/src/composer-logic.test.ts` (44 tests passed)
- `pnpm --filter @t3tools/web typecheck`
- integrated browser verification: Escape stopped a running 120-second turn while the composer retained focus


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop running threads by pressing Escape in the chat composer
> - Adds `Escape` to the `ComposerCommandKey` union type and registers a Lexical `KEY_ESCAPE_COMMAND` handler in `ComposerPromptEditor` to forward the key to `onCommandKeyDown`.
> - Adds `shouldInterruptRunningThreadFromComposerKey` in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/4298/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6), a predicate that returns true only when the key is `Escape` and the thread phase is `running`.
> - `ChatComposer` checks this predicate on each composer key event and calls `onInterrupt()` when it returns true, consuming the key before other handlers run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fce377.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX change that reuses the existing interrupt callback and only runs when `phase === "running"`.
> 
> **Overview**
> **Escape in the chat composer now stops an in-progress turn** without moving focus to the stop control.
> 
> Lexical’s `KEY_ESCAPE_COMMAND` is wired through the same command-key path as arrows, Enter, and Tab. `ChatComposer` checks `shouldInterruptRunningThreadFromComposerKey` first and calls `onInterrupt()` when the session phase is `running`; when idle, Escape is not consumed so existing behavior can stay available elsewhere.
> 
> Shared typing moves to `ComposerCommandKey` (including `Escape`), with unit tests on the interrupt predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fce377276e244ca7bab8dd02b7659143dbc9e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->