### PR TITLE
Recover stalled draft thread promotion

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -6,8 +6,9 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { appAtomRegistry } from "../rpc/atomRegistry";
 import type { Thread } from "../types";
 import {
   MAX_HIDDEN_MOUNTED_PREVIEW_THREADS,
@@ -23,6 +24,7 @@ import {
   isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
+  recoverDraftThreadAfterBootstrap,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   startNewThreadForProject,
@@ -34,6 +36,10 @@ const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
 const now = "2026-03-29T00:00:00.000Z";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -110,6 +116,35 @@ describe("resolveThreadMetadataUpdateForNextTurn", () => {
         nextBranch: "feature/current",
       }),
     ).toBeNull();
+  });
+});
+
+describe("recoverDraftThreadAfterBootstrap", () => {
+  it("refreshes the reserved thread stream when bootstrap hydration stalls", async () => {
+    vi.spyOn(appAtomRegistry, "get").mockReturnValue(null as never);
+    vi.spyOn(appAtomRegistry, "subscribe").mockReturnValue(() => undefined);
+    const refresh = vi.spyOn(appAtomRegistry, "refresh").mockImplementation(() => undefined);
+
+    await expect(recoverDraftThreadAfterBootstrap({ environmentId, threadId }, 0)).resolves.toBe(
+      false,
+    );
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a hydrated thread stream intact", async () => {
+    vi.spyOn(appAtomRegistry, "get").mockReturnValue(
+      makeThread({ session: readySession }) as never,
+    );
+    const subscribe = vi.spyOn(appAtomRegistry, "subscribe");
+    const refresh = vi.spyOn(appAtomRegistry, "refresh");
+
+    await expect(recoverDraftThreadAfterBootstrap({ environmentId, threadId }, 0)).resolves.toBe(
+      true,
+    );
+
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -25,8 +25,9 @@ import {
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
   recoverDraftThreadAfterBootstrap,
-  resolveThreadMetadataUpdateForNextTurn,
+  resolveStartedThreadRef,
   resolveSendEnvMode,
+  resolveThreadMetadataUpdateForNextTurn,
   startNewThreadForProject,
   shouldShowBranchMismatchBanner,
   shouldWriteThreadErrorToCurrentServerThread,
@@ -145,6 +146,21 @@ describe("recoverDraftThreadAfterBootstrap", () => {
 
     expect(subscribe).not.toHaveBeenCalled();
     expect(refresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveStartedThreadRef", () => {
+  const threadRef = { environmentId, threadId };
+
+  it("promotes from authoritative started detail", () => {
+    expect(resolveStartedThreadRef(threadRef, makeThread({ session: readySession }))).toEqual(
+      threadRef,
+    );
+  });
+
+  it("waits while detail has not started", () => {
+    expect(resolveStartedThreadRef(threadRef, makeThread())).toBeNull();
+    expect(resolveStartedThreadRef(threadRef, null)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -14,7 +14,7 @@ import { type ChatMessage, type SessionPhase, type Thread } from "../types";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import * as Schema from "effect/Schema";
 import { appAtomRegistry } from "../rpc/atomRegistry";
-import { environmentThreadDetails } from "../state/threads";
+import { environmentThreadDetails, environmentThreads } from "../state/threads";
 import {
   filterTerminalContextsWithText,
   stripInlineTerminalContextPlaceholders,
@@ -462,6 +462,26 @@ export async function waitForStartedServerThread(
       finish(false);
     }, timeoutMs);
   });
+}
+
+/**
+ * A draft subscribes to its reserved thread id before the bootstrap command
+ * creates that thread. Normally the durable subscription retries and hydrates
+ * as soon as creation commits. If it remains empty after a successful command,
+ * restart only that thread stream so the draft can promote without a reload.
+ */
+export async function recoverDraftThreadAfterBootstrap(
+  threadRef: ScopedThreadRef,
+  timeoutMs = 1_000,
+): Promise<boolean> {
+  if (await waitForStartedServerThread(threadRef, timeoutMs)) {
+    return true;
+  }
+
+  appAtomRegistry.refresh(
+    environmentThreads.stateAtom(threadRef.environmentId, threadRef.threadId),
+  );
+  return false;
 }
 
 export interface LocalDispatchSnapshot {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -485,6 +485,17 @@ export async function recoverDraftThreadAfterBootstrap(
     return true;
   }
 
+  // Hydration can land after the timeout callback unsubscribes but before this
+  // continuation runs. Re-read the authoritative detail before tearing down a
+  // stream that has already recovered.
+  if (
+    threadHasStarted(
+      appAtomRegistry.get(environmentThreadDetails.detailAtom(threadRef)),
+    )
+  ) {
+    return true;
+  }
+
   appAtomRegistry.refresh(
     environmentThreads.stateAtom(threadRef.environmentId, threadRef.threadId),
   );

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -346,6 +346,13 @@ export function threadHasStarted(thread: Thread | null | undefined): boolean {
   );
 }
 
+export function resolveStartedThreadRef(
+  threadRef: ScopedThreadRef | null,
+  threadDetail: Thread | null | undefined,
+): ScopedThreadRef | null {
+  return threadRef !== null && threadHasStarted(threadDetail) ? threadRef : null;
+}
+
 // `threadProvider` is the open branded driver kind carried by the session.
 // Unknown driver kinds degrade to `null` (i.e. "unlocked"), which is the safe
 // rollback / fork behavior — the routing layer is the right place to surface

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -268,8 +268,9 @@ import {
   deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
-  resolveThreadMetadataUpdateForNextTurn,
+  recoverDraftThreadAfterBootstrap,
   resolveSendEnvMode,
+  resolveThreadMetadataUpdateForNextTurn,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   startNewThreadForProject,
@@ -4802,6 +4803,11 @@ function ChatViewContent(props: ChatViewProps) {
         failure = startResult;
       } else {
         turnStartSucceeded = true;
+        if (isLocalDraftThread) {
+          void recoverDraftThreadAfterBootstrap(
+            scopeThreadRef(activeThread.environmentId, threadIdForSend),
+          );
+        }
       }
     }
 

--- a/apps/web/src/routes/_chat.draft.$draftId.tsx
+++ b/apps/web/src/routes/_chat.draft.$draftId.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 import ChatView from "../components/ChatView";
-import { threadHasStarted } from "../components/ChatView.logic";
+import { resolveStartedThreadRef } from "../components/ChatView.logic";
 import {
   DraftId,
   markPromotedDraftThreadByRef,
@@ -10,7 +10,7 @@ import {
 import { SidebarInset } from "../components/ui/sidebar";
 import { waitForDraftHeroTransition } from "../components/chat/draftHeroTransition";
 import { buildThreadRouteParams, resolveDraftThreadSubscriptionRef } from "../threadRoutes";
-import { useThread } from "../state/entities";
+import { useThreadDetail } from "../state/entities";
 
 function DraftChatThreadRouteView() {
   const navigate = useNavigate();
@@ -18,9 +18,12 @@ function DraftChatThreadRouteView() {
   const draftId = DraftId.make(rawDraftId);
   const draftSession = useComposerDraftStore((store) => store.getDraftSession(draftId));
   const serverThreadRef = resolveDraftThreadSubscriptionRef(draftSession);
-  const serverThread = useThread(serverThreadRef);
-  const serverThreadStarted = threadHasStarted(serverThread);
-  const canonicalThreadRef = serverThreadStarted ? serverThreadRef : null;
+  // Promotion is driven by the authoritative detail stream. The composed
+  // `useThread` view intentionally overlays shell metadata, whose independent
+  // subscription can briefly lag and erase a started session/latest turn.
+  const serverThreadDetail = useThreadDetail(serverThreadRef);
+  const canonicalThreadRef = resolveStartedThreadRef(serverThreadRef, serverThreadDetail);
+  const serverThreadStarted = canonicalThreadRef !== null;
 
   useEffect(() => {
     if (!serverThreadStarted || !serverThreadRef || draftSession?.promotedTo) {

--- a/apps/web/src/routes/_chat.draft.$draftId.tsx
+++ b/apps/web/src/routes/_chat.draft.$draftId.tsx
@@ -9,33 +9,25 @@ import {
 } from "../composerDraftStore";
 import { SidebarInset } from "../components/ui/sidebar";
 import { waitForDraftHeroTransition } from "../components/chat/draftHeroTransition";
-import { buildThreadRouteParams } from "../threadRoutes";
-import { useThread, useThreadRefs } from "../state/entities";
+import { buildThreadRouteParams, resolveDraftThreadSubscriptionRef } from "../threadRoutes";
+import { useThread } from "../state/entities";
 
 function DraftChatThreadRouteView() {
   const navigate = useNavigate();
   const { draftId: rawDraftId } = Route.useParams();
   const draftId = DraftId.make(rawDraftId);
   const draftSession = useComposerDraftStore((store) => store.getDraftSession(draftId));
-  const threadRefs = useThreadRefs();
-  const inferredThreadRef = draftSession
-    ? (threadRefs.find(
-        (ref) =>
-          ref.environmentId === draftSession.environmentId &&
-          ref.threadId === draftSession.threadId,
-      ) ?? null)
-    : null;
-  const serverThreadRef = draftSession?.promotedTo ?? inferredThreadRef;
+  const serverThreadRef = resolveDraftThreadSubscriptionRef(draftSession);
   const serverThread = useThread(serverThreadRef);
   const serverThreadStarted = threadHasStarted(serverThread);
   const canonicalThreadRef = serverThreadStarted ? serverThreadRef : null;
 
   useEffect(() => {
-    if (!inferredThreadRef || draftSession?.promotedTo) {
+    if (!serverThreadStarted || !serverThreadRef || draftSession?.promotedTo) {
       return;
     }
-    markPromotedDraftThreadByRef(inferredThreadRef);
-  }, [draftSession?.promotedTo, inferredThreadRef]);
+    markPromotedDraftThreadByRef(serverThreadRef);
+  }, [draftSession?.promotedTo, serverThreadRef, serverThreadStarted]);
 
   useEffect(() => {
     if (!canonicalThreadRef) {

--- a/apps/web/src/routes/_chat.draft.$draftId.tsx
+++ b/apps/web/src/routes/_chat.draft.$draftId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ChatView from "../components/ChatView";
 import { resolveStartedThreadRef } from "../components/ChatView.logic";
 import {
@@ -17,7 +17,10 @@ function DraftChatThreadRouteView() {
   const { draftId: rawDraftId } = Route.useParams();
   const draftId = DraftId.make(rawDraftId);
   const draftSession = useComposerDraftStore((store) => store.getDraftSession(draftId));
-  const serverThreadRef = resolveDraftThreadSubscriptionRef(draftSession);
+  const serverThreadRef = useMemo(
+    () => resolveDraftThreadSubscriptionRef(draftSession),
+    [draftSession],
+  );
   // Promotion is driven by the authoritative detail stream. The composed
   // `useThread` view intentionally overlays shell metadata, whose independent
   // subscription can briefly lag and erase a started session/latest turn.

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -7,6 +7,7 @@ import {
   buildDraftThreadRouteParams,
   buildThreadRouteParams,
   resolveActiveThreadRouteRef,
+  resolveDraftThreadSubscriptionRef,
   resolveThreadRouteRenderState,
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
@@ -93,7 +94,6 @@ describe("threadRoutes", () => {
       }),
     ).toBeNull();
   });
-
   it("keeps shell-only server threads in the loading state", () => {
     expect(
       resolveThreadRouteRenderState({
@@ -158,5 +158,31 @@ describe("threadRoutes", () => {
         draftThreadExists: false,
       }),
     ).toBe("missing");
+  });
+
+  it("observes a draft's reserved server ref before shell promotion", () => {
+    expect(
+      resolveDraftThreadSubscriptionRef({
+        environmentId: "env-1" as never,
+        threadId: ThreadId.make("draft-thread"),
+        promotedTo: null,
+      }),
+    ).toEqual({
+      environmentId: "env-1",
+      threadId: "draft-thread",
+    });
+  });
+
+  it("observes the promoted ref when a draft moves environments", () => {
+    expect(
+      resolveDraftThreadSubscriptionRef({
+        environmentId: "env-1" as never,
+        threadId: ThreadId.make("draft-thread"),
+        promotedTo: scopeThreadRef("env-2" as never, ThreadId.make("server-thread")),
+      }),
+    ).toEqual({
+      environmentId: "env-2",
+      threadId: "server-thread",
+    });
   });
 });

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -101,3 +101,18 @@ export function resolveActiveThreadRouteRef(
   }
   return draftThread.promotedTo;
 }
+
+/**
+ * Resolves the server ref a draft route should observe while its first turn is
+ * materializing. Draft ids reserve the eventual server thread ref up front, so
+ * detail synchronization can start without waiting for the shell stream to
+ * publish the new thread.
+ */
+export function resolveDraftThreadSubscriptionRef(
+  draftThread: DraftThreadRouteState | null,
+): ScopedThreadRef | null {
+  if (!draftThread) {
+    return null;
+  }
+  return draftThread.promotedTo ?? scopeThreadRef(draftThread.environmentId, draftThread.threadId);
+}


### PR DESCRIPTION
## What Changed

- Make draft routes subscribe to the authoritative server thread detail reserved at draft creation instead of waiting for or merging in the shell thread list.
- Promote the draft as soon as that detail stream reports a started server thread.
- After a successful bootstrap send, restart only the reserved thread stream if it is still empty after one second.
- Add regression coverage for reserved/promoted draft refs and stalled-vs-hydrated recovery behavior.

## Why

The server can accept and complete a draft's first prompt while the web client remains on its local draft state. In the observed failure, the client then retried the bootstrap create command 11 times; every retry failed with `Thread already exists`, and reloading fixed the view by rebuilding state from the server.

The draft route previously waited for the shell thread list before it even observed the reserved thread detail. That creates a frontend-only failure mode when the shell upsert is delayed or missed. Observing the reserved detail directly gives the route an independent promotion signal, while the post-bootstrap watchdog recovers a detail stream that stalls after the command succeeds.

Review follow-up: promotion is gated on `useThreadDetail`, not the shell/detail `useThread` merge, so stale shell `session` or `latestTurn` fields cannot mask an already-started authoritative detail.

## UI Changes

No visual design changes. This fixes the first-prompt transition from a local `/draft/<id>` route to the canonical server thread route.

Integrated evidence from an isolated `test-t3-app` environment:

- Run 1: `/draft/bb48ec47-2ee8-4fb9-b4ad-a3945bd12b41` promoted without reload to `/38888177-469a-4f60-9675-188aca9328a4/87c747a4-8bf8-4b19-a41c-74c783498092`.
- The rendered assistant message was `draft promotion verified`.
- SQLite independently confirmed one non-streaming user message and one non-streaming assistant message on that canonical thread.
- Run 2 repeated the flow: `/draft/788e54eb-2945-437f-9997-75ccfb376341` promoted without reload to `/38888177-469a-4f60-9675-188aca9328a4/652c4cf8-b03d-4b9b-93a9-ed6eac2801b8`, rendering `second draft verified`.
- The server trace showed the pre-creation detail requests returning 404, followed by HTTP 200 immediately after the first-prompt bootstrap materialized each thread.

## Verification

- `vp test run apps/web/src/components/ChatView.logic.test.ts apps/web/src/threadRoutes.test.ts` (34 tests passed after rebasing onto current `main`)
- `vp check` on all 6 changed files (format and lint passed)
- `vp run --filter @t3tools/web typecheck`
- Two isolated integrated browser passes using a real GPT-5.6-Sol provider

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after evidence for the affected UI behavior
- [ ] I included a video for the interaction change (the preview encoder produced an unusable green recording, so the two route transitions, rendered DOM, HTTP trace, and SQLite rows are documented instead)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes draft-to-server routing and thread atom refresh on the critical first-send path; scope is focused but incorrect promotion or refresh could still leave users stuck or cause duplicate bootstrap attempts.
> 
> **Overview**
> Fixes a case where the server accepts a draft’s first prompt but the client stays on `/draft/<id>` and may retry bootstrap with “Thread already exists.”
> 
> **Draft route promotion** now resolves the server ref via `resolveDraftThreadSubscriptionRef` (reserved id at creation, or `promotedTo` after env move) and gates navigation on **`useThreadDetail`** plus `resolveStartedThreadRef`, instead of inferring from the shell thread list or the merged `useThread` view that can lag behind authoritative detail.
> 
> **After a successful first send** on a local draft, `ChatView` calls `recoverDraftThreadAfterBootstrap`, which waits briefly for detail hydration and, if still empty, refreshes only that thread’s `environmentThreads` state atom (with a re-read guard to avoid tearing down a stream that recovered on the timeout edge).
> 
> Regression tests cover reserved/promoted subscription refs, promotion gating, and stalled vs hydrated recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42331268c5fae90090d0a9f14a97a0eddf11bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover stalled draft thread promotion by refreshing the thread stream on hydration timeout
> - Adds `recoverDraftThreadAfterBootstrap` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/4318/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) that waits for a server thread to start after a turn is sent; if hydration stalls, it refreshes the specific thread stream via `environmentThreads.stateAtom`.
> - Adds `resolveStartedThreadRef` which returns a thread ref only once `threadHasStarted` is true, used to gate promotion logic.
> - Adds `resolveDraftThreadSubscriptionRef` in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/4318/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3) to resolve the correct scoped ref for a draft thread before or after promotion.
> - Updates `DraftChatThreadRouteView` to use `resolveStartedThreadRef` so promotion marking only fires once the authoritative detail confirms the thread has started.
> - After a successful turn start on a local draft thread, `ChatView.tsx` calls `recoverDraftThreadAfterBootstrap` asynchronously (fire-and-forget).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e423312.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->