### PR TITLE
[codex] Move mobile project grouping to General settings

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -13,7 +13,10 @@ import { ConfirmDialogHost } from "./components/ConfirmDialogHost";
 import { CloudAuthProvider } from "./features/cloud/CloudAuthProvider";
 import { prepareNativeShowcaseCapture } from "./features/showcase/nativeShowcaseScene";
 import { IncomingShareProvider } from "./features/sharing/IncomingShareProvider";
-import { AppearancePreferencesProvider } from "./features/settings/appearance/AppearancePreferencesProvider";
+import {
+  AppearancePreferencesProvider,
+  useAppearancePreferences,
+} from "./features/settings/appearance/AppearancePreferencesProvider";
 import { RootStack } from "./Stack";
 import { appAtomRegistry } from "./state/atom-registry";
 import { OverlayPortalHost } from "./components/OverlayPortal";
@@ -40,18 +43,25 @@ const appLinking = {
 
 const Navigation = createStaticNavigation(RootStack);
 
+function SplashScreenCoordinator() {
+  const { isReady } = useAppearancePreferences();
+
+  useEffect(() => {
+    if (isReady) void SplashScreen.hide();
+  }, [isReady]);
+
+  return null;
+}
+
 export default function App() {
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
-
-  useEffect(() => {
-    SplashScreen.hide();
-  }, []);
 
   return (
     <RegistryContext.Provider value={appAtomRegistry}>
       <CloudAuthProvider>
         <AppearancePreferencesProvider>
+          <SplashScreenCoordinator />
           <GestureHandlerRootView className="flex-1">
             <KeyboardProvider statusBarTranslucent>
               <SafeAreaProvider>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -29,6 +29,10 @@ if (process.env.EXPO_PUBLIC_SHOWCASE === "1") {
   prepareNativeShowcaseCapture();
 }
 
+void SplashScreen.preventAutoHideAsync().catch(() => {
+  // The native module can be unavailable in non-native test environments.
+});
+
 const appLinking = {
   prefixes: [Linking.createURL("/"), "t3code://", "t3code-dev://", "t3code-preview://"],
   // The Expo dev client launches the app via

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -1,8 +1,4 @@
-import type {
-  EnvironmentId,
-  SidebarProjectGroupingMode,
-  SidebarThreadSortOrder,
-} from "@t3tools/contracts";
+import type { EnvironmentId, SidebarThreadSortOrder } from "@t3tools/contracts";
 import type { MenuAction } from "@react-native-menu/menu";
 import { useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
@@ -28,7 +24,6 @@ import {
 } from "./home-list-filter-menu";
 import {
   hasCustomHomeListOptions,
-  PROJECT_GROUPING_OPTIONS,
   PROJECT_SORT_OPTIONS,
   THREAD_SORT_OPTIONS,
 } from "./home-list-options";
@@ -43,13 +38,11 @@ export function HomeHeader(props: {
   readonly selectedProjectKey: string | null;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
-  readonly projectGroupingMode: SidebarProjectGroupingMode;
   readonly onSearchQueryChange: (query: string) => void;
   readonly onEnvironmentChange: (environmentId: EnvironmentId | null) => void;
   readonly onProjectChange: (projectKey: string | null) => void;
   readonly onProjectSortOrderChange: (sortOrder: HomeProjectSortOrder) => void;
   readonly onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
-  readonly onProjectGroupingModeChange: (mode: SidebarProjectGroupingMode) => void;
   readonly onOpenSettings: () => void;
   readonly onStartNewTask: () => void;
 }) {
@@ -143,20 +136,10 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
                 state: checkedMenuState(props.threadSortOrder === option.value),
               })),
             },
-            {
-              id: "project-grouping",
-              title: "Group projects",
-              subactions: PROJECT_GROUPING_OPTIONS.map((option) => ({
-                id: `project-grouping:${option.value}`,
-                title: option.label,
-                state: checkedMenuState(props.projectGroupingMode === option.value),
-              })),
-            },
           ] satisfies MenuAction[])),
     ],
     [
       props.environments,
-      props.projectGroupingMode,
       props.projectSortOrder,
       props.projects,
       props.selectedEnvironmentId,
@@ -209,13 +192,6 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
       if (threadSort) {
         props.onThreadSortOrderChange(threadSort.value);
         return;
-      }
-
-      const grouping = PROJECT_GROUPING_OPTIONS.find(
-        (option) => id === `project-grouping:${option.value}`,
-      );
-      if (grouping) {
-        props.onProjectGroupingModeChange(grouping.value);
       }
     },
     [props],
@@ -475,20 +451,6 @@ function IosHomeHeader(props: HomeHeaderProps) {
                   key={option.value}
                   isOn={props.threadSortOrder === option.value}
                   onPress={() => props.onThreadSortOrderChange(option.value)}
-                >
-                  <NativeHeaderToolbar.Label>{option.label}</NativeHeaderToolbar.Label>
-                </NativeHeaderToolbar.MenuAction>
-              ))}
-            </NativeHeaderToolbar.Menu>
-
-            <NativeHeaderToolbar.Menu title="Group projects">
-              <NativeHeaderToolbar.Label>Group projects</NativeHeaderToolbar.Label>
-              {PROJECT_GROUPING_OPTIONS.map((option) => (
-                <NativeHeaderToolbar.MenuAction
-                  key={option.value}
-                  isOn={props.projectGroupingMode === option.value}
-                  onPress={() => props.onProjectGroupingModeChange(option.value)}
-                  subtitle={option.subtitle}
                 >
                   <NativeHeaderToolbar.Label>{option.label}</NativeHeaderToolbar.Label>
                 </NativeHeaderToolbar.MenuAction>

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -54,7 +54,6 @@ export function HomeRouteScreen() {
   const {
     options: listOptions,
     setSelectedEnvironmentId,
-    setProjectGroupingMode,
     setProjectSortOrder,
     setThreadSortOrder,
   } = useHomeListOptions(availableEnvironmentIds);
@@ -119,11 +118,9 @@ export function HomeRouteScreen() {
           selectedProjectKey={selectedProjectKey}
           projectSortOrder={listOptions.projectSortOrder}
           threadSortOrder={listOptions.threadSortOrder}
-          projectGroupingMode={listOptions.projectGroupingMode}
           onEnvironmentChange={setSelectedEnvironmentId}
           onProjectChange={setSelectedProjectKey}
           onOpenSettings={() => navigation.navigate("SettingsSheet", { screen: "Settings" })}
-          onProjectGroupingModeChange={setProjectGroupingMode}
           onProjectSortOrderChange={setProjectSortOrder}
           onSearchQueryChange={setSearchQuery}
           onStartNewTask={() => navigation.navigate("NewTaskSheet", { screen: "NewTask" })}
@@ -146,7 +143,6 @@ export function HomeRouteScreen() {
             navigation.navigate("SettingsSheet", { screen: "SettingsEnvironments" })
           }
           onOpenSettings={() => navigation.navigate("SettingsSheet", { screen: "Settings" })}
-          onProjectGroupingModeChange={setProjectGroupingMode}
           onProjectSortOrderChange={setProjectSortOrder}
           onSearchQueryChange={setSearchQuery}
           onSelectThread={(thread) => {

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -79,7 +79,6 @@ interface HomeScreenProps {
   readonly onProjectChange: (projectKey: string | null) => void;
   readonly onProjectSortOrderChange: (sortOrder: HomeProjectSortOrder) => void;
   readonly onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
-  readonly onProjectGroupingModeChange: (mode: SidebarProjectGroupingMode) => void;
   readonly onAddConnection: () => void;
   readonly onOpenEnvironments: () => void;
   readonly onOpenSettings: () => void;

--- a/apps/mobile/src/features/home/home-list-filter-menu.test.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.test.ts
@@ -15,12 +15,10 @@ describe("buildHomeListFilterMenu", () => {
       selectedProjectKey: "environment-1:project-1",
       projectSortOrder: "updated_at",
       threadSortOrder: "updated_at",
-      projectGroupingMode: "repository",
       onEnvironmentChange: vi.fn(),
       onProjectChange,
       onProjectSortOrderChange: vi.fn(),
       onThreadSortOrderChange: vi.fn(),
-      onProjectGroupingModeChange: vi.fn(),
     });
 
     const projectMenu = menu.items.find(

--- a/apps/mobile/src/features/home/home-list-filter-menu.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.ts
@@ -1,15 +1,7 @@
-import type {
-  EnvironmentId,
-  SidebarProjectGroupingMode,
-  SidebarThreadSortOrder,
-} from "@t3tools/contracts";
+import type { EnvironmentId, SidebarThreadSortOrder } from "@t3tools/contracts";
 
 import type { HomeProjectSortOrder } from "./homeThreadList";
-import {
-  PROJECT_GROUPING_OPTIONS,
-  PROJECT_SORT_OPTIONS,
-  THREAD_SORT_OPTIONS,
-} from "./home-list-options";
+import { PROJECT_SORT_OPTIONS, THREAD_SORT_OPTIONS } from "./home-list-options";
 
 export interface HomeListFilterMenuEnvironment {
   readonly environmentId: EnvironmentId;
@@ -47,12 +39,10 @@ export function buildHomeListFilterMenu(props: {
   readonly selectedProjectKey: string | null;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
-  readonly projectGroupingMode: SidebarProjectGroupingMode;
   readonly onEnvironmentChange: (environmentId: EnvironmentId | null) => void;
   readonly onProjectChange: (projectKey: string | null) => void;
   readonly onProjectSortOrderChange: (sortOrder: HomeProjectSortOrder) => void;
   readonly onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
-  readonly onProjectGroupingModeChange: (mode: SidebarProjectGroupingMode) => void;
   readonly onOpenSettings?: () => void;
   /** False hides the sort/group submenus. Thread List v2 uses a fixed
       creation-order layout, so offering those controls while it silently
@@ -134,17 +124,6 @@ export function buildHomeListFilterMenu(props: {
           title: option.label,
           state: props.threadSortOrder === option.value ? "on" : "off",
           onPress: () => props.onThreadSortOrderChange(option.value),
-        })),
-      },
-      {
-        type: "submenu",
-        title: "Group projects",
-        items: PROJECT_GROUPING_OPTIONS.map((option) => ({
-          type: "action",
-          title: option.label,
-          subtitle: option.subtitle,
-          state: props.projectGroupingMode === option.value ? "on" : "off",
-          onPress: () => props.onProjectGroupingModeChange(option.value),
         })),
       },
     );

--- a/apps/mobile/src/features/home/home-list-options.test.ts
+++ b/apps/mobile/src/features/home/home-list-options.test.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE,
   DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
   DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
 } from "@t3tools/contracts";
@@ -14,7 +13,6 @@ const defaults: HomeListOptions = {
       ? "updated_at"
       : DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
   threadSortOrder: DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
-  projectGroupingMode: DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE,
 };
 
 describe("home list options", () => {
@@ -22,7 +20,7 @@ describe("home list options", () => {
     expect(hasCustomHomeListOptions(defaults)).toBe(false);
   });
 
-  it("marks environment filters and grouping changes as customized", () => {
+  it("marks environment filters as customized", () => {
     expect(
       hasCustomHomeListOptions({ ...defaults, selectedEnvironmentId: "environment-1" as never }),
     ).toBe(true);

--- a/apps/mobile/src/features/home/home-list-options.test.ts
+++ b/apps/mobile/src/features/home/home-list-options.test.ts
@@ -24,7 +24,6 @@ describe("home list options", () => {
     expect(
       hasCustomHomeListOptions({ ...defaults, selectedEnvironmentId: "environment-1" as never }),
     ).toBe(true);
-    expect(hasCustomHomeListOptions({ ...defaults, projectGroupingMode: "separate" })).toBe(true);
     expect(
       hasCustomHomeListOptions({ ...defaults, selectedProjectKey: "environment-1:project-1" }),
     ).toBe(true);

--- a/apps/mobile/src/features/home/home-list-options.ts
+++ b/apps/mobile/src/features/home/home-list-options.ts
@@ -4,7 +4,6 @@ import type {
   SidebarThreadSortOrder,
 } from "@t3tools/contracts";
 import {
-  DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE,
   DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
   DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
 } from "@t3tools/contracts";
@@ -26,7 +25,16 @@ export interface HomeListOptions {
   readonly selectedEnvironmentId: EnvironmentId | null;
   readonly projectSortOrder: HomeProjectSortOrder;
   readonly threadSortOrder: SidebarThreadSortOrder;
+}
+
+export interface ResolvedHomeListOptions extends HomeListOptions {
   readonly projectGroupingMode: SidebarProjectGroupingMode;
+}
+
+export function resolveProjectGroupingMode(
+  projectGroupingEnabled: boolean | undefined,
+): SidebarProjectGroupingMode {
+  return projectGroupingEnabled === false ? "separate" : "repository";
 }
 
 export const PROJECT_SORT_OPTIONS: ReadonlyArray<{
@@ -45,28 +53,6 @@ export const THREAD_SORT_OPTIONS: ReadonlyArray<{
   { value: "created_at", label: "Created at" },
 ];
 
-export const PROJECT_GROUPING_OPTIONS: ReadonlyArray<{
-  readonly value: SidebarProjectGroupingMode;
-  readonly label: string;
-  readonly subtitle: string;
-}> = [
-  {
-    value: "repository",
-    label: "Group by repository",
-    subtitle: "Combine matching repositories across environments",
-  },
-  {
-    value: "repository_path",
-    label: "Group by repository path",
-    subtitle: "Combine only matching paths within a repository",
-  },
-  {
-    value: "separate",
-    label: "Keep separate",
-    subtitle: "Show every project path separately",
-  },
-];
-
 function defaultHomeListOptions(): HomeListOptions {
   return {
     selectedEnvironmentId: null,
@@ -75,26 +61,35 @@ function defaultHomeListOptions(): HomeListOptions {
         ? "updated_at"
         : DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
     threadSortOrder: DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
-    projectGroupingMode: DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE,
   };
 }
 
 interface HomeListOptionsContextValue {
   readonly options: HomeListOptions;
   readonly setOptions: Dispatch<SetStateAction<HomeListOptions>>;
+  readonly projectGroupingMode: SidebarProjectGroupingMode;
 }
 
 const HomeListOptionsContext = createContext<HomeListOptionsContextValue | null>(null);
 
 /** Keeps list preferences stable while the app moves between compact and split shells. */
-export function HomeListOptionsProvider({ children }: PropsWithChildren) {
+export function HomeListOptionsProvider({
+  children,
+  projectGroupingMode,
+}: PropsWithChildren<{ readonly projectGroupingMode: SidebarProjectGroupingMode }>) {
   const [options, setOptions] = useState<HomeListOptions>(defaultHomeListOptions);
-  const value = useMemo(() => ({ options, setOptions }), [options]);
+  const value = useMemo(
+    () => ({ options, setOptions, projectGroupingMode }),
+    [options, projectGroupingMode],
+  );
   return createElement(HomeListOptionsContext, { value }, children);
 }
 
 export function hasCustomHomeListOptions(
-  options: HomeListOptions & { readonly selectedProjectKey?: string | null },
+  options: HomeListOptions & {
+    readonly selectedProjectKey?: string | null;
+    readonly projectGroupingMode?: SidebarProjectGroupingMode;
+  },
 ): boolean {
   const defaultProjectSortOrder =
     DEFAULT_SIDEBAR_PROJECT_SORT_ORDER === "manual"
@@ -102,10 +97,10 @@ export function hasCustomHomeListOptions(
       : DEFAULT_SIDEBAR_PROJECT_SORT_ORDER;
   return (
     options.selectedEnvironmentId !== null ||
+    (options.projectGroupingMode !== undefined && options.projectGroupingMode !== "repository") ||
     (options.selectedProjectKey !== null && options.selectedProjectKey !== undefined) ||
     options.projectSortOrder !== defaultProjectSortOrder ||
-    options.threadSortOrder !== DEFAULT_SIDEBAR_THREAD_SORT_ORDER ||
-    options.projectGroupingMode !== DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE
+    options.threadSortOrder !== DEFAULT_SIDEBAR_THREAD_SORT_ORDER
   );
 }
 
@@ -119,10 +114,14 @@ export function useHomeListOptions(availableEnvironmentIds: ReadonlySet<Environm
     availableEnvironmentIds.has(options.selectedEnvironmentId)
       ? options.selectedEnvironmentId
       : null;
-  const resolvedOptions =
+  const availableOptions =
     selectedEnvironmentId === options.selectedEnvironmentId
       ? options
       : { ...options, selectedEnvironmentId };
+  const resolvedOptions: ResolvedHomeListOptions = {
+    ...availableOptions,
+    projectGroupingMode: shared?.projectGroupingMode ?? "repository",
+  };
 
   const setSelectedEnvironmentId = useCallback((value: EnvironmentId | null) => {
     setOptions((current) => ({ ...current, selectedEnvironmentId: value }));
@@ -133,15 +132,10 @@ export function useHomeListOptions(availableEnvironmentIds: ReadonlySet<Environm
   const setThreadSortOrder = useCallback((value: SidebarThreadSortOrder) => {
     setOptions((current) => ({ ...current, threadSortOrder: value }));
   }, []);
-  const setProjectGroupingMode = useCallback((value: SidebarProjectGroupingMode) => {
-    setOptions((current) => ({ ...current, projectGroupingMode: value }));
-  }, []);
-
   return {
     options: resolvedOptions,
     setSelectedEnvironmentId,
     setProjectSortOrder,
     setThreadSortOrder,
-    setProjectGroupingMode,
   } as const;
 }

--- a/apps/mobile/src/features/home/home-list-options.ts
+++ b/apps/mobile/src/features/home/home-list-options.ts
@@ -88,7 +88,6 @@ export function HomeListOptionsProvider({
 export function hasCustomHomeListOptions(
   options: HomeListOptions & {
     readonly selectedProjectKey?: string | null;
-    readonly projectGroupingMode?: SidebarProjectGroupingMode;
   },
 ): boolean {
   const defaultProjectSortOrder =
@@ -97,7 +96,6 @@ export function hasCustomHomeListOptions(
       : DEFAULT_SIDEBAR_PROJECT_SORT_ORDER;
   return (
     options.selectedEnvironmentId !== null ||
-    (options.projectGroupingMode !== undefined && options.projectGroupingMode !== "repository") ||
     (options.selectedProjectKey !== null && options.selectedProjectKey !== undefined) ||
     options.projectSortOrder !== defaultProjectSortOrder ||
     options.threadSortOrder !== DEFAULT_SIDEBAR_THREAD_SORT_ORDER

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -2,7 +2,8 @@ import type {
   EnvironmentProject,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { EnvironmentId, ThreadId, type SidebarProjectGroupingMode } from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
 import { useFocusEffect } from "@react-navigation/native";
 import {
   NavigationContext,
@@ -22,6 +23,7 @@ import {
 } from "react";
 import { useWindowDimensions, View } from "react-native";
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+import { AsyncResult } from "effect/unstable/reactivity";
 
 import {
   deriveFileInspectorPaneLayout,
@@ -34,11 +36,12 @@ import {
 } from "../../lib/layout";
 import { resolveThreadSelectionNavigationAction } from "../../lib/adaptive-navigation";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { mobilePreferencesAtom } from "../../state/preferences";
 import {
   parseActiveThreadPath,
   useHardwareKeyboardCommand,
 } from "../keyboard/hardwareKeyboardCommands";
-import { HomeListOptionsProvider } from "../home/home-list-options";
+import { HomeListOptionsProvider, resolveProjectGroupingMode } from "../home/home-list-options";
 import { ThreadNavigationSidebar } from "../threads/ThreadNavigationSidebar";
 import { WORKSPACE_PANE_TIMING } from "./workspace-pane-animation";
 import { WorkspaceInspectorPane } from "./workspace-inspector-pane";
@@ -184,6 +187,31 @@ export function AdaptiveWorkspaceLayout(props: {
   readonly children: ReactNode;
   readonly pathname: string;
 }) {
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  if (!AsyncResult.isSuccess(preferencesResult)) {
+    return AsyncResult.isFailure(preferencesResult) ? (
+      <AdaptiveWorkspaceLayoutContent {...props} projectGroupingMode="repository" />
+    ) : null;
+  }
+  return (
+    <AdaptiveWorkspaceLayoutContent
+      {...props}
+      projectGroupingMode={resolveProjectGroupingMode(
+        preferencesResult.value.projectGroupingEnabled,
+      )}
+    />
+  );
+}
+
+function AdaptiveWorkspaceLayoutContent(
+  props: {
+    readonly children: ReactNode;
+    readonly pathname: string;
+  } & {
+    readonly projectGroupingMode: SidebarProjectGroupingMode;
+  },
+) {
+  const projectGroupingMode = props.projectGroupingMode;
   const { width, height } = useWindowDimensions();
   const pathname = props.pathname;
   const navigation = useNavigation();
@@ -474,7 +502,7 @@ export function AdaptiveWorkspaceLayout(props: {
   );
 
   return (
-    <HomeListOptionsProvider>
+    <HomeListOptionsProvider projectGroupingMode={projectGroupingMode}>
       <AdaptiveWorkspaceContext.Provider value={contextValue}>
         <View testID="adaptive-workspace-layout" className="flex-1 flex-row">
           {shouldRenderPrimarySidebar && layout.listPaneWidth !== null ? (

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -119,6 +119,8 @@ function LocalSettingsRouteScreen() {
           />
         </SettingsSection>
 
+        <GeneralSettingsSection />
+
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
         </SettingsSection>
@@ -504,6 +506,8 @@ function ConfiguredSettingsRouteScreen() {
           />
         </SettingsSection>
 
+        <GeneralSettingsSection />
+
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
         </SettingsSection>
@@ -515,6 +519,25 @@ function ConfiguredSettingsRouteScreen() {
         <AppSettingsSection />
       </ScrollView>
     </View>
+  );
+}
+
+function GeneralSettingsSection() {
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  const projectGroupingEnabled = AsyncResult.isSuccess(preferencesResult)
+    ? preferencesResult.value.projectGroupingEnabled !== false
+    : true;
+
+  return (
+    <SettingsSection title="General">
+      <SettingsSwitchRow
+        icon="folder"
+        label="Project Grouping"
+        value={projectGroupingEnabled}
+        onValueChange={(value) => savePreferences({ projectGroupingEnabled: value })}
+      />
+    </SettingsSection>
   );
 }
 

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -33,7 +33,6 @@ import { useSavedRemoteConnections } from "../../state/use-remote-environment-re
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
 import {
   hasCustomHomeListOptions,
-  PROJECT_GROUPING_OPTIONS,
   PROJECT_SORT_OPTIONS,
   THREAD_SORT_OPTIONS,
   useHomeListOptions,
@@ -217,13 +216,8 @@ function ThreadNavigationSidebarPane(
     () => new Set(environments.map((environment) => environment.environmentId)),
     [environments],
   );
-  const {
-    options,
-    setSelectedEnvironmentId,
-    setProjectGroupingMode,
-    setProjectSortOrder,
-    setThreadSortOrder,
-  } = useHomeListOptions(availableEnvironmentIds);
+  const { options, setSelectedEnvironmentId, setProjectSortOrder, setThreadSortOrder } =
+    useHomeListOptions(availableEnvironmentIds);
   const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
   const projectFilterOptions = useMemo(
     () =>
@@ -541,16 +535,6 @@ function ThreadNavigationSidebarPane(
                 state: options.threadSortOrder === option.value ? "on" : "off",
               })),
             },
-            {
-              id: "project-grouping",
-              title: "Group projects",
-              subactions: PROJECT_GROUPING_OPTIONS.map((option) => ({
-                id: `project-grouping:${option.value}`,
-                title: option.label,
-                subtitle: option.subtitle,
-                state: options.projectGroupingMode === option.value ? "on" : "off",
-              })),
-            },
           ] satisfies MenuAction[])),
     ],
     [environments, options, projectFilterOptions, selectedProjectKey, threadListV2Enabled],
@@ -594,15 +578,10 @@ function ThreadNavigationSidebarPane(
         setThreadSortOrder(threadSort.value);
         return;
       }
-      const grouping = PROJECT_GROUPING_OPTIONS.find(
-        (option) => `project-grouping:${option.value}` === event,
-      );
-      if (grouping) setProjectGroupingMode(grouping.value);
     },
     [
       environments,
       projectFilterOptions,
-      setProjectGroupingMode,
       setProjectSortOrder,
       setSelectedEnvironmentId,
       setThreadSortOrder,
@@ -898,12 +877,10 @@ function ThreadNavigationSidebarPane(
         selectedProjectKey,
         projectSortOrder: options.projectSortOrder,
         threadSortOrder: options.threadSortOrder,
-        projectGroupingMode: options.projectGroupingMode,
         onEnvironmentChange: setSelectedEnvironmentId,
         onProjectChange: setSelectedProjectKey,
         onProjectSortOrderChange: setProjectSortOrder,
         onThreadSortOrderChange: setThreadSortOrder,
-        onProjectGroupingModeChange: setProjectGroupingMode,
         listOrganization: !threadListV2Enabled,
       }),
     [
@@ -911,7 +888,6 @@ function ThreadNavigationSidebarPane(
       options,
       projectFilterOptions,
       selectedProjectKey,
-      setProjectGroupingMode,
       setProjectSortOrder,
       setSelectedEnvironmentId,
       setThreadSortOrder,

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -22,6 +22,7 @@ export interface Preferences {
   readonly codeWordBreak?: boolean;
   readonly connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
   readonly collapsedProjectGroups?: readonly string[];
+  readonly projectGroupingEnabled?: boolean;
   /**
    * Device-local mirror of the web beta's `sidebarV2Enabled`. Mobile has no
    * client-settings sync, so the flat v2 thread list is opted into per
@@ -77,6 +78,7 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     codeWordBreak?: boolean;
     connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
     collapsedProjectGroups?: readonly string[];
+    projectGroupingEnabled?: boolean;
     threadListV2Enabled?: boolean;
   } = {};
 
@@ -103,6 +105,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     preferences.collapsedProjectGroups = parsed.collapsedProjectGroups.filter(
       (key): key is string => typeof key === "string",
     );
+  }
+  if (typeof parsed.projectGroupingEnabled === "boolean") {
+    preferences.projectGroupingEnabled = parsed.projectGroupingEnabled;
   }
   if (typeof parsed.threadListV2Enabled === "boolean") {
     preferences.threadListV2Enabled = parsed.threadListV2Enabled;


### PR DESCRIPTION
## Why

Mobile exposes project grouping as a thread-list organization control even though it is an application-wide preference. The app must also wait for persisted preferences before deciding which grouping mode to show.

## Root cause

The grouping setting is owned by transient home-list state and duplicated in home filter menus.

## Fix

- move Project Grouping to mobile Settings → General
- persist and propagate the preference through the app layout
- remove duplicate grouping controls from home and sidebar menus
- keep startup preference handoff stable while persisted settings load

This PR only relocates and persists the mobile preference; grouped thread filtering remains in its separate behavior PR.

## Verification

- targeted formatting and lint
- `vp run --filter @t3tools/mobile typecheck`
- focused home filter/options tests — 3 tests passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move project grouping control to General settings in mobile app
> - Removes project grouping controls from the home header, sidebar pane, and filter menu, and adds a 'Project Grouping' toggle to the General section in [SettingsRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/4315/files#diff-2f7a2e66b652454e7fd1b30226a5146d595dfe05945b34d90ffd5f3a5037cb1e).
> - Persists the `projectGroupingEnabled` preference via `mobilePreferencesAtom` in [mobile-preferences.ts](https://github.com/pingdotgg/t3code/pull/4315/files#diff-3aa27c7cc6d8de9ee5cea2957f2ae3f02d47323310fab6293827508e890b7be7); [AdaptiveWorkspaceLayout.tsx](https://github.com/pingdotgg/t3code/pull/4315/files#diff-e3c8ebac14b48389f244791990ae9ae42a35b2fc32ca8846c9b3fd106644743c) reads this atom and derives the grouping mode before rendering.
> - `projectGroupingMode` is removed from mutable list options and is now injected into `HomeListOptionsProvider` via a prop, making it read-only from the perspective of home list consumers.
> - Behavioral Change: The layout now returns `null` until mobile preferences have loaded, introducing a brief delay before the home screen renders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e95a0cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workspace/home can briefly not render while mobile preferences load, and thread list layout changes when users toggle grouping—important UX but not security-critical.
> 
> **Overview**
> **Project grouping** is no longer a per-thread-list control. A **Project Grouping** switch in **Settings → General** persists `projectGroupingEnabled` and drives grouping app-wide via `resolveProjectGroupingMode` (`repository` vs `separate` only—the old repository-path / multi-mode menu is gone).
> 
> **Home header, sidebar, and filter menus** drop the “Group projects” submenu and related props/handlers. Mutable `HomeListOptions` no longer stores grouping; `HomeListOptionsProvider` receives `projectGroupingMode` from **`AdaptiveWorkspaceLayout`**, which reads `mobilePreferencesAtom` and renders **nothing** until preferences finish loading (falls back to grouped mode on load failure).
> 
> **Splash screen** uses `preventAutoHideAsync` and **`SplashScreenCoordinator`** so the splash stays up until appearance preferences are ready, instead of hiding immediately on mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95a0cc3ccb4ad8c38332f2cf8096cc10ee1ef7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->