### PR TITLE
feat(claude): discover skills for the $ picker via SDK reloadSkills

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -1,3 +1,5 @@
+import * as NodeOS from "node:os";
+
 import { ClaudeSettings } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
@@ -72,7 +74,19 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
           "const lines = createInterface({ input: process.stdin });",
           'lines.on("line", (line) => {',
           "  const message = JSON.parse(line);",
-          '  if (message.type !== "control_request" || message.request?.subtype !== "initialize") return;',
+          '  if (message.type !== "control_request") return;',
+          '  if (message.request?.subtype === "reload_skills") {',
+          "    process.stdout.write(JSON.stringify({",
+          '      type: "control_response",',
+          "      response: {",
+          '        subtype: "success",',
+          "        request_id: message.request_id,",
+          '        response: { skills: [{ name: "probe-fake-skill", description: "Fake skill (user)", argumentHint: "" }] },',
+          "      },",
+          '    }) + "\\n");',
+          "    return;",
+          "  }",
+          '  if (message.request?.subtype !== "initialize") return;',
           "  process.stdout.write(JSON.stringify({",
           '    type: "control_response",',
           "    response: {",
@@ -105,6 +119,15 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
         workspaceCwd,
       );
 
+      // The fake skill dir doesn't exist on disk, so the mapper falls back to a
+      // constructed path under the default config dir (`~/.claude`) and takes
+      // the scope from the stripped `(user)` description suffix.
+      const expectedSkillPath = path.join(
+        NodeOS.homedir(),
+        ".claude",
+        "skills",
+        "probe-fake-skill",
+      );
       assert.deepEqual(capabilities, {
         email: "dev@example.com",
         subscriptionType: "pro",
@@ -115,6 +138,15 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
             name: "review",
             description: "Review changes",
             input: { hint: "[path]" },
+          },
+        ],
+        skills: [
+          {
+            name: "probe-fake-skill",
+            path: expectedSkillPath,
+            enabled: true,
+            description: "Fake skill",
+            scope: "user",
           },
         ],
       });

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -1,5 +1,3 @@
-import * as NodeOS from "node:os";
-
 import { ClaudeSettings } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
@@ -7,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 
 import {
   buildClaudeCapabilitiesProbeQueryOptions,
@@ -41,7 +40,7 @@ it("isolates Claude capability probes without dropping workspace setting sources
 });
 
 it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
-  it.effect("serializes strict no-MCP options and still resolves account capabilities", () =>
+  it.effect("serializes probe options and keeps core capabilities independent from skills", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -49,6 +48,7 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       const executablePath = path.join(tempDir, "fake-claude.mjs");
       const invocationPath = path.join(tempDir, "invocation.json");
       const workspaceCwd = path.join(tempDir, "workspace");
+      const inheritedConfigDir = path.join(tempDir, "inherited-claude-config");
       yield* fs.makeDirectory(workspaceCwd, { recursive: true });
 
       yield* fs.writeFileString(
@@ -76,6 +76,7 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
           "  const message = JSON.parse(line);",
           '  if (message.type !== "control_request") return;',
           '  if (message.request?.subtype === "reload_skills") {',
+          '    if (process.env.T3_PROBE_SKIP_SKILL_RESPONSE === "true") return;',
           "    process.stdout.write(JSON.stringify({",
           '      type: "control_response",',
           "      response: {",
@@ -113,6 +114,7 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
         decodeClaudeSettings({ binaryPath: executablePath }),
         {
           ...process.env,
+          CLAUDE_CONFIG_DIR: inheritedConfigDir,
           T3_PROBE_INVOCATION_PATH: invocationPath,
           ENABLE_CLAUDEAI_MCP_SERVERS: "true",
         },
@@ -120,14 +122,9 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       );
 
       // The fake skill dir doesn't exist on disk, so the mapper falls back to a
-      // constructed path under the default config dir (`~/.claude`) and takes
-      // the scope from the stripped `(user)` description suffix.
-      const expectedSkillPath = path.join(
-        NodeOS.homedir(),
-        ".claude",
-        "skills",
-        "probe-fake-skill",
-      );
+      // constructed path under the inherited config dir and takes the scope
+      // from the stripped `(user)` description suffix.
+      const expectedSkillPath = path.join(inheritedConfigDir, "skills", "probe-fake-skill");
       assert.deepEqual(capabilities, {
         email: "dev@example.com",
         subscriptionType: "pro",
@@ -149,6 +146,36 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
             scope: "user",
           },
         ],
+      });
+
+      const capabilitiesWithoutSkills = yield* probeClaudeCapabilities(
+        decodeClaudeSettings({ binaryPath: executablePath }),
+        {
+          ...process.env,
+          T3_PROBE_INVOCATION_PATH: invocationPath,
+          T3_PROBE_SKIP_SKILL_RESPONSE: "true",
+        },
+        workspaceCwd,
+        {
+          // A reload may outlive the initialization budget without erasing the
+          // account and command data that initialization already returned.
+          initializationMs: 1_000,
+          skillsReloadMs: 1_250,
+        },
+      ).pipe(TestClock.withLive);
+      assert.deepEqual(capabilitiesWithoutSkills, {
+        email: "dev@example.com",
+        subscriptionType: "pro",
+        tokenSource: "oauth",
+        apiProvider: undefined,
+        slashCommands: [
+          {
+            name: "review",
+            description: "Review changes",
+            input: { hint: "[path]" },
+          },
+        ],
+        skills: [],
       });
 
       // @effect-diagnostics-next-line preferSchemaOverJson:off

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -11,6 +11,7 @@ import {
   buildClaudeCapabilitiesProbeQueryOptions,
   CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES,
   probeClaudeCapabilities,
+  resolveClaudeEnvironmentHomePath,
 } from "./ClaudeProvider.ts";
 
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
@@ -37,6 +38,24 @@ it("isolates Claude capability probes without dropping workspace setting sources
   assert.equal(options.abortController, abortController);
   assert.equal(options.env?.HOME, "/home/user");
   assert.equal(options.env?.ENABLE_CLAUDEAI_MCP_SERVERS, "false");
+});
+
+it("derives the child home with HOME then USERPROFILE precedence", () => {
+  assert.equal(
+    resolveClaudeEnvironmentHomePath(
+      {
+        HOME: "/posix-home",
+        USERPROFILE: "C:\\windows-profile",
+      },
+      "/process-home",
+    ),
+    "/posix-home",
+  );
+  assert.equal(
+    resolveClaudeEnvironmentHomePath({ USERPROFILE: "C:\\windows-profile" }, "/process-home"),
+    "C:\\windows-profile",
+  );
+  assert.equal(resolveClaudeEnvironmentHomePath({}, "/process-home"), "/process-home");
 });
 
 it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
@@ -147,6 +166,23 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
           },
         ],
       });
+
+      const childHome = path.join(tempDir, "child-home");
+      const capabilitiesFromChildHome = yield* probeClaudeCapabilities(
+        decodeClaudeSettings({ binaryPath: executablePath }),
+        {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: undefined,
+          HOME: childHome,
+          USERPROFILE: path.join(tempDir, "other-profile"),
+          T3_PROBE_INVOCATION_PATH: invocationPath,
+        },
+        workspaceCwd,
+      );
+      assert.equal(
+        capabilitiesFromChildHome?.skills[0]?.path,
+        path.join(childHome, ".claude", "skills", "probe-fake-skill"),
+      );
 
       const capabilitiesWithoutSkills = yield* probeClaudeCapabilities(
         decodeClaudeSettings({ binaryPath: executablePath }),

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -184,6 +184,21 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
         path.join(childHome, ".claude", "skills", "probe-fake-skill"),
       );
 
+      const capabilitiesFromTildeConfigDir = yield* probeClaudeCapabilities(
+        decodeClaudeSettings({ binaryPath: executablePath }),
+        {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: "~/custom-claude",
+          HOME: childHome,
+          T3_PROBE_INVOCATION_PATH: invocationPath,
+        },
+        workspaceCwd,
+      );
+      assert.equal(
+        capabilitiesFromTildeConfigDir?.skills[0]?.path,
+        path.join(childHome, "custom-claude", "skills", "probe-fake-skill"),
+      );
+
       const capabilitiesWithoutSkills = yield* probeClaudeCapabilities(
         decodeClaudeSettings({ binaryPath: executablePath }),
         {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -42,7 +42,7 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
-import { makeClaudeEnvironment, resolveClaudeHomePath } from "../Drivers/ClaudeHome.ts";
+import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import { parseClaudeReloadedSkills, pathExistsSync } from "./ClaudeSkillDiscovery.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
@@ -516,6 +516,11 @@ const CAPABILITIES_PROBE_TIMEOUT_MS = 25_000;
 
 const SKILLS_RELOAD_TIMEOUT_MS = 5_000;
 
+type ClaudeCapabilitiesProbeTimeouts = {
+  readonly initializationMs?: number;
+  readonly skillsReloadMs?: number;
+};
+
 /**
  * Keep workspace-scoped command discovery intact while isolating the periodic
  * health check from configured MCP servers.
@@ -662,6 +667,7 @@ const probeClaudeCapabilities = (
   claudeSettings: ClaudeSettings,
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
+  timeouts: ClaudeCapabilitiesProbeTimeouts = {},
 ) => {
   const abort = new AbortController();
   return Effect.gen(function* () {
@@ -671,12 +677,12 @@ const probeClaudeCapabilities = (
       claudeSettings.binaryPath,
       claudeEnvironment,
     );
-    // The effective config dir is `~/.claude` for the default home, or the
-    // configured home path itself (exported as CLAUDE_CONFIG_DIR).
-    const claudeConfigDir =
-      claudeSettings.homePath.trim().length > 0
-        ? yield* resolveClaudeHomePath(claudeSettings)
-        : path.join(NodeOS.homedir(), ".claude");
+    const environmentConfigDir = claudeEnvironment.CLAUDE_CONFIG_DIR?.trim();
+    // Derive this from the exact environment passed to the CLI. In particular,
+    // an inherited CLAUDE_CONFIG_DIR remains effective when homePath is empty.
+    const claudeConfigDir = environmentConfigDir
+      ? path.resolve(cwd ?? process.cwd(), environmentConfigDir)
+      : path.join(NodeOS.homedir(), ".claude");
     const q = claudeQuery({
       // Never yield — we only need initialization data, not a conversation.
       // This prevents any prompt from reaching the Anthropic API.
@@ -691,13 +697,21 @@ const probeClaudeCapabilities = (
         cwd,
       }),
     });
-    const init = yield* Effect.tryPromise(() => q.initializationResult());
+    const initResult = yield* Effect.tryPromise(() => q.initializationResult()).pipe(
+      Effect.timeoutOption(timeouts.initializationMs ?? CAPABILITIES_PROBE_TIMEOUT_MS),
+      Effect.result,
+    );
+    if (Result.isFailure(initResult) || Option.isNone(initResult.success)) {
+      return undefined;
+    }
+    const init = initResult.success.value;
     // `reloadSkills` is best-effort: older CLIs may not answer the control
-    // request (and the SDK never times it out), so bound it ourselves and fall
-    // back to an empty skill list rather than failing the whole probe.
+    // request (and the SDK never times it out). Give it a separate budget after
+    // initialization so it cannot discard already-resolved account and command
+    // capabilities.
     const reloadedSkills = yield* Effect.tryPromise(() => q.reloadSkills()).pipe(
       Effect.map((reloaded) => reloaded.skills),
-      Effect.timeoutOption(SKILLS_RELOAD_TIMEOUT_MS),
+      Effect.timeoutOption(timeouts.skillsReloadMs ?? SKILLS_RELOAD_TIMEOUT_MS),
       Effect.orElseSucceed(() => Option.none<ReadonlyArray<ClaudeSlashCommand>>()),
       Effect.map(Option.getOrElse(() => [] as ReadonlyArray<ClaudeSlashCommand>)),
     );
@@ -728,12 +742,6 @@ const probeClaudeCapabilities = (
         if (!abort.signal.aborted) abort.abort();
       }),
     ),
-    Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),
-    Effect.result,
-    Effect.map((result) => {
-      if (Result.isFailure(result)) return undefined;
-      return Option.isSome(result.success) ? result.success.value : undefined;
-    }),
   );
 };
 

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -521,6 +521,16 @@ type ClaudeCapabilitiesProbeTimeouts = {
   readonly skillsReloadMs?: number;
 };
 
+function resolveClaudeEnvironmentHomePath(
+  environment: NodeJS.ProcessEnv,
+  fallbackHomePath = NodeOS.homedir(),
+): string {
+  // HOME is the POSIX home variable and is also intentionally honored when a
+  // caller supplies it cross-platform; USERPROFILE covers the normal Windows
+  // environment when HOME is absent.
+  return environment.HOME ?? environment.USERPROFILE ?? fallbackHomePath;
+}
+
 /**
  * Keep workspace-scoped command discovery intact while isolating the periodic
  * health check from configured MCP servers.
@@ -682,7 +692,7 @@ const probeClaudeCapabilities = (
     // an inherited CLAUDE_CONFIG_DIR remains effective when homePath is empty.
     const claudeConfigDir = environmentConfigDir
       ? path.resolve(cwd ?? process.cwd(), environmentConfigDir)
-      : path.join(NodeOS.homedir(), ".claude");
+      : path.join(resolveClaudeEnvironmentHomePath(claudeEnvironment), ".claude");
     const q = claudeQuery({
       // Never yield — we only need initialization data, not a conversation.
       // This prevents any prompt from reaching the Anthropic API.
@@ -972,4 +982,4 @@ export const makePendingClaudeProvider = (
     });
   });
 
-export { probeClaudeCapabilities };
+export { probeClaudeCapabilities, resolveClaudeEnvironmentHomePath };

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -1,8 +1,11 @@
+import * as NodeOS from "node:os";
+
 import {
   type ClaudeSettings,
   type ModelCapabilities,
   type ModelSelection,
   type ServerProviderModel,
+  type ServerProviderSkill,
   type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
@@ -39,7 +42,8 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
-import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import { makeClaudeEnvironment, resolveClaudeHomePath } from "../Drivers/ClaudeHome.ts";
+import { parseClaudeReloadedSkills, pathExistsSync } from "./ClaudeSkillDiscovery.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
@@ -510,6 +514,8 @@ function apiProviderAuthMetadata(
 // `undefined` and left the provider unverified and unselectable in the picker.
 const CAPABILITIES_PROBE_TIMEOUT_MS = 25_000;
 
+const SKILLS_RELOAD_TIMEOUT_MS = 5_000;
+
 /**
  * Keep workspace-scoped command discovery intact while isolating the periodic
  * health check from configured MCP servers.
@@ -564,6 +570,7 @@ type ClaudeCapabilitiesProbe = {
    */
   readonly apiProvider: string | undefined;
   readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
 };
 
 function parseClaudeInitializationCommands(
@@ -658,43 +665,63 @@ const probeClaudeCapabilities = (
 ) => {
   const abort = new AbortController();
   return Effect.gen(function* () {
+    const path = yield* Path.Path;
     const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
     const executablePath = yield* resolveClaudeSdkExecutablePath(
       claudeSettings.binaryPath,
       claudeEnvironment,
     );
-    return yield* Effect.tryPromise(async () => {
-      const q = claudeQuery({
-        // Never yield — we only need initialization data, not a conversation.
-        // This prevents any prompt from reaching the Anthropic API.
-        // oxlint-disable-next-line require-yield
-        prompt: (async function* (): AsyncGenerator<SDKUserMessage> {
-          await waitForAbortSignal(abort.signal);
-        })(),
-        options: buildClaudeCapabilitiesProbeQueryOptions({
-          executablePath,
-          abortController: abort,
-          environment: claudeEnvironment,
-          cwd,
-        }),
-      });
-      const init = await q.initializationResult();
-      const account = init.account as
-        | {
-            readonly email?: string;
-            readonly subscriptionType?: string;
-            readonly tokenSource?: string;
-            readonly apiProvider?: string;
-          }
-        | undefined;
-      return {
-        email: account?.email,
-        subscriptionType: account?.subscriptionType,
-        tokenSource: account?.tokenSource,
-        apiProvider: account?.apiProvider,
-        slashCommands: parseClaudeInitializationCommands(init.commands),
-      } satisfies ClaudeCapabilitiesProbe;
+    // The effective config dir is `~/.claude` for the default home, or the
+    // configured home path itself (exported as CLAUDE_CONFIG_DIR).
+    const claudeConfigDir =
+      claudeSettings.homePath.trim().length > 0
+        ? yield* resolveClaudeHomePath(claudeSettings)
+        : path.join(NodeOS.homedir(), ".claude");
+    const q = claudeQuery({
+      // Never yield — we only need initialization data, not a conversation.
+      // This prevents any prompt from reaching the Anthropic API.
+      // oxlint-disable-next-line require-yield
+      prompt: (async function* (): AsyncGenerator<SDKUserMessage> {
+        await waitForAbortSignal(abort.signal);
+      })(),
+      options: buildClaudeCapabilitiesProbeQueryOptions({
+        executablePath,
+        abortController: abort,
+        environment: claudeEnvironment,
+        cwd,
+      }),
     });
+    const init = yield* Effect.tryPromise(() => q.initializationResult());
+    // `reloadSkills` is best-effort: older CLIs may not answer the control
+    // request (and the SDK never times it out), so bound it ourselves and fall
+    // back to an empty skill list rather than failing the whole probe.
+    const reloadedSkills = yield* Effect.tryPromise(() => q.reloadSkills()).pipe(
+      Effect.map((reloaded) => reloaded.skills),
+      Effect.timeoutOption(SKILLS_RELOAD_TIMEOUT_MS),
+      Effect.orElseSucceed(() => Option.none<ReadonlyArray<ClaudeSlashCommand>>()),
+      Effect.map(Option.getOrElse(() => [] as ReadonlyArray<ClaudeSlashCommand>)),
+    );
+    const skills = parseClaudeReloadedSkills(reloadedSkills, {
+      claudeConfigDir,
+      cwd,
+      pathExists: pathExistsSync,
+    });
+    const account = init.account as
+      | {
+          readonly email?: string;
+          readonly subscriptionType?: string;
+          readonly tokenSource?: string;
+          readonly apiProvider?: string;
+        }
+      | undefined;
+    return {
+      email: account?.email,
+      subscriptionType: account?.subscriptionType,
+      tokenSource: account?.tokenSource,
+      apiProvider: account?.apiProvider,
+      slashCommands: parseClaudeInitializationCommands(init.commands),
+      skills,
+    } satisfies ClaudeCapabilitiesProbe;
   }).pipe(
     Effect.ensuring(
       Effect.sync(() => {
@@ -847,6 +874,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     : undefined;
   const slashCommands = capabilities?.slashCommands ?? [];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
+  const skills = capabilities?.skills ?? [];
 
   if (!capabilities) {
     return buildServerProvider({
@@ -855,6 +883,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
       checkedAt,
       models,
       slashCommands: dedupedSlashCommands,
+      skills,
       probe: {
         installed: true,
         version: parsedVersion,
@@ -876,6 +905,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     checkedAt,
     models,
     slashCommands: dedupedSlashCommands,
+    skills,
     probe: {
       installed: true,
       version: parsedVersion,

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -690,9 +690,16 @@ const probeClaudeCapabilities = (
     const environmentConfigDir = claudeEnvironment.CLAUDE_CONFIG_DIR?.trim();
     // Derive this from the exact environment passed to the CLI. In particular,
     // an inherited CLAUDE_CONFIG_DIR remains effective when homePath is empty.
-    const claudeConfigDir = environmentConfigDir
-      ? path.resolve(cwd ?? process.cwd(), environmentConfigDir)
-      : path.join(resolveClaudeEnvironmentHomePath(claudeEnvironment), ".claude");
+    const environmentHomePath = resolveClaudeEnvironmentHomePath(claudeEnvironment);
+    const expandedEnvironmentConfigDir =
+      environmentConfigDir === "~"
+        ? environmentHomePath
+        : environmentConfigDir?.startsWith(`~${path.sep}`)
+          ? path.join(environmentHomePath, environmentConfigDir.slice(2))
+          : environmentConfigDir;
+    const claudeConfigDir = expandedEnvironmentConfigDir
+      ? path.resolve(cwd ?? process.cwd(), expandedEnvironmentConfigDir)
+      : path.join(environmentHomePath, ".claude");
     const q = claudeQuery({
       // Never yield — we only need initialization data, not a conversation.
       // This prevents any prompt from reaching the Anthropic API.

--- a/apps/server/src/provider/Layers/ClaudeSkillDiscovery.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeSkillDiscovery.test.ts
@@ -1,0 +1,152 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  type ClaudeSkillDiscoveryContext,
+  parseClaudeReloadedSkills,
+} from "./ClaudeSkillDiscovery.ts";
+
+const CONFIG_DIR = "/home/dev/.claude";
+const CWD = "/repo";
+
+function makeCtx(overrides?: Partial<ClaudeSkillDiscoveryContext>): ClaudeSkillDiscoveryContext {
+  return {
+    claudeConfigDir: CONFIG_DIR,
+    cwd: CWD,
+    pathExists: () => false,
+    ...overrides,
+  };
+}
+
+describe("parseClaudeReloadedSkills", () => {
+  it("strips the scope suffix and maps it, using the config-dir fallback path", () => {
+    const skills = parseClaudeReloadedSkills(
+      [{ name: "disk-cleanup", description: "Reclaim disk space (user)" }],
+      makeCtx(),
+    );
+
+    expect(skills).toEqual([
+      {
+        name: "disk-cleanup",
+        path: NodePath.join(CONFIG_DIR, "skills", "disk-cleanup"),
+        enabled: true,
+        description: "Reclaim disk space",
+        scope: "user",
+      },
+    ]);
+  });
+
+  it("maps project/local suffixes to project and builtin/bundled/system to system", () => {
+    const scopes = parseClaudeReloadedSkills(
+      [
+        { name: "a", description: "A (project)" },
+        { name: "b", description: "B (local)" },
+        { name: "c", description: "C (builtin)" },
+        { name: "d", description: "D (bundled)" },
+        { name: "e", description: "E (system)" },
+        { name: "f", description: "F (policy)" },
+      ],
+      makeCtx(),
+    ).map((skill) => skill.scope);
+
+    expect(scopes).toEqual(["project", "project", "system", "system", "system", "policy"]);
+  });
+
+  it("resolves a project path when the workspace skill dir exists (defaulting scope to project)", () => {
+    const projectPath = NodePath.join(CWD, ".claude", "skills", "review");
+    const skills = parseClaudeReloadedSkills(
+      [{ name: "review", description: "Review changes" }],
+      makeCtx({ pathExists: (candidate) => candidate === projectPath }),
+    );
+
+    expect(skills[0]).toEqual({
+      name: "review",
+      path: projectPath,
+      enabled: true,
+      description: "Review changes",
+      scope: "project",
+    });
+  });
+
+  it("resolves a user path when only the config-dir skill dir exists", () => {
+    const userPath = NodePath.join(CONFIG_DIR, "skills", "review");
+    const skills = parseClaudeReloadedSkills(
+      [{ name: "review" }],
+      makeCtx({ pathExists: (candidate) => candidate === userPath }),
+    );
+
+    expect(skills[0]).toEqual({
+      name: "review",
+      path: userPath,
+      enabled: true,
+      scope: "user",
+    });
+  });
+
+  it("prefers the description suffix scope over the filesystem default", () => {
+    const projectPath = NodePath.join(CWD, ".claude", "skills", "review");
+    const skills = parseClaudeReloadedSkills(
+      [{ name: "review", description: "Review changes (user)" }],
+      makeCtx({ pathExists: (candidate) => candidate === projectPath }),
+    );
+
+    // Lives in the project dir, but the CLI reported it as a user skill.
+    expect(skills[0]?.path).toBe(projectPath);
+    expect(skills[0]?.scope).toBe("user");
+  });
+
+  it("falls back to a constructed path with no scope when nothing resolves", () => {
+    const skills = parseClaudeReloadedSkills([{ name: "orphan" }], makeCtx());
+
+    expect(skills[0]).toEqual({
+      name: "orphan",
+      path: NodePath.join(CONFIG_DIR, "skills", "orphan"),
+      enabled: true,
+    });
+  });
+
+  it("does not filesystem-resolve plugin-qualified names", () => {
+    const skills = parseClaudeReloadedSkills(
+      [{ name: "my-plugin:helper", description: "Helper (plugin)" }],
+      makeCtx({
+        pathExists: () => {
+          throw new Error("pathExists must not be called for plugin-qualified names");
+        },
+      }),
+    );
+
+    expect(skills[0]).toEqual({
+      name: "my-plugin:helper",
+      path: NodePath.join(CONFIG_DIR, "skills", "my-plugin:helper"),
+      enabled: true,
+      description: "Helper",
+      scope: "plugin",
+    });
+  });
+
+  it("dedupes by lowercased name, first entry wins and later fills a missing description", () => {
+    const skills = parseClaudeReloadedSkills(
+      [
+        { name: "Review" },
+        { name: "review", description: "Filled in later (user)" },
+        { name: "review", description: "Ignored" },
+      ],
+      makeCtx(),
+    );
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.name).toBe("Review");
+    expect(skills[0]?.description).toBe("Filled in later");
+  });
+
+  it("skips entries with empty or whitespace-only names", () => {
+    const skills = parseClaudeReloadedSkills(
+      [{ name: "  " }, { name: "" }, { name: "keep" }],
+      makeCtx(),
+    );
+
+    expect(skills.map((skill) => skill.name)).toEqual(["keep"]);
+  });
+});

--- a/apps/server/src/provider/Layers/ClaudeSkillDiscovery.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeSkillDiscovery.test.ts
@@ -126,7 +126,7 @@ describe("parseClaudeReloadedSkills", () => {
     });
   });
 
-  it("dedupes by lowercased name, first entry wins and later fills a missing description", () => {
+  it("dedupes by lowercased name and backfills missing parsed metadata", () => {
     const skills = parseClaudeReloadedSkills(
       [
         { name: "Review" },
@@ -139,6 +139,7 @@ describe("parseClaudeReloadedSkills", () => {
     expect(skills).toHaveLength(1);
     expect(skills[0]?.name).toBe("Review");
     expect(skills[0]?.description).toBe("Filled in later");
+    expect(skills[0]?.scope).toBe("user");
   });
 
   it("skips entries with empty or whitespace-only names", () => {

--- a/apps/server/src/provider/Layers/ClaudeSkillDiscovery.ts
+++ b/apps/server/src/provider/Layers/ClaudeSkillDiscovery.ts
@@ -75,12 +75,16 @@ export function parseClaudeReloadedSkills(
     const key = name.toLowerCase();
     const existing = byName.get(key);
     if (existing) {
-      // First entry wins; later duplicates only fill in a missing description.
-      if (!existing.description) {
-        const description = parseDescription(skill.description).description;
-        if (description) {
-          byName.set(key, { ...existing, description });
-        }
+      // First entry wins; later duplicates only fill missing parsed metadata.
+      const parsed = parseDescription(skill.description);
+      if ((!existing.description && parsed.description) || (!existing.scope && parsed.scope)) {
+        byName.set(key, {
+          ...existing,
+          ...(!existing.description && parsed.description
+            ? { description: parsed.description }
+            : {}),
+          ...(!existing.scope && parsed.scope ? { scope: parsed.scope } : {}),
+        });
       }
       continue;
     }

--- a/apps/server/src/provider/Layers/ClaudeSkillDiscovery.ts
+++ b/apps/server/src/provider/Layers/ClaudeSkillDiscovery.ts
@@ -1,0 +1,136 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+
+import type { ServerProviderSkill } from "@t3tools/contracts";
+
+/** Production filesystem probe injected into {@link parseClaudeReloadedSkills}. */
+export const pathExistsSync = (candidate: string): boolean => NodeFS.existsSync(candidate);
+
+/**
+ * A skill entry as returned by the Claude Agent SDK's `reloadSkills` control
+ * request. The SDK reuses its `SlashCommand` shape here; only the fields we map
+ * are required.
+ */
+export type ClaudeReloadedSkill = {
+  readonly name: string;
+  readonly description?: string;
+};
+
+export type ClaudeSkillDiscoveryContext = {
+  /**
+   * Effective Claude config dir (the `CLAUDE_CONFIG_DIR` the CLI runs under):
+   * `~/.claude` for the default home, or the configured home path directly.
+   */
+  readonly claudeConfigDir: string;
+  /** Workspace the probe ran in, used to resolve project-scoped skills. */
+  readonly cwd: string | undefined;
+  readonly pathExists: (candidate: string) => boolean;
+};
+
+// `reloadSkills` appends the discovery scope to each description, e.g.
+// "…reclaim disk space (user)". Strip it so it doesn't leak into the UI and
+// reuse it as the skill's scope when we can't derive one from the filesystem.
+const SCOPE_SUFFIX_PATTERN =
+  /\s*\((user|project|local|plugin|builtin|bundled|system|managed|policy)\)\s*$/i;
+
+function mapScopeToken(token: string): string {
+  switch (token.toLowerCase()) {
+    case "user":
+      return "user";
+    case "project":
+    case "local":
+      return "project";
+    case "builtin":
+    case "bundled":
+    case "system":
+      return "system";
+    default:
+      return token.toLowerCase();
+  }
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const candidate = value?.trim();
+  return candidate ? candidate : undefined;
+}
+
+/**
+ * Map the SDK's reloaded skill list into provider-snapshot skills, resolving a
+ * real path on disk when possible and falling back to a constructed path (the
+ * contract requires a non-empty `path`).
+ */
+export function parseClaudeReloadedSkills(
+  skills: ReadonlyArray<ClaudeReloadedSkill> | undefined,
+  ctx: ClaudeSkillDiscoveryContext,
+): ReadonlyArray<ServerProviderSkill> {
+  const byName = new Map<string, ServerProviderSkill>();
+
+  for (const skill of skills ?? []) {
+    const name = nonEmpty(skill.name);
+    if (!name) {
+      continue;
+    }
+
+    const key = name.toLowerCase();
+    const existing = byName.get(key);
+    if (existing) {
+      // First entry wins; later duplicates only fill in a missing description.
+      if (!existing.description) {
+        const description = parseDescription(skill.description).description;
+        if (description) {
+          byName.set(key, { ...existing, description });
+        }
+      }
+      continue;
+    }
+
+    byName.set(key, buildSkill(name, skill.description, ctx));
+  }
+
+  return [...byName.values()];
+}
+
+function parseDescription(raw: string | undefined): {
+  readonly description: string | undefined;
+  readonly scope: string | undefined;
+} {
+  const trimmed = raw?.trim() ?? "";
+  const match = trimmed.match(SCOPE_SUFFIX_PATTERN);
+  const scope = match ? mapScopeToken(match[1]!) : undefined;
+  const description = nonEmpty(match ? trimmed.replace(SCOPE_SUFFIX_PATTERN, "") : trimmed);
+  return { description, scope };
+}
+
+function buildSkill(
+  name: string,
+  rawDescription: string | undefined,
+  ctx: ClaudeSkillDiscoveryContext,
+): ServerProviderSkill {
+  const { description, scope: suffixScope } = parseDescription(rawDescription);
+  const configPath = NodePath.join(ctx.claudeConfigDir, "skills", name);
+
+  let path = configPath;
+  let scope = suffixScope;
+
+  // Plugin-qualified names ("plugin:skill") don't correspond to a
+  // "<root>/skills/<name>" directory, so skip the filesystem probe.
+  if (!name.includes(":")) {
+    const projectPath = ctx.cwd ? NodePath.join(ctx.cwd, ".claude", "skills", name) : undefined;
+    if (projectPath && ctx.pathExists(projectPath)) {
+      path = projectPath;
+      scope = suffixScope ?? "project";
+    } else if (ctx.pathExists(configPath)) {
+      path = configPath;
+      scope = suffixScope ?? "user";
+    }
+  }
+
+  return {
+    name,
+    path,
+    enabled: true,
+    ...(description ? { description } : {}),
+    ...(scope ? { scope } : {}),
+  } satisfies ServerProviderSkill;
+}

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -20,6 +20,7 @@ import {
   ProviderInstanceId,
   ServerSettings,
   type ServerProvider,
+  type ServerProviderSkill,
   type ServerProviderSlashCommand,
   type ServerSettings as ContractServerSettings,
 } from "@t3tools/contracts";
@@ -103,6 +104,7 @@ type TestClaudeCapabilities = {
   readonly tokenSource: string | undefined;
   readonly apiProvider: string | undefined;
   readonly slashCommands: ReadonlyArray<ServerProviderSlashCommand>;
+  readonly skills: ReadonlyArray<ServerProviderSkill>;
 };
 
 function claudeCapabilities(overrides: Partial<TestClaudeCapabilities> = {}) {
@@ -113,6 +115,7 @@ function claudeCapabilities(overrides: Partial<TestClaudeCapabilities> = {}) {
       tokenSource: undefined,
       apiProvider: undefined,
       slashCommands: [],
+      skills: [],
       ...overrides,
     });
 }


### PR DESCRIPTION
## What Changed

- The Claude provider's capability probe now issues the Claude Agent SDK's `reloadSkills` control request after `initializationResult()` and maps the returned entries into `ServerProviderSkill`s, populating `skills` on the provider snapshot.
- New pure mapper `parseClaudeReloadedSkills` (`apps/server/src/provider/Layers/ClaudeSkillDiscovery.ts`):
  - strips the trailing scope suffix `reloadSkills` appends to descriptions (e.g. ` (user)`) and maps it to a snapshot scope (`user`; `project`/`local` → `project`; `builtin`/`bundled`/`system` → `system`);
  - resolves each skill's path best-effort against the workspace `.claude/skills/<name>`, then the effective Claude config dir's `skills/<name>`, falling back to a constructed config-dir path (the contract requires a non-empty `path`); plugin-qualified names skip the filesystem probe;
  - dedupes by name and skips empty names, mirroring the existing slash-command handling.
- The control request is bounded by its own 5s timeout and any failure falls back to an empty list, so older CLIs that don't answer `reload_skills` never fail the capability probe.
- Slash commands are left untouched — skills legitimately also appear as `/` commands for Claude, matching upstream CLI behavior.

## Why

Only the Codex provider populated `skills`, so the composer's `$` skill picker was always empty on Claude threads even though the Claude CLI discovers the same `~/.claude/skills` / `.claude/skills` entries (refs #1480, #2736). With this change Claude skills get the same `$` autocomplete, inline pill rendering, and scope labels (Personal/Project/System) that Codex skills already have.

## Checklist

- [x] Focused tests: `vp test run ClaudeSkillDiscovery.test.ts ClaudeCapabilitiesProbe.test.ts ProviderRegistry.test.ts` → 3 files, 53 tests passed (plus `ClaudeAdapter.test.ts` regression guard → 60 passed)
- [x] Typecheck: `tsgo --noEmit` in `apps/server` → 0 errors
- [x] Lint/format: `vp lint` on changed files, `vp fmt` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider health probing and filesystem path resolution for user config; skill reload is isolated with timeouts so auth/command discovery should remain stable, but probe timing and path edge cases could affect the picker on some setups.
> 
> **Overview**
> **Claude skills now populate the provider snapshot** so the composer `$` picker can list them like Codex already does.
> 
> After a successful SDK initialization, `probeClaudeCapabilities` issues a best-effort `reloadSkills` call with its own timeout; failures yield an empty skill list but no longer fail the whole probe. Account info and slash commands are unchanged.
> 
> New `parseClaudeReloadedSkills` maps SDK entries to `ServerProviderSkill`: strips description scope suffixes (e.g. ` (user)`), resolves paths under workspace `.claude/skills` or the effective config dir (with `CLAUDE_CONFIG_DIR` / `HOME` / `USERPROFILE` handling), and dedupes by name. `checkClaudeProviderStatus` threads `skills` into every built snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac809eae519a69588699c60ff81f0cabc8f4cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discover Claude skills for the $ picker via SDK `reloadSkills`
> - After a successful capabilities probe, `probeClaudeCapabilities` issues a `reloadSkills` request to the Claude SDK subprocess and parses the response into `ServerProviderSkill` objects via the new `parseClaudeReloadedSkills` utility in [`ClaudeSkillDiscovery.ts`](https://github.com/pingdotgg/t3code/pull/4325/files#diff-bc3cb90dda2e0e59cbf282c02dcf471541a7f8e8c9d0afc5a36113470bd1c863).
> - Skill paths are resolved by checking `<cwd>/.claude/skills/<name>` then `<configDir>/skills/<name>`; scope is normalized from description suffix tokens or inferred from the resolved path.
> - The Claude config directory is derived from `CLAUDE_CONFIG_DIR` (with tilde expansion) or defaults to `<home>/.claude`, using a new `resolveClaudeEnvironmentHomePath` helper that prefers `HOME` over `USERPROFILE`.
> - Separate timeouts are now used for initialization and skills reload; a skills reload failure is non-fatal and only the initialization timeout causes the probe to return `undefined`.
> - The `skills` array is threaded through `checkClaudeProviderStatus` and included in the provider snapshot (empty when capabilities are absent).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aac809e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->