### PR TITLE
feat(web): add project filter and flat sidebar grouping

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -54,7 +54,7 @@ import {
   useState,
 } from "react";
 import { flushSync } from "react-dom";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import {
   isAtomCommandInterrupted,
@@ -161,7 +161,7 @@ import {
   deriveLogicalProjectKeyFromSettings,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { buildDraftThreadRouteParams } from "../threadRoutes";
+import { buildDraftThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -1161,6 +1161,7 @@ function ChatViewContent(props: ChatViewProps) {
   const timestampFormat = settings.timestampFormat;
   const autoOpenPlanSidebar = settings.autoOpenPlanSidebar;
   const navigate = useNavigate();
+  const router = useRouter();
   const { resolvedTheme } = useTheme();
   // Granular store selectors — avoid subscribing to prompt changes.
   const composerRuntimeMode = useComposerDraftStore(
@@ -1748,31 +1749,29 @@ function ChatViewContent(props: ChatViewProps) {
   );
 
   useEffect(() => {
-    if (!serverThread?.id) {
-      markActiveThreadVisited(null, null);
+    if (routeKind !== "server") {
       return;
     }
-    const visitedAt = Number.isNaN(Date.parse(serverThread.updatedAt))
-      ? null
-      : serverThread.updatedAt;
-    markActiveThreadVisited(
-      scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-      visitedAt,
-    );
-  }, [
-    markActiveThreadVisited,
-    serverThread?.environmentId,
-    serverThread?.id,
-    serverThread?.updatedAt,
-  ]);
+    const visitedAt =
+      !serverThread || Number.isNaN(Date.parse(serverThread.updatedAt))
+        ? null
+        : serverThread.updatedAt;
+    markActiveThreadVisited(routeThreadKey, visitedAt);
+  }, [markActiveThreadVisited, routeKind, routeThreadKey, serverThread?.updatedAt]);
 
   useEffect(
     () => () => {
+      const currentRouteParams =
+        router.state.matches[router.state.matches.length - 1]?.params ?? {};
+      const currentRouteTarget = resolveThreadRouteTarget(currentRouteParams);
+      if (currentRouteTarget?.kind === "server") {
+        return;
+      }
       if (useUiStateStore.getState().activeThreadVisit?.threadId === routeThreadKey) {
         markActiveThreadVisited(null, null);
       }
     },
-    [markActiveThreadVisited, routeThreadKey],
+    [markActiveThreadVisited, routeThreadKey, router],
   );
 
   const selectedProviderByThreadId = composerActiveProvider ?? null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1149,10 +1149,7 @@ function ChatViewContent(props: ChatViewProps) {
   const composerDraftTarget: ScopedThreadRef | DraftId =
     routeKind === "server" ? routeThreadRef : props.draftId;
   const serverThread = useThread(routeThreadRef);
-  const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
-  const activeThreadLastVisitedAt = useUiStateStore(
-    (store) => store.threadLastVisitedAtById[routeThreadKey],
-  );
+  const markActiveThreadVisited = useUiStateStore((store) => store.markActiveThreadVisited);
   const settings = useEnvironmentSettings(environmentId);
   // New-thread defaults live in the primary environment's settings.json (the
   // settings UI never writes to remote environments), so read them from the
@@ -1751,19 +1748,19 @@ function ChatViewContent(props: ChatViewProps) {
   );
 
   useEffect(() => {
-    if (!serverThread?.id) return;
-    const threadUpdatedAt = Date.parse(serverThread.updatedAt);
-    if (Number.isNaN(threadUpdatedAt)) return;
-    const lastVisitedAt = activeThreadLastVisitedAt ? Date.parse(activeThreadLastVisitedAt) : NaN;
-    if (!Number.isNaN(lastVisitedAt) && lastVisitedAt >= threadUpdatedAt) return;
-
-    markThreadVisited(
+    if (!serverThread?.id) {
+      markActiveThreadVisited(null, null);
+      return;
+    }
+    const visitedAt = Number.isNaN(Date.parse(serverThread.updatedAt))
+      ? null
+      : serverThread.updatedAt;
+    markActiveThreadVisited(
       scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
-      serverThread.updatedAt,
+      visitedAt,
     );
   }, [
-    activeThreadLastVisitedAt,
-    markThreadVisited,
+    markActiveThreadVisited,
     serverThread?.environmentId,
     serverThread?.id,
     serverThread?.updatedAt,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1750,7 +1750,7 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     if (routeKind !== "server") {
-      markActiveThreadVisited(null, null);
+      markActiveThreadVisited(routeThreadKey, null);
       return;
     }
     const visitedAt =

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1750,6 +1750,7 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     if (routeKind !== "server") {
+      markActiveThreadVisited(null, null);
       return;
     }
     const visitedAt =

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -161,7 +161,11 @@ import {
   deriveLogicalProjectKeyFromSettings,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { buildDraftThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
+import {
+  buildDraftThreadRouteParams,
+  resolveThreadRouteTarget,
+  shouldKeepActiveThreadVisitOnUnmount,
+} from "../threadRoutes";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -1765,14 +1769,20 @@ function ChatViewContent(props: ChatViewProps) {
       const currentRouteParams =
         router.state.matches[router.state.matches.length - 1]?.params ?? {};
       const currentRouteTarget = resolveThreadRouteTarget(currentRouteParams);
-      if (currentRouteTarget?.kind === "server") {
+      if (
+        shouldKeepActiveThreadVisitOnUnmount({
+          currentRouteTarget,
+          routeThreadKey,
+          draftId,
+        })
+      ) {
         return;
       }
       if (useUiStateStore.getState().activeThreadVisit?.threadId === routeThreadKey) {
         markActiveThreadVisited(null, null);
       }
     },
-    [markActiveThreadVisited, routeThreadKey, router],
+    [draftId, markActiveThreadVisited, routeThreadKey, router],
   );
 
   const selectedProviderByThreadId = composerActiveProvider ?? null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1766,6 +1766,15 @@ function ChatViewContent(props: ChatViewProps) {
     serverThread?.updatedAt,
   ]);
 
+  useEffect(
+    () => () => {
+      if (useUiStateStore.getState().activeThreadVisit?.threadId === routeThreadKey) {
+        markActiveThreadVisited(null, null);
+      }
+    },
+    [markActiveThreadVisited, routeThreadKey],
+  );
+
   const selectedProviderByThreadId = composerActiveProvider ?? null;
   const threadProvider =
     activeThread?.modelSelection.instanceId ??

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -347,6 +347,69 @@ describe("sidebar thread filters", () => {
     ).toBe(true);
   });
 
+  it("counts activity recorded only on the latest turn as recent", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      recentOnly: true,
+    };
+    const nowMs = Date.parse("2026-03-10T10:00:00.000Z");
+    const recentTimestamp = "2026-03-10T09:00:00.000Z";
+    const olderTurn = {
+      ...makeLatestTurn({
+        completedAt: "2026-03-01T10:05:00.000Z",
+        startedAt: "2026-03-01T10:00:00.000Z",
+      }),
+      requestedAt: "2026-03-01T09:59:00.000Z",
+    };
+    const olderThread = {
+      ...filterableThread,
+      latestUserMessageAt: null,
+      updatedAt: "2026-03-01T10:00:00.000Z",
+      createdAt: "2026-03-01T09:00:00.000Z",
+    };
+
+    for (const latestTurn of [
+      { ...olderTurn, requestedAt: recentTimestamp },
+      { ...olderTurn, startedAt: recentTimestamp },
+      { ...olderTurn, completedAt: recentTimestamp },
+    ]) {
+      expect(
+        matchesSidebarThreadFilters({
+          thread: { ...olderThread, latestTurn },
+          providerDriverKind: ProviderDriverKind.make("codex"),
+          filters,
+          nowMs,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("ignores malformed and older latest-turn timestamps for recent filtering", () => {
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: null,
+          latestTurn: {
+            ...makeLatestTurn({
+              completedAt: "not-a-date",
+              startedAt: "2026-03-01T10:00:00.000Z",
+            }),
+            requestedAt: "not-a-date",
+          },
+          updatedAt: "2026-03-01T10:00:00.000Z",
+          createdAt: "2026-03-01T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          recentOnly: true,
+        },
+        nowMs: Date.parse("2026-03-10T10:00:00.000Z"),
+      }),
+    ).toBe(false);
+  });
+
   it("recognizes the default filter state and meaningful deviations", () => {
     expect(hasActiveSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
     expect(hasNarrowingSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -281,6 +281,106 @@ describe("sidebar thread filters", () => {
     ).toBe(false);
   });
 
+  it("matches unread live threads through either their live or unread status facet", () => {
+    const workingThread = {
+      ...filterableThread,
+      session: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: "Codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-03-09T10:00:00.000Z",
+      },
+    } as const;
+
+    expect(
+      matchesSidebarThreadFilters({
+        thread: workingThread,
+        isExplicitlyUnread: true,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["unread"] },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: workingThread,
+        isExplicitlyUnread: true,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["working"] },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: workingThread,
+        isExplicitlyUnread: true,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["done"] },
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, latestTurn: makeLatestTurn() },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: { ...DEFAULT_SIDEBAR_THREAD_FILTERS, statuses: ["unread"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("composes the attention quick filter with live and unread status facets", () => {
+    const workingThread = {
+      ...filterableThread,
+      session: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: "Codex",
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: "2026-03-09T10:00:00.000Z",
+      },
+    } as const;
+
+    for (const statuses of [["working"], ["unread"]] as const) {
+      expect(
+        matchesSidebarThreadFilters({
+          thread: workingThread,
+          isExplicitlyUnread: true,
+          providerDriverKind: ProviderDriverKind.make("codex"),
+          filters: {
+            ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+            attentionOnly: true,
+            statuses: [...statuses],
+          },
+        }),
+      ).toBe(true);
+    }
+    expect(
+      matchesSidebarThreadFilters({
+        thread: workingThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          attentionOnly: true,
+          statuses: ["working"],
+        },
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...workingThread, hasPendingUserInput: true },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          attentionOnly: true,
+          statuses: ["needs_attention"],
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("matches recent activity within the last seven days", () => {
     const filters = {
       ...DEFAULT_SIDEBAR_THREAD_FILTERS,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -116,6 +116,7 @@ const filterableThread = {
   archivedAt: null,
   createdAt: "2026-03-09T09:00:00.000Z",
   environmentId: localEnvironmentId,
+  projectId: ProjectId.make("project-1"),
   hasActionableProposedPlan: false,
   hasPendingApprovals: false,
   hasPendingUserInput: false,
@@ -208,10 +209,12 @@ describe("sidebar thread filters", () => {
         filters: {
           statuses: ["done"],
           environmentIds: [localEnvironmentId],
+          projectKeys: ["environment-local:project-1"],
           sources: [ProviderDriverKind.make("codex")],
           recentOnly: false,
           attentionOnly: false,
           includeArchived: true,
+          groupByProject: true,
         },
       }),
     ).toBe(true);
@@ -245,6 +248,29 @@ describe("sidebar thread filters", () => {
     );
     expect(hasNarrowingSidebarThreadFilters(filters)).toBe(false);
     expect(hasActiveSidebarThreadFilters(filters)).toBe(false);
+  });
+
+  it("filters by scoped project key", () => {
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          projectKeys: ["environment-local:project-1"],
+        },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          projectKeys: ["environment-local:project-2"],
+        },
+      }),
+    ).toBe(false);
   });
 
   it("matches the attention quick filter as unread OR needs attention", () => {
@@ -568,6 +594,24 @@ describe("sidebar thread filters", () => {
         recentOnly: true,
       }),
     ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        projectKeys: ["environment-local:project-1"],
+      }),
+    ).toBe(true);
+    expect(
+      hasNarrowingSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        projectKeys: ["environment-local:project-1"],
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        groupByProject: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -4,6 +4,7 @@ import {
   buildMultiSelectThreadContextMenuItems,
   classifySidebarThreadFilterStatus,
   createThreadJumpHintVisibilityController,
+  getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
@@ -17,6 +18,7 @@ import {
   matchesSidebarThreadFilters,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolveSidebarArchiveEnvironmentIds,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveSidebarStageBadgeLabel,
@@ -33,6 +35,7 @@ import {
   sortThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
+  sidebarProviderInstanceKey,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
 } from "./Sidebar.logic";
 import {
@@ -150,6 +153,16 @@ describe("sidebar thread filters", () => {
       }),
     ).toBe("unread");
     expect(classifySidebarThreadFilterStatus(filterableThread)).toBe("done");
+  });
+
+  it("keeps needs-attention status when a thread is also explicitly unread", () => {
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        hasPendingUserInput: true,
+        isExplicitlyUnread: true,
+      }),
+    ).toBe("needs_attention");
   });
 
   it("matches status, environment, source, and archived controls", () => {
@@ -296,6 +309,52 @@ describe("sidebar thread filters", () => {
         recentOnly: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("sidebar filter scoping", () => {
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+  it("scopes provider instance ids by environment", () => {
+    const instanceId = ProviderInstanceId.make("codex_work");
+
+    expect(sidebarProviderInstanceKey(localEnvironmentId, instanceId)).not.toBe(
+      sidebarProviderInstanceKey(remoteEnvironmentId, instanceId),
+    );
+  });
+
+  it("loads archived snapshots only for selected environments", () => {
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [remoteEnvironmentId],
+        includeArchived: true,
+      }),
+    ).toEqual([remoteEnvironmentId]);
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [],
+        includeArchived: true,
+      }),
+    ).toEqual([localEnvironmentId, remoteEnvironmentId]);
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [remoteEnvironmentId],
+        includeArchived: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("excludes archived rows from shift-range selection order", () => {
+    expect(
+      getSidebarRangeSelectionThreadKeys([
+        { threadKey: "active-1", archivedAt: null },
+        { threadKey: "archived", archivedAt: "2026-03-09T11:00:00.000Z" },
+        { threadKey: "active-2", archivedAt: null },
+      ]),
+    ).toEqual(["active-1", "active-2"]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -19,6 +19,7 @@ import {
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
+  resolveSidebarV2TopStatus,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   formatWorkingDurationLabel,
@@ -762,6 +763,38 @@ describe("resolveSidebarV2Status", () => {
   });
 });
 
+describe("resolveSidebarV2TopStatus", () => {
+  it.each(["approval", "input", "working", "failed"] as const)(
+    "keeps %s above an explicit unread marker",
+    (status) => {
+      expect(
+        resolveSidebarV2TopStatus({
+          status,
+          isExplicitlyUnread: true,
+          isUnread: true,
+        }),
+      ).toBe(status);
+    },
+  );
+
+  it("uses unread only for a ready thread", () => {
+    expect(
+      resolveSidebarV2TopStatus({
+        status: "ready",
+        isExplicitlyUnread: true,
+        isUnread: true,
+      }),
+    ).toBe("unread");
+    expect(
+      resolveSidebarV2TopStatus({
+        status: "ready",
+        isExplicitlyUnread: false,
+        isUnread: true,
+      }),
+    ).toBe("done");
+  });
+});
+
 describe("sortThreadsForSidebarV2", () => {
   const sortable = (input: { id: string; createdAt: string }) => ({
     id: input.id,
@@ -967,9 +1000,21 @@ describe("resolveThreadStatusPill", () => {
           ...baseThread,
           hasPendingApprovals: true,
           hasPendingUserInput: true,
+          isExplicitlyUnread: true,
         },
       }),
     ).toMatchObject({ label: "Pending Approval", pulse: false });
+  });
+
+  it("shows active work before an explicit unread marker", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          isExplicitlyUnread: true,
+        },
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
   });
 
   it("shows awaiting input when plan mode is blocked on user answers", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -105,13 +105,16 @@ describe("shouldNavigateAfterProjectRemoval", () => {
 
 const filterableThread = {
   archivedAt: null,
+  createdAt: "2026-03-09T09:00:00.000Z",
   environmentId: localEnvironmentId,
   hasActionableProposedPlan: false,
   hasPendingApprovals: false,
   hasPendingUserInput: false,
   interactionMode: "default",
+  latestUserMessageAt: "2026-03-09T10:00:00.000Z",
   latestTurn: null,
   session: null,
+  updatedAt: "2026-03-09T10:00:00.000Z",
 } as const;
 
 describe("sidebar thread filters", () => {
@@ -163,6 +166,8 @@ describe("sidebar thread filters", () => {
           statuses: ["done"],
           environmentIds: [localEnvironmentId],
           sources: [ProviderDriverKind.make("codex")],
+          recentOnly: false,
+          attentionOnly: false,
           includeArchived: true,
         },
       }),
@@ -179,6 +184,78 @@ describe("sidebar thread filters", () => {
     ).toBe(false);
   });
 
+  it("matches the attention quick filter as unread OR needs attention", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      attentionOnly: true,
+    };
+    expect(
+      matchesSidebarThreadFilters({
+        thread: { ...filterableThread, hasPendingUserInput: true },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestTurn: makeLatestTurn(),
+        },
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches recent activity within the last seven days", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      recentOnly: true,
+    };
+    const nowMs = Date.parse("2026-03-10T10:00:00.000Z");
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: null,
+          updatedAt: "2026-03-03T09:59:59.999Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: null,
+          updatedAt: "not-a-date",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(false);
+  });
+
   it("recognizes the default filter state and meaningful deviations", () => {
     expect(hasActiveSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
     expect(
@@ -191,6 +268,18 @@ describe("sidebar thread filters", () => {
       hasActiveSidebarThreadFilters({
         ...DEFAULT_SIDEBAR_THREAD_FILTERS,
         includeArchived: true,
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        attentionOnly: true,
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        recentOnly: true,
       }),
     ).toBe(true);
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -4,6 +4,7 @@ import {
   buildMultiSelectThreadContextMenuItems,
   classifySidebarThreadFilterStatus,
   createThreadJumpHintVisibilityController,
+  filterSidebarThreadsForActiveRoute,
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -19,10 +20,12 @@ import {
   matchesSidebarThreadFilters,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolvePinnedCollapsedSidebarThread,
   resolveSidebarArchiveEnvironmentIds,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveSidebarStageBadgeLabel,
+  resolveSidebarThreadFilterStatuses,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
   resolveSidebarV2TopStatus,
@@ -37,6 +40,8 @@ import {
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
   sidebarProviderInstanceKey,
+  SIDEBAR_RECENT_FILTER_REFRESH_MS,
+  startSidebarRecentFilterClock,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
 } from "./Sidebar.logic";
 import {
@@ -220,6 +225,26 @@ describe("sidebar thread filters", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  it("treats an empty status selection as an unrestricted status filter", () => {
+    const filters = {
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      statuses: [],
+    };
+
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(resolveSidebarThreadFilterStatuses(filters.statuses)).toEqual(
+      DEFAULT_SIDEBAR_THREAD_FILTERS.statuses,
+    );
+    expect(hasNarrowingSidebarThreadFilters(filters)).toBe(false);
+    expect(hasActiveSidebarThreadFilters(filters)).toBe(false);
   });
 
   it("matches the attention quick filter as unread OR needs attention", () => {
@@ -543,6 +568,46 @@ describe("sidebar thread filters", () => {
         recentOnly: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("sidebar recent filter clock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ticks only while the Recent filter is enabled and stops on cleanup", () => {
+    let nowMs = 100;
+    const ticks: number[] = [];
+    const disabledCleanup = startSidebarRecentFilterClock({
+      enabled: false,
+      now: () => nowMs,
+      onTick: (nextNowMs) => ticks.push(nextNowMs),
+    });
+
+    vi.advanceTimersByTime(SIDEBAR_RECENT_FILTER_REFRESH_MS);
+    expect(ticks).toEqual([]);
+    disabledCleanup();
+
+    const cleanup = startSidebarRecentFilterClock({
+      enabled: true,
+      now: () => nowMs,
+      onTick: (nextNowMs) => ticks.push(nextNowMs),
+    });
+    expect(ticks).toEqual([100]);
+
+    nowMs = 200;
+    vi.advanceTimersByTime(SIDEBAR_RECENT_FILTER_REFRESH_MS);
+    expect(ticks).toEqual([100, 200]);
+
+    cleanup();
+    nowMs = 300;
+    vi.advanceTimersByTime(SIDEBAR_RECENT_FILTER_REFRESH_MS);
+    expect(ticks).toEqual([100, 200]);
   });
 });
 
@@ -1654,6 +1719,55 @@ describe("resolveProjectStatusIndicator", () => {
 });
 
 describe("getVisibleThreadsForProject", () => {
+  it("keeps only the active route when every thread fails the filters", () => {
+    const threads = [
+      { threadKey: "environment-local:thread-active", matches: false },
+      { threadKey: "environment-local:thread-hidden", matches: false },
+    ];
+
+    const filteredThreads = filterSidebarThreadsForActiveRoute({
+      threads,
+      activeThreadKey: "environment-local:thread-active",
+      getThreadKey: (thread) => thread.threadKey,
+      matchesFilters: (thread) => thread.matches,
+    });
+
+    expect(filteredThreads).toEqual([threads[0]]);
+    expect(
+      resolvePinnedCollapsedSidebarThread({
+        threads: filteredThreads,
+        activeThreadKey: "environment-local:thread-active",
+        projectExpanded: false,
+        getThreadKey: (thread) => thread.threadKey,
+      }),
+    ).toBe(threads[0]);
+    expect(
+      resolvePinnedCollapsedSidebarThread({
+        threads: filteredThreads,
+        activeThreadKey: "environment-local:thread-active",
+        projectExpanded: true,
+        getThreadKey: (thread) => thread.threadKey,
+      }),
+    ).toBeNull();
+  });
+
+  it("continues applying filters to non-active rows", () => {
+    const threads = [
+      { threadKey: "active", matches: false },
+      { threadKey: "matching", matches: true },
+      { threadKey: "hidden", matches: false },
+    ];
+
+    expect(
+      filterSidebarThreadsForActiveRoute({
+        threads,
+        activeThreadKey: "active",
+        getThreadKey: (thread) => thread.threadKey,
+        matchesFilters: (thread) => thread.matches,
+      }).map((thread) => thread.threadKey),
+    ).toEqual(["active", "matching"]);
+  });
+
   it("includes the active thread even when it falls below the folded preview", () => {
     const threads = Array.from({ length: 8 }, (_, index) =>
       makeThread({
@@ -1664,7 +1778,8 @@ describe("getVisibleThreadsForProject", () => {
 
     const result = getVisibleThreadsForProject({
       threads,
-      activeThreadId: ThreadId.make("thread-8"),
+      activeThreadKey: "environment-local:thread-8",
+      getThreadKey: (thread) => `environment-local:${thread.id}`,
       isThreadListExpanded: false,
       previewLimit: 6,
     });
@@ -1691,7 +1806,8 @@ describe("getVisibleThreadsForProject", () => {
 
     const result = getVisibleThreadsForProject({
       threads,
-      activeThreadId: ThreadId.make("thread-8"),
+      activeThreadKey: "environment-local:thread-8",
+      getThreadKey: (thread) => `environment-local:${thread.id}`,
       isThreadListExpanded: true,
       previewLimit: 6,
     });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -13,6 +13,7 @@ import {
   getProjectSortTimestamp,
   hasUnseenCompletion,
   hasActiveSidebarThreadFilters,
+  hasNarrowingSidebarThreadFilters,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   matchesSidebarThreadFilters,
@@ -300,6 +301,7 @@ describe("sidebar thread filters", () => {
           ...filterableThread,
           latestUserMessageAt: null,
           updatedAt: "2026-03-03T09:59:59.999Z",
+          createdAt: "2026-03-03T09:00:00.000Z",
         },
         providerDriverKind: ProviderDriverKind.make("codex"),
         filters,
@@ -312,16 +314,42 @@ describe("sidebar thread filters", () => {
           ...filterableThread,
           latestUserMessageAt: null,
           updatedAt: "not-a-date",
+          createdAt: "2026-03-03T09:00:00.000Z",
         },
         providerDriverKind: ProviderDriverKind.make("codex"),
         filters,
         nowMs,
       }),
     ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: "2026-03-01T10:00:00.000Z",
+          updatedAt: "2026-03-10T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          latestUserMessageAt: "not-a-date",
+          updatedAt: "2026-03-10T09:00:00.000Z",
+        },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+        nowMs,
+      }),
+    ).toBe(true);
   });
 
   it("recognizes the default filter state and meaningful deviations", () => {
     expect(hasActiveSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
+    expect(hasNarrowingSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
     expect(
       hasActiveSidebarThreadFilters({
         ...DEFAULT_SIDEBAR_THREAD_FILTERS,
@@ -334,6 +362,12 @@ describe("sidebar thread filters", () => {
         includeArchived: true,
       }),
     ).toBe(true);
+    expect(
+      hasNarrowingSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        includeArchived: true,
+      }),
+    ).toBe(false);
     expect(
       hasActiveSidebarThreadFilters({
         ...DEFAULT_SIDEBAR_THREAD_FILTERS,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  classifySidebarThreadFilterStatus,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -10,8 +11,10 @@ import {
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
   hasUnseenCompletion,
+  hasActiveSidebarThreadFilters,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
+  matchesSidebarThreadFilters,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
@@ -36,10 +39,11 @@ import {
   EnvironmentId,
   OrchestrationLatestTurn,
   ProjectId,
+  ProviderDriverKind,
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
-
+import { DEFAULT_SIDEBAR_THREAD_FILTERS } from "@t3tools/contracts/settings";
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -96,6 +100,99 @@ describe("shouldNavigateAfterProjectRemoval", () => {
         projectDraftId: null,
       }),
     ).toBe(false);
+  });
+});
+
+const filterableThread = {
+  archivedAt: null,
+  environmentId: localEnvironmentId,
+  hasActionableProposedPlan: false,
+  hasPendingApprovals: false,
+  hasPendingUserInput: false,
+  interactionMode: "default",
+  latestTurn: null,
+  session: null,
+} as const;
+
+describe("sidebar thread filters", () => {
+  it("classifies attention, working, unread, and done as exclusive statuses", () => {
+    expect(
+      classifySidebarThreadFilterStatus({ ...filterableThread, hasPendingApprovals: true }),
+    ).toBe("needs_attention");
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-03-09T10:00:00.000Z",
+        },
+      }),
+    ).toBe("working");
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        latestTurn: makeLatestTurn(),
+        lastVisitedAt: "2026-03-09T10:04:00.000Z",
+      }),
+    ).toBe("unread");
+    expect(classifySidebarThreadFilterStatus(filterableThread)).toBe("done");
+  });
+
+  it("matches status, environment, source, and archived controls", () => {
+    const archivedThread = {
+      ...filterableThread,
+      archivedAt: "2026-03-09T11:00:00.000Z",
+    };
+    expect(
+      matchesSidebarThreadFilters({
+        thread: archivedThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: DEFAULT_SIDEBAR_THREAD_FILTERS,
+      }),
+    ).toBe(false);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: archivedThread,
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters: {
+          statuses: ["done"],
+          environmentIds: [localEnvironmentId],
+          sources: [ProviderDriverKind.make("codex")],
+          includeArchived: true,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        providerDriverKind: ProviderDriverKind.make("claudeAgent"),
+        filters: {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          sources: [ProviderDriverKind.make("codex")],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes the default filter state and meaningful deviations", () => {
+    expect(hasActiveSidebarThreadFilters(DEFAULT_SIDEBAR_THREAD_FILTERS)).toBe(false);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        statuses: ["needs_attention", "unread", "working"],
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveSidebarThreadFilters({
+        ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+        includeArchived: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -5,6 +5,7 @@ import {
   classifySidebarThreadFilterStatus,
   createThreadJumpHintVisibilityController,
   filterSidebarThreadsForActiveRoute,
+  getFlatSidebarRenderedThreads,
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -1941,6 +1942,55 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     ...overrides,
   };
 }
+
+describe("getFlatSidebarRenderedThreads", () => {
+  it("uses only project refs represented by the flat row", () => {
+    const projectId = ProjectId.make("project-visible");
+    const threads = getFlatSidebarRenderedThreads({
+      threads: [
+        makeThread({
+          id: ThreadId.make("thread-orphan"),
+          projectId: ProjectId.make("project-missing"),
+          updatedAt: "2026-03-09T12:00:00.000Z",
+        }),
+        makeThread({
+          id: ThreadId.make("thread-visible"),
+          projectId,
+          updatedAt: "2026-03-09T11:00:00.000Z",
+        }),
+      ],
+      memberProjectRefs: [{ environmentId: localEnvironmentId, projectId }],
+      sortOrder: "updated_at",
+    });
+
+    expect(threads.map((thread) => thread.id)).toEqual([ThreadId.make("thread-visible")]);
+  });
+
+  it("keeps normal flat rows in the configured thread order", () => {
+    const projectId = ProjectId.make("project-visible");
+    const threads = getFlatSidebarRenderedThreads({
+      threads: [
+        makeThread({
+          id: ThreadId.make("thread-old"),
+          projectId,
+          updatedAt: "2026-03-09T10:00:00.000Z",
+        }),
+        makeThread({
+          id: ThreadId.make("thread-new"),
+          projectId,
+          updatedAt: "2026-03-09T11:00:00.000Z",
+        }),
+      ],
+      memberProjectRefs: [{ environmentId: localEnvironmentId, projectId }],
+      sortOrder: "updated_at",
+    });
+
+    expect(threads.map((thread) => thread.id)).toEqual([
+      ThreadId.make("thread-new"),
+      ThreadId.make("thread-old"),
+    ]);
+  });
+});
 
 describe("getFallbackThreadIdAfterDelete", () => {
   it("returns the top remaining thread in the deleted thread's project sidebar order", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -165,6 +165,24 @@ describe("sidebar thread filters", () => {
     ).toBe("needs_attention");
   });
 
+  it("keeps working status when a live thread is also explicitly unread", () => {
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        isExplicitlyUnread: true,
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "Codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-03-09T10:00:00.000Z",
+        },
+      }),
+    ).toBe("working");
+  });
+
   it("matches status, environment, source, and archived controls", () => {
     const archivedThread = {
       ...filterableThread,
@@ -211,6 +229,25 @@ describe("sidebar thread filters", () => {
     expect(
       matchesSidebarThreadFilters({
         thread: { ...filterableThread, hasPendingUserInput: true },
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: {
+          ...filterableThread,
+          session: {
+            threadId: ThreadId.make("thread-1"),
+            status: "running",
+            providerName: "Codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: "2026-03-09T10:00:00.000Z",
+          },
+        },
+        isExplicitlyUnread: true,
         providerDriverKind: ProviderDriverKind.make("codex"),
         filters,
       }),

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -6,6 +6,7 @@ import {
   createThreadJumpHintVisibilityController,
   filterSidebarThreadsForActiveRoute,
   getFlatSidebarRenderedThreads,
+  getGroupedSidebarRenderedThreads,
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -22,6 +23,7 @@ import {
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
   resolvePinnedCollapsedSidebarThread,
+  removeProjectKeysFromSidebarThreadFilters,
   resolveSidebarArchiveEnvironmentIds,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
@@ -690,6 +692,14 @@ describe("sidebar filter scoping", () => {
         includeArchived: false,
       }),
     ).toEqual([]);
+    expect(
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: [localEnvironmentId, remoteEnvironmentId],
+        selectedEnvironmentIds: [],
+        includeArchived: false,
+        requiredEnvironmentIds: [remoteEnvironmentId],
+      }),
+    ).toEqual([remoteEnvironmentId]);
   });
 
   it("excludes archived rows from shift-range selection order", () => {
@@ -700,6 +710,70 @@ describe("sidebar filter scoping", () => {
         { threadKey: "active-2", archivedAt: null },
       ]),
     ).toEqual(["active-1", "active-2"]);
+  });
+
+  it("budgets grouped previews from active rows before appending archived rows", () => {
+    const activeOne = { id: "active-1", archivedAt: null };
+    const activeTwo = { id: "active-2", archivedAt: null };
+    const activeThree = { id: "active-3", archivedAt: null };
+    const archivedOne = { id: "archived-1", archivedAt: "2026-03-09T11:00:00.000Z" };
+    const archivedTwo = { id: "archived-2", archivedAt: "2026-03-09T10:00:00.000Z" };
+
+    const result = getGroupedSidebarRenderedThreads({
+      threads: [archivedOne, activeOne, archivedTwo, activeTwo, activeThree],
+      activeThreadKey: null,
+      getThreadKey: (thread) => thread.id,
+      previewLimit: 2,
+      showAllThreads: false,
+    });
+
+    expect(result.hasOverflowingThreads).toBe(true);
+    expect(result.renderedThreads.map((thread) => thread.id)).toEqual([
+      "active-1",
+      "active-2",
+      "archived-1",
+      "archived-2",
+    ]);
+    expect(result.hiddenThreads.map((thread) => thread.id)).toEqual(["active-3"]);
+  });
+
+  it("pins an active row below the grouped preview without charging archived rows", () => {
+    const threads = [
+      { id: "active-1", archivedAt: null },
+      { id: "archived-1", archivedAt: "2026-03-09T11:00:00.000Z" },
+      { id: "active-2", archivedAt: null },
+      { id: "active-3", archivedAt: null },
+      { id: "active-4", archivedAt: null },
+    ];
+
+    const result = getGroupedSidebarRenderedThreads({
+      threads,
+      activeThreadKey: "active-4",
+      getThreadKey: (thread) => thread.id,
+      previewLimit: 2,
+      showAllThreads: false,
+    });
+
+    expect(result.hasOverflowingThreads).toBe(true);
+    expect(result.renderedThreads.map((thread) => thread.id)).toEqual([
+      "active-1",
+      "active-2",
+      "active-4",
+      "archived-1",
+    ]);
+    expect(result.hiddenThreads.map((thread) => thread.id)).toEqual(["active-3"]);
+  });
+
+  it("removes only deleted project keys from persisted sidebar filters", () => {
+    expect(
+      removeProjectKeysFromSidebarThreadFilters(
+        {
+          ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+          projectKeys: ["environment-local:project-1", "environment-remote:project-2"],
+        },
+        new Set(["environment-local:project-1"]),
+      ).projectKeys,
+    ).toEqual(["environment-remote:project-2"]);
   });
 });
 
@@ -2197,7 +2271,7 @@ describe("sortProjectsForSidebar", () => {
           updatedAt: "2026-03-09T10:10:00.000Z",
           archivedAt: "2026-03-09T10:11:00.000Z",
         }),
-      ].filter((thread) => thread.archivedAt === null),
+      ],
       "updated_at",
     );
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -943,6 +943,23 @@ describe("resolveThreadStatusPill", () => {
     },
   };
 
+  it("shows explicit unread even without a completed turn", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          isExplicitlyUnread: true,
+          latestTurn: null,
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            activeTurnId: null,
+          },
+        },
+      }),
+    ).toMatchObject({ label: "Unread", pulse: false });
+  });
+
   it("shows pending approval before all other statuses", () => {
     expect(
       resolveThreadStatusPill({

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -34,6 +34,7 @@ import {
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
+  shouldShowAllSidebarThreads,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
   sortThreadsForSidebarV2,
@@ -1861,6 +1862,32 @@ describe("getVisibleThreadsForProject", () => {
       threads.map((thread) => thread.id),
     );
     expect(result.hiddenThreads).toEqual([]);
+  });
+});
+
+describe("shouldShowAllSidebarThreads", () => {
+  it("always shows the complete list in flat mode", () => {
+    expect(
+      shouldShowAllSidebarThreads({
+        flatMode: true,
+        isThreadListExpanded: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves preview folding for grouped projects", () => {
+    expect(
+      shouldShowAllSidebarThreads({
+        flatMode: false,
+        isThreadListExpanded: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowAllSidebarThreads({
+        flatMode: false,
+        isThreadListExpanded: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -143,6 +143,12 @@ describe("sidebar thread filters", () => {
         lastVisitedAt: "2026-03-09T10:04:00.000Z",
       }),
     ).toBe("unread");
+    expect(
+      classifySidebarThreadFilterStatus({
+        ...filterableThread,
+        isExplicitlyUnread: true,
+      }),
+    ).toBe("unread");
     expect(classifySidebarThreadFilterStatus(filterableThread)).toBe("done");
   });
 
@@ -203,6 +209,14 @@ describe("sidebar thread filters", () => {
           latestTurn: makeLatestTurn(),
         },
         lastVisitedAt: "2026-03-09T10:04:00.000Z",
+        providerDriverKind: ProviderDriverKind.make("codex"),
+        filters,
+      }),
+    ).toBe(true);
+    expect(
+      matchesSidebarThreadFilters({
+        thread: filterableThread,
+        isExplicitlyUnread: true,
         providerDriverKind: ProviderDriverKind.make("codex"),
         filters,
       }),

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -266,6 +266,22 @@ type SidebarThreadFilterInput = Pick<
 export const SIDEBAR_RECENT_WINDOW_DAYS = 7;
 const SIDEBAR_RECENT_WINDOW_MS = SIDEBAR_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1_000;
 
+function latestValidTimestampMs(...timestamps: ReadonlyArray<string | null>): number | null {
+  let latestTimestampMs: number | null = null;
+  for (const timestamp of timestamps) {
+    if (timestamp === null) {
+      continue;
+    }
+    const timestampMs = Date.parse(timestamp);
+    if (Number.isNaN(timestampMs)) {
+      continue;
+    }
+    latestTimestampMs =
+      latestTimestampMs === null ? timestampMs : Math.max(latestTimestampMs, timestampMs);
+  }
+  return latestTimestampMs;
+}
+
 export function classifySidebarThreadFilterStatus(
   thread: SidebarThreadFilterInput & { readonly lastVisitedAt?: string | undefined },
 ): SidebarThreadFilterStatus {
@@ -329,10 +345,13 @@ export function matchesSidebarThreadFilters(input: {
     return false;
   }
   if (filters.recentOnly) {
-    const recentTimestamp = thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt;
-    const recentTimestampMs = Date.parse(recentTimestamp);
+    const recentTimestampMs = latestValidTimestampMs(
+      thread.latestUserMessageAt,
+      thread.updatedAt,
+      thread.createdAt,
+    );
     if (
-      Number.isNaN(recentTimestampMs) ||
+      recentTimestampMs === null ||
       recentTimestampMs < (input.nowMs ?? Date.now()) - SIDEBAR_RECENT_WINDOW_MS
     ) {
       return false;
@@ -341,7 +360,7 @@ export function matchesSidebarThreadFilters(input: {
   return filters.statuses.includes(status);
 }
 
-export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
+export function hasNarrowingSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
   const selectedStatuses = new Set(filters.statuses);
   const includesEveryStatus = SIDEBAR_THREAD_FILTER_STATUSES.every((status) =>
     selectedStatuses.has(status),
@@ -349,12 +368,15 @@ export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): bo
   return (
     filters.attentionOnly ||
     filters.recentOnly ||
-    filters.includeArchived ||
     filters.environmentIds.length > 0 ||
     filters.sources.length > 0 ||
     selectedStatuses.size !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
     !includesEveryStatus
   );
+}
+
+export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
+  return filters.includeArchived || hasNarrowingSidebarThreadFilters(filters);
 }
 
 export function sidebarProviderInstanceKey(

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -265,6 +265,32 @@ type SidebarThreadFilterInput = Pick<
 
 export const SIDEBAR_RECENT_WINDOW_DAYS = 7;
 const SIDEBAR_RECENT_WINDOW_MS = SIDEBAR_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1_000;
+export const SIDEBAR_RECENT_FILTER_REFRESH_MS = 60_000;
+
+export function startSidebarRecentFilterClock(input: {
+  readonly enabled: boolean;
+  readonly onTick: (nowMs: number) => void;
+  readonly now?: () => number;
+}): () => void {
+  if (!input.enabled) {
+    return () => {};
+  }
+
+  const now = input.now ?? Date.now;
+  input.onTick(now());
+  const interval = globalThis.setInterval(() => {
+    input.onTick(now());
+  }, SIDEBAR_RECENT_FILTER_REFRESH_MS);
+  return () => {
+    globalThis.clearInterval(interval);
+  };
+}
+
+export function resolveSidebarThreadFilterStatuses(
+  statuses: ReadonlyArray<SidebarThreadFilterStatus>,
+): ReadonlyArray<SidebarThreadFilterStatus> {
+  return statuses.length === 0 ? SIDEBAR_THREAD_FILTER_STATUSES : statuses;
+}
 
 function latestValidTimestampMs(...timestamps: ReadonlyArray<string | null>): number | null {
   let latestTimestampMs: number | null = null;
@@ -360,11 +386,12 @@ export function matchesSidebarThreadFilters(input: {
       return false;
     }
   }
-  return filters.statuses.includes(status) || (isUnread && filters.statuses.includes("unread"));
+  const selectedStatuses = resolveSidebarThreadFilterStatuses(filters.statuses);
+  return selectedStatuses.includes(status) || (isUnread && selectedStatuses.includes("unread"));
 }
 
 export function hasNarrowingSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
-  const selectedStatuses = new Set(filters.statuses);
+  const selectedStatuses = new Set(resolveSidebarThreadFilterStatuses(filters.statuses));
   const includesEveryStatus = SIDEBAR_THREAD_FILTER_STATUSES.every((status) =>
     selectedStatuses.has(status),
   );
@@ -380,6 +407,32 @@ export function hasNarrowingSidebarThreadFilters(filters: SidebarThreadFilters):
 
 export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
   return filters.includeArchived || hasNarrowingSidebarThreadFilters(filters);
+}
+
+export function filterSidebarThreadsForActiveRoute<T>(input: {
+  readonly threads: ReadonlyArray<T>;
+  readonly activeThreadKey: string | null;
+  readonly getThreadKey: (thread: T) => string;
+  readonly matchesFilters: (thread: T) => boolean;
+}): T[] {
+  return input.threads.filter(
+    (thread) =>
+      input.getThreadKey(thread) === input.activeThreadKey || input.matchesFilters(thread),
+  );
+}
+
+export function resolvePinnedCollapsedSidebarThread<T>(input: {
+  readonly threads: ReadonlyArray<T>;
+  readonly activeThreadKey: string | null;
+  readonly projectExpanded: boolean;
+  readonly getThreadKey: (thread: T) => string;
+}): T | null {
+  if (input.projectExpanded || input.activeThreadKey === null) {
+    return null;
+  }
+  return (
+    input.threads.find((thread) => input.getThreadKey(thread) === input.activeThreadKey) ?? null
+  );
 }
 
 export function sidebarProviderInstanceKey(
@@ -889,9 +942,10 @@ export function resolveProjectStatusIndicator(
   return highestPriorityStatus;
 }
 
-export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input: {
+export function getVisibleThreadsForProject<T>(input: {
   threads: readonly T[];
-  activeThreadId: T["id"] | undefined;
+  activeThreadKey: string | null;
+  getThreadKey: (thread: T) => string;
   isThreadListExpanded: boolean;
   previewLimit: number;
 }): {
@@ -899,7 +953,7 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
   visibleThreads: T[];
   hiddenThreads: T[];
 } {
-  const { activeThreadId, isThreadListExpanded, previewLimit, threads } = input;
+  const { activeThreadKey, getThreadKey, isThreadListExpanded, previewLimit, threads } = input;
   const hasHiddenThreads = threads.length > previewLimit;
 
   if (!hasHiddenThreads || isThreadListExpanded) {
@@ -911,7 +965,10 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
   }
 
   const previewThreads = threads.slice(0, previewLimit);
-  if (!activeThreadId || previewThreads.some((thread) => thread.id === activeThreadId)) {
+  if (
+    activeThreadKey === null ||
+    previewThreads.some((thread) => getThreadKey(thread) === activeThreadKey)
+  ) {
     return {
       hasHiddenThreads: true,
       hiddenThreads: threads.slice(previewLimit),
@@ -919,7 +976,7 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
     };
   }
 
-  const activeThread = threads.find((thread) => thread.id === activeThreadId);
+  const activeThread = threads.find((thread) => getThreadKey(thread) === activeThreadKey);
   if (!activeThread) {
     return {
       hasHiddenThreads: true,
@@ -928,12 +985,14 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
     };
   }
 
-  const visibleThreadIds = new Set([...previewThreads, activeThread].map((thread) => thread.id));
+  const visibleThreadKeys = new Set(
+    [...previewThreads, activeThread].map((thread) => getThreadKey(thread)),
+  );
 
   return {
     hasHiddenThreads: true,
-    hiddenThreads: threads.filter((thread) => !visibleThreadIds.has(thread.id)),
-    visibleThreads: threads.filter((thread) => visibleThreadIds.has(thread.id)),
+    hiddenThreads: threads.filter((thread) => !visibleThreadKeys.has(getThreadKey(thread))),
+    visibleThreads: threads.filter((thread) => visibleThreadKeys.has(getThreadKey(thread))),
   };
 }
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -255,7 +255,9 @@ type SidebarThreadFilterInput = Pick<
   | "latestTurn"
   | "session"
   | "updatedAt"
->;
+> & {
+  readonly isExplicitlyUnread?: boolean | undefined;
+};
 
 export const SIDEBAR_RECENT_WINDOW_DAYS = 7;
 const SIDEBAR_RECENT_WINDOW_MS = SIDEBAR_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1_000;
@@ -263,6 +265,10 @@ const SIDEBAR_RECENT_WINDOW_MS = SIDEBAR_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1_0
 export function classifySidebarThreadFilterStatus(
   thread: SidebarThreadFilterInput & { readonly lastVisitedAt?: string | undefined },
 ): SidebarThreadFilterStatus {
+  if (thread.isExplicitlyUnread) {
+    return "unread";
+  }
+
   const needsAttention =
     thread.hasPendingApprovals ||
     thread.hasPendingUserInput ||
@@ -288,6 +294,7 @@ export function classifySidebarThreadFilterStatus(
 export function matchesSidebarThreadFilters(input: {
   readonly thread: SidebarThreadFilterInput;
   readonly lastVisitedAt?: string | null | undefined;
+  readonly isExplicitlyUnread?: boolean | undefined;
   readonly providerDriverKind: ProviderDriverKind | null;
   readonly filters: SidebarThreadFilters;
   readonly nowMs?: number | undefined;
@@ -309,6 +316,7 @@ export function matchesSidebarThreadFilters(input: {
   const status = classifySidebarThreadFilterStatus({
     ...thread,
     ...(input.lastVisitedAt ? { lastVisitedAt: input.lastVisitedAt } : {}),
+    ...(input.isExplicitlyUnread ? { isExplicitlyUnread: true } : {}),
   });
   if (filters.attentionOnly && status !== "needs_attention" && status !== "unread") {
     return false;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -950,6 +950,13 @@ export function resolveProjectStatusIndicator(
   return highestPriorityStatus;
 }
 
+export function shouldShowAllSidebarThreads(input: {
+  flatMode: boolean;
+  isThreadListExpanded: boolean;
+}): boolean {
+  return input.flatMode || input.isThreadListExpanded;
+}
+
 export function getVisibleThreadsForProject<T>(input: {
   threads: readonly T[];
   activeThreadKey: string | null;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -280,12 +280,12 @@ export function classifySidebarThreadFilterStatus(
     return "needs_attention";
   }
 
-  if (thread.isExplicitlyUnread) {
-    return "unread";
-  }
-
   if (thread.session?.status === "running" || thread.session?.status === "starting") {
     return "working";
+  }
+
+  if (thread.isExplicitlyUnread) {
+    return "unread";
   }
 
   if (hasUnseenCompletion(thread)) {
@@ -317,12 +317,15 @@ export function matchesSidebarThreadFilters(input: {
     return false;
   }
 
-  const status = classifySidebarThreadFilterStatus({
+  const classifiedThread = {
     ...thread,
     ...(input.lastVisitedAt ? { lastVisitedAt: input.lastVisitedAt } : {}),
     ...(input.isExplicitlyUnread ? { isExplicitlyUnread: true } : {}),
-  });
-  if (filters.attentionOnly && status !== "needs_attention" && status !== "unread") {
+  };
+  const status = classifySidebarThreadFilterStatus(classifiedThread);
+  const isUnread =
+    classifiedThread.isExplicitlyUnread === true || hasUnseenCompletion(classifiedThread);
+  if (filters.attentionOnly && status !== "needs_attention" && !isUnread) {
     return false;
   }
   if (filters.recentOnly) {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -99,6 +99,7 @@ export interface ThreadStatusPill {
   label:
     | "Working"
     | "Connecting"
+    | "Unread"
     | "Completed"
     | "Pending Approval"
     | "Awaiting Input"
@@ -114,6 +115,7 @@ const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
   Working: 3,
   Connecting: 3,
   "Plan Ready": 2,
+  Unread: 1,
   Completed: 1,
 };
 
@@ -127,6 +129,7 @@ type ThreadStatusInput = Pick<
   | "session"
 > & {
   lastVisitedAt?: string | undefined;
+  isExplicitlyUnread?: boolean | undefined;
 };
 
 export interface ThreadJumpHintVisibilityController {
@@ -599,6 +602,15 @@ export function resolveThreadStatusPill(input: {
   thread: ThreadStatusInput;
 }): ThreadStatusPill | null {
   const { thread } = input;
+
+  if (thread.isExplicitlyUnread) {
+    return {
+      label: "Unread",
+      colorClass: "text-blue-600 dark:text-blue-300/90",
+      dotClass: "bg-blue-500 dark:bg-blue-300/90",
+      pulse: false,
+    };
+  }
 
   if (thread.hasPendingApprovals) {
     return {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -347,6 +347,9 @@ export function matchesSidebarThreadFilters(input: {
   if (filters.recentOnly) {
     const recentTimestampMs = latestValidTimestampMs(
       thread.latestUserMessageAt,
+      thread.latestTurn?.requestedAt ?? null,
+      thread.latestTurn?.startedAt ?? null,
+      thread.latestTurn?.completedAt ?? null,
       thread.updatedAt,
       thread.createdAt,
     );

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,6 +1,13 @@
 import * as React from "react";
 import type { ContextMenuItem } from "@t3tools/contracts";
-import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import {
+  SIDEBAR_THREAD_FILTER_STATUSES,
+  type SidebarProjectSortOrder,
+  type SidebarThreadFilters,
+  type SidebarThreadFilterStatus,
+  type SidebarThreadSortOrder,
+} from "@t3tools/contracts/settings";
+import type { ProviderDriverKind } from "@t3tools/contracts";
 import {
   getThreadSortTimestamp,
   sortThreads,
@@ -233,6 +240,84 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   const lastVisitedAt = Date.parse(thread.lastVisitedAt);
   if (Number.isNaN(lastVisitedAt)) return true;
   return completedAt > lastVisitedAt;
+}
+
+type SidebarThreadFilterInput = Pick<
+  SidebarThreadSummary,
+  | "archivedAt"
+  | "environmentId"
+  | "hasActionableProposedPlan"
+  | "hasPendingApprovals"
+  | "hasPendingUserInput"
+  | "interactionMode"
+  | "latestTurn"
+  | "session"
+>;
+
+export function classifySidebarThreadFilterStatus(
+  thread: SidebarThreadFilterInput & { readonly lastVisitedAt?: string | undefined },
+): SidebarThreadFilterStatus {
+  const needsAttention =
+    thread.hasPendingApprovals ||
+    thread.hasPendingUserInput ||
+    thread.session?.status === "error" ||
+    (thread.interactionMode === "plan" &&
+      isLatestTurnSettled(thread.latestTurn, thread.session) &&
+      thread.hasActionableProposedPlan);
+  if (needsAttention) {
+    return "needs_attention";
+  }
+
+  if (thread.session?.status === "running" || thread.session?.status === "starting") {
+    return "working";
+  }
+
+  if (hasUnseenCompletion(thread)) {
+    return "unread";
+  }
+
+  return "done";
+}
+
+export function matchesSidebarThreadFilters(input: {
+  readonly thread: SidebarThreadFilterInput;
+  readonly lastVisitedAt?: string | null | undefined;
+  readonly providerDriverKind: ProviderDriverKind | null;
+  readonly filters: SidebarThreadFilters;
+}): boolean {
+  const { filters, thread } = input;
+  if (thread.archivedAt !== null && !filters.includeArchived) {
+    return false;
+  }
+  if (filters.environmentIds.length > 0 && !filters.environmentIds.includes(thread.environmentId)) {
+    return false;
+  }
+  if (
+    filters.sources.length > 0 &&
+    (input.providerDriverKind === null || !filters.sources.includes(input.providerDriverKind))
+  ) {
+    return false;
+  }
+
+  const status = classifySidebarThreadFilterStatus({
+    ...thread,
+    ...(input.lastVisitedAt ? { lastVisitedAt: input.lastVisitedAt } : {}),
+  });
+  return filters.statuses.includes(status);
+}
+
+export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): boolean {
+  const selectedStatuses = new Set(filters.statuses);
+  const includesEveryStatus = SIDEBAR_THREAD_FILTER_STATUSES.every((status) =>
+    selectedStatuses.has(status),
+  );
+  return (
+    filters.includeArchived ||
+    filters.environmentIds.length > 0 ||
+    filters.sources.length > 0 ||
+    selectedStatuses.size !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
+    !includesEveryStatus
+  );
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -251,6 +251,7 @@ type SidebarThreadFilterInput = Pick<
   | "archivedAt"
   | "createdAt"
   | "environmentId"
+  | "projectId"
   | "hasActionableProposedPlan"
   | "hasPendingApprovals"
   | "hasPendingUserInput"
@@ -353,6 +354,12 @@ export function matchesSidebarThreadFilters(input: {
     return false;
   }
   if (
+    filters.projectKeys.length > 0 &&
+    !filters.projectKeys.includes(`${thread.environmentId}:${thread.projectId}`)
+  ) {
+    return false;
+  }
+  if (
     filters.sources.length > 0 &&
     (input.providerDriverKind === null || !filters.sources.includes(input.providerDriverKind))
   ) {
@@ -399,6 +406,7 @@ export function hasNarrowingSidebarThreadFilters(filters: SidebarThreadFilters):
     filters.attentionOnly ||
     filters.recentOnly ||
     filters.environmentIds.length > 0 ||
+    filters.projectKeys.length > 0 ||
     filters.sources.length > 0 ||
     selectedStatuses.size !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
     !includesEveryStatus

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -477,6 +477,36 @@ export function getSidebarRangeSelectionThreadKeys(
   return threads.filter((thread) => thread.archivedAt === null).map((thread) => thread.threadKey);
 }
 
+export function getFlatSidebarRenderedThreads<
+  TThread extends {
+    readonly id: string;
+    readonly environmentId: string;
+    readonly projectId: string;
+    readonly archivedAt: string | null;
+  } & ThreadSortInput,
+>(input: {
+  readonly threads: readonly TThread[];
+  readonly memberProjectRefs: readonly {
+    readonly environmentId: string;
+    readonly projectId: string;
+  }[];
+  readonly sortOrder: SidebarThreadSortOrder;
+}): TThread[] {
+  const memberProjectKeys = new Set(
+    input.memberProjectRefs.map(
+      (projectRef) => `${projectRef.environmentId}\u0000${projectRef.projectId}`,
+    ),
+  );
+  return sortThreads(
+    input.threads.filter(
+      (thread) =>
+        thread.archivedAt === null &&
+        memberProjectKeys.has(`${thread.environmentId}\u0000${thread.projectId}`),
+    ),
+    input.sortOrder,
+  );
+}
+
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
   if (target === null) return true;
   return !target.closest(THREAD_SELECTION_SAFE_SELECTOR);

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -454,17 +454,15 @@ export function resolveSidebarArchiveEnvironmentIds(input: {
   readonly availableEnvironmentIds: readonly EnvironmentId[];
   readonly selectedEnvironmentIds: readonly EnvironmentId[];
   readonly includeArchived: boolean;
+  readonly requiredEnvironmentIds?: readonly EnvironmentId[];
 }): EnvironmentId[] {
-  if (!input.includeArchived) {
-    return [];
-  }
-  if (input.selectedEnvironmentIds.length === 0) {
-    return [...input.availableEnvironmentIds];
-  }
-
   const selectedEnvironmentIds = new Set(input.selectedEnvironmentIds);
-  return input.availableEnvironmentIds.filter((environmentId) =>
-    selectedEnvironmentIds.has(environmentId),
+  const requiredEnvironmentIds = new Set(input.requiredEnvironmentIds);
+  return input.availableEnvironmentIds.filter(
+    (environmentId) =>
+      requiredEnvironmentIds.has(environmentId) ||
+      (input.includeArchived &&
+        (selectedEnvironmentIds.size === 0 || selectedEnvironmentIds.has(environmentId))),
   );
 }
 
@@ -505,6 +503,60 @@ export function getFlatSidebarRenderedThreads<
     ),
     input.sortOrder,
   );
+}
+
+export function getGroupedSidebarRenderedThreads<
+  TThread extends {
+    readonly archivedAt: string | null;
+  },
+>(input: {
+  readonly threads: readonly TThread[];
+  readonly activeThreadKey: string | null;
+  readonly getThreadKey: (thread: TThread) => string;
+  readonly previewLimit: number | null;
+  readonly showAllThreads: boolean;
+}): {
+  readonly hasOverflowingThreads: boolean;
+  readonly hiddenThreads: TThread[];
+  readonly renderedThreads: TThread[];
+} {
+  const activeThreads = input.threads.filter((thread) => thread.archivedAt === null);
+  const archivedThreads = input.threads.filter((thread) => thread.archivedAt !== null);
+  const activePreview =
+    input.previewLimit === null
+      ? {
+          hasHiddenThreads: false,
+          hiddenThreads: [],
+          visibleThreads: activeThreads,
+        }
+      : getVisibleThreadsForProject({
+          threads: activeThreads,
+          activeThreadKey: input.activeThreadKey,
+          getThreadKey: input.getThreadKey,
+          isThreadListExpanded: input.showAllThreads,
+          previewLimit: input.previewLimit,
+        });
+
+  return {
+    hasOverflowingThreads: activePreview.hasHiddenThreads,
+    hiddenThreads: activePreview.hiddenThreads,
+    renderedThreads: [...activePreview.visibleThreads, ...archivedThreads],
+  };
+}
+
+export function removeProjectKeysFromSidebarThreadFilters(
+  filters: SidebarThreadFilters,
+  removedProjectKeys: ReadonlySet<string>,
+): SidebarThreadFilters {
+  const projectKeys = filters.projectKeys.filter(
+    (projectKey) => !removedProjectKeys.has(projectKey),
+  );
+  return projectKeys.length === filters.projectKeys.length
+    ? filters
+    : {
+        ...filters,
+        projectKeys,
+      };
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
@@ -1106,7 +1158,10 @@ function sortProjectsByActivity<TProject extends SidebarProject>(
 
 export function sortProjectsForSidebar<
   TProject extends SidebarProject,
-  TThread extends Pick<Thread, "projectId" | "createdAt" | "updatedAt"> & ThreadSortInput,
+  TThread extends Pick<Thread, "projectId" | "createdAt" | "updatedAt"> &
+    ThreadSortInput & {
+      readonly archivedAt?: string | null;
+    },
 >(
   projects: readonly TProject[],
   threads: readonly TThread[],
@@ -1114,6 +1169,7 @@ export function sortProjectsForSidebar<
 ): TProject[] {
   const threadsByProjectId = new Map<string, TThread[]>();
   for (const thread of threads) {
+    if (thread.archivedAt != null) continue;
     const existing = threadsByProjectId.get(thread.projectId) ?? [];
     existing.push(thread);
     threadsByProjectId.set(thread.projectId, existing);

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -245,14 +245,20 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
 type SidebarThreadFilterInput = Pick<
   SidebarThreadSummary,
   | "archivedAt"
+  | "createdAt"
   | "environmentId"
   | "hasActionableProposedPlan"
   | "hasPendingApprovals"
   | "hasPendingUserInput"
   | "interactionMode"
+  | "latestUserMessageAt"
   | "latestTurn"
   | "session"
+  | "updatedAt"
 >;
+
+export const SIDEBAR_RECENT_WINDOW_DAYS = 7;
+const SIDEBAR_RECENT_WINDOW_MS = SIDEBAR_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1_000;
 
 export function classifySidebarThreadFilterStatus(
   thread: SidebarThreadFilterInput & { readonly lastVisitedAt?: string | undefined },
@@ -284,6 +290,7 @@ export function matchesSidebarThreadFilters(input: {
   readonly lastVisitedAt?: string | null | undefined;
   readonly providerDriverKind: ProviderDriverKind | null;
   readonly filters: SidebarThreadFilters;
+  readonly nowMs?: number | undefined;
 }): boolean {
   const { filters, thread } = input;
   if (thread.archivedAt !== null && !filters.includeArchived) {
@@ -303,6 +310,19 @@ export function matchesSidebarThreadFilters(input: {
     ...thread,
     ...(input.lastVisitedAt ? { lastVisitedAt: input.lastVisitedAt } : {}),
   });
+  if (filters.attentionOnly && status !== "needs_attention" && status !== "unread") {
+    return false;
+  }
+  if (filters.recentOnly) {
+    const recentTimestamp = thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt;
+    const recentTimestampMs = Date.parse(recentTimestamp);
+    if (
+      Number.isNaN(recentTimestampMs) ||
+      recentTimestampMs < (input.nowMs ?? Date.now()) - SIDEBAR_RECENT_WINDOW_MS
+    ) {
+      return false;
+    }
+  }
   return filters.statuses.includes(status);
 }
 
@@ -312,6 +332,8 @@ export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): bo
     selectedStatuses.has(status),
   );
   return (
+    filters.attentionOnly ||
+    filters.recentOnly ||
     filters.includeArchived ||
     filters.environmentIds.length > 0 ||
     filters.sources.length > 0 ||

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -484,6 +484,22 @@ export function resolveSidebarV2Status(thread: SidebarV2StatusInput): SidebarV2S
   return "ready";
 }
 
+export type SidebarV2TopStatus = Exclude<SidebarV2Status, "ready"> | "unread" | "done" | null;
+
+export function resolveSidebarV2TopStatus(input: {
+  readonly status: SidebarV2Status;
+  readonly isExplicitlyUnread: boolean;
+  readonly isUnread: boolean;
+}): SidebarV2TopStatus {
+  if (input.status !== "ready") {
+    return input.status;
+  }
+  if (input.isExplicitlyUnread) {
+    return "unread";
+  }
+  return input.isUnread ? "done" : null;
+}
+
 /** NaN-safe Date.parse for sort comparators: a malformed timestamp must not
     poison the whole ordering, so it sinks to the epoch instead. */
 export function parseTimestampMs(isoDate: string): number {
@@ -603,15 +619,6 @@ export function resolveThreadStatusPill(input: {
 }): ThreadStatusPill | null {
   const { thread } = input;
 
-  if (thread.isExplicitlyUnread) {
-    return {
-      label: "Unread",
-      colorClass: "text-blue-600 dark:text-blue-300/90",
-      dotClass: "bg-blue-500 dark:bg-blue-300/90",
-      pulse: false,
-    };
-  }
-
   if (thread.hasPendingApprovals) {
     return {
       label: "Pending Approval",
@@ -658,6 +665,15 @@ export function resolveThreadStatusPill(input: {
       label: "Plan Ready",
       colorClass: "text-violet-600 dark:text-violet-300/90",
       dotClass: "bg-violet-500 dark:bg-violet-300/90",
+      pulse: false,
+    };
+  }
+
+  if (thread.isExplicitlyUnread) {
+    return {
+      label: "Unread",
+      colorClass: "text-blue-600 dark:text-blue-300/90",
+      dotClass: "bg-blue-500 dark:bg-blue-300/90",
       pulse: false,
     };
   }

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,5 +1,10 @@
 import * as React from "react";
-import type { ContextMenuItem } from "@t3tools/contracts";
+import type {
+  ContextMenuItem,
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
 import {
   SIDEBAR_THREAD_FILTER_STATUSES,
   type SidebarProjectSortOrder,
@@ -7,7 +12,6 @@ import {
   type SidebarThreadFilterStatus,
   type SidebarThreadSortOrder,
 } from "@t3tools/contracts/settings";
-import type { ProviderDriverKind } from "@t3tools/contracts";
 import {
   getThreadSortTimestamp,
   sortThreads,
@@ -265,10 +269,6 @@ const SIDEBAR_RECENT_WINDOW_MS = SIDEBAR_RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1_0
 export function classifySidebarThreadFilterStatus(
   thread: SidebarThreadFilterInput & { readonly lastVisitedAt?: string | undefined },
 ): SidebarThreadFilterStatus {
-  if (thread.isExplicitlyUnread) {
-    return "unread";
-  }
-
   const needsAttention =
     thread.hasPendingApprovals ||
     thread.hasPendingUserInput ||
@@ -278,6 +278,10 @@ export function classifySidebarThreadFilterStatus(
       thread.hasActionableProposedPlan);
   if (needsAttention) {
     return "needs_attention";
+  }
+
+  if (thread.isExplicitlyUnread) {
+    return "unread";
   }
 
   if (thread.session?.status === "running" || thread.session?.status === "starting") {
@@ -348,6 +352,40 @@ export function hasActiveSidebarThreadFilters(filters: SidebarThreadFilters): bo
     selectedStatuses.size !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
     !includesEveryStatus
   );
+}
+
+export function sidebarProviderInstanceKey(
+  environmentId: EnvironmentId,
+  instanceId: ProviderInstanceId,
+): string {
+  return `${environmentId}\u0000${instanceId}`;
+}
+
+export function resolveSidebarArchiveEnvironmentIds(input: {
+  readonly availableEnvironmentIds: readonly EnvironmentId[];
+  readonly selectedEnvironmentIds: readonly EnvironmentId[];
+  readonly includeArchived: boolean;
+}): EnvironmentId[] {
+  if (!input.includeArchived) {
+    return [];
+  }
+  if (input.selectedEnvironmentIds.length === 0) {
+    return [...input.availableEnvironmentIds];
+  }
+
+  const selectedEnvironmentIds = new Set(input.selectedEnvironmentIds);
+  return input.availableEnvironmentIds.filter((environmentId) =>
+    selectedEnvironmentIds.has(environmentId),
+  );
+}
+
+export function getSidebarRangeSelectionThreadKeys(
+  threads: readonly {
+    readonly threadKey: string;
+    readonly archivedAt: string | null;
+  }[],
+): string[] {
+  return threads.filter((thread) => thread.archivedAt === null).map((thread) => thread.threadKey);
 }
 
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -360,7 +360,7 @@ export function matchesSidebarThreadFilters(input: {
       return false;
     }
   }
-  return filters.statuses.includes(status);
+  return filters.statuses.includes(status) || (isUnread && filters.statuses.includes("unread"));
 }
 
 export function hasNarrowingSidebarThreadFilters(filters: SidebarThreadFilters): boolean {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -196,6 +196,7 @@ import { openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   hasActiveSidebarThreadFilters,
   matchesSidebarThreadFilters,
@@ -203,11 +204,13 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   resolveProjectStatusIndicator,
+  resolveSidebarArchiveEnvironmentIds,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
+  sidebarProviderInstanceKey,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
   useThreadJumpHintVisibility,
@@ -219,11 +222,7 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import {
-  primaryServerKeybindingsAtom,
-  primaryServerProvidersAtom,
-  primaryServerSettingsAtom,
-} from "../state/server";
+import { primaryServerKeybindingsAtom, primaryServerSettingsAtom } from "../state/server";
 import { deriveProviderInstanceEntries } from "../providerInstances";
 import {
   derivePhysicalProjectKey,
@@ -557,6 +556,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   );
   const handleRowKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
+      if (event.target !== event.currentTarget) return;
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
       if (isArchived) return;
@@ -1142,7 +1142,7 @@ interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
   archivedThreads: readonly SidebarThreadSummary[];
   sidebarThreadFilters: SidebarThreadFilters;
-  providerDriverKindByInstanceId: ReadonlyMap<string, ProviderDriverKind>;
+  providerDriverKindByScopedInstanceKey: ReadonlyMap<string, ProviderDriverKind>;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
@@ -1166,7 +1166,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     project,
     archivedThreads,
     sidebarThreadFilters,
-    providerDriverKindByInstanceId,
+    providerDriverKindByScopedInstanceKey,
     isThreadListExpanded,
     activeRouteThreadKey,
     newThreadShortcutLabel,
@@ -1397,7 +1397,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           thread,
           lastVisitedAt: lastVisitedAtByThreadKey.get(threadKey),
           isExplicitlyUnread: explicitlyUnreadByThreadKey.get(threadKey),
-          providerDriverKind: providerDriverKindByInstanceId.get(providerInstanceId) ?? null,
+          providerDriverKind:
+            providerDriverKindByScopedInstanceKey.get(
+              sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+            ) ?? null,
           filters: sidebarThreadFilters,
         });
       }),
@@ -1407,15 +1410,18 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       visibleProjectThreads.map((thread) => resolveProjectThreadStatus(thread)),
     );
     return {
-      orderedProjectThreadKeys: visibleProjectThreads.map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      orderedProjectThreadKeys: getSidebarRangeSelectionThreadKeys(
+        visibleProjectThreads.map((thread) => ({
+          threadKey: scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          archivedAt: thread.archivedAt,
+        })),
       ),
       projectStatus,
       visibleProjectThreads,
     };
   }, [
     projectThreads,
-    providerDriverKindByInstanceId,
+    providerDriverKindByScopedInstanceKey,
     sidebarThreadFilters,
     threadExplicitlyUnreadStates,
     threadLastVisitedAts,
@@ -2955,16 +2961,16 @@ function SidebarFilterMenu({
       <MenuPopup align="end" side="bottom" className="w-60">
         <div className="flex items-center justify-between px-2 py-0.5 text-xs font-medium text-muted-foreground">
           <span>Filters</span>
-          <button
-            type="button"
-            className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-40"
+          <MenuItem
+            closeOnClick={false}
+            className="min-h-0 cursor-pointer p-0 text-[11px] text-muted-foreground hover:text-foreground sm:min-h-0 sm:text-[11px]"
             disabled={!filtersActive}
             onClick={() => {
               onFiltersChange(DEFAULT_SIDEBAR_THREAD_FILTERS);
             }}
           >
             Reset
-          </button>
+          </MenuItem>
         </div>
         <MenuCheckboxItem
           checked={filters.recentOnly}
@@ -3097,7 +3103,15 @@ function SidebarFilterMenu({
           <span className="flex items-center gap-2">
             Archived
             {archiveLoading ? <LoaderIcon className="size-3 animate-spin" /> : null}
-            {archiveError ? <TriangleAlertIcon className="size-3 text-warning" /> : null}
+            {archiveError ? (
+              <span
+                role="img"
+                aria-label={`Archived threads failed to load: ${archiveError}`}
+                title={archiveError}
+              >
+                <TriangleAlertIcon aria-hidden className="size-3 text-warning" />
+              </span>
+            ) : null}
           </span>
         </MenuCheckboxItem>
       </MenuPopup>
@@ -3157,7 +3171,7 @@ interface SidebarProjectsContentProps {
     readonly driverKind: ProviderDriverKind;
     readonly label: string;
   }>;
-  providerDriverKindByInstanceId: ReadonlyMap<string, ProviderDriverKind>;
+  providerDriverKindByScopedInstanceKey: ReadonlyMap<string, ProviderDriverKind>;
   archivedThreads: readonly SidebarThreadSummary[];
   archiveLoading: boolean;
   archiveError: string | null;
@@ -3206,7 +3220,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     sidebarThreadFilters,
     environments,
     providerSources,
-    providerDriverKindByInstanceId,
+    providerDriverKindByScopedInstanceKey,
     archivedThreads,
     archiveLoading,
     archiveError,
@@ -3239,6 +3253,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     attachProjectListAutoAnimateRef,
     projectsLength,
   } = props;
+  const clearThreadSelection = useThreadSelectionStore((state) => state.clearSelection);
 
   const handleProjectSortOrderChange = useCallback(
     (sortOrder: SidebarProjectSortOrder) => {
@@ -3248,9 +3263,10 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
   );
   const handleSidebarThreadFiltersChange = useCallback(
     (filters: SidebarThreadFilters) => {
+      clearThreadSelection();
       updateSettings({ sidebarThreadFilters: filters });
     },
-    [updateSettings],
+    [clearThreadSelection, updateSettings],
   );
   const handleThreadSortOrderChange = useCallback(
     (sortOrder: SidebarThreadSortOrder) => {
@@ -3374,7 +3390,9 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         project={project}
                         archivedThreads={archivedThreads}
                         sidebarThreadFilters={sidebarThreadFilters}
-                        providerDriverKindByInstanceId={providerDriverKindByInstanceId}
+                        providerDriverKindByScopedInstanceKey={
+                          providerDriverKindByScopedInstanceKey
+                        }
                         isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -3410,7 +3428,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 project={project}
                 archivedThreads={archivedThreads}
                 sidebarThreadFilters={sidebarThreadFilters}
-                providerDriverKindByInstanceId={providerDriverKindByInstanceId}
+                providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -3484,7 +3502,6 @@ export default function Sidebar() {
       : false,
   );
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
     [],
@@ -3504,10 +3521,12 @@ export default function Sidebar() {
   const { environments } = useEnvironments();
   const archiveEnvironmentIds = useMemo(
     () =>
-      sidebarThreadFilters.includeArchived
-        ? environments.map((environment) => environment.environmentId)
-        : [],
-    [environments, sidebarThreadFilters.includeArchived],
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+        selectedEnvironmentIds: sidebarThreadFilters.environmentIds,
+        includeArchived: sidebarThreadFilters.includeArchived,
+      }),
+    [environments, sidebarThreadFilters.environmentIds, sidebarThreadFilters.includeArchived],
   );
   const {
     snapshots: archivedSnapshots,
@@ -3524,11 +3543,26 @@ export default function Sidebar() {
     [archivedSnapshots],
   );
   const providerEntries = useMemo(
-    () => deriveProviderInstanceEntries(serverProviders),
-    [serverProviders],
+    () =>
+      environments.flatMap((environment) =>
+        deriveProviderInstanceEntries(environment.serverConfig?.providers ?? []).map((entry) => ({
+          ...entry,
+          environmentId: environment.environmentId,
+        })),
+      ),
+    [environments],
   );
-  const providerDriverKindByInstanceId = useMemo(
-    () => new Map(providerEntries.map((entry) => [entry.instanceId, entry.driverKind] as const)),
+  const providerDriverKindByScopedInstanceKey = useMemo(
+    () =>
+      new Map(
+        providerEntries.map(
+          (entry) =>
+            [
+              sidebarProviderInstanceKey(entry.environmentId, entry.instanceId),
+              entry.driverKind,
+            ] as const,
+        ),
+      ),
     [providerEntries],
   );
   const providerSources = useMemo(() => {
@@ -3651,12 +3685,15 @@ export default function Sidebar() {
           thread,
           lastVisitedAt: threadLastVisitedAtById[threadKey],
           isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
-          providerDriverKind: providerDriverKindByInstanceId.get(providerInstanceId) ?? null,
+          providerDriverKind:
+            providerDriverKindByScopedInstanceKey.get(
+              sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+            ) ?? null,
           filters: sidebarThreadFilters,
         });
       }),
     [
-      providerDriverKindByInstanceId,
+      providerDriverKindByScopedInstanceKey,
       sidebarThreadFilters,
       sidebarThreadsWithArchived,
       threadExplicitlyUnreadById,
@@ -4156,7 +4193,7 @@ export default function Sidebar() {
             sidebarThreadFilters={sidebarThreadFilters}
             environments={environments}
             providerSources={providerSources}
-            providerDriverKindByInstanceId={providerDriverKindByInstanceId}
+            providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
             archivedThreads={archivedThreads}
             archiveLoading={archiveLoading}
             archiveError={archiveError}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1396,6 +1396,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         return matchesSidebarThreadFilters({
           thread,
           lastVisitedAt: lastVisitedAtByThreadKey.get(threadKey),
+          isExplicitlyUnread: explicitlyUnreadByThreadKey.get(threadKey),
           providerDriverKind: providerDriverKindByInstanceId.get(providerInstanceId) ?? null,
           filters: sidebarThreadFilters,
         });
@@ -2951,8 +2952,8 @@ function SidebarFilterMenu({
           {filtersActive ? "Sidebar filters are active" : "Filter sidebar threads"}
         </TooltipPopup>
       </Tooltip>
-      <MenuPopup align="end" side="bottom" className="min-w-64">
-        <div className="flex items-center justify-between px-2 py-1 text-xs font-medium text-muted-foreground">
+      <MenuPopup align="end" side="bottom" className="w-60">
+        <div className="flex items-center justify-between px-2 py-0.5 text-xs font-medium text-muted-foreground">
           <span>Filters</span>
           <button
             type="button"
@@ -2968,7 +2969,7 @@ function SidebarFilterMenu({
         <MenuCheckboxItem
           checked={filters.recentOnly}
           closeOnClick={false}
-          className="sm:text-xs"
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
           onCheckedChange={(checked) => {
             onFiltersChange({ ...filters, recentOnly: checked });
           }}
@@ -2981,19 +2982,19 @@ function SidebarFilterMenu({
         <MenuCheckboxItem
           checked={filters.attentionOnly}
           closeOnClick={false}
-          className="sm:text-xs"
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
           onCheckedChange={(checked) => {
             onFiltersChange({ ...filters, attentionOnly: checked });
           }}
         >
           <span className="flex min-w-0 items-center justify-between gap-3">
-            <span>Attention</span>
+            <span>Inbox</span>
             <span className="text-[10px] text-muted-foreground">Unread + needs attention</span>
           </span>
         </MenuCheckboxItem>
-        <MenuSeparator />
+        <MenuSeparator className="my-0.5" />
         <MenuSub>
-          <MenuSubTrigger className="sm:text-xs">
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
             <span>Status</span>
             {statusFilterActive ? (
               <span className="ml-auto size-1.5 rounded-full bg-primary" />
@@ -3019,7 +3020,7 @@ function SidebarFilterMenu({
           </MenuSubPopup>
         </MenuSub>
         <MenuSub>
-          <MenuSubTrigger className="sm:text-xs">
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
             <span>Environment</span>
             {filters.environmentIds.length > 0 ? (
               <span className="ml-auto size-1.5 rounded-full bg-primary" />
@@ -3054,7 +3055,7 @@ function SidebarFilterMenu({
           </MenuSubPopup>
         </MenuSub>
         <MenuSub>
-          <MenuSubTrigger className="sm:text-xs">
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
             <span>Source</span>
             {filters.sources.length > 0 ? (
               <span className="ml-auto size-1.5 rounded-full bg-primary" />
@@ -3084,11 +3085,11 @@ function SidebarFilterMenu({
             ) : null}
           </MenuSubPopup>
         </MenuSub>
-        <MenuSeparator />
+        <MenuSeparator className="my-0.5" />
         <MenuCheckboxItem
           checked={filters.includeArchived}
           closeOnClick={false}
-          className="sm:text-xs"
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
           onCheckedChange={(checked) => {
             onFiltersChange({ ...filters, includeArchived: checked });
           }}
@@ -3638,6 +3639,7 @@ export default function Sidebar() {
     return [...threadsByKey.values()];
   }, [archivedThreads, sidebarThreads]);
   const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
+  const threadExplicitlyUnreadById = useUiStateStore((state) => state.threadExplicitlyUnreadById);
   const filtersActive = hasActiveSidebarThreadFilters(sidebarThreadFilters);
   const filteredSidebarThreads = useMemo(
     () =>
@@ -3648,6 +3650,7 @@ export default function Sidebar() {
         return matchesSidebarThreadFilters({
           thread,
           lastVisitedAt: threadLastVisitedAtById[threadKey],
+          isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
           providerDriverKind: providerDriverKindByInstanceId.get(providerInstanceId) ?? null,
           filters: sidebarThreadFilters,
         });
@@ -3656,6 +3659,7 @@ export default function Sidebar() {
       providerDriverKindByInstanceId,
       sidebarThreadFilters,
       sidebarThreadsWithArchived,
+      threadExplicitlyUnreadById,
       threadLastVisitedAtById,
     ],
   );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -197,6 +197,7 @@ import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
   filterSidebarThreadsForActiveRoute,
+  getFlatSidebarRenderedThreads,
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   getVisibleThreadsForProject,
@@ -4051,10 +4052,15 @@ export default function Sidebar() {
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
   const visibleSidebarThreadKeys = useMemo(() => {
     if (!sidebarThreadFilters.groupByProject) {
-      const sortedThreads = sortThreads(filteredSidebarThreads, sidebarThreadSortOrder);
-      return sortedThreads
-        .filter((thread) => thread.archivedAt === null)
-        .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)));
+      const flatProject = buildFlatSidebarProjectSnapshot(sortedProjects);
+      if (!flatProject) {
+        return [];
+      }
+      return getFlatSidebarRenderedThreads({
+        threads: filteredSidebarThreads,
+        memberProjectRefs: flatProject.memberProjectRefs,
+        sortOrder: sidebarThreadSortOrder,
+      }).map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)));
     }
 
     return sortedProjects.flatMap((project) => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -217,6 +217,7 @@ import {
   orderItemsByPreferredIds,
   sidebarProviderInstanceKey,
   shouldClearThreadSelectionOnMouseDown,
+  shouldShowAllSidebarThreads,
   sortProjectsForSidebar,
   startSidebarRecentFilterClock,
   useThreadJumpHintVisibility,
@@ -1498,17 +1499,22 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
+    const showAllThreads = shouldShowAllSidebarThreads({
+      flatMode,
+      isThreadListExpanded,
+    });
     const {
-      hasHiddenThreads: hasOverflowingThreads,
+      hasHiddenThreads,
       hiddenThreads,
       visibleThreads: previewThreads,
     } = getVisibleThreadsForProject({
       threads: visibleProjectThreads,
       activeThreadKey: activeRouteThreadKey,
       getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      isThreadListExpanded,
+      isThreadListExpanded: showAllThreads,
       previewLimit: sidebarThreadPreviewCount,
     });
+    const hasOverflowingThreads = !flatMode && hasHiddenThreads;
     const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
     return {
       hasOverflowingThreads,
@@ -1520,6 +1526,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       shouldShowThreadPanel: projectExpanded || pinnedCollapsedThread !== null,
     };
   }, [
+    flatMode,
     isThreadListExpanded,
     activeRouteThreadKey,
     pinnedCollapsedThread,
@@ -4044,11 +4051,8 @@ export default function Sidebar() {
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
   const visibleSidebarThreadKeys = useMemo(() => {
     if (!sidebarThreadFilters.groupByProject) {
-      const flatProject = buildFlatSidebarProjectSnapshot(sortedProjects);
       const sortedThreads = sortThreads(filteredSidebarThreads, sidebarThreadSortOrder);
-      const showAll =
-        flatProject !== null && expandedThreadListsByProject.has(flatProject.projectKey);
-      return (showAll ? sortedThreads : sortedThreads.slice(0, sidebarThreadPreviewCount))
+      return sortedThreads
         .filter((thread) => thread.archivedAt === null)
         .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)));
     }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -238,6 +238,7 @@ import {
 } from "../logicalProject";
 import type { SidebarThreadSummary } from "../types";
 import {
+  buildFlatSidebarProjectSnapshot,
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectSnapshots,
   type SidebarProjectGroupMember,
@@ -1178,6 +1179,7 @@ interface SidebarProjectItemProps {
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
   isManualProjectSorting: boolean;
   dragHandleProps: SortableProjectHandleProps | null;
+  flatMode?: boolean;
 }
 
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
@@ -1203,6 +1205,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     suppressProjectClickForContextMenuRef,
     isManualProjectSorting,
     dragHandleProps,
+    flatMode = false,
   } = props;
   const threadSortOrder = useClientSettings<SidebarThreadSortOrder>(
     (settings) => settings.sidebarThreadSortOrder,
@@ -1320,9 +1323,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const sidebarThreadByKeyRef = useRef(sidebarThreadByKey);
   sidebarThreadByKeyRef.current = sidebarThreadByKey;
   const projectPreferenceKeys = useMemo(() => projectExpansionPreferenceKeys(project), [project]);
-  const projectExpanded = useUiStateStore((state) =>
+  const storedProjectExpanded = useUiStateStore((state) =>
     resolveProjectExpanded(state.projectExpandedById, projectPreferenceKeys),
   );
+  const projectExpanded = flatMode || storedProjectExpanded;
   const threadLastVisitedAts = useUiStateStore(
     useShallow((state) =>
       projectThreads.map(
@@ -2449,111 +2453,113 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
   return (
     <>
-      <div className="group/project-header relative">
-        <SidebarMenuButton
-          ref={isManualProjectSorting ? dragHandleProps?.setActivatorNodeRef : undefined}
-          size="sm"
-          className={`h-8 gap-2 rounded-md px-2 py-1.5 pr-8 text-left hover:bg-sidebar-row-hover group-hover/project-header:bg-sidebar-row-hover group-hover/project-header:text-sidebar-foreground max-sm:pr-14 ${
-            isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
-          }`}
-          {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
-          {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.listeners : {})}
-          onPointerDownCapture={handleProjectButtonPointerDownCapture}
-          onClick={handleProjectButtonClick}
-          onKeyDown={handleProjectButtonKeyDown}
-          onContextMenu={handleProjectButtonContextMenu}
-        >
-          {!projectExpanded && projectStatus ? (
+      {!flatMode ? (
+        <div className="group/project-header relative">
+          <SidebarMenuButton
+            ref={isManualProjectSorting ? dragHandleProps?.setActivatorNodeRef : undefined}
+            size="sm"
+            className={`h-8 gap-2 rounded-md px-2 py-1.5 pr-8 text-left hover:bg-sidebar-row-hover group-hover/project-header:bg-sidebar-row-hover group-hover/project-header:text-sidebar-foreground max-sm:pr-14 ${
+              isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
+            }`}
+            {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
+            {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.listeners : {})}
+            onPointerDownCapture={handleProjectButtonPointerDownCapture}
+            onClick={handleProjectButtonClick}
+            onKeyDown={handleProjectButtonKeyDown}
+            onContextMenu={handleProjectButtonContextMenu}
+          >
+            {!projectExpanded && projectStatus ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      aria-label={projectStatus.label}
+                      className={`-ml-0.5 relative inline-flex size-3.5 shrink-0 items-center justify-center ${projectStatus.colorClass}`}
+                    />
+                  }
+                >
+                  <span className="absolute inset-0 flex items-center justify-center transition-opacity duration-150 group-hover/project-header:opacity-0">
+                    <span
+                      className={`size-[9px] rounded-full ${projectStatus.dotClass} ${
+                        projectStatus.pulse ? "animate-status-pulse" : ""
+                      }`}
+                    />
+                  </span>
+                  <ChevronRightIcon className="absolute inset-0 m-auto size-3.5 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-hover/project-header:opacity-100" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">{projectStatus.label}</TooltipPopup>
+              </Tooltip>
+            ) : (
+              <ChevronRightIcon
+                className={`-ml-0.5 size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150 ${
+                  projectExpanded ? "rotate-90" : ""
+                }`}
+              />
+            )}
+            <ProjectFavicon environmentId={project.environmentId} cwd={project.workspaceRoot} />
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              <span className="truncate text-sm font-medium text-sidebar-foreground/90">
+                {project.displayName}
+              </span>
+              {project.groupedProjectCount > 1 ? (
+                <span className="shrink-0 text-[10px] text-muted-foreground/60">
+                  {project.groupedProjectCount} projects
+                </span>
+              ) : null}
+            </span>
+          </SidebarMenuButton>
+          {/* Environment badge – visible by default, crossfades with the
+            "new thread" button on hover using the same pointer-events +
+            opacity pattern as the thread row archive/timestamp swap. */}
+          {project.environmentPresence === "remote-only" && (
             <Tooltip>
               <TooltipTrigger
                 render={
                   <span
-                    aria-label={projectStatus.label}
-                    className={`-ml-0.5 relative inline-flex size-3.5 shrink-0 items-center justify-center ${projectStatus.colorClass}`}
+                    aria-label={
+                      project.allRemoteMembersAreDesktopLocal
+                        ? "Local sandbox project"
+                        : "Remote project"
+                    }
+                    className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/60 transition-opacity duration-150 max-sm:right-7 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0 max-sm:group-hover/project-header:opacity-100 max-sm:group-focus-within/project-header:opacity-100"
                   />
                 }
               >
-                <span className="absolute inset-0 flex items-center justify-center transition-opacity duration-150 group-hover/project-header:opacity-0">
-                  <span
-                    className={`size-[9px] rounded-full ${projectStatus.dotClass} ${
-                      projectStatus.pulse ? "animate-status-pulse" : ""
-                    }`}
-                  />
-                </span>
-                <ChevronRightIcon className="absolute inset-0 m-auto size-3.5 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-hover/project-header:opacity-100" />
+                {project.allRemoteMembersAreDesktopLocal ? (
+                  <ContainerIcon className="size-3" />
+                ) : (
+                  <CloudIcon className="size-3" />
+                )}
               </TooltipTrigger>
-              <TooltipPopup side="top">{projectStatus.label}</TooltipPopup>
+              <TooltipPopup side="top">
+                {project.allRemoteMembersAreDesktopLocal
+                  ? `Local sandbox: ${project.remoteEnvironmentLabels.join(", ")}`
+                  : `Remote environment: ${project.remoteEnvironmentLabels.join(", ")}`}
+              </TooltipPopup>
             </Tooltip>
-          ) : (
-            <ChevronRightIcon
-              className={`-ml-0.5 size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150 ${
-                projectExpanded ? "rotate-90" : ""
-              }`}
-            />
           )}
-          <ProjectFavicon environmentId={project.environmentId} cwd={project.workspaceRoot} />
-          <span className="flex min-w-0 flex-1 items-center gap-2">
-            <span className="truncate text-sm font-medium text-sidebar-foreground/90">
-              {project.displayName}
-            </span>
-            {project.groupedProjectCount > 1 ? (
-              <span className="shrink-0 text-[10px] text-muted-foreground/60">
-                {project.groupedProjectCount} projects
-              </span>
-            ) : null}
-          </span>
-        </SidebarMenuButton>
-        {/* Environment badge – visible by default, crossfades with the
-            "new thread" button on hover using the same pointer-events +
-            opacity pattern as the thread row archive/timestamp swap. */}
-        {project.environmentPresence === "remote-only" && (
           <Tooltip>
             <TooltipTrigger
               render={
-                <span
-                  aria-label={
-                    project.allRemoteMembersAreDesktopLocal
-                      ? "Local sandbox project"
-                      : "Remote project"
-                  }
-                  className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/60 transition-opacity duration-150 max-sm:right-7 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0 max-sm:group-hover/project-header:opacity-100 max-sm:group-focus-within/project-header:opacity-100"
-                />
+                <div className="pointer-events-none absolute top-[calc(50%+1px)] right-0.5 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100">
+                  <button
+                    type="button"
+                    aria-label={`Create new thread in ${project.displayName}`}
+                    data-testid="new-thread-button"
+                    className={SIDEBAR_ICON_ACTION_BUTTON_CLASS}
+                    onClick={handleCreateThreadClick}
+                  >
+                    <SquarePenIcon className="size-3.5" />
+                  </button>
+                </div>
               }
-            >
-              {project.allRemoteMembersAreDesktopLocal ? (
-                <ContainerIcon className="size-3" />
-              ) : (
-                <CloudIcon className="size-3" />
-              )}
-            </TooltipTrigger>
+            />
             <TooltipPopup side="top">
-              {project.allRemoteMembersAreDesktopLocal
-                ? `Local sandbox: ${project.remoteEnvironmentLabels.join(", ")}`
-                : `Remote environment: ${project.remoteEnvironmentLabels.join(", ")}`}
+              {newThreadShortcutLabel ? `New thread (${newThreadShortcutLabel})` : "New thread"}
             </TooltipPopup>
           </Tooltip>
-        )}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <div className="pointer-events-none absolute top-[calc(50%+1px)] right-0.5 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100">
-                <button
-                  type="button"
-                  aria-label={`Create new thread in ${project.displayName}`}
-                  data-testid="new-thread-button"
-                  className={SIDEBAR_ICON_ACTION_BUTTON_CLASS}
-                  onClick={handleCreateThreadClick}
-                >
-                  <SquarePenIcon className="size-3.5" />
-                </button>
-              </div>
-            }
-          />
-          <TooltipPopup side="top">
-            {newThreadShortcutLabel ? `New thread (${newThreadShortcutLabel})` : "New thread"}
-          </TooltipPopup>
-        </Tooltip>
-      </div>
+        </div>
+      ) : null}
 
       <SidebarProjectThreadList
         projectKey={project.projectKey}
@@ -2806,6 +2812,7 @@ function ProjectSortMenu({
   projectSortOrder,
   threadSortOrder,
   threadPreviewCount,
+  showThreadPreviewCount,
   onProjectSortOrderChange,
   onThreadSortOrderChange,
   onThreadPreviewCountChange,
@@ -2813,6 +2820,7 @@ function ProjectSortMenu({
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   threadPreviewCount: SidebarThreadPreviewCount;
+  showThreadPreviewCount: boolean;
   onProjectSortOrderChange: (sortOrder: SidebarProjectSortOrder) => void;
   onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
   onThreadPreviewCountChange: (count: SidebarThreadPreviewCount) => void;
@@ -2882,42 +2890,44 @@ function ProjectSortMenu({
             ))}
           </MenuRadioGroup>
         </MenuGroup>
-        <MenuGroup>
-          <div className="px-2 pt-2 pb-1 text-muted-foreground sm:text-xs font-medium">
-            Visible threads
-          </div>
-          <div className="px-2 py-1">
-            <NumberField
-              aria-label="Visible thread count"
-              className="w-28 gap-0"
-              max={MAX_SIDEBAR_THREAD_PREVIEW_COUNT}
-              min={MIN_SIDEBAR_THREAD_PREVIEW_COUNT}
-              onValueChange={handleThreadPreviewCountChange}
-              size="sm"
-              step={1}
-              value={threadPreviewCount}
-            >
-              <NumberFieldGroup className="h-7 rounded-md sm:h-6.5">
-                <NumberFieldDecrement
-                  aria-label="Decrease visible thread count"
-                  className="px-2 sm:px-2 [&_svg]:size-3.5"
-                />
-                <NumberFieldInput
-                  aria-label="Visible thread count"
-                  className="h-7 w-9 grow-0 px-0 text-xs leading-7 sm:h-6.5 sm:leading-6.5"
-                  inputMode="numeric"
-                  onKeyDownCapture={(event) => {
-                    event.stopPropagation();
-                  }}
-                />
-                <NumberFieldIncrement
-                  aria-label="Increase visible thread count"
-                  className="px-2 sm:px-2 [&_svg]:size-3.5"
-                />
-              </NumberFieldGroup>
-            </NumberField>
-          </div>
-        </MenuGroup>
+        {showThreadPreviewCount ? (
+          <MenuGroup>
+            <div className="px-2 pt-2 pb-1 text-muted-foreground sm:text-xs font-medium">
+              Visible threads
+            </div>
+            <div className="px-2 py-1">
+              <NumberField
+                aria-label="Visible thread count"
+                className="w-28 gap-0"
+                max={MAX_SIDEBAR_THREAD_PREVIEW_COUNT}
+                min={MIN_SIDEBAR_THREAD_PREVIEW_COUNT}
+                onValueChange={handleThreadPreviewCountChange}
+                size="sm"
+                step={1}
+                value={threadPreviewCount}
+              >
+                <NumberFieldGroup className="h-7 rounded-md sm:h-6.5">
+                  <NumberFieldDecrement
+                    aria-label="Decrease visible thread count"
+                    className="px-2 sm:px-2 [&_svg]:size-3.5"
+                  />
+                  <NumberFieldInput
+                    aria-label="Visible thread count"
+                    className="h-7 w-9 grow-0 px-0 text-xs leading-7 sm:h-6.5 sm:leading-6.5"
+                    inputMode="numeric"
+                    onKeyDownCapture={(event) => {
+                      event.stopPropagation();
+                    }}
+                  />
+                  <NumberFieldIncrement
+                    aria-label="Increase visible thread count"
+                    className="px-2 sm:px-2 [&_svg]:size-3.5"
+                  />
+                </NumberFieldGroup>
+              </NumberField>
+            </div>
+          </MenuGroup>
+        ) : null}
       </MenuPopup>
     </Menu>
   );
@@ -2930,9 +2940,26 @@ function toggleSidebarFilterValue<T>(values: readonly T[], value: T, checked: bo
   return values.filter((candidate) => candidate !== value);
 }
 
+function toggleSidebarFilterValues<T>(
+  values: readonly T[],
+  toggledValues: readonly T[],
+  checked: boolean,
+): T[] {
+  const next = new Set(values);
+  for (const value of toggledValues) {
+    if (checked) {
+      next.add(value);
+    } else {
+      next.delete(value);
+    }
+  }
+  return [...next];
+}
+
 function SidebarFilterMenu({
   filters,
   environments,
+  projects,
   providerSources,
   archiveLoading,
   archiveError,
@@ -2940,6 +2967,7 @@ function SidebarFilterMenu({
 }: {
   filters: SidebarThreadFilters;
   environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>;
+  projects: ReadonlyArray<SidebarProjectSnapshot>;
   providerSources: ReadonlyArray<{
     readonly driverKind: ProviderDriverKind;
     readonly label: string;
@@ -2978,6 +3006,17 @@ function SidebarFilterMenu({
         </TooltipPopup>
       </Tooltip>
       <MenuPopup align="end" side="bottom" className="w-60">
+        <MenuCheckboxItem
+          checked={filters.groupByProject}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, groupByProject: checked });
+          }}
+        >
+          Group by project
+        </MenuCheckboxItem>
+        <MenuSeparator className="my-0.5" />
         <div className="flex items-center justify-between px-2 py-0.5 text-xs font-medium text-muted-foreground">
           <span>Filters</span>
           <MenuItem
@@ -2985,7 +3024,10 @@ function SidebarFilterMenu({
             className="min-h-0 cursor-pointer p-0 text-[11px] text-muted-foreground hover:text-foreground sm:min-h-0 sm:text-[11px]"
             disabled={!filtersActive}
             onClick={() => {
-              onFiltersChange(DEFAULT_SIDEBAR_THREAD_FILTERS);
+              onFiltersChange({
+                ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+                groupByProject: filters.groupByProject,
+              });
             }}
           >
             Reset
@@ -3042,6 +3084,47 @@ function SidebarFilterMenu({
                 {SIDEBAR_THREAD_FILTER_STATUS_LABELS[status]}
               </MenuCheckboxItem>
             ))}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Project</span>
+            {filters.projectKeys.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-56">
+            {projects.map((project) => {
+              const projectKeys = project.memberProjectRefs.map(scopedProjectKey);
+              const checked =
+                filters.projectKeys.length > 0 &&
+                projectKeys.every((projectKey) => filters.projectKeys.includes(projectKey));
+              return (
+                <MenuCheckboxItem
+                  key={project.projectKey}
+                  checked={checked}
+                  closeOnClick={false}
+                  className="sm:text-xs"
+                  onCheckedChange={(nextChecked) => {
+                    onFiltersChange({
+                      ...filters,
+                      projectKeys: toggleSidebarFilterValues(
+                        filters.projectKeys,
+                        projectKeys,
+                        nextChecked,
+                      ),
+                    });
+                  }}
+                >
+                  <span className="truncate">{project.displayName}</span>
+                </MenuCheckboxItem>
+              );
+            })}
+            {projects.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No projects
+              </MenuItem>
+            ) : null}
           </MenuSubPopup>
         </MenuSub>
         <MenuSub>
@@ -3208,6 +3291,7 @@ interface SidebarProjectsContentProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   unarchiveThread: ReturnType<typeof useThreadActions>["unarchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
+  availableProjects: readonly SidebarProjectSnapshot[];
   sortedProjects: readonly SidebarProjectSnapshot[];
   expandedThreadListsByProject: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
@@ -3258,6 +3342,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     archiveThread,
     unarchiveThread,
     deleteThread,
+    availableProjects,
     sortedProjects,
     expandedThreadListsByProject,
     activeRouteProjectKey,
@@ -3300,6 +3385,10 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
       updateSettings({ sidebarThreadPreviewCount: count });
     },
     [updateSettings],
+  );
+  const flatProject = useMemo(
+    () => buildFlatSidebarProjectSnapshot(sortedProjects),
+    [sortedProjects],
   );
 
   return (
@@ -3353,11 +3442,14 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
       <LocalSecondaryStatus />
       <SidebarGroup className="px-2 py-2">
         <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
-          <span className="text-xs font-medium text-sidebar-muted-foreground/80">Projects</span>
+          <span className="text-xs font-medium text-sidebar-muted-foreground/80">
+            {sidebarThreadFilters.groupByProject ? "Projects" : "Threads"}
+          </span>
           <div className="flex items-center gap-1">
             <SidebarFilterMenu
               filters={sidebarThreadFilters}
               environments={environments}
+              projects={availableProjects}
               providerSources={providerSources}
               archiveLoading={archiveLoading}
               archiveError={archiveError}
@@ -3367,6 +3459,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               projectSortOrder={projectSortOrder}
               threadSortOrder={threadSortOrder}
               threadPreviewCount={threadPreviewCount}
+              showThreadPreviewCount={sidebarThreadFilters.groupByProject}
               onProjectSortOrderChange={handleProjectSortOrderChange}
               onThreadSortOrderChange={handleThreadSortOrderChange}
               onThreadPreviewCountChange={handleThreadPreviewCountChange}
@@ -3390,7 +3483,35 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </div>
         </div>
 
-        {isManualProjectSorting ? (
+        {!sidebarThreadFilters.groupByProject ? (
+          <SidebarMenu ref={attachProjectListAutoAnimateRef}>
+            {flatProject ? (
+              <SidebarProjectListRow
+                flatMode
+                project={flatProject}
+                archivedThreads={archivedThreads}
+                sidebarThreadFilters={sidebarThreadFilters}
+                providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
+                isThreadListExpanded={expandedThreadListsByProject.has(flatProject.projectKey)}
+                activeRouteThreadKey={routeThreadKey}
+                newThreadShortcutLabel={newThreadShortcutLabel}
+                handleNewThread={handleNewThread}
+                archiveThread={archiveThread}
+                unarchiveThread={unarchiveThread}
+                deleteThread={deleteThread}
+                threadJumpLabelByKey={threadJumpLabelByKey}
+                attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
+                expandThreadListForProject={expandThreadListForProject}
+                collapseThreadListForProject={collapseThreadListForProject}
+                dragInProgressRef={dragInProgressRef}
+                suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
+                suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
+                isManualProjectSorting={false}
+                dragHandleProps={null}
+              />
+            ) : null}
+          </SidebarMenu>
+        ) : isManualProjectSorting ? (
           <DndContext
             sensors={projectDnDSensors}
             collisionDetection={projectCollisionDetection}
@@ -3921,50 +4042,60 @@ export default function Sidebar() {
     threadsByProjectKey,
   ]);
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
-  const visibleSidebarThreadKeys = useMemo(
-    () =>
-      sortedProjects.flatMap((project) => {
-        const projectThreads = sortThreads(
-          threadsByProjectKey.get(project.projectKey) ?? [],
-          sidebarThreadSortOrder,
-        );
-        const projectExpanded = resolveProjectExpanded(
-          projectExpandedById,
-          projectExpansionPreferenceKeys(project),
-        );
-        const getThreadKey = (thread: SidebarThreadSummary) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-        const pinnedCollapsedThread = resolvePinnedCollapsedSidebarThread({
-          threads: projectThreads,
-          activeThreadKey: routeThreadKey,
-          projectExpanded,
-          getThreadKey,
-        });
-        const shouldShowThreadPanel = projectExpanded || pinnedCollapsedThread !== null;
-        if (!shouldShowThreadPanel) {
-          return [];
-        }
-        const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
-        const { visibleThreads: previewThreads } = getVisibleThreadsForProject({
-          threads: projectThreads,
-          activeThreadKey: routeThreadKey,
-          getThreadKey,
-          isThreadListExpanded,
-          previewLimit: sidebarThreadPreviewCount,
-        });
-        const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
-        return renderedThreads.filter((thread) => thread.archivedAt === null).map(getThreadKey);
-      }),
-    [
-      sidebarThreadSortOrder,
-      sidebarThreadPreviewCount,
-      expandedThreadListsByProject,
-      projectExpandedById,
-      routeThreadKey,
-      sortedProjects,
-      threadsByProjectKey,
-    ],
-  );
+  const visibleSidebarThreadKeys = useMemo(() => {
+    if (!sidebarThreadFilters.groupByProject) {
+      const flatProject = buildFlatSidebarProjectSnapshot(sortedProjects);
+      const sortedThreads = sortThreads(filteredSidebarThreads, sidebarThreadSortOrder);
+      const showAll =
+        flatProject !== null && expandedThreadListsByProject.has(flatProject.projectKey);
+      return (showAll ? sortedThreads : sortedThreads.slice(0, sidebarThreadPreviewCount))
+        .filter((thread) => thread.archivedAt === null)
+        .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)));
+    }
+
+    return sortedProjects.flatMap((project) => {
+      const projectThreads = sortThreads(
+        threadsByProjectKey.get(project.projectKey) ?? [],
+        sidebarThreadSortOrder,
+      );
+      const projectExpanded = resolveProjectExpanded(
+        projectExpandedById,
+        projectExpansionPreferenceKeys(project),
+      );
+      const getThreadKey = (thread: SidebarThreadSummary) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      const pinnedCollapsedThread = resolvePinnedCollapsedSidebarThread({
+        threads: projectThreads,
+        activeThreadKey: routeThreadKey,
+        projectExpanded,
+        getThreadKey,
+      });
+      const shouldShowThreadPanel = projectExpanded || pinnedCollapsedThread !== null;
+      if (!shouldShowThreadPanel) {
+        return [];
+      }
+      const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
+      const { visibleThreads: previewThreads } = getVisibleThreadsForProject({
+        threads: projectThreads,
+        activeThreadKey: routeThreadKey,
+        getThreadKey,
+        isThreadListExpanded,
+        previewLimit: sidebarThreadPreviewCount,
+      });
+      const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
+      return renderedThreads.filter((thread) => thread.archivedAt === null).map(getThreadKey);
+    });
+  }, [
+    filteredSidebarThreads,
+    sidebarThreadSortOrder,
+    sidebarThreadPreviewCount,
+    sidebarThreadFilters.groupByProject,
+    expandedThreadListsByProject,
+    projectExpandedById,
+    routeThreadKey,
+    sortedProjects,
+    threadsByProjectKey,
+  ]);
   const threadJumpCommandByKey = useMemo(() => {
     const mapping = new Map<string, NonNullable<ReturnType<typeof threadJumpCommandForIndex>>>();
     for (const [visibleThreadIndex, threadKey] of visibleSidebarThreadKeys.entries()) {
@@ -4251,6 +4382,7 @@ export default function Sidebar() {
             archiveThread={archiveThread}
             unarchiveThread={unarchiveThread}
             deleteThread={deleteThread}
+            availableProjects={sidebarProjects}
             sortedProjects={sortedProjects}
             expandedThreadListsByProject={expandedThreadListsByProject}
             activeRouteProjectKey={activeRouteProjectKey}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2951,7 +2951,7 @@ function SidebarFilterMenu({
           {filtersActive ? "Sidebar filters are active" : "Filter sidebar threads"}
         </TooltipPopup>
       </Tooltip>
-      <MenuPopup align="end" side="bottom" className="min-w-52">
+      <MenuPopup align="end" side="bottom" className="min-w-64">
         <div className="flex items-center justify-between px-2 py-1 text-xs font-medium text-muted-foreground">
           <span>Filters</span>
           <button
@@ -2965,6 +2965,33 @@ function SidebarFilterMenu({
             Reset
           </button>
         </div>
+        <MenuCheckboxItem
+          checked={filters.recentOnly}
+          closeOnClick={false}
+          className="sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, recentOnly: checked });
+          }}
+        >
+          <span className="flex min-w-0 items-center justify-between gap-3">
+            <span>Recent</span>
+            <span className="text-[10px] text-muted-foreground">Last 7 days</span>
+          </span>
+        </MenuCheckboxItem>
+        <MenuCheckboxItem
+          checked={filters.attentionOnly}
+          closeOnClick={false}
+          className="sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, attentionOnly: checked });
+          }}
+        >
+          <span className="flex min-w-0 items-center justify-between gap-3">
+            <span>Attention</span>
+            <span className="text-[10px] text-muted-foreground">Unread + needs attention</span>
+          </span>
+        </MenuCheckboxItem>
+        <MenuSeparator />
         <MenuSub>
           <MenuSubTrigger className="sm:text-xs">
             <span>Status</span>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -198,9 +198,9 @@ import {
   buildMultiSelectThreadContextMenuItems,
   filterSidebarThreadsForActiveRoute,
   getFlatSidebarRenderedThreads,
+  getGroupedSidebarRenderedThreads,
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
-  getVisibleThreadsForProject,
   hasActiveSidebarThreadFilters,
   hasNarrowingSidebarThreadFilters,
   matchesSidebarThreadFilters,
@@ -209,6 +209,7 @@ import {
   isTrailingDoubleClick,
   resolvePinnedCollapsedSidebarThread,
   resolveProjectStatusIndicator,
+  removeProjectKeysFromSidebarThreadFilters,
   resolveSidebarArchiveEnvironmentIds,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
@@ -1504,23 +1505,20 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       flatMode,
       isThreadListExpanded,
     });
-    const {
-      hasHiddenThreads,
-      hiddenThreads,
-      visibleThreads: previewThreads,
-    } = getVisibleThreadsForProject({
+    const preview = getGroupedSidebarRenderedThreads({
       threads: visibleProjectThreads,
       activeThreadKey: activeRouteThreadKey,
       getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      isThreadListExpanded: showAllThreads,
-      previewLimit: sidebarThreadPreviewCount,
+      previewLimit: flatMode ? null : sidebarThreadPreviewCount,
+      showAllThreads,
     });
-    const hasOverflowingThreads = !flatMode && hasHiddenThreads;
-    const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
+    const renderedThreads = pinnedCollapsedThread
+      ? [pinnedCollapsedThread]
+      : preview.renderedThreads;
     return {
-      hasOverflowingThreads,
+      hasOverflowingThreads: preview.hasOverflowingThreads,
       hiddenThreadStatus: resolveProjectStatusIndicator(
-        hiddenThreads.map((thread) => resolveProjectThreadStatus(thread)),
+        preview.hiddenThreads.map((thread) => resolveProjectThreadStatus(thread)),
       ),
       renderedThreads,
       showEmptyThreadState: projectExpanded && visibleProjectThreads.length === 0,
@@ -1639,9 +1637,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         draftStore.clearDraftThread(projectDraftThread.draftId);
       }
       draftStore.clearProjectDraftThreadId(memberProjectRef);
+      const nextSidebarThreadFilters = removeProjectKeysFromSidebarThreadFilters(
+        sidebarThreadFilters,
+        new Set([scopedProjectKey(memberProjectRef)]),
+      );
+      if (nextSidebarThreadFilters !== sidebarThreadFilters) {
+        updateSettings({ sidebarThreadFilters: nextSidebarThreadFilters });
+      }
       return result;
     },
-    [deleteProject],
+    [deleteProject, sidebarThreadFilters, updateSettings],
   );
 
   const handleRemoveProject = useCallback(
@@ -3398,6 +3403,19 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     () => buildFlatSidebarProjectSnapshot(sortedProjects),
     [sortedProjects],
   );
+  const { isMobile, setOpenMobile } = useSidebar();
+  const handleFlatNewThread = useCallback(() => {
+    if (!flatProject) return;
+    if (flatProject.memberProjects.length !== 1) {
+      openCommandPalette({ open: "new-thread-in" });
+      return;
+    }
+    const member = flatProject.memberProjects[0]!;
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+    void handleNewThread(scopeProjectRef(member.environmentId, member.id));
+  }, [flatProject, handleNewThread, isMobile, setOpenMobile]);
 
   return (
     <SidebarContent className="gap-0">
@@ -3454,6 +3472,26 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
             {sidebarThreadFilters.groupByProject ? "Projects" : "Threads"}
           </span>
           <div className="flex items-center gap-1">
+            {!sidebarThreadFilters.groupByProject && flatProject ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label="New thread"
+                      data-testid="flat-sidebar-new-thread-button"
+                      className="inline-flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-md px-[calc(--spacing(1)-1px)] text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+                      onClick={handleFlatNewThread}
+                    />
+                  }
+                >
+                  <SquarePenIcon className="size-3.5" />
+                </TooltipTrigger>
+                <TooltipPopup side="right">
+                  {newThreadShortcutLabel ? `New thread (${newThreadShortcutLabel})` : "New thread"}
+                </TooltipPopup>
+              </Tooltip>
+            ) : null}
             <SidebarFilterMenu
               filters={sidebarThreadFilters}
               environments={environments}
@@ -3499,6 +3537,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 project={flatProject}
                 archivedThreads={archivedThreads}
                 sidebarThreadFilters={sidebarThreadFilters}
+                sidebarFilterNowMs={sidebarFilterNowMs}
                 providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
                 isThreadListExpanded={expandedThreadListsByProject.has(flatProject.projectKey)}
                 activeRouteThreadKey={routeThreadKey}
@@ -4085,14 +4124,16 @@ export default function Sidebar() {
         return [];
       }
       const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
-      const { visibleThreads: previewThreads } = getVisibleThreadsForProject({
+      const preview = getGroupedSidebarRenderedThreads({
         threads: projectThreads,
         activeThreadKey: routeThreadKey,
         getThreadKey,
-        isThreadListExpanded,
         previewLimit: sidebarThreadPreviewCount,
+        showAllThreads: isThreadListExpanded,
       });
-      const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
+      const renderedThreads = pinnedCollapsedThread
+        ? [pinnedCollapsedThread]
+        : preview.renderedThreads;
       return renderedThreads.filter((thread) => thread.archivedAt === null).map(getThreadKey);
     });
   }, [

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -715,7 +715,10 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     },
     [attemptUnarchiveThread, threadRef],
   );
-  const rowButtonRender = useMemo(() => <div role="button" tabIndex={0} />, []);
+  const rowButtonRender = useMemo(
+    () => (isArchived ? <div /> : <div role="button" tabIndex={0} />),
+    [isArchived],
+  );
 
   return (
     <SidebarMenuSubItem
@@ -732,7 +735,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
-        })} relative isolate ${isArchived ? "text-muted-foreground/65" : ""}`}
+        })} relative isolate ${
+          isArchived
+            ? "cursor-default text-muted-foreground/65 hover:bg-transparent active:bg-transparent"
+            : ""
+        }`}
         onClick={handleRowClick}
         onDoubleClick={handleRowDoubleClick}
         onKeyDown={handleRowKeyDown}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -199,6 +199,7 @@ import {
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
   hasActiveSidebarThreadFilters,
+  hasNarrowingSidebarThreadFilters,
   matchesSidebarThreadFilters,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
@@ -3682,6 +3683,7 @@ export default function Sidebar() {
   const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
   const threadExplicitlyUnreadById = useUiStateStore((state) => state.threadExplicitlyUnreadById);
   const filtersActive = hasActiveSidebarThreadFilters(sidebarThreadFilters);
+  const narrowingFiltersActive = hasNarrowingSidebarThreadFilters(sidebarThreadFilters);
   const filteredSidebarThreads = useMemo(
     () =>
       sidebarThreadsWithArchived.filter((thread) => {
@@ -3852,7 +3854,7 @@ export default function Sidebar() {
     const sortableProjects = sidebarProjects
       .filter(
         (project) =>
-          !filtersActive || (threadsByProjectKey.get(project.projectKey)?.length ?? 0) > 0,
+          !narrowingFiltersActive || (threadsByProjectKey.get(project.projectKey)?.length ?? 0) > 0,
       )
       .map((project) => ({
         ...project,
@@ -3879,7 +3881,7 @@ export default function Sidebar() {
   }, [
     sidebarProjectSortOrder,
     filteredSidebarThreads,
-    filtersActive,
+    narrowingFiltersActive,
     physicalToLogicalKey,
     projectPhysicalKeyByScopedRef,
     sidebarProjectByKey,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -463,6 +463,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const isHighlighted = isActive || isSelected;
   const handleOpenDiscoveredPort = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (isArchived) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       const port = discoveredPorts[0];
       if (!port) return;
       event.preventDefault();
@@ -484,7 +489,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         );
       })();
     },
-    [discoveredPorts, navigateToThread, openPreview, threadRef],
+    [discoveredPorts, isArchived, navigateToThread, openPreview, threadRef],
   );
   const isThreadRunning =
     thread.session?.status === "running" && thread.session.activeTurnId != null;
@@ -798,7 +803,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
           )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          {discoveredPorts.length > 0 && (
+          {!isArchived && discoveredPorts.length > 0 && (
             <Tooltip>
               <TooltipTrigger
                 render={

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -196,24 +196,29 @@ import { openCommandPalette } from "../commandPaletteBus";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  filterSidebarThreadsForActiveRoute,
   getSidebarRangeSelectionThreadKeys,
   getSidebarThreadIdsToPrewarm,
+  getVisibleThreadsForProject,
   hasActiveSidebarThreadFilters,
   hasNarrowingSidebarThreadFilters,
   matchesSidebarThreadFilters,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
+  resolvePinnedCollapsedSidebarThread,
   resolveProjectStatusIndicator,
   resolveSidebarArchiveEnvironmentIds,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
+  resolveSidebarThreadFilterStatuses,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
   sidebarProviderInstanceKey,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
+  startSidebarRecentFilterClock,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
 } from "./Sidebar.logic";
@@ -1155,6 +1160,7 @@ interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
   archivedThreads: readonly SidebarThreadSummary[];
   sidebarThreadFilters: SidebarThreadFilters;
+  sidebarFilterNowMs: number;
   providerDriverKindByScopedInstanceKey: ReadonlyMap<string, ProviderDriverKind>;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
@@ -1179,6 +1185,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     project,
     archivedThreads,
     sidebarThreadFilters,
+    sidebarFilterNowMs,
     providerDriverKindByScopedInstanceKey,
     isThreadListExpanded,
     activeRouteThreadKey,
@@ -1402,20 +1409,26 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       });
     };
     const visibleProjectThreads = sortThreads(
-      projectThreads.filter((thread) => {
-        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-        const providerInstanceId =
-          thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
-        return matchesSidebarThreadFilters({
-          thread,
-          lastVisitedAt: lastVisitedAtByThreadKey.get(threadKey),
-          isExplicitlyUnread: explicitlyUnreadByThreadKey.get(threadKey),
-          providerDriverKind:
-            providerDriverKindByScopedInstanceKey.get(
-              sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
-            ) ?? null,
-          filters: sidebarThreadFilters,
-        });
+      filterSidebarThreadsForActiveRoute({
+        threads: projectThreads,
+        activeThreadKey: activeRouteThreadKey,
+        getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        matchesFilters: (thread) => {
+          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+          const providerInstanceId =
+            thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+          return matchesSidebarThreadFilters({
+            thread,
+            lastVisitedAt: lastVisitedAtByThreadKey.get(threadKey),
+            isExplicitlyUnread: explicitlyUnreadByThreadKey.get(threadKey),
+            providerDriverKind:
+              providerDriverKindByScopedInstanceKey.get(
+                sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+              ) ?? null,
+            filters: sidebarThreadFilters,
+            nowMs: sidebarFilterNowMs,
+          });
+        },
       }),
       threadSortOrder,
     );
@@ -1435,22 +1448,20 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   }, [
     projectThreads,
     providerDriverKindByScopedInstanceKey,
+    activeRouteThreadKey,
+    sidebarFilterNowMs,
     sidebarThreadFilters,
     threadExplicitlyUnreadStates,
     threadLastVisitedAts,
     threadSortOrder,
   ]);
   const pinnedCollapsedThread = useMemo(() => {
-    const activeThreadKey = activeRouteThreadKey ?? undefined;
-    if (!activeThreadKey || projectExpanded) {
-      return null;
-    }
-    return (
-      visibleProjectThreads.find(
-        (thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === activeThreadKey,
-      ) ?? null
-    );
+    return resolvePinnedCollapsedSidebarThread({
+      threads: visibleProjectThreads,
+      activeThreadKey: activeRouteThreadKey,
+      projectExpanded,
+      getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+    });
   }, [activeRouteThreadKey, projectExpanded, visibleProjectThreads]);
 
   const {
@@ -1483,25 +1494,18 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
-    const hasOverflowingThreads = visibleProjectThreads.length > sidebarThreadPreviewCount;
-    const previewThreads =
-      isThreadListExpanded || !hasOverflowingThreads
-        ? visibleProjectThreads
-        : visibleProjectThreads.slice(0, sidebarThreadPreviewCount);
-    const visibleThreadKeys = new Set(
-      [...previewThreads, ...(pinnedCollapsedThread ? [pinnedCollapsedThread] : [])].map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      ),
-    );
-    const renderedThreads = pinnedCollapsedThread
-      ? [pinnedCollapsedThread]
-      : visibleProjectThreads.filter((thread) =>
-          visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-        );
-    const hiddenThreads = visibleProjectThreads.filter(
-      (thread) =>
-        !visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-    );
+    const {
+      hasHiddenThreads: hasOverflowingThreads,
+      hiddenThreads,
+      visibleThreads: previewThreads,
+    } = getVisibleThreadsForProject({
+      threads: visibleProjectThreads,
+      activeThreadKey: activeRouteThreadKey,
+      getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      isThreadListExpanded,
+      previewLimit: sidebarThreadPreviewCount,
+    });
+    const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
     return {
       hasOverflowingThreads,
       hiddenThreadStatus: resolveProjectStatusIndicator(
@@ -1513,6 +1517,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     };
   }, [
     isThreadListExpanded,
+    activeRouteThreadKey,
     pinnedCollapsedThread,
     projectExpanded,
     projectThreads,
@@ -2944,9 +2949,10 @@ function SidebarFilterMenu({
   onFiltersChange: (filters: SidebarThreadFilters) => void;
 }) {
   const filtersActive = hasActiveSidebarThreadFilters(filters);
+  const selectedStatuses = resolveSidebarThreadFilterStatuses(filters.statuses);
   const statusFilterActive =
-    filters.statuses.length !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
-    !SIDEBAR_THREAD_FILTER_STATUSES.every((status) => filters.statuses.includes(status));
+    selectedStatuses.length !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
+    !SIDEBAR_THREAD_FILTER_STATUSES.every((status) => selectedStatuses.includes(status));
 
   return (
     <Menu>
@@ -3023,13 +3029,13 @@ function SidebarFilterMenu({
             {SIDEBAR_THREAD_FILTER_STATUSES.map((status) => (
               <MenuCheckboxItem
                 key={status}
-                checked={filters.statuses.includes(status)}
+                checked={selectedStatuses.includes(status)}
                 closeOnClick={false}
                 className="sm:text-xs"
                 onCheckedChange={(checked) => {
                   onFiltersChange({
                     ...filters,
-                    statuses: toggleSidebarFilterValue(filters.statuses, status, checked),
+                    statuses: toggleSidebarFilterValue(selectedStatuses, status, checked),
                   });
                 }}
               >
@@ -3179,6 +3185,7 @@ interface SidebarProjectsContentProps {
   threadSortOrder: SidebarThreadSortOrder;
   threadPreviewCount: SidebarThreadPreviewCount;
   sidebarThreadFilters: SidebarThreadFilters;
+  sidebarFilterNowMs: number;
   environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>;
   providerSources: ReadonlyArray<{
     readonly driverKind: ProviderDriverKind;
@@ -3231,6 +3238,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     threadSortOrder,
     threadPreviewCount,
     sidebarThreadFilters,
+    sidebarFilterNowMs,
     environments,
     providerSources,
     providerDriverKindByScopedInstanceKey,
@@ -3403,6 +3411,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         project={project}
                         archivedThreads={archivedThreads}
                         sidebarThreadFilters={sidebarThreadFilters}
+                        sidebarFilterNowMs={sidebarFilterNowMs}
                         providerDriverKindByScopedInstanceKey={
                           providerDriverKindByScopedInstanceKey
                         }
@@ -3441,6 +3450,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 project={project}
                 archivedThreads={archivedThreads}
                 sidebarThreadFilters={sidebarThreadFilters}
+                sidebarFilterNowMs={sidebarFilterNowMs}
                 providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
@@ -3493,6 +3503,15 @@ export default function Sidebar() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
   const sidebarThreadFilters = useClientSettings((s) => s.sidebarThreadFilters);
+  const [sidebarFilterNowMs, setSidebarFilterNowMs] = useState(() => Date.now());
+  useEffect(
+    () =>
+      startSidebarRecentFilterClock({
+        enabled: sidebarThreadFilters.recentOnly,
+        onTick: setSidebarFilterNowMs,
+      }),
+    [sidebarThreadFilters.recentOnly],
+  );
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
   const { archiveThread, unarchiveThread, deleteThread } = useThreadActions();
@@ -3691,23 +3710,31 @@ export default function Sidebar() {
   const narrowingFiltersActive = hasNarrowingSidebarThreadFilters(sidebarThreadFilters);
   const filteredSidebarThreads = useMemo(
     () =>
-      sidebarThreadsWithArchived.filter((thread) => {
-        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-        const providerInstanceId =
-          thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
-        return matchesSidebarThreadFilters({
-          thread,
-          lastVisitedAt: threadLastVisitedAtById[threadKey],
-          isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
-          providerDriverKind:
-            providerDriverKindByScopedInstanceKey.get(
-              sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
-            ) ?? null,
-          filters: sidebarThreadFilters,
-        });
+      filterSidebarThreadsForActiveRoute({
+        threads: sidebarThreadsWithArchived,
+        activeThreadKey: routeThreadKey,
+        getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        matchesFilters: (thread) => {
+          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+          const providerInstanceId =
+            thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+          return matchesSidebarThreadFilters({
+            thread,
+            lastVisitedAt: threadLastVisitedAtById[threadKey],
+            isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
+            providerDriverKind:
+              providerDriverKindByScopedInstanceKey.get(
+                sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+              ) ?? null,
+            filters: sidebarThreadFilters,
+            nowMs: sidebarFilterNowMs,
+          });
+        },
       }),
     [
       providerDriverKindByScopedInstanceKey,
+      routeThreadKey,
+      sidebarFilterNowMs,
       sidebarThreadFilters,
       sidebarThreadsWithArchived,
       threadExplicitlyUnreadById,
@@ -3905,29 +3932,28 @@ export default function Sidebar() {
           projectExpandedById,
           projectExpansionPreferenceKeys(project),
         );
-        const activeThreadKey = routeThreadKey ?? undefined;
-        const pinnedCollapsedThread =
-          !projectExpanded && activeThreadKey
-            ? (projectThreads.find(
-                (thread) =>
-                  scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) ===
-                  activeThreadKey,
-              ) ?? null)
-            : null;
+        const getThreadKey = (thread: SidebarThreadSummary) =>
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+        const pinnedCollapsedThread = resolvePinnedCollapsedSidebarThread({
+          threads: projectThreads,
+          activeThreadKey: routeThreadKey,
+          projectExpanded,
+          getThreadKey,
+        });
         const shouldShowThreadPanel = projectExpanded || pinnedCollapsedThread !== null;
         if (!shouldShowThreadPanel) {
           return [];
         }
         const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
-        const hasOverflowingThreads = projectThreads.length > sidebarThreadPreviewCount;
-        const previewThreads =
-          isThreadListExpanded || !hasOverflowingThreads
-            ? projectThreads
-            : projectThreads.slice(0, sidebarThreadPreviewCount);
+        const { visibleThreads: previewThreads } = getVisibleThreadsForProject({
+          threads: projectThreads,
+          activeThreadKey: routeThreadKey,
+          getThreadKey,
+          isThreadListExpanded,
+          previewLimit: sidebarThreadPreviewCount,
+        });
         const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
-        return renderedThreads
-          .filter((thread) => thread.archivedAt === null)
-          .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)));
+        return renderedThreads.filter((thread) => thread.archivedAt === null).map(getThreadKey);
       }),
     [
       sidebarThreadSortOrder,
@@ -4205,6 +4231,7 @@ export default function Sidebar() {
             threadSortOrder={sidebarThreadSortOrder}
             threadPreviewCount={sidebarThreadPreviewCount}
             sidebarThreadFilters={sidebarThreadFilters}
+            sidebarFilterNowMs={sidebarFilterNowMs}
             environments={environments}
             providerSources={providerSources}
             providerDriverKindByScopedInstanceKey={providerDriverKindByScopedInstanceKey}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveIcon,
+  ArchiveRestoreIcon,
   ArrowUpDownIcon,
   ChevronRightIcon,
   CloudIcon,
@@ -7,6 +8,7 @@ import {
   FolderPlusIcon,
   Globe2Icon,
   LoaderIcon,
+  ListFilterIcon,
   SearchIcon,
   SquarePenIcon,
   TerminalIcon,
@@ -43,7 +45,10 @@ import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-
 import { CSS } from "@dnd-kit/utilities";
 import {
   type ContextMenuItem,
+  type EnvironmentId,
   ProjectId,
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderDriverKind,
   type ScopedThreadRef,
   type ResolvedKeybindingsConfig,
   type SidebarProjectGroupingMode,
@@ -64,12 +69,17 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import { useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
+  DEFAULT_SIDEBAR_THREAD_FILTERS,
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
   MIN_SIDEBAR_THREAD_PREVIEW_COUNT,
+  SIDEBAR_THREAD_FILTER_STATUSES,
   type SidebarProjectSortOrder,
+  type SidebarThreadFilters,
+  type SidebarThreadFilterStatus,
   type SidebarThreadPreviewCount,
   type SidebarThreadSortOrder,
 } from "@t3tools/contracts/settings";
+import { scopeThreadShell } from "@t3tools/client-runtime/state/models";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
@@ -110,6 +120,7 @@ import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
 
 import { useThreadActions } from "../hooks/useThreadActions";
+import { useArchivedThreadSnapshots } from "../lib/archivedThreadsState";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
@@ -145,7 +156,20 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Input } from "./ui/input";
-import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuGroup,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "./ui/menu";
 import {
   NumberField,
   NumberFieldDecrement,
@@ -173,6 +197,8 @@ import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
   getSidebarThreadIdsToPrewarm,
+  hasActiveSidebarThreadFilters,
+  matchesSidebarThreadFilters,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
@@ -193,7 +219,12 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerKeybindingsAtom, primaryServerSettingsAtom } from "../state/server";
+import {
+  primaryServerKeybindingsAtom,
+  primaryServerProvidersAtom,
+  primaryServerSettingsAtom,
+} from "../state/server";
+import { deriveProviderInstanceEntries } from "../providerInstances";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -215,6 +246,12 @@ const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
 const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
+};
+const SIDEBAR_THREAD_FILTER_STATUS_LABELS: Record<SidebarThreadFilterStatus, string> = {
+  needs_attention: "Needs attention",
+  unread: "Unread",
+  working: "Working",
+  done: "Done",
 };
 const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   duration: 180,
@@ -338,6 +375,7 @@ interface SidebarThreadRowProps {
   ) => Promise<void>;
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
+  attemptUnarchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
 }
 
@@ -364,11 +402,13 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     commitRename,
     cancelRename,
     attemptArchiveThread,
+    attemptUnarchiveThread,
     openPrLink,
     thread,
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
+  const isArchived = thread.archivedAt !== null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isExplicitlyUnread = useUiStateStore(
     (state) => state.threadExplicitlyUnreadById[threadKey] === true,
@@ -488,14 +528,19 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   );
   const handleRowClick = useCallback(
     (event: React.MouseEvent) => {
+      if (isArchived) {
+        event.preventDefault();
+        return;
+      }
       handleThreadClick(event, threadRef, orderedProjectThreadKeys);
     },
-    [handleThreadClick, orderedProjectThreadKeys, threadRef],
+    [handleThreadClick, isArchived, orderedProjectThreadKeys, threadRef],
   );
   const handleRowDoubleClick = useCallback(
     (event: React.MouseEvent) => {
       // Already renaming this row: a double-click on the row chrome (outside the
       // input) must not restart and discard the in-progress edit.
+      if (isArchived) return;
       if (renamingThreadKey === threadKey) return;
       // On mobile the first tap navigates and closes the sidebar sheet, so the
       // inline rename can't be shown. Renaming there stays on the context menu.
@@ -508,15 +553,16 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
       event.preventDefault();
       startThreadRename(threadKey, thread.title);
     },
-    [isMobile, renamingThreadKey, startThreadRename, threadKey, thread.title],
+    [isArchived, isMobile, renamingThreadKey, startThreadRename, threadKey, thread.title],
   );
   const handleRowKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
+      if (isArchived) return;
       navigateToThread(threadRef);
     },
-    [navigateToThread, threadRef],
+    [isArchived, navigateToThread, threadRef],
   );
   const handleRowContextMenu = useCallback(
     (event: React.MouseEvent) => {
@@ -661,6 +707,14 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     },
     [attemptArchiveThread, threadRef],
   );
+  const handleUnarchiveClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void attemptUnarchiveThread(threadRef);
+    },
+    [attemptUnarchiveThread, threadRef],
+  );
   const rowButtonRender = useMemo(() => <div role="button" tabIndex={0} />, []);
 
   return (
@@ -678,13 +732,14 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
-        })} relative isolate`}
+        })} relative isolate ${isArchived ? "text-muted-foreground/65" : ""}`}
         onClick={handleRowClick}
         onDoubleClick={handleRowDoubleClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
+          {isArchived ? <ArchiveIcon className="size-3 shrink-0 opacity-60" /> : null}
           {prStatus && (
             <Tooltip>
               <TooltipTrigger
@@ -779,7 +834,28 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               isRemoteThread ? "max-sm:min-w-24" : "max-sm:min-w-20"
             }`}
           >
-            {isConfirmingArchive ? (
+            {isArchived ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <div className="pointer-events-none absolute top-1/2 right-0.5 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
+                      <button
+                        type="button"
+                        data-thread-selection-safe
+                        data-testid={`thread-unarchive-${thread.id}`}
+                        aria-label={`Unarchive ${thread.title}`}
+                        className={SIDEBAR_ICON_ACTION_BUTTON_CLASS}
+                        onPointerDown={stopPropagationOnPointerDown}
+                        onClick={handleUnarchiveClick}
+                      >
+                        <ArchiveRestoreIcon className="size-3.5" />
+                      </button>
+                    </div>
+                  }
+                />
+                <TooltipPopup side="top">Unarchive</TooltipPopup>
+              </Tooltip>
+            ) : isConfirmingArchive ? (
               <button
                 ref={handleConfirmArchiveRef}
                 type="button"
@@ -926,6 +1002,7 @@ interface SidebarProjectThreadListProps {
   ) => Promise<void>;
   cancelRename: () => void;
   attemptArchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
+  attemptUnarchiveThread: (threadRef: ScopedThreadRef) => Promise<void>;
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
@@ -966,6 +1043,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     commitRename,
     cancelRename,
     attemptArchiveThread,
+    attemptUnarchiveThread,
     openPrLink,
     expandThreadListForProject,
     collapseThreadListForProject,
@@ -1017,6 +1095,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
               commitRename={commitRename}
               cancelRename={cancelRename}
               attemptArchiveThread={attemptArchiveThread}
+              attemptUnarchiveThread={attemptUnarchiveThread}
               openPrLink={openPrLink}
             />
           );
@@ -1061,11 +1140,15 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
 
 interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
+  archivedThreads: readonly SidebarThreadSummary[];
+  sidebarThreadFilters: SidebarThreadFilters;
+  providerDriverKindByInstanceId: ReadonlyMap<string, ProviderDriverKind>;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
+  unarchiveThread: ReturnType<typeof useThreadActions>["unarchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
@@ -1081,11 +1164,15 @@ interface SidebarProjectItemProps {
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
   const {
     project,
+    archivedThreads,
+    sidebarThreadFilters,
+    providerDriverKindByInstanceId,
     isThreadListExpanded,
     activeRouteThreadKey,
     newThreadShortcutLabel,
     handleNewThread,
     archiveThread,
+    unarchiveThread,
     deleteThread,
     threadJumpLabelByKey,
     attachThreadListAutoAnimateRef,
@@ -1172,22 +1259,46 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   });
   const openPrLink = useOpenPrLink();
   const sidebarThreads = useThreadShellsForProjectRefs(project.memberProjectRefs);
+  const memberProjectKeys = useMemo(
+    () => new Set(project.memberProjectRefs.map((projectRef) => scopedProjectKey(projectRef))),
+    [project.memberProjectRefs],
+  );
+  const projectThreads = useMemo(() => {
+    const threadsByKey = new Map(
+      sidebarThreads.map(
+        (thread) =>
+          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+      ),
+    );
+    for (const thread of archivedThreads) {
+      const threadProjectKey = scopedProjectKey(
+        scopeProjectRef(thread.environmentId, thread.projectId),
+      );
+      if (!memberProjectKeys.has(threadProjectKey)) {
+        continue;
+      }
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      if (!threadsByKey.has(threadKey)) {
+        threadsByKey.set(threadKey, thread);
+      }
+    }
+    return [...threadsByKey.values()];
+  }, [archivedThreads, memberProjectKeys, sidebarThreads]);
   const sidebarThreadByKey = useMemo(
     () =>
       new Map(
-        sidebarThreads.map(
+        projectThreads.map(
           (thread) =>
             [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
         ),
       ),
-    [sidebarThreads],
+    [projectThreads],
   );
   // Keep a ref so callbacks can read the latest map without appearing in
   // dependency arrays (avoids invalidating every thread-row memo on each
   // thread-list change).
   const sidebarThreadByKeyRef = useRef(sidebarThreadByKey);
   sidebarThreadByKeyRef.current = sidebarThreadByKey;
-  const projectThreads = sidebarThreads;
   const projectPreferenceKeys = useMemo(() => projectExpansionPreferenceKeys(project), [project]);
   const projectExpanded = useUiStateStore((state) =>
     resolveProjectExpanded(state.projectExpandedById, projectPreferenceKeys),
@@ -1278,7 +1389,17 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       });
     };
     const visibleProjectThreads = sortThreads(
-      projectThreads.filter((thread) => thread.archivedAt === null),
+      projectThreads.filter((thread) => {
+        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+        const providerInstanceId =
+          thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+        return matchesSidebarThreadFilters({
+          thread,
+          lastVisitedAt: lastVisitedAtByThreadKey.get(threadKey),
+          providerDriverKind: providerDriverKindByInstanceId.get(providerInstanceId) ?? null,
+          filters: sidebarThreadFilters,
+        });
+      }),
       threadSortOrder,
     );
     const projectStatus = resolveProjectStatusIndicator(
@@ -1291,7 +1412,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadExplicitlyUnreadStates, threadLastVisitedAts, threadSortOrder]);
+  }, [
+    projectThreads,
+    providerDriverKindByInstanceId,
+    sidebarThreadFilters,
+    threadExplicitlyUnreadStates,
+    threadLastVisitedAts,
+    threadSortOrder,
+  ]);
   const pinnedCollapsedThread = useMemo(() => {
     const activeThreadKey = activeRouteThreadKey ?? undefined;
     if (!activeThreadKey || projectExpanded) {
@@ -2044,6 +2172,23 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [archiveThread],
   );
 
+  const attemptUnarchiveThread = useCallback(
+    async (threadRef: ScopedThreadRef) => {
+      const result = await unarchiveThread(threadRef);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to unarchive thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    },
+    [unarchiveThread],
+  );
+
   const cancelRename = useCallback(() => {
     setRenamingThreadKey(null);
     renamingInputRef.current = null;
@@ -2189,16 +2334,29 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       );
       const threadWorkspacePath =
         thread.worktreePath ?? threadProject?.workspaceRoot ?? project.workspaceRoot ?? null;
+      const isArchived = thread.archivedAt !== null;
       const clicked = await api.contextMenu.show(
-        [
-          { id: "rename", label: "Rename thread" },
-          { id: "mark-unread", label: "Mark unread" },
-          { id: "copy-path", label: "Copy Path" },
-          { id: "copy-thread-id", label: "Copy Thread ID" },
-          { id: "delete", label: "Delete", destructive: true, icon: "trash" },
-        ],
+        isArchived
+          ? [
+              { id: "unarchive", label: "Unarchive thread" },
+              { id: "copy-path", label: "Copy Path" },
+              { id: "copy-thread-id", label: "Copy Thread ID" },
+              { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+            ]
+          : [
+              { id: "rename", label: "Rename thread" },
+              { id: "mark-unread", label: "Mark unread" },
+              { id: "copy-path", label: "Copy Path" },
+              { id: "copy-thread-id", label: "Copy Thread ID" },
+              { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+            ],
         position,
       );
+
+      if (clicked === "unarchive") {
+        await attemptUnarchiveThread(threadRef);
+        return;
+      }
 
       if (clicked === "rename") {
         startThreadRename(threadKey, thread.title);
@@ -2253,6 +2411,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     },
     [
       appSettingsConfirmThreadDelete,
+      attemptUnarchiveThread,
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
@@ -2403,6 +2562,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         commitRename={commitRename}
         cancelRename={cancelRename}
         attemptArchiveThread={attemptArchiveThread}
+        attemptUnarchiveThread={attemptUnarchiveThread}
         openPrLink={openPrLink}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
@@ -2738,6 +2898,185 @@ function ProjectSortMenu({
   );
 }
 
+function toggleSidebarFilterValue<T>(values: readonly T[], value: T, checked: boolean): T[] {
+  if (checked) {
+    return values.includes(value) ? [...values] : [...values, value];
+  }
+  return values.filter((candidate) => candidate !== value);
+}
+
+function SidebarFilterMenu({
+  filters,
+  environments,
+  providerSources,
+  archiveLoading,
+  archiveError,
+  onFiltersChange,
+}: {
+  filters: SidebarThreadFilters;
+  environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>;
+  providerSources: ReadonlyArray<{
+    readonly driverKind: ProviderDriverKind;
+    readonly label: string;
+  }>;
+  archiveLoading: boolean;
+  archiveError: string | null;
+  onFiltersChange: (filters: SidebarThreadFilters) => void;
+}) {
+  const filtersActive = hasActiveSidebarThreadFilters(filters);
+  const statusFilterActive =
+    filters.statuses.length !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
+    !SIDEBAR_THREAD_FILTER_STATUSES.every((status) => filters.statuses.includes(status));
+
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              aria-label="Filter sidebar threads"
+              data-testid="sidebar-filter-trigger"
+              className={`relative inline-flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-md px-[calc(--spacing(1)-1px)] transition-colors hover:bg-accent hover:text-foreground ${
+                filtersActive ? "text-primary" : "text-muted-foreground/60"
+              }`}
+            />
+          }
+        >
+          <ListFilterIcon className="size-3.5" />
+          {filtersActive ? (
+            <span className="absolute right-0.5 bottom-0.5 size-1.5 rounded-full bg-primary ring-1 ring-sidebar" />
+          ) : null}
+        </TooltipTrigger>
+        <TooltipPopup side="right">
+          {filtersActive ? "Sidebar filters are active" : "Filter sidebar threads"}
+        </TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="end" side="bottom" className="min-w-52">
+        <div className="flex items-center justify-between px-2 py-1 text-xs font-medium text-muted-foreground">
+          <span>Filters</span>
+          <button
+            type="button"
+            className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-40"
+            disabled={!filtersActive}
+            onClick={() => {
+              onFiltersChange(DEFAULT_SIDEBAR_THREAD_FILTERS);
+            }}
+          >
+            Reset
+          </button>
+        </div>
+        <MenuSub>
+          <MenuSubTrigger className="sm:text-xs">
+            <span>Status</span>
+            {statusFilterActive ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {SIDEBAR_THREAD_FILTER_STATUSES.map((status) => (
+              <MenuCheckboxItem
+                key={status}
+                checked={filters.statuses.includes(status)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    statuses: toggleSidebarFilterValue(filters.statuses, status, checked),
+                  });
+                }}
+              >
+                {SIDEBAR_THREAD_FILTER_STATUS_LABELS[status]}
+              </MenuCheckboxItem>
+            ))}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="sm:text-xs">
+            <span>Environment</span>
+            {filters.environmentIds.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {environments.map((environment) => (
+              <MenuCheckboxItem
+                key={environment.environmentId}
+                checked={filters.environmentIds.includes(environment.environmentId)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    environmentIds: toggleSidebarFilterValue(
+                      filters.environmentIds,
+                      environment.environmentId,
+                      checked,
+                    ),
+                  });
+                }}
+              >
+                {environment.label}
+              </MenuCheckboxItem>
+            ))}
+            {environments.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No environments
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="sm:text-xs">
+            <span>Source</span>
+            {filters.sources.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {providerSources.map((source) => (
+              <MenuCheckboxItem
+                key={source.driverKind}
+                checked={filters.sources.includes(source.driverKind)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    sources: toggleSidebarFilterValue(filters.sources, source.driverKind, checked),
+                  });
+                }}
+              >
+                {source.label}
+              </MenuCheckboxItem>
+            ))}
+            {providerSources.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No providers
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSeparator />
+        <MenuCheckboxItem
+          checked={filters.includeArchived}
+          closeOnClick={false}
+          className="sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, includeArchived: checked });
+          }}
+        >
+          <span className="flex items-center gap-2">
+            Archived
+            {archiveLoading ? <LoaderIcon className="size-3 animate-spin" /> : null}
+            {archiveError ? <TriangleAlertIcon className="size-3 text-warning" /> : null}
+          </span>
+        </MenuCheckboxItem>
+      </MenuPopup>
+    </Menu>
+  );
+}
+
 function SortableProjectItem({
   projectId,
   disabled = false,
@@ -2784,6 +3123,17 @@ interface SidebarProjectsContentProps {
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   threadPreviewCount: SidebarThreadPreviewCount;
+  sidebarThreadFilters: SidebarThreadFilters;
+  environments: ReadonlyArray<{ readonly environmentId: EnvironmentId; readonly label: string }>;
+  providerSources: ReadonlyArray<{
+    readonly driverKind: ProviderDriverKind;
+    readonly label: string;
+  }>;
+  providerDriverKindByInstanceId: ReadonlyMap<string, ProviderDriverKind>;
+  archivedThreads: readonly SidebarThreadSummary[];
+  archiveLoading: boolean;
+  archiveError: string | null;
+  filtersActive: boolean;
   updateSettings: ReturnType<typeof useUpdateClientSettings>;
   openAddProject: () => void;
   isManualProjectSorting: boolean;
@@ -2794,6 +3144,7 @@ interface SidebarProjectsContentProps {
   handleProjectDragCancel: (event: DragCancelEvent) => void;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
+  unarchiveThread: ReturnType<typeof useThreadActions>["unarchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
   expandedThreadListsByProject: ReadonlySet<string>;
@@ -2824,6 +3175,14 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     projectSortOrder,
     threadSortOrder,
     threadPreviewCount,
+    sidebarThreadFilters,
+    environments,
+    providerSources,
+    providerDriverKindByInstanceId,
+    archivedThreads,
+    archiveLoading,
+    archiveError,
+    filtersActive,
     updateSettings,
     openAddProject,
     isManualProjectSorting,
@@ -2834,6 +3193,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     handleProjectDragCancel,
     handleNewThread,
     archiveThread,
+    unarchiveThread,
     deleteThread,
     sortedProjects,
     expandedThreadListsByProject,
@@ -2855,6 +3215,12 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
   const handleProjectSortOrderChange = useCallback(
     (sortOrder: SidebarProjectSortOrder) => {
       updateSettings({ sidebarProjectSortOrder: sortOrder });
+    },
+    [updateSettings],
+  );
+  const handleSidebarThreadFiltersChange = useCallback(
+    (filters: SidebarThreadFilters) => {
+      updateSettings({ sidebarThreadFilters: filters });
     },
     [updateSettings],
   );
@@ -2924,6 +3290,14 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
         <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
           <span className="text-xs font-medium text-sidebar-muted-foreground/80">Projects</span>
           <div className="flex items-center gap-1">
+            <SidebarFilterMenu
+              filters={sidebarThreadFilters}
+              environments={environments}
+              providerSources={providerSources}
+              archiveLoading={archiveLoading}
+              archiveError={archiveError}
+              onFiltersChange={handleSidebarThreadFiltersChange}
+            />
             <ProjectSortMenu
               projectSortOrder={projectSortOrder}
               threadSortOrder={threadSortOrder}
@@ -2970,6 +3344,9 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                     {(dragHandleProps) => (
                       <SidebarProjectItem
                         project={project}
+                        archivedThreads={archivedThreads}
+                        sidebarThreadFilters={sidebarThreadFilters}
+                        providerDriverKindByInstanceId={providerDriverKindByInstanceId}
                         isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -2977,6 +3354,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         newThreadShortcutLabel={newThreadShortcutLabel}
                         handleNewThread={handleNewThread}
                         archiveThread={archiveThread}
+                        unarchiveThread={unarchiveThread}
                         deleteThread={deleteThread}
                         threadJumpLabelByKey={threadJumpLabelByKey}
                         attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
@@ -3002,6 +3380,9 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               <SidebarProjectListRow
                 key={project.projectKey}
                 project={project}
+                archivedThreads={archivedThreads}
+                sidebarThreadFilters={sidebarThreadFilters}
+                providerDriverKindByInstanceId={providerDriverKindByInstanceId}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -3009,6 +3390,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 newThreadShortcutLabel={newThreadShortcutLabel}
                 handleNewThread={handleNewThread}
                 archiveThread={archiveThread}
+                unarchiveThread={unarchiveThread}
                 deleteThread={deleteThread}
                 threadJumpLabelByKey={threadJumpLabelByKey}
                 attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
@@ -3024,9 +3406,13 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </SidebarMenu>
         )}
 
-        {projectsLength === 0 && (
+        {sortedProjects.length === 0 && (
           <div className="px-2 pt-4 text-center text-xs text-muted-foreground/60">
-            No projects yet
+            {projectsLength === 0
+              ? "No projects yet"
+              : filtersActive
+                ? "No threads match these filters"
+                : "No projects to show"}
           </div>
         )}
       </SidebarGroup>
@@ -3047,9 +3433,10 @@ export default function Sidebar() {
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
+  const sidebarThreadFilters = useClientSettings((s) => s.sidebarThreadFilters);
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
-  const { archiveThread, deleteThread } = useThreadActions();
+  const { archiveThread, unarchiveThread, deleteThread } = useThreadActions();
   const { isMobile, setOpenMobile } = useSidebar();
   const routeTarget = useParams({
     strict: false,
@@ -3069,6 +3456,7 @@ export default function Sidebar() {
       : false,
   );
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
     [],
@@ -3086,6 +3474,47 @@ export default function Sidebar() {
   const platform = navigator.platform;
   const shortcutModifiers = useShortcutModifierState();
   const { environments } = useEnvironments();
+  const archiveEnvironmentIds = useMemo(
+    () =>
+      sidebarThreadFilters.includeArchived
+        ? environments.map((environment) => environment.environmentId)
+        : [],
+    [environments, sidebarThreadFilters.includeArchived],
+  );
+  const {
+    snapshots: archivedSnapshots,
+    isLoading: archiveLoading,
+    error: archiveError,
+  } = useArchivedThreadSnapshots(archiveEnvironmentIds);
+  const archivedThreads = useMemo(
+    () =>
+      archivedSnapshots.flatMap((entry) =>
+        entry.snapshot.threads
+          .filter((thread) => thread.archivedAt !== null)
+          .map((thread) => scopeThreadShell(entry.environmentId, thread)),
+      ),
+    [archivedSnapshots],
+  );
+  const providerEntries = useMemo(
+    () => deriveProviderInstanceEntries(serverProviders),
+    [serverProviders],
+  );
+  const providerDriverKindByInstanceId = useMemo(
+    () => new Map(providerEntries.map((entry) => [entry.instanceId, entry.driverKind] as const)),
+    [providerEntries],
+  );
+  const providerSources = useMemo(() => {
+    const labelsByDriverKind = new Map<ProviderDriverKind, string>();
+    for (const entry of providerEntries) {
+      if (!labelsByDriverKind.has(entry.driverKind)) {
+        labelsByDriverKind.set(
+          entry.driverKind,
+          PROVIDER_DISPLAY_NAMES[entry.driverKind] ?? entry.displayName,
+        );
+      }
+    }
+    return [...labelsByDriverKind].map(([driverKind, label]) => ({ driverKind, label }));
+  }, [providerEntries]);
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const environmentLabelById = useMemo(
     () =>
@@ -3166,6 +3595,43 @@ export default function Sidebar() {
       ),
     [sidebarThreads],
   );
+  const sidebarThreadsWithArchived = useMemo(() => {
+    const threadsByKey = new Map(
+      sidebarThreads.map(
+        (thread) =>
+          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+      ),
+    );
+    for (const thread of archivedThreads) {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      if (!threadsByKey.has(threadKey)) {
+        threadsByKey.set(threadKey, thread);
+      }
+    }
+    return [...threadsByKey.values()];
+  }, [archivedThreads, sidebarThreads]);
+  const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
+  const filtersActive = hasActiveSidebarThreadFilters(sidebarThreadFilters);
+  const filteredSidebarThreads = useMemo(
+    () =>
+      sidebarThreadsWithArchived.filter((thread) => {
+        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+        const providerInstanceId =
+          thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+        return matchesSidebarThreadFilters({
+          thread,
+          lastVisitedAt: threadLastVisitedAtById[threadKey],
+          providerDriverKind: providerDriverKindByInstanceId.get(providerInstanceId) ?? null,
+          filters: sidebarThreadFilters,
+        });
+      }),
+    [
+      providerDriverKindByInstanceId,
+      sidebarThreadFilters,
+      sidebarThreadsWithArchived,
+      threadLastVisitedAtById,
+    ],
+  );
   // Resolve the active route's project key to a logical key so it matches the
   // sidebar's grouped project entries.
   const activeRouteProjectKey = useMemo(() => {
@@ -3185,7 +3651,7 @@ export default function Sidebar() {
   // are displayed together.
   const threadsByProjectKey = useMemo(() => {
     const next = new Map<string, SidebarThreadSummary[]>();
-    for (const thread of sidebarThreads) {
+    for (const thread of filteredSidebarThreads) {
       const physicalKey =
         projectPhysicalKeyByScopedRef.get(
           scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
@@ -3199,7 +3665,7 @@ export default function Sidebar() {
       }
     }
     return next;
-  }, [sidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
+  }, [filteredSidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
   const getCurrentSidebarShortcutContext = useCallback(
     () => ({
       terminalFocus: isTerminalFocused(),
@@ -3307,16 +3773,17 @@ export default function Sidebar() {
     animatedThreadListsRef.current.add(node);
   }, []);
 
-  const visibleThreads = useMemo(
-    () => sidebarThreads.filter((thread) => thread.archivedAt === null),
-    [sidebarThreads],
-  );
   const sortedProjects = useMemo(() => {
-    const sortableProjects = sidebarProjects.map((project) => ({
-      ...project,
-      id: project.projectKey,
-    }));
-    const sortableThreads = visibleThreads.map((thread) => {
+    const sortableProjects = sidebarProjects
+      .filter(
+        (project) =>
+          !filtersActive || (threadsByProjectKey.get(project.projectKey)?.length ?? 0) > 0,
+      )
+      .map((project) => ({
+        ...project,
+        id: project.projectKey,
+      }));
+    const sortableThreads = filteredSidebarThreads.map((thread) => {
       const physicalKey =
         projectPhysicalKeyByScopedRef.get(
           scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
@@ -3336,20 +3803,20 @@ export default function Sidebar() {
     });
   }, [
     sidebarProjectSortOrder,
+    filteredSidebarThreads,
+    filtersActive,
     physicalToLogicalKey,
     projectPhysicalKeyByScopedRef,
     sidebarProjectByKey,
     sidebarProjects,
-    visibleThreads,
+    threadsByProjectKey,
   ]);
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
   const visibleSidebarThreadKeys = useMemo(
     () =>
       sortedProjects.flatMap((project) => {
         const projectThreads = sortThreads(
-          (threadsByProjectKey.get(project.projectKey) ?? []).filter(
-            (thread) => thread.archivedAt === null,
-          ),
+          threadsByProjectKey.get(project.projectKey) ?? [],
           sidebarThreadSortOrder,
         );
         const projectExpanded = resolveProjectExpanded(
@@ -3376,9 +3843,9 @@ export default function Sidebar() {
             ? projectThreads
             : projectThreads.slice(0, sidebarThreadPreviewCount);
         const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
-        return renderedThreads.map((thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-        );
+        return renderedThreads
+          .filter((thread) => thread.archivedAt === null)
+          .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)));
       }),
     [
       sidebarThreadSortOrder,
@@ -3655,6 +4122,14 @@ export default function Sidebar() {
             projectSortOrder={sidebarProjectSortOrder}
             threadSortOrder={sidebarThreadSortOrder}
             threadPreviewCount={sidebarThreadPreviewCount}
+            sidebarThreadFilters={sidebarThreadFilters}
+            environments={environments}
+            providerSources={providerSources}
+            providerDriverKindByInstanceId={providerDriverKindByInstanceId}
+            archivedThreads={archivedThreads}
+            archiveLoading={archiveLoading}
+            archiveError={archiveError}
+            filtersActive={filtersActive}
             updateSettings={updateSettings}
             openAddProject={openAddProjectCommandPalette}
             isManualProjectSorting={isManualProjectSorting}
@@ -3665,6 +4140,7 @@ export default function Sidebar() {
             handleProjectDragCancel={handleProjectDragCancel}
             handleNewThread={handleNewThread}
             archiveThread={archiveThread}
+            unarchiveThread={unarchiveThread}
             deleteThread={deleteThread}
             sortedProjects={sortedProjects}
             expandedThreadListsByProject={expandedThreadListsByProject}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -370,6 +370,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isExplicitlyUnread = useUiStateStore(
+    (state) => state.threadExplicitlyUnreadById[threadKey] === true,
+  );
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: thread.environmentId,
@@ -449,6 +452,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     thread: {
       ...thread,
       lastVisitedAt,
+      isExplicitlyUnread,
     },
   });
   const pr = resolveThreadPr({
@@ -1198,6 +1202,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       ),
     ),
   );
+  const threadExplicitlyUnreadStates = useUiStateStore(
+    useShallow((state) =>
+      projectThreads.map(
+        (thread) =>
+          state.threadExplicitlyUnreadById[
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))
+          ] === true,
+      ),
+    ),
+  );
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
   const [confirmingArchiveThreadKey, setConfirmingArchiveThreadKey] = useState<string | null>(null);
@@ -1246,14 +1260,20 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         threadLastVisitedAts[index] ?? null,
       ]),
     );
-    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
-      const lastVisitedAt = lastVisitedAtByThreadKey.get(
+    const explicitlyUnreadByThreadKey = new Map(
+      projectThreads.map((thread, index) => [
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      );
+        threadExplicitlyUnreadStates[index] ?? false,
+      ]),
+    );
+    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      const lastVisitedAt = lastVisitedAtByThreadKey.get(threadKey);
       return resolveThreadStatusPill({
         thread: {
           ...thread,
           ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
+          ...(explicitlyUnreadByThreadKey.get(threadKey) ? { isExplicitlyUnread: true } : {}),
         },
       });
     };
@@ -1271,7 +1291,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
+  }, [projectThreads, threadExplicitlyUnreadStates, threadLastVisitedAts, threadSortOrder]);
   const pinnedCollapsedThread = useMemo(() => {
     const activeThreadKey = activeRouteThreadKey ?? undefined;
     if (!activeThreadKey || projectExpanded) {
@@ -1298,14 +1318,20 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         threadLastVisitedAts[index] ?? null,
       ]),
     );
-    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
-      const lastVisitedAt = lastVisitedAtByThreadKey.get(
+    const explicitlyUnreadByThreadKey = new Map(
+      projectThreads.map((thread, index) => [
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      );
+        threadExplicitlyUnreadStates[index] ?? false,
+      ]),
+    );
+    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      const lastVisitedAt = lastVisitedAtByThreadKey.get(threadKey);
       return resolveThreadStatusPill({
         thread: {
           ...thread,
           ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
+          ...(explicitlyUnreadByThreadKey.get(threadKey) ? { isExplicitlyUnread: true } : {}),
         },
       });
     };
@@ -1343,6 +1369,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     projectExpanded,
     projectThreads,
     sidebarThreadPreviewCount,
+    threadExplicitlyUnreadStates,
     threadLastVisitedAts,
     visibleProjectThreads,
   ]);

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -98,6 +98,7 @@ import { formatRelativeTimeLabel } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import {
+  filterSidebarThreadsForActiveRoute,
   firstValidTimestampMs,
   formatWorkingDurationLabel,
   hasUnseenCompletion,
@@ -1360,20 +1361,25 @@ export default function SidebarV2() {
   // form a third, explicit tail only while the Archived filter is enabled.
   const { activeThreads, settledThreads, filteredArchivedThreads } = useMemo(() => {
     const now = `${nowMinute}:00.000Z`;
-    const visible = threadsWithArchived.filter((thread) => {
-      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-      const providerInstanceId =
-        thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
-      return matchesSidebarThreadFilters({
-        thread,
-        lastVisitedAt: threadLastVisitedAtById[threadKey],
-        isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
-        providerDriverKind:
-          providerFilterState.driverKindByScopedInstanceKey.get(
-            sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
-          ) ?? null,
-        filters: sidebarThreadFilters,
-      });
+    const visible = filterSidebarThreadsForActiveRoute({
+      threads: threadsWithArchived,
+      activeThreadKey: routeThreadKey,
+      getThreadKey: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      matchesFilters: (thread) => {
+        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+        const providerInstanceId =
+          thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+        return matchesSidebarThreadFilters({
+          thread,
+          lastVisitedAt: threadLastVisitedAtById[threadKey],
+          isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
+          providerDriverKind:
+            providerFilterState.driverKindByScopedInstanceKey.get(
+              sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+            ) ?? null,
+          filters: sidebarThreadFilters,
+        });
+      },
     });
     const active: EnvironmentThreadShell[] = [];
     const settled: EnvironmentThreadShell[] = [];
@@ -1414,6 +1420,7 @@ export default function SidebarV2() {
     changeRequestStateByKey,
     nowMinute,
     providerFilterState.driverKindByScopedInstanceKey,
+    routeThreadKey,
     serverConfigs,
     sidebarThreadFilters,
     threadExplicitlyUnreadById,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -326,12 +326,15 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   );
   const threadKey = scopedThreadKey(threadRef);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isExplicitlyUnread = useUiStateStore(
+    (state) => state.threadExplicitlyUnreadById[threadKey] === true,
+  );
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const openPrLink = useOpenPrLink();
 
   // Same semantics as v1 (never-visited counts as read): flipping the beta
   // flag must not light up every historical thread as unread.
-  const isUnread = hasUnseenCompletion({ ...thread, lastVisitedAt });
+  const isUnread = isExplicitlyUnread || hasUnseenCompletion({ ...thread, lastVisitedAt });
   const status = resolveSidebarV2Status(thread);
   // In-flight rows (working, or waiting on approval/input) fade as a whole:
   // there is nothing for the user to do yet, so prominence is reserved for
@@ -345,8 +348,13 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // Status hues follow the system-wide convention set by sidebar v1 and the
   // mobile Live Activity/widgets (amber approval, indigo input, sky working)
   // so a thread reads the same color everywhere it surfaces.
-  const topStatus =
-    status === "working"
+  const topStatus = isExplicitlyUnread
+    ? {
+        label: "Unread",
+        icon: null,
+        className: "text-blue-600 dark:text-blue-300",
+      }
+    : status === "working"
       ? {
           label: "Working",
           icon: "working" as const,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -73,6 +73,7 @@ import {
 } from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
+  getSidebarProjectRemovalRefs,
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
@@ -104,8 +105,10 @@ import {
   isTrailingDoubleClick,
   matchesSidebarThreadFilters,
   orderItemsByPreferredIds,
+  removeProjectKeysFromSidebarThreadFilters,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
+  resolveSidebarArchiveEnvironmentIds,
   resolveSidebarV2Status,
   resolveSidebarV2TopStatus,
   resolveWorkingStartedAt,
@@ -1014,18 +1017,31 @@ export default function SidebarV2() {
           ),
     [projectGroups, sidebarThreadFilters.projectKeys],
   );
+  const projectActionEnvironmentIds = useMemo(
+    () =>
+      projectActionsTarget
+        ? [
+            ...new Set(
+              projectActionsTarget.memberProjectRefs.map((projectRef) => projectRef.environmentId),
+            ),
+          ]
+        : [],
+    [projectActionsTarget],
+  );
   const archiveEnvironmentIds = useMemo(
     () =>
-      sidebarThreadFilters.includeArchived
-        ? environments
-            .map((environment) => environment.environmentId)
-            .filter(
-              (environmentId) =>
-                sidebarThreadFilters.environmentIds.length === 0 ||
-                sidebarThreadFilters.environmentIds.includes(environmentId),
-            )
-        : [],
-    [environments, sidebarThreadFilters.environmentIds, sidebarThreadFilters.includeArchived],
+      resolveSidebarArchiveEnvironmentIds({
+        availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+        selectedEnvironmentIds: sidebarThreadFilters.environmentIds,
+        includeArchived: sidebarThreadFilters.includeArchived,
+        requiredEnvironmentIds: projectActionEnvironmentIds,
+      }),
+    [
+      environments,
+      projectActionEnvironmentIds,
+      sidebarThreadFilters.environmentIds,
+      sidebarThreadFilters.includeArchived,
+    ],
   );
   const {
     snapshots: archivedSnapshots,
@@ -1041,6 +1057,34 @@ export default function SidebarV2() {
       ),
     [archivedSnapshots],
   );
+  const projectByRefKey = useMemo(
+    () =>
+      new Map(
+        projects.map(
+          (project) =>
+            [
+              scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+              project,
+            ] as const,
+        ),
+      ),
+    [projects],
+  );
+  const threadsWithArchived = useMemo(() => {
+    const byKey = new Map(
+      threads.map(
+        (thread) =>
+          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+      ),
+    );
+    for (const thread of archivedThreads) {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      if (!byKey.has(threadKey)) {
+        byKey.set(threadKey, thread);
+      }
+    }
+    return [...byKey.values()];
+  }, [archivedThreads, threads]);
   const projectCwdByKey = useMemo(
     () =>
       new Map(
@@ -1133,11 +1177,16 @@ export default function SidebarV2() {
   const handleRemoveProjectMembers = useCallback(
     async (projectGroup: SidebarProjectSnapshot, members: readonly SidebarProjectGroupMember[]) => {
       const api = readLocalApi();
-      if (!api) return;
+      if (!api || archiveLoading || archiveError !== null) return;
 
-      const memberKeys = new Set(members.map((member) => `${member.environmentId}:${member.id}`));
-      const projectThreads = threads.filter((thread) =>
-        memberKeys.has(`${thread.environmentId}:${thread.projectId}`),
+      const projectRefs = getSidebarProjectRemovalRefs({
+        projectGroup,
+        members,
+        projects,
+      });
+      const memberKeys = new Set(projectRefs.map(scopedProjectKey));
+      const projectThreads = threadsWithArchived.filter((thread) =>
+        memberKeys.has(scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId))),
       );
       const isWholeGroup = members.length === projectGroup.memberProjects.length;
       const singleMember = members.length === 1 ? members[0]! : null;
@@ -1154,7 +1203,7 @@ export default function SidebarV2() {
                         ? [`Environment: ${singleMember.environmentLabel}`]
                         : []),
                     ]
-                  : [`This removes ${members.length} grouped project entries.`]),
+                  : [`This removes ${projectRefs.length} grouped project entries.`]),
                 "This permanently clears conversation history for those threads.",
                 isWholeGroup
                   ? "This removes only the project entries, not the files on disk."
@@ -1170,7 +1219,7 @@ export default function SidebarV2() {
                         ? [`Environment: ${singleMember.environmentLabel}`]
                         : []),
                     ]
-                  : [`This removes ${members.length} grouped project entries.`]),
+                  : [`This removes ${projectRefs.length} grouped project entries.`]),
                 isWholeGroup
                   ? "This removes only the project entries, not the files on disk."
                   : "Other entries in this grouped project are unaffected.",
@@ -1181,12 +1230,12 @@ export default function SidebarV2() {
 
       const draftStore = useComposerDraftStore.getState();
       let shouldNavigate = false;
-      for (const project of members) {
+      for (const projectRef of projectRefs) {
         const memberThreads = projectThreads.filter(
           (thread) =>
-            thread.environmentId === project.environmentId && thread.projectId === project.id,
+            thread.environmentId === projectRef.environmentId &&
+            thread.projectId === projectRef.projectId,
         );
-        const projectRef = scopeProjectRef(project.environmentId, project.id);
         const projectDraftThread = draftStore.getDraftThreadByProjectRef(projectRef);
         const memberRemovalNeedsNavigation = shouldNavigateAfterProjectRemoval({
           routeTarget: routeTargetRef.current,
@@ -1195,9 +1244,9 @@ export default function SidebarV2() {
         });
 
         const result = await deleteProject({
-          environmentId: project.environmentId,
+          environmentId: projectRef.environmentId,
           input: {
-            projectId: project.id,
+            projectId: projectRef.projectId,
             ...(memberThreads.length > 0 ? { force: true } : {}),
           },
         });
@@ -1207,7 +1256,9 @@ export default function SidebarV2() {
             toastManager.add(
               stackedThreadToast({
                 type: "error",
-                title: `Failed to remove "${project.title}"`,
+                title: `Failed to remove "${
+                  projectByRefKey.get(scopedProjectKey(projectRef))?.title ?? targetLabel
+                }"`,
                 description: error instanceof Error ? error.message : "An error occurred.",
               }),
             );
@@ -1225,25 +1276,29 @@ export default function SidebarV2() {
         draftStore.clearProjectDraftThreadId(projectRef);
       }
 
-      const removedProjectKeys = new Set(
-        members.map((member) => scopedProjectKey(scopeProjectRef(member.environmentId, member.id))),
+      const nextSidebarThreadFilters = removeProjectKeysFromSidebarThreadFilters(
+        sidebarThreadFilters,
+        new Set(projectRefs.map(scopedProjectKey)),
       );
-      if (
-        sidebarThreadFilters.projectKeys.some((projectKey) => removedProjectKeys.has(projectKey))
-      ) {
-        handleSidebarThreadFiltersChange({
-          ...sidebarThreadFilters,
-          projectKeys: sidebarThreadFilters.projectKeys.filter(
-            (projectKey) => !removedProjectKeys.has(projectKey),
-          ),
-        });
+      if (nextSidebarThreadFilters !== sidebarThreadFilters) {
+        handleSidebarThreadFiltersChange(nextSidebarThreadFilters);
       }
 
       if (shouldNavigate) {
         void router.navigate({ to: "/" });
       }
     },
-    [deleteProject, handleSidebarThreadFiltersChange, router, sidebarThreadFilters, threads],
+    [
+      deleteProject,
+      archiveError,
+      archiveLoading,
+      handleSidebarThreadFiltersChange,
+      projectByRefKey,
+      projects,
+      router,
+      sidebarThreadFilters,
+      threadsWithArchived,
+    ],
   );
 
   const renameProjectMember = useCallback(
@@ -1296,21 +1351,6 @@ export default function SidebarV2() {
     [],
   );
 
-  const threadsWithArchived = useMemo(() => {
-    const byKey = new Map(
-      threads.map(
-        (thread) =>
-          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
-      ),
-    );
-    for (const thread of archivedThreads) {
-      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-      if (!byKey.has(threadKey)) {
-        byKey.set(threadKey, thread);
-      }
-    }
-    return [...byKey.values()];
-  }, [archivedThreads, threads]);
   const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
   const threadExplicitlyUnreadById = useUiStateStore((state) => state.threadExplicitlyUnreadById);
   const filtersActive = hasActiveSidebarThreadFilters(sidebarThreadFilters);
@@ -2293,6 +2333,15 @@ export default function SidebarV2() {
                 ? `${projectActionsTarget.displayName} has an entry in each environment. Changes apply only to the entry you choose.`
                 : `Manage ${projectActionsTarget?.displayName ?? "this project"} in this environment.`}
             </DialogDescription>
+            {archiveLoading ? (
+              <p className="text-xs text-muted-foreground">
+                Checking archived conversations before project removal…
+              </p>
+            ) : archiveError ? (
+              <p className="text-xs text-destructive-foreground">
+                Archived conversations could not be checked, so project removal is unavailable.
+              </p>
+            ) : null}
           </DialogHeader>
           <DialogPanel className="p-0">
             <div className="divide-y divide-border/60">
@@ -2405,6 +2454,7 @@ export default function SidebarV2() {
                     <Button
                       size="sm"
                       variant="ghost"
+                      disabled={archiveLoading || archiveError !== null}
                       className="text-destructive-foreground hover:bg-destructive/8 hover:text-destructive-foreground sm:ml-auto"
                       onClick={() => {
                         const projectGroup = projectActionsTarget;
@@ -2433,6 +2483,7 @@ export default function SidebarV2() {
                 <Button
                   size="sm"
                   variant="destructive-outline"
+                  disabled={archiveLoading || archiveError !== null}
                   className="shrink-0"
                   onClick={() => {
                     const projectGroup = projectActionsTarget;

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1,14 +1,20 @@
 import { autoAnimate } from "@formkit/auto-animate";
 import { useAtomValue } from "@effect/atom-react";
 import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
-import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import {
+  scopeThreadShell,
+  type EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
   scopeThreadRef,
+  scopedProjectKey,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
 import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
+import type { SidebarThreadFilters } from "@t3tools/contracts/settings";
 import {
+  ArchiveRestoreIcon,
   CheckIcon,
   ChevronDownIcon,
   CircleAlertIcon,
@@ -91,9 +97,12 @@ import { formatRelativeTimeLabel } from "../timestampFormat";
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import {
+  firstValidTimestampMs,
   formatWorkingDurationLabel,
   hasUnseenCompletion,
+  hasActiveSidebarThreadFilters,
   isTrailingDoubleClick,
+  matchesSidebarThreadFilters,
   orderItemsByPreferredIds,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
@@ -110,8 +119,7 @@ import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
-import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
-import { primaryServerProvidersAtom } from "../state/server";
+import type { ProviderInstanceEntry } from "../providerInstances";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { CommandDialogTrigger } from "./ui/command";
 import { Button } from "./ui/button";
@@ -126,12 +134,22 @@ import {
 } from "./ui/dialog";
 import { Input } from "./ui/input";
 import { Kbd } from "./ui/kbd";
-import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import { Menu, MenuCheckboxItem, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "./ui/menu";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import { useComposerDraftStore } from "../composerDraftStore";
+import { useArchivedThreadSnapshots } from "../lib/archivedThreadsState";
+import {
+  SidebarFilterMenu,
+  toggleSidebarFilterValues,
+  type SidebarFilterProjectOption,
+} from "./sidebar/SidebarFilterMenu";
+import {
+  buildSidebarProviderFilterState,
+  sidebarProviderInstanceKey,
+} from "./sidebar/sidebarProviderFilters";
 
 // Settled-tail paging: recent history is the common lookup; the deep tail
 // stays behind an explicit Show more.
@@ -280,7 +298,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   variant: "card" | "slim";
   // Slim rows are either settled (action: un-settle) or merely quiet
   // (seen Ready threads — action: settle).
-  variantAction: "settle" | "unsettle";
+  variantAction: "settle" | "unsettle" | "unarchive";
   // False on environments whose server predates thread.settle/unsettle:
   // the lifecycle affordances hide entirely rather than fail on click.
   settlementSupported: boolean;
@@ -290,7 +308,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   environmentLabel: string | null;
   projectCwd: string | null;
   projectTitle: string | null;
-  providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
+  providerEntryByScopedInstanceKey: ReadonlyMap<string, ProviderInstanceEntry>;
   onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
   onThreadActivate: (threadRef: ScopedThreadRef) => void;
   onStartRename: (threadRef: ScopedThreadRef, title: string) => void;
@@ -302,6 +320,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   onContextMenu: (threadRef: ScopedThreadRef, position: { x: number; y: number }) => void;
   onSettle: (threadRef: ScopedThreadRef) => void;
   onUnsettle: (threadRef: ScopedThreadRef) => void;
+  onUnarchive: (threadRef: ScopedThreadRef) => void;
   onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
 }) {
   const {
@@ -316,6 +335,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     onThreadActivate,
     onThreadClick,
     onUnsettle,
+    onUnarchive,
     renamingTitle,
     thread,
     variant,
@@ -326,6 +346,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     [thread.environmentId, thread.id],
   );
   const threadKey = scopedThreadKey(threadRef);
+  const isArchived = thread.archivedAt !== null;
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isExplicitlyUnread = useUiStateStore(
     (state) => state.threadExplicitlyUnreadById[threadKey] === true,
@@ -423,7 +444,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   }, [onChangeRequestState, prState, threadKey]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
-  const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
+  const providerEntry =
+    props.providerEntryByScopedInstanceKey.get(
+      sidebarProviderInstanceKey(thread.environmentId, modelInstanceId),
+    ) ?? null;
   const driverKind = providerEntry?.driverKind ?? null;
   const selectedModel = providerEntry?.models.find(
     (model) => model.slug === thread.modelSelection.model,
@@ -450,9 +474,13 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
 
   const handleClick = useCallback(
     (event: ReactMouseEvent) => {
+      if (isArchived) {
+        event.preventDefault();
+        return;
+      }
       onThreadClick(event, threadRef);
     },
-    [onThreadClick, threadRef],
+    [isArchived, onThreadClick, threadRef],
   );
   const handleContextMenu = useCallback(
     (event: ReactMouseEvent) => {
@@ -466,20 +494,28 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       if (event.target !== event.currentTarget) return;
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
+      if (isArchived) return;
       onThreadActivate(threadRef);
     },
-    [onThreadActivate, threadRef],
+    [isArchived, onThreadActivate, threadRef],
   );
   const handleDoubleClick = useCallback(
     (event: ReactMouseEvent) => {
-      if (isRenaming || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      if (
+        isArchived ||
+        isRenaming ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
         return;
       }
       if ((event.target as HTMLElement).closest("button, a, input")) return;
       event.preventDefault();
       onStartRename(threadRef, thread.title);
     },
-    [isRenaming, onStartRename, thread.title, threadRef],
+    [isArchived, isRenaming, onStartRename, thread.title, threadRef],
   );
   const renameCommittedRef = useRef(false);
   useEffect(() => {
@@ -521,6 +557,14 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     },
     [onUnsettle, threadRef],
   );
+  const handleUnarchiveClick = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onUnarchive(threadRef);
+    },
+    [onUnarchive, threadRef],
+  );
   const handlePrClick = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
       if (pr?.url) openPrLink(event, pr.url);
@@ -533,8 +577,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // a useful hierarchy nor a reliable hover cue. Status now lives in the row
   // content; surface is reserved for interaction (hover, multi-select, route).
   const rowSurfaceClassName = cn(
-    "group/v2-row relative w-full cursor-pointer overflow-hidden rounded-md text-left outline-none select-none",
+    "group/v2-row relative w-full overflow-hidden rounded-md text-left outline-none select-none",
+    isArchived ? "cursor-default" : "cursor-pointer",
     variant === "card" && "backdrop-blur-[16px]",
+    isArchived && "opacity-65",
     props.isActive
       ? "bg-sidebar-row-active text-sidebar-foreground"
       : isSelected
@@ -620,8 +666,8 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
           <TooltipTrigger
             render={
               <div
-                role="button"
-                tabIndex={0}
+                role={isArchived ? undefined : "button"}
+                tabIndex={isArchived ? undefined : 0}
                 data-testid="sidebar-v2-row-slim"
                 className={cn(rowSurfaceClassName, "flex h-9 items-center gap-2.5 px-2.5")}
                 onClick={handleClick}
@@ -660,7 +706,16 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                     : threadTimeLabel(thread)}
                 </span>
               </span>
-              {!props.settlementSupported ? null : variantAction === "unsettle" ? (
+              {variantAction === "unarchive" ? (
+                <button
+                  type="button"
+                  aria-label="Unarchive thread"
+                  onClick={handleUnarchiveClick}
+                  className="absolute inset-y-0 right-0 inline-flex cursor-pointer items-center gap-1 rounded-md border border-sidebar-border bg-sidebar-row-hover px-2 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/v2-row:opacity-100 dark:border-transparent dark:inset-ring-1 dark:inset-ring-white/5"
+                >
+                  <ArchiveRestoreIcon className="size-3" />
+                </button>
+              ) : !props.settlementSupported ? null : variantAction === "unsettle" ? (
                 <button
                   type="button"
                   aria-label="Un-settle thread"
@@ -833,7 +888,8 @@ export default function SidebarV2() {
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const { settleThread, unsettleThread, deleteThread } = useThreadActions();
+  const sidebarThreadFilters = useClientSettings((s) => s.sidebarThreadFilters);
+  const { settleThread, unsettleThread, unarchiveThread, deleteThread } = useThreadActions();
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
@@ -872,6 +928,7 @@ export default function SidebarV2() {
     [],
   );
   const { environments } = useEnvironments();
+  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
@@ -933,15 +990,56 @@ export default function SidebarV2() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const providerEntryByInstanceId = useMemo(
+  const providerFilterState = useMemo(
+    () => buildSidebarProviderFilterState(serverConfigs),
+    [serverConfigs],
+  );
+  const filterProjectOptions = useMemo<SidebarFilterProjectOption[]>(
     () =>
-      new Map(
-        deriveProviderInstanceEntries(serverProviders).map(
-          (entry) => [entry.instanceId as string, entry] as const,
-        ),
+      projectGroups.map((project) => ({
+        id: project.projectKey,
+        label: project.displayName,
+        projectKeys: project.memberProjectRefs.map(scopedProjectKey),
+      })),
+    [projectGroups],
+  );
+  const selectedProjectGroups = useMemo(
+    () =>
+      sidebarThreadFilters.projectKeys.length === 0
+        ? []
+        : projectGroups.filter((project) =>
+            project.memberProjectRefs
+              .map(scopedProjectKey)
+              .every((projectKey) => sidebarThreadFilters.projectKeys.includes(projectKey)),
+          ),
+    [projectGroups, sidebarThreadFilters.projectKeys],
+  );
+  const archiveEnvironmentIds = useMemo(
+    () =>
+      sidebarThreadFilters.includeArchived
+        ? environments
+            .map((environment) => environment.environmentId)
+            .filter(
+              (environmentId) =>
+                sidebarThreadFilters.environmentIds.length === 0 ||
+                sidebarThreadFilters.environmentIds.includes(environmentId),
+            )
+        : [],
+    [environments, sidebarThreadFilters.environmentIds, sidebarThreadFilters.includeArchived],
+  );
+  const {
+    snapshots: archivedSnapshots,
+    isLoading: archiveLoading,
+    error: archiveError,
+  } = useArchivedThreadSnapshots(archiveEnvironmentIds);
+  const archivedThreads = useMemo(
+    () =>
+      archivedSnapshots.flatMap((entry) =>
+        entry.snapshot.threads
+          .filter((thread) => thread.archivedAt !== null)
+          .map((thread) => scopeThreadShell(entry.environmentId, thread)),
       ),
-    [serverProviders],
+    [archivedSnapshots],
   );
   const projectCwdByKey = useMemo(
     () =>
@@ -997,37 +1095,40 @@ export default function SidebarV2() {
     [],
   );
 
-  // Project scope: one menu above the list. Scoping filters the list without
-  // making the header width depend on the number or length of project names.
-  const [projectScopeKey, setProjectScopeKey] = useState<string | null>(null);
-  const scopedProjectGroup = useMemo(
-    () =>
-      projectScopeKey === null
-        ? null
-        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
-    [projectGroups, projectScopeKey],
+  const handleSidebarThreadFiltersChange = useCallback(
+    (filters: SidebarThreadFilters) => {
+      updateSettings({ sidebarThreadFilters: filters });
+    },
+    [updateSettings],
   );
-  const scopedProjectKeys = useMemo(
-    () =>
-      scopedProjectGroup === null
-        ? null
-        : new Set(
-            scopedProjectGroup.memberProjectRefs.map(
-              (projectRef) => `${projectRef.environmentId}:${projectRef.projectId}`,
-            ),
-          ),
-    [scopedProjectGroup],
+  const selectOnlyProjectGroup = useCallback(
+    (project: SidebarProjectSnapshot | null) => {
+      handleSidebarThreadFiltersChange({
+        ...sidebarThreadFilters,
+        projectKeys: project === null ? [] : project.memberProjectRefs.map(scopedProjectKey),
+      });
+    },
+    [handleSidebarThreadFiltersChange, sidebarThreadFilters],
   );
-  useEffect(() => {
-    if (projectScopeKey !== null && scopedProjectGroup === null) {
-      setProjectScopeKey(null);
-    }
-  }, [projectScopeKey, scopedProjectGroup]);
-  // Scope flips drop the selection: rows selected under the old scope may be
-  // hidden now, and bulk actions must never count or touch invisible rows.
+  const singleSelectedProjectGroup =
+    selectedProjectGroups.length === 1 &&
+    selectedProjectGroups[0]!.memberProjectRefs.length === sidebarThreadFilters.projectKeys.length
+      ? selectedProjectGroups[0]!
+      : null;
+  const selectedProjectCount =
+    selectedProjectGroups.length || sidebarThreadFilters.projectKeys.length;
+  const projectFilterLabel =
+    sidebarThreadFilters.projectKeys.length === 0
+      ? "All projects"
+      : singleSelectedProjectGroup
+        ? singleSelectedProjectGroup.displayName
+        : `${selectedProjectCount} ${selectedProjectCount === 1 ? "project" : "projects"}`;
+
+  // Filter changes drop the selection: rows selected under the old filter may
+  // be hidden now, and bulk actions must never count or touch invisible rows.
   useEffect(() => {
     clearSelection();
-  }, [clearSelection, projectScopeKey]);
+  }, [clearSelection, sidebarThreadFilters]);
 
   const handleRemoveProjectMembers = useCallback(
     async (projectGroup: SidebarProjectSnapshot, members: readonly SidebarProjectGroupMember[]) => {
@@ -1124,11 +1225,25 @@ export default function SidebarV2() {
         draftStore.clearProjectDraftThreadId(projectRef);
       }
 
+      const removedProjectKeys = new Set(
+        members.map((member) => scopedProjectKey(scopeProjectRef(member.environmentId, member.id))),
+      );
+      if (
+        sidebarThreadFilters.projectKeys.some((projectKey) => removedProjectKeys.has(projectKey))
+      ) {
+        handleSidebarThreadFiltersChange({
+          ...sidebarThreadFilters,
+          projectKeys: sidebarThreadFilters.projectKeys.filter(
+            (projectKey) => !removedProjectKeys.has(projectKey),
+          ),
+        });
+      }
+
       if (shouldNavigate) {
         void router.navigate({ to: "/" });
       }
     },
-    [deleteProject, router, threads],
+    [deleteProject, handleSidebarThreadFiltersChange, router, sidebarThreadFilters, threads],
   );
 
   const renameProjectMember = useCallback(
@@ -1181,22 +1296,53 @@ export default function SidebarV2() {
     [],
   );
 
-  // Settled threads stay in the live shell stream (settled ≠ archived), so
-  // the partition works directly off live shells: no archived-snapshot
-  // merging, no optimistic holds. Archived threads remain hidden here —
-  // archive keeps its original "remove from sidebar" meaning.
-  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
-  const { activeThreads, settledThreads } = useMemo(() => {
-    const now = `${nowMinute}:00.000Z`;
-    const visible = threads.filter(
-      (thread) =>
-        thread.archivedAt === null &&
-        (scopedProjectKeys === null ||
-          scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
+  const threadsWithArchived = useMemo(() => {
+    const byKey = new Map(
+      threads.map(
+        (thread) =>
+          [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
+      ),
     );
+    for (const thread of archivedThreads) {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      if (!byKey.has(threadKey)) {
+        byKey.set(threadKey, thread);
+      }
+    }
+    return [...byKey.values()];
+  }, [archivedThreads, threads]);
+  const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
+  const threadExplicitlyUnreadById = useUiStateStore((state) => state.threadExplicitlyUnreadById);
+  const filtersActive = hasActiveSidebarThreadFilters(sidebarThreadFilters);
+
+  // V2 keeps its active/settled visual partition after applying the same
+  // persisted filter predicate as the classic sidebar. Archived snapshots
+  // form a third, explicit tail only while the Archived filter is enabled.
+  const { activeThreads, settledThreads, filteredArchivedThreads } = useMemo(() => {
+    const now = `${nowMinute}:00.000Z`;
+    const visible = threadsWithArchived.filter((thread) => {
+      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      const providerInstanceId =
+        thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+      return matchesSidebarThreadFilters({
+        thread,
+        lastVisitedAt: threadLastVisitedAtById[threadKey],
+        isExplicitlyUnread: threadExplicitlyUnreadById[threadKey],
+        providerDriverKind:
+          providerFilterState.driverKindByScopedInstanceKey.get(
+            sidebarProviderInstanceKey(thread.environmentId, providerInstanceId),
+          ) ?? null,
+        filters: sidebarThreadFilters,
+      });
+    });
     const active: EnvironmentThreadShell[] = [];
     const settled: EnvironmentThreadShell[] = [];
+    const archived: EnvironmentThreadShell[] = [];
     for (const thread of visible) {
+      if (thread.archivedAt !== null) {
+        archived.push(thread);
+        continue;
+      }
       // Threads on servers without the settlement capability (old server,
       // or descriptor not loaded yet) never classify as settled: the user
       // could neither un-settle nor pin them, so auto-settling them would
@@ -1217,14 +1363,22 @@ export default function SidebarV2() {
     return {
       activeThreads: sortThreadsForSidebarV2(active),
       settledThreads: sortSettledThreadsForSidebarV2(settled),
+      filteredArchivedThreads: archived.toSorted(
+        (left, right) =>
+          firstValidTimestampMs(right.latestUserMessageAt, right.updatedAt) -
+          firstValidTimestampMs(left.latestUserMessageAt, left.updatedAt),
+      ),
     };
   }, [
     autoSettleAfterDays,
     changeRequestStateByKey,
     nowMinute,
-    scopedProjectKeys,
+    providerFilterState.driverKindByScopedInstanceKey,
     serverConfigs,
-    threads,
+    sidebarThreadFilters,
+    threadExplicitlyUnreadById,
+    threadLastVisitedAtById,
+    threadsWithArchived,
   ]);
 
   // The settled tail renders in pages: history shouldn't dominate the
@@ -1232,7 +1386,7 @@ export default function SidebarV2() {
   // filter context changes so a scope/search flip never inherits a deep
   // page state.
   const [settledVisibleCount, setSettledVisibleCount] = useState(SETTLED_TAIL_INITIAL_COUNT);
-  const settledResetKey = projectScopeKey ?? "all";
+  const settledResetKey = JSON.stringify(sidebarThreadFilters);
   const lastSettledResetKeyRef = useRef(settledResetKey);
   if (lastSettledResetKeyRef.current !== settledResetKey) {
     lastSettledResetKeyRef.current = settledResetKey;
@@ -1249,14 +1403,14 @@ export default function SidebarV2() {
   );
 
   const orderedThreads = useMemo(
-    () => [...activeThreads, ...visibleSettledThreads],
-    [activeThreads, visibleSettledThreads],
+    () => [...activeThreads, ...visibleSettledThreads, ...filteredArchivedThreads],
+    [activeThreads, filteredArchivedThreads, visibleSettledThreads],
   );
   const orderedThreadKeys = useMemo(
     () =>
-      orderedThreads.map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      ),
+      orderedThreads
+        .filter((thread) => thread.archivedAt === null)
+        .map((thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
     [orderedThreads],
   );
   // Rows call back into the click handler without carrying the ordered list as
@@ -1295,6 +1449,15 @@ export default function SidebarV2() {
   );
   const settledThreadKeysRef = useRef(settledThreadKeys);
   settledThreadKeysRef.current = settledThreadKeys;
+  const archivedThreadKeys = useMemo(
+    () =>
+      new Set(
+        filteredArchivedThreads.map((thread) =>
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        ),
+      ),
+    [filteredArchivedThreads],
+  );
 
   const jumpLabelByKey = useMemo(() => {
     const mapping = new Map<string, string>();
@@ -1470,6 +1633,24 @@ export default function SidebarV2() {
     },
     [unsettleThread],
   );
+  const attemptUnarchive = useCallback(
+    (threadRef: ScopedThreadRef) => {
+      void (async () => {
+        const result = await unarchiveThread(threadRef);
+        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to unarchive thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+      })();
+    },
+    [unarchiveThread],
+  );
 
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
   const handleMultiSelectContextMenu = useCallback(
@@ -1581,6 +1762,7 @@ export default function SidebarV2() {
         }
         const thread = threadByKeyRef.current.get(threadKey);
         if (!thread) return;
+        const isArchived = thread.archivedAt !== null;
         // Un-settle works on every settled row: for explicit settles it
         // clears the override, for auto-settled rows it pins the thread
         // active until real activity clears the pin. Environments without
@@ -1591,18 +1773,23 @@ export default function SidebarV2() {
         const isSettled = settledThreadKeysRef.current.has(threadKey);
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
-            [
-              ...(supportsSettlement
-                ? [
-                    isSettled
-                      ? { id: "unsettle", label: "Un-settle thread" }
-                      : { id: "settle", label: "Settle thread" },
-                  ]
-                : []),
-              { id: "rename", label: "Rename thread" },
-              { id: "mark-unread", label: "Mark unread" },
-              { id: "delete", label: "Delete", destructive: true, icon: "trash" },
-            ],
+            isArchived
+              ? [
+                  { id: "unarchive", label: "Unarchive thread" },
+                  { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+                ]
+              : [
+                  ...(supportsSettlement
+                    ? [
+                        isSettled
+                          ? { id: "unsettle", label: "Un-settle thread" }
+                          : { id: "settle", label: "Settle thread" },
+                      ]
+                    : []),
+                  { id: "rename", label: "Rename thread" },
+                  { id: "mark-unread", label: "Mark unread" },
+                  { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+                ],
             position,
           ),
         );
@@ -1613,6 +1800,9 @@ export default function SidebarV2() {
             return;
           case "unsettle":
             attemptUnsettle(threadRef);
+            return;
+          case "unarchive":
+            attemptUnarchive(threadRef);
             return;
           case "rename":
             startThreadRename(threadRef, thread.title);
@@ -1653,6 +1843,7 @@ export default function SidebarV2() {
     },
     [
       attemptSettle,
+      attemptUnarchive,
       attemptUnsettle,
       confirmThreadDelete,
       deleteThread,
@@ -1760,6 +1951,19 @@ export default function SidebarV2() {
   const newThreadShortcutLabel =
     shortcutLabelForCommand(keybindings, "chat.newLocal") ??
     shortcutLabelForCommand(keybindings, "chat.new");
+  const showMoreSettledRow =
+    hiddenSettledCount > 0 ? (
+      <li key="show-more-settled" className="list-none">
+        <button
+          type="button"
+          onClick={showMoreSettled}
+          className="mt-1 flex h-[30px] w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border font-mono text-[11px] text-muted-foreground transition-colors hover:border-solid hover:border-input hover:bg-background/45 hover:text-foreground dark:border-white/15 dark:hover:border-white/30 dark:hover:bg-transparent"
+        >
+          Show {Math.min(hiddenSettledCount, SETTLED_TAIL_PAGE_COUNT)} more
+          <span className="text-muted-foreground/50">({hiddenSettledCount} settled hidden)</span>
+        </button>
+      </li>
+    ) : null;
   return (
     <>
       <SidebarChromeHeader isElectron={isElectron} />
@@ -1822,50 +2026,61 @@ export default function SidebarV2() {
                   aria-label="Filter threads by project"
                   className="flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 text-left text-sm font-medium text-sidebar-muted-foreground outline-none hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                 >
-                  {scopedProjectGroup ? (
+                  {singleSelectedProjectGroup ? (
                     <ProjectFavicon
-                      environmentId={scopedProjectGroup.environmentId}
-                      cwd={scopedProjectGroup.workspaceRoot}
+                      environmentId={singleSelectedProjectGroup.environmentId}
+                      cwd={singleSelectedProjectGroup.workspaceRoot}
                       className="size-4 shrink-0"
                     />
                   ) : (
                     <FolderIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
                   )}
-                  <span className="min-w-0 flex-1 truncate">
-                    {scopedProjectGroup?.displayName ?? "All projects"}
-                  </span>
+                  <span className="min-w-0 flex-1 truncate">{projectFilterLabel}</span>
                   <ChevronDownIcon className="size-4 shrink-0 text-sidebar-muted-foreground/70" />
                 </MenuTrigger>
                 <MenuPopup align="start" className="w-(--anchor-width)">
-                  <MenuRadioGroup
-                    value={projectScopeKey ?? "all"}
-                    onValueChange={(value) =>
-                      setProjectScopeKey(value === "all" ? null : (value as string))
-                    }
+                  <MenuItem
+                    closeOnClick
+                    className="h-8 min-h-8 px-2 py-0 text-sm font-medium"
+                    onClick={() => selectOnlyProjectGroup(null)}
                   >
-                    <MenuRadioItem
-                      value="all"
-                      closeOnClick
-                      className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
-                    >
-                      <FolderIcon className="size-4 shrink-0" />
-                      <span className="min-w-0 truncate text-sm">All projects</span>
-                    </MenuRadioItem>
-                    {projectGroups.map((project) => {
-                      const scopeKey = project.projectKey;
-                      return (
-                        <MenuRadioItem
-                          key={scopeKey}
-                          value={scopeKey}
-                          closeOnClick
-                          className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
-                        >
+                    <FolderIcon className="size-4 shrink-0" />
+                    <span className="min-w-0 truncate text-sm">All projects</span>
+                  </MenuItem>
+                  <MenuSeparator />
+                  {projectGroups.map((project) => {
+                    const projectKeys = project.memberProjectRefs.map(scopedProjectKey);
+                    const checked =
+                      projectKeys.length > 0 &&
+                      projectKeys.every((projectKey) =>
+                        sidebarThreadFilters.projectKeys.includes(projectKey),
+                      );
+                    return (
+                      <MenuCheckboxItem
+                        key={project.projectKey}
+                        checked={checked}
+                        closeOnClick={false}
+                        className="h-8 min-h-8 py-0 text-sm font-medium"
+                        onCheckedChange={(nextChecked) => {
+                          handleSidebarThreadFiltersChange({
+                            ...sidebarThreadFilters,
+                            projectKeys: toggleSidebarFilterValues(
+                              sidebarThreadFilters.projectKeys,
+                              projectKeys,
+                              nextChecked,
+                            ),
+                          });
+                        }}
+                      >
+                        <span className="flex min-w-0 items-center gap-2">
                           <ProjectFavicon
                             environmentId={project.environmentId}
                             cwd={project.workspaceRoot}
                             className="size-4 shrink-0"
                           />
-                          <span className="min-w-0 truncate text-sm">{project.displayName}</span>
+                          <span className="min-w-0 flex-1 truncate text-sm">
+                            {project.displayName}
+                          </span>
                           <button
                             type="button"
                             aria-label={`Project actions for ${project.displayName}`}
@@ -1878,12 +2093,23 @@ export default function SidebarV2() {
                           >
                             <EllipsisIcon className="size-3.5" />
                           </button>
-                        </MenuRadioItem>
-                      );
-                    })}
-                  </MenuRadioGroup>
+                        </span>
+                      </MenuCheckboxItem>
+                    );
+                  })}
                 </MenuPopup>
               </Menu>
+              <SidebarFilterMenu
+                filters={sidebarThreadFilters}
+                environments={environments}
+                projects={filterProjectOptions}
+                providerSources={providerFilterState.sources}
+                archiveLoading={archiveLoading}
+                archiveError={archiveError}
+                onFiltersChange={handleSidebarThreadFiltersChange}
+                showGroupByProject={false}
+                triggerClassName="size-8 min-w-8 bg-transparent p-0 text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+              />
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -1917,12 +2143,13 @@ export default function SidebarV2() {
             <ul ref={attachListAutoAnimateRef} role="list" className="flex flex-col gap-px">
               {orderedThreads.flatMap((thread, threadIndex) => {
                 const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-                const isSettledRow = settledThreadKeys.has(threadKey);
+                const isArchivedRow = archivedThreadKeys.has(threadKey);
+                const isSettledRow = !isArchivedRow && settledThreadKeys.has(threadKey);
                 // Settled is the ONLY thing that collapses a row: every
                 // not-settled thread is a full card. Density comes from users
                 // (or the auto rules) actually settling work, not from the
                 // sidebar second-guessing what still matters.
-                const isCard = !isSettledRow;
+                const isCard = !isSettledRow && !isArchivedRow;
                 const previousThread = threadIndex > 0 ? orderedThreads[threadIndex - 1] : null;
                 const previousWasCard =
                   previousThread != null &&
@@ -1932,6 +2159,14 @@ export default function SidebarV2() {
                     ),
                   );
                 const showSettledGap = !isCard && previousWasCard;
+                const showArchivedGap =
+                  isArchivedRow &&
+                  (previousThread == null ||
+                    !archivedThreadKeys.has(
+                      scopedThreadKey(
+                        scopeThreadRef(previousThread.environmentId, previousThread.id),
+                      ),
+                    ));
                 const row = (
                   <SidebarV2Row
                     // Keyed per variant on purpose: when a thread settles, the
@@ -1944,7 +2179,9 @@ export default function SidebarV2() {
                     variant={isCard ? "card" : "slim"}
                     // Every settled row can un-settle: explicit settles clear
                     // the override, auto-settled rows get pinned active.
-                    variantAction={isSettledRow ? "unsettle" : "settle"}
+                    variantAction={
+                      isArchivedRow ? "unarchive" : isSettledRow ? "unsettle" : "settle"
+                    }
                     settlementSupported={
                       serverConfigs.get(thread.environmentId)?.environment.capabilities
                         .threadSettlement === true
@@ -1960,7 +2197,7 @@ export default function SidebarV2() {
                       projectDisplayNameByKey.get(`${thread.environmentId}:${thread.projectId}`) ??
                       null
                     }
-                    providerEntryByInstanceId={providerEntryByInstanceId}
+                    providerEntryByScopedInstanceKey={providerFilterState.entryByScopedInstanceKey}
                     onThreadClick={handleThreadClick}
                     onThreadActivate={navigateToThread}
                     onStartRename={startThreadRename}
@@ -1972,10 +2209,30 @@ export default function SidebarV2() {
                     onContextMenu={handleThreadContextMenu}
                     onSettle={attemptSettle}
                     onUnsettle={attemptUnsettle}
+                    onUnarchive={attemptUnarchive}
                     onChangeRequestState={handleChangeRequestState}
                   />
                 );
-                if (!showSettledGap) return [row];
+                if (showArchivedGap) {
+                  return [
+                    ...(showMoreSettledRow ? [showMoreSettledRow] : []),
+                    <li
+                      key="archived-divider"
+                      aria-hidden
+                      data-thread-selection-safe
+                      className="list-none"
+                    >
+                      <div className="mb-1 mt-3 flex items-center gap-2 px-2.5">
+                        <span className="text-xs font-medium text-muted-foreground/50">
+                          Archived
+                        </span>
+                        <span className="h-px flex-1 bg-sidebar-border/60" />
+                      </div>
+                    </li>,
+                    row,
+                  ];
+                }
+                if (!showSettledGap || isArchivedRow) return [row];
                 // The divider is its own keyed list item (not part of the first
                 // settled row): it keeps one stable DOM node at the boundary,
                 // so settling a thread slides it instead of teleporting it
@@ -1996,20 +2253,7 @@ export default function SidebarV2() {
                   row,
                 ];
               })}
-              {hiddenSettledCount > 0 ? (
-                <li className="list-none">
-                  <button
-                    type="button"
-                    onClick={showMoreSettled}
-                    className="mt-1 flex h-[30px] w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border font-mono text-[11px] text-muted-foreground transition-colors hover:border-solid hover:border-input hover:bg-background/45 hover:text-foreground dark:border-white/15 dark:hover:border-white/30 dark:hover:bg-transparent"
-                  >
-                    Show {Math.min(hiddenSettledCount, SETTLED_TAIL_PAGE_COUNT)} more
-                    <span className="text-muted-foreground/50">
-                      ({hiddenSettledCount} settled hidden)
-                    </span>
-                  </button>
-                </li>
-              ) : null}
+              {filteredArchivedThreads.length === 0 ? showMoreSettledRow : null}
             </ul>
           </TooltipProvider>
           {orderedThreads.length === 0 ? (
@@ -2026,8 +2270,8 @@ export default function SidebarV2() {
                     Add project
                   </button>
                 </>
-              ) : scopedProjectGroup ? (
-                `No threads in ${scopedProjectGroup.displayName} yet`
+              ) : filtersActive ? (
+                "No threads match these filters"
               ) : (
                 "No threads yet"
               )}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -98,6 +98,7 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
+  resolveSidebarV2TopStatus,
   resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
@@ -336,6 +337,11 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // flag must not light up every historical thread as unread.
   const isUnread = isExplicitlyUnread || hasUnseenCompletion({ ...thread, lastVisitedAt });
   const status = resolveSidebarV2Status(thread);
+  const topStatusKind = resolveSidebarV2TopStatus({
+    status,
+    isExplicitlyUnread,
+    isUnread,
+  });
   // In-flight rows (working, or waiting on approval/input) fade as a whole:
   // there is nothing for the user to do yet, so prominence is reserved for
   // rows that need a human — done (unread), read-but-unsettled, and failed.
@@ -348,44 +354,45 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   // Status hues follow the system-wide convention set by sidebar v1 and the
   // mobile Live Activity/widgets (amber approval, indigo input, sky working)
   // so a thread reads the same color everywhere it surfaces.
-  const topStatus = isExplicitlyUnread
-    ? {
-        label: "Unread",
-        icon: null,
-        className: "text-blue-600 dark:text-blue-300",
-      }
-    : status === "working"
+  const topStatus =
+    topStatusKind === "working"
       ? {
           label: "Working",
           icon: "working" as const,
           className:
             "animate-sidebar-working-text text-sky-600 motion-reduce:animate-none dark:text-sky-400",
         }
-      : status === "approval"
+      : topStatusKind === "approval"
         ? {
             label: "Approval",
             icon: null,
             className: "text-amber-700 dark:text-amber-300",
           }
-        : status === "input"
+        : topStatusKind === "input"
           ? {
               label: "Input",
               icon: null,
               className: "text-indigo-600 dark:text-indigo-300",
             }
-          : status === "failed"
+          : topStatusKind === "failed"
             ? {
                 label: "Failed",
                 icon: null,
                 className: "text-red-700 dark:text-red-300",
               }
-            : isUnread
+            : topStatusKind === "unread"
               ? {
-                  label: "Done",
-                  icon: "done" as const,
-                  className: "text-emerald-700 dark:text-emerald-300",
+                  label: "Unread",
+                  icon: null,
+                  className: "text-blue-600 dark:text-blue-300",
                 }
-              : null;
+              : topStatusKind === "done"
+                ? {
+                    label: "Done",
+                    icon: "done" as const,
+                    className: "text-emerald-700 dark:text-emerald-300",
+                  }
+                : null;
 
   const gitCwd = thread.worktreePath ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -225,8 +225,10 @@ export function ThreadStatusLabel({
  */
 export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummary }) {
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
-  const lastVisitedAt = useUiStateStore(
-    (state) => state.threadLastVisitedAtById[scopedThreadKey(threadRef)],
+  const threadKey = scopedThreadKey(threadRef);
+  const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isExplicitlyUnread = useUiStateStore(
+    (state) => state.threadExplicitlyUnreadById[threadKey] === true,
   );
   const threadProject = useProject(
     useMemo(
@@ -254,6 +256,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
     thread: {
       ...thread,
       lastVisitedAt,
+      isExplicitlyUnread,
     },
   });
 

--- a/apps/web/src/components/sidebar/SidebarFilterMenu.tsx
+++ b/apps/web/src/components/sidebar/SidebarFilterMenu.tsx
@@ -1,0 +1,339 @@
+import {
+  DEFAULT_SIDEBAR_THREAD_FILTERS,
+  SIDEBAR_THREAD_FILTER_STATUSES,
+  type SidebarThreadFilters,
+  type SidebarThreadFilterStatus,
+} from "@t3tools/contracts/settings";
+import type { EnvironmentId, ProviderDriverKind } from "@t3tools/contracts";
+import { ListFilterIcon, LoaderIcon, TriangleAlertIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { hasActiveSidebarThreadFilters } from "../Sidebar.logic";
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuItem,
+  MenuPopup,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "../ui/menu";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+const SIDEBAR_THREAD_FILTER_STATUS_LABELS: Record<SidebarThreadFilterStatus, string> = {
+  needs_attention: "Needs attention",
+  unread: "Unread",
+  working: "Working",
+  done: "Done",
+};
+
+export interface SidebarFilterProjectOption {
+  readonly id: string;
+  readonly label: string;
+  readonly projectKeys: readonly string[];
+}
+
+export interface SidebarFilterEnvironmentOption {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}
+
+export interface SidebarFilterProviderOption {
+  readonly driverKind: ProviderDriverKind;
+  readonly label: string;
+}
+
+export function toggleSidebarFilterValue<T>(values: readonly T[], value: T, checked: boolean): T[] {
+  if (checked) {
+    return values.includes(value) ? [...values] : [...values, value];
+  }
+  return values.filter((candidate) => candidate !== value);
+}
+
+export function toggleSidebarFilterValues<T>(
+  values: readonly T[],
+  toggledValues: readonly T[],
+  checked: boolean,
+): T[] {
+  const next = new Set(values);
+  for (const value of toggledValues) {
+    if (checked) {
+      next.add(value);
+    } else {
+      next.delete(value);
+    }
+  }
+  return [...next];
+}
+
+export function SidebarFilterMenu({
+  filters,
+  environments,
+  projects,
+  providerSources,
+  archiveLoading,
+  archiveError,
+  onFiltersChange,
+  showGroupByProject = true,
+  triggerClassName,
+}: {
+  filters: SidebarThreadFilters;
+  environments: ReadonlyArray<SidebarFilterEnvironmentOption>;
+  projects: ReadonlyArray<SidebarFilterProjectOption>;
+  providerSources: ReadonlyArray<SidebarFilterProviderOption>;
+  archiveLoading: boolean;
+  archiveError: string | null;
+  onFiltersChange: (filters: SidebarThreadFilters) => void;
+  showGroupByProject?: boolean;
+  triggerClassName?: string;
+}) {
+  const filtersActive = hasActiveSidebarThreadFilters(filters);
+  const statusFilterActive =
+    filters.statuses.length !== SIDEBAR_THREAD_FILTER_STATUSES.length ||
+    !SIDEBAR_THREAD_FILTER_STATUSES.every((status) => filters.statuses.includes(status));
+
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              aria-label="Filter sidebar threads"
+              data-testid="sidebar-filter-trigger"
+              className={cn(
+                "relative inline-flex h-6 min-w-6 cursor-pointer items-center justify-center rounded-md px-[calc(--spacing(1)-1px)] transition-colors hover:bg-accent hover:text-foreground",
+                filtersActive ? "text-primary" : "text-muted-foreground/60",
+                triggerClassName,
+              )}
+            />
+          }
+        >
+          <ListFilterIcon className="size-3.5" />
+          {filtersActive ? (
+            <span className="absolute right-0.5 bottom-0.5 size-1.5 rounded-full bg-primary ring-1 ring-sidebar" />
+          ) : null}
+        </TooltipTrigger>
+        <TooltipPopup side="right">
+          {filtersActive ? "Sidebar filters are active" : "Filter sidebar threads"}
+        </TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="end" side="bottom" className="w-60">
+        {showGroupByProject ? (
+          <>
+            <MenuCheckboxItem
+              checked={filters.groupByProject}
+              closeOnClick={false}
+              className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+              onCheckedChange={(checked) => {
+                onFiltersChange({ ...filters, groupByProject: checked });
+              }}
+            >
+              Group by project
+            </MenuCheckboxItem>
+            <MenuSeparator className="my-0.5" />
+          </>
+        ) : null}
+        <div className="flex items-center justify-between px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          <span>Filters</span>
+          <MenuItem
+            closeOnClick={false}
+            className="min-h-0 cursor-pointer p-0 text-[11px] text-muted-foreground hover:text-foreground sm:min-h-0 sm:text-[11px]"
+            disabled={!filtersActive}
+            onClick={() => {
+              onFiltersChange({
+                ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+                groupByProject: filters.groupByProject,
+              });
+            }}
+          >
+            Reset
+          </MenuItem>
+        </div>
+        <MenuCheckboxItem
+          checked={filters.recentOnly}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, recentOnly: checked });
+          }}
+        >
+          <span className="flex min-w-0 items-center justify-between gap-3">
+            <span>Recent</span>
+            <span className="text-[10px] text-muted-foreground">Last 7 days</span>
+          </span>
+        </MenuCheckboxItem>
+        <MenuCheckboxItem
+          checked={filters.attentionOnly}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, attentionOnly: checked });
+          }}
+        >
+          <span className="flex min-w-0 items-center justify-between gap-3">
+            <span>Inbox</span>
+            <span className="text-[10px] text-muted-foreground">Unread + needs attention</span>
+          </span>
+        </MenuCheckboxItem>
+        <MenuSeparator className="my-0.5" />
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Status</span>
+            {statusFilterActive ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {SIDEBAR_THREAD_FILTER_STATUSES.map((status) => (
+              <MenuCheckboxItem
+                key={status}
+                checked={filters.statuses.includes(status)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    statuses: toggleSidebarFilterValue(filters.statuses, status, checked),
+                  });
+                }}
+              >
+                {SIDEBAR_THREAD_FILTER_STATUS_LABELS[status]}
+              </MenuCheckboxItem>
+            ))}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Project</span>
+            {filters.projectKeys.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-56">
+            {projects.map((project) => {
+              const checked =
+                filters.projectKeys.length > 0 &&
+                project.projectKeys.every((projectKey) => filters.projectKeys.includes(projectKey));
+              return (
+                <MenuCheckboxItem
+                  key={project.id}
+                  checked={checked}
+                  closeOnClick={false}
+                  className="sm:text-xs"
+                  onCheckedChange={(nextChecked) => {
+                    onFiltersChange({
+                      ...filters,
+                      projectKeys: toggleSidebarFilterValues(
+                        filters.projectKeys,
+                        project.projectKeys,
+                        nextChecked,
+                      ),
+                    });
+                  }}
+                >
+                  <span className="truncate">{project.label}</span>
+                </MenuCheckboxItem>
+              );
+            })}
+            {projects.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No projects
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Environment</span>
+            {filters.environmentIds.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {environments.map((environment) => (
+              <MenuCheckboxItem
+                key={environment.environmentId}
+                checked={filters.environmentIds.includes(environment.environmentId)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    environmentIds: toggleSidebarFilterValue(
+                      filters.environmentIds,
+                      environment.environmentId,
+                      checked,
+                    ),
+                  });
+                }}
+              >
+                {environment.label}
+              </MenuCheckboxItem>
+            ))}
+            {environments.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No environments
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSub>
+          <MenuSubTrigger className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs">
+            <span>Source</span>
+            {filters.sources.length > 0 ? (
+              <span className="ml-auto size-1.5 rounded-full bg-primary" />
+            ) : null}
+          </MenuSubTrigger>
+          <MenuSubPopup className="min-w-48">
+            {providerSources.map((source) => (
+              <MenuCheckboxItem
+                key={source.driverKind}
+                checked={filters.sources.includes(source.driverKind)}
+                closeOnClick={false}
+                className="sm:text-xs"
+                onCheckedChange={(checked) => {
+                  onFiltersChange({
+                    ...filters,
+                    sources: toggleSidebarFilterValue(filters.sources, source.driverKind, checked),
+                  });
+                }}
+              >
+                {source.label}
+              </MenuCheckboxItem>
+            ))}
+            {providerSources.length === 0 ? (
+              <MenuItem disabled className="sm:text-xs">
+                No providers
+              </MenuItem>
+            ) : null}
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSeparator className="my-0.5" />
+        <MenuCheckboxItem
+          checked={filters.includeArchived}
+          closeOnClick={false}
+          className="min-h-6 py-0.5 sm:min-h-6 sm:text-xs"
+          onCheckedChange={(checked) => {
+            onFiltersChange({ ...filters, includeArchived: checked });
+          }}
+        >
+          <span className="flex items-center gap-2">
+            Archived
+            {archiveLoading ? <LoaderIcon className="size-3 animate-spin" /> : null}
+            {archiveError ? (
+              <span
+                role="img"
+                aria-label={`Archived threads failed to load: ${archiveError}`}
+                title={archiveError}
+              >
+                <TriangleAlertIcon aria-hidden className="size-3 text-warning" />
+              </span>
+            ) : null}
+          </span>
+        </MenuCheckboxItem>
+      </MenuPopup>
+    </Menu>
+  );
+}

--- a/apps/web/src/components/sidebar/sidebarProviderFilters.test.ts
+++ b/apps/web/src/components/sidebar/sidebarProviderFilters.test.ts
@@ -1,0 +1,70 @@
+import {
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerConfig,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildSidebarProviderFilterState,
+  sidebarProviderInstanceKey,
+} from "./sidebarProviderFilters";
+
+function provider(instanceId: string, driverKind: string): ServerProvider {
+  return {
+    instanceId: ProviderInstanceId.make(instanceId),
+    driver: ProviderDriverKind.make(driverKind),
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-07-23T00:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+  };
+}
+
+function config(providers: readonly ServerProvider[]): ServerConfig {
+  return { providers } as ServerConfig;
+}
+
+describe("buildSidebarProviderFilterState", () => {
+  it("keeps provider instance lookups scoped to their environment", () => {
+    const localEnvironmentId = EnvironmentId.make("environment-local");
+    const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+    const state = buildSidebarProviderFilterState(
+      new Map([
+        [localEnvironmentId, config([provider("shared", "codex")])],
+        [remoteEnvironmentId, config([provider("shared", "claudeAgent")])],
+      ]),
+    );
+
+    expect(
+      state.driverKindByScopedInstanceKey.get(
+        sidebarProviderInstanceKey(localEnvironmentId, ProviderInstanceId.make("shared")),
+      ),
+    ).toBe("codex");
+    expect(
+      state.driverKindByScopedInstanceKey.get(
+        sidebarProviderInstanceKey(remoteEnvironmentId, ProviderInstanceId.make("shared")),
+      ),
+    ).toBe("claudeAgent");
+  });
+
+  it("includes provider sources that exist only on remote environments", () => {
+    const localEnvironmentId = EnvironmentId.make("environment-local");
+    const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+    const state = buildSidebarProviderFilterState(
+      new Map([
+        [localEnvironmentId, config([provider("codex", "codex")])],
+        [remoteEnvironmentId, config([provider("grok-remote", "grok")])],
+      ]),
+    );
+
+    expect(state.sources.map((source) => source.driverKind)).toEqual(["codex", "grok"]);
+  });
+});

--- a/apps/web/src/components/sidebar/sidebarProviderFilters.ts
+++ b/apps/web/src/components/sidebar/sidebarProviderFilters.ts
@@ -1,0 +1,46 @@
+import {
+  PROVIDER_DISPLAY_NAMES,
+  type EnvironmentId,
+  type ProviderDriverKind,
+  type ServerConfig,
+} from "@t3tools/contracts";
+
+import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../../providerInstances";
+import { sidebarProviderInstanceKey } from "../Sidebar.logic";
+import type { SidebarFilterProviderOption } from "./SidebarFilterMenu";
+
+export { sidebarProviderInstanceKey } from "../Sidebar.logic";
+
+export interface SidebarProviderFilterState {
+  readonly entryByScopedInstanceKey: ReadonlyMap<string, ProviderInstanceEntry>;
+  readonly driverKindByScopedInstanceKey: ReadonlyMap<string, ProviderDriverKind>;
+  readonly sources: ReadonlyArray<SidebarFilterProviderOption>;
+}
+
+export function buildSidebarProviderFilterState(
+  serverConfigs: ReadonlyMap<EnvironmentId, ServerConfig>,
+): SidebarProviderFilterState {
+  const entryByScopedInstanceKey = new Map<string, ProviderInstanceEntry>();
+  const driverKindByScopedInstanceKey = new Map<string, ProviderDriverKind>();
+  const labelsByDriverKind = new Map<ProviderDriverKind, string>();
+
+  for (const [environmentId, config] of serverConfigs) {
+    for (const entry of deriveProviderInstanceEntries(config.providers)) {
+      const key = sidebarProviderInstanceKey(environmentId, entry.instanceId);
+      entryByScopedInstanceKey.set(key, entry);
+      driverKindByScopedInstanceKey.set(key, entry.driverKind);
+      if (!labelsByDriverKind.has(entry.driverKind)) {
+        labelsByDriverKind.set(
+          entry.driverKind,
+          PROVIDER_DISPLAY_NAMES[entry.driverKind] ?? entry.displayName,
+        );
+      }
+    }
+  }
+
+  return {
+    entryByScopedInstanceKey,
+    driverKindByScopedInstanceKey,
+    sources: [...labelsByDriverKind].map(([driverKind, label]) => ({ driverKind, label })),
+  };
+}

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -103,7 +103,9 @@ function MenuCheckboxItem({
       checked={checked}
       className={cn(
         "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default items-center gap-2 rounded-sm py-1 ps-2 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        variant === "switch" ? "grid-cols-[1fr_auto] gap-4 pe-1.5" : "grid-cols-[1rem_1fr] pe-4",
+        variant === "switch"
+          ? "grid-cols-[1fr_auto] gap-4 pe-1.5"
+          : "grid-cols-[minmax(0,1fr)_1rem] ps-3 pe-2",
         className,
       )}
       data-slot="menu-checkbox-item"
@@ -121,7 +123,8 @@ function MenuCheckboxItem({
         </>
       ) : (
         <>
-          <MenuPrimitive.CheckboxItemIndicator className="col-start-1">
+          <span className="col-start-1">{children}</span>
+          <MenuPrimitive.CheckboxItemIndicator className="col-start-2 justify-self-end">
             <svg
               fill="none"
               height="24"
@@ -136,7 +139,6 @@ function MenuCheckboxItem({
               <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
             </svg>
           </MenuPrimitive.CheckboxItemIndicator>
-          <span className="col-start-2">{children}</span>
         </>
       )}
     </MenuPrimitive.CheckboxItem>

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -12,6 +12,7 @@ import {
   buildFlatSidebarProjectSnapshot,
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
+  getSidebarProjectRemovalRefs,
   buildSidebarProjectSnapshots,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
@@ -257,6 +258,14 @@ describe("environment grouping", () => {
     });
     expect(pickerEntry?.isPreferred).toBe(true);
     expect(pickerEntry?.targetProject.id).toBe(canonical.id);
+
+    expect(
+      getSidebarProjectRemovalRefs({
+        projectGroup: snapshots[0]!,
+        members: [snapshots[0]!.memberProjects[0]!],
+        projects: [staleWithoutRepositoryIdentity, canonical, remote],
+      }).map((projectRef) => projectRef.projectId),
+    ).toEqual([staleWithoutRepositoryIdentity.id, canonical.id]);
   });
 
   it("routes duplicate physical project keys to the winning logical group", () => {
@@ -382,7 +391,6 @@ describe("environment grouping", () => {
 
     expect(flat?.displayName).toBe("Threads");
     expect(flat?.memberProjectRefs.map((projectRef) => projectRef.projectId)).toEqual([
-      stale.id,
       canonical.id,
       second.id,
     ]);

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -391,6 +391,7 @@ describe("environment grouping", () => {
 
     expect(flat?.displayName).toBe("Threads");
     expect(flat?.memberProjectRefs.map((projectRef) => projectRef.projectId)).toEqual([
+      stale.id,
       canonical.id,
       second.id,
     ]);

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -9,6 +9,7 @@ import {
   resolveProjectGroupingMode,
 } from "./logicalProject";
 import {
+  buildFlatSidebarProjectSnapshot,
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
@@ -348,5 +349,43 @@ describe("environment grouping", () => {
     });
 
     expect(groups.map((group) => group.displayName)).toEqual(["separate", "shared-repo"]);
+  });
+
+  it("combines project groups into one flat thread-list snapshot", () => {
+    const stale = makeProject({
+      id: ProjectId.make("project-stale"),
+      repositoryIdentity,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const canonical = makeProject({
+      id: ProjectId.make("project-canonical"),
+      repositoryIdentity,
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    const second = makeProject({
+      id: ProjectId.make("project-second"),
+      title: "another-repo",
+      workspaceRoot: "/tmp/another-repo",
+      repositoryIdentity: {
+        ...repositoryIdentity,
+        canonicalKey: "github.com/example/another-repo",
+      },
+    });
+    const snapshots = buildSidebarProjectSnapshots({
+      projects: [stale, canonical, second],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => "primary",
+    });
+
+    const flat = buildFlatSidebarProjectSnapshot(snapshots);
+
+    expect(flat?.displayName).toBe("Threads");
+    expect(flat?.memberProjectRefs.map((projectRef) => projectRef.projectId)).toEqual([
+      stale.id,
+      canonical.id,
+      second.id,
+    ]);
+    expect(flat?.memberProjects.map((project) => project.id)).toEqual([canonical.id, second.id]);
   });
 });

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -43,30 +43,27 @@ describe("resolveFirstSeenCompletedThreads", () => {
     );
   });
 
-  it("waits for lagging snapshot threads before seeding history", () => {
-    const beforeThreadsHydrate = resolveFirstSeenCompletedThreads({
+  it("seeds a genuinely empty snapshot before observing later completions", () => {
+    const emptySnapshot = resolveFirstSeenCompletedThreads({
       threads: [],
       environmentSnapshotIds: [localEnvironmentId],
       previouslyObservedThreadsByEnvironment: new Map(),
     });
-    const afterThreadsHydrate = resolveFirstSeenCompletedThreads({
-      threads: [thread("historical")],
+    const laterCompletion = resolveFirstSeenCompletedThreads({
+      threads: [thread("completed")],
       environmentSnapshotIds: [localEnvironmentId],
-      previouslyObservedThreadsByEnvironment: beforeThreadsHydrate.nextObservedThreadsByEnvironment,
+      previouslyObservedThreadsByEnvironment: emptySnapshot.nextObservedThreadsByEnvironment,
     });
 
-    expect(beforeThreadsHydrate.nextObservedThreadsByEnvironment.has(localEnvironmentId)).toBe(
-      false,
+    expect(emptySnapshot.nextObservedThreadsByEnvironment.get(localEnvironmentId)).toEqual(
+      new Map(),
     );
-    expect(afterThreadsHydrate.newlyUnreadThreads).toEqual([]);
-    expect(afterThreadsHydrate.nextObservedThreadsByEnvironment.get(localEnvironmentId)).toEqual(
-      new Map([
-        [
-          scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("historical"))),
-          { turnId: "turn-historical", state: "completed" },
-        ],
-      ]),
-    );
+    expect(laterCompletion.newlyUnreadThreads).toEqual([
+      {
+        threadKey: scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("completed"))),
+        completedAt: "2026-06-18T09:00:00.000Z",
+      },
+    ]);
   });
 
   it("marks a completed thread that first appears after bootstrap unread", () => {

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -19,7 +19,7 @@ function thread(
     latestTurn: {
       turnId,
       state,
-      completedAt: "2026-06-18T09:00:00.000Z",
+      completedAt: state === "completed" ? "2026-06-18T09:00:00.000Z" : null,
     },
   } as const;
 }
@@ -103,19 +103,41 @@ describe("resolveFirstSeenCompletedThreads", () => {
     expect(result.nextObservedThreadsByEnvironment.has(remoteEnvironmentId)).toBe(false);
   });
 
-  it("marks a previously observed running thread unread when its turn completes", () => {
-    const runningKey = scopedThreadKey(
-      scopeThreadRef(localEnvironmentId, ThreadId.make("running")),
+  it("marks a remote thread unread when a turn first seen running after bootstrap completes", () => {
+    const historicalKey = scopedThreadKey(
+      scopeThreadRef(remoteEnvironmentId, ThreadId.make("historical")),
     );
-    const result = resolveFirstSeenCompletedThreads({
-      threads: [thread("running", "completed")],
-      environmentSnapshotIds: [localEnvironmentId],
-      previouslyObservedThreadsByEnvironment: new Map([
-        [localEnvironmentId, new Map([[runningKey, { turnId: "turn-running", state: "running" }]])],
-      ]),
+    const runningKey = scopedThreadKey(
+      scopeThreadRef(remoteEnvironmentId, ThreadId.make("running")),
+    );
+    const bootstrap = resolveFirstSeenCompletedThreads({
+      threads: [thread("historical", "completed", remoteEnvironmentId)],
+      environmentSnapshotIds: [remoteEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map(),
+    });
+    const runningObservation = resolveFirstSeenCompletedThreads({
+      threads: [
+        thread("historical", "completed", remoteEnvironmentId),
+        thread("running", "running", remoteEnvironmentId),
+      ],
+      environmentSnapshotIds: [remoteEnvironmentId],
+      previouslyObservedThreadsByEnvironment: bootstrap.nextObservedThreadsByEnvironment,
+    });
+    const completion = resolveFirstSeenCompletedThreads({
+      threads: [
+        thread("historical", "completed", remoteEnvironmentId),
+        thread("running", "completed", remoteEnvironmentId),
+      ],
+      environmentSnapshotIds: [remoteEnvironmentId],
+      previouslyObservedThreadsByEnvironment: runningObservation.nextObservedThreadsByEnvironment,
     });
 
-    expect(result.newlyUnreadThreads).toEqual([
+    expect(bootstrap.newlyUnreadThreads).toEqual([]);
+    expect(
+      bootstrap.nextObservedThreadsByEnvironment.get(remoteEnvironmentId)?.get(historicalKey),
+    ).toEqual({ turnId: "turn-historical", state: "completed" });
+    expect(runningObservation.newlyUnreadThreads).toEqual([]);
+    expect(completion.newlyUnreadThreads).toEqual([
       {
         threadKey: runningKey,
         completedAt: "2026-06-18T09:00:00.000Z",

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -1,0 +1,72 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveFirstSeenCompletedThreads } from "./useMarkFirstSeenCompletedThreadsUnread";
+
+const localEnvironmentId = EnvironmentId.make("environment-local");
+const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+function thread(
+  id: string,
+  state: "completed" | "running" = "completed",
+  environmentId = localEnvironmentId,
+) {
+  return {
+    environmentId,
+    id: ThreadId.make(id),
+    latestTurn: {
+      state,
+      completedAt: "2026-06-18T09:00:00.000Z",
+    },
+  } as const;
+}
+
+describe("resolveFirstSeenCompletedThreads", () => {
+  it("seeds initial snapshot history without marking it unread", () => {
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("historical")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslySeenThreadKeysByEnvironment: new Map(),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([]);
+    expect(result.nextSeenThreadKeysByEnvironment.get(localEnvironmentId)).toEqual(
+      new Set([scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("historical")))]),
+    );
+  });
+
+  it("marks a completed thread that first appears after bootstrap unread", () => {
+    const historicalKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("historical")),
+    );
+    const completedKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("completed")),
+    );
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("historical"), thread("completed")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslySeenThreadKeysByEnvironment: new Map([
+        [localEnvironmentId, new Set([historicalKey])],
+      ]),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([
+      {
+        threadKey: completedKey,
+        completedAt: "2026-06-18T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("does not mark a new unfinished thread or a thread outside a snapshot environment", () => {
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("running", "running"), thread("remote", "completed", remoteEnvironmentId)],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslySeenThreadKeysByEnvironment: new Map([[localEnvironmentId, new Set()]]),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([]);
+    expect(result.nextSeenThreadKeysByEnvironment.has(remoteEnvironmentId)).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -11,11 +11,13 @@ function thread(
   id: string,
   state: "completed" | "running" = "completed",
   environmentId = localEnvironmentId,
+  turnId = `turn-${id}`,
 ) {
   return {
     environmentId,
     id: ThreadId.make(id),
     latestTurn: {
+      turnId,
       state,
       completedAt: "2026-06-18T09:00:00.000Z",
     },
@@ -27,12 +29,17 @@ describe("resolveFirstSeenCompletedThreads", () => {
     const result = resolveFirstSeenCompletedThreads({
       threads: [thread("historical")],
       environmentSnapshotIds: [localEnvironmentId],
-      previouslySeenThreadKeysByEnvironment: new Map(),
+      previouslyObservedThreadsByEnvironment: new Map(),
     });
 
     expect(result.newlyUnreadThreads).toEqual([]);
-    expect(result.nextSeenThreadKeysByEnvironment.get(localEnvironmentId)).toEqual(
-      new Set([scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("historical")))]),
+    expect(result.nextObservedThreadsByEnvironment.get(localEnvironmentId)).toEqual(
+      new Map([
+        [
+          scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("historical"))),
+          { turnId: "turn-historical", state: "completed" },
+        ],
+      ]),
     );
   });
 
@@ -46,8 +53,11 @@ describe("resolveFirstSeenCompletedThreads", () => {
     const result = resolveFirstSeenCompletedThreads({
       threads: [thread("historical"), thread("completed")],
       environmentSnapshotIds: [localEnvironmentId],
-      previouslySeenThreadKeysByEnvironment: new Map([
-        [localEnvironmentId, new Set([historicalKey])],
+      previouslyObservedThreadsByEnvironment: new Map([
+        [
+          localEnvironmentId,
+          new Map([[historicalKey, { turnId: "turn-historical", state: "completed" }]]),
+        ],
       ]),
     });
 
@@ -63,10 +73,82 @@ describe("resolveFirstSeenCompletedThreads", () => {
     const result = resolveFirstSeenCompletedThreads({
       threads: [thread("running", "running"), thread("remote", "completed", remoteEnvironmentId)],
       environmentSnapshotIds: [localEnvironmentId],
-      previouslySeenThreadKeysByEnvironment: new Map([[localEnvironmentId, new Set()]]),
+      previouslyObservedThreadsByEnvironment: new Map([[localEnvironmentId, new Map()]]),
     });
 
     expect(result.newlyUnreadThreads).toEqual([]);
-    expect(result.nextSeenThreadKeysByEnvironment.has(remoteEnvironmentId)).toBe(false);
+    expect(result.nextObservedThreadsByEnvironment.has(remoteEnvironmentId)).toBe(false);
+  });
+
+  it("marks a previously observed running thread unread when its turn completes", () => {
+    const runningKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("running")),
+    );
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("running", "completed")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map([
+        [localEnvironmentId, new Map([[runningKey, { turnId: "turn-running", state: "running" }]])],
+      ]),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([
+      {
+        threadKey: runningKey,
+        completedAt: "2026-06-18T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("marks a later completed turn unread even when the prior turn was completed", () => {
+    const threadKey = scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("reused")));
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("reused", "completed", localEnvironmentId, "turn-new")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map([
+        [
+          localEnvironmentId,
+          new Map([[threadKey, { turnId: "turn-previous", state: "completed" }]]),
+        ],
+      ]),
+    });
+
+    expect(result.newlyUnreadThreads).toHaveLength(1);
+  });
+
+  it("retains observations while a thread is archived and does not flag it on re-entry", () => {
+    const threadKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("archived")),
+    );
+    const previous = new Map([
+      [localEnvironmentId, new Map([[threadKey, { turnId: "turn-archived", state: "completed" }]])],
+    ]);
+    const whileArchived = resolveFirstSeenCompletedThreads({
+      threads: [],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: previous,
+    });
+    const afterUnarchive = resolveFirstSeenCompletedThreads({
+      threads: [thread("archived")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: whileArchived.nextObservedThreadsByEnvironment,
+    });
+
+    expect(
+      whileArchived.nextObservedThreadsByEnvironment.get(localEnvironmentId)?.has(threadKey),
+    ).toBe(true);
+    expect(afterUnarchive.newlyUnreadThreads).toEqual([]);
+  });
+
+  it("does not mark the currently active thread unread", () => {
+    const activeKey = scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("active")));
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("active")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map([[localEnvironmentId, new Map()]]),
+      activeThreadKey: activeKey,
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([]);
   });
 });

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -2,6 +2,7 @@ import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environ
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
+import { createFirstSeenCompletedThreadObservationSeedStore } from "../lib/firstSeenCompletedThreadObservations";
 import { resolveFirstSeenCompletedThreads } from "./useMarkFirstSeenCompletedThreadsUnread";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
@@ -183,6 +184,55 @@ describe("resolveFirstSeenCompletedThreads", () => {
       whileArchived.nextObservedThreadsByEnvironment.get(localEnvironmentId)?.has(threadKey),
     ).toBe(true);
     expect(afterUnarchive.newlyUnreadThreads).toEqual([]);
+  });
+
+  it("seeds loaded archived history before the thread is unarchived", () => {
+    const archivedKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("archived")),
+    );
+    const seedStore = createFirstSeenCompletedThreadObservationSeedStore();
+    seedStore.seed([thread("archived")]);
+
+    const afterUnarchive = resolveFirstSeenCompletedThreads({
+      threads: [thread("archived")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map([[localEnvironmentId, new Map()]]),
+      seededObservedThreadsByEnvironment: seedStore.snapshot(),
+    });
+    expect(afterUnarchive.newlyUnreadThreads).toEqual([]);
+    expect(
+      afterUnarchive.nextObservedThreadsByEnvironment.get(localEnvironmentId)?.get(archivedKey),
+    ).toEqual({
+      turnId: "turn-archived",
+      state: "completed",
+    });
+
+    const laterCompletion = resolveFirstSeenCompletedThreads({
+      threads: [thread("archived", "completed", localEnvironmentId, "turn-new")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: afterUnarchive.nextObservedThreadsByEnvironment,
+      seededObservedThreadsByEnvironment: seedStore.snapshot(),
+    });
+    expect(laterCompletion.newlyUnreadThreads).toEqual([
+      {
+        threadKey: archivedKey,
+        completedAt: "2026-06-18T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("does not let archived seeds turn initial active history into unread history", () => {
+    const seedStore = createFirstSeenCompletedThreadObservationSeedStore();
+    seedStore.seed([thread("archived")]);
+
+    const initialSnapshot = resolveFirstSeenCompletedThreads({
+      threads: [thread("active-history")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map(),
+      seededObservedThreadsByEnvironment: seedStore.snapshot(),
+    });
+
+    expect(initialSnapshot.newlyUnreadThreads).toEqual([]);
   });
 
   it("does not mark the currently active thread unread", () => {

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -43,6 +43,32 @@ describe("resolveFirstSeenCompletedThreads", () => {
     );
   });
 
+  it("waits for lagging snapshot threads before seeding history", () => {
+    const beforeThreadsHydrate = resolveFirstSeenCompletedThreads({
+      threads: [],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: new Map(),
+    });
+    const afterThreadsHydrate = resolveFirstSeenCompletedThreads({
+      threads: [thread("historical")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslyObservedThreadsByEnvironment: beforeThreadsHydrate.nextObservedThreadsByEnvironment,
+    });
+
+    expect(beforeThreadsHydrate.nextObservedThreadsByEnvironment.has(localEnvironmentId)).toBe(
+      false,
+    );
+    expect(afterThreadsHydrate.newlyUnreadThreads).toEqual([]);
+    expect(afterThreadsHydrate.nextObservedThreadsByEnvironment.get(localEnvironmentId)).toEqual(
+      new Map([
+        [
+          scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("historical"))),
+          { turnId: "turn-historical", state: "completed" },
+        ],
+      ]),
+    );
+  });
+
   it("marks a completed thread that first appears after bootstrap unread", () => {
     const historicalKey = scopedThreadKey(
       scopeThreadRef(localEnvironmentId, ThreadId.make("historical")),

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -1,0 +1,57 @@
+import { useAtomValue } from "@effect/atom-react";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { Atom } from "effect/unstable/reactivity";
+import { useEffect, useRef } from "react";
+
+import { environmentCatalog } from "../connection/catalog";
+import { useThreadShells } from "../state/entities";
+import { environmentShell } from "../state/shell";
+import { useUiStateStore } from "../uiStateStore";
+
+const environmentSnapshotIdsAtom = Atom.make((get): ReadonlyArray<EnvironmentId> => {
+  const environmentIds: EnvironmentId[] = [];
+  for (const environmentId of get(environmentCatalog.catalogValueAtom).entries.keys()) {
+    if (Option.isSome(get(environmentShell.stateValueAtom(environmentId)).snapshot)) {
+      environmentIds.push(environmentId);
+    }
+  }
+  return environmentIds;
+}).pipe(Atom.withLabel("completed-thread-unread:snapshot-environments"));
+
+export function useMarkFirstSeenCompletedThreadsUnread(): void {
+  const threads = useThreadShells();
+  const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
+  const seenThreadKeysByEnvironmentRef = useRef<Map<EnvironmentId, Set<string>>>(new Map());
+
+  useEffect(() => {
+    const snapshotEnvironmentIds = new Set(environmentSnapshotIds);
+    const nextThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
+    for (const environmentId of snapshotEnvironmentIds) {
+      nextThreadKeysByEnvironment.set(environmentId, new Set());
+    }
+
+    for (const thread of threads) {
+      if (!snapshotEnvironmentIds.has(thread.environmentId)) {
+        continue;
+      }
+
+      const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+      const threadKey = scopedThreadKey(threadRef);
+      const nextThreadKeys = nextThreadKeysByEnvironment.get(thread.environmentId);
+      nextThreadKeys?.add(threadKey);
+
+      const previousThreadKeys = seenThreadKeysByEnvironmentRef.current.get(thread.environmentId);
+      if (
+        previousThreadKeys !== undefined &&
+        !previousThreadKeys.has(threadKey) &&
+        thread.latestTurn?.state === "completed"
+      ) {
+        useUiStateStore.getState().markThreadUnread(threadKey, thread.latestTurn.completedAt);
+      }
+    }
+
+    seenThreadKeysByEnvironmentRef.current = nextThreadKeysByEnvironment;
+  }, [environmentSnapshotIds, threads]);
+}

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -1,6 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { Atom } from "effect/unstable/reactivity";
 import { useEffect, useRef } from "react";
@@ -20,38 +20,78 @@ const environmentSnapshotIdsAtom = Atom.make((get): ReadonlyArray<EnvironmentId>
   return environmentIds;
 }).pipe(Atom.withLabel("completed-thread-unread:snapshot-environments"));
 
+interface FirstSeenThreadInput {
+  readonly environmentId: EnvironmentId;
+  readonly id: ThreadId;
+  readonly latestTurn: {
+    readonly state: string;
+    readonly completedAt: string | null;
+  } | null;
+}
+
+export function resolveFirstSeenCompletedThreads(input: {
+  readonly threads: ReadonlyArray<FirstSeenThreadInput>;
+  readonly environmentSnapshotIds: ReadonlyArray<EnvironmentId>;
+  readonly previouslySeenThreadKeysByEnvironment: ReadonlyMap<EnvironmentId, ReadonlySet<string>>;
+}): {
+  readonly nextSeenThreadKeysByEnvironment: Map<EnvironmentId, Set<string>>;
+  readonly newlyUnreadThreads: ReadonlyArray<{
+    readonly threadKey: string;
+    readonly completedAt: string | null;
+  }>;
+} {
+  const snapshotEnvironmentIds = new Set(input.environmentSnapshotIds);
+  const nextSeenThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
+  const newlyUnreadThreads: Array<{
+    readonly threadKey: string;
+    readonly completedAt: string | null;
+  }> = [];
+  for (const environmentId of snapshotEnvironmentIds) {
+    nextSeenThreadKeysByEnvironment.set(environmentId, new Set());
+  }
+
+  for (const thread of input.threads) {
+    if (!snapshotEnvironmentIds.has(thread.environmentId)) {
+      continue;
+    }
+
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    nextSeenThreadKeysByEnvironment.get(thread.environmentId)?.add(threadKey);
+
+    const previousThreadKeys = input.previouslySeenThreadKeysByEnvironment.get(
+      thread.environmentId,
+    );
+    if (
+      previousThreadKeys !== undefined &&
+      !previousThreadKeys.has(threadKey) &&
+      thread.latestTurn?.state === "completed"
+    ) {
+      newlyUnreadThreads.push({
+        threadKey,
+        completedAt: thread.latestTurn.completedAt,
+      });
+    }
+  }
+
+  return { nextSeenThreadKeysByEnvironment, newlyUnreadThreads };
+}
+
 export function useMarkFirstSeenCompletedThreadsUnread(): void {
   const threads = useThreadShells();
   const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
   const seenThreadKeysByEnvironmentRef = useRef<Map<EnvironmentId, Set<string>>>(new Map());
 
   useEffect(() => {
-    const snapshotEnvironmentIds = new Set(environmentSnapshotIds);
-    const nextThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
-    for (const environmentId of snapshotEnvironmentIds) {
-      nextThreadKeysByEnvironment.set(environmentId, new Set());
+    const { nextSeenThreadKeysByEnvironment, newlyUnreadThreads } =
+      resolveFirstSeenCompletedThreads({
+        threads,
+        environmentSnapshotIds,
+        previouslySeenThreadKeysByEnvironment: seenThreadKeysByEnvironmentRef.current,
+      });
+    for (const thread of newlyUnreadThreads) {
+      useUiStateStore.getState().markThreadUnread(thread.threadKey, thread.completedAt);
     }
 
-    for (const thread of threads) {
-      if (!snapshotEnvironmentIds.has(thread.environmentId)) {
-        continue;
-      }
-
-      const threadRef = scopeThreadRef(thread.environmentId, thread.id);
-      const threadKey = scopedThreadKey(threadRef);
-      const nextThreadKeys = nextThreadKeysByEnvironment.get(thread.environmentId);
-      nextThreadKeys?.add(threadKey);
-
-      const previousThreadKeys = seenThreadKeysByEnvironmentRef.current.get(thread.environmentId);
-      if (
-        previousThreadKeys !== undefined &&
-        !previousThreadKeys.has(threadKey) &&
-        thread.latestTurn?.state === "completed"
-      ) {
-        useUiStateStore.getState().markThreadUnread(threadKey, thread.latestTurn.completedAt);
-      }
-    }
-
-    seenThreadKeysByEnvironmentRef.current = nextThreadKeysByEnvironment;
+    seenThreadKeysByEnvironmentRef.current = nextSeenThreadKeysByEnvironment;
   }, [environmentSnapshotIds, threads]);
 }

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -6,19 +6,26 @@ import { Atom } from "effect/unstable/reactivity";
 import { useEffect, useRef } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
-import { useThreadShells } from "../state/entities";
 import { environmentShell } from "../state/shell";
+import { environmentThreadShells } from "../state/threads";
 import { useUiStateStore } from "../uiStateStore";
 
-const environmentSnapshotIdsAtom = Atom.make((get): ReadonlyArray<EnvironmentId> => {
+// Read snapshot readiness and the shells derived from those snapshots in one
+// Atom transaction. Separate React subscriptions can briefly observe a new
+// snapshot with the prior shell list and misclassify its history as newly
+// completed on the following render.
+const completedThreadObservationSnapshotAtom = Atom.make((get) => {
   const environmentIds: EnvironmentId[] = [];
   for (const environmentId of get(environmentCatalog.catalogValueAtom).entries.keys()) {
     if (Option.isSome(get(environmentShell.stateValueAtom(environmentId)).snapshot)) {
       environmentIds.push(environmentId);
     }
   }
-  return environmentIds;
-}).pipe(Atom.withLabel("completed-thread-unread:snapshot-environments"));
+  return {
+    environmentSnapshotIds: environmentIds,
+    threads: get(environmentThreadShells.threadShellsAtom),
+  };
+}).pipe(Atom.withLabel("completed-thread-unread:observation-snapshot"));
 
 interface FirstSeenThreadInput {
   readonly environmentId: EnvironmentId;
@@ -61,14 +68,17 @@ export function resolveFirstSeenCompletedThreads(input: {
     readonly threadKey: string;
     readonly completedAt: string | null;
   }> = [];
+  for (const environmentId of snapshotEnvironmentIds) {
+    if (!nextObservedThreadsByEnvironment.has(environmentId)) {
+      nextObservedThreadsByEnvironment.set(environmentId, new Map());
+    }
+  }
+
   for (const thread of input.threads) {
     if (!snapshotEnvironmentIds.has(thread.environmentId)) {
       continue;
     }
 
-    if (!nextObservedThreadsByEnvironment.has(thread.environmentId)) {
-      nextObservedThreadsByEnvironment.set(thread.environmentId, new Map());
-    }
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
     const observedThread: ObservedThreadTurn = {
       turnId: thread.latestTurn?.turnId ?? null,
@@ -98,8 +108,7 @@ export function resolveFirstSeenCompletedThreads(input: {
 }
 
 export function useMarkFirstSeenCompletedThreadsUnread(): void {
-  const threads = useThreadShells();
-  const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
+  const { environmentSnapshotIds, threads } = useAtomValue(completedThreadObservationSnapshotAtom);
   const observedThreadsByEnvironmentRef = useRef<
     Map<EnvironmentId, Map<string, ObservedThreadTurn>>
   >(new Map());

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -61,17 +61,14 @@ export function resolveFirstSeenCompletedThreads(input: {
     readonly threadKey: string;
     readonly completedAt: string | null;
   }> = [];
-  for (const environmentId of snapshotEnvironmentIds) {
-    if (!nextObservedThreadsByEnvironment.has(environmentId)) {
-      nextObservedThreadsByEnvironment.set(environmentId, new Map());
-    }
-  }
-
   for (const thread of input.threads) {
     if (!snapshotEnvironmentIds.has(thread.environmentId)) {
       continue;
     }
 
+    if (!nextObservedThreadsByEnvironment.has(thread.environmentId)) {
+      nextObservedThreadsByEnvironment.set(thread.environmentId, new Map());
+    }
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
     const observedThread: ObservedThreadTurn = {
       turnId: thread.latestTurn?.turnId ?? null,

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -24,30 +24,47 @@ interface FirstSeenThreadInput {
   readonly environmentId: EnvironmentId;
   readonly id: ThreadId;
   readonly latestTurn: {
+    readonly turnId: string;
     readonly state: string;
     readonly completedAt: string | null;
   } | null;
 }
 
+export interface ObservedThreadTurn {
+  readonly turnId: string | null;
+  readonly state: string | null;
+}
+
 export function resolveFirstSeenCompletedThreads(input: {
   readonly threads: ReadonlyArray<FirstSeenThreadInput>;
   readonly environmentSnapshotIds: ReadonlyArray<EnvironmentId>;
-  readonly previouslySeenThreadKeysByEnvironment: ReadonlyMap<EnvironmentId, ReadonlySet<string>>;
+  readonly previouslyObservedThreadsByEnvironment: ReadonlyMap<
+    EnvironmentId,
+    ReadonlyMap<string, ObservedThreadTurn>
+  >;
+  readonly activeThreadKey?: string | null;
 }): {
-  readonly nextSeenThreadKeysByEnvironment: Map<EnvironmentId, Set<string>>;
+  readonly nextObservedThreadsByEnvironment: Map<EnvironmentId, Map<string, ObservedThreadTurn>>;
   readonly newlyUnreadThreads: ReadonlyArray<{
     readonly threadKey: string;
     readonly completedAt: string | null;
   }>;
 } {
   const snapshotEnvironmentIds = new Set(input.environmentSnapshotIds);
-  const nextSeenThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
+  const nextObservedThreadsByEnvironment = new Map(
+    [...input.previouslyObservedThreadsByEnvironment].map(([environmentId, threads]) => [
+      environmentId,
+      new Map(threads),
+    ]),
+  );
   const newlyUnreadThreads: Array<{
     readonly threadKey: string;
     readonly completedAt: string | null;
   }> = [];
   for (const environmentId of snapshotEnvironmentIds) {
-    nextSeenThreadKeysByEnvironment.set(environmentId, new Set());
+    if (!nextObservedThreadsByEnvironment.has(environmentId)) {
+      nextObservedThreadsByEnvironment.set(environmentId, new Map());
+    }
   }
 
   for (const thread of input.threads) {
@@ -56,42 +73,52 @@ export function resolveFirstSeenCompletedThreads(input: {
     }
 
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-    nextSeenThreadKeysByEnvironment.get(thread.environmentId)?.add(threadKey);
-
-    const previousThreadKeys = input.previouslySeenThreadKeysByEnvironment.get(
+    const observedThread: ObservedThreadTurn = {
+      turnId: thread.latestTurn?.turnId ?? null,
+      state: thread.latestTurn?.state ?? null,
+    };
+    const previousEnvironmentThreads = input.previouslyObservedThreadsByEnvironment.get(
       thread.environmentId,
     );
+    const previousThread = previousEnvironmentThreads?.get(threadKey);
     if (
-      previousThreadKeys !== undefined &&
-      !previousThreadKeys.has(threadKey) &&
-      thread.latestTurn?.state === "completed"
+      previousEnvironmentThreads !== undefined &&
+      thread.latestTurn?.state === "completed" &&
+      threadKey !== input.activeThreadKey &&
+      (previousThread === undefined ||
+        previousThread.turnId !== observedThread.turnId ||
+        previousThread.state !== "completed")
     ) {
       newlyUnreadThreads.push({
         threadKey,
         completedAt: thread.latestTurn.completedAt,
       });
     }
+    nextObservedThreadsByEnvironment.get(thread.environmentId)?.set(threadKey, observedThread);
   }
 
-  return { nextSeenThreadKeysByEnvironment, newlyUnreadThreads };
+  return { nextObservedThreadsByEnvironment, newlyUnreadThreads };
 }
 
 export function useMarkFirstSeenCompletedThreadsUnread(): void {
   const threads = useThreadShells();
   const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
-  const seenThreadKeysByEnvironmentRef = useRef<Map<EnvironmentId, Set<string>>>(new Map());
+  const observedThreadsByEnvironmentRef = useRef<
+    Map<EnvironmentId, Map<string, ObservedThreadTurn>>
+  >(new Map());
 
   useEffect(() => {
-    const { nextSeenThreadKeysByEnvironment, newlyUnreadThreads } =
+    const { nextObservedThreadsByEnvironment, newlyUnreadThreads } =
       resolveFirstSeenCompletedThreads({
         threads,
         environmentSnapshotIds,
-        previouslySeenThreadKeysByEnvironment: seenThreadKeysByEnvironmentRef.current,
+        previouslyObservedThreadsByEnvironment: observedThreadsByEnvironmentRef.current,
+        activeThreadKey: useUiStateStore.getState().activeThreadVisit?.threadId ?? null,
       });
     for (const thread of newlyUnreadThreads) {
       useUiStateStore.getState().markThreadUnread(thread.threadKey, thread.completedAt);
     }
 
-    seenThreadKeysByEnvironmentRef.current = nextSeenThreadKeysByEnvironment;
+    observedThreadsByEnvironmentRef.current = nextObservedThreadsByEnvironment;
   }, [environmentSnapshotIds, threads]);
 }

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -6,6 +6,10 @@ import { Atom } from "effect/unstable/reactivity";
 import { useEffect, useRef } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
+import {
+  archivedThreadObservationSeeds,
+  type ObservedThreadTurn,
+} from "../lib/firstSeenCompletedThreadObservations";
 import { environmentShell } from "../state/shell";
 import { environmentThreadShells } from "../state/threads";
 import { useUiStateStore } from "../uiStateStore";
@@ -37,15 +41,14 @@ interface FirstSeenThreadInput {
   } | null;
 }
 
-export interface ObservedThreadTurn {
-  readonly turnId: string | null;
-  readonly state: string | null;
-}
-
 export function resolveFirstSeenCompletedThreads(input: {
   readonly threads: ReadonlyArray<FirstSeenThreadInput>;
   readonly environmentSnapshotIds: ReadonlyArray<EnvironmentId>;
   readonly previouslyObservedThreadsByEnvironment: ReadonlyMap<
+    EnvironmentId,
+    ReadonlyMap<string, ObservedThreadTurn>
+  >;
+  readonly seededObservedThreadsByEnvironment?: ReadonlyMap<
     EnvironmentId,
     ReadonlyMap<string, ObservedThreadTurn>
   >;
@@ -72,6 +75,14 @@ export function resolveFirstSeenCompletedThreads(input: {
     if (!nextObservedThreadsByEnvironment.has(environmentId)) {
       nextObservedThreadsByEnvironment.set(environmentId, new Map());
     }
+    const nextEnvironmentThreads = nextObservedThreadsByEnvironment.get(environmentId);
+    for (const [threadKey, observedThread] of input.seededObservedThreadsByEnvironment?.get(
+      environmentId,
+    ) ?? []) {
+      if (!nextEnvironmentThreads?.has(threadKey)) {
+        nextEnvironmentThreads?.set(threadKey, observedThread);
+      }
+    }
   }
 
   for (const thread of input.threads) {
@@ -87,7 +98,9 @@ export function resolveFirstSeenCompletedThreads(input: {
     const previousEnvironmentThreads = input.previouslyObservedThreadsByEnvironment.get(
       thread.environmentId,
     );
-    const previousThread = previousEnvironmentThreads?.get(threadKey);
+    const previousThread =
+      previousEnvironmentThreads?.get(threadKey) ??
+      input.seededObservedThreadsByEnvironment?.get(thread.environmentId)?.get(threadKey);
     if (
       previousEnvironmentThreads !== undefined &&
       thread.latestTurn?.state === "completed" &&
@@ -119,6 +132,7 @@ export function useMarkFirstSeenCompletedThreadsUnread(): void {
         threads,
         environmentSnapshotIds,
         previouslyObservedThreadsByEnvironment: observedThreadsByEnvironmentRef.current,
+        seededObservedThreadsByEnvironment: archivedThreadObservationSeeds.snapshot(),
         activeThreadKey: useUiStateStore.getState().activeThreadVisit?.threadId ?? null,
       });
     for (const thread of newlyUnreadThreads) {

--- a/apps/web/src/lib/archivedThreadsState.ts
+++ b/apps/web/src/lib/archivedThreadsState.ts
@@ -5,10 +5,11 @@ import {
   makeArchivedThreadsEnvironmentKey,
 } from "@t3tools/client-runtime/state/threads";
 import type { EnvironmentId } from "@t3tools/contracts";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { orchestrationEnvironment } from "../state/orchestration";
 import { appAtomRegistry } from "../rpc/atomRegistry";
+import { archivedThreadObservationSeeds } from "./firstSeenCompletedThreadObservations";
 
 function archivedSnapshotAtom(environmentId: EnvironmentId) {
   return orchestrationEnvironment.archivedShellSnapshot({
@@ -37,6 +38,19 @@ export function useArchivedThreadSnapshots(environmentIds: ReadonlyArray<Environ
     [environmentIds],
   );
   const result = useAtomValue(archivedSnapshotsAtom(environmentKey));
+  useEffect(() => {
+    archivedThreadObservationSeeds.seed(
+      result.snapshots.flatMap((entry) =>
+        entry.snapshot.threads
+          .filter((thread) => thread.archivedAt !== null)
+          .map((thread) => ({
+            environmentId: entry.environmentId,
+            id: thread.id,
+            latestTurn: thread.latestTurn,
+          })),
+      ),
+    );
+  }, [result.snapshots]);
   const refresh = useCallback(() => {
     for (const environmentId of environmentIds) {
       appAtomRegistry.refresh(archivedSnapshotAtom(environmentId));

--- a/apps/web/src/lib/firstSeenCompletedThreadObservations.ts
+++ b/apps/web/src/lib/firstSeenCompletedThreadObservations.ts
@@ -1,0 +1,52 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+
+export interface ObservedThreadTurn {
+  readonly turnId: string | null;
+  readonly state: string | null;
+}
+
+interface ThreadObservationSeed {
+  readonly environmentId: EnvironmentId;
+  readonly id: ThreadId;
+  readonly latestTurn: {
+    readonly turnId: string;
+    readonly state: string;
+  } | null;
+}
+
+export interface FirstSeenCompletedThreadObservationSeedStore {
+  readonly seed: (threads: ReadonlyArray<ThreadObservationSeed>) => void;
+  readonly snapshot: () => ReadonlyMap<EnvironmentId, ReadonlyMap<string, ObservedThreadTurn>>;
+}
+
+export function createFirstSeenCompletedThreadObservationSeedStore(): FirstSeenCompletedThreadObservationSeedStore {
+  const observationsByEnvironment = new Map<EnvironmentId, Map<string, ObservedThreadTurn>>();
+
+  return {
+    seed(threads) {
+      for (const thread of threads) {
+        const environmentObservations =
+          observationsByEnvironment.get(thread.environmentId) ?? new Map();
+        environmentObservations.set(
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          {
+            turnId: thread.latestTurn?.turnId ?? null,
+            state: thread.latestTurn?.state ?? null,
+          },
+        );
+        observationsByEnvironment.set(thread.environmentId, environmentObservations);
+      }
+    },
+    snapshot() {
+      return new Map(
+        [...observationsByEnvironment].map(([environmentId, observations]) => [
+          environmentId,
+          new Map(observations),
+        ]),
+      );
+    },
+  };
+}
+
+export const archivedThreadObservationSeeds = createFirstSeenCompletedThreadObservationSeedStore();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   type ErrorComponentProps,
   useLocation,
   useNavigate,
+  useRouterState,
 } from "@tanstack/react-router";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
@@ -49,6 +50,7 @@ import {
   primaryServerWelcomeAtom,
 } from "../state/server";
 import { readProject, setActiveEnvironmentId, useActiveEnvironmentId } from "../state/entities";
+import { resolveThreadRouteTarget } from "../threadRoutes";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -135,6 +137,7 @@ function RootRouteView() {
         <SshPasswordPromptDialog />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
+        <ActiveThreadRouteTracker />
         <CompletedThreadUnreadTracker />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
@@ -201,6 +204,24 @@ function HostedStaticEnvironmentBootstrap() {
 
 function CompletedThreadUnreadTracker() {
   useMarkFirstSeenCompletedThreadsUnread();
+  return null;
+}
+
+function ActiveThreadRouteTracker() {
+  const routeKind = useRouterState({
+    select: (state) => {
+      const params = state.matches[state.matches.length - 1]?.params ?? {};
+      return resolveThreadRouteTarget(params)?.kind ?? null;
+    },
+  });
+  const markActiveThreadVisited = useUiStateStore((state) => state.markActiveThreadVisited);
+
+  useEffect(() => {
+    if (routeKind === null) {
+      markActiveThreadVisited(null, null);
+    }
+  }, [markActiveThreadVisited, routeKind]);
+
   return null;
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -27,6 +27,7 @@ import {
   toastManager,
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
+import { useMarkFirstSeenCompletedThreadsUnread } from "../hooks/useMarkFirstSeenCompletedThreadsUnread";
 import { useClientSettings } from "../hooks/useSettings";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -277,6 +278,8 @@ function AuthenticatedTracingBootstrap() {
 }
 
 function EventRouter() {
+  useMarkFirstSeenCompletedThreadsUnread();
+
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -135,6 +135,7 @@ function RootRouteView() {
         <SshPasswordPromptDialog />
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
+        <CompletedThreadUnreadTracker />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
         {appShell}
@@ -195,6 +196,11 @@ function HostedStaticEnvironmentBootstrap() {
     setActiveEnvironmentId(firstSavedEnvironment.environmentId);
   }, [activeEnvironmentId, environments]);
 
+  return null;
+}
+
+function CompletedThreadUnreadTracker() {
+  useMarkFirstSeenCompletedThreadsUnread();
   return null;
 }
 
@@ -278,8 +284,6 @@ function AuthenticatedTracingBootstrap() {
 }
 
 function EventRouter() {
-  useMarkFirstSeenCompletedThreadsUnread();
-
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -50,7 +50,7 @@ import {
   primaryServerWelcomeAtom,
 } from "../state/server";
 import { readProject, setActiveEnvironmentId, useActiveEnvironmentId } from "../state/entities";
-import { resolveThreadRouteTarget } from "../threadRoutes";
+import { resolveEagerActiveThreadRouteKey, resolveThreadRouteTarget } from "../threadRoutes";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -208,19 +208,19 @@ function CompletedThreadUnreadTracker() {
 }
 
 function ActiveThreadRouteTracker() {
-  const routeKind = useRouterState({
+  const routeThreadKey = useRouterState({
     select: (state) => {
       const params = state.matches[state.matches.length - 1]?.params ?? {};
-      return resolveThreadRouteTarget(params)?.kind ?? null;
+      return resolveEagerActiveThreadRouteKey(resolveThreadRouteTarget(params));
     },
   });
   const markActiveThreadVisited = useUiStateStore((state) => state.markActiveThreadVisited);
 
   useEffect(() => {
-    if (routeKind === null) {
-      markActiveThreadVisited(null, null);
+    if (routeThreadKey !== undefined) {
+      markActiveThreadVisited(routeThreadKey, null);
     }
-  }, [markActiveThreadVisited, routeKind]);
+  }, [markActiveThreadVisited, routeThreadKey]);
 
   return null;
 }

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,4 +1,4 @@
-import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -35,6 +35,42 @@ export interface SidebarProjectPickerEntry {
   group: SidebarProjectSnapshot;
   targetProject: SidebarProjectGroupMember;
   isPreferred: boolean;
+}
+
+const FLAT_THREAD_LIST_PROJECT_KEY = "__all_threads__";
+
+export function buildFlatSidebarProjectSnapshot(
+  projects: ReadonlyArray<SidebarProjectSnapshot>,
+): SidebarProjectSnapshot | null {
+  const representative = projects[0];
+  if (!representative) {
+    return null;
+  }
+
+  const membersByKey = new Map<string, SidebarProjectGroupMember>();
+  const projectRefsByKey = new Map<string, ScopedProjectRef>();
+  for (const project of projects) {
+    for (const member of project.memberProjects) {
+      membersByKey.set(scopedProjectKey(scopeProjectRef(member.environmentId, member.id)), member);
+    }
+    for (const projectRef of project.memberProjectRefs) {
+      projectRefsByKey.set(scopedProjectKey(projectRef), projectRef);
+    }
+  }
+  const memberProjects = [...membersByKey.values()];
+  const memberProjectRefs = [...projectRefsByKey.values()];
+
+  return {
+    ...representative,
+    projectKey: FLAT_THREAD_LIST_PROJECT_KEY,
+    displayName: "Threads",
+    groupedProjectCount: memberProjects.length,
+    memberProjects,
+    memberProjectRefs,
+    remoteEnvironmentLabels: projects
+      .flatMap((project) => project.remoteEnvironmentLabels)
+      .filter((label, index, labels) => labels.indexOf(label) === index),
+  };
 }
 
 interface SidebarProjectGroupCandidate {

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -48,15 +48,17 @@ export function buildFlatSidebarProjectSnapshot(
   }
 
   const membersByKey = new Map<string, SidebarProjectGroupMember>();
+  const memberProjectRefsByKey = new Map<string, ScopedProjectRef>();
   for (const project of projects) {
     for (const member of project.memberProjects) {
       membersByKey.set(scopedProjectKey(scopeProjectRef(member.environmentId, member.id)), member);
     }
+    for (const projectRef of project.memberProjectRefs) {
+      memberProjectRefsByKey.set(scopedProjectKey(projectRef), projectRef);
+    }
   }
   const memberProjects = [...membersByKey.values()];
-  const memberProjectRefs = memberProjects.map((member) =>
-    scopeProjectRef(member.environmentId, member.id),
-  );
+  const memberProjectRefs = [...memberProjectRefsByKey.values()];
 
   return {
     ...representative,

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -48,17 +48,15 @@ export function buildFlatSidebarProjectSnapshot(
   }
 
   const membersByKey = new Map<string, SidebarProjectGroupMember>();
-  const projectRefsByKey = new Map<string, ScopedProjectRef>();
   for (const project of projects) {
     for (const member of project.memberProjects) {
       membersByKey.set(scopedProjectKey(scopeProjectRef(member.environmentId, member.id)), member);
     }
-    for (const projectRef of project.memberProjectRefs) {
-      projectRefsByKey.set(scopedProjectKey(projectRef), projectRef);
-    }
   }
   const memberProjects = [...membersByKey.values()];
-  const memberProjectRefs = [...projectRefsByKey.values()];
+  const memberProjectRefs = memberProjects.map((member) =>
+    scopeProjectRef(member.environmentId, member.id),
+  );
 
   return {
     ...representative,
@@ -71,6 +69,41 @@ export function buildFlatSidebarProjectSnapshot(
       .flatMap((project) => project.remoteEnvironmentLabels)
       .filter((label, index, labels) => labels.indexOf(label) === index),
   };
+}
+
+export function getSidebarProjectRemovalRefs(input: {
+  projectGroup: SidebarProjectSnapshot;
+  members: readonly SidebarProjectGroupMember[];
+  projects: readonly Project[];
+}): ScopedProjectRef[] {
+  const selectedPhysicalProjectKeys = new Set(
+    input.members.map((member) => member.physicalProjectKey),
+  );
+  const removesWholeGroup = input.projectGroup.memberProjects.every((member) =>
+    selectedPhysicalProjectKeys.has(member.physicalProjectKey),
+  );
+  if (removesWholeGroup) {
+    return [...input.projectGroup.memberProjectRefs];
+  }
+
+  const projectByRefKey = new Map(
+    input.projects.map((project) => [
+      scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+      project,
+    ]),
+  );
+  const selectedMemberRefKeys = new Set(
+    input.members.map((member) =>
+      scopedProjectKey(scopeProjectRef(member.environmentId, member.id)),
+    ),
+  );
+  return input.projectGroup.memberProjectRefs.filter((projectRef) => {
+    const projectRefKey = scopedProjectKey(projectRef);
+    const project = projectByRefKey.get(projectRefKey);
+    return project
+      ? selectedPhysicalProjectKeys.has(derivePhysicalProjectKey(project))
+      : selectedMemberRefKeys.has(projectRefKey);
+  });
 }
 
 interface SidebarProjectGroupCandidate {

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -10,6 +10,7 @@ import {
   resolveThreadRouteRenderState,
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
+  shouldKeepActiveThreadVisitOnUnmount,
 } from "./threadRoutes";
 
 describe("threadRoutes", () => {
@@ -65,6 +66,48 @@ describe("threadRoutes", () => {
       kind: "draft",
       draftId: "draft-1",
     });
+
+    expect(resolveThreadRouteTarget({ environmentId: "env-1" })).toBeNull();
+    expect(resolveThreadRouteTarget({ threadId: "thread-1" })).toBeNull();
+  });
+
+  it("keeps an active visit only while the same chat route remains mounted", () => {
+    const routeThreadKey = "env-1:thread-1";
+
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({
+          environmentId: "env-1",
+          threadId: "thread-1",
+        }),
+        routeThreadKey,
+        draftId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({
+          environmentId: "env-1",
+          threadId: "thread-2",
+        }),
+        routeThreadKey,
+        draftId: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({ draftId: "draft-1" }),
+        routeThreadKey,
+        draftId: DraftId.make("draft-1"),
+      }),
+    ).toBe(true);
+    expect(
+      shouldKeepActiveThreadVisitOnUnmount({
+        currentRouteTarget: resolveThreadRouteTarget({ draftId: "draft-2" }),
+        routeThreadKey,
+        draftId: DraftId.make("draft-1"),
+      }),
+    ).toBe(false);
   });
 
   it("resolves the backing thread while a draft route is being promoted", () => {

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -7,6 +7,7 @@ import {
   buildDraftThreadRouteParams,
   buildThreadRouteParams,
   resolveActiveThreadRouteRef,
+  resolveEagerActiveThreadRouteKey,
   resolveThreadRouteRenderState,
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
@@ -69,6 +70,21 @@ describe("threadRoutes", () => {
 
     expect(resolveThreadRouteTarget({ environmentId: "env-1" })).toBeNull();
     expect(resolveThreadRouteTarget({ threadId: "thread-1" })).toBeNull();
+  });
+
+  it("eagerly tracks server routes before their thread detail mounts", () => {
+    expect(
+      resolveEagerActiveThreadRouteKey(
+        resolveThreadRouteTarget({
+          environmentId: "env-1",
+          threadId: "thread-1",
+        }),
+      ),
+    ).toBe("env-1:thread-1");
+    expect(
+      resolveEagerActiveThreadRouteKey(resolveThreadRouteTarget({ draftId: "draft-1" })),
+    ).toBeUndefined();
+    expect(resolveEagerActiveThreadRouteKey(null)).toBeNull();
   });
 
   it("keeps an active visit only while the same chat route remains mounted", () => {

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -85,6 +85,20 @@ export function resolveThreadRouteTarget(
   };
 }
 
+/**
+ * Canonical routes can register their active thread before thread detail has
+ * loaded. Draft routes defer to ChatView because the draft id alone does not
+ * identify its scoped thread ref.
+ */
+export function resolveEagerActiveThreadRouteKey(
+  target: ThreadRouteTarget | null,
+): string | null | undefined {
+  if (target === null) {
+    return null;
+  }
+  return target.kind === "server" ? scopedThreadKey(target.threadRef) : undefined;
+}
+
 export function shouldKeepActiveThreadVisitOnUnmount(input: {
   readonly currentRouteTarget: ThreadRouteTarget | null;
   readonly routeThreadKey: string;

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -1,4 +1,4 @@
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { DraftId } from "./composerDraftStore";
 
@@ -83,6 +83,21 @@ export function resolveThreadRouteTarget(
     kind: "draft",
     draftId: params.draftId as DraftId,
   };
+}
+
+export function shouldKeepActiveThreadVisitOnUnmount(input: {
+  readonly currentRouteTarget: ThreadRouteTarget | null;
+  readonly routeThreadKey: string;
+  readonly draftId: DraftId | null;
+}): boolean {
+  if (input.currentRouteTarget?.kind === "server") {
+    return scopedThreadKey(input.currentRouteTarget.threadRef) === input.routeThreadKey;
+  }
+  return (
+    input.currentRouteTarget?.kind === "draft" &&
+    input.draftId !== null &&
+    input.currentRouteTarget.draftId === input.draftId
+  );
 }
 
 /**

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -25,6 +25,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     threadLastVisitedAtById: {},
     threadExplicitlyUnreadById: {},
     threadChangedFilesExpandedById: {},
+    hasTrackedActiveThreadRoute: false,
     activeThreadVisit: null,
     defaultAdvertisedEndpointKey: null,
     ...overrides,
@@ -69,6 +70,48 @@ describe("uiStateStore pure functions", () => {
 
     const away = markActiveThreadVisited(unread, otherThreadId, null);
     const returned = markActiveThreadVisited(away, threadId, updatedAt);
+    expect(returned.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+  });
+
+  it("preserves persisted unread state through initial route hydration", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const restarted = parsePersistedState({
+      threadLastVisitedAtById: { [threadId]: updatedAt },
+      threadExplicitlyUnreadById: { [threadId]: true },
+    });
+
+    const routed = markActiveThreadVisited(restarted, threadId, null);
+    const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
+
+    expect(routed.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.activeThreadVisit).toEqual({ threadId, visitedAt: updatedAt });
+  });
+
+  it("preserves active unread state through a transient detail gap", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const active = markActiveThreadVisited(makeUiState(), threadId, updatedAt);
+    const unread = markThreadUnread(active, threadId, null);
+
+    const missing = markActiveThreadVisited(unread, threadId, null);
+    const restored = markActiveThreadVisited(missing, threadId, updatedAt);
+
+    expect(missing).toBe(unread);
+    expect(restored).toBe(unread);
+    expect(restored.threadExplicitlyUnreadById[threadId]).toBe(true);
+  });
+
+  it("clears explicit unread after leaving and returning to the same route", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const active = markActiveThreadVisited(makeUiState(), threadId, updatedAt);
+    const unread = markThreadUnread(active, threadId, null);
+
+    const away = markActiveThreadVisited(unread, null, null);
+    const returned = markActiveThreadVisited(away, threadId, updatedAt);
+
     expect(returned.threadExplicitlyUnreadById[threadId]).toBeUndefined();
   });
 
@@ -207,6 +250,7 @@ describe("parsePersistedState", () => {
       threadExplicitlyUnreadById: {
         "environment:thread-1": true,
       },
+      hasTrackedActiveThreadRoute: false,
       activeThreadVisit: null,
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpandedById: {

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -89,6 +89,24 @@ describe("uiStateStore pure functions", () => {
     expect(hydrated.activeThreadVisit).toEqual({ threadId, visitedAt: updatedAt });
   });
 
+  it("clears persisted unread after tracking a draft route before opening the thread", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const restarted = parsePersistedState({
+      threadLastVisitedAtById: { [threadId]: updatedAt },
+      threadExplicitlyUnreadById: { [threadId]: true },
+    });
+
+    const draft = markActiveThreadVisited(restarted, null, null);
+    const routed = markActiveThreadVisited(draft, threadId, null);
+    const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
+
+    expect(draft.hasTrackedActiveThreadRoute).toBe(true);
+    expect(routed.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+    expect(hydrated.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+    expect(hydrated.activeThreadVisit).toEqual({ threadId, visitedAt: updatedAt });
+  });
+
   it("preserves active unread state through a transient detail gap", () => {
     const threadId = ThreadId.make("thread-1");
     const updatedAt = "2026-02-25T12:30:00.000Z";

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -160,6 +160,21 @@ describe("uiStateStore pure functions", () => {
     expect(updated.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:35:00.000Z");
   });
 
+  it("preserves explicit unread when an active visit timestamp regresses", () => {
+    const threadId = ThreadId.make("thread-1");
+    const active = markActiveThreadVisited(makeUiState(), threadId, "2026-02-25T12:35:00.000Z");
+    const unread = markThreadUnread(active, threadId, null);
+
+    const stale = markActiveThreadVisited(unread, threadId, "2026-02-25T12:30:00.000Z");
+
+    expect(stale).toBe(unread);
+    expect(stale.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(stale.activeThreadVisit).toEqual({
+      threadId,
+      visitedAt: "2026-02-25T12:35:00.000Z",
+    });
+  });
+
   it("resolves project expansion from logical, physical, and legacy preference keys", () => {
     const physicalKey = "environment:/repo/project";
     const legacyKey = legacyProjectCwdPreferenceKey("/repo/project");

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -89,7 +89,7 @@ describe("uiStateStore pure functions", () => {
     expect(hydrated.activeThreadVisit).toEqual({ threadId, visitedAt: updatedAt });
   });
 
-  it("clears persisted unread after tracking a draft route before opening the thread", () => {
+  it("preserves persisted unread when a draft promotes to the same thread", () => {
     const threadId = ThreadId.make("thread-1");
     const updatedAt = "2026-02-25T12:30:00.000Z";
     const restarted = parsePersistedState({
@@ -97,14 +97,31 @@ describe("uiStateStore pure functions", () => {
       threadExplicitlyUnreadById: { [threadId]: true },
     });
 
-    const draft = markActiveThreadVisited(restarted, null, null);
+    const draft = markActiveThreadVisited(restarted, threadId, null);
     const routed = markActiveThreadVisited(draft, threadId, null);
     const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
 
     expect(draft.hasTrackedActiveThreadRoute).toBe(true);
+    expect(routed.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(hydrated.activeThreadVisit).toEqual({ threadId, visitedAt: updatedAt });
+  });
+
+  it("clears persisted unread after tracking a non-chat route", () => {
+    const threadId = ThreadId.make("thread-1");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const restarted = parsePersistedState({
+      threadLastVisitedAtById: { [threadId]: updatedAt },
+      threadExplicitlyUnreadById: { [threadId]: true },
+    });
+
+    const nonChatRoute = markActiveThreadVisited(restarted, null, null);
+    const routed = markActiveThreadVisited(nonChatRoute, threadId, null);
+    const hydrated = markActiveThreadVisited(routed, threadId, updatedAt);
+
+    expect(nonChatRoute.hasTrackedActiveThreadRoute).toBe(true);
     expect(routed.threadExplicitlyUnreadById[threadId]).toBeUndefined();
     expect(hydrated.threadExplicitlyUnreadById[threadId]).toBeUndefined();
-    expect(hydrated.activeThreadVisit).toEqual({ threadId, visitedAt: updatedAt });
   });
 
   it("preserves active unread state through a transient detail gap", () => {

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import {
   legacyProjectCwdPreferenceKey,
+  markActiveThreadVisited,
   markThreadUnread,
   markThreadVisited,
   parsePersistedState,
@@ -22,7 +23,9 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectExpandedById: {},
     projectOrder: [],
     threadLastVisitedAtById: {},
+    threadExplicitlyUnreadById: {},
     threadChangedFilesExpandedById: {},
+    activeThreadVisit: null,
     defaultAdvertisedEndpointKey: null,
     ...overrides,
   };
@@ -39,7 +42,7 @@ describe("uiStateStore pure functions", () => {
     expect(markThreadVisited(visited, threadId, "not-a-date")).toBe(visited);
   });
 
-  it("marks a completed thread unread using the server completion timestamp", () => {
+  it("marks any thread explicitly unread without requiring a completion timestamp", () => {
     const threadId = ThreadId.make("thread-1");
     const initialState = makeUiState({
       threadLastVisitedAtById: {
@@ -49,8 +52,34 @@ describe("uiStateStore pure functions", () => {
 
     const next = markThreadUnread(initialState, threadId, "2026-02-25T12:30:00.000Z");
 
-    expect(next.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:29:59.999Z");
+    expect(next.threadExplicitlyUnreadById[threadId]).toBe(true);
+    expect(next.threadLastVisitedAtById).toBe(initialState.threadLastVisitedAtById);
     expect(markThreadUnread(next, threadId, null)).toBe(next);
+  });
+
+  it("keeps an active thread unread until its route or update changes", () => {
+    const threadId = ThreadId.make("thread-1");
+    const otherThreadId = ThreadId.make("thread-2");
+    const updatedAt = "2026-02-25T12:30:00.000Z";
+    const active = markActiveThreadVisited(makeUiState(), threadId, updatedAt);
+    const unread = markThreadUnread(active, threadId, null);
+
+    expect(markActiveThreadVisited(unread, threadId, updatedAt)).toBe(unread);
+    expect(unread.threadExplicitlyUnreadById[threadId]).toBe(true);
+
+    const away = markActiveThreadVisited(unread, otherThreadId, null);
+    const returned = markActiveThreadVisited(away, threadId, updatedAt);
+    expect(returned.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+  });
+
+  it("clears explicit unread when the active thread updates", () => {
+    const threadId = ThreadId.make("thread-1");
+    const active = markActiveThreadVisited(makeUiState(), threadId, "2026-02-25T12:30:00.000Z");
+    const unread = markThreadUnread(active, threadId, null);
+    const updated = markActiveThreadVisited(unread, threadId, "2026-02-25T12:35:00.000Z");
+
+    expect(updated.threadExplicitlyUnreadById[threadId]).toBeUndefined();
+    expect(updated.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:35:00.000Z");
   });
 
   it("resolves project expansion from logical, physical, and legacy preference keys", () => {
@@ -154,6 +183,10 @@ describe("parsePersistedState", () => {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
         invalid: "not-a-date",
       },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
+        read: false,
+      },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
@@ -171,6 +204,10 @@ describe("parsePersistedState", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
+      },
+      activeThreadVisit: null,
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
@@ -255,6 +292,9 @@ describe("uiStateStore persistence", () => {
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
       },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
+      },
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
           "turn-1": false,
@@ -276,6 +316,9 @@ describe("uiStateStore persistence", () => {
       projectOrder: ["physical-b", "physical-a"],
       threadLastVisitedAtById: {
         "environment:thread-1": "2026-02-25T12:35:00.000Z",
+      },
+      threadExplicitlyUnreadById: {
+        "environment:thread-1": true,
       },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
       threadChangedFilesExpandedById: {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -312,6 +312,15 @@ export function markActiveThreadVisited(
         activeThreadVisit: { threadId, visitedAt },
       };
     }
+
+    const previousVisitedAtMs = Date.parse(state.activeThreadVisit.visitedAt);
+    const nextVisitedAtMs = Date.parse(visitedAt);
+    if (
+      !Number.isFinite(nextVisitedAtMs) ||
+      (Number.isFinite(previousVisitedAtMs) && nextVisitedAtMs <= previousVisitedAtMs)
+    ) {
+      return state;
+    }
   }
 
   const visitedState = visitedAt === null ? state : markThreadVisited(state, threadId, visitedAt);

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -20,6 +20,7 @@ export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
+  threadExplicitlyUnreadById?: Record<string, boolean>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
@@ -34,7 +35,12 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
+  threadExplicitlyUnreadById: Record<string, boolean>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  activeThreadVisit: {
+    readonly threadId: string;
+    readonly visitedAt: string | null;
+  } | null;
 }
 
 export interface UiEndpointState {
@@ -47,7 +53,9 @@ const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
+  threadExplicitlyUnreadById: {},
   threadChangedFilesExpandedById: {},
+  activeThreadVisit: null,
   defaultAdvertisedEndpointKey: null,
 };
 
@@ -124,9 +132,15 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     projectExpandedById,
     projectOrder,
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
+    threadExplicitlyUnreadById: Object.fromEntries(
+      Object.entries(sanitizeBooleanRecord(parsed.threadExplicitlyUnreadById)).filter(
+        ([, unread]) => unread,
+      ),
+    ),
     threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
       parsed.threadChangedFilesExpandedById,
     ),
+    activeThreadVisit: null,
     defaultAdvertisedEndpointKey:
       typeof parsed.defaultAdvertisedEndpointKey === "string" &&
       parsed.defaultAdvertisedEndpointKey.length > 0
@@ -209,6 +223,7 @@ export function persistState(state: UiState): void {
         projectExpandedById,
         projectOrder: state.projectOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
+        threadExplicitlyUnreadById: state.threadExplicitlyUnreadById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpandedById,
       } satisfies PersistedUiState),
@@ -252,25 +267,46 @@ export function markThreadVisited(state: UiState, threadId: string, visitedAt: s
 export function markThreadUnread(
   state: UiState,
   threadId: string,
-  latestTurnCompletedAt: string | null | undefined,
+  _latestTurnCompletedAt?: string | null | undefined,
 ): UiState {
-  if (!latestTurnCompletedAt) {
-    return state;
-  }
-  const latestTurnCompletedAtMs = Date.parse(latestTurnCompletedAt);
-  if (Number.isNaN(latestTurnCompletedAtMs)) {
-    return state;
-  }
-  const unreadVisitedAt = new Date(latestTurnCompletedAtMs - 1).toISOString();
-  if (state.threadLastVisitedAtById[threadId] === unreadVisitedAt) {
+  if (state.threadExplicitlyUnreadById[threadId]) {
     return state;
   }
   return {
     ...state,
-    threadLastVisitedAtById: {
-      ...state.threadLastVisitedAtById,
-      [threadId]: unreadVisitedAt,
+    threadExplicitlyUnreadById: {
+      ...state.threadExplicitlyUnreadById,
+      [threadId]: true,
     },
+  };
+}
+
+export function markActiveThreadVisited(
+  state: UiState,
+  threadId: string | null,
+  visitedAt: string | null,
+): UiState {
+  if (threadId === null) {
+    return state.activeThreadVisit === null ? state : { ...state, activeThreadVisit: null };
+  }
+
+  if (
+    state.activeThreadVisit?.threadId === threadId &&
+    state.activeThreadVisit.visitedAt === visitedAt
+  ) {
+    return state;
+  }
+
+  const visitedState = visitedAt === null ? state : markThreadVisited(state, threadId, visitedAt);
+  const nextExplicitlyUnreadById = {
+    ...visitedState.threadExplicitlyUnreadById,
+  };
+  delete nextExplicitlyUnreadById[threadId];
+
+  return {
+    ...visitedState,
+    threadExplicitlyUnreadById: nextExplicitlyUnreadById,
+    activeThreadVisit: { threadId, visitedAt },
   };
 }
 
@@ -414,6 +450,7 @@ export function reorderProjects(
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
+  markActiveThreadVisited: (threadId: string | null, visitedAt: string | null) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
@@ -430,6 +467,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => markThreadVisited(state, threadId, visitedAt)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
+  markActiveThreadVisited: (threadId, visitedAt) =>
+    set((state) => markActiveThreadVisited(state, threadId, visitedAt)),
   setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
   setDefaultAdvertisedEndpointKey: (key) =>

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -37,6 +37,7 @@ export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadExplicitlyUnreadById: Record<string, boolean>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  hasTrackedActiveThreadRoute: boolean;
   activeThreadVisit: {
     readonly threadId: string;
     readonly visitedAt: string | null;
@@ -55,6 +56,7 @@ const initialState: UiState = {
   threadLastVisitedAtById: {},
   threadExplicitlyUnreadById: {},
   threadChangedFilesExpandedById: {},
+  hasTrackedActiveThreadRoute: false,
   activeThreadVisit: null,
   defaultAdvertisedEndpointKey: null,
 };
@@ -140,6 +142,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
       parsed.threadChangedFilesExpandedById,
     ),
+    hasTrackedActiveThreadRoute: false,
     activeThreadVisit: null,
     defaultAdvertisedEndpointKey:
       typeof parsed.defaultAdvertisedEndpointKey === "string" &&
@@ -287,25 +290,42 @@ export function markActiveThreadVisited(
   visitedAt: string | null,
 ): UiState {
   if (threadId === null) {
-    return state.activeThreadVisit === null ? state : { ...state, activeThreadVisit: null };
+    return state.activeThreadVisit === null && state.hasTrackedActiveThreadRoute
+      ? state
+      : {
+          ...state,
+          hasTrackedActiveThreadRoute: true,
+          activeThreadVisit: null,
+        };
   }
 
-  if (
-    state.activeThreadVisit?.threadId === threadId &&
-    state.activeThreadVisit.visitedAt === visitedAt
-  ) {
-    return state;
+  if (state.activeThreadVisit?.threadId === threadId) {
+    if (visitedAt === null || state.activeThreadVisit.visitedAt === visitedAt) {
+      return state;
+    }
+
+    if (state.activeThreadVisit.visitedAt === null) {
+      const visitedState = markThreadVisited(state, threadId, visitedAt);
+      return {
+        ...visitedState,
+        hasTrackedActiveThreadRoute: true,
+        activeThreadVisit: { threadId, visitedAt },
+      };
+    }
   }
 
   const visitedState = visitedAt === null ? state : markThreadVisited(state, threadId, visitedAt);
   const nextExplicitlyUnreadById = {
     ...visitedState.threadExplicitlyUnreadById,
   };
-  delete nextExplicitlyUnreadById[threadId];
+  if (state.hasTrackedActiveThreadRoute) {
+    delete nextExplicitlyUnreadById[threadId];
+  }
 
   return {
     ...visitedState,
     threadExplicitlyUnreadById: nextExplicitlyUnreadById,
+    hasTrackedActiveThreadRoute: true,
     activeThreadVisit: { threadId, visitedAt },
   };
 }

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -75,10 +75,12 @@ describe("ClientSettings sidebar thread filters", () => {
     expect(DEFAULT_SIDEBAR_THREAD_FILTERS).toEqual({
       statuses: ["needs_attention", "unread", "working", "done"],
       environmentIds: [],
+      projectKeys: [],
       sources: [],
       recentOnly: false,
       attentionOnly: false,
       includeArchived: false,
+      groupByProject: true,
     });
   });
 
@@ -96,19 +98,23 @@ describe("ClientSettings sidebar thread filters", () => {
         sidebarThreadFilters: {
           statuses: ["unread"],
           environmentIds: ["environment-local"],
+          projectKeys: ["environment-local:project-1"],
           sources: ["codex"],
           recentOnly: true,
           attentionOnly: true,
           includeArchived: true,
+          groupByProject: false,
         },
       }).sidebarThreadFilters,
     ).toEqual({
       statuses: ["unread"],
       environmentIds: ["environment-local"],
+      projectKeys: ["environment-local:project-1"],
       sources: ["codex"],
       recentOnly: true,
       attentionOnly: true,
       includeArchived: true,
+      groupByProject: false,
     });
   });
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -5,6 +5,7 @@ import { ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
   ClientSettingsPatch,
+  DEFAULT_SIDEBAR_THREAD_FILTERS,
   DEFAULT_SERVER_SETTINGS,
   ServerSettings,
   ServerSettingsPatch,
@@ -65,6 +66,54 @@ describe("ClientSettings sidebar v2", () => {
   it.each([-1, 0, 91])("rejects an auto-settle threshold outside 1..90: %s", (value) => {
     expect(() => decodeClientSettings({ sidebarAutoSettleAfterDays: value })).toThrow();
     expect(() => decodeClientSettingsPatch({ sidebarAutoSettleAfterDays: value })).toThrow();
+  });
+});
+
+describe("ClientSettings sidebar thread filters", () => {
+  it("defaults to showing every active thread", () => {
+    expect(decodeClientSettings({}).sidebarThreadFilters).toEqual(DEFAULT_SIDEBAR_THREAD_FILTERS);
+    expect(DEFAULT_SIDEBAR_THREAD_FILTERS).toEqual({
+      statuses: ["needs_attention", "unread", "working", "done"],
+      environmentIds: [],
+      sources: [],
+      includeArchived: false,
+    });
+  });
+
+  it("hydrates missing nested fields and accepts a complete filter patch", () => {
+    expect(
+      decodeClientSettings({ sidebarThreadFilters: { includeArchived: true } })
+        .sidebarThreadFilters,
+    ).toEqual({
+      ...DEFAULT_SIDEBAR_THREAD_FILTERS,
+      includeArchived: true,
+    });
+
+    expect(
+      decodeClientSettingsPatch({
+        sidebarThreadFilters: {
+          statuses: ["unread"],
+          environmentIds: ["environment-local"],
+          sources: ["codex"],
+          includeArchived: true,
+        },
+      }).sidebarThreadFilters,
+    ).toEqual({
+      statuses: ["unread"],
+      environmentIds: ["environment-local"],
+      sources: ["codex"],
+      includeArchived: true,
+    });
+  });
+
+  it("rejects unknown status values", () => {
+    expect(() =>
+      decodeClientSettingsPatch({
+        sidebarThreadFilters: {
+          statuses: ["paused"],
+        },
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -76,6 +76,8 @@ describe("ClientSettings sidebar thread filters", () => {
       statuses: ["needs_attention", "unread", "working", "done"],
       environmentIds: [],
       sources: [],
+      recentOnly: false,
+      attentionOnly: false,
       includeArchived: false,
     });
   });
@@ -95,6 +97,8 @@ describe("ClientSettings sidebar thread filters", () => {
           statuses: ["unread"],
           environmentIds: ["environment-local"],
           sources: ["codex"],
+          recentOnly: true,
+          attentionOnly: true,
           includeArchived: true,
         },
       }).sidebarThreadFilters,
@@ -102,6 +106,8 @@ describe("ClientSettings sidebar thread filters", () => {
       statuses: ["unread"],
       environmentIds: ["environment-local"],
       sources: ["codex"],
+      recentOnly: true,
+      attentionOnly: true,
       includeArchived: true,
     });
   });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,10 +2,14 @@ import * as Effect from "effect/Effect";
 import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
-import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
+import { EnvironmentId, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL, ProviderOptionSelections } from "./model.ts";
 import { ModelSelection } from "./orchestration.ts";
-import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.ts";
+import {
+  ProviderDriverKind,
+  ProviderInstanceConfig,
+  ProviderInstanceId,
+} from "./providerInstance.ts";
 
 // ── Client Settings (local-only) ───────────────────────────────
 
@@ -20,6 +24,32 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "upda
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
+
+export const SidebarThreadFilterStatus = Schema.Literals([
+  "needs_attention",
+  "unread",
+  "working",
+  "done",
+]);
+export type SidebarThreadFilterStatus = typeof SidebarThreadFilterStatus.Type;
+export const SIDEBAR_THREAD_FILTER_STATUSES: readonly SidebarThreadFilterStatus[] = [
+  "needs_attention",
+  "unread",
+  "working",
+  "done",
+];
+export const SidebarThreadFilters = Schema.Struct({
+  statuses: Schema.Array(SidebarThreadFilterStatus).pipe(
+    Schema.withDecodingDefault(Effect.succeed([...SIDEBAR_THREAD_FILTER_STATUSES])),
+  ),
+  environmentIds: Schema.Array(EnvironmentId).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  sources: Schema.Array(ProviderDriverKind).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  includeArchived: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+});
+export type SidebarThreadFilters = typeof SidebarThreadFilters.Type;
+export const DEFAULT_SIDEBAR_THREAD_FILTERS: SidebarThreadFilters = Schema.decodeSync(
+  SidebarThreadFilters,
+)({});
 
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
@@ -110,6 +140,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
+  ),
+  sidebarThreadFilters: SidebarThreadFilters.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_FILTERS)),
   ),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
@@ -602,6 +635,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
+  sidebarThreadFilters: Schema.optionalKey(SidebarThreadFilters),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   sidebarV2Enabled: Schema.optionalKey(Schema.Boolean),
   timestampFormat: Schema.optionalKey(TimestampFormat),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -43,10 +43,14 @@ export const SidebarThreadFilters = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed([...SIDEBAR_THREAD_FILTER_STATUSES])),
   ),
   environmentIds: Schema.Array(EnvironmentId).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  projectKeys: Schema.Array(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   sources: Schema.Array(ProviderDriverKind).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
   recentOnly: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   attentionOnly: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   includeArchived: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  groupByProject: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 });
 export type SidebarThreadFilters = typeof SidebarThreadFilters.Type;
 export const DEFAULT_SIDEBAR_THREAD_FILTERS: SidebarThreadFilters = Schema.decodeSync(

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -44,6 +44,8 @@ export const SidebarThreadFilters = Schema.Struct({
   ),
   environmentIds: Schema.Array(EnvironmentId).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
   sources: Schema.Array(ProviderDriverKind).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  recentOnly: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  attentionOnly: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   includeArchived: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
 });
 export type SidebarThreadFilters = typeof SidebarThreadFilters.Type;


### PR DESCRIPTION
## What Changed

- Added a persistent Group by project toggle to the shared sidebar filter system.
- Added project filtering and an ungrouped flat chat list in both classic and Sidebar V2.
- Kept flat mode fully visible while retaining thread ordering and project-aware actions.
- Added a direct New thread control in classic flat mode.
- Preserved every underlying project reference when repositories are deduplicated in flat mode.
- Kept the active V2 route visible even when the selected filters would otherwise hide it.
- Excluded archived rows from activity sorting and active preview budgets.
- Hardened project removal so archived threads, stale member refs, drafts, and persisted project filters are handled consistently.

## Why

Sidebar V2 introduced useful project filtering and a flat thread list, but those controls should live in the shared filter model so either sidebar can use the same persisted behavior.

## Stack

This is intentionally stacked on #4330 and has been restacked onto its exact current head. After the unread and filter PRs land, GitHub reduces this PR to the six grouping-only commits.

## UI Changes

Users can switch between project groups and one flat chat list without changing sidebar implementations. Project filters remain available in either mode, and flat mode retains an obvious New thread action.

## Verification

- Six grouping commits remained patch-identical in the final restack.
- The combined patched-nightly integration passed 183 focused sidebar/grouping/unread/route tests and web typecheck.
- Targeted lint, formatting, range-diff, and `git diff --check` passed.
- The classic and Sidebar V2 filter/grouping flows were manually exercised in an isolated environment.

## Checklist

- [x] This PR is focused on sidebar project grouping
- [x] Classic and Sidebar V2 are both supported
- [x] Active routes and duplicate/stale project references remain visible
- [x] Archived and project-removal edge cases have focused regression coverage


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add project filter and flat thread grouping to the sidebar
> - Introduces a `SidebarFilterMenu` component that lets users filter sidebar threads by status, project, environment, provider source, and archived state, with multi-select checkboxes and a reset action.
> - Adds a flat (non-grouped) sidebar view that renders all threads under a single 'Threads' snapshot instead of per-project sections; the project header and sort menu are hidden in this mode.
> - Merges archived thread snapshots into the live thread list when 'Archived' is enabled, renders them in a dedicated section, and exposes an Unarchive action on each archived row.
> - Introduces explicit unread tracking: `markThreadUnread` now sets a flag in `threadExplicitlyUnreadById` instead of backdating last-visited timestamps; the sidebar and status pill render an 'Unread' pill and badge for flagged threads.
> - Adds `markActiveThreadVisited` to the UI state store and mounts `ActiveThreadRouteTracker` / `CompletedThreadUnreadTracker` at the root to clear explicit unread flags when a thread is revisited and to mark first-seen completed threads unread.
> - Persists `sidebarThreadFilters` in `ClientSettings` with a validated schema defaulting to all statuses, grouped-by-project, and no archive inclusion.
> - Risk: `markThreadUnread` behavior changes — it no longer adjusts `threadLastVisitedAt`, so any code relying on the old timestamp backdating to detect unread state will no longer work.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e98d34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->