### PR TITLE
Refresh a project favicon when its icon is clicked

### DIFF
--- a/apps/web/src/assets/assetUrls.ts
+++ b/apps/web/src/assets/assetUrls.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import type { AssetResource, EnvironmentId } from "@t3tools/contracts";
 import { AsyncResult } from "effect/unstable/reactivity";
@@ -41,6 +41,26 @@ export function useAssetUrl(environmentId: EnvironmentId, resource: AssetResourc
     return null;
   }
   return result.url;
+}
+
+/**
+ * Re-issue an asset URL from the environment.
+ *
+ * Asset URLs embed the resolution the server performed when the URL was minted
+ * (for project favicons: which icon file was found, or that none was). Asking
+ * for a new URL therefore re-runs that resolution and yields a freshly signed
+ * URL, which also gets the browser past its cached copy of the old one.
+ */
+export function useRefreshAssetUrl(
+  environmentId: EnvironmentId,
+  resource: AssetResource,
+): () => void {
+  return useAtomRefresh(
+    assetEnvironment.createUrl({
+      environmentId,
+      input: { resource },
+    }),
+  );
 }
 
 export function useAssetUrls(

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -34,6 +34,7 @@ export function ProjectFavicon(input: {
 
   return (
     <ProjectFaviconImage
+      key={`${input.environmentId}:${input.cwd}`}
       src={src}
       className={input.className}
       fallbackIcon={FallbackIcon}
@@ -65,9 +66,9 @@ function ProjectFaviconFallback({
   );
 }
 
-// Not keyed on `src`: a refresh mints a new URL for the same icon, and
-// remounting would drop back to the placeholder for a frame. Reusing the
-// element lets the browser hold the current image until the new bytes decode.
+// Keyed by environment and cwd rather than `src`: switching projects resets
+// stale image state, while refreshing one project's URL keeps its current
+// image visible until the new bytes decode.
 function ProjectFaviconImage({
   src,
   className,

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -3,7 +3,7 @@ import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
 import { FolderIcon } from "lucide-react";
 import type { ComponentType } from "react";
 import { useState } from "react";
-import { useAssetUrl } from "../assets/assetUrls";
+import { useAssetUrl, useRefreshAssetUrl } from "../assets/assetUrls";
 
 const loadedProjectFaviconSrcs = new Set<string>();
 
@@ -13,22 +13,31 @@ export function ProjectFavicon(input: {
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
-  const src = useAssetUrl(input.environmentId, {
-    _tag: "project-favicon",
-    cwd: input.cwd,
-  });
+  const resource = { _tag: "project-favicon", cwd: input.cwd } as const;
+  const src = useAssetUrl(input.environmentId, resource);
+  // Clicking an icon re-issues its asset URL, which makes the server resolve
+  // the project's icon from scratch. That is what picks up an icon that was
+  // just added, replaced, or moved — the URL bakes in the file the server
+  // found when it was minted, so cache-busting the old URL would keep
+  // fetching the old file. Every icon for this project shares one query, so
+  // they all refresh together.
+  const refresh = useRefreshAssetUrl(input.environmentId, resource);
   const FallbackIcon = input.fallbackIcon ?? FolderIcon;
 
+  // The click is deliberately not consumed: it still bubbles to the
+  // surrounding row, so pressing the icon both opens the row and refreshes.
   if (!src || isProjectFaviconFallbackUrl(src)) {
-    return <ProjectFaviconFallback className={input.className} icon={FallbackIcon} />;
+    return (
+      <ProjectFaviconFallback className={input.className} icon={FallbackIcon} onClick={refresh} />
+    );
   }
 
   return (
     <ProjectFaviconImage
-      key={src}
       src={src}
       className={input.className}
       fallbackIcon={FallbackIcon}
+      onClick={refresh}
     />
   );
 }
@@ -36,21 +45,39 @@ export function ProjectFavicon(input: {
 function ProjectFaviconFallback({
   className,
   icon: Icon,
+  onClick,
 }: {
   readonly className?: string | undefined;
   readonly icon: ComponentType<{ className?: string }>;
+  readonly onClick?: (() => void) | undefined;
 }) {
-  return <Icon className={`size-3.5 shrink-0 text-muted-foreground/50 ${className ?? ""}`} />;
+  const icon = <Icon className={`size-3.5 shrink-0 text-muted-foreground/50 ${className ?? ""}`} />;
+  if (onClick === undefined) {
+    return icon;
+  }
+  // A project showing the placeholder still needs a refresh target, otherwise
+  // an icon it just gained could never be picked up by clicking. `contents`
+  // keeps the wrapper out of layout while giving the click somewhere to land.
+  return (
+    <span className="contents" onClick={onClick}>
+      {icon}
+    </span>
+  );
 }
 
+// Not keyed on `src`: a refresh mints a new URL for the same icon, and
+// remounting would drop back to the placeholder for a frame. Reusing the
+// element lets the browser hold the current image until the new bytes decode.
 function ProjectFaviconImage({
   src,
   className,
   fallbackIcon: FallbackIcon,
+  onClick,
 }: {
   readonly src: string;
   readonly className?: string | undefined;
   readonly fallbackIcon: ComponentType<{ className?: string }>;
+  readonly onClick: () => void;
 }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>
     loadedProjectFaviconSrcs.has(src) ? "loaded" : "loading",
@@ -59,11 +86,12 @@ function ProjectFaviconImage({
   return (
     <>
       {status !== "loaded" ? (
-        <ProjectFaviconFallback className={className} icon={FallbackIcon} />
+        <ProjectFaviconFallback className={className} icon={FallbackIcon} onClick={onClick} />
       ) : null}
       <img
         src={src}
         alt=""
+        onClick={onClick}
         className={`size-3.5 shrink-0 rounded-sm object-contain ${status === "loaded" ? "" : "hidden"} ${className ?? ""}`}
         onLoad={() => {
           loadedProjectFaviconSrcs.add(src);

--- a/packages/client-runtime/src/state/assets.test.ts
+++ b/packages/client-runtime/src/state/assets.test.ts
@@ -80,6 +80,25 @@ describe("createAssetEnvironmentAtoms", () => {
     ).not.toBe(assets.createUrl(originalTarget));
   });
 
+  it("forwards manual refreshes so a stale asset URL can be re-issued", () => {
+    const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
+      EnvironmentRegistry,
+      never
+    >;
+    const assets = createAssetEnvironmentAtoms(runtime);
+    const atom = assets.createUrl({
+      environmentId: EnvironmentId.make("environment-1"),
+      input: {
+        resource: { _tag: "project-favicon", cwd: "/repo/original" },
+      },
+    });
+
+    // Clicking a project favicon re-issues its URL so the server resolves the
+    // project's icon again. That only works while the query atom carries a
+    // refresh hook down to the underlying request.
+    expect(typeof atom.refresh).toBe("function");
+  });
+
   it("keys collections while preserving independent resource queries", () => {
     const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
       EnvironmentRegistry,


### PR DESCRIPTION
## What Changed

Clicking a project icon now re-issues its asset URL, so the sidebar picks up an icon that changed on disk without reloading the app.

Project favicon asset URLs are signed tokens that bake in the file the server resolved when the URL was minted. Cache-busting that URL is not enough: it keeps pointing at the file the server found last time. And a project with no icon renders a placeholder rather than an `<img>`, so previously there was no target to click at all — a project that just gained an icon could never pick it up.

- `apps/web/src/assets/assetUrls.ts`: new `useRefreshAssetUrl` hook that refreshes the `assets.createUrl` query for a resource, making the server resolve it again and mint a freshly signed URL.
- `apps/web/src/components/ProjectFavicon.tsx`: clicking the icon — **or the placeholder** — refreshes it. Because every instance of a project's icon shares one query, they all refresh together. Dropped the `key={src}` remount so a refresh swaps the `<img>` source in place and the loaded image stays on screen while the new bytes decode, instead of flashing back to the placeholder.

The click is deliberately not consumed (`stopPropagation` is avoided), so pressing an icon in a sidebar row still opens the row as before.

## Why

When a project's favicon changes, the sidebar icon stays stale until the app reloads. Click-to-refresh gives a direct way to pull the current icon in place — including the common case where a project only just got an icon and was showing the folder placeholder.

## UI Changes

Verified live against a real project in an isolated dev environment, in the sidebar v2 project selector. Screenshots are cropped from the sidebar and upscaled 3× so the 14px icon is legible.

| Step | Sidebar |
| --- | --- |
| Baseline: project icon is `favicon.svg` (red) | ![baseline](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/favicon-reload-on-click/01-red.png) |
| Icon replaced on disk at a **different path** (`favicon.svg` deleted, `app/icon.svg` added, blue) — still stale before the click | ![stale](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/favicon-reload-on-click/02-stale.png) |
| After clicking the icon — served file moved from `favicon.svg` to `app/icon.svg`, which cache-busting alone could not do | ![refreshed](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/favicon-reload-on-click/03-blue.png) |
| Icon deleted on disk, then clicked — falls back to the placeholder | ![placeholder](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/favicon-reload-on-click/04-placeholder.png) |
| New `favicon.svg` (green) added, then the **placeholder** clicked — the icon appears | ![recovered](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/favicon-reload-on-click/05-green.png) |

The last row is the case the icon-only click handler could not reach: with no `<img>` rendered, there was nothing to click.

## Checklist

- [x] `vp test run packages/client-runtime/src/state/assets.test.ts` (5 passed, incl. new refresh-forwarding case)
- [x] `vp run --filter @t3tools/web --filter @t3tools/client-runtime typecheck`
- [x] `vp lint apps/web/src packages/client-runtime/src` (no new findings)
- [x] `vp fmt`
- [x] Integrated browser verification in an isolated dev environment: project icon added/replaced/moved/deleted on disk and refreshed by clicking, with the served asset path confirmed in the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh a project favicon by clicking its icon
> - Adds a `useRefreshAssetUrl` hook in [assetUrls.ts](https://github.com/pingdotgg/t3code/pull/4337/files#diff-770036760f7db849ead3c80b42095cf357deb640201898aa6495da9868544937) that returns a callback to manually re-issue an asset URL query for a given environment and resource.
> - Wires that refresh callback to `onClick` on both the favicon image and the fallback placeholder in [ProjectFavicon.tsx](https://github.com/pingdotgg/t3code/pull/4337/files#diff-ba3b3091a902090e72f9ecf4b437466f7adea984de7f3827b82726cae0f7e604), so clicking either triggers a server re-resolve of the project icon.
> - Changes the image `key` from the asset URL to `${environmentId}:${cwd}`, keeping the image mounted across URL refreshes while still remounting when switching projects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37604c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and asset-query refresh behavior with no auth, data, or API contract changes.
> 
> **Overview**
> Clicking a project favicon (or its folder placeholder) now **re-issues the signed asset URL** so the server resolves the icon from disk again, picking up adds, moves, deletes, or replacements without reloading the app.
> 
> Adds **`useRefreshAssetUrl`** in `assetUrls.ts`, wired through `useAtomRefresh` on the shared `assets.createUrl` query so every instance of that project’s icon refreshes together. **`ProjectFavicon`** attaches the refresh handler to both the `<img>` and the placeholder (via a `contents` wrapper), and leaves clicks bubbling so sidebar row navigation still works.
> 
> The image component **`key`** is now `${environmentId}:${cwd}` instead of `src`, so a URL refresh keeps the current image visible while new bytes load instead of remounting and flashing the placeholder. A client-runtime test asserts the asset URL atom exposes a **`refresh`** hook for manual re-issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37604c99b46f990e333033ec143f391719d05093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->