### PR TITLE
feat(web): add right-click remove to sidebar v2 project chips

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -37,6 +37,7 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import { isElectron } from "../env";
 import {
   resolveShortcutCommand,
@@ -65,6 +66,8 @@ import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
+import { projectEnvironment } from "../state/projects";
+import { useComposerDraftStore } from "../composerDraftStore";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
@@ -621,6 +624,9 @@ export default function SidebarV2() {
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const { settleThread, unsettleThread, deleteThread } = useThreadActions();
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
+    reportFailure: false,
+  });
+  const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
   const newThreadContext = useHandleNewThread();
@@ -1225,6 +1231,87 @@ export default function SidebarV2() {
     ],
   );
 
+  // Project removal lives behind right-click + confirm only: the chips are
+  // compact horizontal-scroll targets, and removal can cascade into deleting
+  // every thread in the project — no hover affordance puts that one
+  // mis-click away from the filter tap.
+  const handleProjectChipContextMenu = useCallback(
+    (project: (typeof projects)[number], position: { x: number; y: number }) => {
+      void (async () => {
+        const api = readLocalApi();
+        if (!api) return;
+        const clicked = await settlePromise(() =>
+          api.contextMenu.show(
+            [{ id: "remove", label: "Remove project", destructive: true, icon: "trash" }],
+            position,
+          ),
+        );
+        if (clicked._tag === "Failure" || clicked.value !== "remove") return;
+        const projectThreadCount = threads.filter(
+          (thread) =>
+            thread.environmentId === project.environmentId && thread.projectId === project.id,
+        ).length;
+        const environmentLabel =
+          environments.length > 1
+            ? (environmentLabelById.get(project.environmentId) ?? null)
+            : null;
+        const confirmed = await settlePromise(() =>
+          api.dialogs.confirm(
+            [
+              projectThreadCount > 0
+                ? `Remove project "${project.title}" and delete its ${projectThreadCount} thread${
+                    projectThreadCount === 1 ? "" : "s"
+                  }?`
+                : `Remove project "${project.title}"?`,
+              `Path: ${project.workspaceRoot}`,
+              ...(environmentLabel ? [`Environment: ${environmentLabel}`] : []),
+              ...(projectThreadCount > 0
+                ? ["This permanently clears conversation history for those threads."]
+                : []),
+              "This removes only this project entry.",
+              ...(projectThreadCount > 0 ? ["This action cannot be undone."] : []),
+            ].join("\n"),
+          ),
+        );
+        if (confirmed._tag === "Failure" || !confirmed.value) return;
+        const result = await deleteProject({
+          environmentId: project.environmentId,
+          input: {
+            projectId: project.id,
+            ...(projectThreadCount > 0 ? { force: true } : {}),
+          },
+        });
+        if (result._tag === "Failure") {
+          if (!isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            console.error("Failed to remove project", {
+              projectId: project.id,
+              environmentId: project.environmentId,
+              ...safeErrorLogAttributes(error),
+            });
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: `Failed to remove "${project.title}"`,
+                description:
+                  error instanceof Error ? error.message : "Unknown error removing project.",
+              }),
+            );
+          }
+          return;
+        }
+        const projectRef = scopeProjectRef(project.environmentId, project.id);
+        const draftStore = useComposerDraftStore.getState();
+        const projectDraftThread = draftStore.getDraftThreadByProjectRef(projectRef);
+        if (projectDraftThread) {
+          draftStore.clearDraftThread(projectDraftThread.draftId);
+        }
+        draftStore.clearProjectDraftThreadId(projectRef);
+      })();
+    },
+    [deleteProject, environmentLabelById, environments.length, threads],
+  );
+
   // Thread jump (cmd+1..9) and prev/next traversal reuse the same commands as
   // v1 — the keybinding layer is shared, only the ordered list differs.
   const routeTerminalOpen = useTerminalUiStateStore((state) =>
@@ -1425,6 +1512,13 @@ export default function SidebarV2() {
                       role="tab"
                       aria-selected={isScoped}
                       onClick={() => setProjectScopeKey(isScoped ? null : scopeKey)}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        handleProjectChipContextMenu(project, {
+                          x: event.clientX,
+                          y: event.clientY,
+                        });
+                      }}
                       className={cn(
                         "flex shrink-0 items-center gap-1.5 rounded-md border py-1 pl-1.5 pr-2.5 text-[11px] font-medium transition-colors",
                         isScoped


### PR DESCRIPTION
## What

Adds a right-click context menu to the project chips in the nightly Sidebar v2 with a destructive **Remove project** action, followed by a confirmation dialog.

## Why

The v2 sidebar had no way to remove a project — the old sidebar's remove action lives on the per-project headers that v2 replaced with chips.

## How

- Reuses the same native `api.contextMenu.show` pattern the v2 thread rows already use.
- Confirm dialog mirrors the old sidebar's messaging: title, path, environment label (multi-env only), and thread count with a history-loss warning when the project isn't empty (`force: true` removal).
- Clears the project's composer drafts after removal; the existing scope-reset effect handles un-scoping a removed chip.
- No hover ✕ on purpose: chips are compact horizontal-scroll targets and removal can cascade into deleting threads — a one-click destructive target next to the filter tap is a mis-click trap. Context menu + confirm matches the thread rows' convention.

## Screenshots

| Before | After |
| --- | --- |
| <img width="239" height="283" alt="image" src="https://github.com/user-attachments/assets/a8cd8a5b-88cb-45ba-ba39-1186bf2f09c5" /> | <img width="239" height="283" alt="image" src="https://github.com/user-attachments/assets/5637f66b-61c8-4bd1-ad47-25a5496cb551" /> |

## Testing

- `pnpm typecheck` passes
- `pnpm test` (apps/web): 1438 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removal can permanently delete all threads in a project, but the flow reuses the established v1 delete API and requires an explicit context-menu choice plus confirmation.
> 
> **Overview**
> Sidebar v2 **project chips** now support **right-click → Remove project**, closing the gap where v2 had no way to drop a project after chips replaced v1’s per-project headers.
> 
> The flow matches v2 thread rows: native `contextMenu.show`, then a confirm dialog with path, optional environment label, and thread-count / history-loss copy when the project isn’t empty. Removal calls `projectEnvironment.delete` with `force: true` when threads exist, shows errors via toast, and clears related **composer drafts**; scope reset when a chip disappears stays on the existing effect. There’s **no hover remove** on chips—only context menu + confirm—to avoid accidental deletes next to the filter tap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c974ac9084c637cbd0d08126d1cd36379da1b1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add right-click context menu to sidebar v2 project chips for project removal
> - Right-clicking a project chip in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4310/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) opens a custom context menu with a destructive "Remove project" action.
> - On confirmation, the project is deleted via the `deleteProject` atom command; if the project has associated threads, deletion is forced and the confirmation dialog includes an irreversible deletion notice.
> - After successful removal, any composer draft scoped to the removed project is cleared via `useComposerDraftStore`.
> - Errors (excluding user interruptions) are logged with `safeErrorLogAttributes` and surfaced as an error toast.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c974ac9. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->