### PR TITLE
Add persistent filters to the classic sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  classifySidebarThreadFilterStatus,
   createThreadJumpHintVisibilityController,
+  filterSidebarThreadsForActiveRoute,
+  getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
@@ -10,11 +13,17 @@ import {
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
   hasUnseenCompletion,
+  hasActiveSidebarThreadFilters,
+  hasNarrowingSidebarThreadFilters,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
+  matchesSidebarThreadFilters,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolvePinnedCollapsedSidebarThread,
+  resolveSidebarArchiveEnvironmentIds,
   resolveSidebarStageBadgeLabel,
+  resolveSidebarThreadFilterStatuses,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
   resolveThreadStatusPill,
@@ -27,16 +36,18 @@ import {
   sortThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
+  sidebarProviderInstanceKey,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
 } from "./Sidebar.logic";
 import {
   EnvironmentId,
   OrchestrationLatestTurn,
   ProjectId,
+  ProviderDriverKind,
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
-
+import { DEFAULT_SIDEBAR_THREAD_FILTERS } from "@t3tools/contracts/settings";
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -93,6 +104,500 @@ describe("shouldNavigateAfterProjectRemoval", () => {
         projectDraftId: null,
       }),
     ).toBe(false);
+  });
+});
+
+const filterableThread = {
+  archivedAt: null,
+  createdAt: "2026-03-09T09:00:00.000Z",
+  environmentId: localEnvironmentId,
+  hasActionableProposedPlan: false,
+  hasPendingApprovals: false,
+  hasPendingUserInput: false,
+  interactionMode: "default",
+  latestUserMessageAt: "2026-03-09T10:00:00.000Z",
+  latestTurn: null,
+  session: null,
+  updatedAt: "2026-03-09T10:00:00.000Z",
+} as const;
+
+describe("sidebar thread filters", () => {
+  it("classifies attention, working, unread, and done as exclusive statuses", () => {
+    expect(
+      classifySidebarThreadFilterStatus({ ...filterableThread, hasPendingApprovals: true }),
+    ).toBe("needs_attention");
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-03-09T10:00:00.000Z",
+        },
+      }),
+    ).toBe("working");
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        latestTurn: makeLatestTurn(),
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+      }),
+    ).toBe("unread");
+    expect(classifySidebarThreadFilterStatus(filterableThread)).toBe("done");
+  });
+
+  it("keeps needs-attention status when a thread also has an unseen completion", () => {
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        hasPendingUserInput: true,
+        latestTurn: makeLatestTurn(),
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+      }),
+    ).toBe("needs_attention");
+  });
+
+  it("keeps working status when a live thread also has an unseen completion", () => {
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        latestTurn: makeLatestTurn(),
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-03-09T10:00:00.000Z",
+        },
+      }),
+    ).toBe("working");
+  });
+
+  it("matches status, environment, source, and archived controls", () => {
+    const archivedThread = {
+      ...filterableThread,
+      archivedAt: "2026-03-09T11:00:00.000Z",
+    };
+    expect(
+      matchesSidebarThreadFilters({
+        thread: archivedThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: DEFAULT_SIDEBAR_THREAD_FILTERS,
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: archivedThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          statuses: ["done"],
+          environmentIds: [localEnvironmentId],
+          sources: [ProviderDriverKind.make("codex")],
+          recentOnly: false,
+          attentionOnly: false,
+          includeArchived: true,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("claudeAgent"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          sources: [ProviderDriverKind.make("codex")],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats an empty status selection as an unrestricted status filter", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      statuses: [],
+    };
+
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(resolveSidebarThreadFilterStatuses(filters.statuses)).toEqual(
+      DEFAULT_SIDEBAR_THREAD_FILTERS.statuses,
+    );
+    expect(hasNarrowingSidebarThreadFilters(filters)).toBe(false);
+    expect(hasActiveSidebarThreadFilters(filters)).toBe(false);
+  });
+
+  it("matches the attention quick filter as unread OR needs attention", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      attentionOnly: true,
+    };
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...filterableThread, hasPendingUserInput: true },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestTurn: makeLatestTurn(),
+          session: {
+            threadId: ThreadId.make("thread-1"),
+            status: "running",
+            providerName: "Codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: "2026-03-09T10:00:00.000Z",
+          },
+        },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestTurn: makeLatestTurn(),
+        },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches unread live threads through either their live or unread status facet", () => {
+    const workingThread = {
+      ...filterableThread,
+      session: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: "Codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-03-09T10:00:00.000Z",
+      },
+    } as const;
+
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, latestTurn: makeLatestTurn() },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["unread"] },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, latestTurn: makeLatestTurn() },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["working"] },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, latestTurn: makeLatestTurn() },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["done"] },
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, latestTurn: makeLatestTurn() },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["unread"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("composes the attention quick filter with live and unread status facets", () => {
+    const workingThread = {
+      ...filterableThread,
+      session: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: "Codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-03-09T10:00:00.000Z",
+      },
+    } as const;
+
+    for (const statuses of [["working"], ["unread"]] as const) {
+      expect(
+        matchesSidebarThreadFilters({
+          thread: { ...workingThread, latestTurn: makeLatestTurn() },
+          lastVisitedAt: "2026-03-09T10:04:00.000Z",
+          providerDriverKind: ProviderDriverKind.make("codex"),
+          filters: {
+            ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+            attentionOnly: true,
+            statuses: [...statuses],
+          },
+        }),
+      ).toBe(true);
+    }
+    expect(
+      matchesSidebarThreadFilters({
+        thread: workingThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          attentionOnly: true,
+          statuses: ["working"],
+        },
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, hasPendingUserInput: true },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          attentionOnly: true,
+          statuses: ["needs_attention"],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("matches recent activity within the last seven days", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      recentOnly: true,
+    };
+    const nowMs = Date.parse("2026-03-10T10:00:00.000Z");
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: null,
+          updatedAt: "2026-03-03T09:59:59.999Z",
+          createdAt: "2026-03-03T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: null,
+          updatedAt: "not-a-date",
+          createdAt: "2026-03-03T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: "2026-03-01T10:00:00.000Z",
+          updatedAt: "2026-03-10T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: "not-a-date",
+          updatedAt: "2026-03-10T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(true);
+  });
+
+  it("counts activity recorded only on the latest turn as recent", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      recentOnly: true,
+    };
+    const nowMs = Date.parse("2026-03-10T10:00:00.000Z");
+    const recentTimestamp = "2026-03-10T09:00:00.000Z";
+    const olderTurn = {
+      ...makeLatestTurn({
+        completedAt: "2026-03-01T10:05:00.000Z",
+        startedAt: "2026-03-01T10:00:00.000Z",
+      }),
+      requestedAt: "2026-03-01T09:59:00.000Z",
+    };
+    const olderThread = {
+      ...filterableThread,
+      latestUserMessageAt: null,
+      updatedAt: "2026-03-01T10:00:00.000Z",
+      createdAt: "2026-03-01T09:00:00.000Z",
+    };
+
+    for (const latestTurn of [
+      { ...olderTurn, requestedAt: recentTimestamp },
+      { ...olderTurn, startedAt: recentTimestamp },
+      { ...olderTurn, completedAt: recentTimestamp },
+    ]) {
+      expect(
+        matchesSidebarThreadFilters({
+          thread: { ...olderThread, latestTurn },
+          providerDriverKind: ProviderDriverKind.make("codex"),
+          filters,
+          nowMs,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("ignores malformed and older latest-turn timestamps for recent filtering", () => {
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: null,
+          latestTurn: {
+            ...makeLatestTurn({
+              completedAt: "not-a-date",
+              startedAt: "2026-03-01T10:00:00.000Z",
+            }),
+            requestedAt: "not-a-date",
+          },
+          updatedAt: "2026-03-01T10:00:00.000Z",
+          createdAt: "2026-03-01T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          recentOnly: true,
+        },
+        nowMs: Date.parse("2026-03-10T10:00:00.000Z"),
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes the default filter state and meaningful deviations", () => {
+    expect(hasActiveSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
+    expect(hasNarrowingSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        statuses: ["needs_attention", "unread", "working"],
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        includeArchived: true,
+      }),
+    ).toBe(true);
+    expect(
+      hasNarrowingSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        includeArchived: true,
+      }),
+    ).toBe(false);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        attentionOnly: true,
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        recentOnly: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("sidebar filter scoping", () => {
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+  it("scopes provider instance ids by environment", () => {
+    const instanceId = ProviderInstanceId.make("codex_work");
+
+    expect(sidebarProviderInstanceKey(localEnvironmentId, instanceId)).not.toBe(
+      sidebarProviderInstanceKey(remoteEnvironmentId, instanceId),
+    );
+  });
+
+  it("loads archived snapshots only for selected environments", () => {
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [remoteEnvironmentId],
+        includeArchived: true,
+      }),
+    ).toEqual([remoteEnvironmentId]);
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [],
+        includeArchived: true,
+      }),
+    ).toEqual([localEnvironmentId, remoteEnvironmentId]);
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [remoteEnvironmentId],
+        includeArchived: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("excludes archived rows from shift-range selection order", () => {
+    expect(
+      getSidebarRangeSelectionThreadKeys([
+        { threadKey: "active-1", archivedAt: null },
+        { threadKey: "archived", archivedAt: "2026-03-09T11:00:00.000Z" },
+        { threadKey: "active-2", archivedAt: null },
+      ]),
+    ).toEqual(["active-1", "active-2"]);
   });
 });
 
@@ -991,6 +1496,55 @@ describe("resolveProjectStatusIndicator", () => {
 });
 
 describe("getVisibleThreadsForProject", () => {
+  it("keeps only the active route when every thread fails the filters", () => {
+    const threads = [
+      { threadKey: "environment-local:thread-active", matches: false },
+      { threadKey: "environment-local:thread-hidden", matches: false },
+    ];
+
+    const filteredThreads = filterSidebarThreadsForActiveRoute({
+      threads,
+      activeThreadKey: "environment-local:thread-active",
+      getThreadKey: (thread) => thread.threadKey,
+      matchesFilters: (thread) => thread.matches,
+    });
+
+    expect(filteredThreads).toEqual([threads[0]]);
+    expect(
+      resolvePinnedCollapsedSidebarThread({
+        threads: filteredThreads,
+        activeThreadKey: "environment-local:thread-active",
+        projectExpanded: false,
+        getThreadKey: (thread) => thread.threadKey,
+      }),
+    ).toBe(threads[0]);
+    expect(
+      resolvePinnedCollapsedSidebarThread({
+        threads: filteredThreads,
+        activeThreadKey: "environment-local:thread-active",
+        projectExpanded: true,
+        getThreadKey: (thread) => thread.threadKey,
+      }),
+    ).toBeNull();
+  });
+
+  it("continues applying filters to non-active rows", () => {
+    const threads = [
+      { threadKey: "active", matches: false },
+      { threadKey: "matching", matches: true },
+      { threadKey: "hidden", matches: false },
+    ];
+
+    expect(
+      filterSidebarThreadsForActiveRoute({
+        threads,
+        activeThreadKey: "active",
+        getThreadKey: (thread) => thread.threadKey,
+        matchesFilters: (thread) => thread.matches,
+      }).map((thread) => thread.threadKey),
+    ).toEqual(["active", "matching"]);
+  });
+
   it("includes the active thread even when it falls below the folded preview", () => {
     const threads = Array.from({ length: 8 }, (_, index) =>
       makeThread({
@@ -1001,7 +1555,8 @@ describe("getVisibleThreadsForProject", () => {
 
     const result = getVisibleThreadsForProject({
       threads,
-      activeThreadId: ThreadId.make("thread-8"),
+      activeThreadKey: "environment-local:thread-8",
+      getThreadKey: (thread) => `environment-local:${thread.id}`,
       isThreadListExpanded: false,
       previewLimit: 6,
     });
@@ -1028,7 +1583,8 @@ describe("getVisibleThreadsForProject", () => {
 
     const result = getVisibleThreadsForProject({
       threads,
-      activeThreadId: ThreadId.make("thread-8"),
+      activeThreadKey: "environment-local:thread-8",
+      getThreadKey: (thread) => `environment-local:${thread.id}`,
       isThreadListExpanded: true,
       previewLimit: 6,
     });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,6 +1,17 @@
 import * as React from "react";
-import type { ContextMenuItem } from "@t3tools/contracts";
-import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import type {
+  ContextMenuItem,
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+import {
+  SIDEBAR_THREAD_FILTER_STATUSES,
+  type SidebarProjectSortOrder,
+  type SidebarThreadFilters,
+  type SidebarThreadFilterStatus,
+  type SidebarThreadSortOrder,
+} from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
   sortThreads,
@@ -229,6 +240,184 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   const lastVisitedAt = Date.parse(thread.lastVisitedAt);
   if (Number.isNaN(lastVisitedAt)) return true;
   return completedAt > lastVisitedAt;
+}
+
+type SidebarThreadFilterInput = Pick<
+  SidebarThreadSummary,
+  | "archivedAt"
+  | "createdAt"
+  | "environmentId"
+  | "hasActionableProposedPlan"
+  | "hasPendingApprovals"
+  | "hasPendingUserInput"
+  | "interactionMode"
+  | "latestUserMessageAt"
+  | "latestTurn"
+  | "session"
+  | "updatedAt"
+>;
+
+const SIDEBAR_RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1_000;
+
+export function resolveSidebarThreadFilterStatuses(statuses: readonly SidebarThreadFilterStatus[]) {
+  return statuses.length === 0 ? SIDEBAR_THREAD_FILTER_STATUSES : statuses;
+}
+
+function latestValidTimestampMs(...timestamps: ReadonlyArray<string | null>): number | null {
+  return timestamps.reduce<number | null>((latest, timestamp) => {
+    const timestampMs = timestamp === null ? Number.NaN : Date.parse(timestamp);
+    return Number.isNaN(timestampMs) ? latest : Math.max(latest ?? timestampMs, timestampMs);
+  }, null);
+}
+
+export function classifySidebarThreadFilterStatus(
+  thread: SidebarThreadFilterInput & { readonly lastVisitedAt?: string | undefined },
+): SidebarThreadFilterStatus {
+  const needsAttention =
+    thread.hasPendingApprovals ||
+    thread.hasPendingUserInput ||
+    thread.session?.status === "error" ||
+    (thread.interactionMode === "plan" &&
+      isLatestTurnSettled(thread.latestTurn, thread.session) &&
+      thread.hasActionableProposedPlan);
+  if (needsAttention) {
+    return "needs_attention";
+  }
+
+  if (thread.session?.status === "running" || thread.session?.status === "starting") {
+    return "working";
+  }
+
+  if (hasUnseenCompletion(thread)) {
+    return "unread";
+  }
+
+  return "done";
+}
+
+export function matchesSidebarThreadFilters(input: {
+  readonly thread: SidebarThreadFilterInput;
+  readonly lastVisitedAt?: string | null | undefined;
+  readonly providerDriverKind: ProviderDriverKind | null;
+  readonly filters: SidebarThreadFilters;
+  readonly nowMs?: number | undefined;
+}): boolean {
+  const { filters, thread } = input;
+  if (thread.archivedAt !== null && !filters.includeArchived) {
+    return false;
+  }
+  if (filters.environmentIds.length > 0 && !filters.environmentIds.includes(thread.environmentId)) {
+    return false;
+  }
+  if (
+    filters.sources.length > 0 &&
+    (input.providerDriverKind === null || !filters.sources.includes(input.providerDriverKind))
+  ) {
+    return false;
+  }
+
+  const classifiedThread = {
+    ...thread,
+    ...(input.lastVisitedAt ? { lastVisitedAt: input.lastVisitedAt } : {}),
+  };
+  const status = classifySidebarThreadFilterStatus(classifiedThread);
+  const isUnread = hasUnseenCompletion(classifiedThread);
+  if (filters.attentionOnly && status !== "needs_attention" && !isUnread) {
+    return false;
+  }
+  if (filters.recentOnly) {
+    const recentTimestampMs = latestValidTimestampMs(
+      thread.latestUserMessageAt,
+      thread.latestTurn?.requestedAt ?? null,
+      thread.latestTurn?.startedAt ?? null,
+      thread.latestTurn?.completedAt ?? null,
+      thread.updatedAt,
+      thread.createdAt,
+    );
+    if (
+      recentTimestampMs === null ||
+      recentTimestampMs < (input.nowMs ?? Date.now()) - SIDEBAR_RECENT_WINDOW_MS
+    ) {
+      return false;
+    }
+  }
+  const selectedStatuses = resolveSidebarThreadFilterStatuses(filters.statuses);
+  return selectedStatuses.includes(status) || (isUnread && selectedStatuses.includes("unread"));
+}
+
+export function hasNarrowingSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
+  const selectedStatuses = new Set(resolveSidebarThreadFilterStatuses(filters.statuses));
+  const includesEveryStatus = SIDEBAR_THREAD_FILTER_STATUSES.every((status) =>
+    selectedStatuses.has(status),
+  );
+  return (
+    filters.attentionOnly ||
+    filters.recentOnly ||
+    filters.environmentIds.length > 0 ||
+    filters.sources.length > 0 ||
+    selectedStatuses.size !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
+    !includesEveryStatus
+  );
+}
+
+export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
+  return filters.includeArchived || hasNarrowingSidebarThreadFilters(filters);
+}
+
+export function filterSidebarThreadsForActiveRoute<T>(input: {
+  readonly threads: ReadonlyArray<T>;
+  readonly activeThreadKey: string | null;
+  readonly getThreadKey: (thread: T) => string;
+  readonly matchesFilters: (thread: T) => boolean;
+}): T[] {
+  return input.threads.filter(
+    (thread) =>
+      input.getThreadKey(thread) === input.activeThreadKey || input.matchesFilters(thread),
+  );
+}
+
+export function resolvePinnedCollapsedSidebarThread<T>(input: {
+  readonly threads: ReadonlyArray<T>;
+  readonly activeThreadKey: string | null;
+  readonly projectExpanded: boolean;
+  readonly getThreadKey: (thread: T) => string;
+}): T | null {
+  if (input.projectExpanded || input.activeThreadKey === null) {
+    return null;
+  }
+  return (
+    input.threads.find((thread) => input.getThreadKey(thread) === input.activeThreadKey) ?? null
+  );
+}
+
+export function sidebarProviderInstanceKey(
+  environmentId: EnvironmentId,
+  instanceId: ProviderInstanceId,
+): string {
+  return `${environmentId}\u0000${instanceId}`;
+}
+
+export function resolveSidebarArchiveEnvironmentIds(input: {
+  readonly availableEnvironmentIds: readonly EnvironmentId[];
+  readonly selectedEnvironmentIds: readonly EnvironmentId[];
+  readonly includeArchived: boolean;
+}): EnvironmentId[] {
+  if (!input.includeArchived) return [];
+  if (input.selectedEnvironmentIds.length === 0) return [...input.availableEnvironmentIds];
+
+  const selectedEnvironmentIds = new Set(input.selectedEnvironmentIds);
+  return input.availableEnvironmentIds.filter((environmentId) =>
+    selectedEnvironmentIds.has(environmentId),
+  );
+}
+
+export function getSidebarRangeSelectionThreadKeys(
+  threads: readonly {
+    readonly threadKey: string;
+    readonly archivedAt: string | null;
+  }[],
+): string[] {
+  return threads.filter((thread) => thread.archivedAt === null).map((thread) => thread.threadKey);
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
@@ -623,9 +812,10 @@ export function resolveProjectStatusIndicator(
   return highestPriorityStatus;
 }
 
-export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input: {
+export function getVisibleThreadsForProject<T>(input: {
   threads: readonly T[];
-  activeThreadId: T["id"] | undefined;
+  activeThreadKey: string | null;
+  getThreadKey: (thread: T) => string;
   isThreadListExpanded: boolean;
   previewLimit: number;
 }): {
@@ -633,7 +823,7 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
   visibleThreads: T[];
   hiddenThreads: T[];
 } {
-  const { activeThreadId, isThreadListExpanded, previewLimit, threads } = input;
+  const { activeThreadKey, getThreadKey, isThreadListExpanded, previewLimit, threads } = input;
   const hasHiddenThreads = threads.length > previewLimit;
 
   if (!hasHiddenThreads || isThreadListExpanded) {
@@ -645,7 +835,10 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
   }
 
   const previewThreads = threads.slice(0, previewLimit);
-  if (!activeThreadId || previewThreads.some((thread) => thread.id === activeThreadId)) {
+  if (
+    activeThreadKey === null ||
+    previewThreads.some((thread) => getThreadKey(thread) === activeThreadKey)
+  ) {
     return {
       hasHiddenThreads: true,
       hiddenThreads: threads.slice(previewLimit),
@@ -653,7 +846,7 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
     };
   }
 
-  const activeThread = threads.find((thread) => thread.id === activeThreadId);
+  const activeThread = threads.find((thread) => getThreadKey(thread) === activeThreadKey);
   if (!activeThread) {
     return {
       hasHiddenThreads: true,
@@ -662,12 +855,14 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
     };
   }
 
-  const visibleThreadIds = new Set([...previewThreads, activeThread].map((thread) => thread.id));
+  const visibleThreadKeys = new Set(
+    [...previewThreads, activeThread].map((thread) => getThreadKey(thread)),
+  );
 
   return {
     hasHiddenThreads: true,
-    hiddenThreads: threads.filter((thread) => !visibleThreadIds.has(thread.id)),
-    visibleThreads: threads.filter((thread) => visibleThreadIds.has(thread.id)),
+    hiddenThreads: threads.filter((thread) => !visibleThreadKeys.has(getThreadKey(thread))),
+    visibleThreads: threads.filter((thread) => visibleThreadKeys.has(getThreadKey(thread))),
   };
 }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveIcon,
+  ArchiveRestoreIcon,
   ArrowUpDownIcon,
   ChevronRightIcon,
   CloudIcon,
@@ -7,6 +8,7 @@ import {
   FolderPlusIcon,
   Globe2Icon,
   LoaderIcon,
+  ListFilterIcon,
   SearchIcon,
   SquarePenIcon,
   TerminalIcon,
@@ -43,7 +45,10 @@ import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-
 import { CSS } from "@dnd-kit/utilities";
 import {
   type ContextMenuItem,
+  type EnvironmentId,
   ProjectId,
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderDriverKind,
   type ScopedThreadRef,
   type ResolvedKeybindingsConfig,
   type SidebarProjectGroupingMode,
@@ -64,12 +69,17 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import { useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
+  DEFAULT_SIDEBAR_THREAD_FILTERS,
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
   MIN_SIDEBAR_THREAD_PREVIEW_COUNT,
+  SIDEBAR_THREAD_FILTER_STATUSES,
   type SidebarProjectSortOrder,
+  type SidebarThreadFilters,
+  type SidebarThreadFilterStatus,
   type SidebarThreadPreviewCount,
   type SidebarThreadSortOrder,
 } from "@t3tools/contracts/settings";
+import { scopeThreadShell } from "@t3tools/client-runtime/state/models";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
@@ -110,6 +120,7 @@ import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
 
 import { useThreadActions } from "../hooks/useThreadActions";
+import { useArchivedThreadSnapshots } from "../lib/archivedThreadsState";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
@@ -145,7 +156,20 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Input } from "./ui/input";
-import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuGroup,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "./ui/menu";
 import {
   NumberField,
   NumberFieldDecrement,
@@ -172,14 +196,24 @@ import { openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  filterSidebarThreadsForActiveRoute,
+  getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
+  getVisibleThreadsForProject,
+  hasActiveSidebarThreadFilters,
+  hasNarrowingSidebarThreadFilters,
+  matchesSidebarThreadFilters,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
+  resolvePinnedCollapsedSidebarThread,
   resolveProjectStatusIndicator,
+  resolveSidebarArchiveEnvironmentIds,
+  resolveSidebarThreadFilterStatuses,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
+  sidebarProviderInstanceKey,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
   useThreadJumpHintVisibility,
@@ -189,9 +223,11 @@ import { sortThreads } from "../lib/threadSort";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
+import { useNowMinute } from "../hooks/useNowMinute";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
 import { primaryServerKeybindingsAtom } from "../state/server";
+import { deriveProviderInstanceEntries } from "../providerInstances";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -213,6 +249,12 @@ const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
 const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
+};
+const SIDEBAR_THREAD_FILTER_STATUS_LABELS: Record<SidebarThreadFilterStatus, string> = {
+  needs_attention: "Needs attention",
+  unread: "Unread",
+  working: "Working",
+  done: "Done",
 };
 const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   duration: 180,
@@ -336,6 +378,7 @@ interface SidebarThreadRowProps {
   ) => Promise<void>;
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
+  attemptUnarchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
 }
 
@@ -362,11 +405,13 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     commitRename,
     cancelRename,
     attemptArchiveThread,
+    attemptUnarchiveThread,
     openPrLink,
     thread,
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
+  const isArchived = thread.archivedAt !== null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const runningTerminalIds = useThreadRunningTerminalIds({
@@ -418,6 +463,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const isHighlighted = isActive || isSelected;
   const handleOpenDiscoveredPort = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (isArchived) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       const port = discoveredPorts[0];
       if (!port) return;
       event.preventDefault();
@@ -439,7 +489,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         );
       })();
     },
-    [discoveredPorts, navigateToThread, openPreview, threadRef],
+    [discoveredPorts, isArchived, navigateToThread, openPreview, threadRef],
   );
   const isThreadRunning =
     thread.session?.status === "running" && thread.session.activeTurnId != null;
@@ -482,14 +532,19 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   );
   const handleRowClick = useCallback(
     (event: React.MouseEvent) => {
+      if (isArchived) {
+        event.preventDefault();
+        return;
+      }
       handleThreadClick(event, threadRef, orderedProjectThreadKeys);
     },
-    [handleThreadClick, orderedProjectThreadKeys, threadRef],
+    [handleThreadClick, isArchived, orderedProjectThreadKeys, threadRef],
   );
   const handleRowDoubleClick = useCallback(
     (event: React.MouseEvent) => {
       // Already renaming this row: a double-click on the row chrome (outside the
       // input) must not restart and discard the in-progress edit.
+      if (isArchived) return;
       if (renamingThreadKey === threadKey) return;
       // On mobile the first tap navigates and closes the sidebar sheet, so the
       // inline rename can't be shown. Renaming there stays on the context menu.
@@ -502,15 +557,17 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
       event.preventDefault();
       startThreadRename(threadKey, thread.title);
     },
-    [isMobile, renamingThreadKey, startThreadRename, threadKey, thread.title],
+    [isArchived, isMobile, renamingThreadKey, startThreadRename, threadKey, thread.title],
   );
   const handleRowKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
+      if (event.target !== event.currentTarget) return;
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
+      if (isArchived) return;
       navigateToThread(threadRef);
     },
-    [navigateToThread, threadRef],
+    [isArchived, navigateToThread, threadRef],
   );
   const handleRowContextMenu = useCallback(
     (event: React.MouseEvent) => {
@@ -655,7 +712,15 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     },
     [attemptArchiveThread, threadRef],
   );
-  const rowButtonRender = useMemo(() => <div role="button" tabIndex={0} />, []);
+  const handleUnarchiveClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void attemptUnarchiveThread(threadRef);
+    },
+    [attemptUnarchiveThread, threadRef],
+  );
+  const rowButtonRender = isArchived ? <div /> : <div role="button" tabIndex={0} />;
 
   return (
     <SidebarMenuSubItem
@@ -672,13 +737,18 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
-        })} relative isolate`}
+        })} relative isolate ${
+          isArchived
+            ? "cursor-default text-muted-foreground/65 hover:bg-transparent active:bg-transparent"
+            : ""
+        }`}
         onClick={handleRowClick}
         onDoubleClick={handleRowDoubleClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
+          {isArchived ? <ArchiveIcon className="size-3 shrink-0 opacity-60" /> : null}
           {prStatus && (
             <Tooltip>
               <TooltipTrigger
@@ -729,7 +799,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
           )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          {discoveredPorts.length > 0 && (
+          {!isArchived && discoveredPorts.length > 0 && (
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -773,7 +843,28 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               isRemoteThread ? "max-sm:min-w-24" : "max-sm:min-w-20"
             }`}
           >
-            {isConfirmingArchive ? (
+            {isArchived ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <div className="pointer-events-none absolute top-1/2 right-0.5 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
+                      <button
+                        type="button"
+                        data-thread-selection-safe
+                        data-testid={`thread-unarchive-${thread.id}`}
+                        aria-label={`Unarchive ${thread.title}`}
+                        className={SIDEBAR_ICON_ACTION_BUTTON_CLASS}
+                        onPointerDown={stopPropagationOnPointerDown}
+                        onClick={handleUnarchiveClick}
+                      >
+                        <ArchiveRestoreIcon className="size-3.5" />
+                      </button>
+                    </div>
+                  }
+                />
+                <TooltipPopup side="top">Unarchive</TooltipPopup>
+              </Tooltip>
+            ) : isConfirmingArchive ? (
               <button
                 ref={handleConfirmArchiveRef}
                 type="button"
@@ -920,6 +1011,7 @@ interface SidebarProjectThreadListProps {
   ) => Promise<void>;
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
+  attemptUnarchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
@@ -960,6 +1052,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     commitRename,
     cancelRename,
     attemptArchiveThread,
+    attemptUnarchiveThread,
     openPrLink,
     expandThreadListForProject,
     collapseThreadListForProject,
@@ -1011,6 +1104,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
               commitRename={commitRename}
               cancelRename={cancelRename}
               attemptArchiveThread={attemptArchiveThread}
+              attemptUnarchiveThread={attemptUnarchiveThread}
               openPrLink={openPrLink}
             />
           );
@@ -1055,11 +1149,16 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
 
 interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
+  archivedThreads: readonly SidebarThreadSummary[];
+  sidebarThreadFilters: SidebarThreadFilters;
+  sidebarFilterNowMs: number;
+  providerDriverKindByScopedInstanceKey: ReadonlyMap<string, ProviderDriverKind>;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
+  unarchiveThread: ReturnType<typeof useThreadActions>["unarchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
@@ -1075,11 +1174,16 @@ interface SidebarProjectItemProps {
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
   const {
     project,
+    archivedThreads,
+    sidebarThreadFilters,
+    sidebarFilterNowMs,
+    providerDriverKindByScopedInstanceKey,
     isThreadListExpanded,
     activeRouteThreadKey,
     newThreadShortcutLabel,
     handleNewThread,
     archiveThread,
+    unarchiveThread,
     deleteThread,
     threadJumpLabelByKey,
     attachThreadListAutoAnimateRef,
@@ -1165,22 +1269,46 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   });
   const openPrLink = useOpenPrLink();
   const sidebarThreads = useThreadShellsForProjectRefs(project.memberProjectRefs);
+  const memberProjectKeys = useMemo(
+    () => new Set(project.memberProjectRefs.map((projectRef) => scopedProjectKey(projectRef))),
+    [project.memberProjectRefs],
+  );
+  const projectThreads = useMemo(() => {
+    const threadsByKey = new Map(
+      sidebarThreads.map(
+        (thread) =>
+          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+      ),
+    );
+    for (const thread of archivedThreads) {
+      const threadProjectKey = scopedProjectKey(
+        scopeProjectRef(thread.environmentId, thread.projectId),
+      );
+      if (!memberProjectKeys.has(threadProjectKey)) {
+        continue;
+      }
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      if (!threadsByKey.has(threadKey)) {
+        threadsByKey.set(threadKey, thread);
+      }
+    }
+    return [...threadsByKey.values()];
+  }, [archivedThreads, memberProjectKeys, sidebarThreads]);
   const sidebarThreadByKey = useMemo(
     () =>
       new Map(
-        sidebarThreads.map(
+        projectThreads.map(
           (thread) =>
             [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
         ),
       ),
-    [sidebarThreads],
+    [projectThreads],
   );
   // Keep a ref so callbacks can read the latest map without appearing in
   // dependency arrays (avoids invalidating every thread-row memo on each
   // thread-list change).
   const sidebarThreadByKeyRef = useRef(sidebarThreadByKey);
   sidebarThreadByKeyRef.current = sidebarThreadByKey;
-  const projectThreads = sidebarThreads;
   const projectPreferenceKeys = useMemo(() => projectExpansionPreferenceKeys(project), [project]);
   const projectExpanded = useUiStateStore((state) =>
     resolveProjectExpanded(state.projectExpandedById, projectPreferenceKeys),
@@ -1255,31 +1383,57 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       });
     };
     const visibleProjectThreads = sortThreads(
-      projectThreads.filter((thread) => thread.archivedAt === null),
+      filterSidebarThreadsForActiveRoute({
+        threads: projectThreads,
+        activeThreadKey: activeRouteThreadKey,
+        getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        matchesFilters: (thread) => {
+          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+          const providerInstanceId =
+            thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+          return matchesSidebarThreadFilters({
+            thread,
+            lastVisitedAt: lastVisitedAtByThreadKey.get(threadKey),
+            providerDriverKind:
+              providerDriverKindByScopedInstanceKey.get(
+                sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+              ) ?? null,
+            filters: sidebarThreadFilters,
+            nowMs: sidebarFilterNowMs,
+          });
+        },
+      }),
       threadSortOrder,
     );
     const projectStatus = resolveProjectStatusIndicator(
       visibleProjectThreads.map((thread) => resolveProjectThreadStatus(thread)),
     );
     return {
-      orderedProjectThreadKeys: visibleProjectThreads.map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      orderedProjectThreadKeys: getSidebarRangeSelectionThreadKeys(
+        visibleProjectThreads.map((thread) => ({
+          threadKey: scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          archivedAt: thread.archivedAt,
+        })),
       ),
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
+  }, [
+    activeRouteThreadKey,
+    projectThreads,
+    providerDriverKindByScopedInstanceKey,
+    sidebarFilterNowMs,
+    sidebarThreadFilters,
+    threadLastVisitedAts,
+    threadSortOrder,
+  ]);
   const pinnedCollapsedThread = useMemo(() => {
-    const activeThreadKey = activeRouteThreadKey ?? undefined;
-    if (!activeThreadKey || projectExpanded) {
-      return null;
-    }
-    return (
-      visibleProjectThreads.find(
-        (thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === activeThreadKey,
-      ) ?? null
-    );
+    return resolvePinnedCollapsedSidebarThread({
+      threads: visibleProjectThreads,
+      activeThreadKey: activeRouteThreadKey,
+      projectExpanded,
+      getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+    });
   }, [activeRouteThreadKey, projectExpanded, visibleProjectThreads]);
 
   const {
@@ -1306,25 +1460,18 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
-    const hasOverflowingThreads = visibleProjectThreads.length > sidebarThreadPreviewCount;
-    const previewThreads =
-      isThreadListExpanded || !hasOverflowingThreads
-        ? visibleProjectThreads
-        : visibleProjectThreads.slice(0, sidebarThreadPreviewCount);
-    const visibleThreadKeys = new Set(
-      [...previewThreads, ...(pinnedCollapsedThread ? [pinnedCollapsedThread] : [])].map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      ),
-    );
-    const renderedThreads = pinnedCollapsedThread
-      ? [pinnedCollapsedThread]
-      : visibleProjectThreads.filter((thread) =>
-          visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-        );
-    const hiddenThreads = visibleProjectThreads.filter(
-      (thread) =>
-        !visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-    );
+    const {
+      hasHiddenThreads: hasOverflowingThreads,
+      hiddenThreads,
+      visibleThreads: previewThreads,
+    } = getVisibleThreadsForProject({
+      threads: visibleProjectThreads,
+      activeThreadKey: activeRouteThreadKey,
+      getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      isThreadListExpanded,
+      previewLimit: sidebarThreadPreviewCount,
+    });
+    const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
     return {
       hasOverflowingThreads,
       hiddenThreadStatus: resolveProjectStatusIndicator(
@@ -1336,6 +1483,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     };
   }, [
     isThreadListExpanded,
+    activeRouteThreadKey,
     pinnedCollapsedThread,
     projectExpanded,
     projectThreads,
@@ -1967,6 +2115,23 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [archiveThread],
   );
 
+  const attemptUnarchiveThread = useCallback(
+    async (threadRef: ScopedThreadRef) => {
+      const result = await unarchiveThread(threadRef);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to unarchive thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    },
+    [unarchiveThread],
+  );
+
   const cancelRename = useCallback(() => {
     setRenamingThreadKey(null);
     renamingInputRef.current = null;
@@ -2112,19 +2277,32 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       );
       const threadWorkspacePath =
         thread.worktreePath ?? threadProject?.workspaceRoot ?? project.workspaceRoot ?? null;
+      const isArchived = thread.archivedAt !== null;
       const clicked = await api.contextMenu.show(
-        [
-          ...(thread.branch
-            ? [{ id: "new-thread-on-branch", label: `New thread on ${thread.branch}` }]
-            : []),
-          { id: "rename", label: "Rename thread" },
-          { id: "mark-unread", label: "Mark unread" },
-          { id: "copy-path", label: "Copy Path" },
-          { id: "copy-thread-id", label: "Copy Thread ID" },
-          { id: "delete", label: "Delete", destructive: true, icon: "trash" },
-        ],
+        isArchived
+          ? [
+              { id: "unarchive", label: "Unarchive thread" },
+              { id: "copy-path", label: "Copy Path" },
+              { id: "copy-thread-id", label: "Copy Thread ID" },
+              { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+            ]
+          : [
+              ...(thread.branch
+                ? [{ id: "new-thread-on-branch", label: `New thread on ${thread.branch}` }]
+                : []),
+              { id: "rename", label: "Rename thread" },
+              { id: "mark-unread", label: "Mark unread" },
+              { id: "copy-path", label: "Copy Path" },
+              { id: "copy-thread-id", label: "Copy Thread ID" },
+              { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+            ],
         position,
       );
+
+      if (clicked === "unarchive") {
+        await attemptUnarchiveThread(threadRef);
+        return;
+      }
 
       if (clicked === "new-thread-on-branch") {
         // Explicit branch carry-over: reuse the thread's worktree when it
@@ -2203,6 +2381,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     },
     [
       appSettingsConfirmThreadDelete,
+      attemptUnarchiveThread,
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
@@ -2354,6 +2533,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         commitRename={commitRename}
         cancelRename={cancelRename}
         attemptArchiveThread={attemptArchiveThread}
+        attemptUnarchiveThread={attemptUnarchiveThread}
         openPrLink={openPrLink}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
@@ -2689,6 +2869,221 @@ function ProjectSortMenu({
   );
 }
 
+function toggleSidebarFilterValue<T>(values: readonly T[], value: T, checked: boolean): T[] {
+  if (checked) {
+    return values.includes(value) ? [...values] : [...values, value];
+  }
+  return values.filter((candidate) => candidate !== value);
+}
+
+function SidebarFilterMenu({
+  filters,
+  environments,
+  providerSources,
+  archiveLoading,
+  archiveError,
+  onFiltersChange,
+}: {
+  filters: SidebarThreadFilters;
+  environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>;
+  providerSources: ReadonlyArray<{
+    readonly driverKind: ProviderDriverKind;
+    readonly label: string;
+  }>;
+  archiveLoading: boolean;
+  archiveError: string | null;
+  onFiltersChange: (filters: SidebarThreadFilters) => void;
+}) {
+  const filtersActive = hasActiveSidebarThreadFilters(filters);
+  const selectedStatuses = resolveSidebarThreadFilterStatuses(filters.statuses);
+  const statusFilterActive =
+    selectedStatuses.length !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
+    !SIDEBAR_THREAD_FILTER_STATUSES.every((status) => selectedStatuses.includes(status));
+
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              aria-label="Filter sidebar threads"
+              data-testid="sidebar-filter-trigger"
+              className={`relative inline-flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-md px-[calc(--spacing(1)-1px)] transition-colors hover:bg-accent hover:text-foreground ${
+                filtersActive ? "text-primary" : "text-muted-foreground/60"
+              }`}
+            />
+          }
+        >
+          <ListFilterIcon className="size-3.5" />
+          {filtersActive ? (
+            <span className="absolute right-0.5 bottom-0.5 size-1.5 rounded-full bg-primary ring-1 ring-sidebar" />
+          ) : null}
+        </TooltipTrigger>
+        <TooltipPopup side="right">
+          {filtersActive ? "Sidebar filters are active" : "Filter sidebar threads"}
+        </TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="end" side="bottom" className="w-60">
+        <div className="flex items-center justify-between px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          <span>Filters</span>
+          <MenuItem
+            closeOnClick={false}
+            className="min-h-0 cursor-pointer p-0 text-[11px] text-muted-foreground hover:text-foreground sm:min-h-0 sm:text-[11px]"
+            disabled={!filtersActive}
+            onClick={() => {
+              onFiltersChange(DEFAULT_SIDEBAR_THREAD_FILTERS);
+            }}
+          >
+            Reset
+          </MenuItem>
+        </div>
+        <MenuCheckboxItem
+          checked={filters.recentOnly}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, recentOnly: checked });
+          }}
+        >
+          <span className="flex min-w-0 items-center justify-between gap-3">
+            <span>Recent</span>
+            <span className="text-[10px] text-muted-foreground">Last 7 days</span>
+          </span>
+        </MenuCheckboxItem>
+        <MenuCheckboxItem
+          checked={filters.attentionOnly}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, attentionOnly: checked });
+          }}
+        >
+          <span className="flex min-w-0 items-center justify-between gap-3">
+            <span>Inbox</span>
+            <span className="text-[10px] text-muted-foreground">Unread + needs attention</span>
+          </span>
+        </MenuCheckboxItem>
+        <MenuSeparator className="my-0.5" />
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Status</span>
+            {statusFilterActive ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {SIDEBAR_THREAD_FILTER_STATUSES.map((status) => (
+              <MenuCheckboxItem
+                key={status}
+                checked={selectedStatuses.includes(status)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    statuses: toggleSidebarFilterValue(selectedStatuses, status, checked),
+                  });
+                }}
+              >
+                {SIDEBAR_THREAD_FILTER_STATUS_LABELS[status]}
+              </MenuCheckboxItem>
+            ))}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Environment</span>
+            {filters.environmentIds.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {environments.map((environment) => (
+              <MenuCheckboxItem
+                key={environment.environmentId}
+                checked={filters.environmentIds.includes(environment.environmentId)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    environmentIds: toggleSidebarFilterValue(
+                      filters.environmentIds,
+                      environment.environmentId,
+                      checked,
+                    ),
+                  });
+                }}
+              >
+                {environment.label}
+              </MenuCheckboxItem>
+            ))}
+            {environments.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No environments
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Source</span>
+            {filters.sources.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {providerSources.map((source) => (
+              <MenuCheckboxItem
+                key={source.driverKind}
+                checked={filters.sources.includes(source.driverKind)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    sources: toggleSidebarFilterValue(filters.sources, source.driverKind, checked),
+                  });
+                }}
+              >
+                {source.label}
+              </MenuCheckboxItem>
+            ))}
+            {providerSources.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No providers
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSeparator className="my-0.5" />
+        <MenuCheckboxItem
+          checked={filters.includeArchived}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, includeArchived: checked });
+          }}
+        >
+          <span className="flex items-center gap-2">
+            Archived
+            {archiveLoading ? <LoaderIcon className="size-3 animate-spin" /> : null}
+            {archiveError ? (
+              <span
+                role="img"
+                aria-label={`Archived threads failed to load: ${archiveError}`}
+                title={archiveError}
+              >
+                <TriangleAlertIcon aria-hidden className="size-3 text-warning" />
+              </span>
+            ) : null}
+          </span>
+        </MenuCheckboxItem>
+      </MenuPopup>
+    </Menu>
+  );
+}
+
 function SortableProjectItem({
   projectId,
   disabled = false,
@@ -2735,6 +3130,18 @@ interface SidebarProjectsContentProps {
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   threadPreviewCount: SidebarThreadPreviewCount;
+  sidebarThreadFilters: SidebarThreadFilters;
+  sidebarFilterNowMs: number;
+  environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>;
+  providerSources: ReadonlyArray<{
+    readonly driverKind: ProviderDriverKind;
+    readonly label: string;
+  }>;
+  providerDriverKindByScopedInstanceKey: ReadonlyMap<string, ProviderDriverKind>;
+  archivedThreads: readonly SidebarThreadSummary[];
+  archiveLoading: boolean;
+  archiveError: string | null;
+  filtersActive: boolean;
   updateSettings: ReturnType<typeof useUpdateClientSettings>;
   openAddProject: () => void;
   isManualProjectSorting: boolean;
@@ -2745,6 +3152,7 @@ interface SidebarProjectsContentProps {
   handleProjectDragCancel: (event: DragCancelEvent) => void;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
+  unarchiveThread: ReturnType<typeof useThreadActions>["unarchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
   expandedThreadListsByProject: ReadonlySet<string>;
@@ -2775,6 +3183,15 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     projectSortOrder,
     threadSortOrder,
     threadPreviewCount,
+    sidebarThreadFilters,
+    sidebarFilterNowMs,
+    environments,
+    providerSources,
+    providerDriverKindByScopedInstanceKey,
+    archivedThreads,
+    archiveLoading,
+    archiveError,
+    filtersActive,
     updateSettings,
     openAddProject,
     isManualProjectSorting,
@@ -2785,6 +3202,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     handleProjectDragCancel,
     handleNewThread,
     archiveThread,
+    unarchiveThread,
     deleteThread,
     sortedProjects,
     expandedThreadListsByProject,
@@ -2802,12 +3220,20 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     attachProjectListAutoAnimateRef,
     projectsLength,
   } = props;
+  const clearThreadSelection = useThreadSelectionStore((state) => state.clearSelection);
 
   const handleProjectSortOrderChange = useCallback(
     (sortOrder: SidebarProjectSortOrder) => {
       updateSettings({ sidebarProjectSortOrder: sortOrder });
     },
     [updateSettings],
+  );
+  const handleSidebarThreadFiltersChange = useCallback(
+    (filters: SidebarThreadFilters) => {
+      clearThreadSelection();
+      updateSettings({ sidebarThreadFilters: filters });
+    },
+    [clearThreadSelection, updateSettings],
   );
   const handleThreadSortOrderChange = useCallback(
     (sortOrder: SidebarThreadSortOrder) => {
@@ -2875,6 +3301,14 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
         <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
           <span className="text-xs font-medium text-sidebar-muted-foreground/80">Projects</span>
           <div className="flex items-center gap-1">
+            <SidebarFilterMenu
+              filters={sidebarThreadFilters}
+              environments={environments}
+              providerSources={providerSources}
+              archiveLoading={archiveLoading}
+              archiveError={archiveError}
+              onFiltersChange={handleSidebarThreadFiltersChange}
+            />
             <ProjectSortMenu
               projectSortOrder={projectSortOrder}
               threadSortOrder={threadSortOrder}
@@ -2921,6 +3355,12 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                     {(dragHandleProps) => (
                       <SidebarProjectItem
                         project={project}
+                        archivedThreads={archivedThreads}
+                        sidebarThreadFilters={sidebarThreadFilters}
+                        sidebarFilterNowMs={sidebarFilterNowMs}
+                        providerDriverKindByScopedInstanceKey={
+                          providerDriverKindByScopedInstanceKey
+                        }
                         isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -2928,6 +3368,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         newThreadShortcutLabel={newThreadShortcutLabel}
                         handleNewThread={handleNewThread}
                         archiveThread={archiveThread}
+                        unarchiveThread={unarchiveThread}
                         deleteThread={deleteThread}
                         threadJumpLabelByKey={threadJumpLabelByKey}
                         attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
@@ -2953,6 +3394,10 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               <SidebarProjectListRow
                 key={project.projectKey}
                 project={project}
+                archivedThreads={archivedThreads}
+                sidebarThreadFilters={sidebarThreadFilters}
+                sidebarFilterNowMs={sidebarFilterNowMs}
+                providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -2960,6 +3405,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 newThreadShortcutLabel={newThreadShortcutLabel}
                 handleNewThread={handleNewThread}
                 archiveThread={archiveThread}
+                unarchiveThread={unarchiveThread}
                 deleteThread={deleteThread}
                 threadJumpLabelByKey={threadJumpLabelByKey}
                 attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
@@ -2975,9 +3421,13 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </SidebarMenu>
         )}
 
-        {projectsLength === 0 && (
+        {sortedProjects.length === 0 && (
           <div className="px-2 pt-4 text-center text-xs text-muted-foreground/60">
-            No projects yet
+            {projectsLength === 0
+              ? "No projects yet"
+              : filtersActive
+                ? "No threads match these filters"
+                : "No projects to show"}
           </div>
         )}
       </SidebarGroup>
@@ -2998,9 +3448,11 @@ export default function Sidebar() {
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
+  const sidebarThreadFilters = useClientSettings((s) => s.sidebarThreadFilters);
+  const sidebarFilterNowMs = Date.parse(`${useNowMinute()}:00.000Z`);
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
-  const { archiveThread, deleteThread } = useThreadActions();
+  const { archiveThread, unarchiveThread, deleteThread } = useThreadActions();
   const { isMobile, setOpenMobile } = useSidebar();
   const routeTarget = useParams({
     strict: false,
@@ -3037,6 +3489,64 @@ export default function Sidebar() {
   const platform = navigator.platform;
   const shortcutModifiers = useShortcutModifierState();
   const { environments } = useEnvironments();
+  const archiveEnvironmentIds = useMemo(
+    () =>
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+        selectedEnvironmentIds: sidebarThreadFilters.environmentIds,
+        includeArchived: sidebarThreadFilters.includeArchived,
+      }),
+    [environments, sidebarThreadFilters.environmentIds, sidebarThreadFilters.includeArchived],
+  );
+  const {
+    snapshots: archivedSnapshots,
+    isLoading: archiveLoading,
+    error: archiveError,
+  } = useArchivedThreadSnapshots(archiveEnvironmentIds);
+  const archivedThreads = useMemo(
+    () =>
+      archivedSnapshots.flatMap((entry) =>
+        entry.snapshot.threads
+          .filter((thread) => thread.archivedAt !== null)
+          .map((thread) => scopeThreadShell(entry.environmentId, thread)),
+      ),
+    [archivedSnapshots],
+  );
+  const providerEntries = useMemo(
+    () =>
+      environments.flatMap((environment) =>
+        deriveProviderInstanceEntries(environment.serverConfig?.providers ?? []).map((entry) => ({
+          ...entry,
+          environmentId: environment.environmentId,
+        })),
+      ),
+    [environments],
+  );
+  const providerDriverKindByScopedInstanceKey = useMemo(
+    () =>
+      new Map(
+        providerEntries.map(
+          (entry) =>
+            [
+              sidebarProviderInstanceKey(entry.environmentId, entry.instanceId),
+              entry.driverKind,
+            ] as const,
+        ),
+      ),
+    [providerEntries],
+  );
+  const providerSources = useMemo(() => {
+    const labelsByDriverKind = new Map<ProviderDriverKind, string>();
+    for (const entry of providerEntries) {
+      if (!labelsByDriverKind.has(entry.driverKind)) {
+        labelsByDriverKind.set(
+          entry.driverKind,
+          PROVIDER_DISPLAY_NAMES[entry.driverKind] ?? entry.displayName,
+        );
+      }
+    }
+    return [...labelsByDriverKind].map(([driverKind, label]) => ({ driverKind, label }));
+  }, [providerEntries]);
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const environmentLabelById = useMemo(
     () =>
@@ -3117,6 +3627,55 @@ export default function Sidebar() {
       ),
     [sidebarThreads],
   );
+  const sidebarThreadsWithArchived = useMemo(() => {
+    const threadsByKey = new Map(
+      sidebarThreads.map(
+        (thread) =>
+          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+      ),
+    );
+    for (const thread of archivedThreads) {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      if (!threadsByKey.has(threadKey)) {
+        threadsByKey.set(threadKey, thread);
+      }
+    }
+    return [...threadsByKey.values()];
+  }, [archivedThreads, sidebarThreads]);
+  const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
+  const filtersActive = hasActiveSidebarThreadFilters(sidebarThreadFilters);
+  const narrowingFiltersActive = hasNarrowingSidebarThreadFilters(sidebarThreadFilters);
+  const filteredSidebarThreads = useMemo(
+    () =>
+      filterSidebarThreadsForActiveRoute({
+        threads: sidebarThreadsWithArchived,
+        activeThreadKey: routeThreadKey,
+        getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        matchesFilters: (thread) => {
+          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+          const providerInstanceId =
+            thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+          return matchesSidebarThreadFilters({
+            thread,
+            lastVisitedAt: threadLastVisitedAtById[threadKey],
+            providerDriverKind:
+              providerDriverKindByScopedInstanceKey.get(
+                sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+              ) ?? null,
+            filters: sidebarThreadFilters,
+            nowMs: sidebarFilterNowMs,
+          });
+        },
+      }),
+    [
+      providerDriverKindByScopedInstanceKey,
+      routeThreadKey,
+      sidebarFilterNowMs,
+      sidebarThreadFilters,
+      sidebarThreadsWithArchived,
+      threadLastVisitedAtById,
+    ],
+  );
   // Resolve the active route's project key to a logical key so it matches the
   // sidebar's grouped project entries.
   const activeRouteProjectKey = useMemo(() => {
@@ -3136,7 +3695,7 @@ export default function Sidebar() {
   // are displayed together.
   const threadsByProjectKey = useMemo(() => {
     const next = new Map<string, SidebarThreadSummary[]>();
-    for (const thread of sidebarThreads) {
+    for (const thread of filteredSidebarThreads) {
       const physicalKey =
         projectPhysicalKeyByScopedRef.get(
           scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
@@ -3150,7 +3709,7 @@ export default function Sidebar() {
       }
     }
     return next;
-  }, [sidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
+  }, [filteredSidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
   const getCurrentSidebarShortcutContext = useCallback(
     () => ({
       terminalFocus: isTerminalFocused(),
@@ -3258,25 +3817,31 @@ export default function Sidebar() {
     animatedThreadListsRef.current.add(node);
   }, []);
 
-  const visibleThreads = useMemo(
-    () => sidebarThreads.filter((thread) => thread.archivedAt === null),
-    [sidebarThreads],
-  );
+  const routeProjectPending = routeThreadKey !== null && activeRouteProjectKey === null;
   const sortedProjects = useMemo(() => {
-    const sortableProjects = sidebarProjects.map((project) => ({
-      ...project,
-      id: project.projectKey,
-    }));
-    const sortableThreads = visibleThreads.map((thread) => {
-      const physicalKey =
-        projectPhysicalKeyByScopedRef.get(
-          scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
-        ) ?? scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId));
-      return {
-        ...thread,
-        projectId: (physicalToLogicalKey.get(physicalKey) ?? physicalKey) as ProjectId,
-      };
-    });
+    const sortableProjects = sidebarProjects
+      .filter(
+        (project) =>
+          !narrowingFiltersActive ||
+          routeProjectPending ||
+          (threadsByProjectKey.get(project.projectKey)?.length ?? 0) > 0,
+      )
+      .map((project) => ({
+        ...project,
+        id: project.projectKey,
+      }));
+    const sortableThreads = filteredSidebarThreads
+      .filter((thread) => thread.archivedAt === null)
+      .map((thread) => {
+        const physicalKey =
+          projectPhysicalKeyByScopedRef.get(
+            scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
+          ) ?? scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId));
+        return {
+          ...thread,
+          projectId: (physicalToLogicalKey.get(physicalKey) ?? physicalKey) as ProjectId,
+        };
+      });
     return sortProjectsForSidebar(
       sortableProjects,
       sortableThreads,
@@ -3287,49 +3852,49 @@ export default function Sidebar() {
     });
   }, [
     sidebarProjectSortOrder,
+    filteredSidebarThreads,
+    narrowingFiltersActive,
     physicalToLogicalKey,
     projectPhysicalKeyByScopedRef,
+    routeProjectPending,
     sidebarProjectByKey,
     sidebarProjects,
-    visibleThreads,
+    threadsByProjectKey,
   ]);
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
   const visibleSidebarThreadKeys = useMemo(
     () =>
       sortedProjects.flatMap((project) => {
         const projectThreads = sortThreads(
-          (threadsByProjectKey.get(project.projectKey) ?? []).filter(
-            (thread) => thread.archivedAt === null,
-          ),
+          threadsByProjectKey.get(project.projectKey) ?? [],
           sidebarThreadSortOrder,
         );
         const projectExpanded = resolveProjectExpanded(
           projectExpandedById,
           projectExpansionPreferenceKeys(project),
         );
-        const activeThreadKey = routeThreadKey ?? undefined;
-        const pinnedCollapsedThread =
-          !projectExpanded && activeThreadKey
-            ? (projectThreads.find(
-                (thread) =>
-                  scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) ===
-                  activeThreadKey,
-              ) ?? null)
-            : null;
+        const getThreadKey = (thread: SidebarThreadSummary) =>
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+        const pinnedCollapsedThread = resolvePinnedCollapsedSidebarThread({
+          threads: projectThreads,
+          activeThreadKey: routeThreadKey,
+          projectExpanded,
+          getThreadKey,
+        });
         const shouldShowThreadPanel = projectExpanded || pinnedCollapsedThread !== null;
         if (!shouldShowThreadPanel) {
           return [];
         }
         const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
-        const hasOverflowingThreads = projectThreads.length > sidebarThreadPreviewCount;
-        const previewThreads =
-          isThreadListExpanded || !hasOverflowingThreads
-            ? projectThreads
-            : projectThreads.slice(0, sidebarThreadPreviewCount);
+        const { visibleThreads: previewThreads } = getVisibleThreadsForProject({
+          threads: projectThreads,
+          activeThreadKey: routeThreadKey,
+          getThreadKey,
+          isThreadListExpanded,
+          previewLimit: sidebarThreadPreviewCount,
+        });
         const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
-        return renderedThreads.map((thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-        );
+        return renderedThreads.filter((thread) => thread.archivedAt === null).map(getThreadKey);
       }),
     [
       sidebarThreadSortOrder,
@@ -3606,6 +4171,15 @@ export default function Sidebar() {
             projectSortOrder={sidebarProjectSortOrder}
             threadSortOrder={sidebarThreadSortOrder}
             threadPreviewCount={sidebarThreadPreviewCount}
+            sidebarThreadFilters={sidebarThreadFilters}
+            sidebarFilterNowMs={sidebarFilterNowMs}
+            environments={environments}
+            providerSources={providerSources}
+            providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
+            archivedThreads={archivedThreads}
+            archiveLoading={archiveLoading}
+            archiveError={archiveError}
+            filtersActive={filtersActive}
             updateSettings={updateSettings}
             openAddProject={openAddProjectCommandPalette}
             isManualProjectSorting={isManualProjectSorting}
@@ -3616,6 +4190,7 @@ export default function Sidebar() {
             handleProjectDragCancel={handleProjectDragCancel}
             handleNewThread={handleNewThread}
             archiveThread={archiveThread}
+            unarchiveThread={unarchiveThread}
             deleteThread={deleteThread}
             sortedProjects={sortedProjects}
             expandedThreadListsByProject={expandedThreadListsByProject}

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -103,7 +103,9 @@ function MenuCheckboxItem({
       checked={checked}
       className={cn(
         "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default items-center gap-2 rounded-sm py-1 ps-2 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        variant === "switch" ? "grid-cols-[1fr_auto] gap-4 pe-1.5" : "grid-cols-[1rem_1fr] pe-4",
+        variant === "switch"
+          ? "grid-cols-[1fr_auto] gap-4 pe-1.5"
+          : "grid-cols-[minmax(0,1fr)_1rem] ps-3 pe-2",
         className,
       )}
       data-slot="menu-checkbox-item"
@@ -121,7 +123,8 @@ function MenuCheckboxItem({
         </>
       ) : (
         <>
-          <MenuPrimitive.CheckboxItemIndicator className="col-start-1">
+          <span className="col-start-1">{children}</span>
+          <MenuPrimitive.CheckboxItemIndicator className="col-start-2 justify-self-end">
             <svg
               fill="none"
               height="24"
@@ -136,7 +139,6 @@ function MenuCheckboxItem({
               <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
             </svg>
           </MenuPrimitive.CheckboxItemIndicator>
-          <span className="col-start-2">{children}</span>
         </>
       )}
     </MenuPrimitive.CheckboxItem>

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -5,6 +5,7 @@ import { ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
   ClientSettingsPatch,
+  DEFAULT_SIDEBAR_THREAD_FILTERS,
   DEFAULT_SERVER_SETTINGS,
   ServerSettings,
   ServerSettingsPatch,
@@ -65,6 +66,60 @@ describe("ClientSettings sidebar v2", () => {
   it.each([-1, 0, 91])("rejects an auto-settle threshold outside 1..90: %s", (value) => {
     expect(() => decodeClientSettings({ sidebarAutoSettleAfterDays: value })).toThrow();
     expect(() => decodeClientSettingsPatch({ sidebarAutoSettleAfterDays: value })).toThrow();
+  });
+});
+
+describe("ClientSettings sidebar thread filters", () => {
+  it("defaults to showing every active thread", () => {
+    expect(decodeClientSettings({}).sidebarThreadFilters).toEqual(DEFAULT_SIDEBAR_THREAD_FILTERS);
+    expect(DEFAULT_SIDEBAR_THREAD_FILTERS).toEqual({
+      statuses: ["needs_attention", "unread", "working", "done"],
+      environmentIds: [],
+      sources: [],
+      recentOnly: false,
+      attentionOnly: false,
+      includeArchived: false,
+    });
+  });
+
+  it("hydrates missing nested fields and accepts a complete filter patch", () => {
+    expect(
+      decodeClientSettings({ sidebarThreadFilters: { includeArchived: true } })
+        .sidebarThreadFilters,
+    ).toEqual({
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      includeArchived: true,
+    });
+
+    expect(
+      decodeClientSettingsPatch({
+        sidebarThreadFilters: {
+          statuses: ["unread"],
+          environmentIds: ["environment-local"],
+          sources: ["codex"],
+          recentOnly: true,
+          attentionOnly: true,
+          includeArchived: true,
+        },
+      }).sidebarThreadFilters,
+    ).toEqual({
+      statuses: ["unread"],
+      environmentIds: ["environment-local"],
+      sources: ["codex"],
+      recentOnly: true,
+      attentionOnly: true,
+      includeArchived: true,
+    });
+  });
+
+  it("rejects unknown status values", () => {
+    expect(() =>
+      decodeClientSettingsPatch({
+        sidebarThreadFilters: {
+          statuses: ["paused"],
+        },
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,10 +2,14 @@ import * as Effect from "effect/Effect";
 import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
-import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
+import { EnvironmentId, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL, ProviderOptionSelections } from "./model.ts";
 import { ModelSelection } from "./orchestration.ts";
-import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.ts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceConfig,
+  ProviderInstanceId,
+} from "./providerInstance.ts";
 
 // ── Client Settings (local-only) ───────────────────────────────
 
@@ -20,6 +24,34 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "upda
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
+
+export const SidebarThreadFilterStatus = Schema.Literals([
+  "needs_attention",
+  "unread",
+  "working",
+  "done",
+]);
+export type SidebarThreadFilterStatus = typeof SidebarThreadFilterStatus.Type;
+export const SIDEBAR_THREAD_FILTER_STATUSES: readonly SidebarThreadFilterStatus[] = [
+  "needs_attention",
+  "unread",
+  "working",
+  "done",
+];
+export const SidebarThreadFilters = Schema.Struct({
+  statuses: Schema.Array(SidebarThreadFilterStatus).pipe(
+    Schema.withDecodingDefault(Effect.succeed([...SIDEBAR_THREAD_FILTER_STATUSES])),
+  ),
+  environmentIds: Schema.Array(EnvironmentId).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  sources: Schema.Array(ProviderDriverKind).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  recentOnly: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  attentionOnly: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  includeArchived: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+});
+export type SidebarThreadFilters = typeof SidebarThreadFilters.Type;
+export const DEFAULT_SIDEBAR_THREAD_FILTERS: SidebarThreadFilters = Schema.decodeSync(
+  SidebarThreadFilters,
+)({});
 
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
@@ -110,6 +142,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
+  ),
+  sidebarThreadFilters: SidebarThreadFilters.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_FILTERS)),
   ),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
@@ -602,6 +637,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
+  sidebarThreadFilters: Schema.optionalKey(SidebarThreadFilters),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   sidebarV2Enabled: Schema.optionalKey(Schema.Boolean),
   timestampFormat: Schema.optionalKey(TimestampFormat),


### PR DESCRIPTION
## What changed

- Added persisted classic-sidebar filters for status, environment, provider source, and archived threads.
- Added **Recent** (last seven days) and **Inbox** (unread or needs attention) shortcuts.
- Kept live/needs-attention classification primary while allowing unread to act as a secondary selectable facet.
- Moved checkbox indicators to the right so unchecked rows keep the same compact alignment.
- Loaded archived snapshots only when requested and kept archived rows out of navigation, range selection, and project-activity sorting.
- Kept the active route visible while narrowing filters, including collapsed projects and route-detail hydration.

## Scope

This PR intentionally covers the classic/V1 sidebar only. V2 integration and project grouping are held as follow-ups so this review stays below the repository's XXL cutoff: **994 effective production lines (`size:XL`)**.

Related prior art: #1043 and @jjjjjjjjjjjjjjjjacob's demo explored sidebar filtering, including Terminal and Unsent Draft facets. Those extra facets are not bundled into this smaller V1 review.

## V2 readiness

> Compatibility proof from the patched nightly: one persisted filter selection across classic and Sidebar V2, using disposable demo data.

![Classic and Sidebar V2 using the same persisted filters](https://raw.githubusercontent.com/danieliser/t3code/f262a23caf36a87c3623cbe4519ed0fecbb6be8e/docs/pr-assets/sidebar-filters-v1-v2.gif)

This is not a classic-sidebar dead end. The persisted filter model and matching logic are sidebar-agnostic, and the working draft follow-up #4334 already applies the same controls to Sidebar V2 alongside project filtering and flat mode. That combined integration has been exercised in the patched nightly on both sidebar surfaces.

The V2 adapter is intentionally kept out of this diff so #4330 remains a direct-main `size:XL` review. #4334 stays draft until the foundation lands and its V2/grouping delta can be restacked without inherited history.

## Why

Large sidebars need focused views for recent and actionable work without exposing archived history by default. “Inbox” communicates the unread-or-needs-attention union without colliding with the existing “Needs attention” status.

## UI changes

Before, the classic sidebar always showed the full active thread set and unchecked submenu rows reserved an awkward leading indicator column. After, a compact filter menu provides persistent facets with right-aligned checks and opt-in archived history.

## Verification

- 125 focused sidebar/filter and settings tests passed.
- `@t3tools/contracts` and `@t3tools/web` typechecks passed.
- Targeted lint, formatting, and `git diff --check` passed.
- Integrated browser verification confirmed the menu, nested status controls, right-aligned checkbox geometry, non-closing multi-select behavior, and persistence of Recent, status, and Archived selections across reload.

## Checklist

- [x] One focused commit based directly on `main`
- [x] Active routes remain reachable under narrowing filters
- [x] Recent, Inbox, status, environment, source, and archived behavior is covered
- [x] Classic-sidebar interaction and persistence were exercised in a local build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent thread filters to the classic sidebar
> - Adds a `SidebarFilterMenu` to the sidebar projects header, allowing users to filter threads by recency (7-day window), attention/unread status, explicit status facets, environment, provider source, and inclusion of archived threads.
> - Introduces `SidebarThreadFilters` to client settings so filter state persists across sessions, with schema validation and decoded defaults via `DEFAULT_SIDEBAR_THREAD_FILTERS`.
> - Archived threads are loaded via `useArchivedThreadSnapshots` when the archived filter is active, merged with live threads, and rendered in a disabled state with an inline Unarchive action.
> - Projects with no matching threads are hidden when narrowing filters are active (unless the active route's project is pending).
> - Adds core logic utilities in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/4330/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a): `classifySidebarThreadFilterStatus`, `matchesSidebarThreadFilters`, `filterSidebarThreadsForActiveRoute`, and related helpers; `getVisibleThreadsForProject` is refactored from id-based to key-based selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a60b0f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large classic-sidebar behavior change with persisted settings and archived-thread merging, but logic is heavily unit-tested and active-route visibility is explicitly preserved to avoid navigation traps.
> 
> **Overview**
> **Adds persistent thread filtering to the classic sidebar**, stored in client settings as `sidebarThreadFilters` (status facets, environment, provider source, **Recent** / **Inbox** shortcuts, and opt-in **Archived**).
> 
> New logic in `Sidebar.logic.ts` classifies each thread into exclusive filter statuses (`needs_attention`, `working`, `unread`, `done`), applies combined filters (including a 7-day recency window and inbox = unread ∪ needs attention), and **always keeps the active route’s thread visible** even when it would otherwise be filtered out—including collapsed projects and folded preview lists (`getVisibleThreadsForProject` now keys by scoped `activeThreadKey`).
> 
> The sidebar toolbar gets a **Filter** menu (`SidebarFilterMenu`); checkbox menu items move indicators to the **right** for alignment. When **Archived** is enabled, snapshots load only for relevant environments, merge with live shells, and render as read-only rows (no navigation/rename/range select) with **Unarchive** in-row and context menu. Projects with no matching threads hide when narrowing filters are active; empty state distinguishes “no projects” vs “no matches.”
> 
> `packages/contracts` adds the `SidebarThreadFilters` schema and patch support with defaults and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60b0f22f9990db8cbc51f0eeaa674e7c2e6c881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
