### PR TITLE
Confirm before running git init

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1738,7 +1738,7 @@ export default function GitActionsControl({
     <>
       {!isRepo ? (
         <InitializeGitControl
-          key={gitCwd}
+          key={`${activeEnvironmentId ?? "no-environment"}:${gitCwd}`}
           environmentId={activeEnvironmentId}
           gitCwd={gitCwd}
           threadToastData={threadToastData}

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -50,6 +50,15 @@ import {
   resolveThreadBranchUpdate,
 } from "./GitActionsControl.logic";
 import { AnimatedHeight } from "./AnimatedHeight";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import {
@@ -997,6 +1006,7 @@ export default function GitActionsControl({
     waitForShell: activeDraftThread !== null,
   });
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const [confirmInitOpen, setConfirmInitOpen] = useState(false);
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
   const [dialogCommitMessage, setDialogCommitMessage] = useState("");
   const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
@@ -1652,38 +1662,62 @@ export default function GitActionsControl({
 
   const canPublishRepository = isRepo && gitStatusForActions !== null && !hasPrimaryRemote;
 
+  const runGitInit = useCallback(() => {
+    if (initAction.isPending) return;
+    setConfirmInitOpen(false);
+    void (async () => {
+      const result = await initAction.run();
+      if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+        return;
+      }
+      const error = squashAtomCommandFailure(result);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Git initialization failed",
+          description: error instanceof Error ? error.message : "An error occurred.",
+          ...(threadToastData !== undefined ? { data: threadToastData } : {}),
+        }),
+      );
+    })();
+  }, [initAction, threadToastData]);
+
   if (!gitCwd) return null;
 
   return (
     <>
       {!isRepo ? (
-        <Button
-          variant="outline"
-          size="xs"
-          disabled={initAction.isPending}
-          onClick={() => {
-            void (async () => {
-              const result = await initAction.run();
-              if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-                return;
-              }
-              const error = squashAtomCommandFailure(result);
-              toastManager.add(
-                stackedThreadToast({
-                  type: "error",
-                  title: "Git initialization failed",
-                  description: error instanceof Error ? error.message : "An error occurred.",
-                  ...(threadToastData !== undefined ? { data: threadToastData } : {}),
-                }),
-              );
-            })();
-          }}
-        >
-          <GitBranchPlusIcon className="size-3.5" aria-hidden />
-          <span className="ml-0.5">
-            {initAction.isPending ? "Initializing..." : "Initialize Git"}
-          </span>
-        </Button>
+        <>
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={initAction.isPending}
+            onClick={() => setConfirmInitOpen(true)}
+          >
+            <GitBranchPlusIcon className="size-3.5" aria-hidden />
+            <span className="ml-0.5">
+              {initAction.isPending ? "Initializing..." : "Initialize Git"}
+            </span>
+          </Button>
+          <AlertDialog open={confirmInitOpen} onOpenChange={setConfirmInitOpen}>
+            <AlertDialogPopup>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Initialize Git repository?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will run{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">git init</code> in{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs break-all">{gitCwd}</code>
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                <Button disabled={initAction.isPending} onClick={runGitInit}>
+                  Initialize
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogPopup>
+          </AlertDialog>
+        </>
       ) : (
         <Group aria-label="Git actions" className="shrink-0">
           {quickActionDisabledReason ? (

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -976,6 +976,78 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
   );
 }
 
+interface InitializeGitControlProps {
+  readonly environmentId: ScopedThreadRef["environmentId"] | null;
+  readonly gitCwd: string;
+  readonly threadToastData: { threadRef: ScopedThreadRef } | undefined;
+}
+
+function InitializeGitControl({
+  environmentId,
+  gitCwd,
+  threadToastData,
+}: InitializeGitControlProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const sourceControlScope = useMemo(
+    () => ({ environmentId, cwd: gitCwd }),
+    [environmentId, gitCwd],
+  );
+  const initAction = useVcsInitAction(sourceControlScope);
+
+  const runGitInit = useCallback(() => {
+    if (initAction.isPending) return;
+    setConfirmOpen(false);
+    void (async () => {
+      const result = await initAction.run();
+      if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+        return;
+      }
+      const error = squashAtomCommandFailure(result);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Git initialization failed",
+          description: error instanceof Error ? error.message : "An error occurred.",
+          ...(threadToastData !== undefined ? { data: threadToastData } : {}),
+        }),
+      );
+    })();
+  }, [initAction, threadToastData]);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="xs"
+        disabled={initAction.isPending}
+        onClick={() => setConfirmOpen(true)}
+      >
+        <GitBranchPlusIcon className="size-3.5" aria-hidden />
+        <span className="ml-0.5">
+          {initAction.isPending ? "Initializing..." : "Initialize Git"}
+        </span>
+      </Button>
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Initialize Git repository?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will run <code className="rounded bg-muted px-1 py-0.5 text-xs">git init</code>{" "}
+              in <code className="rounded bg-muted px-1 py-0.5 text-xs break-all">{gitCwd}</code>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button disabled={initAction.isPending} onClick={runGitInit}>
+              Initialize
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
+  );
+}
+
 export default function GitActionsControl({
   gitCwd,
   activeThreadRef,
@@ -1006,7 +1078,6 @@ export default function GitActionsControl({
     waitForShell: activeDraftThread !== null,
   });
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
-  const [confirmInitOpen, setConfirmInitOpen] = useState(false);
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
   const [dialogCommitMessage, setDialogCommitMessage] = useState("");
   const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
@@ -1116,7 +1187,6 @@ export default function GitActionsControl({
   const allSelected = excludedFiles.size === 0;
   const noneSelected = selectedFiles.length === 0;
 
-  const initAction = useVcsInitAction(sourceControlScope);
   const runImmediateGitAction = useGitStackedAction(sourceControlScope);
   const pullAction = useVcsPullAction(sourceControlScope);
   const isGitActionRunning = useSourceControlActionRunning(
@@ -1662,62 +1732,17 @@ export default function GitActionsControl({
 
   const canPublishRepository = isRepo && gitStatusForActions !== null && !hasPrimaryRemote;
 
-  const runGitInit = useCallback(() => {
-    if (initAction.isPending) return;
-    setConfirmInitOpen(false);
-    void (async () => {
-      const result = await initAction.run();
-      if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-        return;
-      }
-      const error = squashAtomCommandFailure(result);
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Git initialization failed",
-          description: error instanceof Error ? error.message : "An error occurred.",
-          ...(threadToastData !== undefined ? { data: threadToastData } : {}),
-        }),
-      );
-    })();
-  }, [initAction, threadToastData]);
-
   if (!gitCwd) return null;
 
   return (
     <>
       {!isRepo ? (
-        <>
-          <Button
-            variant="outline"
-            size="xs"
-            disabled={initAction.isPending}
-            onClick={() => setConfirmInitOpen(true)}
-          >
-            <GitBranchPlusIcon className="size-3.5" aria-hidden />
-            <span className="ml-0.5">
-              {initAction.isPending ? "Initializing..." : "Initialize Git"}
-            </span>
-          </Button>
-          <AlertDialog open={confirmInitOpen} onOpenChange={setConfirmInitOpen}>
-            <AlertDialogPopup>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Initialize Git repository?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will run{" "}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs">git init</code> in{" "}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs break-all">{gitCwd}</code>
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
-                <Button disabled={initAction.isPending} onClick={runGitInit}>
-                  Initialize
-                </Button>
-              </AlertDialogFooter>
-            </AlertDialogPopup>
-          </AlertDialog>
-        </>
+        <InitializeGitControl
+          key={gitCwd}
+          environmentId={activeEnvironmentId}
+          gitCwd={gitCwd}
+          threadToastData={threadToastData}
+        />
       ) : (
         <Group aria-label="Git actions" className="shrink-0">
           {quickActionDisabledReason ? (


### PR DESCRIPTION
## Summary
- Require a confirmation dialog before initializing Git from the header action
- Show the target path and command in the dialog copy

Closes #1316

## Context
This re-applies #1318, which was closed during backlog cleanup for inactivity ("if the change is still relevant, please rebase onto current main"). The change is still relevant: issue #1316 is still open and the "Initialize Git" button on `main` still calls `initMutation.mutate()` directly with no confirmation. Rebased onto current `main` — same one-file change to `GitActionsControl.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guard around an existing init action; no changes to VCS APIs or server behavior.
> 
> **Overview**
> **Initialize Git** in the git header no longer runs `git init` on the first click. It opens a confirmation **`AlertDialog`** that names the command and the working directory, then runs init only after the user confirms.
> 
> The flow is moved into a dedicated **`InitializeGitControl`** component (init hook, pending state, and failure toasts live there). The parent renders that component when the folder is not yet a repo, with a remount key tied to environment and path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f11bd68724860bb273ca8ef09e412a070db291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Confirm before running `git init` in GitActionsControl
> Wraps the git repository initialization action in a new `InitializeGitControl` component that shows an `AlertDialog` confirmation modal before running `git init`. The action button is disabled while the initialization is pending, and errors surface as toasts. Behavioral Change: clicking the init button no longer immediately runs `git init`; it now requires explicit confirmation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4f11bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->