### PR TITLE
Add optional larger project icons to sidebar v2

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -418,6 +418,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const openPrLink = useOpenPrLink();
+  const largeIcons = useClientSettings((settings) => settings.sidebarV2LargeIcons);
 
   // Same semantics as v1 (never-visited counts as read): flipping the beta
   // flag must not light up every historical thread as unread.
@@ -763,7 +764,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
-                className="size-4"
+                className={largeIcons ? "size-6" : "size-4"}
                 fallbackIcon={MessageSquareIcon}
               />
             </span>
@@ -860,122 +861,140 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
             />
           }
         >
-          <div className="relative z-10 h-[4.875rem] px-2.5 py-2">
-            <div className="flex h-5 min-w-0 items-center gap-1.5">
+          <div
+            className={cn(
+              "relative z-10 h-[4.875rem] px-2.5 py-2",
+              largeIcons && "flex items-center gap-2.5",
+            )}
+          >
+            {largeIcons ? (
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
-                className="size-4 shrink-0"
+                className="size-14 shrink-0"
               />
-              {props.projectTitle ? (
-                <span
-                  className={cn(
-                    "min-w-0 flex-1 truncate text-xs text-muted-foreground/85",
-                    shouldRecede ? "font-normal" : "font-medium",
-                  )}
-                >
-                  {props.projectTitle}
-                </span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
-                <span
-                  className={cn(
-                    "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
-                    snoozeMenuOpen && "opacity-0",
-                  )}
-                >
-                  {topStatus ? (
-                    <span
-                      className={cn(
-                        "inline-flex items-center gap-1 font-medium",
-                        topStatus.className,
-                      )}
-                    >
-                      {topStatus.icon === "working" ? (
-                        <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
-                      ) : topStatus.icon === "done" ? (
-                        <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
-                      ) : topStatus.icon === "woke" ? (
-                        <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
-                      ) : null}
-                      {/* The label alone is the live region: a role="status"
-                          wrapper around the ticking duration would make
-                          screen readers announce every second. */}
-                      <span role="status">{topStatus.label}</span>
-                      {status === "working" ? (
-                        <span aria-hidden>
-                          <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
-                        </span>
-                      ) : null}
-                    </span>
-                  ) : (
-                    threadTimeLabel(thread)
-                  )}
-                </span>
-                {props.settlementSupported || showSnoozeButton ? (
+            ) : null}
+            <div className={cn(largeIcons && "min-w-0 flex-1")}>
+              <div className="flex h-5 min-w-0 items-center gap-1.5">
+                {largeIcons ? null : (
+                  <ProjectFavicon
+                    environmentId={thread.environmentId}
+                    cwd={props.projectCwd ?? ""}
+                    className="size-4 shrink-0"
+                  />
+                )}
+                {props.projectTitle ? (
                   <span
                     className={cn(
-                      "absolute inset-y-0 right-0 flex items-stretch gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
-                      snoozeMenuOpen && "opacity-100",
+                      "min-w-0 flex-1 truncate text-xs text-muted-foreground/85",
+                      shouldRecede ? "font-normal" : "font-medium",
                     )}
                   >
-                    {showSnoozeButton ? (
-                      <SnoozePopoverButton
-                        open={snoozeMenuOpen}
-                        onOpenChange={setSnoozeMenuOpen}
-                        onSnooze={handleSnoozePreset}
-                      />
-                    ) : null}
-                    {props.settlementSupported ? (
-                      <button
-                        type="button"
-                        aria-label="Settle thread"
-                        onClick={handleSettleClick}
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground hover:text-foreground"
+                    {props.projectTitle}
+                  </span>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
+                  <span
+                    className={cn(
+                      "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
+                      snoozeMenuOpen && "opacity-0",
+                    )}
+                  >
+                    {topStatus ? (
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 font-medium",
+                          topStatus.className,
+                        )}
                       >
-                        <CheckIcon className="size-3" />
-                        Settle
-                      </button>
-                    ) : null}
+                        {topStatus.icon === "working" ? (
+                          <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
+                        ) : topStatus.icon === "done" ? (
+                          <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
+                        ) : topStatus.icon === "woke" ? (
+                          <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                        ) : null}
+                        {/* The label alone is the live region: a role="status"
+                          wrapper around the ticking duration would make
+                          screen readers announce every second. */}
+                        <span role="status">{topStatus.label}</span>
+                        {status === "working" ? (
+                          <span aria-hidden>
+                            <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
+                          </span>
+                        ) : null}
+                      </span>
+                    ) : (
+                      threadTimeLabel(thread)
+                    )}
                   </span>
-                ) : null}
-              </span>
-            </div>
-            <div className="mt-1 flex min-w-0">{title}</div>
-            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
-              {thread.branch ? (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {prBadge}
-              {diff ? (
-                <span className="shrink-0 font-mono">
-                  <span className="text-emerald-600 dark:text-emerald-400">+{diff.insertions}</span>{" "}
-                  <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
+                  {props.settlementSupported || showSnoozeButton ? (
+                    <span
+                      className={cn(
+                        "absolute inset-y-0 right-0 flex items-stretch gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
+                        snoozeMenuOpen && "opacity-100",
+                      )}
+                    >
+                      {showSnoozeButton ? (
+                        <SnoozePopoverButton
+                          open={snoozeMenuOpen}
+                          onOpenChange={setSnoozeMenuOpen}
+                          onSnooze={handleSnoozePreset}
+                        />
+                      ) : null}
+                      {props.settlementSupported ? (
+                        <button
+                          type="button"
+                          aria-label="Settle thread"
+                          onClick={handleSettleClick}
+                          className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground hover:text-foreground"
+                        >
+                          <CheckIcon className="size-3" />
+                          Settle
+                        </button>
+                      ) : null}
+                    </span>
+                  ) : null}
                 </span>
-              ) : null}
-              <span
-                aria-hidden
-                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-              >
-                {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <ServerIcon aria-hidden className="size-3.5" />
+              </div>
+              <div className="mt-1 flex min-w-0">{title}</div>
+              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
+                {thread.branch ? (
+                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                {prBadge}
+                {diff ? (
+                  <span className="shrink-0 font-mono">
+                    <span className="text-emerald-600 dark:text-emerald-400">
+                      +{diff.insertions}
+                    </span>{" "}
+                    <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
                   </span>
                 ) : null}
-                {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center opacity-60">
-                    <ProviderInstanceIcon
-                      driverKind={driverKind}
-                      displayName={thread.session?.providerName ?? modelInstanceId}
-                      iconClassName="size-3.5"
-                    />
-                  </span>
-                ) : null}
-              </span>
+                <span
+                  aria-hidden
+                  className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
+                >
+                  {isRemote ? (
+                    <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
+                      <ServerIcon aria-hidden className="size-3.5" />
+                    </span>
+                  ) : null}
+                  {driverKind ? (
+                    <span className="inline-flex shrink-0 items-center opacity-60">
+                      <ProviderInstanceIcon
+                        driverKind={driverKind}
+                        displayName={thread.session?.providerName ?? modelInstanceId}
+                        iconClassName="size-3.5"
+                      />
+                    </span>
+                  ) : null}
+                </span>
+              </div>
             </div>
           </div>
           {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}

--- a/apps/web/src/components/settings/BetaSettingsPanel.tsx
+++ b/apps/web/src/components/settings/BetaSettingsPanel.tsx
@@ -52,6 +52,7 @@ function AutoSettleDaysInput({
 
 export function BetaSettingsPanel() {
   const sidebarV2Enabled = useClientSettings((settings) => settings.sidebarV2Enabled);
+  const sidebarV2LargeIcons = useClientSettings((settings) => settings.sidebarV2LargeIcons);
   const sidebarAutoSettleAfterDays = useClientSettings(
     (settings) => settings.sidebarAutoSettleAfterDays,
   );
@@ -73,6 +74,19 @@ export function BetaSettingsPanel() {
         />
         {sidebarV2Enabled ? (
           <>
+            <SettingsRow
+              title="Larger project icons"
+              description="Give the project icon the full height of active thread cards and enlarge it on settled rows."
+              control={
+                <Switch
+                  checked={sidebarV2LargeIcons}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ sidebarV2LargeIcons: Boolean(checked) })
+                  }
+                  aria-label="Use larger project icons on thread rows"
+                />
+              }
+            />
             <SettingsRow
               title="Auto-settle inactive threads"
               description="Threads with no activity for this long settle automatically. Threads on merged or closed PRs always settle."

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -56,6 +56,10 @@ describe("ClientSettings sidebar v2", () => {
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
   });
 
+  it("defaults large thread-row icons off", () => {
+    expect(decodeClientSettings({}).sidebarV2LargeIcons).toBe(false);
+  });
+
   it("allows auto-settle by inactivity to be disabled", () => {
     expect(
       decodeClientSettings({ sidebarAutoSettleAfterDays: null }).sidebarAutoSettleAfterDays,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -115,6 +115,7 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
   ),
   sidebarV2Enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarV2LargeIcons: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
@@ -636,6 +637,7 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   sidebarV2Enabled: Schema.optionalKey(Schema.Boolean),
+  sidebarV2LargeIcons: Schema.optionalKey(Schema.Boolean),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   wordWrap: Schema.optionalKey(Schema.Boolean),
 });


### PR DESCRIPTION
## What Changed

Adds a new client setting, **Larger project icons** (`sidebarV2LargeIcons`, default **off**), for the sidebar v2 thread list. When enabled:

- On **active thread cards**, the project favicon becomes a full-height leading element (56px, spanning the card's vertical space), with the project/header, title, and branch rows stacked beside it.
- On **settled slim rows**, the favicon renders at 24px instead of 16px.

The toggle lives in **Settings → Beta**, nested under the existing Sidebar v2 rows and only visible while sidebar v2 is enabled. Default-off keeps the current density for everyone else.

- `packages/contracts/src/settings.ts`: new `sidebarV2LargeIcons` boolean on `ClientSettings` (decoding default `false`) and on `ClientSettingsPatch`.
- `apps/web/src/components/SidebarV2.tsx`: card variant switches to an icon-leading flex layout when enabled; slim rows enlarge the favicon.
- `apps/web/src/components/settings/BetaSettingsPanel.tsx`: new switch row.

## Why

The 16px favicon is hard to scan when using the sidebar v2 flat list to tell threads from different projects apart at a glance. Giving the icon the card's full height makes each row's project identity immediately recognizable, without changing the default layout.

## UI Changes

| Default (off) | Larger project icons (on) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/sidebar-v2-large-icons/before-default-icons.png) | ![after](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/sidebar-v2-large-icons/after-large-icons.png) |

Verified live in an isolated dev environment: paired a fresh browser, enabled Sidebar v2 and the new toggle through the settings UI, and confirmed the card layout switches to the full-height icon (and back when toggled off).

## Checklist

- [x] `vp test run packages/contracts/src/settings.test.ts` (18 passed, includes new default test)
- [x] `vp run --filter @t3tools/contracts --filter @t3tools/web typecheck`
- [x] `vp fmt`
- [x] Integrated browser verification of the toggle and both layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional large project icons to Sidebar v2 via a beta settings toggle
> - Adds a `sidebarV2LargeIcons` boolean to the client settings schema (default `false`) in [settings.ts](https://github.com/pingdotgg/t3code/pull/4324/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c).
> - When enabled, `SidebarV2Row` renders a larger `ProjectFavicon` (`size-14` in card view, `size-6` in slim view) and adjusts the row layout to accommodate it.
> - A new toggle in [BetaSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/4324/files#diff-7cc018b55a78281318b114e44898712836d74582a8148368ac46409808a9260c) under the existing Sidebar v2 section lets users enable or disable the feature.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 923db8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only beta preference with a safe default; no auth, server, or data-path changes.
> 
> **Overview**
> Introduces **`sidebarV2LargeIcons`** on client settings (schema + patch, default **`false`**) with a contract test for the default.
> 
> **Settings → Beta** gains a **Larger project icons** switch, shown only when Sidebar v2 is enabled.
> 
> When on, **`SidebarV2Row`** uses a leading **`size-14`** favicon on active cards (flex layout beside title/metadata) and **`size-6`** favicons on settled slim rows instead of **`size-4`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923db8ca6a3ace6365cd9539a714e93837cc88cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->