### PR TITLE
Fix manual unread state handling

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -24,6 +24,7 @@ import {
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
+  resolveThreadVisitCompletedAt,
   resolveSendEnvMode,
   shouldShowBranchMismatchBanner,
   shouldWriteThreadErrorToCurrentServerThread,
@@ -83,6 +84,25 @@ const readySession = {
   lastError: null,
   updatedAt: "2026-03-29T00:00:10.000Z",
 };
+
+describe("resolveThreadVisitCompletedAt", () => {
+  it("tracks the latest completion rather than metadata-only updates", () => {
+    const metadataUpdatedThread = makeThread({
+      updatedAt: "2026-03-29T00:05:00.000Z",
+      latestTurn: completedTurn,
+    });
+
+    expect(resolveThreadVisitCompletedAt(metadataUpdatedThread)).toBe(completedTurn.completedAt);
+    expect(resolveThreadVisitCompletedAt(makeThread({ latestTurn: null }))).toBeNull();
+    expect(
+      resolveThreadVisitCompletedAt(
+        makeThread({
+          latestTurn: { ...completedTurn, completedAt: "invalid" },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
 
 describe("resolveThreadMetadataUpdateForNextTurn", () => {
   const modelSelection = {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -27,6 +27,13 @@ export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
+export function resolveThreadVisitCompletedAt(
+  thread: Pick<Thread, "latestTurn"> | null | undefined,
+): string | null {
+  const completedAt = thread?.latestTurn?.completedAt;
+  return completedAt && !Number.isNaN(Date.parse(completedAt)) ? completedAt : null;
+}
+
 export function resolveThreadMetadataUpdateForNextTurn(input: {
   currentModelSelection: ModelSelection;
   nextModelSelection?: ModelSelection;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -55,7 +55,7 @@ import {
   useState,
 } from "react";
 import { flushSync } from "react-dom";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import {
   isAtomCommandInterrupted,
@@ -170,7 +170,11 @@ import {
   deriveLogicalProjectKeyFromSettings,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { buildDraftThreadRouteParams } from "../threadRoutes";
+import {
+  buildDraftThreadRouteParams,
+  resolveThreadRouteTarget,
+  shouldKeepActiveThreadVisitOnUnmount,
+} from "../threadRoutes";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -263,6 +267,7 @@ import {
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
+  resolveThreadVisitCompletedAt,
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
@@ -1174,10 +1179,7 @@ function ChatViewContent(props: ChatViewProps) {
   const composerDraftTarget: ScopedThreadRef | DraftId =
     routeKind === "server" ? routeThreadRef : props.draftId;
   const serverThread = useThread(routeThreadRef);
-  const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
-  const activeThreadLastVisitedAt = useUiStateStore(
-    (store) => store.threadLastVisitedAtById[routeThreadKey],
-  );
+  const markActiveThreadVisited = useUiStateStore((store) => store.markActiveThreadVisited);
   const settings = useEnvironmentSettings(environmentId);
   // New-thread defaults live in the primary environment's settings.json (the
   // settings UI never writes to remote environments), so read them from the
@@ -1189,6 +1191,7 @@ function ChatViewContent(props: ChatViewProps) {
   const timestampFormat = settings.timestampFormat;
   const autoOpenPlanSidebar = settings.autoOpenPlanSidebar;
   const navigate = useNavigate();
+  const router = useRouter();
   const { resolvedTheme } = useTheme();
   // Granular store selectors — avoid subscribing to prompt changes.
   const composerRuntimeMode = useComposerDraftStore(
@@ -1776,23 +1779,34 @@ function ChatViewContent(props: ChatViewProps) {
   );
 
   useEffect(() => {
-    if (!serverThread?.id) return;
-    const threadUpdatedAt = Date.parse(serverThread.updatedAt);
-    if (Number.isNaN(threadUpdatedAt)) return;
-    const lastVisitedAt = activeThreadLastVisitedAt ? Date.parse(activeThreadLastVisitedAt) : NaN;
-    if (!Number.isNaN(lastVisitedAt) && lastVisitedAt >= threadUpdatedAt) return;
+    if (serverThread === null) {
+      markActiveThreadVisited(routeThreadKey, null);
+      return;
+    }
+    useUiStateStore.getState().markThreadVisited(routeThreadKey, serverThread.updatedAt);
+    markActiveThreadVisited(routeThreadKey, resolveThreadVisitCompletedAt(serverThread));
+  }, [markActiveThreadVisited, routeThreadKey, serverThread]);
 
-    markThreadVisited(
-      scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-      serverThread.updatedAt,
-    );
-  }, [
-    activeThreadLastVisitedAt,
-    markThreadVisited,
-    serverThread?.environmentId,
-    serverThread?.id,
-    serverThread?.updatedAt,
-  ]);
+  useEffect(
+    () => () => {
+      const currentRouteParams =
+        router.state.matches[router.state.matches.length - 1]?.params ?? {};
+      const currentRouteTarget = resolveThreadRouteTarget(currentRouteParams);
+      if (
+        shouldKeepActiveThreadVisitOnUnmount({
+          currentRouteTarget,
+          routeThreadKey,
+          draftId,
+        })
+      ) {
+        return;
+      }
+      if (useUiStateStore.getState().activeThreadVisit?.threadKey === routeThreadKey) {
+        markActiveThreadVisited(null, null);
+      }
+    },
+    [draftId, markActiveThreadVisited, routeThreadKey, router],
+  );
 
   const selectedProviderByThreadId = composerActiveProvider ?? null;
   const threadProvider =

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -17,8 +17,10 @@ import {
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
+  resolveSidebarV2TopStatus,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
+  shouldShowSidebarV2UnreadProminence,
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
@@ -654,6 +656,47 @@ describe("resolveSidebarV2Status", () => {
   });
 });
 
+describe("resolveSidebarV2TopStatus", () => {
+  it.each(["approval", "input", "working", "failed"] as const)(
+    "keeps %s above an explicit unread marker",
+    (status) => {
+      expect(
+        resolveSidebarV2TopStatus({
+          status,
+          isExplicitlyUnread: true,
+          isUnread: true,
+        }),
+      ).toBe(status);
+    },
+  );
+
+  it("uses unread only for a ready thread", () => {
+    expect(
+      resolveSidebarV2TopStatus({
+        status: "ready",
+        isExplicitlyUnread: true,
+        isUnread: true,
+      }),
+    ).toBe("unread");
+    expect(
+      resolveSidebarV2TopStatus({
+        status: "ready",
+        isExplicitlyUnread: false,
+        isUnread: true,
+      }),
+    ).toBe("done");
+  });
+});
+
+describe("shouldShowSidebarV2UnreadProminence", () => {
+  it("keeps unread prominence for ready rows only", () => {
+    expect(shouldShowSidebarV2UnreadProminence({ status: "ready", isUnread: true })).toBe(true);
+    expect(shouldShowSidebarV2UnreadProminence({ status: "working", isUnread: true })).toBe(false);
+    expect(shouldShowSidebarV2UnreadProminence({ status: "approval", isUnread: true })).toBe(false);
+    expect(shouldShowSidebarV2UnreadProminence({ status: "input", isUnread: true })).toBe(false);
+  });
+});
+
 describe("sortThreadsForSidebarV2", () => {
   const sortable = (input: { id: string; createdAt: string }) => ({
     id: input.id,
@@ -835,6 +878,23 @@ describe("resolveThreadStatusPill", () => {
     },
   };
 
+  it("shows explicit unread even without a completed turn", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          isExplicitlyUnread: true,
+          latestTurn: null,
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            activeTurnId: null,
+          },
+        },
+      }),
+    ).toMatchObject({ label: "Unread", pulse: false });
+  });
+
   it("shows pending approval before all other statuses", () => {
     expect(
       resolveThreadStatusPill({
@@ -842,9 +902,21 @@ describe("resolveThreadStatusPill", () => {
           ...baseThread,
           hasPendingApprovals: true,
           hasPendingUserInput: true,
+          isExplicitlyUnread: true,
         },
       }),
     ).toMatchObject({ label: "Pending Approval", pulse: false });
+  });
+
+  it("shows active work before an explicit unread marker", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          isExplicitlyUnread: true,
+        },
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
   });
 
   it("shows awaiting input when plan mode is blocked on user answers", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -98,6 +98,7 @@ export interface ThreadStatusPill {
   label:
     | "Working"
     | "Connecting"
+    | "Unread"
     | "Completed"
     | "Pending Approval"
     | "Awaiting Input"
@@ -113,7 +114,8 @@ const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
   Working: 3,
   Connecting: 3,
   "Plan Ready": 2,
-  Completed: 1,
+  Unread: 1,
+  Completed: 0,
 };
 
 type ThreadStatusInput = Pick<
@@ -126,6 +128,7 @@ type ThreadStatusInput = Pick<
   | "session"
 > & {
   lastVisitedAt?: string | undefined;
+  isExplicitlyUnread?: boolean | undefined;
 };
 
 export interface ThreadJumpHintVisibilityController {
@@ -424,6 +427,29 @@ export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2S
   return "ready";
 }
 
+export type SidebarV2TopStatus = Exclude<SidebarV2Status, "ready"> | "unread" | "done" | null;
+
+export function resolveSidebarV2TopStatus(input: {
+  readonly status: SidebarV2Status;
+  readonly isExplicitlyUnread: boolean;
+  readonly isUnread: boolean;
+}): SidebarV2TopStatus {
+  if (input.status !== "ready") {
+    return input.status;
+  }
+  if (input.isExplicitlyUnread) {
+    return "unread";
+  }
+  return input.isUnread ? "done" : null;
+}
+
+export function shouldShowSidebarV2UnreadProminence(input: {
+  readonly status: SidebarV2Status;
+  readonly isUnread: boolean;
+}): boolean {
+  return input.status === "ready" && input.isUnread;
+}
+
 /** NaN-safe Date.parse for sort comparators: a malformed timestamp must not
     poison the whole ordering, so it sinks to the epoch instead. */
 export function parseTimestampMs(isoDate: string): number {
@@ -589,6 +615,15 @@ export function resolveThreadStatusPill(input: {
       label: "Plan Ready",
       colorClass: "text-violet-600 dark:text-violet-300/90",
       dotClass: "bg-violet-500 dark:bg-violet-300/90",
+      pulse: false,
+    };
+  }
+
+  if (thread.isExplicitlyUnread) {
+    return {
+      label: "Unread",
+      colorClass: "text-blue-600 dark:text-blue-300/90",
+      dotClass: "bg-blue-500 dark:bg-blue-300/90",
       pulse: false,
     };
   }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -368,6 +368,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isExplicitlyUnread = useUiStateStore(
+    (state) => state.threadExplicitlyUnreadById[threadKey] === true,
+  );
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: thread.environmentId,
@@ -447,6 +450,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     thread: {
       ...thread,
       lastVisitedAt,
+      isExplicitlyUnread,
     },
   });
   const pr = resolveThreadPr({
@@ -1195,6 +1199,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       ),
     ),
   );
+  const threadExplicitlyUnreadStates = useUiStateStore(
+    useShallow((state) =>
+      projectThreads.map(
+        (thread) =>
+          state.threadExplicitlyUnreadById[
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))
+          ] === true,
+      ),
+    ),
+  );
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
   const [confirmingArchiveThreadKey, setConfirmingArchiveThreadKey] = useState<string | null>(null);
@@ -1243,14 +1257,20 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         threadLastVisitedAts[index] ?? null,
       ]),
     );
-    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
-      const lastVisitedAt = lastVisitedAtByThreadKey.get(
+    const explicitlyUnreadByThreadKey = new Map(
+      projectThreads.map((thread, index) => [
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      );
+        threadExplicitlyUnreadStates[index] ?? false,
+      ]),
+    );
+    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      const lastVisitedAt = lastVisitedAtByThreadKey.get(threadKey);
       return resolveThreadStatusPill({
         thread: {
           ...thread,
           ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
+          ...(explicitlyUnreadByThreadKey.get(threadKey) ? { isExplicitlyUnread: true } : {}),
         },
       });
     };
@@ -1268,7 +1288,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
+  }, [projectThreads, threadExplicitlyUnreadStates, threadLastVisitedAts, threadSortOrder]);
   const pinnedCollapsedThread = useMemo(() => {
     const activeThreadKey = activeRouteThreadKey ?? undefined;
     if (!activeThreadKey || projectExpanded) {
@@ -1295,14 +1315,20 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         threadLastVisitedAts[index] ?? null,
       ]),
     );
-    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
-      const lastVisitedAt = lastVisitedAtByThreadKey.get(
+    const explicitlyUnreadByThreadKey = new Map(
+      projectThreads.map((thread, index) => [
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      );
+        threadExplicitlyUnreadStates[index] ?? false,
+      ]),
+    );
+    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      const lastVisitedAt = lastVisitedAtByThreadKey.get(threadKey);
       return resolveThreadStatusPill({
         thread: {
           ...thread,
           ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
+          ...(explicitlyUnreadByThreadKey.get(threadKey) ? { isExplicitlyUnread: true } : {}),
         },
       });
     };
@@ -1340,6 +1366,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     projectExpanded,
     projectThreads,
     sidebarThreadPreviewCount,
+    threadExplicitlyUnreadStates,
     threadLastVisitedAts,
     visibleProjectThreads,
   ]);

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -109,7 +109,9 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
+  resolveSidebarV2TopStatus,
   resolveWorkingStartedAt,
+  shouldShowSidebarV2UnreadProminence,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
@@ -415,13 +417,17 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   );
   const threadKey = scopedThreadKey(threadRef);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isExplicitlyUnread = useUiStateStore(
+    (state) => state.threadExplicitlyUnreadById[threadKey] === true,
+  );
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const openPrLink = useOpenPrLink();
 
   // Same semantics as v1 (never-visited counts as read): flipping the beta
   // flag must not light up every historical thread as unread.
-  const isUnread = hasUnseenCompletion({ ...thread, lastVisitedAt });
+  const isUnread = isExplicitlyUnread || hasUnseenCompletion({ ...thread, lastVisitedAt });
   const status = resolveSidebarV2Status(thread);
+  const hasUnreadProminence = shouldShowSidebarV2UnreadProminence({ status, isUnread });
   // A woken thread reappears at its original position (the sort is
   // deliberately static), so the pill has to carry the weight. Snoozing is
   // an explicit act, so unlike Done, a never-visited woke thread still
@@ -431,6 +437,11 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   const lastVisitedDate = lastVisitedAt === undefined ? null : parseTimestampDate(lastVisitedAt);
   const wokeAtDate = props.wokeAt === null ? null : parseTimestampDate(props.wokeAt);
   const isWoke = wokeAtDate !== null && (lastVisitedDate === null || lastVisitedDate < wokeAtDate);
+  const topStatusKind = resolveSidebarV2TopStatus({
+    status,
+    isExplicitlyUnread,
+    isUnread,
+  });
   // In-flight rows (working, or waiting on approval/input) fade as a whole:
   // there is nothing for the user to do yet, so prominence is reserved for
   // rows that need a human — done (unread), read-but-unsettled, failed, and
@@ -440,31 +451,35 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // stands out.
   const isInFlight = status === "working" || status === "approval" || status === "input";
   const shouldRecede =
-    (status === "ready" || isInFlight) && !isUnread && !isWoke && !props.isActive && !isSelected;
+    (status === "ready" || isInFlight) &&
+    !hasUnreadProminence &&
+    !isWoke &&
+    !props.isActive &&
+    !isSelected;
   // Status hues follow the system-wide convention set by sidebar v1 and the
   // mobile Live Activity/widgets (amber approval, indigo input, sky working)
   // so a thread reads the same color everywhere it surfaces.
   const topStatus =
-    status === "working"
+    topStatusKind === "working"
       ? {
           label: "Working",
           icon: "working" as const,
           className:
             "animate-sidebar-working-text text-sky-600 motion-reduce:animate-none dark:text-sky-400",
         }
-      : status === "approval"
+      : topStatusKind === "approval"
         ? {
             label: "Approval",
             icon: null,
             className: "text-amber-700 dark:text-amber-300",
           }
-        : status === "input"
+        : topStatusKind === "input"
           ? {
               label: "Input",
               icon: null,
               className: "text-indigo-600 dark:text-indigo-300",
             }
-          : status === "failed"
+          : topStatusKind === "failed"
             ? {
                 label: "Failed",
                 icon: null,
@@ -476,13 +491,19 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                   icon: "woke" as const,
                   className: "text-amber-700 dark:text-amber-300",
                 }
-              : isUnread
+              : topStatusKind === "unread"
                 ? {
-                    label: "Done",
-                    icon: "done" as const,
-                    className: "text-emerald-700 dark:text-emerald-300",
+                    label: "Unread",
+                    icon: null,
+                    className: "text-blue-600 dark:text-blue-300",
                   }
-                : null;
+                : topStatusKind === "done"
+                  ? {
+                      label: "Done",
+                      icon: "done" as const,
+                      className: "text-emerald-700 dark:text-emerald-300",
+                    }
+                  : null;
 
   const gitCwd = thread.worktreePath ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(
@@ -689,7 +710,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
         variant === "card"
           ? cn(
               "truncate",
-              isUnread || isWoke
+              hasUnreadProminence || isWoke
                 ? "text-foreground"
                 : shouldRecede
                   ? "text-muted-foreground/80"
@@ -701,7 +722,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               "truncate group-hover/v2-row:text-foreground",
               props.isActive || isWoke
                 ? "text-foreground"
-                : isUnread
+                : hasUnreadProminence
                   ? "text-muted-foreground"
                   : "text-muted-foreground/70",
             ),

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -236,8 +236,10 @@ export function ThreadStatusLabel({
  */
 export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummary }) {
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
-  const lastVisitedAt = useUiStateStore(
-    (state) => state.threadLastVisitedAtById[scopedThreadKey(threadRef)],
+  const threadKey = scopedThreadKey(threadRef);
+  const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isExplicitlyUnread = useUiStateStore(
+    (state) => state.threadExplicitlyUnreadById[threadKey] === true,
   );
   const threadProject = useProject(
     useMemo(
@@ -265,6 +267,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
     thread: {
       ...thread,
       lastVisitedAt,
+      isExplicitlyUnread,
     },
   });
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   type ErrorComponentProps,
   useLocation,
   useNavigate,
+  useRouterState,
 } from "@tanstack/react-router";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
@@ -48,6 +49,7 @@ import {
   primaryServerWelcomeAtom,
 } from "../state/server";
 import { readProject, setActiveEnvironmentId, useActiveEnvironmentId } from "../state/entities";
+import { resolveThreadRouteTarget } from "../threadRoutes";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -134,6 +136,7 @@ function RootRouteView() {
         <SshPasswordPromptDialog />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
+        <NonChatRouteVisitTracker />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
         {appShell}
@@ -193,6 +196,24 @@ function HostedStaticEnvironmentBootstrap() {
 
     setActiveEnvironmentId(firstSavedEnvironment.environmentId);
   }, [activeEnvironmentId, environments]);
+
+  return null;
+}
+
+function NonChatRouteVisitTracker() {
+  const hasThreadRoute = useRouterState({
+    select: (state) => {
+      const params = state.matches[state.matches.length - 1]?.params ?? {};
+      return resolveThreadRouteTarget(params) !== null;
+    },
+  });
+  const markActiveThreadVisited = useUiStateStore((state) => state.markActiveThreadVisited);
+
+  useEffect(() => {
+    if (!hasThreadRoute) {
+      markActiveThreadVisited(null, null);
+    }
+  }, [hasThreadRoute, markActiveThreadVisited]);
 
   return null;
 }

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -10,6 +10,7 @@ import {
   resolveThreadRouteRenderState,
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
+  shouldKeepActiveThreadVisitOnUnmount,
 } from "./threadRoutes";
 
 describe("threadRoutes", () => {
@@ -65,6 +66,48 @@ describe("threadRoutes", () => {
       kind: "draft",
       draftId: "draft-1",
     });
+
+    expect(resolveThreadRouteTarget({ environmentId: "env-1" })).toBeNull();
+    expect(resolveThreadRouteTarget({ threadId: "thread-1" })).toBeNull();
+  });
+
+  it("keeps an active visit only while the same chat route remains mounted", () => {
+    const routeThreadKey = "env-1:thread-1";
+
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({
+          environmentId: "env-1",
+          threadId: "thread-1",
+        }),
+        routeThreadKey,
+        draftId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({
+          environmentId: "env-1",
+          threadId: "thread-2",
+        }),
+        routeThreadKey,
+        draftId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({ draftId: "draft-1" }),
+        routeThreadKey,
+        draftId: DraftId.make("draft-1"),
+      }),
+    ).toBe(true);
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({ draftId: "draft-2" }),
+        routeThreadKey,
+        draftId: DraftId.make("draft-1"),
+      }),
+    ).toBe(false);
   });
 
   it("resolves the backing thread while a draft route is being promoted", () => {

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -1,4 +1,4 @@
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { DraftId } from "./composerDraftStore";
 
@@ -83,6 +83,21 @@ export function resolveThreadRouteTarget(
     kind: "draft",
     draftId: params.draftId as DraftId,
   };
+}
+
+export function shouldKeepActiveThreadVisitOnUnmount(input: {
+  readonly currentRouteTarget: ThreadRouteTarget | null;
+  readonly routeThreadKey: string;
+  readonly draftId: DraftId | null;
+}): boolean {
+  if (input.currentRouteTarget?.kind === "server") {
+    return scopedThreadKey(input.currentRouteTarget.threadRef) === input.routeThreadKey;
+  }
+  return (
+    input.currentRouteTarget?.kind === "draft" &&
+    input.draftId !== null &&
+    input.currentRouteTarget.draftId === input.draftId
+  );
 }
 
 /**

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import {
   legacyProjectCwdPreferenceKey,
+  markActiveThreadVisited,
   markThreadUnread,
   markThreadVisited,
   parsePersistedState,
@@ -22,7 +23,10 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectExpandedById: {},
     projectOrder: [],
     threadLastVisitedAtById: {},
+    threadExplicitlyUnreadById: {},
     threadChangedFilesExpandedById: {},
+    hasTrackedActiveThreadRoute: false,
+    activeThreadVisit: null,
     defaultAdvertisedEndpointKey: null,
     ...overrides,
   };
@@ -39,7 +43,7 @@ describe("uiStateStore pure functions", () => {
     expect(markThreadVisited(visited, threadId, "not-a-date")).toBe(visited);
   });
 
-  it("marks a completed thread unread using the server completion timestamp", () => {
+  it("marks any thread explicitly unread without requiring a completion timestamp", () => {
     const threadId = ThreadId.make("thread-1");
     const initialState = makeUiState({
       threadLastVisitedAtById: {
@@ -49,8 +53,145 @@ describe("uiStateStore pure functions", () => {
 
     const next = markThreadUnread(initialState, threadId, "2026-02-25T12:30:00.000Z");
 
-    expect(next.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:29:59.999Z");
+    expect(next.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(next.threadLastVisitedAtById).toBe(initialState.threadLastVisitedAtById);
     expect(markThreadUnread(next, threadId, null)).toBe(next);
+  });
+
+  it("keeps an active thread unread until its route or update changes", () => {
+    const threadId = ThreadId.make("thread-1");
+    const otherThreadId = ThreadId.make("thread-2");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const active = markActiveThreadVisited(makeUiState(), threadId, updatedAt);
+    const unread = markThreadUnread(active, threadId, null);
+
+    expect(markActiveThreadVisited(unread, threadId, updatedAt)).toBe(unread);
+    expect(unread.threadExplicitlyUnreadById[threadId]).toBe(true);
+
+    const away = markActiveThreadVisited(unread, otherThreadId, null);
+    const returned = markActiveThreadVisited(away, threadId, updatedAt);
+    expect(returned.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+  });
+
+  it("preserves persisted unread state through initial route hydration", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const restarted = parsePersistedState({
+      threadLastVisitedAtById: { [threadId]: updatedAt },
+      threadExplicitlyUnreadById: { [threadId]: true },
+    });
+
+    const routed = markActiveThreadVisited(restarted, threadId, null);
+    const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
+
+    expect(routed.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.activeThreadVisit).toEqual({
+      threadKey: threadId,
+      visitedAt: updatedAt,
+      preserveUnreadOnFirstCompletion: false,
+    });
+  });
+
+  it("preserves persisted unread when a draft promotes to the same thread", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const restarted = parsePersistedState({
+      threadLastVisitedAtById: { [threadId]: updatedAt },
+      threadExplicitlyUnreadById: { [threadId]: true },
+    });
+
+    const draft = markActiveThreadVisited(restarted, threadId, null);
+    const routed = markActiveThreadVisited(draft, threadId, null);
+    const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
+
+    expect(draft.hasTrackedActiveThreadRoute).toBe(true);
+    expect(routed.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.activeThreadVisit).toEqual({
+      threadKey: threadId,
+      visitedAt: updatedAt,
+      preserveUnreadOnFirstCompletion: false,
+    });
+  });
+
+  it("clears persisted unread after tracking a non-chat route", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const restarted = parsePersistedState({
+      threadLastVisitedAtById: { [threadId]: updatedAt },
+      threadExplicitlyUnreadById: { [threadId]: true },
+    });
+
+    const nonChatRoute = markActiveThreadVisited(restarted, null, null);
+    const routed = markActiveThreadVisited(nonChatRoute, threadId, null);
+    const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
+
+    expect(nonChatRoute.hasTrackedActiveThreadRoute).toBe(true);
+    expect(routed.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+    expect(hydrated.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+  });
+
+  it("preserves active unread state through a transient detail gap", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const active = markActiveThreadVisited(makeUiState(), threadId, updatedAt);
+    const unread = markThreadUnread(active, threadId, null);
+
+    const missing = markActiveThreadVisited(unread, threadId, null);
+    const restored = markActiveThreadVisited(missing, threadId, updatedAt);
+
+    expect(missing).toBe(unread);
+    expect(restored).toBe(unread);
+    expect(restored.threadExplicitlyUnreadById[threadId]).toBe(true);
+  });
+
+  it("clears explicit unread after leaving and returning to the same route", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const active = markActiveThreadVisited(makeUiState(), threadId, updatedAt);
+    const unread = markThreadUnread(active, threadId, null);
+
+    const away = markActiveThreadVisited(unread, null, null);
+    const returned = markActiveThreadVisited(away, threadId, updatedAt);
+
+    expect(returned.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+  });
+
+  it("clears explicit unread when the active thread receives a newer completion", () => {
+    const threadId = ThreadId.make("thread-1");
+    const active = markActiveThreadVisited(makeUiState(), threadId, "2026-02-25T12:30:00.000Z");
+    const unread = markThreadUnread(active, threadId, null);
+    const updated = markActiveThreadVisited(unread, threadId, "2026-02-25T12:35:00.000Z");
+
+    expect(updated.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+    expect(updated.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:35:00.000Z");
+  });
+
+  it("clears a manual unread mark when an active thread's first turn completes", () => {
+    const threadId = ThreadId.make("thread-1");
+    const routed = markActiveThreadVisited(makeUiState(), threadId, null);
+    const unread = markThreadUnread(routed, threadId, null);
+    const completed = markActiveThreadVisited(unread, threadId, "2026-02-25T12:35:00.000Z");
+
+    expect(completed.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+    expect(completed.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:35:00.000Z");
+  });
+
+  it("preserves explicit unread when an active visit timestamp regresses", () => {
+    const threadId = ThreadId.make("thread-1");
+    const active = markActiveThreadVisited(makeUiState(), threadId, "2026-02-25T12:35:00.000Z");
+    const unread = markThreadUnread(active, threadId, null);
+
+    const stale = markActiveThreadVisited(unread, threadId, "2026-02-25T12:30:00.000Z");
+
+    expect(stale).toBe(unread);
+    expect(stale.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(stale.activeThreadVisit).toEqual({
+      threadKey: threadId,
+      visitedAt: "2026-02-25T12:35:00.000Z",
+      preserveUnreadOnFirstCompletion: false,
+    });
   });
 
   it("resolves project expansion from logical, physical, and legacy preference keys", () => {
@@ -158,6 +299,10 @@ describe("parsePersistedState", () => {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
       },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
+        read: false,
+      },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpansionVersion: 1,
       threadChangedFilesExpandedById: {
@@ -176,6 +321,11 @@ describe("parsePersistedState", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
+      },
+      hasTrackedActiveThreadRoute: false,
+      activeThreadVisit: null,
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
@@ -273,6 +423,9 @@ describe("uiStateStore persistence", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
+      },
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
           "turn-1": false,
@@ -294,6 +447,9 @@ describe("uiStateStore persistence", () => {
       projectOrder: ["physical-b", "physical-a"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
+      },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
       },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpansionVersion: 1,

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -21,6 +21,7 @@ export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
+  threadExplicitlyUnreadById?: Record<string, boolean>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
@@ -36,7 +37,14 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
+  threadExplicitlyUnreadById: Record<string, boolean>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  hasTrackedActiveThreadRoute: boolean;
+  activeThreadVisit: {
+    readonly threadKey: string;
+    readonly visitedAt: string | null;
+    readonly preserveUnreadOnFirstCompletion: boolean;
+  } | null;
 }
 
 export interface UiEndpointState {
@@ -49,7 +57,10 @@ const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
+  threadExplicitlyUnreadById: {},
   threadChangedFilesExpandedById: {},
+  hasTrackedActiveThreadRoute: false,
+  activeThreadVisit: null,
   defaultAdvertisedEndpointKey: null,
 };
 
@@ -126,10 +137,17 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     projectExpandedById,
     projectOrder,
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
+    threadExplicitlyUnreadById: Object.fromEntries(
+      Object.entries(sanitizeBooleanRecord(parsed.threadExplicitlyUnreadById)).filter(
+        ([, unread]) => unread,
+      ),
+    ),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
         ? sanitizePersistedThreadChangedFilesExpanded(parsed.threadChangedFilesExpandedById)
         : {},
+    hasTrackedActiveThreadRoute: false,
+    activeThreadVisit: null,
     defaultAdvertisedEndpointKey:
       typeof parsed.defaultAdvertisedEndpointKey === "string" &&
       parsed.defaultAdvertisedEndpointKey.length > 0
@@ -204,6 +222,7 @@ export function persistState(state: UiState): void {
         projectExpandedById,
         projectOrder: state.projectOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
+        threadExplicitlyUnreadById: state.threadExplicitlyUnreadById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
         threadChangedFilesExpandedById: state.threadChangedFilesExpandedById,
@@ -248,24 +267,89 @@ export function markThreadVisited(state: UiState, threadId: string, visitedAt: s
 export function markThreadUnread(
   state: UiState,
   threadId: string,
-  latestTurnCompletedAt: string | null | undefined,
+  _latestTurnCompletedAt?: string | null | undefined,
 ): UiState {
-  if (!latestTurnCompletedAt) {
-    return state;
-  }
-  const latestTurnCompletedAtMs = Date.parse(latestTurnCompletedAt);
-  if (Number.isNaN(latestTurnCompletedAtMs)) {
-    return state;
-  }
-  const unreadVisitedAt = new Date(latestTurnCompletedAtMs - 1).toISOString();
-  if (state.threadLastVisitedAtById[threadId] === unreadVisitedAt) {
+  if (state.threadExplicitlyUnreadById[threadId]) {
     return state;
   }
   return {
     ...state,
-    threadLastVisitedAtById: {
-      ...state.threadLastVisitedAtById,
-      [threadId]: unreadVisitedAt,
+    threadExplicitlyUnreadById: {
+      ...state.threadExplicitlyUnreadById,
+      [threadId]: true,
+    },
+  };
+}
+
+export function markActiveThreadVisited(
+  state: UiState,
+  threadKey: string | null,
+  visitedAt: string | null,
+): UiState {
+  if (threadKey === null) {
+    return state.activeThreadVisit === null && state.hasTrackedActiveThreadRoute
+      ? state
+      : {
+          ...state,
+          hasTrackedActiveThreadRoute: true,
+          activeThreadVisit: null,
+        };
+  }
+
+  if (state.activeThreadVisit?.threadKey === threadKey) {
+    if (visitedAt === null || state.activeThreadVisit.visitedAt === visitedAt) {
+      return state;
+    }
+
+    if (state.activeThreadVisit.visitedAt === null) {
+      const visitedState = markThreadVisited(state, threadKey, visitedAt);
+      const nextExplicitlyUnreadById = {
+        ...visitedState.threadExplicitlyUnreadById,
+      };
+      if (!state.activeThreadVisit.preserveUnreadOnFirstCompletion) {
+        delete nextExplicitlyUnreadById[threadKey];
+      }
+      return {
+        ...visitedState,
+        threadExplicitlyUnreadById: nextExplicitlyUnreadById,
+        hasTrackedActiveThreadRoute: true,
+        activeThreadVisit: {
+          threadKey,
+          visitedAt,
+          preserveUnreadOnFirstCompletion: false,
+        },
+      };
+    }
+
+    const previousVisitedAtMs = Date.parse(state.activeThreadVisit.visitedAt);
+    const nextVisitedAtMs = Date.parse(visitedAt);
+    if (
+      !Number.isFinite(nextVisitedAtMs) ||
+      (Number.isFinite(previousVisitedAtMs) && nextVisitedAtMs <= previousVisitedAtMs)
+    ) {
+      return state;
+    }
+  }
+
+  const visitedState = visitedAt === null ? state : markThreadVisited(state, threadKey, visitedAt);
+  const nextExplicitlyUnreadById = {
+    ...visitedState.threadExplicitlyUnreadById,
+  };
+  if (state.hasTrackedActiveThreadRoute) {
+    delete nextExplicitlyUnreadById[threadKey];
+  }
+
+  return {
+    ...visitedState,
+    threadExplicitlyUnreadById: nextExplicitlyUnreadById,
+    hasTrackedActiveThreadRoute: true,
+    activeThreadVisit: {
+      threadKey,
+      visitedAt,
+      preserveUnreadOnFirstCompletion:
+        visitedAt === null &&
+        !state.hasTrackedActiveThreadRoute &&
+        state.threadExplicitlyUnreadById[threadKey] === true,
     },
   };
 }
@@ -384,6 +468,7 @@ export function reorderProjects(
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
+  markActiveThreadVisited: (threadKey: string | null, visitedAt: string | null) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
@@ -400,6 +485,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => markThreadVisited(state, threadId, visitedAt)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
+  markActiveThreadVisited: (threadKey, visitedAt) =>
+    set((state) => markActiveThreadVisited(state, threadKey, visitedAt)),
   setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
   setDefaultAdvertisedEndpointKey: (key) =>


### PR DESCRIPTION
## What Changed

- Replaced timestamp backdating with a persisted explicit per-thread manual-unread flag.
- Kept a manually unread active thread unread until the user genuinely leaves and returns.
- Preserved manual unread through initial route hydration, transient detail gaps, and same-thread draft promotion.
- Rendered **Unread** consistently in Sidebar V1, Sidebar V2, project aggregates, and compact thread indicators.
- Kept live actionable states such as approval, input, and working above the manual unread presentation.

## Why

The previous `Mark unread` flow could immediately re-mark the active thread as read and could not mark threads without a completed-turn timestamp. Manual unread state is now represented directly instead of being inferred by manipulating visit timestamps.

## Scope

This PR only fixes explicit manual-unread behavior. Automatic first-seen completion monitoring was removed from this branch and is not required by this fix.

## Verification

- Rebased onto current `main` (`5719e8ac4`).
- 156 tests passed across the four affected suites; this branch adds 16 focused regression cases.
- Scoped formatting and lint checks passed for all 13 changed files.
- Isolated browser verification passed: marking the active thread unread remains visible immediately, and leaving then returning clears it.

## Checklist

- [x] This PR is focused on manual unread-state correctness
- [x] No automatic completion-monitoring behavior is included
- [x] Both sidebar implementations render the explicit state
- [x] No new layout or animation behavior is introduced


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix manual unread state handling using explicit unread flags and active thread visit tracking
> - Replaces the previous `lastVisitedAt`-manipulation approach with a persistent `threadExplicitlyUnreadById` flag in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/4329/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8), so marking a thread unread no longer depends on completion timestamps.
> - Adds `markActiveThreadVisited` to the UI store to track which thread route is currently active and its latest completion time; explicit unread is cleared when the user returns to a route or receives a newer completion.
> - Sidebar components ([Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4329/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4329/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c), [ThreadStatusIndicators.tsx](https://github.com/pingdotgg/t3code/pull/4329/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189)) now read `threadExplicitlyUnreadById` and pass `isExplicitlyUnread` into status resolution, surfacing a distinct blue 'Unread' pill.
> - Adds `shouldKeepActiveThreadVisitOnUnmount` in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/4329/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3) and a `NonChatRouteVisitTracker` in [__root.tsx](https://github.com/pingdotgg/t3code/pull/4329/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) to clear active visit state when navigating away from thread routes.
> - Behavioral Change: explicit unread flags are now persisted to and restored from localStorage via `threadExplicitlyUnreadById`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11081d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->