### PR TITLE
fix(client-runtime): keep a warm thread un-settled despite a merged/closed PR

### DIFF
--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -163,6 +163,31 @@ describe("effectiveSettled", () => {
     ).toBe(true);
   });
 
+  it("does not re-settle a warm thread on the merge signal: a message sent in a settled thread keeps it active until idle", () => {
+    // The merge signal never clears, so without the idle guard a follow-up
+    // message would un-settle the row only until its turn completed, then
+    // snap straight back into the settled tail.
+    const justActive = makeShell({ activityAt: "2026-04-09T23:30:00.000Z" });
+    const idle = makeShell({ activityAt: "2026-04-09T22:59:59.999Z" });
+
+    for (const changeRequestState of ["merged", "closed"] as const) {
+      expect(
+        effectiveSettled(justActive, {
+          now: NOW,
+          autoSettleAfterDays: null,
+          changeRequestState,
+        }),
+      ).toBe(false);
+      expect(
+        effectiveSettled(idle, {
+          now: NOW,
+          autoSettleAfterDays: null,
+          changeRequestState,
+        }),
+      ).toBe(true);
+    }
+  });
+
   it("never settles a starting session, even with a settled override", () => {
     const shell = makeShell({
       settledOverride: "settled",

--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -168,11 +168,20 @@ describe("effectiveSettled", () => {
     // message would un-settle the row only until its turn completed, then
     // snap straight back into the settled tail.
     const justActive = makeShell({ activityAt: "2026-04-09T23:30:00.000Z" });
+    // The idle gate is strict: activity exactly one hour old is still warm.
+    const boundary = makeShell({ activityAt: "2026-04-09T23:00:00.000Z" });
     const idle = makeShell({ activityAt: "2026-04-09T22:59:59.999Z" });
 
     for (const changeRequestState of ["merged", "closed"] as const) {
       expect(
         effectiveSettled(justActive, {
+          now: NOW,
+          autoSettleAfterDays: null,
+          changeRequestState,
+        }),
+      ).toBe(false);
+      expect(
+        effectiveSettled(boundary, {
           now: NOW,
           autoSettleAfterDays: null,
           changeRequestState,
@@ -186,6 +195,16 @@ describe("effectiveSettled", () => {
         }),
       ).toBe(true);
     }
+  });
+
+  it("re-settles a merged-PR thread once the follow-up burst goes idle", () => {
+    // Same shell, advancing clock: active while warm, settled again after
+    // the idle window passes — the burst cools and the merge signal wins.
+    const shell = makeShell({ activityAt: "2026-04-09T23:30:00.000Z" });
+    const options = { autoSettleAfterDays: null, changeRequestState: "merged" as const };
+
+    expect(effectiveSettled(shell, { ...options, now: NOW })).toBe(false);
+    expect(effectiveSettled(shell, { ...options, now: "2026-04-10T00:30:00.001Z" })).toBe(true);
   });
 
   it("never settles a starting session, even with a settled override", () => {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -91,12 +91,24 @@ export function canSettle(
 }
 
 /**
+ * A merged/closed change request settles its thread only once the thread has
+ * been idle this long. Without the idle guard the merge signal is permanent:
+ * sending a message to a merged-PR thread would un-settle the row only until
+ * its turn completed, then the still-merged PR would snap it straight back
+ * into the settled tail. An hour keeps the follow-up conversation visible
+ * while it is warm; once the burst goes stale the merge signal settles it
+ * again.
+ */
+export const CHANGE_REQUEST_SETTLE_IDLE_MS = 60 * 60 * 1_000;
+
+/**
  * Settled resolution over the server-backed settled lifecycle. The explicit
  * user override (thread.settle / thread.unsettle commands, projected into
  * settledOverride + settledAt) wins in both directions; without one, a
- * thread auto-settles on a merged/closed PR or inactivity past the window.
- * The server un-settles on real activity (user message, session start,
- * approval/user-input request), so an override never goes stale silently.
+ * thread auto-settles on a merged/closed PR (once idle) or inactivity past
+ * the window. The server un-settles on real activity (user message, session
+ * start, approval/user-input request), so an override never goes stale
+ * silently.
  */
 export function effectiveSettled(
   shell: OrchestrationThreadShell,
@@ -130,7 +142,16 @@ export function effectiveSettled(
   // until real activity clears it server-side.
   if (shell.settledOverride === "active") return false;
   if (options.changeRequestState === "merged" || options.changeRequestState === "closed") {
-    return true;
+    // Only an idle thread settles on the merge signal: the signal itself
+    // never clears, so without this guard fresh activity (a message sent in
+    // a settled thread) would re-settle the moment its turn completed.
+    const lastActivityAt = threadLastActivityAt(shell);
+    if (
+      lastActivityAt === null ||
+      Date.parse(lastActivityAt) < Date.parse(options.now) - CHANGE_REQUEST_SETTLE_IDLE_MS
+    ) {
+      return true;
+    }
   }
   if (options.autoSettleAfterDays === null) return false;
 

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -97,7 +97,10 @@ export function canSettle(
  * its turn completed, then the still-merged PR would snap it straight back
  * into the settled tail. An hour keeps the follow-up conversation visible
  * while it is warm; once the burst goes stale the merge signal settles it
- * again.
+ * again. Activity timestamps can originate on another device while `now` is
+ * this caller's clock: skew shortens or stretches the window by its size,
+ * the same exposure the inactivity auto-settle already accepts — worst case
+ * is a row changing lists early or late, never lost work.
  */
 export const CHANGE_REQUEST_SETTLE_IDLE_MS = 60 * 60 * 1_000;
 

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -105,13 +105,15 @@ export function canSettle(
 export const CHANGE_REQUEST_SETTLE_IDLE_MS = 60 * 60 * 1_000;
 
 /**
- * Settled resolution over the server-backed settled lifecycle. The explicit
- * user override (thread.settle / thread.unsettle commands, projected into
- * settledOverride + settledAt) wins in both directions; without one, a
- * thread auto-settles on a merged/closed PR (once idle) or inactivity past
- * the window. The server un-settles on real activity (user message, session
- * start, approval/user-input request), so an override never goes stale
- * silently.
+ * Settled resolution over the server-backed settled lifecycle. Activity
+ * blockers (pending approval/user-input, a live session, an unadjudicated
+ * queued turn) are checked first and hold a thread active regardless of any
+ * override. Past the blockers, the explicit user override (thread.settle /
+ * thread.unsettle commands, projected into settledOverride + settledAt)
+ * wins in both directions; without one, a thread auto-settles on a
+ * merged/closed PR (once idle) or inactivity past the window. The server
+ * un-settles on real activity (user message, session start, approval/
+ * user-input request), so an override never goes stale silently.
  */
 export function effectiveSettled(
   shell: OrchestrationThreadShell,


### PR DESCRIPTION
## Problem

Sending a message in a settled thread should un-settle it. Two of the three settle signals already behaved:

- **Explicit override** — the server decider prepends `thread.unsettled` when `thread.turn.start` hits an overridden thread (`decider.ts`).
- **Inactivity auto-settle** — the new message refreshes `threadLastActivityAt`.

But the **merged/closed-PR auto-settle** signal in `effectiveSettled` is client-derived and never clears. Send a message in a merged-PR thread and the row un-settles only while the queued-turn grace / live-session blockers hold — the moment the turn completes, `changeRequestState === "merged"` classifies it right back into the settled tail. This also defeats the server's un-settle on explicitly settled threads whose PR is merged: the override clears on send, then the merge signal re-settles the row anyway.

## Fix

Gate the change-request signal on idleness: a merged/closed PR settles a thread only after it has been quiet for `CHANGE_REQUEST_SETTLE_IDLE_MS` (1 hour). Fresh activity — the sent message, its turn starting and completing — keeps the follow-up conversation in the active list; once the burst goes stale, the merge signal settles it again. This mirrors the decider's own "activity clears overrides so the thread can auto-settle again after this burst of work goes stale" model.

Web (`SidebarV2.tsx`) and mobile (`threadListV2.ts`) both partition through the shared `effectiveSettled`, so one change covers both clients. No contract or server changes: the VCS status contract carries no merge timestamp, so idle-based gating is the clean option.

The explicit **Settle** action on a warm merged-PR thread still works — a user settle sets `settledOverride`, which is checked before the merge signal.

## Testing

- New test: a warm thread (recent activity) stays active under both `merged` and `closed` PR states; an idle one still settles.
- Full client-runtime suite passes (449 tests), mobile `threadListV2` tests pass, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only list-partitioning logic in shared `effectiveSettled`; behavior is narrower (fewer surprise re-settles) with targeted tests and no server/contract changes.
> 
> **Overview**
> **Fixes merged/closed PR threads snapping back to settled** right after a follow-up message’s turn finishes. `effectiveSettled` used to treat merged/closed change requests as an always-on settle signal, so activity blockers only briefly kept the row active.
> 
> Merged/closed PRs now auto-settle only when `threadLastActivityAt` is missing or older than **`CHANGE_REQUEST_SETTLE_IDLE_MS` (1 hour)** relative to `now`. Recent follow-ups stay in the active list; after the burst goes idle, the merge signal settles the thread again. Explicit `settled` / `active` overrides and existing activity blockers are unchanged.
> 
> Tests cover warm vs idle boundaries for `merged` and `closed`, and re-settling once the idle window passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cea3f93648344c4a02cc022b357a3f8297321ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep warm threads active despite merged/closed PR until idle for one hour
> - Previously, `effectiveSettled` would auto-settle a thread as soon as its change request reached `merged` or `closed` state, even if the thread had recent activity.
> - Adds a `CHANGE_REQUEST_SETTLE_IDLE_MS` constant (1 hour) in [threadSettled.ts](https://github.com/pingdotgg/t3code/pull/4309/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c); a thread now only auto-settles if `lastActivityAt` is older than `now - 1h` (or absent).
> - Behavioral Change: threads with a merged/closed PR that receive post-merge activity will remain unsettled for up to one hour after the last activity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cea3f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Threads associated with merged or closed change requests now remain active during follow-up activity.
  * Threads automatically settle after at least one hour of inactivity, preventing premature status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->