### PR TITLE
Coalesce high-frequency assistant streaming deltas

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2730,6 +2730,182 @@ describe("ProviderRuntimeIngestion", () => {
     ).toBe("visible tail");
   });
 
+  it("keeps timer-flushed assistant timestamps monotonic after a newer flush", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-monotonic-timer");
+    const itemId = asItemId("item-streaming-monotonic-timer");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-monotonic-timer"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    for (const [offsetMillis, delta] of [
+      [0, "first "],
+      [200, "second "],
+      [201, "tail"],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-message-delta-streaming-monotonic-timer-${offsetMillis}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: timestampAt(offsetMillis),
+        threadId: asThreadId("thread-1"),
+        turnId,
+        itemId,
+        payload: { streamKind: "assistant_text", delta },
+      });
+    }
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-monotonic-timer" &&
+            message.text === "first second tail",
+        ),
+      5000,
+    );
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantEvents = events.filter(
+      (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-streaming-monotonic-timer",
+    );
+    expect(assistantEvents.map((event) => event.payload.updatedAt)).toEqual([
+      timestampAt(0),
+      timestampAt(200),
+      timestampAt(201),
+    ]);
+  });
+
+  it("defers failed final assistant deltas without blocking the ingestion worker", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-finalization-retry");
+    const itemId = asItemId("item-streaming-finalization-retry");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-finalization-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-finalization-retry-first"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "retained " },
+    });
+    await waitForThread(harness.readModel, (thread) =>
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-finalization-retry" &&
+          message.text === "retained ",
+      ),
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-finalization-retry-tail"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(1),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "tail" },
+    });
+    const getFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-runtime-error-streaming-finalization-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(2),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { message: "provider stopped during finalization" },
+    });
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-streaming-finalization-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(3),
+      threadId: asThreadId("thread-1"),
+      payload: { name: "Worker stayed live" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.title === "Worker stayed live" &&
+        entry.session?.status === "error" &&
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-finalization-retry" &&
+            !message.streaming &&
+            message.text === "retained tail",
+        ),
+      5000,
+    );
+    expect(getFailureCount()).toBe(3);
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-finalization-retry",
+      )?.updatedAt,
+    ).toBe(timestampAt(2));
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-finalization-retry-duplicate"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(4),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed", detail: "retained tail" },
+    });
+    await harness.drain();
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "thread.message-sent" &&
+          event.payload.messageId === "assistant:item-streaming-finalization-retry" &&
+          !event.payload.streaming,
+      ),
+    ).toHaveLength(2);
+  });
+
   it("keeps retained streaming chunks bounded while dispatch retries", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
     const turnId = asTurnId("turn-streaming-bounded-retry");

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -23,6 +23,7 @@ import {
   TurnId,
 } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
@@ -2389,6 +2390,93 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(finalMessage?.text).toBe("hello live");
     expect(finalMessage?.streaming).toBe(false);
+  });
+
+  it("coalesces high-frequency streaming assistant deltas before persistence", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+    const turnId = asTurnId("turn-streaming-coalesced");
+    const itemId = asItemId("item-streaming-coalesced");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-coalesced"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(
+      harness.readModel,
+      (thread) => thread.session?.status === "running" && thread.session?.activeTurnId === turnId,
+    );
+
+    for (let index = 0; index < 250; index += 1) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-message-delta-streaming-coalesced-${index}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: timestampAt(index),
+        threadId: asThreadId("thread-1"),
+        turnId,
+        itemId,
+        payload: {
+          streamKind: "assistant_text",
+          delta: "x",
+        },
+      });
+    }
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-coalesced"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(250),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const expectedText = "x".repeat(250);
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-coalesced" &&
+            !message.streaming &&
+            message.text === expectedText,
+        ),
+      5000,
+    );
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-coalesced",
+      )?.text,
+    ).toBe(expectedText);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantEvents = events.filter(
+      (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-streaming-coalesced",
+    );
+    const streamingEvents = assistantEvents.filter((event) => event.payload.streaming);
+
+    expect(streamingEvents).toHaveLength(4);
+    expect(streamingEvents.map((event) => event.payload.text).join("")).toBe(expectedText);
+    expect(assistantEvents).toHaveLength(5);
+    expect(assistantEvents.at(-1)?.payload.streaming).toBe(false);
   });
 
   it("spills oversized buffered deltas and still finalizes full assistant text", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -51,6 +51,7 @@ import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeInge
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { OrchestrationCommandInvariantError } from "../Errors.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 
 function makeTestServerSettingsLayer(overrides: Partial<ServerSettings> = {}) {
@@ -311,12 +312,42 @@ describe("ProviderRuntimeIngestion", () => {
       updatedAt: createdAt,
     });
 
+    const failDispatches = (
+      count: number,
+      predicate: (command: Parameters<typeof engine.dispatch>[0]) => boolean,
+    ) => {
+      const originalDispatch = engine.dispatch;
+      let failureCount = 0;
+      (engine as { dispatch: typeof engine.dispatch }).dispatch = (command) => {
+        if (failureCount < count && predicate(command)) {
+          failureCount += 1;
+          return Effect.fail(
+            new OrchestrationCommandInvariantError({
+              commandType: command.type,
+              detail: "Injected orchestration dispatch failure",
+            }),
+          );
+        }
+        return originalDispatch(command);
+      };
+      return () => failureCount;
+    };
+
+    const failNextDispatch = (
+      predicate: (command: Parameters<typeof engine.dispatch>[0]) => boolean,
+    ) => {
+      const getFailureCount = failDispatches(1, predicate);
+      return () => getFailureCount() === 1;
+    };
+
     return {
       engine,
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       emit: provider.emit,
       setProviderSession: provider.setSession,
       drain,
+      failDispatches,
+      failNextDispatch,
     };
   }
 
@@ -2477,6 +2508,529 @@ describe("ProviderRuntimeIngestion", () => {
     expect(streamingEvents.map((event) => event.payload.text).join("")).toBe(expectedText);
     expect(assistantEvents).toHaveLength(5);
     expect(assistantEvents.at(-1)?.payload.streaming).toBe(false);
+  });
+
+  it("retains a coalesced streaming chunk when dispatch fails", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+    const turnId = asTurnId("turn-streaming-dispatch-retry");
+    const itemId = asItemId("item-streaming-dispatch-retry");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-dispatch-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(
+      harness.readModel,
+      (thread) => thread.session?.status === "running" && thread.session?.activeTurnId === turnId,
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-dispatch-retry-first"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "first " },
+    });
+    await waitForThread(harness.readModel, (thread) =>
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-dispatch-retry" && message.text === "first ",
+      ),
+    );
+
+    const didInjectFailure = harness.failNextDispatch(
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-dispatch-retry-buffered"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(1),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "still " },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-dispatch-retry-failed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(101),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "present" },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-dispatch-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(102),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-dispatch-retry" &&
+            !message.streaming &&
+            message.text === "first still present",
+        ),
+      5000,
+    );
+    expect(didInjectFailure()).toBe(true);
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-dispatch-retry",
+      )?.text,
+    ).toBe("first still present");
+  });
+
+  it("flushes pending coalesced assistant text when the session exits", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+    const turnId = asTurnId("turn-streaming-session-exit");
+    const itemId = asItemId("item-streaming-session-exit");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-session-exit"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(
+      harness.readModel,
+      (thread) => thread.session?.status === "running" && thread.session?.activeTurnId === turnId,
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-session-exit-first"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "before " },
+    });
+    await waitForThread(harness.readModel, (thread) =>
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-session-exit" && message.text === "before ",
+      ),
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-session-exit-buffered"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(1),
+      threadId: asThreadId("thread-1"),
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "exit" },
+    });
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-session-exited-streaming-session-exit"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(2),
+      threadId: asThreadId("thread-1"),
+      payload: { reason: "provider terminated" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.session?.status === "stopped" &&
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-session-exit" &&
+            !message.streaming &&
+            message.text === "before exit",
+        ),
+      5000,
+    );
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-session-exit",
+      )?.text,
+    ).toBe("before exit");
+  });
+
+  it("flushes a trailing streaming burst after the coalescing interval", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-timer-flush");
+    const itemId = asItemId("item-streaming-timer-flush");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-timer-flush"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    for (const [offsetMillis, delta] of [
+      [0, "visible "],
+      [1, "tail"],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-message-delta-streaming-timer-flush-${offsetMillis}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: timestampAt(offsetMillis),
+        threadId: asThreadId("thread-1"),
+        turnId,
+        itemId,
+        payload: { streamKind: "assistant_text", delta },
+      });
+    }
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-timer-flush" &&
+            message.streaming &&
+            message.text === "visible tail",
+        ),
+      5000,
+    );
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-timer-flush",
+      )?.text,
+    ).toBe("visible tail");
+  });
+
+  it("keeps retained streaming chunks bounded while dispatch retries", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-bounded-retry");
+    const itemId = asItemId("item-streaming-bounded-retry");
+    const now = "2026-01-01T00:00:00.000Z";
+    const expectedText = "x".repeat(2_500);
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-bounded-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    const getFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-bounded-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: expectedText },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-bounded-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-bounded-retry" &&
+            !message.streaming &&
+            message.text === expectedText,
+        ),
+      5000,
+    );
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const persistedChunks = events
+      .filter(
+        (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+          event.type === "thread.message-sent" &&
+          event.payload.messageId === "assistant:item-streaming-bounded-retry" &&
+          event.payload.streaming,
+      )
+      .map((event) => event.payload.text);
+    expect(getFailureCount()).toBe(3);
+    expect(Math.max(...persistedChunks.map((text) => text.length))).toBeLessThanOrEqual(512);
+    expect(persistedChunks.join("")).toBe(expectedText);
+  });
+
+  it("yields the ingestion worker after bounded assistant dispatch retries", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-worker-liveness");
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-worker-liveness"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    const getFailureCount = harness.failDispatches(
+      100,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-worker-liveness"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId: asItemId("item-streaming-worker-liveness"),
+      payload: { streamKind: "assistant_text", delta: "retained during outage" },
+    });
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-streaming-worker-liveness"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: { name: "Worker remained live" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.title === "Worker remained live",
+      2000,
+    );
+    expect(thread.title).toBe("Worker remained live");
+    expect(getFailureCount()).toBeGreaterThanOrEqual(3);
+  });
+
+  it("finalizes only the completed turn's assistant messages", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const firstTurnId = asTurnId("turn-streaming-completed-scope-first");
+    const secondTurnId = asTurnId("turn-streaming-completed-scope-second");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-completed-scope"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId: firstTurnId,
+    });
+    await waitForThread(
+      harness.readModel,
+      (thread) => thread.session?.activeTurnId === firstTurnId,
+    );
+
+    for (const [turnId, itemId, delta] of [
+      [firstTurnId, asItemId("item-streaming-completed-scope-first"), "first"],
+      [secondTurnId, asItemId("item-streaming-completed-scope-second"), "second"],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-message-delta-${turnId}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: timestampAt(0),
+        threadId: asThreadId("thread-1"),
+        turnId,
+        itemId,
+        payload: { streamKind: "assistant_text", delta },
+      });
+    }
+    await waitForThread(harness.readModel, (thread) =>
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-completed-scope-second" && message.streaming,
+      ),
+    );
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-streaming-completed-scope-first"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(1),
+      threadId: asThreadId("thread-1"),
+      turnId: firstTurnId,
+      payload: { state: "completed" },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-completed-scope-first" && !message.streaming,
+      ),
+    );
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-completed-scope-second",
+      )?.streaming,
+    ).toBe(true);
+  });
+
+  it("finalizes pending coalesced assistant text on runtime error", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-runtime-error");
+    const itemId = asItemId("item-streaming-runtime-error");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-runtime-error"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+    for (const [offsetMillis, delta] of [
+      [0, "before "],
+      [1, "error"],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-message-delta-streaming-runtime-error-${offsetMillis}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: timestampAt(offsetMillis),
+        threadId: asThreadId("thread-1"),
+        turnId,
+        itemId,
+        payload: { streamKind: "assistant_text", delta },
+      });
+    }
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-streaming-runtime-error"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(2),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { message: "provider failed" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.session?.status === "error" &&
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-runtime-error" &&
+            !message.streaming &&
+            message.text === "before error",
+        ),
+      5000,
+    );
+  });
+
+  it("preserves a whitespace-only buffered tail when finalizing", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-streaming-whitespace-tail");
+    const itemId = asItemId("item-streaming-whitespace-tail");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-whitespace-tail"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+    for (const [offsetMillis, delta] of [
+      [0, "answer"],
+      [1, "\n\n"],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-message-delta-streaming-whitespace-tail-${offsetMillis}`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: timestampAt(offsetMillis),
+        threadId: asThreadId("thread-1"),
+        turnId,
+        itemId,
+        payload: { streamKind: "assistant_text", delta },
+      });
+    }
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-whitespace-tail"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(2),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-whitespace-tail" &&
+            !message.streaming &&
+            message.text === "answer\n\n",
+        ),
+      5000,
+    );
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-whitespace-tail",
+      )?.text,
+    ).toBe("answer\n\n");
   });
 
   it("spills oversized buffered deltas and still finalizes full assistant text", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3990,6 +3990,38 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
     expect(requestActivityIndex).toBeGreaterThan(assistantCompletionIndex);
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-after-deferred-request-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: " after approval" },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-item-completed-after-deferred-request-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-request-finalization:segment:1" &&
+            !message.streaming &&
+            message.text === " after approval",
+        ),
+      5000,
+    );
   });
 
   it("keeps a terminal session boundary behind fallback item finalization", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3052,6 +3052,49 @@ describe("ProviderRuntimeIngestion", () => {
     expect(assistantEvents.map((event) => event.payload.streaming)).toEqual([true, false]);
   });
 
+  it("retains fallback completion text when its final delta retries", async () => {
+    const harness = await createHarness();
+    const itemId = asItemId("item-fallback-delta-retry");
+    const now = "2026-01-01T00:00:00.000Z";
+    const getDeltaFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-fallback-delta-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      itemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "fallback survives the retry",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-fallback-delta-retry" &&
+            !message.streaming &&
+            message.text === "fallback survives the retry",
+        ),
+      5000,
+    );
+    expect(getDeltaFailureCount()).toBe(3);
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-fallback-delta-retry",
+      )?.text,
+    ).toBe("fallback survives the retry");
+  });
+
   it("keeps retained streaming chunks bounded while dispatch retries", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
     const turnId = asTurnId("turn-streaming-bounded-retry");
@@ -3550,6 +3593,73 @@ describe("ProviderRuntimeIngestion", () => {
       );
     });
     expect(completionEvents).toHaveLength(1);
+  });
+
+  it("publishes assistant completion before a successful turn boundary", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-successful-boundary-order");
+    const itemId = asItemId("item-successful-boundary-order");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-successful-boundary-order"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-successful-boundary-order"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: {
+        streamKind: "assistant_text",
+        delta: "complete before ready",
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-successful-boundary-order"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "ready" &&
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-successful-boundary-order" && !message.streaming,
+        ),
+    );
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantCompletionIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-successful-boundary-order" &&
+        !event.payload.streaming,
+    );
+    const turnReadyIndex = events.findLastIndex(
+      (event) => event.type === "thread.session-set" && event.payload.session.status === "ready",
+    );
+    expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
+    expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
   });
 
   it("keeps a turn boundary behind deferred item finalization", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3056,6 +3056,7 @@ describe("ProviderRuntimeIngestion", () => {
     const harness = await createHarness();
     const itemId = asItemId("item-fallback-delta-retry");
     const now = "2026-01-01T00:00:00.000Z";
+    const fallbackText = "fallback survives the retry ".repeat(120);
     const getDeltaFailureCount = harness.failDispatches(
       3,
       (command) => command.type === "thread.message.assistant.delta",
@@ -3071,7 +3072,7 @@ describe("ProviderRuntimeIngestion", () => {
       payload: {
         itemType: "assistant_message",
         status: "completed",
-        detail: "fallback survives the retry",
+        detail: fallbackText,
       },
     });
 
@@ -3082,7 +3083,7 @@ describe("ProviderRuntimeIngestion", () => {
           (message: ProviderRuntimeTestMessage) =>
             message.id === "assistant:item-fallback-delta-retry" &&
             !message.streaming &&
-            message.text === "fallback survives the retry",
+            message.text === fallbackText,
         ),
       5000,
     );
@@ -3092,7 +3093,23 @@ describe("ProviderRuntimeIngestion", () => {
         (message: ProviderRuntimeTestMessage) =>
           message.id === "assistant:item-fallback-delta-retry",
       )?.text,
-    ).toBe("fallback survives the retry");
+    ).toBe(fallbackText);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const persistedChunks = events
+      .filter(
+        (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+          event.type === "thread.message-sent" &&
+          event.payload.messageId === "assistant:item-fallback-delta-retry" &&
+          event.payload.streaming,
+      )
+      .map((event) => event.payload.text);
+    expect(Math.max(...persistedChunks.map((text) => text.length))).toBeLessThanOrEqual(512);
+    expect(persistedChunks.join("")).toBe(fallbackText);
   });
 
   it("keeps retained streaming chunks bounded while dispatch retries", async () => {
@@ -3741,6 +3758,85 @@ describe("ProviderRuntimeIngestion", () => {
     expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
     expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
     expect(completionEvents).toHaveLength(1);
+  });
+
+  it("keeps a request boundary behind deferred pause finalization", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-deferred-request-finalization");
+    const itemId = asItemId("item-deferred-request-finalization");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-deferred-request-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-deferred-request-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "before approval" },
+    });
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "request.opened",
+      eventId: asEventId("evt-request-opened-deferred-request-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      requestId: ApprovalRequestId.make("req-deferred-request-finalization"),
+      payload: {
+        requestType: "command_execution_approval",
+        detail: "pwd",
+      },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-request-finalization" && !message.streaming,
+        ) &&
+        thread.activities.some(
+          (activity: ProviderRuntimeTestActivity) =>
+            activity.id === "evt-request-opened-deferred-request-finalization",
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(3);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantCompletionIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-deferred-request-finalization" &&
+        !event.payload.streaming,
+    );
+    const requestActivityIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.activity-appended" &&
+        event.payload.activity.id === "evt-request-opened-deferred-request-finalization",
+    );
+    expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
+    expect(requestActivityIndex).toBeGreaterThan(assistantCompletionIndex);
   });
 
   it("keeps a terminal session boundary behind fallback item finalization", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2792,7 +2792,7 @@ describe("ProviderRuntimeIngestion", () => {
     ]);
   });
 
-  it("defers failed final assistant deltas without blocking the ingestion worker", async () => {
+  it("retries failed final assistant deltas and completion without replaying the runtime event", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
     const turnId = asTurnId("turn-streaming-finalization-retry");
     const itemId = asItemId("item-streaming-finalization-retry");
@@ -2841,6 +2841,10 @@ describe("ProviderRuntimeIngestion", () => {
       3,
       (command) => command.type === "thread.message.assistant.delta",
     );
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
     harness.emit({
       type: "runtime.error",
       eventId: asEventId("evt-runtime-error-streaming-finalization-retry"),
@@ -2873,6 +2877,7 @@ describe("ProviderRuntimeIngestion", () => {
       5000,
     );
     expect(getFailureCount()).toBe(3);
+    expect(getCompleteFailureCount()).toBe(3);
     expect(
       thread.messages.find(
         (message: ProviderRuntimeTestMessage) =>
@@ -2899,11 +2904,96 @@ describe("ProviderRuntimeIngestion", () => {
     expect(
       events.filter(
         (event) =>
+          event.type === "thread.session-set" &&
+          event.payload.session.status === "error" &&
+          event.payload.session.updatedAt === timestampAt(2),
+      ),
+    ).toHaveLength(1);
+    expect(
+      events.filter(
+        (event) =>
           event.type === "thread.message-sent" &&
           event.payload.messageId === "assistant:item-streaming-finalization-retry" &&
           !event.payload.streaming,
       ),
     ).toHaveLength(2);
+  });
+
+  it("does not duplicate a recovered final delta when completion also retries", async () => {
+    const harness = await createHarness();
+    const turnId = asTurnId("turn-finalization-stage-retry");
+    const itemId = asItemId("item-finalization-stage-retry");
+    const startedAt = DateTime.makeUnsafe("2026-01-01T00:00:00.000Z");
+    const timestampAt = (offsetMillis: number) =>
+      DateTime.formatIso(DateTime.addDuration(startedAt, offsetMillis));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-finalization-stage-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(0),
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-finalization-stage-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(1),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "persist exactly once" },
+    });
+
+    const getDeltaFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-session-exited-finalization-stage-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(2),
+      threadId: asThreadId("thread-1"),
+      payload: { reason: "provider failed" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "stopped" &&
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-finalization-stage-retry" &&
+            !message.streaming &&
+            message.text === "persist exactly once",
+        ),
+      5000,
+    );
+    expect(getDeltaFailureCount()).toBe(3);
+    expect(getCompleteFailureCount()).toBe(3);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantEvents = events.filter(
+      (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-finalization-stage-retry",
+    );
+    expect(assistantEvents.map((event) => event.payload.text)).toEqual([
+      "persist exactly once",
+      "",
+    ]);
+    expect(assistantEvents.map((event) => event.payload.streaming)).toEqual([true, false]);
   });
 
   it("keeps retained streaming chunks bounded while dispatch retries", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3054,7 +3054,8 @@ describe("ProviderRuntimeIngestion", () => {
     const turnId = asTurnId("turn-streaming-bounded-retry");
     const itemId = asItemId("item-streaming-bounded-retry");
     const now = "2026-01-01T00:00:00.000Z";
-    const expectedText = "x".repeat(2_500);
+    const initialText = "x".repeat(2_500);
+    const expectedText = `${initialText}after`;
 
     harness.emit({
       type: "turn.started",
@@ -3078,7 +3079,17 @@ describe("ProviderRuntimeIngestion", () => {
       threadId: asThreadId("thread-1"),
       turnId,
       itemId,
-      payload: { streamKind: "assistant_text", delta: expectedText },
+      payload: { streamKind: "assistant_text", delta: initialText },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-bounded-retry-after"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "after" },
     });
     harness.emit({
       type: "item.completed",
@@ -3497,6 +3508,80 @@ describe("ProviderRuntimeIngestion", () => {
       );
     });
     expect(completionEvents).toHaveLength(1);
+  });
+
+  it("keeps a turn boundary behind deferred item finalization", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-deferred-item-finalization");
+    const itemId = asItemId("item-deferred-item-finalization");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-deferred-item-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-item-completed-deferred-item-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "finalized before the boundary",
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-deferred-item-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "ready" &&
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-item-finalization" && !message.streaming,
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(3);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantCompletionIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-deferred-item-finalization" &&
+        !event.payload.streaming,
+    );
+    const turnReadyIndex = events.findLastIndex(
+      (event) => event.type === "thread.session-set" && event.payload.session.status === "ready",
+    );
+    expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
+    expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
   });
 
   it("maps canonical request events into approval activities with requestKind", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3580,8 +3580,15 @@ describe("ProviderRuntimeIngestion", () => {
     const turnReadyIndex = events.findLastIndex(
       (event) => event.type === "thread.session-set" && event.payload.session.status === "ready",
     );
+    const completionEvents = events.filter(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-deferred-item-finalization" &&
+        !event.payload.streaming,
+    );
     expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
     expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
+    expect(completionEvents).toHaveLength(1);
   });
 
   it("maps canonical request events into approval activities with requestKind", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3743,6 +3743,82 @@ describe("ProviderRuntimeIngestion", () => {
     expect(completionEvents).toHaveLength(1);
   });
 
+  it("keeps a terminal session boundary behind fallback item finalization", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-deferred-fallback-terminal");
+    const itemId = asItemId("item-deferred-fallback-terminal");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-deferred-fallback-terminal"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    const getCompleteFailureCount = harness.failDispatches(
+      6,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-item-completed-deferred-fallback-terminal"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "fallback before terminal",
+      },
+    });
+    harness.emit({
+      type: "runtime.error",
+      eventId: asEventId("evt-runtime-error-deferred-fallback-terminal"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { message: "provider stopped during fallback finalization" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "error" &&
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-fallback-terminal" &&
+            !message.streaming &&
+            message.text === "fallback before terminal",
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(6);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantCompletionIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-deferred-fallback-terminal" &&
+        !event.payload.streaming,
+    );
+    const sessionErrorIndex = events.findLastIndex(
+      (event) => event.type === "thread.session-set" && event.payload.session.status === "error",
+    );
+    expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
+    expect(sessionErrorIndex).toBeGreaterThan(assistantCompletionIndex);
+  });
+
   it("keeps deferred assistant deltas ahead of finalization retries", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2996,6 +2996,59 @@ describe("ProviderRuntimeIngestion", () => {
     expect(assistantEvents.map((event) => event.payload.streaming)).toEqual([true, false]);
   });
 
+  it("does not resend fallback completion text when only completion retries", async () => {
+    const harness = await createHarness();
+    const itemId = asItemId("item-fallback-completion-retry");
+    const now = "2026-01-01T00:00:00.000Z";
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-fallback-completion-retry"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      itemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "fallback exactly once",
+      },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-fallback-completion-retry" &&
+            !message.streaming &&
+            message.text === "fallback exactly once",
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(3);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantEvents = events.filter(
+      (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-fallback-completion-retry",
+    );
+    expect(assistantEvents.map((event) => event.payload.text)).toEqual([
+      "fallback exactly once",
+      "",
+    ]);
+    expect(assistantEvents.map((event) => event.payload.streaming)).toEqual([true, false]);
+  });
+
   it("keeps retained streaming chunks bounded while dispatch retries", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
     const turnId = asTurnId("turn-streaming-bounded-retry");

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2922,6 +2922,99 @@ describe("ProviderRuntimeIngestion", () => {
     ).toHaveLength(2);
   });
 
+  it("resets assistant segment state after deferred finalization succeeds", async () => {
+    const harness = await createHarness();
+    const turnId = asTurnId("turn-deferred-finalization-segment-reset");
+    const itemId = asItemId("item-deferred-finalization-segment-reset");
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-deferred-finalization-segment-reset"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-first-delta-deferred-finalization-segment-reset"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "first" },
+    });
+
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-first-complete-deferred-finalization-segment-reset"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-finalization-segment-reset" &&
+            !message.streaming &&
+            message.text === "first",
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(3);
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-second-delta-deferred-finalization-segment-reset"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: " second" },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-second-complete-deferred-finalization-segment-reset"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-finalization-segment-reset" &&
+            !message.streaming &&
+            message.text === "first second",
+        ),
+      5000,
+    );
+    expect(
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-deferred-finalization-segment-reset:segment:1",
+      ),
+    ).toBe(false);
+  });
+
   it("does not duplicate a recovered final delta when completion also retries", async () => {
     const harness = await createHarness();
     const turnId = asTurnId("turn-finalization-stage-retry");
@@ -3677,6 +3770,66 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
     expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
+  });
+
+  it("publishes the completed session before later plan finalization fails", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-session-before-plan-finalization");
+    const itemId = asItemId("item-session-before-plan-finalization");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-session-before-plan-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-session-before-plan-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: "assistant completed" },
+    });
+    harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-session-before-plan-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { delta: "# Proposed plan" },
+    });
+    const didFailPlanUpsert = harness.failNextDispatch(
+      (command) => command.type === "thread.proposed-plan.upsert",
+    );
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-session-before-plan-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { state: "completed" },
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "ready" &&
+        thread.session.activeTurnId === null &&
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-session-before-plan-finalization" && !message.streaming,
+        ),
+    );
+    expect(didFailPlanUpsert()).toBe(true);
   });
 
   it("keeps a turn boundary behind deferred item finalization", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -45,7 +45,10 @@ import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityRes
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
-import { ProviderRuntimeIngestionLive } from "./ProviderRuntimeIngestion.ts";
+import {
+  finalizeTrackedAssistantMessages,
+  ProviderRuntimeIngestionLive,
+} from "./ProviderRuntimeIngestion.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -3244,6 +3247,23 @@ describe("ProviderRuntimeIngestion", () => {
       )?.streaming,
     ).toBe(true);
   });
+
+  effectIt.effect("releases each successful message after a partial turn finalization", () =>
+    Effect.gen(function* () {
+      const releasedMessageIds: string[] = [];
+      const results = yield* finalizeTrackedAssistantMessages(
+        ["successful", "failed"],
+        (messageId) => Effect.succeed(messageId === "successful"),
+        (messageId) =>
+          Effect.sync(() => {
+            releasedMessageIds.push(messageId);
+          }),
+      );
+
+      expect(results).toEqual([true, false]);
+      expect(releasedMessageIds).toEqual(["successful"]);
+    }),
+  );
 
   it("finalizes pending coalesced assistant text on runtime error", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3299,6 +3299,28 @@ describe("ProviderRuntimeIngestion", () => {
         ),
       5000,
     );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-runtime-error-after"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: timestampAt(3),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId: asItemId("item-streaming-runtime-error-after"),
+      payload: { streamKind: "assistant_text", delta: "after error" },
+    });
+    await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-streaming-runtime-error-after" &&
+            message.streaming &&
+            message.text === "after error",
+        ),
+      5000,
+    );
   });
 
   it("preserves a whitespace-only buffered tail when finalizing", async () => {
@@ -3589,6 +3611,71 @@ describe("ProviderRuntimeIngestion", () => {
     expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
     expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
     expect(completionEvents).toHaveLength(1);
+  });
+
+  it("keeps deferred assistant deltas ahead of finalization retries", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-deferred-delta-before-finalization");
+    const itemId = asItemId("item-deferred-delta-before-finalization");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-deferred-delta-before-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-item-completed-deferred-delta-before-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "before",
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-deferred-delta-before-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: " after" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-deferred-delta-before-finalization" &&
+            !message.streaming &&
+            message.text === "before after",
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(3);
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-deferred-delta-before-finalization",
+      )?.text,
+    ).toBe("before after");
   });
 
   it("maps canonical request events into approval activities with requestKind", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3867,6 +3867,15 @@ describe("ProviderRuntimeIngestion", () => {
       },
     });
     harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-deferred-item-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { delta: "# Finalized after the assistant" },
+    });
+    harness.emit({
       type: "turn.completed",
       eventId: asEventId("evt-turn-completed-deferred-item-finalization"),
       provider: ProviderDriverKind.make("codex"),
@@ -3899,6 +3908,11 @@ describe("ProviderRuntimeIngestion", () => {
         event.payload.messageId === "assistant:item-deferred-item-finalization" &&
         !event.payload.streaming,
     );
+    const proposedPlanIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.proposed-plan-upserted" &&
+        event.payload.proposedPlan.id === "plan:thread-1:turn:turn-deferred-item-finalization",
+    );
     const turnReadyIndex = events.findLastIndex(
       (event) => event.type === "thread.session-set" && event.payload.session.status === "ready",
     );
@@ -3909,6 +3923,7 @@ describe("ProviderRuntimeIngestion", () => {
         !event.payload.streaming,
     );
     expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
+    expect(proposedPlanIndex).toBeGreaterThan(assistantCompletionIndex);
     expect(turnReadyIndex).toBeGreaterThan(assistantCompletionIndex);
     expect(completionEvents).toHaveLength(1);
   });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3418,6 +3418,125 @@ describe("ProviderRuntimeIngestion", () => {
     expect(getFailureCount()).toBeLessThan(100);
   });
 
+  it("keeps already streamed text when the terminal fallback completes a message", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-terminal-fallback-prefix");
+    const itemId = asItemId("item-terminal-fallback-prefix");
+    const now = "2026-01-01T00:00:00.000Z";
+    const streamedPrefix = "already streamed and persisted prefix ";
+    const undispatchedSuffix = "suffix that only the fallback carries";
+    const expectedText = `${streamedPrefix}${undispatchedSuffix}`;
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-terminal-fallback-prefix"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    // The first delta flushes immediately, so the prefix is projected before
+    // any dispatch failure is injected.
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-terminal-fallback-prefix"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: streamedPrefix },
+    });
+    await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-terminal-fallback-prefix" &&
+            message.text === streamedPrefix,
+        ),
+      5000,
+    );
+
+    const getFailureCount = harness.failDispatches(
+      100,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-terminal-fallback-suffix"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: undispatchedSuffix },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-item-completed-terminal-fallback-prefix"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-terminal-fallback-prefix"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { state: "completed" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-terminal-fallback-prefix" && !message.streaming,
+        ),
+      5000,
+    );
+    await harness.drain();
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-terminal-fallback-prefix",
+      ),
+    ).toMatchObject({ text: expectedText, streaming: false });
+    expect(getFailureCount()).toBeGreaterThanOrEqual(3);
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const messageEvents = events.filter(
+      (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-terminal-fallback-prefix",
+    );
+    // The fallback appends its remainder as a streaming delta; no settling
+    // event may replace the message with that suffix alone.
+    expect(
+      messageEvents
+        .filter((event) => event.payload.streaming)
+        .map((event) => event.payload.text)
+        .join(""),
+    ).toBe(expectedText);
+    const settleTexts = messageEvents
+      .filter((event) => !event.payload.streaming)
+      .map((event) => event.payload.text);
+    expect(settleTexts.length).toBeGreaterThan(0);
+    expect(settleTexts.every((text) => text === "")).toBe(true);
+  });
+
   it("finalizes only the completed turn's assistant messages", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
     const firstTurnId = asTurnId("turn-streaming-completed-scope-first");

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3928,6 +3928,99 @@ describe("ProviderRuntimeIngestion", () => {
     expect(completionEvents).toHaveLength(1);
   });
 
+  it("preserves an aborted turn plan behind deferred assistant finalization", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-aborted-deferred-finalization");
+    const itemId = asItemId("item-aborted-deferred-finalization");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-aborted-deferred-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-aborted-deferred-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: {
+        streamKind: "assistant_text",
+        delta: "assistant before abort",
+      },
+    });
+    harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-aborted-deferred-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { delta: "# Preserve this aborted plan" },
+    });
+    const getCompleteFailureCount = harness.failDispatches(
+      3,
+      (command) => command.type === "thread.message.assistant.complete",
+    );
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-deferred-finalization"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { reason: "Interrupted by user." },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-aborted-deferred-finalization" && !message.streaming,
+        ) &&
+        entry.proposedPlans.some(
+          (proposedPlan: ProviderRuntimeTestProposedPlan) =>
+            proposedPlan.id === "plan:thread-1:turn:turn-aborted-deferred-finalization",
+        ),
+      5000,
+    );
+    expect(getCompleteFailureCount()).toBe(3);
+    expect(
+      thread.proposedPlans.find(
+        (proposedPlan: ProviderRuntimeTestProposedPlan) =>
+          proposedPlan.id === "plan:thread-1:turn:turn-aborted-deferred-finalization",
+      )?.planMarkdown,
+    ).toBe("# Preserve this aborted plan");
+
+    const events = await runtime!.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const assistantCompletionIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.messageId === "assistant:item-aborted-deferred-finalization" &&
+        !event.payload.streaming,
+    );
+    const proposedPlanIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.proposed-plan-upserted" &&
+        event.payload.proposedPlan.id === "plan:thread-1:turn:turn-aborted-deferred-finalization",
+    );
+    expect(assistantCompletionIndex).toBeGreaterThanOrEqual(0);
+    expect(proposedPlanIndex).toBeGreaterThan(assistantCompletionIndex);
+  });
+
   it("keeps a request boundary behind deferred pause finalization", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3334,6 +3334,90 @@ describe("ProviderRuntimeIngestion", () => {
     expect(getFailureCount()).toBeGreaterThanOrEqual(3);
   });
 
+  it("retains text and releases the turn boundary after permanent typed delta failures", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const turnId = asTurnId("turn-permanent-delta-failure");
+    const itemId = asItemId("item-permanent-delta-failure");
+    const now = "2026-01-01T00:00:00.000Z";
+    const assistantText = `${"retained through terminal fallback ".repeat(40)}tail`;
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-permanent-delta-failure"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+    await waitForThread(harness.readModel, (thread) => thread.session?.activeTurnId === turnId);
+
+    const getFailureCount = harness.failDispatches(
+      100,
+      (command) => command.type === "thread.message.assistant.delta",
+    );
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-content-delta-permanent-delta-failure"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { streamKind: "assistant_text", delta: assistantText },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-item-completed-permanent-delta-failure"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      itemId,
+      payload: { itemType: "assistant_message", status: "completed" },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-permanent-delta-failure"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId,
+      payload: { state: "completed" },
+    });
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-permanent-delta-failure"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: { name: "Boundary released after permanent failure" },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.title === "Boundary released after permanent failure" &&
+        entry.session?.status === "ready" &&
+        entry.session.activeTurnId === null &&
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-permanent-delta-failure" &&
+            !message.streaming &&
+            message.text === assistantText,
+        ),
+      5000,
+    );
+    await harness.drain();
+    expect(
+      thread.messages.find(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-permanent-delta-failure",
+      ),
+    ).toMatchObject({ text: assistantText, streaming: false });
+    expect(getFailureCount()).toBeGreaterThanOrEqual(3);
+    expect(getFailureCount()).toBeLessThan(100);
+  });
+
   it("finalizes only the completed turn's assistant messages", async () => {
     const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
     const firstTurnId = asTurnId("turn-streaming-completed-scope-first");

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -148,6 +148,24 @@ type RuntimeIngestionInput =
       isDeferred: true;
     };
 
+export const finalizeTrackedAssistantMessages = <MessageIdValue, FinalizeError, FinalizeServices>(
+  messageIds: Iterable<MessageIdValue>,
+  finalize: (messageId: MessageIdValue) => Effect.Effect<boolean, FinalizeError, FinalizeServices>,
+  release: (messageId: MessageIdValue) => Effect.Effect<void>,
+) =>
+  Effect.forEach(
+    messageIds,
+    (messageId) =>
+      Effect.gen(function* () {
+        const finalized = yield* finalize(messageId);
+        if (finalized) {
+          yield* release(messageId);
+        }
+        return finalized;
+      }),
+    { concurrency: 1 },
+  );
+
 function toTurnId(value: TurnId | string | undefined): TurnId | undefined {
   return value === undefined ? undefined : TurnId.make(String(value));
 }
@@ -2252,7 +2270,7 @@ const make = Effect.gen(function* () {
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(thread.id, turnId);
-          const finalizedAssistantMessages = yield* Effect.forEach(
+          const finalizedAssistantMessages = yield* finalizeTrackedAssistantMessages(
             assistantMessageIds,
             (assistantMessageId) =>
               finalizeAssistantMessage({
@@ -2265,7 +2283,8 @@ const make = Effect.gen(function* () {
                 finalDeltaCommandTag: "assistant-delta-finalize-fallback",
                 hasProjectedMessage: findMessageById(messages, assistantMessageId) !== undefined,
               }),
-            { concurrency: 1 },
+            (assistantMessageId) =>
+              releaseFinalizedAssistantMessageForTurn(thread.id, turnId, assistantMessageId),
           );
           if (finalizedAssistantMessages.every(Boolean)) {
             yield* clearAssistantMessageIdsForTurn(thread.id, turnId);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1415,8 +1415,14 @@ const make = Effect.gen(function* () {
             yield* markDeferredAssistantDelta(input.messageId);
           }
           yield* scheduleAssistantFinalizationRetry({
-            ...input,
             source: "assistant-finalize",
+            event: input.event,
+            threadId: input.threadId,
+            messageId: input.messageId,
+            ...(input.turnId ? { turnId: input.turnId } : {}),
+            createdAt: input.createdAt,
+            commandTag: input.commandTag,
+            finalDeltaCommandTag: input.finalDeltaCommandTag,
             hasProjectedMessage: shouldComplete,
             isDeferred: true,
           });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1921,6 +1921,7 @@ const make = Effect.gen(function* () {
           loadedThreadDetail = (yield* resolveThreadDetail(thread.id)) ?? null;
           return loadedThreadDetail;
         });
+      let deferredThreadSession: NonNullable<typeof thread.session> | null = null;
 
       const now = event.createdAt;
       const eventTurnId = toTurnId(event.turnId);
@@ -2049,24 +2050,34 @@ const make = Effect.gen(function* () {
             );
           }
 
-          yield* orchestrationEngine.dispatch({
-            type: "thread.session.set",
-            commandId: yield* providerCommandId(event, "thread-session-set"),
+          const nextSession = {
             threadId: thread.id,
-            session: {
+            status,
+            providerName: event.provider,
+            ...(event.providerInstanceId !== undefined
+              ? { providerInstanceId: event.providerInstanceId }
+              : {}),
+            runtimeMode: thread.session?.runtimeMode ?? "full-access",
+            activeTurnId: nextActiveTurnId,
+            lastError,
+            updatedAt: now,
+          } satisfies NonNullable<typeof thread.session>;
+          const shouldDeferSessionUpdate =
+            event.type === "turn.completed" ||
+            event.type === "session.exited" ||
+            (event.type === "session.state.changed" &&
+              (event.payload.state === "error" || event.payload.state === "stopped"));
+          if (shouldDeferSessionUpdate) {
+            deferredThreadSession = nextSession;
+          } else {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.session.set",
+              commandId: yield* providerCommandId(event, "thread-session-set"),
               threadId: thread.id,
-              status,
-              providerName: event.provider,
-              ...(event.providerInstanceId !== undefined
-                ? { providerInstanceId: event.providerInstanceId }
-                : {}),
-              runtimeMode: thread.session?.runtimeMode ?? "full-access",
-              activeTurnId: nextActiveTurnId,
-              lastError,
-              updatedAt: now,
-            },
-            createdAt: now,
-          });
+              session: nextSession,
+              createdAt: now,
+            });
+          }
         }
       }
 
@@ -2308,6 +2319,9 @@ const make = Effect.gen(function* () {
           threadId: thread.id,
           createdAt: now,
         });
+        if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
+          return;
+        }
         yield* clearTurnStateForSession(thread.id);
       }
 
@@ -2319,24 +2333,18 @@ const make = Effect.gen(function* () {
           : activeTurnId === null || eventTurnId === undefined || sameId(activeTurnId, eventTurnId);
 
         if (shouldApplyRuntimeError) {
-          yield* orchestrationEngine.dispatch({
-            type: "thread.session.set",
-            commandId: yield* providerCommandId(event, "runtime-error-session-set"),
+          deferredThreadSession = {
             threadId: thread.id,
-            session: {
-              threadId: thread.id,
-              status: "error",
-              providerName: event.provider,
-              ...(event.providerInstanceId !== undefined
-                ? { providerInstanceId: event.providerInstanceId }
-                : {}),
-              runtimeMode: thread.session?.runtimeMode ?? "full-access",
-              activeTurnId: eventTurnId ?? null,
-              lastError: runtimeErrorMessage,
-              updatedAt: now,
-            },
-            createdAt: now,
-          });
+            status: "error",
+            providerName: event.provider,
+            ...(event.providerInstanceId !== undefined
+              ? { providerInstanceId: event.providerInstanceId }
+              : {}),
+            runtimeMode: thread.session?.runtimeMode ?? "full-access",
+            activeTurnId: eventTurnId ?? null,
+            lastError: runtimeErrorMessage,
+            updatedAt: now,
+          };
           yield* finalizeAssistantMessagesForTerminalEvent({
             event,
             threadId: thread.id,
@@ -2404,6 +2412,22 @@ const make = Effect.gen(function* () {
           const threadDetail = yield* getLoadedThreadDetail();
           taskTitle = findTaskTitleInActivities(threadDetail?.activities, event.payload.taskId);
         }
+      }
+
+      if (deferredThreadSession !== null) {
+        if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
+          return;
+        }
+        yield* orchestrationEngine.dispatch({
+          type: "thread.session.set",
+          commandId: yield* providerCommandId(
+            event,
+            event.type === "runtime.error" ? "runtime-error-session-set" : "thread-session-set",
+          ),
+          threadId: thread.id,
+          session: deferredThreadSession,
+          createdAt: now,
+        });
       }
 
       const activities = runtimeEventToActivities(event, taskTitle);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2718,11 +2718,22 @@ const make = Effect.gen(function* () {
           }
           const finalized = yield* finalizeAssistantMessage(input);
           if (finalized && input.turnId) {
-            yield* resetFinalizedAssistantMessageForTurn(
-              input.threadId,
-              input.turnId,
-              input.messageId,
-            );
+            if (
+              input.event.type === "request.opened" ||
+              input.event.type === "user-input.requested"
+            ) {
+              yield* releaseFinalizedAssistantMessageForTurn(
+                input.threadId,
+                input.turnId,
+                input.messageId,
+              );
+            } else {
+              yield* resetFinalizedAssistantMessageForTurn(
+                input.threadId,
+                input.turnId,
+                input.messageId,
+              );
+            }
           }
         }).pipe(
           Effect.catchCause((cause) =>
@@ -2769,11 +2780,22 @@ const make = Effect.gen(function* () {
               yield* clearAssistantMessageState(input.messageId);
               yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
               if (input.turnId) {
-                yield* resetFinalizedAssistantMessageForTurn(
-                  input.threadId,
-                  input.turnId,
-                  input.messageId,
-                );
+                if (
+                  input.event.type === "request.opened" ||
+                  input.event.type === "user-input.requested"
+                ) {
+                  yield* releaseFinalizedAssistantMessageForTurn(
+                    input.threadId,
+                    input.turnId,
+                    input.messageId,
+                  );
+                } else {
+                  yield* resetFinalizedAssistantMessageForTurn(
+                    input.threadId,
+                    input.turnId,
+                    input.messageId,
+                  );
+                }
               }
             }),
           ),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -748,6 +748,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(0),
   });
 
+  const assistantLatestOccurredAtByMessageId = yield* Cache.make<MessageId, string>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(""),
+  });
+
   const streamingAssistantFlushScheduledByMessageId = yield* Cache.make<MessageId, boolean>({
     capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
@@ -1079,14 +1085,59 @@ const make = Effect.gen(function* () {
       clearBufferedAssistantText(messageId),
       Cache.invalidate(streamingAssistantLastFlushAtByMessageId, messageId),
       Cache.invalidate(streamingAssistantFlushScheduledByMessageId, messageId),
+      Cache.invalidate(assistantLatestOccurredAtByMessageId, messageId),
+      Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId),
     ]).pipe(Effect.asVoid);
+
+  const laterOccurredAt = (left: string, right: string) => {
+    const leftMillis = Date.parse(left);
+    const rightMillis = Date.parse(right);
+    if (!Number.isFinite(leftMillis)) return right;
+    if (!Number.isFinite(rightMillis)) return left;
+    return rightMillis >= leftMillis ? right : left;
+  };
+
+  const rememberAssistantOccurredAt = (messageId: MessageId, occurredAt: string) =>
+    Cache.getOption(assistantLatestOccurredAtByMessageId, messageId).pipe(
+      Effect.flatMap((existing) =>
+        Cache.set(
+          assistantLatestOccurredAtByMessageId,
+          messageId,
+          Option.match(existing, {
+            onNone: () => occurredAt,
+            onSome: (value) => (value.length > 0 ? laterOccurredAt(value, occurredAt) : occurredAt),
+          }),
+        ),
+      ),
+    );
+
+  const getLatestAssistantOccurredAt = (messageId: MessageId, fallback: string) =>
+    Cache.getOption(assistantLatestOccurredAtByMessageId, messageId).pipe(
+      Effect.map((existing) =>
+        Option.match(existing, {
+          onNone: () => fallback,
+          onSome: (value) => (value.length > 0 ? laterOccurredAt(value, fallback) : fallback),
+        }),
+      ),
+    );
 
   const commitStreamingAssistantFlush = (messageId: MessageId, occurredAt: string) =>
     Effect.gen(function* () {
       yield* clearBufferedAssistantText(messageId);
       const occurredAtMillis = Date.parse(occurredAt);
       if (Number.isFinite(occurredAtMillis)) {
-        yield* Cache.set(streamingAssistantLastFlushAtByMessageId, messageId, occurredAtMillis);
+        const previous = yield* Cache.getOption(
+          streamingAssistantLastFlushAtByMessageId,
+          messageId,
+        );
+        yield* Cache.set(
+          streamingAssistantLastFlushAtByMessageId,
+          messageId,
+          Math.max(
+            Option.getOrElse(previous, () => 0),
+            occurredAtMillis,
+          ),
+        );
       }
     });
 
@@ -1113,6 +1164,7 @@ const make = Effect.gen(function* () {
     commandTag: string;
   }) =>
     Effect.gen(function* () {
+      const createdAt = yield* getLatestAssistantOccurredAt(input.messageId, input.createdAt);
       const commandId = yield* providerCommandId(input.event, input.commandTag);
       yield* dispatchRetainedAssistantDelta(
         {
@@ -1122,9 +1174,9 @@ const make = Effect.gen(function* () {
           messageId: input.messageId,
           delta: input.delta,
           ...(input.turnId ? { turnId: input.turnId } : {}),
-          createdAt: input.createdAt,
+          createdAt,
         },
-        commitStreamingAssistantFlush(input.messageId, input.createdAt),
+        commitStreamingAssistantFlush(input.messageId, createdAt),
       ).pipe(
         // Keep a short synchronous retry window, then let the caller retain
         // and defer the chunk so one failed message cannot monopolize the
@@ -1199,6 +1251,17 @@ const make = Effect.gen(function* () {
       Effect.flatMap(() =>
         enqueueInput
           ? enqueueInput(input)
+          : Effect.die(new Error("provider runtime ingestion worker is not initialized")),
+      ),
+      Effect.forkIn(streamingFlushTimerScope),
+      Effect.asVoid,
+    );
+
+  const scheduleRuntimeEventRetry = (event: ProviderRuntimeEvent) =>
+    Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
+      Effect.flatMap(() =>
+        enqueueInput
+          ? enqueueInput({ source: "runtime", event })
           : Effect.die(new Error("provider runtime ingestion worker is not initialized")),
       ),
       Effect.forkIn(streamingFlushTimerScope),
@@ -1288,20 +1351,54 @@ const make = Effect.gen(function* () {
           : "";
       const shouldDispatchText =
         hasRenderableAssistantText(text) || (hasBufferedText && input.hasProjectedMessage === true);
+      const createdAt = yield* getLatestAssistantOccurredAt(input.messageId, input.createdAt);
 
       if (shouldDispatchText) {
-        yield* dispatchRetainedAssistantDelta(
-          {
-            type: "thread.message.assistant.delta",
-            commandId: yield* providerCommandId(input.event, input.finalDeltaCommandTag),
+        const commandId = yield* providerCommandId(input.event, input.finalDeltaCommandTag);
+        const dispatchExit = yield* Effect.exit(
+          dispatchRetainedAssistantDelta(
+            {
+              type: "thread.message.assistant.delta",
+              commandId,
+              threadId: input.threadId,
+              messageId: input.messageId,
+              delta: text,
+              ...(input.turnId ? { turnId: input.turnId } : {}),
+              createdAt,
+            },
+            clearBufferedAssistantText(input.messageId),
+          ).pipe(
+            Effect.retry({
+              schedule: Schedule.spaced(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)),
+              times: 2,
+            }),
+          ),
+        );
+        if (Exit.isFailure(dispatchExit)) {
+          yield* Effect.logWarning(
+            "provider runtime ingestion deferred assistant finalization after retries",
+            {
+              eventId: input.event.eventId,
+              messageId: input.messageId,
+              cause: Cause.pretty(dispatchExit.cause),
+            },
+          );
+          yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, text);
+          yield* markDeferredAssistantDelta(input.messageId);
+          yield* scheduleAssistantDeltaRetry({
+            source: "assistant-delta",
+            event: input.event,
             threadId: input.threadId,
             messageId: input.messageId,
-            delta: text,
             ...(input.turnId ? { turnId: input.turnId } : {}),
-            createdAt: input.createdAt,
-          },
-          clearBufferedAssistantText(input.messageId),
-        );
+            deliveryMode: "streaming",
+            delta: "",
+            flushPendingFirst: true,
+            isDeferred: true,
+          });
+          yield* scheduleRuntimeEventRetry(input.event);
+          return yield* Effect.failCause(dispatchExit.cause);
+        }
       }
 
       if (input.hasProjectedMessage || shouldDispatchText) {
@@ -1311,7 +1408,7 @@ const make = Effect.gen(function* () {
           threadId: input.threadId,
           messageId: input.messageId,
           ...(input.turnId ? { turnId: input.turnId } : {}),
-          createdAt: input.createdAt,
+          createdAt,
         });
       }
       yield* clearAssistantMessageState(input.messageId);
@@ -1682,15 +1779,7 @@ const make = Effect.gen(function* () {
       if (!hasDeferredDeltas) {
         return false;
       }
-
-      const enqueue = enqueueInput;
-      if (!enqueue) {
-        return yield* Effect.die(new Error("provider runtime ingestion worker is not initialized"));
-      }
-      yield* Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
-        Effect.flatMap(() => enqueue({ source: "runtime", event })),
-        Effect.forkIn(streamingFlushTimerScope),
-      );
+      yield* scheduleRuntimeEventRetry(event);
       return true;
     });
 
@@ -2201,6 +2290,7 @@ const make = Effect.gen(function* () {
     input: Extract<RuntimeIngestionInput, { source: "assistant-delta" }>,
   ) =>
     Effect.gen(function* () {
+      yield* rememberAssistantOccurredAt(input.messageId, input.event.createdAt);
       const maxRetainedChars =
         input.deliveryMode === "streaming"
           ? MAX_COALESCED_STREAMING_ASSISTANT_CHARS

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1451,7 +1451,7 @@ const make = Effect.gen(function* () {
         );
         if (Exit.isFailure(dispatchExit)) {
           yield* deferFinalization(dispatchExit.cause, true);
-          return;
+          return false;
         }
       }
 
@@ -1476,11 +1476,12 @@ const make = Effect.gen(function* () {
         );
         if (Exit.isFailure(dispatchExit)) {
           yield* deferFinalization(dispatchExit.cause, false);
-          return;
+          return false;
         }
       }
       yield* clearAssistantMessageState(input.messageId);
       yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
+      return true;
     });
 
   const finalizeActiveAssistantSegmentForTurn = (input: {
@@ -1502,7 +1503,7 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      yield* finalizeAssistantMessage({
+      const finalized = yield* finalizeAssistantMessage({
         event: input.event,
         threadId: input.threadId,
         messageId: activeMessageId.value,
@@ -1514,6 +1515,9 @@ const make = Effect.gen(function* () {
           input.hasProjectedMessage ||
           (input.flushedMessageIds?.has(activeMessageId.value) ?? false),
       });
+      if (!finalized) {
+        return;
+      }
       yield* forgetAssistantMessageId(input.threadId, input.turnId, activeMessageId.value);
 
       const state = yield* getAssistantSegmentStateForTurn(input.threadId, input.turnId);
@@ -2059,7 +2063,7 @@ const make = Effect.gen(function* () {
           serverSettingsService.getSettings,
           (settings) => (settings.enableAssistantStreaming ? "streaming" : "buffered"),
         );
-        yield* processAssistantDelta({
+        const assistantDeltaInput = {
           source: "assistant-delta",
           event,
           threadId: thread.id,
@@ -2067,7 +2071,20 @@ const make = Effect.gen(function* () {
           ...(turnId ? { turnId } : {}),
           deliveryMode: assistantDeliveryMode,
           delta: assistantDelta,
-        });
+        } as const;
+        if (yield* hasDeferredAssistantDelta(assistantMessageId)) {
+          // Keep later provider events behind the already scheduled retry.
+          // Otherwise they can enter the retained buffer between a failed
+          // chunk and that input's unprocessed remainder.
+          yield* markDeferredAssistantDelta(assistantMessageId);
+          yield* scheduleAssistantDeltaRetry({
+            ...assistantDeltaInput,
+            flushPendingFirst: true,
+            isDeferred: true,
+          });
+        } else {
+          yield* processAssistantDelta(assistantDeltaInput);
+        }
       }
 
       const pauseForUserTurnId =
@@ -2161,12 +2178,13 @@ const make = Effect.gen(function* () {
           hasAssistantMessagesForTurn &&
           (assistantCompletion.fallbackText?.trim().length ?? 0) === 0;
 
+        let assistantFinalized = true;
         if (!shouldSkipRedundantCompletion) {
           if (turnId && Option.isNone(activeAssistantMessageId)) {
             yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
           }
 
-          yield* finalizeAssistantMessage({
+          assistantFinalized = yield* finalizeAssistantMessage({
             event,
             threadId: thread.id,
             messageId: assistantMessageId,
@@ -2180,12 +2198,12 @@ const make = Effect.gen(function* () {
               : {}),
           });
 
-          if (turnId) {
+          if (turnId && assistantFinalized) {
             yield* forgetAssistantMessageId(thread.id, turnId, assistantMessageId);
           }
         }
 
-        if (turnId) {
+        if (turnId && assistantFinalized) {
           yield* clearAssistantSegmentStateForTurn(thread.id, turnId);
         }
       }
@@ -2210,7 +2228,7 @@ const make = Effect.gen(function* () {
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(thread.id, turnId);
-          yield* Effect.forEach(
+          const finalizedAssistantMessages = yield* Effect.forEach(
             assistantMessageIds,
             (assistantMessageId) =>
               finalizeAssistantMessage({
@@ -2224,9 +2242,11 @@ const make = Effect.gen(function* () {
                 hasProjectedMessage: findMessageById(messages, assistantMessageId) !== undefined,
               }),
             { concurrency: 1 },
-          ).pipe(Effect.asVoid);
-          yield* clearAssistantMessageIdsForTurn(thread.id, turnId);
-          yield* clearAssistantSegmentStateForTurn(thread.id, turnId);
+          );
+          if (finalizedAssistantMessages.every(Boolean)) {
+            yield* clearAssistantMessageIdsForTurn(thread.id, turnId);
+            yield* clearAssistantSegmentStateForTurn(thread.id, turnId);
+          }
 
           yield* finalizeBufferedProposedPlan({
             event,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -959,6 +959,19 @@ const make = Effect.gen(function* () {
       ),
     );
 
+  const releaseFinalizedAssistantMessageForTurn = Effect.fn(
+    "releaseFinalizedAssistantMessageForTurn",
+  )(function* (threadId: ThreadId, turnId: TurnId, messageId: MessageId) {
+    yield* forgetAssistantMessageId(threadId, turnId, messageId);
+    const state = yield* getAssistantSegmentStateForTurn(threadId, turnId);
+    if (Option.isSome(state) && state.value.activeMessageId === messageId) {
+      yield* setAssistantSegmentStateForTurn(threadId, turnId, {
+        ...state.value,
+        activeMessageId: null,
+      });
+    }
+  });
+
   const startAssistantSegmentForTurn = (input: {
     threadId: ThreadId;
     turnId: TurnId;
@@ -1518,15 +1531,11 @@ const make = Effect.gen(function* () {
       if (!finalized) {
         return;
       }
-      yield* forgetAssistantMessageId(input.threadId, input.turnId, activeMessageId.value);
-
-      const state = yield* getAssistantSegmentStateForTurn(input.threadId, input.turnId);
-      if (Option.isSome(state)) {
-        yield* setAssistantSegmentStateForTurn(input.threadId, input.turnId, {
-          ...state.value,
-          activeMessageId: null,
-        });
-      }
+      yield* releaseFinalizedAssistantMessageForTurn(
+        input.threadId,
+        input.turnId,
+        activeMessageId.value,
+      );
     });
 
   const upsertProposedPlan = (input: {
@@ -2568,10 +2577,17 @@ const make = Effect.gen(function* () {
       case "assistant-delta":
         return processAssistantDelta(input);
       case "assistant-finalize":
-        return Cache.invalidate(
-          assistantFinalizationRetryScheduledByMessageId,
-          input.messageId,
-        ).pipe(Effect.andThen(finalizeAssistantMessage(input)));
+        return Effect.gen(function* () {
+          yield* Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, input.messageId);
+          const finalized = yield* finalizeAssistantMessage(input);
+          if (finalized && input.turnId) {
+            yield* releaseFinalizedAssistantMessageForTurn(
+              input.threadId,
+              input.turnId,
+              input.messageId,
+            );
+          }
+        });
     }
   };
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -22,8 +22,11 @@ import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
@@ -111,6 +114,25 @@ type RuntimeIngestionInput =
   | {
       source: "domain";
       event: TurnStartRequestedDomainEvent;
+    }
+  | {
+      source: "assistant-flush";
+      event: ProviderRuntimeEvent;
+      threadId: ThreadId;
+      messageId: MessageId;
+      turnId?: TurnId;
+      isDeferred?: boolean;
+    }
+  | {
+      source: "assistant-delta";
+      event: ProviderRuntimeEvent;
+      threadId: ThreadId;
+      messageId: MessageId;
+      turnId?: TurnId;
+      deliveryMode: AssistantDeliveryMode;
+      delta: string;
+      flushPendingFirst?: boolean;
+      isDeferred?: boolean;
     };
 
 function toTurnId(value: TurnId | string | undefined): TurnId | undefined {
@@ -708,6 +730,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(new Set<MessageId>()),
   });
 
+  const assistantMessageIdsByThreadId = yield* Cache.make<ThreadId, Set<MessageId>>({
+    capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
+    timeToLive: TURN_MESSAGE_IDS_BY_TURN_TTL,
+    lookup: () => Effect.succeed(new Set<MessageId>()),
+  });
+
   const bufferedAssistantTextByMessageId = yield* Cache.make<MessageId, string>({
     capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
@@ -719,6 +747,22 @@ const make = Effect.gen(function* () {
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
     lookup: () => Effect.succeed(0),
   });
+
+  const streamingAssistantFlushScheduledByMessageId = yield* Cache.make<MessageId, boolean>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(false),
+  });
+
+  const deferredAssistantDeltaCountByMessageId = yield* Cache.make<MessageId, number>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(0),
+  });
+
+  const streamingFlushTimerScope = yield* Scope.make("sequential");
+  yield* Effect.addFinalizer(() => Scope.close(streamingFlushTimerScope, Exit.void));
+  let enqueueInput: ((input: RuntimeIngestionInput) => Effect.Effect<void>) | undefined;
 
   const assistantSegmentStateByTurnKey = yield* Cache.make<string, AssistantSegmentState>({
     capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
@@ -784,6 +828,62 @@ const make = Effect.gen(function* () {
           }),
         ),
       ),
+    );
+
+  const rememberAssistantMessageIdForThread = (threadId: ThreadId, messageId: MessageId) =>
+    Cache.getOption(assistantMessageIdsByThreadId, threadId).pipe(
+      Effect.flatMap((existingIds) =>
+        Cache.set(
+          assistantMessageIdsByThreadId,
+          threadId,
+          Option.match(existingIds, {
+            onNone: () => new Set([messageId]),
+            onSome: (ids) => new Set([...ids, messageId]),
+          }),
+        ),
+      ),
+    );
+
+  const forgetAssistantMessageIdForThread = (threadId: ThreadId, messageId: MessageId) =>
+    Cache.getOption(assistantMessageIdsByThreadId, threadId).pipe(
+      Effect.flatMap((existingIds) =>
+        Option.match(existingIds, {
+          onNone: () => Effect.void,
+          onSome: (ids) => {
+            const nextIds = new Set(ids);
+            nextIds.delete(messageId);
+            return nextIds.size === 0
+              ? Cache.invalidate(assistantMessageIdsByThreadId, threadId)
+              : Cache.set(assistantMessageIdsByThreadId, threadId, nextIds);
+          },
+        }),
+      ),
+    );
+
+  const markDeferredAssistantDelta = (messageId: MessageId) =>
+    Cache.getOption(deferredAssistantDeltaCountByMessageId, messageId).pipe(
+      Effect.flatMap((count) =>
+        Cache.set(
+          deferredAssistantDeltaCountByMessageId,
+          messageId,
+          Option.getOrElse(count, () => 0) + 1,
+        ),
+      ),
+    );
+
+  const completeDeferredAssistantDelta = (messageId: MessageId) =>
+    Cache.getOption(deferredAssistantDeltaCountByMessageId, messageId).pipe(
+      Effect.flatMap((count) => {
+        const nextCount = Math.max(0, Option.getOrElse(count, () => 0) - 1);
+        return nextCount === 0
+          ? Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId)
+          : Cache.set(deferredAssistantDeltaCountByMessageId, messageId, nextCount);
+      }),
+    );
+
+  const hasDeferredAssistantDelta = (messageId: MessageId) =>
+    Cache.getOption(deferredAssistantDeltaCountByMessageId, messageId).pipe(
+      Effect.map((count) => Option.getOrElse(count, () => 0) > 0),
     );
 
   const forgetAssistantMessageId = (threadId: ThreadId, turnId: TurnId, messageId: MessageId) =>
@@ -897,13 +997,12 @@ const make = Effect.gen(function* () {
             onNone: () => delta,
             onSome: (text) => `${text}${delta}`,
           });
-          if (nextText.length <= MAX_BUFFERED_ASSISTANT_CHARS) {
-            yield* Cache.set(bufferedAssistantTextByMessageId, messageId, nextText);
+          yield* Cache.set(bufferedAssistantTextByMessageId, messageId, nextText);
+          if (nextText.length < MAX_BUFFERED_ASSISTANT_CHARS) {
             return "";
           }
 
           // Safety valve: flush full buffered text as an assistant delta to cap memory.
-          yield* Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
           return nextText;
         }),
       ),
@@ -936,20 +1035,16 @@ const make = Effect.gen(function* () {
         return "";
       }
 
-      yield* Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
-      if (Number.isFinite(occurredAtMillis)) {
-        yield* Cache.set(streamingAssistantLastFlushAtByMessageId, messageId, occurredAtMillis);
-      }
+      // Keep the pending text buffered until the caller confirms dispatch. If
+      // dispatch fails, a later delta or terminal event can retry the complete
+      // chunk instead of silently dropping it.
+      yield* Cache.set(bufferedAssistantTextByMessageId, messageId, nextText);
       return nextText;
     });
 
-  const takeBufferedAssistantText = (messageId: MessageId) =>
+  const peekBufferedAssistantText = (messageId: MessageId) =>
     Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
-      Effect.flatMap((existingText) =>
-        Cache.invalidate(bufferedAssistantTextByMessageId, messageId).pipe(
-          Effect.as(Option.getOrElse(existingText, () => "")),
-        ),
-      ),
+      Effect.map((existingText) => Option.getOrElse(existingText, () => "")),
     );
 
   const clearBufferedAssistantText = (messageId: MessageId) =>
@@ -983,7 +1078,132 @@ const make = Effect.gen(function* () {
     Effect.all([
       clearBufferedAssistantText(messageId),
       Cache.invalidate(streamingAssistantLastFlushAtByMessageId, messageId),
+      Cache.invalidate(streamingAssistantFlushScheduledByMessageId, messageId),
     ]).pipe(Effect.asVoid);
+
+  const commitStreamingAssistantFlush = (messageId: MessageId, occurredAt: string) =>
+    Effect.gen(function* () {
+      yield* clearBufferedAssistantText(messageId);
+      const occurredAtMillis = Date.parse(occurredAt);
+      if (Number.isFinite(occurredAtMillis)) {
+        yield* Cache.set(streamingAssistantLastFlushAtByMessageId, messageId, occurredAtMillis);
+      }
+    });
+
+  const dispatchRetainedAssistantDelta = (
+    command: Parameters<typeof orchestrationEngine.dispatch>[0],
+    acknowledge: Effect.Effect<void>,
+  ) =>
+    // Engine dispatch is transactional: failure means no event was committed.
+    // Mask interruption across a successful dispatch and its cache
+    // acknowledgement so a committed chunk cannot remain buffered for retry.
+    Effect.uninterruptible(
+      Effect.suspend(() => orchestrationEngine.dispatch(command)).pipe(
+        Effect.tap(() => acknowledge),
+      ),
+    );
+
+  const dispatchStreamingAssistantDelta = (input: {
+    event: ProviderRuntimeEvent;
+    threadId: ThreadId;
+    messageId: MessageId;
+    turnId?: TurnId;
+    delta: string;
+    createdAt: string;
+    commandTag: string;
+  }) =>
+    Effect.gen(function* () {
+      const commandId = yield* providerCommandId(input.event, input.commandTag);
+      yield* dispatchRetainedAssistantDelta(
+        {
+          type: "thread.message.assistant.delta",
+          commandId,
+          threadId: input.threadId,
+          messageId: input.messageId,
+          delta: input.delta,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          createdAt: input.createdAt,
+        },
+        commitStreamingAssistantFlush(input.messageId, input.createdAt),
+      ).pipe(
+        // Keep a short synchronous retry window, then let the caller retain
+        // and defer the chunk so one failed message cannot monopolize the
+        // shared ingestion worker. One command id keeps retries idempotent.
+        Effect.retry({
+          schedule: Schedule.spaced(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)),
+          times: 2,
+        }),
+      );
+    });
+
+  const dispatchBufferedAssistantDelta = (input: {
+    event: ProviderRuntimeEvent;
+    threadId: ThreadId;
+    messageId: MessageId;
+    turnId?: TurnId;
+    delta: string;
+    createdAt: string;
+  }) =>
+    Effect.gen(function* () {
+      const commandId = yield* providerCommandId(input.event, "assistant-delta-buffer-spill");
+      yield* dispatchRetainedAssistantDelta(
+        {
+          type: "thread.message.assistant.delta",
+          commandId,
+          threadId: input.threadId,
+          messageId: input.messageId,
+          delta: input.delta,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          createdAt: input.createdAt,
+        },
+        clearBufferedAssistantText(input.messageId),
+      ).pipe(
+        Effect.retry({
+          schedule: Schedule.spaced(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)),
+          times: 2,
+        }),
+      );
+    });
+
+  const scheduleStreamingAssistantFlush = (input: {
+    event: ProviderRuntimeEvent;
+    threadId: ThreadId;
+    messageId: MessageId;
+    turnId?: TurnId;
+    isDeferred?: boolean;
+  }) =>
+    Effect.gen(function* () {
+      const existing = yield* Cache.getOption(
+        streamingAssistantFlushScheduledByMessageId,
+        input.messageId,
+      );
+      if (Option.getOrElse(existing, () => false)) {
+        return;
+      }
+
+      yield* Cache.set(streamingAssistantFlushScheduledByMessageId, input.messageId, true);
+      yield* Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
+        Effect.flatMap(() =>
+          enqueueInput
+            ? enqueueInput({ source: "assistant-flush", ...input })
+            : Effect.die(new Error("provider runtime ingestion worker is not initialized")),
+        ),
+        Effect.forkIn(streamingFlushTimerScope),
+      );
+    });
+
+  const scheduleAssistantDeltaRetry = (
+    input: Extract<RuntimeIngestionInput, { source: "assistant-delta" }>,
+  ) =>
+    Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
+      Effect.flatMap(() =>
+        enqueueInput
+          ? enqueueInput(input)
+          : Effect.die(new Error("provider runtime ingestion worker is not initialized")),
+      ),
+      Effect.forkIn(streamingFlushTimerScope),
+      Effect.asVoid,
+    );
 
   const flushBufferedAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -994,20 +1214,23 @@ const make = Effect.gen(function* () {
     commandTag: string;
   }) =>
     Effect.gen(function* () {
-      const bufferedText = yield* takeBufferedAssistantText(input.messageId);
+      const bufferedText = yield* peekBufferedAssistantText(input.messageId);
       if (!hasRenderableAssistantText(bufferedText)) {
         return false;
       }
 
-      yield* orchestrationEngine.dispatch({
-        type: "thread.message.assistant.delta",
-        commandId: yield* providerCommandId(input.event, input.commandTag),
-        threadId: input.threadId,
-        messageId: input.messageId,
-        delta: bufferedText,
-        ...(input.turnId ? { turnId: input.turnId } : {}),
-        createdAt: input.createdAt,
-      });
+      yield* dispatchRetainedAssistantDelta(
+        {
+          type: "thread.message.assistant.delta",
+          commandId: yield* providerCommandId(input.event, input.commandTag),
+          threadId: input.threadId,
+          messageId: input.messageId,
+          delta: bufferedText,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          createdAt: input.createdAt,
+        },
+        clearBufferedAssistantText(input.messageId),
+      );
       return true;
     });
 
@@ -1056,28 +1279,32 @@ const make = Effect.gen(function* () {
     hasProjectedMessage?: boolean;
   }) =>
     Effect.gen(function* () {
-      const bufferedText = yield* takeBufferedAssistantText(input.messageId);
-      const text =
-        bufferedText.length > 0
-          ? bufferedText
-          : (input.fallbackText?.trim().length ?? 0) > 0
-            ? input.fallbackText!
-            : "";
-      const hasRenderableText = hasRenderableAssistantText(text);
+      const bufferedText = yield* peekBufferedAssistantText(input.messageId);
+      const hasBufferedText = bufferedText.length > 0;
+      const text = hasBufferedText
+        ? bufferedText
+        : (input.fallbackText?.trim().length ?? 0) > 0
+          ? input.fallbackText!
+          : "";
+      const shouldDispatchText =
+        hasRenderableAssistantText(text) || (hasBufferedText && input.hasProjectedMessage === true);
 
-      if (hasRenderableText) {
-        yield* orchestrationEngine.dispatch({
-          type: "thread.message.assistant.delta",
-          commandId: yield* providerCommandId(input.event, input.finalDeltaCommandTag),
-          threadId: input.threadId,
-          messageId: input.messageId,
-          delta: text,
-          ...(input.turnId ? { turnId: input.turnId } : {}),
-          createdAt: input.createdAt,
-        });
+      if (shouldDispatchText) {
+        yield* dispatchRetainedAssistantDelta(
+          {
+            type: "thread.message.assistant.delta",
+            commandId: yield* providerCommandId(input.event, input.finalDeltaCommandTag),
+            threadId: input.threadId,
+            messageId: input.messageId,
+            delta: text,
+            ...(input.turnId ? { turnId: input.turnId } : {}),
+            createdAt: input.createdAt,
+          },
+          clearBufferedAssistantText(input.messageId),
+        );
       }
 
-      if (input.hasProjectedMessage || hasRenderableText) {
+      if (input.hasProjectedMessage || shouldDispatchText) {
         yield* orchestrationEngine.dispatch({
           type: "thread.message.assistant.complete",
           commandId: yield* providerCommandId(input.event, input.commandTag),
@@ -1088,6 +1315,7 @@ const make = Effect.gen(function* () {
         });
       }
       yield* clearAssistantMessageState(input.messageId);
+      yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
     });
 
   const finalizeActiveAssistantSegmentForTurn = (input: {
@@ -1210,6 +1438,77 @@ const make = Effect.gen(function* () {
       yield* clearBufferedProposedPlan(input.planId);
     });
 
+  const finalizeAssistantMessagesForTerminalEvent = (input: {
+    event: ProviderRuntimeEvent;
+    threadId: ThreadId;
+    createdAt: string;
+  }) =>
+    Effect.gen(function* () {
+      const prefix = `${input.threadId}:`;
+      const turnKeys = Array.from(yield* Cache.keys(turnMessageIdsByTurnKey));
+      const detailedThread = yield* resolveThreadDetail(input.threadId);
+      const messages = detailedThread?.messages ?? [];
+      const finalizedMessageIds = new Set<MessageId>();
+
+      yield* Effect.forEach(
+        turnKeys,
+        (key) =>
+          Effect.gen(function* () {
+            if (!key.startsWith(prefix)) {
+              return;
+            }
+
+            const turnId = TurnId.make(key.slice(prefix.length));
+            const messageIds = yield* Cache.getOption(turnMessageIdsByTurnKey, key);
+            if (Option.isNone(messageIds)) {
+              return;
+            }
+
+            yield* Effect.forEach(
+              messageIds.value,
+              (messageId) => {
+                finalizedMessageIds.add(messageId);
+                return finalizeAssistantMessage({
+                  event: input.event,
+                  threadId: input.threadId,
+                  messageId,
+                  turnId,
+                  createdAt: input.createdAt,
+                  commandTag: "assistant-complete-on-session-exit",
+                  finalDeltaCommandTag: "assistant-delta-finalize-on-session-exit",
+                  hasProjectedMessage: findMessageById(messages, messageId) !== undefined,
+                });
+              },
+              { concurrency: 1 },
+            ).pipe(Effect.asVoid);
+          }),
+        { concurrency: 1 },
+      ).pipe(Effect.asVoid);
+
+      const threadMessageIds = yield* Cache.getOption(
+        assistantMessageIdsByThreadId,
+        input.threadId,
+      );
+      if (Option.isSome(threadMessageIds)) {
+        yield* Effect.forEach(
+          threadMessageIds.value,
+          (messageId) =>
+            finalizedMessageIds.has(messageId)
+              ? Effect.void
+              : finalizeAssistantMessage({
+                  event: input.event,
+                  threadId: input.threadId,
+                  messageId,
+                  createdAt: input.createdAt,
+                  commandTag: "assistant-complete-on-session-exit",
+                  finalDeltaCommandTag: "assistant-delta-finalize-on-session-exit",
+                  hasProjectedMessage: findMessageById(messages, messageId) !== undefined,
+                }),
+          { concurrency: 1 },
+        ).pipe(Effect.asVoid);
+      }
+    });
+
   const clearTurnStateForSession = (threadId: ThreadId) =>
     Effect.gen(function* () {
       const prefix = `${threadId}:`;
@@ -1237,6 +1536,7 @@ const make = Effect.gen(function* () {
           }),
         { concurrency: 1 },
       ).pipe(Effect.asVoid);
+      yield* Cache.invalidate(assistantMessageIdsByThreadId, threadId);
       yield* Effect.forEach(
         assistantSegmentKeys,
         (key) =>
@@ -1337,10 +1637,70 @@ const make = Effect.gen(function* () {
     },
   );
 
+  const assistantMessageIdsForBoundaryEvent = (event: ProviderRuntimeEvent, threadId: ThreadId) =>
+    Effect.gen(function* () {
+      if (event.type === "item.completed" && event.payload.itemType === "assistant_message") {
+        const turnId = toTurnId(event.turnId);
+        const activeMessageId = turnId
+          ? yield* getActiveAssistantMessageIdForTurn(threadId, turnId)
+          : Option.none<MessageId>();
+        return [
+          Option.getOrElse(activeMessageId, () =>
+            MessageId.make(`assistant:${event.itemId ?? event.turnId ?? event.eventId}`),
+          ),
+        ];
+      }
+
+      if (
+        event.type === "turn.completed" ||
+        event.type === "turn.aborted" ||
+        event.type === "request.opened" ||
+        event.type === "user-input.requested"
+      ) {
+        const turnId = toTurnId(event.turnId);
+        return turnId ? Array.from(yield* getAssistantMessageIdsForTurn(threadId, turnId)) : [];
+      }
+
+      const isThreadTerminalBoundary =
+        event.type === "session.exited" ||
+        event.type === "runtime.error" ||
+        (event.type === "session.state.changed" &&
+          (event.payload.state === "error" || event.payload.state === "stopped"));
+      if (!isThreadTerminalBoundary) {
+        return [];
+      }
+      const messageIds = yield* Cache.getOption(assistantMessageIdsByThreadId, threadId);
+      return Array.from(Option.getOrElse(messageIds, () => new Set<MessageId>()));
+    });
+
+  const deferBoundaryEventForAssistantDeltas = (event: ProviderRuntimeEvent, threadId: ThreadId) =>
+    Effect.gen(function* () {
+      const messageIds = yield* assistantMessageIdsForBoundaryEvent(event, threadId);
+      const hasDeferredDeltas = yield* Effect.forEach(messageIds, hasDeferredAssistantDelta).pipe(
+        Effect.map((entries) => entries.some(Boolean)),
+      );
+      if (!hasDeferredDeltas) {
+        return false;
+      }
+
+      const enqueue = enqueueInput;
+      if (!enqueue) {
+        return yield* Effect.die(new Error("provider runtime ingestion worker is not initialized"));
+      }
+      yield* Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
+        Effect.flatMap(() => enqueue({ source: "runtime", event })),
+        Effect.forkIn(streamingFlushTimerScope),
+      );
+      return true;
+    });
+
   const processRuntimeEvent = (event: ProviderRuntimeEvent) =>
     Effect.gen(function* () {
       const thread = yield* resolveThreadShell(event.threadId);
       if (!thread) return;
+      if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
+        return;
+      }
 
       let loadedThreadDetail: OrchestrationThread | null | undefined;
       const getLoadedThreadDetail = () =>
@@ -1500,6 +1860,18 @@ const make = Effect.gen(function* () {
         }
       }
 
+      if (
+        event.type === "session.state.changed" &&
+        shouldApplyThreadLifecycle &&
+        (event.payload.state === "error" || event.payload.state === "stopped")
+      ) {
+        yield* finalizeAssistantMessagesForTerminalEvent({
+          event,
+          threadId: thread.id,
+          createdAt: now,
+        });
+      }
+
       const assistantDelta =
         event.type === "content.delta" && event.payload.streamKind === "assistant_text"
           ? event.payload.delta
@@ -1514,6 +1886,7 @@ const make = Effect.gen(function* () {
           event,
           ...(turnId ? { turnId } : {}),
         });
+        yield* rememberAssistantMessageIdForThread(thread.id, assistantMessageId);
         if (turnId) {
           yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
         }
@@ -1522,37 +1895,15 @@ const make = Effect.gen(function* () {
           serverSettingsService.getSettings,
           (settings) => (settings.enableAssistantStreaming ? "streaming" : "buffered"),
         );
-        if (assistantDeliveryMode === "buffered") {
-          const spillChunk = yield* appendBufferedAssistantText(assistantMessageId, assistantDelta);
-          if (spillChunk.length > 0) {
-            yield* orchestrationEngine.dispatch({
-              type: "thread.message.assistant.delta",
-              commandId: yield* providerCommandId(event, "assistant-delta-buffer-spill"),
-              threadId: thread.id,
-              messageId: assistantMessageId,
-              delta: spillChunk,
-              ...(turnId ? { turnId } : {}),
-              createdAt: now,
-            });
-          }
-        } else {
-          const flushChunk = yield* appendCoalescedStreamingAssistantText(
-            assistantMessageId,
-            assistantDelta,
-            now,
-          );
-          if (flushChunk.length > 0) {
-            yield* orchestrationEngine.dispatch({
-              type: "thread.message.assistant.delta",
-              commandId: yield* providerCommandId(event, "assistant-delta"),
-              threadId: thread.id,
-              messageId: assistantMessageId,
-              delta: flushChunk,
-              ...(turnId ? { turnId } : {}),
-              createdAt: now,
-            });
-          }
-        }
+        yield* processAssistantDelta({
+          source: "assistant-delta",
+          event,
+          threadId: thread.id,
+          messageId: assistantMessageId,
+          ...(turnId ? { turnId } : {}),
+          deliveryMode: assistantDeliveryMode,
+          delta: assistantDelta,
+        });
       }
 
       const pauseForUserTurnId =
@@ -1688,7 +2039,7 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (event.type === "turn.completed") {
+      if (event.type === "turn.completed" || event.type === "turn.aborted") {
         const detailedThread = yield* getLoadedThreadDetail();
         const messages = detailedThread?.messages ?? [];
         const proposedPlans = detailedThread?.proposedPlans ?? [];
@@ -1725,6 +2076,11 @@ const make = Effect.gen(function* () {
       }
 
       if (event.type === "session.exited") {
+        yield* finalizeAssistantMessagesForTerminalEvent({
+          event,
+          threadId: thread.id,
+          createdAt: now,
+        });
         yield* clearTurnStateForSession(thread.id);
       }
 
@@ -1752,6 +2108,11 @@ const make = Effect.gen(function* () {
               lastError: runtimeErrorMessage,
               updatedAt: now,
             },
+            createdAt: now,
+          });
+          yield* finalizeAssistantMessagesForTerminalEvent({
+            event,
+            threadId: thread.id,
             createdAt: now,
           });
         }
@@ -1836,8 +2197,193 @@ const make = Effect.gen(function* () {
 
   const processDomainEvent = (_event: TurnStartRequestedDomainEvent) => Effect.void;
 
-  const processInput = (input: RuntimeIngestionInput) =>
-    input.source === "runtime" ? processRuntimeEvent(input.event) : processDomainEvent(input.event);
+  const processAssistantDelta = (
+    input: Extract<RuntimeIngestionInput, { source: "assistant-delta" }>,
+  ) =>
+    Effect.gen(function* () {
+      const maxRetainedChars =
+        input.deliveryMode === "streaming"
+          ? MAX_COALESCED_STREAMING_ASSISTANT_CHARS
+          : MAX_BUFFERED_ASSISTANT_CHARS;
+      let offset = 0;
+      let flushPendingFirst = input.flushPendingFirst === true;
+
+      const deferRemainder = (cause: Cause.Cause<unknown>) =>
+        Effect.gen(function* () {
+          yield* Effect.logWarning(
+            "provider runtime ingestion deferred assistant delta after retries",
+            {
+              eventId: input.event.eventId,
+              messageId: input.messageId,
+              deliveryMode: input.deliveryMode,
+              cause: Cause.pretty(cause),
+            },
+          );
+          if (input.isDeferred !== true) {
+            yield* markDeferredAssistantDelta(input.messageId);
+          }
+          yield* scheduleAssistantDeltaRetry({
+            ...input,
+            delta: input.delta.slice(offset),
+            flushPendingFirst: true,
+            isDeferred: true,
+          });
+        });
+
+      while (offset < input.delta.length || flushPendingFirst) {
+        const pendingText = yield* peekBufferedAssistantText(input.messageId);
+        if (
+          pendingText.length > 0 &&
+          (flushPendingFirst || pendingText.length >= maxRetainedChars)
+        ) {
+          const dispatchExit = yield* Effect.exit(
+            input.deliveryMode === "streaming"
+              ? dispatchStreamingAssistantDelta({
+                  event: input.event,
+                  threadId: input.threadId,
+                  messageId: input.messageId,
+                  ...(input.turnId ? { turnId: input.turnId } : {}),
+                  delta: pendingText,
+                  createdAt: input.event.createdAt,
+                  commandTag: "assistant-delta-deferred-retry",
+                })
+              : dispatchBufferedAssistantDelta({
+                  event: input.event,
+                  threadId: input.threadId,
+                  messageId: input.messageId,
+                  ...(input.turnId ? { turnId: input.turnId } : {}),
+                  delta: pendingText,
+                  createdAt: input.event.createdAt,
+                }),
+          );
+          if (Exit.isFailure(dispatchExit)) {
+            yield* deferRemainder(dispatchExit.cause);
+            return;
+          }
+          flushPendingFirst = false;
+          continue;
+        }
+
+        if (offset >= input.delta.length) {
+          break;
+        }
+
+        const availableChars = Math.max(1, maxRetainedChars - pendingText.length);
+        const deltaChunk = input.delta.slice(offset, offset + availableChars);
+        offset += deltaChunk.length;
+        const flushChunk =
+          input.deliveryMode === "streaming"
+            ? yield* appendCoalescedStreamingAssistantText(
+                input.messageId,
+                deltaChunk,
+                input.event.createdAt,
+              )
+            : yield* appendBufferedAssistantText(input.messageId, deltaChunk);
+
+        if (input.deliveryMode === "streaming") {
+          yield* scheduleStreamingAssistantFlush({
+            event: input.event,
+            threadId: input.threadId,
+            messageId: input.messageId,
+            ...(input.turnId ? { turnId: input.turnId } : {}),
+          });
+        }
+
+        if (flushChunk.length === 0) {
+          continue;
+        }
+
+        const dispatchExit = yield* Effect.exit(
+          input.deliveryMode === "streaming"
+            ? dispatchStreamingAssistantDelta({
+                event: input.event,
+                threadId: input.threadId,
+                messageId: input.messageId,
+                ...(input.turnId ? { turnId: input.turnId } : {}),
+                delta: flushChunk,
+                createdAt: input.event.createdAt,
+                commandTag: "assistant-delta",
+              })
+            : dispatchBufferedAssistantDelta({
+                event: input.event,
+                threadId: input.threadId,
+                messageId: input.messageId,
+                ...(input.turnId ? { turnId: input.turnId } : {}),
+                delta: flushChunk,
+                createdAt: input.event.createdAt,
+              }),
+        );
+        if (Exit.isFailure(dispatchExit)) {
+          yield* deferRemainder(dispatchExit.cause);
+          return;
+        }
+      }
+
+      if (input.isDeferred === true) {
+        yield* completeDeferredAssistantDelta(input.messageId);
+      }
+    });
+
+  const processScheduledAssistantFlush = (
+    input: Extract<RuntimeIngestionInput, { source: "assistant-flush" }>,
+  ) =>
+    Effect.gen(function* () {
+      yield* Cache.invalidate(streamingAssistantFlushScheduledByMessageId, input.messageId);
+      const bufferedText = yield* peekBufferedAssistantText(input.messageId);
+      if (bufferedText.length === 0) {
+        if (input.isDeferred === true) {
+          yield* completeDeferredAssistantDelta(input.messageId);
+        }
+        return;
+      }
+
+      const dispatchExit = yield* Effect.exit(
+        dispatchStreamingAssistantDelta({
+          event: input.event,
+          threadId: input.threadId,
+          messageId: input.messageId,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          delta: bufferedText,
+          createdAt: input.event.createdAt,
+          commandTag: "assistant-delta-timer-flush",
+        }),
+      );
+      if (Exit.isFailure(dispatchExit)) {
+        yield* Effect.logWarning(
+          "provider runtime ingestion rescheduled assistant timer flush after retries",
+          {
+            eventId: input.event.eventId,
+            messageId: input.messageId,
+            cause: Cause.pretty(dispatchExit.cause),
+          },
+        );
+        if (input.isDeferred !== true) {
+          yield* markDeferredAssistantDelta(input.messageId);
+        }
+        yield* scheduleStreamingAssistantFlush({
+          event: input.event,
+          threadId: input.threadId,
+          messageId: input.messageId,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          isDeferred: true,
+        });
+      } else if (input.isDeferred === true) {
+        yield* completeDeferredAssistantDelta(input.messageId);
+      }
+    });
+
+  const processInput = (input: RuntimeIngestionInput) => {
+    switch (input.source) {
+      case "runtime":
+        return processRuntimeEvent(input.event);
+      case "domain":
+        return processDomainEvent(input.event);
+      case "assistant-flush":
+        return processScheduledAssistantFlush(input);
+      case "assistant-delta":
+        return processAssistantDelta(input);
+    }
+  };
 
   const processInputSafely = (input: RuntimeIngestionInput) =>
     processInput(input).pipe(
@@ -1855,6 +2401,7 @@ const make = Effect.gen(function* () {
     );
 
   const worker = yield* makeDrainableWorker(processInputSafely);
+  enqueueInput = worker.enqueue;
 
   const start: ProviderRuntimeIngestionShape["start"] = () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1004,6 +1004,16 @@ const make = Effect.gen(function* () {
     }
   });
 
+  const resetFinalizedAssistantMessageForTurn = Effect.fn("resetFinalizedAssistantMessageForTurn")(
+    function* (threadId: ThreadId, turnId: TurnId, messageId: MessageId) {
+      yield* forgetAssistantMessageId(threadId, turnId, messageId);
+      const state = yield* getAssistantSegmentStateForTurn(threadId, turnId);
+      if (Option.isSome(state) && state.value.activeMessageId === messageId) {
+        yield* clearAssistantSegmentStateForTurn(threadId, turnId);
+      }
+    },
+  );
+
   const startAssistantSegmentForTurn = (input: {
     threadId: ThreadId;
     turnId: TurnId;
@@ -1953,6 +1963,27 @@ const make = Effect.gen(function* () {
           return loadedThreadDetail;
         });
       let deferredThreadSession: NonNullable<typeof thread.session> | null = null;
+      const flushDeferredThreadSession = Effect.fnUntraced(function* () {
+        if (deferredThreadSession === null) {
+          return false;
+        }
+        if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
+          return true;
+        }
+        const session = deferredThreadSession;
+        yield* orchestrationEngine.dispatch({
+          type: "thread.session.set",
+          commandId: yield* providerCommandId(
+            event,
+            event.type === "runtime.error" ? "runtime-error-session-set" : "thread-session-set",
+          ),
+          threadId: thread.id,
+          session,
+          createdAt: event.createdAt,
+        });
+        deferredThreadSession = null;
+        return false;
+      });
 
       const now = event.createdAt;
       const eventTurnId = toTurnId(event.turnId);
@@ -2122,6 +2153,9 @@ const make = Effect.gen(function* () {
           threadId: thread.id,
           createdAt: now,
         });
+        if (yield* flushDeferredThreadSession()) {
+          return;
+        }
       }
 
       const assistantDelta =
@@ -2337,6 +2371,9 @@ const make = Effect.gen(function* () {
           if (finalizedAssistantMessages.every(Boolean)) {
             yield* clearAssistantMessageIdsForTurn(thread.id, turnId);
             yield* clearAssistantSegmentStateForTurn(thread.id, turnId);
+            if (event.type === "turn.completed" && (yield* flushDeferredThreadSession())) {
+              return;
+            }
           }
 
           yield* finalizeBufferedProposedPlan({
@@ -2356,7 +2393,7 @@ const make = Effect.gen(function* () {
           threadId: thread.id,
           createdAt: now,
         });
-        if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
+        if (yield* flushDeferredThreadSession()) {
           return;
         }
         yield* clearTurnStateForSession(thread.id);
@@ -2387,6 +2424,9 @@ const make = Effect.gen(function* () {
             threadId: thread.id,
             createdAt: now,
           });
+          if (yield* flushDeferredThreadSession()) {
+            return;
+          }
         }
       }
 
@@ -2451,20 +2491,8 @@ const make = Effect.gen(function* () {
         }
       }
 
-      if (deferredThreadSession !== null) {
-        if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
-          return;
-        }
-        yield* orchestrationEngine.dispatch({
-          type: "thread.session.set",
-          commandId: yield* providerCommandId(
-            event,
-            event.type === "runtime.error" ? "runtime-error-session-set" : "thread-session-set",
-          ),
-          threadId: thread.id,
-          session: deferredThreadSession,
-          createdAt: now,
-        });
+      if (yield* flushDeferredThreadSession()) {
+        return;
       }
 
       const activities = runtimeEventToActivities(event, taskTitle);
@@ -2690,7 +2718,7 @@ const make = Effect.gen(function* () {
           }
           const finalized = yield* finalizeAssistantMessage(input);
           if (finalized && input.turnId) {
-            yield* releaseFinalizedAssistantMessageForTurn(
+            yield* resetFinalizedAssistantMessageForTurn(
               input.threadId,
               input.turnId,
               input.messageId,
@@ -2741,7 +2769,7 @@ const make = Effect.gen(function* () {
               yield* clearAssistantMessageState(input.messageId);
               yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
               if (input.turnId) {
-                yield* releaseFinalizedAssistantMessageForTurn(
+                yield* resetFinalizedAssistantMessageForTurn(
                   input.threadId,
                   input.turnId,
                   input.messageId,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1450,6 +1450,7 @@ const make = Effect.gen(function* () {
             yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, text);
           }
           if (input.isDeferred !== true) {
+            yield* rememberAssistantMessageIdForThread(input.threadId, input.messageId);
             yield* markDeferredAssistantDelta(input.messageId);
           }
           yield* scheduleAssistantFinalizationRetry({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -911,6 +911,13 @@ const make = Effect.gen(function* () {
       Effect.map((count) => Option.getOrElse(count, () => 0) > 0),
     );
 
+  const hasDeferredAssistantDeltaAheadOfFinalization = (messageId: MessageId) =>
+    Cache.getOption(deferredAssistantDeltaCountByMessageId, messageId).pipe(
+      // One deferred entry belongs to the finalization retry itself. Any
+      // additional entries are delta retries that must drain first.
+      Effect.map((count) => Option.getOrElse(count, () => 0) > 1),
+    );
+
   const forgetAssistantMessageId = (threadId: ThreadId, turnId: TurnId, messageId: MessageId) =>
     Cache.getOption(turnMessageIdsByTurnKey, providerTurnKey(threadId, turnId)).pipe(
       Effect.flatMap((existingIds) =>
@@ -1644,19 +1651,27 @@ const make = Effect.gen(function* () {
 
             yield* Effect.forEach(
               messageIds.value,
-              (messageId) => {
-                finalizedMessageIds.add(messageId);
-                return finalizeAssistantMessage({
-                  event: input.event,
-                  threadId: input.threadId,
-                  messageId,
-                  turnId,
-                  createdAt: input.createdAt,
-                  commandTag: "assistant-complete-on-session-exit",
-                  finalDeltaCommandTag: "assistant-delta-finalize-on-session-exit",
-                  hasProjectedMessage: findMessageById(messages, messageId) !== undefined,
-                });
-              },
+              (messageId) =>
+                Effect.gen(function* () {
+                  finalizedMessageIds.add(messageId);
+                  const finalized = yield* finalizeAssistantMessage({
+                    event: input.event,
+                    threadId: input.threadId,
+                    messageId,
+                    turnId,
+                    createdAt: input.createdAt,
+                    commandTag: "assistant-complete-on-session-exit",
+                    finalDeltaCommandTag: "assistant-delta-finalize-on-session-exit",
+                    hasProjectedMessage: findMessageById(messages, messageId) !== undefined,
+                  });
+                  if (finalized) {
+                    yield* releaseFinalizedAssistantMessageForTurn(
+                      input.threadId,
+                      turnId,
+                      messageId,
+                    );
+                  }
+                }),
               { concurrency: 1 },
             ).pipe(Effect.asVoid);
           }),
@@ -2579,6 +2594,10 @@ const make = Effect.gen(function* () {
       case "assistant-finalize":
         return Effect.gen(function* () {
           yield* Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, input.messageId);
+          if (yield* hasDeferredAssistantDeltaAheadOfFinalization(input.messageId)) {
+            yield* scheduleAssistantFinalizationRetry(input);
+            return;
+          }
           const finalized = yield* finalizeAssistantMessage(input);
           if (finalized && input.turnId) {
             yield* releaseFinalizedAssistantMessageForTurn(

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -133,6 +133,19 @@ type RuntimeIngestionInput =
       delta: string;
       flushPendingFirst?: boolean;
       isDeferred?: boolean;
+    }
+  | {
+      source: "assistant-finalize";
+      event: ProviderRuntimeEvent;
+      threadId: ThreadId;
+      messageId: MessageId;
+      turnId?: TurnId;
+      createdAt: string;
+      commandTag: string;
+      finalDeltaCommandTag: string;
+      fallbackText?: string;
+      hasProjectedMessage?: boolean;
+      isDeferred: true;
     };
 
 function toTurnId(value: TurnId | string | undefined): TurnId | undefined {
@@ -766,6 +779,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(0),
   });
 
+  const assistantFinalizationRetryScheduledByMessageId = yield* Cache.make<MessageId, boolean>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(false),
+  });
+
   const streamingFlushTimerScope = yield* Scope.make("sequential");
   yield* Effect.addFinalizer(() => Scope.close(streamingFlushTimerScope, Exit.void));
   let enqueueInput: ((input: RuntimeIngestionInput) => Effect.Effect<void>) | undefined;
@@ -1087,6 +1106,7 @@ const make = Effect.gen(function* () {
       Cache.invalidate(streamingAssistantFlushScheduledByMessageId, messageId),
       Cache.invalidate(assistantLatestOccurredAtByMessageId, messageId),
       Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId),
+      Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, messageId),
     ]).pipe(Effect.asVoid);
 
   const laterOccurredAt = (left: string, right: string) => {
@@ -1257,6 +1277,29 @@ const make = Effect.gen(function* () {
       Effect.asVoid,
     );
 
+  const scheduleAssistantFinalizationRetry = (
+    input: Extract<RuntimeIngestionInput, { source: "assistant-finalize" }>,
+  ) =>
+    Effect.gen(function* () {
+      const existing = yield* Cache.getOption(
+        assistantFinalizationRetryScheduledByMessageId,
+        input.messageId,
+      );
+      if (Option.getOrElse(existing, () => false)) {
+        return;
+      }
+
+      yield* Cache.set(assistantFinalizationRetryScheduledByMessageId, input.messageId, true);
+      yield* Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
+        Effect.flatMap(() =>
+          enqueueInput
+            ? enqueueInput(input)
+            : Effect.die(new Error("provider runtime ingestion worker is not initialized")),
+        ),
+        Effect.forkIn(streamingFlushTimerScope),
+      );
+    });
+
   const scheduleRuntimeEventRetry = (event: ProviderRuntimeEvent) =>
     Effect.sleep(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)).pipe(
       Effect.flatMap(() =>
@@ -1340,6 +1383,7 @@ const make = Effect.gen(function* () {
     finalDeltaCommandTag: string;
     fallbackText?: string;
     hasProjectedMessage?: boolean;
+    isDeferred?: boolean;
   }) =>
     Effect.gen(function* () {
       const bufferedText = yield* peekBufferedAssistantText(input.messageId);
@@ -1351,7 +1395,32 @@ const make = Effect.gen(function* () {
           : "";
       const shouldDispatchText =
         hasRenderableAssistantText(text) || (hasBufferedText && input.hasProjectedMessage === true);
+      const shouldComplete = input.hasProjectedMessage === true || shouldDispatchText;
       const createdAt = yield* getLatestAssistantOccurredAt(input.messageId, input.createdAt);
+
+      const deferFinalization = (cause: Cause.Cause<unknown>, retainText: boolean) =>
+        Effect.gen(function* () {
+          yield* Effect.logWarning(
+            "provider runtime ingestion deferred assistant finalization after retries",
+            {
+              eventId: input.event.eventId,
+              messageId: input.messageId,
+              cause: Cause.pretty(cause),
+            },
+          );
+          if (retainText && shouldDispatchText) {
+            yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, text);
+          }
+          if (input.isDeferred !== true) {
+            yield* markDeferredAssistantDelta(input.messageId);
+          }
+          yield* scheduleAssistantFinalizationRetry({
+            ...input,
+            source: "assistant-finalize",
+            hasProjectedMessage: shouldComplete,
+            isDeferred: true,
+          });
+        });
 
       if (shouldDispatchText) {
         const commandId = yield* providerCommandId(input.event, input.finalDeltaCommandTag);
@@ -1375,41 +1444,34 @@ const make = Effect.gen(function* () {
           ),
         );
         if (Exit.isFailure(dispatchExit)) {
-          yield* Effect.logWarning(
-            "provider runtime ingestion deferred assistant finalization after retries",
-            {
-              eventId: input.event.eventId,
-              messageId: input.messageId,
-              cause: Cause.pretty(dispatchExit.cause),
-            },
-          );
-          yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, text);
-          yield* markDeferredAssistantDelta(input.messageId);
-          yield* scheduleAssistantDeltaRetry({
-            source: "assistant-delta",
-            event: input.event,
-            threadId: input.threadId,
-            messageId: input.messageId,
-            ...(input.turnId ? { turnId: input.turnId } : {}),
-            deliveryMode: "streaming",
-            delta: "",
-            flushPendingFirst: true,
-            isDeferred: true,
-          });
-          yield* scheduleRuntimeEventRetry(input.event);
-          return yield* Effect.failCause(dispatchExit.cause);
+          yield* deferFinalization(dispatchExit.cause, true);
+          return;
         }
       }
 
-      if (input.hasProjectedMessage || shouldDispatchText) {
-        yield* orchestrationEngine.dispatch({
-          type: "thread.message.assistant.complete",
-          commandId: yield* providerCommandId(input.event, input.commandTag),
-          threadId: input.threadId,
-          messageId: input.messageId,
-          ...(input.turnId ? { turnId: input.turnId } : {}),
-          createdAt,
-        });
+      if (shouldComplete) {
+        const commandId = yield* providerCommandId(input.event, input.commandTag);
+        const dispatchExit = yield* Effect.exit(
+          Effect.suspend(() =>
+            orchestrationEngine.dispatch({
+              type: "thread.message.assistant.complete",
+              commandId,
+              threadId: input.threadId,
+              messageId: input.messageId,
+              ...(input.turnId ? { turnId: input.turnId } : {}),
+              createdAt,
+            }),
+          ).pipe(
+            Effect.retry({
+              schedule: Schedule.spaced(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)),
+              times: 2,
+            }),
+          ),
+        );
+        if (Exit.isFailure(dispatchExit)) {
+          yield* deferFinalization(dispatchExit.cause, false);
+          return;
+        }
       }
       yield* clearAssistantMessageState(input.messageId);
       yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
@@ -1624,9 +1686,16 @@ const make = Effect.gen(function* () {
 
             const messageIds = yield* Cache.getOption(turnMessageIdsByTurnKey, key);
             if (Option.isSome(messageIds)) {
-              yield* Effect.forEach(messageIds.value, clearAssistantMessageState, {
-                concurrency: 1,
-              }).pipe(Effect.asVoid);
+              yield* Effect.forEach(
+                messageIds.value,
+                (messageId) =>
+                  hasDeferredAssistantDelta(messageId).pipe(
+                    Effect.flatMap((isDeferred) =>
+                      isDeferred ? Effect.void : clearAssistantMessageState(messageId),
+                    ),
+                  ),
+                { concurrency: 1 },
+              ).pipe(Effect.asVoid);
             }
 
             yield* Cache.invalidate(turnMessageIdsByTurnKey, key);
@@ -2472,6 +2541,11 @@ const make = Effect.gen(function* () {
         return processScheduledAssistantFlush(input);
       case "assistant-delta":
         return processAssistantDelta(input);
+      case "assistant-finalize":
+        return Cache.invalidate(
+          assistantFinalizationRetryScheduledByMessageId,
+          input.messageId,
+        ).pipe(Effect.andThen(finalizeAssistantMessage(input)));
     }
   };
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -92,6 +92,10 @@ const BUFFERED_PROPOSED_PLAN_BY_ID_TTL = Duration.minutes(120);
 const TASK_DESCRIPTION_BY_TASK_CACHE_CAPACITY = 10_000;
 const TASK_DESCRIPTION_BY_TASK_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
+// Keep streaming responsive while preventing character-sized provider deltas
+// from forcing persistence and renderer reconciliation on every token.
+const STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS = 100;
+const MAX_COALESCED_STREAMING_ASSISTANT_CHARS = 512;
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
 type TurnStartRequestedDomainEvent = Extract<
@@ -710,6 +714,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(""),
   });
 
+  const streamingAssistantLastFlushAtByMessageId = yield* Cache.make<MessageId, number>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(0),
+  });
+
   const assistantSegmentStateByTurnKey = yield* Cache.make<string, AssistantSegmentState>({
     capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
     timeToLive: TURN_MESSAGE_IDS_BY_TURN_TTL,
@@ -899,6 +909,40 @@ const make = Effect.gen(function* () {
       ),
     );
 
+  const appendCoalescedStreamingAssistantText = (
+    messageId: MessageId,
+    delta: string,
+    occurredAt: string,
+  ) =>
+    Effect.gen(function* () {
+      const pendingText = yield* Cache.getOption(bufferedAssistantTextByMessageId, messageId);
+      const nextText = `${Option.getOrElse(pendingText, () => "")}${delta}`;
+      const lastFlushedAt = yield* Cache.getOption(
+        streamingAssistantLastFlushAtByMessageId,
+        messageId,
+      );
+      const occurredAtMillis = Date.parse(occurredAt);
+      const elapsedSinceFlush = Option.match(lastFlushedAt, {
+        onNone: () => Number.POSITIVE_INFINITY,
+        onSome: (value) =>
+          Number.isFinite(occurredAtMillis) ? Math.max(0, occurredAtMillis - value) : 0,
+      });
+      const shouldFlush =
+        elapsedSinceFlush >= STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS ||
+        nextText.length >= MAX_COALESCED_STREAMING_ASSISTANT_CHARS;
+
+      if (!shouldFlush) {
+        yield* Cache.set(bufferedAssistantTextByMessageId, messageId, nextText);
+        return "";
+      }
+
+      yield* Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
+      if (Number.isFinite(occurredAtMillis)) {
+        yield* Cache.set(streamingAssistantLastFlushAtByMessageId, messageId, occurredAtMillis);
+      }
+      return nextText;
+    });
+
   const takeBufferedAssistantText = (messageId: MessageId) =>
     Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
       Effect.flatMap((existingText) =>
@@ -936,7 +980,10 @@ const make = Effect.gen(function* () {
     Cache.invalidate(bufferedProposedPlanById, planId);
 
   const clearAssistantMessageState = (messageId: MessageId) =>
-    clearBufferedAssistantText(messageId);
+    Effect.all([
+      clearBufferedAssistantText(messageId),
+      Cache.invalidate(streamingAssistantLastFlushAtByMessageId, messageId),
+    ]).pipe(Effect.asVoid);
 
   const flushBufferedAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -1489,15 +1536,22 @@ const make = Effect.gen(function* () {
             });
           }
         } else {
-          yield* orchestrationEngine.dispatch({
-            type: "thread.message.assistant.delta",
-            commandId: yield* providerCommandId(event, "assistant-delta"),
-            threadId: thread.id,
-            messageId: assistantMessageId,
-            delta: assistantDelta,
-            ...(turnId ? { turnId } : {}),
-            createdAt: now,
-          });
+          const flushChunk = yield* appendCoalescedStreamingAssistantText(
+            assistantMessageId,
+            assistantDelta,
+            now,
+          );
+          if (flushChunk.length > 0) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.message.assistant.delta",
+              commandId: yield* providerCommandId(event, "assistant-delta"),
+              threadId: thread.id,
+              messageId: assistantMessageId,
+              delta: flushChunk,
+              ...(turnId ? { turnId } : {}),
+              createdAt: now,
+            });
+          }
         }
       }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -99,6 +99,7 @@ const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
 // from forcing persistence and renderer reconciliation on every token.
 const STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS = 100;
 const MAX_COALESCED_STREAMING_ASSISTANT_CHARS = 512;
+const MAX_ASSISTANT_FINALIZATION_DEFECT_RETRIES = 3;
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
 type TurnStartRequestedDomainEvent = Extract<
@@ -803,6 +804,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(false),
   });
 
+  const assistantFinalizationDefectRetriesByMessageId = yield* Cache.make<MessageId, number>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(0),
+  });
+
   const streamingFlushTimerScope = yield* Scope.make("sequential");
   yield* Effect.addFinalizer(() => Scope.close(streamingFlushTimerScope, Exit.void));
   let enqueueInput: ((input: RuntimeIngestionInput) => Effect.Effect<void>) | undefined;
@@ -1113,6 +1120,17 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
+  const consumeBufferedAssistantText = (messageId: MessageId, consumedText: string) =>
+    Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
+      Effect.flatMap((existing) => {
+        const text = Option.getOrElse(existing, () => "");
+        const remaining = text.startsWith(consumedText) ? text.slice(consumedText.length) : "";
+        return remaining.length === 0
+          ? clearBufferedAssistantText(messageId)
+          : Cache.set(bufferedAssistantTextByMessageId, messageId, remaining);
+      }),
+    );
+
   const appendBufferedProposedPlan = (planId: string, delta: string, createdAt: string) =>
     Cache.getOption(bufferedProposedPlanById, planId).pipe(
       Effect.flatMap((existingEntry) => {
@@ -1145,6 +1163,7 @@ const make = Effect.gen(function* () {
       Cache.invalidate(assistantLatestOccurredAtByMessageId, messageId),
       Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId),
       Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, messageId),
+      Cache.invalidate(assistantFinalizationDefectRetriesByMessageId, messageId),
     ]).pipe(Effect.asVoid);
 
   const laterOccurredAt = (left: string, right: string) => {
@@ -1179,9 +1198,13 @@ const make = Effect.gen(function* () {
       ),
     );
 
-  const commitStreamingAssistantFlush = (messageId: MessageId, occurredAt: string) =>
+  const commitStreamingAssistantFlush = (
+    messageId: MessageId,
+    occurredAt: string,
+    consumedText: string,
+  ) =>
     Effect.gen(function* () {
-      yield* clearBufferedAssistantText(messageId);
+      yield* consumeBufferedAssistantText(messageId, consumedText);
       const occurredAtMillis = Date.parse(occurredAt);
       if (Number.isFinite(occurredAtMillis)) {
         const previous = yield* Cache.getOption(
@@ -1234,7 +1257,7 @@ const make = Effect.gen(function* () {
           ...(input.turnId ? { turnId: input.turnId } : {}),
           createdAt,
         },
-        commitStreamingAssistantFlush(input.messageId, createdAt),
+        commitStreamingAssistantFlush(input.messageId, createdAt, input.delta),
       ).pipe(
         // Keep a short synchronous retry window, then let the caller retain
         // and defer the chunk so one failed message cannot monopolize the
@@ -1266,7 +1289,7 @@ const make = Effect.gen(function* () {
           ...(input.turnId ? { turnId: input.turnId } : {}),
           createdAt: input.createdAt,
         },
-        clearBufferedAssistantText(input.messageId),
+        consumeBufferedAssistantText(input.messageId, input.delta),
       ).pipe(
         Effect.retry({
           schedule: Schedule.spaced(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)),
@@ -1436,7 +1459,7 @@ const make = Effect.gen(function* () {
       const shouldComplete = input.hasProjectedMessage === true || shouldDispatchText;
       const createdAt = yield* getLatestAssistantOccurredAt(input.messageId, input.createdAt);
 
-      const deferFinalization = (cause: Cause.Cause<unknown>, retainText: boolean) =>
+      const deferFinalization = (cause: Cause.Cause<unknown>, retainedText: string | undefined) =>
         Effect.gen(function* () {
           yield* Effect.logWarning(
             "provider runtime ingestion deferred assistant finalization after retries",
@@ -1446,8 +1469,8 @@ const make = Effect.gen(function* () {
               cause: Cause.pretty(cause),
             },
           );
-          if (retainText && shouldDispatchText) {
-            yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, text);
+          if (retainedText !== undefined && shouldDispatchText) {
+            yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, retainedText);
           }
           if (input.isDeferred !== true) {
             yield* rememberAssistantMessageIdForThread(input.threadId, input.messageId);
@@ -1468,29 +1491,36 @@ const make = Effect.gen(function* () {
         });
 
       if (shouldDispatchText) {
-        const commandId = yield* providerCommandId(input.event, input.finalDeltaCommandTag);
-        const dispatchExit = yield* Effect.exit(
-          dispatchRetainedAssistantDelta(
-            {
-              type: "thread.message.assistant.delta",
-              commandId,
-              threadId: input.threadId,
-              messageId: input.messageId,
-              delta: text,
-              ...(input.turnId ? { turnId: input.turnId } : {}),
-              createdAt,
-            },
-            clearBufferedAssistantText(input.messageId),
-          ).pipe(
-            Effect.retry({
-              schedule: Schedule.spaced(Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS)),
-              times: 2,
-            }),
-          ),
-        );
-        if (Exit.isFailure(dispatchExit)) {
-          yield* deferFinalization(dispatchExit.cause, true);
-          return false;
+        let offset = 0;
+        while (offset < text.length) {
+          const delta = text.slice(offset, offset + MAX_COALESCED_STREAMING_ASSISTANT_CHARS);
+          const commandId = yield* providerCommandId(input.event, input.finalDeltaCommandTag);
+          const dispatchExit = yield* Effect.exit(
+            dispatchRetainedAssistantDelta(
+              {
+                type: "thread.message.assistant.delta",
+                commandId,
+                threadId: input.threadId,
+                messageId: input.messageId,
+                delta,
+                ...(input.turnId ? { turnId: input.turnId } : {}),
+                createdAt,
+              },
+              hasBufferedText ? consumeBufferedAssistantText(input.messageId, delta) : Effect.void,
+            ).pipe(
+              Effect.retry({
+                schedule: Schedule.spaced(
+                  Duration.millis(STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS),
+                ),
+                times: 2,
+              }),
+            ),
+          );
+          if (Exit.isFailure(dispatchExit)) {
+            yield* deferFinalization(dispatchExit.cause, text.slice(offset));
+            return false;
+          }
+          offset += delta.length;
         }
       }
 
@@ -1514,7 +1544,7 @@ const make = Effect.gen(function* () {
           ),
         );
         if (Exit.isFailure(dispatchExit)) {
-          yield* deferFinalization(dispatchExit.cause, false);
+          yield* deferFinalization(dispatchExit.cause, undefined);
           return false;
         }
       }
@@ -2184,6 +2214,12 @@ const make = Effect.gen(function* () {
             }),
           flushedMessageIds,
         });
+        // Finalization above can itself enter deferred retry state. Keep the
+        // request boundary behind that retry just like turn/session boundaries
+        // so approval and user-input activities never outrun assistant output.
+        if (yield* deferBoundaryEventForAssistantDeltas(event, thread.id)) {
+          return;
+        }
       }
 
       if (proposedPlanDelta && proposedPlanDelta.length > 0) {
@@ -2489,6 +2525,7 @@ const make = Effect.gen(function* () {
           pendingText.length > 0 &&
           (flushPendingFirst || pendingText.length >= maxRetainedChars)
         ) {
+          const retainedChunk = pendingText.slice(0, maxRetainedChars);
           const dispatchExit = yield* Effect.exit(
             input.deliveryMode === "streaming"
               ? dispatchStreamingAssistantDelta({
@@ -2496,7 +2533,7 @@ const make = Effect.gen(function* () {
                   threadId: input.threadId,
                   messageId: input.messageId,
                   ...(input.turnId ? { turnId: input.turnId } : {}),
-                  delta: pendingText,
+                  delta: retainedChunk,
                   createdAt: input.event.createdAt,
                   commandTag: "assistant-delta-deferred-retry",
                 })
@@ -2505,7 +2542,7 @@ const make = Effect.gen(function* () {
                   threadId: input.threadId,
                   messageId: input.messageId,
                   ...(input.turnId ? { turnId: input.turnId } : {}),
-                  delta: pendingText,
+                  delta: retainedChunk,
                   createdAt: input.event.createdAt,
                 }),
           );
@@ -2513,7 +2550,7 @@ const make = Effect.gen(function* () {
             yield* deferRemainder(dispatchExit.cause);
             return;
           }
-          flushPendingFirst = false;
+          flushPendingFirst = pendingText.length > retainedChunk.length;
           continue;
         }
 
@@ -2590,13 +2627,14 @@ const make = Effect.gen(function* () {
         return;
       }
 
+      const retainedChunk = bufferedText.slice(0, MAX_COALESCED_STREAMING_ASSISTANT_CHARS);
       const dispatchExit = yield* Effect.exit(
         dispatchStreamingAssistantDelta({
           event: input.event,
           threadId: input.threadId,
           messageId: input.messageId,
           ...(input.turnId ? { turnId: input.turnId } : {}),
-          delta: bufferedText,
+          delta: retainedChunk,
           createdAt: input.event.createdAt,
           commandTag: "assistant-delta-timer-flush",
         }),
@@ -2619,6 +2657,14 @@ const make = Effect.gen(function* () {
           messageId: input.messageId,
           ...(input.turnId ? { turnId: input.turnId } : {}),
           isDeferred: true,
+        });
+      } else if (bufferedText.length > retainedChunk.length) {
+        yield* scheduleStreamingAssistantFlush({
+          event: input.event,
+          threadId: input.threadId,
+          messageId: input.messageId,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          ...(input.isDeferred === true ? { isDeferred: true } : {}),
         });
       } else if (input.isDeferred === true) {
         yield* completeDeferredAssistantDelta(input.messageId);
@@ -2650,7 +2696,60 @@ const make = Effect.gen(function* () {
               input.messageId,
             );
           }
-        });
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              if (Cause.hasInterruptsOnly(cause)) {
+                return yield* Effect.failCause(cause);
+              }
+              const attempts = yield* Cache.getOption(
+                assistantFinalizationDefectRetriesByMessageId,
+                input.messageId,
+              ).pipe(Effect.map((count) => Option.getOrElse(count, () => 0)));
+              if (attempts < MAX_ASSISTANT_FINALIZATION_DEFECT_RETRIES) {
+                yield* Cache.set(
+                  assistantFinalizationDefectRetriesByMessageId,
+                  input.messageId,
+                  attempts + 1,
+                );
+                yield* Effect.logWarning(
+                  "provider runtime ingestion rescheduled defective assistant finalization",
+                  {
+                    eventId: input.event.eventId,
+                    messageId: input.messageId,
+                    attempt: attempts + 1,
+                    cause: Cause.pretty(cause),
+                  },
+                );
+                yield* scheduleAssistantFinalizationRetry(input);
+                return;
+              }
+
+              yield* Effect.logError(
+                "provider runtime ingestion abandoned defective assistant finalization",
+                {
+                  eventId: input.event.eventId,
+                  messageId: input.messageId,
+                  attempts,
+                  cause: Cause.pretty(cause),
+                },
+              );
+              // Release every ordering marker after bounded defect retries so
+              // a permanently broken finalizer cannot stall turn/session
+              // boundaries forever. The already persisted message content is
+              // left intact; only in-memory retry bookkeeping is discarded.
+              yield* clearAssistantMessageState(input.messageId);
+              yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
+              if (input.turnId) {
+                yield* releaseFinalizedAssistantMessageForTurn(
+                  input.threadId,
+                  input.turnId,
+                  input.messageId,
+                );
+              }
+            }),
+          ),
+        );
     }
   };
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1503,7 +1503,10 @@ const make = Effect.gen(function* () {
             input.messageId,
           ).pipe(Effect.map((count) => Option.getOrElse(count, () => 0)));
           if (retries >= MAX_ASSISTANT_FINALIZATION_DEFECT_RETRIES) {
-            const finalText = yield* peekBufferedAssistantText(input.messageId);
+            // Only undispatched text is buffered here — everything else has
+            // already been projected — so the fallback carries it as an append
+            // rather than as a replacement for the whole message.
+            const appendText = yield* peekBufferedAssistantText(input.messageId);
             const fallbackCommandId = yield* providerCommandId(
               input.event,
               `${input.commandTag}-terminal-fallback`,
@@ -1516,7 +1519,7 @@ const make = Effect.gen(function* () {
                       commandId: fallbackCommandId,
                       threadId: input.threadId,
                       messageId: input.messageId,
-                      ...(finalText.length > 0 ? { finalText } : {}),
+                      ...(appendText.length > 0 ? { appendText } : {}),
                       ...(input.turnId ? { turnId: input.turnId } : {}),
                       createdAt,
                     }),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2383,6 +2383,8 @@ const make = Effect.gen(function* () {
               turnId,
               updatedAt: now,
             });
+          } else if (event.type === "turn.aborted") {
+            yield* scheduleRuntimeEventRetry(event);
           }
         }
       }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2379,12 +2379,17 @@ const make = Effect.gen(function* () {
         const existingAssistantMessage = findMessageById(messages, assistantMessageId);
         const shouldApplyFallbackCompletionText =
           !existingAssistantMessage || existingAssistantMessage.text.length === 0;
+        const sameMessageAlreadyCompleted =
+          existingAssistantMessage !== undefined &&
+          !existingAssistantMessage.streaming &&
+          !shouldApplyFallbackCompletionText;
 
         const shouldSkipRedundantCompletion =
           Option.isNone(activeAssistantMessageId) &&
-          turnId !== undefined &&
-          hasAssistantMessagesForTurn &&
-          (assistantCompletion.fallbackText?.trim().length ?? 0) === 0;
+          (sameMessageAlreadyCompleted ||
+            (turnId !== undefined &&
+              hasAssistantMessagesForTurn &&
+              (assistantCompletion.fallbackText?.trim().length ?? 0) === 0));
 
         let assistantFinalized = true;
         if (!shouldSkipRedundantCompletion) {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2411,7 +2411,11 @@ const make = Effect.gen(function* () {
           }
         }
 
-        if (turnId && assistantFinalized) {
+        if (!assistantFinalized) {
+          yield* scheduleRuntimeEventRetry(event);
+          return;
+        }
+        if (turnId) {
           yield* clearAssistantSegmentStateForTurn(thread.id, turnId);
         }
       }
@@ -2467,8 +2471,9 @@ const make = Effect.gen(function* () {
               turnId,
               updatedAt: now,
             });
-          } else if (event.type === "turn.aborted") {
+          } else {
             yield* scheduleRuntimeEventRetry(event);
+            return;
           }
         }
       }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2374,16 +2374,16 @@ const make = Effect.gen(function* () {
             if (event.type === "turn.completed" && (yield* flushDeferredThreadSession())) {
               return;
             }
-          }
 
-          yield* finalizeBufferedProposedPlan({
-            event,
-            threadId: thread.id,
-            threadProposedPlans: proposedPlans,
-            planId: proposedPlanIdForTurn(thread.id, turnId),
-            turnId,
-            updatedAt: now,
-          });
+            yield* finalizeBufferedProposedPlan({
+              event,
+              threadId: thread.id,
+              threadProposedPlans: proposedPlans,
+              planId: proposedPlanIdForTurn(thread.id, turnId),
+              turnId,
+              updatedAt: now,
+            });
+          }
         }
       }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -100,6 +100,7 @@ const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
 const STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS = 100;
 const MAX_COALESCED_STREAMING_ASSISTANT_CHARS = 512;
 const MAX_ASSISTANT_FINALIZATION_DEFECT_RETRIES = 3;
+const MAX_DEFERRED_ASSISTANT_DELTA_RETRIES = 3;
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
 type TurnStartRequestedDomainEvent = Extract<
@@ -810,6 +811,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(0),
   });
 
+  const deferredAssistantDeltaRetriesByMessageId = yield* Cache.make<MessageId, number>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(0),
+  });
+
   const streamingFlushTimerScope = yield* Scope.make("sequential");
   yield* Effect.addFinalizer(() => Scope.close(streamingFlushTimerScope, Exit.void));
   let enqueueInput: ((input: RuntimeIngestionInput) => Effect.Effect<void>) | undefined;
@@ -1174,6 +1181,7 @@ const make = Effect.gen(function* () {
       Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId),
       Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, messageId),
       Cache.invalidate(assistantFinalizationDefectRetriesByMessageId, messageId),
+      Cache.invalidate(deferredAssistantDeltaRetriesByMessageId, messageId),
     ]).pipe(Effect.asVoid);
 
   const laterOccurredAt = (left: string, right: string) => {
@@ -1486,6 +1494,47 @@ const make = Effect.gen(function* () {
             yield* rememberAssistantMessageIdForThread(input.threadId, input.messageId);
             yield* markDeferredAssistantDelta(input.messageId);
           }
+          const retries = yield* Cache.getOption(
+            assistantFinalizationDefectRetriesByMessageId,
+            input.messageId,
+          ).pipe(Effect.map((count) => Option.getOrElse(count, () => 0)));
+          if (retries >= MAX_ASSISTANT_FINALIZATION_DEFECT_RETRIES) {
+            yield* Effect.logError(
+              "provider runtime ingestion abandoned deferred assistant finalization",
+              {
+                eventId: input.event.eventId,
+                messageId: input.messageId,
+                retries,
+                cause: Cause.pretty(cause),
+              },
+            );
+            yield* clearAssistantMessageState(input.messageId);
+            yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
+            if (input.turnId) {
+              if (
+                input.event.type === "request.opened" ||
+                input.event.type === "user-input.requested"
+              ) {
+                yield* releaseFinalizedAssistantMessageForTurn(
+                  input.threadId,
+                  input.turnId,
+                  input.messageId,
+                );
+              } else {
+                yield* resetFinalizedAssistantMessageForTurn(
+                  input.threadId,
+                  input.turnId,
+                  input.messageId,
+                );
+              }
+            }
+            return;
+          }
+          yield* Cache.set(
+            assistantFinalizationDefectRetriesByMessageId,
+            input.messageId,
+            retries + 1,
+          );
           yield* scheduleAssistantFinalizationRetry({
             source: "assistant-finalize",
             event: input.event,
@@ -2541,6 +2590,28 @@ const make = Effect.gen(function* () {
           if (input.isDeferred !== true) {
             yield* markDeferredAssistantDelta(input.messageId);
           }
+          const retries = yield* Cache.getOption(
+            deferredAssistantDeltaRetriesByMessageId,
+            input.messageId,
+          ).pipe(Effect.map((count) => Option.getOrElse(count, () => 0)));
+          if (retries >= MAX_DEFERRED_ASSISTANT_DELTA_RETRIES) {
+            yield* Effect.logError(
+              "provider runtime ingestion abandoned deferred assistant delta",
+              {
+                eventId: input.event.eventId,
+                messageId: input.messageId,
+                retries,
+                cause: Cause.pretty(cause),
+              },
+            );
+            // Do not retain an ordering marker once a typed dispatch failure
+            // has exhausted its retry budget. A finalization already waiting
+            // for this delta can then release its lifecycle boundary.
+            yield* completeDeferredAssistantDelta(input.messageId);
+            yield* Cache.invalidate(deferredAssistantDeltaRetriesByMessageId, input.messageId);
+            return;
+          }
+          yield* Cache.set(deferredAssistantDeltaRetriesByMessageId, input.messageId, retries + 1);
           yield* scheduleAssistantDeltaRetry({
             ...input,
             delta: input.delta.slice(offset),
@@ -2641,6 +2712,7 @@ const make = Effect.gen(function* () {
 
       if (input.isDeferred === true) {
         yield* completeDeferredAssistantDelta(input.messageId);
+        yield* Cache.invalidate(deferredAssistantDeltaRetriesByMessageId, input.messageId);
       }
     });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -124,6 +124,7 @@ type RuntimeIngestionInput =
       messageId: MessageId;
       turnId?: TurnId;
       isDeferred?: boolean;
+      retryAttempt?: number;
     }
   | {
       source: "assistant-delta";
@@ -135,6 +136,7 @@ type RuntimeIngestionInput =
       delta: string;
       flushPendingFirst?: boolean;
       isDeferred?: boolean;
+      retryAttempt?: number;
     }
   | {
       source: "assistant-finalize";
@@ -811,12 +813,6 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed(0),
   });
 
-  const deferredAssistantDeltaRetriesByMessageId = yield* Cache.make<MessageId, number>({
-    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
-    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
-    lookup: () => Effect.succeed(0),
-  });
-
   const streamingFlushTimerScope = yield* Scope.make("sequential");
   yield* Effect.addFinalizer(() => Scope.close(streamingFlushTimerScope, Exit.void));
   let enqueueInput: ((input: RuntimeIngestionInput) => Effect.Effect<void>) | undefined;
@@ -1181,7 +1177,14 @@ const make = Effect.gen(function* () {
       Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId),
       Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, messageId),
       Cache.invalidate(assistantFinalizationDefectRetriesByMessageId, messageId),
-      Cache.invalidate(deferredAssistantDeltaRetriesByMessageId, messageId),
+    ]).pipe(Effect.asVoid);
+
+  const releaseAssistantRetryState = (messageId: MessageId) =>
+    Effect.all([
+      Cache.invalidate(streamingAssistantFlushScheduledByMessageId, messageId),
+      Cache.invalidate(deferredAssistantDeltaCountByMessageId, messageId),
+      Cache.invalidate(assistantFinalizationRetryScheduledByMessageId, messageId),
+      Cache.invalidate(assistantFinalizationDefectRetriesByMessageId, messageId),
     ]).pipe(Effect.asVoid);
 
   const laterOccurredAt = (left: string, right: string) => {
@@ -1322,6 +1325,7 @@ const make = Effect.gen(function* () {
     messageId: MessageId;
     turnId?: TurnId;
     isDeferred?: boolean;
+    retryAttempt?: number;
   }) =>
     Effect.gen(function* () {
       const existing = yield* Cache.getOption(
@@ -1499,16 +1503,45 @@ const make = Effect.gen(function* () {
             input.messageId,
           ).pipe(Effect.map((count) => Option.getOrElse(count, () => 0)));
           if (retries >= MAX_ASSISTANT_FINALIZATION_DEFECT_RETRIES) {
+            const finalText = yield* peekBufferedAssistantText(input.messageId);
+            const fallbackCommandId = yield* providerCommandId(
+              input.event,
+              `${input.commandTag}-terminal-fallback`,
+            );
+            const fallbackExit = shouldComplete
+              ? yield* Effect.exit(
+                  Effect.suspend(() =>
+                    orchestrationEngine.dispatch({
+                      type: "thread.message.assistant.complete",
+                      commandId: fallbackCommandId,
+                      threadId: input.threadId,
+                      messageId: input.messageId,
+                      ...(finalText.length > 0 ? { finalText } : {}),
+                      ...(input.turnId ? { turnId: input.turnId } : {}),
+                      createdAt,
+                    }),
+                  ),
+                )
+              : Exit.succeed({ sequence: 0 });
+            if (Exit.isSuccess(fallbackExit)) {
+              yield* clearAssistantMessageState(input.messageId);
+              yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
+              return true;
+            }
+
             yield* Effect.logError(
-              "provider runtime ingestion abandoned deferred assistant finalization",
+              "provider runtime ingestion exhausted assistant finalization fallback",
               {
                 eventId: input.event.eventId,
                 messageId: input.messageId,
                 retries,
-                cause: Cause.pretty(cause),
+                cause: Cause.pretty(fallbackExit.cause),
               },
             );
-            yield* clearAssistantMessageState(input.messageId);
+            // Preserve any undispatched text for diagnostics or a duplicate
+            // terminal event, but release every retry marker. A permanently
+            // rejected command must not hold turn/session lifecycle forever.
+            yield* releaseAssistantRetryState(input.messageId);
             yield* forgetAssistantMessageIdForThread(input.threadId, input.messageId);
             if (input.turnId) {
               if (
@@ -1528,7 +1561,7 @@ const make = Effect.gen(function* () {
                 );
               }
             }
-            return;
+            return false;
           }
           yield* Cache.set(
             assistantFinalizationDefectRetriesByMessageId,
@@ -1547,6 +1580,7 @@ const make = Effect.gen(function* () {
             hasProjectedMessage: shouldComplete,
             isDeferred: true,
           });
+          return false;
         });
 
       if (shouldDispatchText) {
@@ -1576,8 +1610,7 @@ const make = Effect.gen(function* () {
             ),
           );
           if (Exit.isFailure(dispatchExit)) {
-            yield* deferFinalization(dispatchExit.cause, text.slice(offset));
-            return false;
+            return yield* deferFinalization(dispatchExit.cause, text.slice(offset));
           }
           offset += delta.length;
         }
@@ -1603,8 +1636,7 @@ const make = Effect.gen(function* () {
           ),
         );
         if (Exit.isFailure(dispatchExit)) {
-          yield* deferFinalization(dispatchExit.cause, undefined);
-          return false;
+          return yield* deferFinalization(dispatchExit.cause, undefined);
         }
       }
       yield* clearAssistantMessageState(input.messageId);
@@ -2578,6 +2610,7 @@ const make = Effect.gen(function* () {
 
       const deferRemainder = (cause: Cause.Cause<unknown>) =>
         Effect.gen(function* () {
+          const retryAttempt = input.retryAttempt ?? 0;
           yield* Effect.logWarning(
             "provider runtime ingestion deferred assistant delta after retries",
             {
@@ -2590,33 +2623,36 @@ const make = Effect.gen(function* () {
           if (input.isDeferred !== true) {
             yield* markDeferredAssistantDelta(input.messageId);
           }
-          const retries = yield* Cache.getOption(
-            deferredAssistantDeltaRetriesByMessageId,
-            input.messageId,
-          ).pipe(Effect.map((count) => Option.getOrElse(count, () => 0)));
-          if (retries >= MAX_DEFERRED_ASSISTANT_DELTA_RETRIES) {
+          if (retryAttempt >= MAX_DEFERRED_ASSISTANT_DELTA_RETRIES) {
+            const unbufferedRemainder = input.delta.slice(offset);
+            if (unbufferedRemainder.length > 0) {
+              const bufferedText = yield* peekBufferedAssistantText(input.messageId);
+              yield* Cache.set(
+                bufferedAssistantTextByMessageId,
+                input.messageId,
+                `${bufferedText}${unbufferedRemainder}`,
+              );
+            }
             yield* Effect.logError(
-              "provider runtime ingestion abandoned deferred assistant delta",
+              "provider runtime ingestion retained assistant delta after retry exhaustion",
               {
                 eventId: input.event.eventId,
                 messageId: input.messageId,
-                retries,
+                retryAttempt,
                 cause: Cause.pretty(cause),
               },
             );
-            // Do not retain an ordering marker once a typed dispatch failure
-            // has exhausted its retry budget. A finalization already waiting
-            // for this delta can then release its lifecycle boundary.
-            yield* completeDeferredAssistantDelta(input.messageId);
-            yield* Cache.invalidate(deferredAssistantDeltaRetriesByMessageId, input.messageId);
+            if (input.isDeferred === true) {
+              yield* completeDeferredAssistantDelta(input.messageId);
+            }
             return;
           }
-          yield* Cache.set(deferredAssistantDeltaRetriesByMessageId, input.messageId, retries + 1);
           yield* scheduleAssistantDeltaRetry({
             ...input,
             delta: input.delta.slice(offset),
             flushPendingFirst: true,
             isDeferred: true,
+            retryAttempt: retryAttempt + 1,
           });
         });
 
@@ -2712,7 +2748,6 @@ const make = Effect.gen(function* () {
 
       if (input.isDeferred === true) {
         yield* completeDeferredAssistantDelta(input.messageId);
-        yield* Cache.invalidate(deferredAssistantDeltaRetriesByMessageId, input.messageId);
       }
     });
 
@@ -2742,6 +2777,7 @@ const make = Effect.gen(function* () {
         }),
       );
       if (Exit.isFailure(dispatchExit)) {
+        const retryAttempt = input.retryAttempt ?? 0;
         yield* Effect.logWarning(
           "provider runtime ingestion rescheduled assistant timer flush after retries",
           {
@@ -2753,12 +2789,28 @@ const make = Effect.gen(function* () {
         if (input.isDeferred !== true) {
           yield* markDeferredAssistantDelta(input.messageId);
         }
+        if (retryAttempt >= MAX_DEFERRED_ASSISTANT_DELTA_RETRIES) {
+          yield* Effect.logError(
+            "provider runtime ingestion retained assistant timer flush after retry exhaustion",
+            {
+              eventId: input.event.eventId,
+              messageId: input.messageId,
+              retryAttempt,
+              cause: Cause.pretty(dispatchExit.cause),
+            },
+          );
+          if (input.isDeferred === true) {
+            yield* completeDeferredAssistantDelta(input.messageId);
+          }
+          return;
+        }
         yield* scheduleStreamingAssistantFlush({
           event: input.event,
           threadId: input.threadId,
           messageId: input.messageId,
           ...(input.turnId ? { turnId: input.turnId } : {}),
           isDeferred: true,
+          retryAttempt: retryAttempt + 1,
         });
       } else if (bufferedText.length > retainedChunk.length) {
         yield* scheduleStreamingAssistantFlush({
@@ -2767,6 +2819,7 @@ const make = Effect.gen(function* () {
           messageId: input.messageId,
           ...(input.turnId ? { turnId: input.turnId } : {}),
           ...(input.isDeferred === true ? { isDeferred: true } : {}),
+          ...(input.isDeferred === true ? { retryAttempt: 0 } : {}),
         });
       } else if (input.isDeferred === true) {
         yield* completeDeferredAssistantDelta(input.messageId);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1024,7 +1024,35 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
-      return {
+      // A non-streaming message-sent replaces the projected message text, so
+      // undispatched text must never ride along on the completion itself: it
+      // would drop every already-projected delta. Append it as one more
+      // streaming delta first, then settle with an empty text — projectors
+      // keep the existing text when a completion carries none.
+      const appendText = command.appendText ?? "";
+      const appendEvents: Array<Omit<OrchestrationEvent, "sequence">> = [];
+      if (appendText.length > 0) {
+        appendEvents.push({
+          ...(yield* withEventBase({
+            aggregateKind: "thread",
+            aggregateId: command.threadId,
+            occurredAt: command.createdAt,
+            commandId: command.commandId,
+          })),
+          type: "thread.message-sent",
+          payload: {
+            threadId: command.threadId,
+            messageId: command.messageId,
+            role: "assistant",
+            text: appendText,
+            turnId: command.turnId ?? null,
+            streaming: true,
+            createdAt: command.createdAt,
+            updatedAt: command.createdAt,
+          },
+        });
+      }
+      const completeEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
           aggregateId: command.threadId,
@@ -1036,13 +1064,14 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           role: "assistant",
-          text: command.finalText ?? "",
+          text: "",
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },
       };
+      return appendEvents.length > 0 ? [...appendEvents, completeEvent] : completeEvent;
     }
 
     case "thread.proposed-plan.upsert": {

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1036,7 +1036,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           role: "assistant",
-          text: "",
+          text: command.finalText ?? "",
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -818,7 +818,10 @@ const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   messageId: MessageId,
-  finalText: Schema.optional(Schema.String),
+  // Text that has not been projected yet and must be appended before the
+  // message settles. Completion replaces message text, so this can never
+  // carry an already-projected prefix.
+  appendText: Schema.optional(Schema.String),
   turnId: Schema.optional(TurnId),
   createdAt: IsoDateTime,
 });

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -818,6 +818,7 @@ const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   messageId: MessageId,
+  finalText: Schema.optional(Schema.String),
   turnId: Schema.optional(TurnId),
   createdAt: IsoDateTime,
 });


### PR DESCRIPTION
## What Changed

- Coalesce high-frequency streaming assistant text before dispatching it to the orchestration engine.
- Flush the first delta immediately, then flush at most every 100 ms or once 512 buffered characters accumulate.
- Preserve pending text across setting transitions and flush it before message completion or lifecycle pauses.
- Add a regression test covering 250 one-character deltas and exact final-text preservation.

## Why

Providers can emit assistant text one token or character at a time. Persisting and broadcasting every tiny delta creates thousands of durable events, repeatedly rebuilds the client message, and forces the renderer to reconcile and re-render Markdown at token frequency. In long-running sessions this can drive the Electron renderer past its practical memory limit even while the backend remains healthy.

The bounded coalescing keeps the streaming UI responsive while reducing persistence, replay, and renderer work by roughly two orders of magnitude for high-frequency streams. Completion and pause paths still flush all pending text, so no content is lost.

## UI Changes

No visual changes. Assistant text continues to stream, with updates grouped into intervals of at most 100 ms under normal timestamped provider traffic.

## Checklist

- [x] Added focused coverage for high-frequency streaming deltas
- [x] Ran `pnpm --config.enableGlobalVirtualStore=false exec vp test run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`
- [x] Ran `pnpm --config.enableGlobalVirtualStore=false exec vp check`
- [x] Ran `pnpm --config.enableGlobalVirtualStore=false exec vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the core provider-to-orchestration message pipeline, event ordering, and completion semantics; regressions could lose assistant text, duplicate completions, or stall threads on stuck retries.
> 
> **Overview**
> **Provider runtime ingestion** now batches high-frequency assistant text when streaming is enabled: pending text flushes on a **100ms** interval or when **512** characters accumulate, routed through dedicated worker inputs (`assistant-delta`, `assistant-flush`, `assistant-finalize`) instead of dispatching every token immediately.
> 
> Failed `thread.message.assistant.delta` / `complete` dispatches **retain buffered text** and retry with bounded backoff; turn completion, session exit, runtime errors, and approval pauses **wait** until deferred assistant work drains so lifecycle events do not overtake partial messages. Session `thread.session.set` for terminal boundaries can be **deferred** until assistant finalization finishes.
> 
> **`thread.message.assistant.complete`** gains optional **`appendText`**; the decider emits a final streaming delta for undispatched text, then an empty-text completion so projectors do not replace already-streamed content. Terminal fallback completion after exhausted retries uses the same path.
> 
> **`finalizeTrackedAssistantMessages`** is exported for partial turn finalization (release segment state only for messages that actually completed). Integration tests cover coalescing event counts, dispatch failures, timer flush, ordering vs plans/requests, and deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8638e03b83b6936f0cfa7a6fa324dffe66565f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce high-frequency assistant streaming deltas with retry and deferred finalization
> - Streaming assistant text is now coalesced by time interval (`STREAMING_ASSISTANT_FLUSH_INTERVAL_MILLIS`) and size threshold (`MAX_COALESCED_STREAMING_ASSISTANT_CHARS`) in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/4323/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) to reduce high-frequency tiny delta updates.
> - Adds timer-driven flush scheduling, per-message deferred delta counters, and bounded retry logic so transient dispatch failures do not lose buffered text or stall turn/session boundaries.
> - Boundary events (turn completed/aborted, session exited, runtime error) are deferred until all outstanding assistant deltas drain, then finalized with chunked dispatch and retries.
> - `ThreadMessageAssistantCompleteCommand` gains an optional `appendText` field in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/4323/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af); [decider.ts](https://github.com/pingdotgg/t3code/pull/4323/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6) emits a preceding streaming delta event when this field is set, enabling best-effort fallback completion.
> - Risk: significantly increased internal state per message (flush timestamps, deferred delta counts, finalization retry flags); clearing turn state now conditionally preserves per-message buffers when deferred deltas are outstanding, changing previous always-clear behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8638e03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->