### PR TITLE
feat: terminal-style prompt history for the chat composer

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1759,6 +1759,137 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, []);
 
   // ------------------------------------------------------------------
+  // Prompt history
+  // ------------------------------------------------------------------
+  const promptHistoryEntries = useMemo(() => {
+    const entries: string[] = [];
+    for (const message of activeThread?.messages ?? []) {
+      if (message.role !== "user") continue;
+      if (message.text.trim().length === 0) continue;
+      if (entries[entries.length - 1] === message.text) continue;
+      entries.push(message.text);
+    }
+    return entries;
+  }, [activeThread?.messages]);
+  const [promptHistoryIndex, setPromptHistoryIndex] = useState<number | null>(null);
+  const promptHistoryRecallRef = useRef<string | null>(null);
+  const promptHistoryDraftRef = useRef("");
+
+  useEffect(() => {
+    return () => {
+      // Leaving this thread (or unmounting) while browsing history: put the
+      // saved draft back so the recalled entry doesn't overwrite it.
+      if (promptHistoryRecallRef.current !== null) {
+        setComposerDraftPrompt(composerDraftTarget, promptHistoryDraftRef.current);
+      }
+      setPromptHistoryIndex(null);
+      promptHistoryRecallRef.current = null;
+      promptHistoryDraftRef.current = "";
+    };
+  }, [composerDraftTarget, setComposerDraftPrompt]);
+
+  // A thread-snapshot reload can shrink the entry list while browsing it.
+  useEffect(() => {
+    if (promptHistoryIndex !== null && promptHistoryIndex >= promptHistoryEntries.length) {
+      promptHistoryRecallRef.current = null;
+      setPromptHistoryIndex(null);
+    }
+  }, [promptHistoryEntries, promptHistoryIndex]);
+
+  // Editing a recalled entry (or any external prompt change, e.g. clearing on
+  // send) leaves history mode; the recalled text stays behind as a plain draft.
+  useEffect(() => {
+    if (promptHistoryRecallRef.current === null) return;
+    if (prompt === promptHistoryRecallRef.current) return;
+    promptHistoryRecallRef.current = null;
+    setPromptHistoryIndex(null);
+  }, [prompt]);
+
+  const recallPromptHistoryEntry = (index: number | null) => {
+    const nextPrompt =
+      index === null ? promptHistoryDraftRef.current : (promptHistoryEntries[index] ?? "");
+    promptHistoryRecallRef.current = index === null ? null : nextPrompt;
+    setPromptHistoryIndex(index);
+    promptRef.current = nextPrompt;
+    setPrompt(nextPrompt);
+    setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+    setComposerTrigger(null);
+  };
+
+  // History only activates when the caret cannot move further in the pressed
+  // direction, so arrow keys keep their normal movement inside multiline text.
+  const caretOnComposerEdgeLine = (event: KeyboardEvent, edge: "top" | "bottom"): boolean => {
+    if (promptRef.current.length === 0) return true;
+    // Logical gate first: the caret must be on the first/last hard line. The
+    // visual check below can't be trusted alone — empty lines yield zero-size
+    // caret rects whose fallback measures the whole block.
+    const snapshot = composerEditorRef.current?.readSnapshot();
+    if (!snapshot) return false;
+    // snapshot.value is source text, so index it with the expanded cursor —
+    // the collapsed cursor counts inline tokens (mentions, skills) as 1 char.
+    const beforeCaret = snapshot.value.slice(0, snapshot.expandedCursor);
+    const afterCaret = snapshot.value.slice(snapshot.expandedCursor);
+    if (edge === "top" ? beforeCaret.includes("\n") : afterCaret.includes("\n")) {
+      return false;
+    }
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return false;
+    const root = target.closest<HTMLElement>('[contenteditable="true"]') ?? target;
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+    const range = selection.getRangeAt(0);
+    let caretRect = range.getBoundingClientRect();
+    if (caretRect.height === 0) {
+      // Collapsed selections on empty lines report a zero rect.
+      const container = range.startContainer;
+      const element = container instanceof HTMLElement ? container : container.parentElement;
+      if (!element) return false;
+      caretRect = element.getBoundingClientRect();
+    }
+    // Compare against the first/last block of text rather than the editor box:
+    // the box can be taller than its content (min-height, padding).
+    const edgeElement = edge === "top" ? root.firstElementChild : root.lastElementChild;
+    const edgeRect = (edgeElement ?? root).getBoundingClientRect();
+    const threshold = (caretRect.height || 20) / 2;
+    if (edge === "top") {
+      return caretRect.top - edgeRect.top < threshold;
+    }
+    return edgeRect.bottom - caretRect.bottom < threshold;
+  };
+
+  const navigateComposerPromptHistory = (
+    key: "ArrowUp" | "ArrowDown",
+    event: KeyboardEvent,
+  ): boolean => {
+    if (isComposerApprovalState || activePendingProgress || pendingUserInputs.length > 0) {
+      return false;
+    }
+    if (event.shiftKey || event.altKey || event.metaKey || event.ctrlKey || event.isComposing) {
+      return false;
+    }
+    // Terminal-context chips only render as inline placeholders in the draft
+    // text; a recalled entry has none, so the chips would vanish from view yet
+    // still be appended on send. Keep history off while any are attached.
+    if (composerTerminalContexts.length > 0) return false;
+    if (promptHistoryEntries.length === 0) return false;
+    if (key === "ArrowUp") {
+      if (!caretOnComposerEdgeLine(event, "top")) return false;
+      const currentIndex = promptHistoryIndex ?? promptHistoryEntries.length;
+      if (currentIndex === 0) return false;
+      if (promptHistoryIndex === null) {
+        promptHistoryDraftRef.current = promptRef.current;
+      }
+      recallPromptHistoryEntry(currentIndex - 1);
+      return true;
+    }
+    if (promptHistoryIndex === null) return false;
+    if (!caretOnComposerEdgeLine(event, "bottom")) return false;
+    const nextIndex = promptHistoryIndex + 1;
+    recallPromptHistoryEntry(nextIndex >= promptHistoryEntries.length ? null : nextIndex);
+    return true;
+  };
+
+  // ------------------------------------------------------------------
   // Callbacks: command key
   // ------------------------------------------------------------------
   const onComposerCommandKey = (
@@ -1784,6 +1915,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
       if ((key === "Enter" || key === "Tab") && selectedItem) {
         onSelectComposerItem(selectedItem);
+        return true;
+      }
+    }
+    // Gate history on the visible popup, not the live-resolved trigger: a
+    // recalled entry ending in "@name"/"$20" resolves a trigger at the caret
+    // even though no menu is open, which would strand history navigation.
+    if ((key === "ArrowUp" || key === "ArrowDown") && !composerMenuOpenRef.current) {
+      if (navigateComposerPromptHistory(key, event)) {
         return true;
       }
     }
@@ -2479,6 +2618,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               )}
 
             <div className="relative">
+              {promptHistoryIndex !== null &&
+              !isComposerApprovalState &&
+              activePendingProgress === null ? (
+                <div
+                  data-testid="composer-history-indicator"
+                  className="pb-1.5 text-xs text-muted-foreground/70"
+                >
+                  History {promptHistoryIndex + 1}/{promptHistoryEntries.length}
+                </div>
+              ) : null}
               <ComposerPromptEditor
                 editorRef={composerEditorRef}
                 value={


### PR DESCRIPTION
closes #1777

## What Changed

Pressing `↑`/`↓` in the composer walks through previously sent user messages, shell-style. Recall only triggers when the caret is on the first/last line of the input, so arrow keys keep their normal movement inside multiline text (a visual check handles soft-wrapped lines, and recalled multiline prompts stay navigable). A small `History k/n` note shows while browsing; the unsent draft is saved on the first `↑` and restored when stepping past the newest entry with `↓`. Editing a recalled message drops out of history mode and keeps the text as a plain draft.

History is seeded per thread from its sent user messages and resets on send and thread switch. Navigation stays out of the way of the `@`/`$`//` autocomplete menus, pending plan questions, approvals, IME composition, and modifier-key combos, and is disabled while terminal-context chips are attached (a recalled entry can't render them). Recalled entries are the sent text verbatim.

## Why

Re-running or slightly tweaking a previous prompt is a common workflow and shell muscle memory. Previous attempts (#1778, #1848) went stale on merge conflicts; this is a fresh implementation on current `main`, contained in `ChatComposer.tsx` with no new files.

## UI Changes

Interaction only, plus the small `History k/n` label above the input while browsing. Video demonstrating the interaction:

https://github.com/user-attachments/assets/0c61a16b-525a-4f64-89f2-43df32839653
                         
## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer-only keyboard and draft UX in ChatComposer.tsx; no API, auth, or persistence changes beyond existing draft store behavior.
> 
> **Overview**
> Adds **terminal-style prompt history** to the chat composer: **↑/↓** walk prior sent user messages for the active thread when the caret is on the first or last line (multiline prompts still use arrows normally inside the text).
> 
> History is built from thread user messages (deduped consecutive), saves the in-progress draft on first **↑**, restores it when stepping past the newest entry with **↓**, and shows a **`History k/n`** label while browsing. Leaving history mode on edit/send, thread switch, or unmount keeps recalled text as a normal draft and restores the saved draft when appropriate.
> 
> Navigation is wired through `onComposerCommandKey` only when the command menu popup is not open (so recalled `@`/`$` text does not block history), and is turned off during approvals, pending questions, IME/modifier keys, and while terminal-context chips are attached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70c9060fdb082370cb3a3b40da3bf3ed62a36ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal-style prompt history navigation to the chat composer
> - Adds ArrowUp/ArrowDown prompt history navigation to [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/4336/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), scoped to the active thread's user messages.
> - Navigation is gated: requires the caret to be at the visual top/bottom line of the editor, no composer menu open, no approval/progress/user-input states, no terminal-context chips, no modifier keys, and no active IME composition.
> - On first entry into history mode, the current draft is saved and restored when the user navigates back past the oldest entry or leaves the thread.
> - Displays a `History i/n` indicator above the editor while browsing history.
> - Behavioral Change: ArrowUp/ArrowDown at the editor edge no longer move the cursor when history navigation is triggered — default browser cursor movement is suppressed in those cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d70c906.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->