### PR TITLE
Add working wave animation to thread statuses

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -6,6 +6,16 @@ import type { MenuAction } from "@react-native-menu/menu";
 import { memo, useCallback, useEffect, useMemo, type ComponentProps } from "react";
 import { Platform, Pressable, useWindowDimensions, View } from "react-native";
 import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
+import Animated, {
+  cancelAnimation,
+  Easing,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+  type SharedValue,
+} from "react-native-reanimated";
 
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
@@ -37,6 +47,93 @@ const STATUS_LABEL_BY_STATUS: Partial<
   working: { label: "Working", className: "text-blue-600 dark:text-blue-400" },
   failed: { label: "Failed", className: "text-red-700 dark:text-red-300" },
 };
+
+const WORKING_WAVE_CYCLE_MS = 4000;
+const WORKING_WAVE_STAGGER_MS = 60;
+const WORKING_WAVE_OFFSET = 1.1;
+const WORKING_WAVE_EASING = Easing.bezierFn(0.42, 0, 0.58, 1);
+
+function WorkingStatusLetter(props: {
+  readonly letter: string;
+  readonly index: number;
+  readonly progress: SharedValue<number>;
+  readonly className: string;
+}) {
+  const style = useAnimatedStyle(() => {
+    const phase =
+      (props.progress.value - (props.index * WORKING_WAVE_STAGGER_MS) / WORKING_WAVE_CYCLE_MS + 1) %
+      1;
+    let translateY = 0;
+
+    if (phase < 0.04) {
+      translateY = -WORKING_WAVE_OFFSET * WORKING_WAVE_EASING(phase / 0.04);
+    } else if (phase < 0.08) {
+      translateY =
+        -WORKING_WAVE_OFFSET + WORKING_WAVE_OFFSET * 2 * WORKING_WAVE_EASING((phase - 0.04) / 0.04);
+    } else if (phase < 0.12) {
+      translateY = WORKING_WAVE_OFFSET * (1 - WORKING_WAVE_EASING((phase - 0.08) / 0.04));
+    }
+
+    return { transform: [{ translateY }] };
+  });
+
+  return (
+    <Animated.View style={style}>
+      <Text className={props.className}>{props.letter}</Text>
+    </Animated.View>
+  );
+}
+
+function WorkingStatusText({ className }: { readonly className: string }) {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = 0;
+    progress.value = withRepeat(
+      withTiming(1, {
+        duration: WORKING_WAVE_CYCLE_MS,
+        easing: Easing.linear,
+        reduceMotion: ReduceMotion.System,
+      }),
+      -1,
+      false,
+      undefined,
+      ReduceMotion.System,
+    );
+
+    return () => {
+      cancelAnimation(progress);
+    };
+  }, [progress]);
+
+  return (
+    <View accessible accessibilityLabel="Working" className="flex-row items-center">
+      {Array.from("Working", (letter, index) => (
+        <WorkingStatusLetter
+          key={`${letter}-${index}`}
+          letter={letter}
+          index={index}
+          progress={progress}
+          className={className}
+        />
+      ))}
+    </View>
+  );
+}
+
+function ThreadListV2StatusText({
+  label,
+  className,
+}: {
+  readonly label: string;
+  readonly className: string;
+}) {
+  if (label === "Working") {
+    return <WorkingStatusText className={className} />;
+  }
+
+  return <Text className={className}>{label}</Text>;
+}
 
 function threadTimeLabel(thread: EnvironmentThreadShell): string {
   return relativeTime(thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt);
@@ -212,14 +309,13 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
                 >
                   {props.project?.title ?? ""}
                 </Text>
-                <Text
+                <ThreadListV2StatusText
+                  label={statusLabel?.label ?? timeLabel}
                   className={cn(
                     "text-xs tabular-nums",
                     statusLabel?.className ?? "text-foreground-tertiary",
                   )}
-                >
-                  {statusLabel?.label ?? timeLabel}
-                </Text>
+                />
               </View>
               <Text className="mt-1 text-base font-t3-medium text-foreground" numberOfLines={2}>
                 {thread.title}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -85,7 +85,7 @@ import {
   resolveSidebarV2Status,
   sortThreadsForSidebarV2,
 } from "./Sidebar.logic";
-import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
+import { prStatusIndicator, resolveThreadPr, ThreadStatusText } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
@@ -185,8 +185,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       ? {
           label: "Working",
           icon: "working" as const,
-          className:
-            "animate-sidebar-working-text font-semibold text-blue-600 motion-reduce:animate-none dark:text-blue-400",
+          className: "font-semibold text-blue-600 dark:text-blue-400",
         }
       : status === "approval"
         ? {
@@ -518,17 +517,21 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 ) : topStatus ? (
                   <span
                     role="status"
+                    aria-label={topStatus.label}
                     className={cn(
                       "inline-flex items-center gap-1 text-[11px]",
                       topStatus.className,
                     )}
                   >
                     {topStatus.icon === "working" ? (
-                      <CircleDashedIcon aria-hidden className="size-3" />
+                      <CircleDashedIcon
+                        aria-hidden
+                        className="size-3 animate-spin motion-reduce:animate-none"
+                      />
                     ) : topStatus.icon === "done" ? (
                       <CircleCheckIcon aria-hidden className="size-3" />
                     ) : null}
-                    {topStatus.label}
+                    <ThreadStatusText label={topStatus.label} className="inline whitespace-pre" />
                   </span>
                 ) : (
                   threadTimeLabel(thread)

--- a/apps/web/src/components/ThreadStatusIndicators.test.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.test.tsx
@@ -2,7 +2,56 @@ import { ThreadId } from "@t3tools/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
-import { ThreadWorktreeIndicator } from "./ThreadStatusIndicators";
+import {
+  ThreadStatusLabel,
+  ThreadStatusText,
+  ThreadWorktreeIndicator,
+} from "./ThreadStatusIndicators";
+
+describe("ThreadStatusLabel", () => {
+  it("renders the Working label as an accessible staggered wave", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadStatusLabel
+        status={{
+          label: "Working",
+          colorClass: "text-sky-600",
+          dotClass: "bg-sky-500",
+          pulse: true,
+        }}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Working"');
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup.match(/animate-working-wave/g)).toHaveLength("Working".length);
+    expect(markup).toContain("animation-delay:360ms");
+  });
+
+  it("leaves non-working status text static", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadStatusLabel
+        status={{
+          label: "Connecting",
+          colorClass: "text-sky-600",
+          dotClass: "bg-sky-500",
+          pulse: true,
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Connecting");
+    expect(markup).not.toContain("animate-working-wave");
+  });
+
+  it("renders sidebar-specific status copy without animation", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadStatusText label="Failed" className="inline whitespace-pre" />,
+    );
+
+    expect(markup).toContain("Failed");
+    expect(markup).not.toContain("animate-working-wave");
+  });
+});
 
 describe("ThreadWorktreeIndicator", () => {
   it("renders the worktree folder and branch in an accessible label", () => {

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -173,10 +173,36 @@ export function ThreadStatusLabel({
             status.pulse ? "animate-status-pulse" : ""
           }`}
         />
-        <span className="hidden md:inline">{status.label}</span>
+        <ThreadStatusText label={status.label} />
       </TooltipTrigger>
       <TooltipPopup side="top">{status.label}</TooltipPopup>
     </Tooltip>
+  );
+}
+
+export function ThreadStatusText({
+  label,
+  className = "hidden md:inline whitespace-pre",
+}: {
+  label: string;
+  className?: string;
+}) {
+  if (label !== "Working") {
+    return <span className={className}>{label}</span>;
+  }
+
+  return (
+    <span aria-hidden="true" className={className}>
+      {Array.from(label, (letter, index) => (
+        <span
+          key={`${letter}-${index}`}
+          className="inline-block animate-working-wave motion-reduce:animate-none"
+          style={{ animationDelay: `${index * 60}ms` }}
+        >
+          {letter}
+        </span>
+      ))}
+    </span>
   );
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -55,7 +55,9 @@ html[data-mobile-composer-route-transition="true"]::view-transition-new(t3-mobil
   }
 }
 
-html[data-mobile-composer-route-transition="true"]::view-transition-group(t3-mobile-draft-headline) {
+html[data-mobile-composer-route-transition="true"]::view-transition-group(
+    t3-mobile-draft-headline
+  ) {
   animation-duration: 130ms;
 }
 
@@ -112,7 +114,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
      compositor updates discrete frames instead of every vsync. */
   --animate-status-pulse: status-pulse 2s infinite;
   --animate-status-ping: status-ping 2s infinite;
-  --animate-sidebar-working-text: sidebar-working-text 3.4s infinite;
+  --animate-working-wave: working-wave 4s ease-in-out infinite;
   --font-sans:
     "DM Sans Variable", "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
     sans-serif;
@@ -185,19 +187,20 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
       scale: 2;
     }
   }
-  @keyframes sidebar-working-text {
+  @keyframes working-wave {
     0%,
-    36% {
-      opacity: 1;
-      animation-timing-function: steps(10);
-    }
-    50%,
-    86% {
-      opacity: 0.75;
-      animation-timing-function: steps(10);
-    }
+    15%,
     100% {
-      opacity: 1;
+      transform: translateY(0);
+    }
+    4% {
+      transform: translateY(-0.1em);
+    }
+    8% {
+      transform: translateY(0.1em);
+    }
+    12% {
+      transform: translateY(0);
     }
   }
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Animate the Working status in web and mobile thread lists
- Reuse shared status text rendering in the sidebar
- Update tests and keyframes for the new wave motion

## Why

To nicely better the indication of working threads

## UI Changes

https://github.com/user-attachments/assets/e9e4f42e-91b0-472a-ba6c-ac495692df84

https://github.com/user-attachments/assets/2b93fb77-4bbe-4ab5-9060-faa31c550609

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only status UI and CSS animations with reduce-motion hooks; no auth, data, or business-logic changes.
> 
> **Overview**
> **Working** thread status in web and mobile thread lists now uses a **staggered letter wave** instead of static text or the old sidebar opacity pulse.
> 
> On **web**, shared `ThreadStatusText` drives the effect via `animate-working-wave` (per-letter delays, `motion-reduce:animate-none`). It is wired into status pills and **Sidebar v2**; the working row keeps a spinning dashed icon and uses `aria-label` on the status while animated letters stay `aria-hidden`. CSS replaces `--animate-sidebar-working-text` with `--animate-working-wave` and new `working-wave` keyframes.
> 
> On **mobile** thread list v2, `ThreadListV2StatusText` runs an equivalent wave with **Reanimated** (`ReduceMotion.System`, `accessibilityLabel="Working"`).
> 
> Tests cover accessible Working markup and unchanged static labels for other statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26d17d8351f3b17ee5d89d2de06ca156a7be540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add wave animation to 'Working' thread status labels on web and mobile
> - Adds per-letter vertical wave animation to the 'Working' status label using staggered `animationDelay` on web (via new `animate-working-wave` CSS keyframes) and a `SharedValue`-driven `translateY` transform on mobile.
> - Introduces `ThreadStatusText` (web) and `WorkingStatusText` (mobile) components that conditionally render animated letters for 'Working' and plain text for all other statuses.
> - The spinning `CircleDashedIcon` in the sidebar replaces the previous static icon for working threads.
> - All animations respect system reduced-motion preferences (`motion-reduce` on web, `ReduceMotion.System` on mobile); mobile cancels the animation on unmount.
> - Removes the old `--animate-sidebar-working-text` CSS token and its keyframes in favor of the new shared `working-wave` animation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a26d17d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->