### PR TITLE
fix(server): clean status fetch temporary packs

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -12,7 +12,10 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
-import { splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import {
+  findNewGitTemporaryPackFiles,
+  splitNullSeparatedGitStdoutPaths,
+} from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
@@ -94,6 +97,20 @@ const initRepoWithCommit = (
     const initialBranch = yield* git(cwd, ["branch", "--show-current"]);
     return { initialBranch };
   });
+
+describe("findNewGitTemporaryPackFiles", () => {
+  it("returns only temporary packs created after the status fetch started", () => {
+    const preexistingEntries = new Set(["pack-existing.pack", "tmp_pack_existing"]);
+
+    assert.deepStrictEqual(
+      findNewGitTemporaryPackFiles(
+        ["pack-existing.pack", "pack-new.pack", "tmp_pack_existing", "tmp_pack_new", "tmp_other"],
+        preexistingEntries,
+      ),
+      ["tmp_pack_new"],
+    );
+  });
+});
 
 it.effect("uses stable diagnostics for every parsed non-repository command", () => {
   const commands: Array<{ readonly args: ReadonlyArray<string>; readonly lcAll?: string }> = [];

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1,5 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it, describe } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -464,7 +466,6 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         const cachedStatus = yield* driver.statusDetailsRemote(cwd, {
           refreshUpstream: false,
         });
-        const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
         const fileSystem = yield* FileSystem.FileSystem;
         const pathService = yield* Path.Path;
         const gitCommonDirRaw = yield* git(cwd, ["rev-parse", "--git-common-dir"]);
@@ -472,6 +473,15 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           ? gitCommonDirRaw
           : pathService.resolve(cwd, gitCommonDirRaw);
         const isolatedFetchRoot = pathService.join(gitCommonDir, "objects", "t3-status-fetch");
+        const staleFetchRoot = pathService.join(isolatedFetchRoot, "stale-fetch");
+        yield* fileSystem.makeDirectory(pathService.join(staleFetchRoot, "objects"), {
+          recursive: true,
+        });
+        const now = yield* DateTime.now;
+        const staleTime = DateTime.toDateUtc(DateTime.subtractDuration(now, Duration.hours(2)));
+        yield* fileSystem.utimes(staleFetchRoot, staleTime, staleTime);
+
+        const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
         const isolatedFetchEntries = (yield* fileSystem.exists(isolatedFetchRoot))
           ? yield* fileSystem.readDirectory(isolatedFetchRoot, { recursive: false })
           : [];
@@ -485,6 +495,87 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(refreshedStatus.behindCount, 1);
         assert.deepStrictEqual(isolatedFetchEntries, []);
         assert.equal(temporaryRefs, "");
+      }),
+    );
+
+    it.effect("honors custom upstream fetch refspecs", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+        yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["checkout", "-b", "feature/custom-upstream"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["push", "origin", "HEAD:refs/pull/123/head"]);
+        yield* git(cwd, [
+          "config",
+          "remote.origin.fetch",
+          "+refs/pull/*/head:refs/remotes/origin/pr/*",
+        ]);
+        yield* git(cwd, ["fetch", "origin"]);
+        yield* git(cwd, ["config", "branch.feature/custom-upstream.remote", "origin"]);
+        yield* git(cwd, ["config", "branch.feature/custom-upstream.merge", "refs/pull/123/head"]);
+
+        yield* git(updater, ["init"]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* git(updater, ["remote", "add", "origin", remote]);
+        yield* git(updater, ["fetch", "origin", "refs/pull/123/head"]);
+        yield* git(updater, ["checkout", "-b", "custom-upstream", "FETCH_HEAD"]);
+        yield* writeTextFile(updater, "remote.txt", "remote\n");
+        yield* git(updater, ["add", "remote.txt"]);
+        yield* git(updater, ["commit", "-m", "remote commit"]);
+        yield* git(updater, ["push", "origin", "HEAD:refs/pull/123/head"]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const cachedStatus = yield* driver.statusDetailsRemote(cwd, {
+          refreshUpstream: false,
+        });
+        const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
+
+        assert.equal(cachedStatus.behindCount, 0);
+        assert.equal(refreshedStatus.upstreamRef, "origin/pr/123");
+        assert.equal(refreshedStatus.behindCount, 1);
+      }),
+    );
+
+    it.effect("refreshes the default branch with a feature upstream", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+        yield* initRepoWithCommit(cwd);
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", "main"]);
+        yield* git(remote, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+        yield* git(cwd, ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+        yield* git(cwd, ["checkout", "-b", "feature/default-refresh"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["push", "-u", "origin", "feature/default-refresh"]);
+
+        yield* git(updater, ["clone", remote, "."]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* writeTextFile(updater, "remote.txt", "remote\n");
+        yield* git(updater, ["add", "remote.txt"]);
+        yield* git(updater, ["commit", "-m", "remote commit"]);
+        yield* git(updater, ["push", "origin", "main"]);
+        const remoteMain = yield* git(updater, ["rev-parse", "HEAD"]);
+
+        const localMainBefore = yield* git(cwd, ["rev-parse", "refs/remotes/origin/main"]);
+        yield* (yield* GitVcsDriver.GitVcsDriver).statusDetailsRemote(cwd);
+        const localMainAfter = yield* git(cwd, ["rev-parse", "refs/remotes/origin/main"]);
+
+        assert.notEqual(localMainBefore, remoteMain);
+        assert.equal(localMainAfter, remoteMain);
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -465,9 +465,26 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           refreshUpstream: false,
         });
         const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        const gitCommonDirRaw = yield* git(cwd, ["rev-parse", "--git-common-dir"]);
+        const gitCommonDir = pathService.isAbsolute(gitCommonDirRaw)
+          ? gitCommonDirRaw
+          : pathService.resolve(cwd, gitCommonDirRaw);
+        const isolatedFetchRoot = pathService.join(gitCommonDir, "objects", "t3-status-fetch");
+        const isolatedFetchEntries = (yield* fileSystem.exists(isolatedFetchRoot))
+          ? yield* fileSystem.readDirectory(isolatedFetchRoot, { recursive: false })
+          : [];
+        const temporaryRefs = yield* git(cwd, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/t3-status-fetch",
+        ]);
 
         assert.equal(cachedStatus.behindCount, 0);
         assert.equal(refreshedStatus.behindCount, 1);
+        assert.deepStrictEqual(isolatedFetchEntries, []);
+        assert.equal(temporaryRefs, "");
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -13,7 +13,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { GitCommandError } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
 import {
-  findNewGitTemporaryPackFiles,
+  isStaleGitTemporaryPackFile,
   splitNullSeparatedGitStdoutPaths,
 } from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
@@ -98,16 +98,42 @@ const initRepoWithCommit = (
     return { initialBranch };
   });
 
-describe("findNewGitTemporaryPackFiles", () => {
-  it("returns only temporary packs created after the status fetch started", () => {
-    const preexistingEntries = new Set(["pack-existing.pack", "tmp_pack_existing"]);
+describe("isStaleGitTemporaryPackFile", () => {
+  it("only selects temporary packs older than the cleanup grace period", () => {
+    const nowMs = 10_000;
+    const staleAfterMs = 1_000;
 
-    assert.deepStrictEqual(
-      findNewGitTemporaryPackFiles(
-        ["pack-existing.pack", "pack-new.pack", "tmp_pack_existing", "tmp_pack_new", "tmp_other"],
-        preexistingEntries,
-      ),
-      ["tmp_pack_new"],
+    assert.isTrue(
+      isStaleGitTemporaryPackFile({
+        entry: "tmp_pack_stale",
+        modifiedAtMs: 9_000,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+    assert.isFalse(
+      isStaleGitTemporaryPackFile({
+        entry: "tmp_pack_active",
+        modifiedAtMs: 9_001,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+    assert.isFalse(
+      isStaleGitTemporaryPackFile({
+        entry: "pack-complete.pack",
+        modifiedAtMs: 1_000,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+    assert.isFalse(
+      isStaleGitTemporaryPackFile({
+        entry: "tmp_pack_unknown",
+        modifiedAtMs: null,
+        nowMs,
+        staleAfterMs,
+      }),
     );
   });
 });

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -579,6 +579,48 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("refreshes the upstream when the configured default branch is missing", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+        yield* initRepoWithCommit(cwd);
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", "main"]);
+        yield* git(remote, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+        yield* git(cwd, [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/missing",
+        ]);
+        yield* git(cwd, ["checkout", "-b", "feature/missing-default"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["push", "-u", "origin", "feature/missing-default"]);
+
+        yield* git(updater, ["clone", remote, "."]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* git(updater, ["checkout", "feature/missing-default"]);
+        yield* writeTextFile(updater, "remote.txt", "remote\n");
+        yield* git(updater, ["add", "remote.txt"]);
+        yield* git(updater, ["commit", "-m", "remote commit"]);
+        yield* git(updater, ["push", "origin", "feature/missing-default"]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const cachedStatus = yield* driver.statusDetailsRemote(cwd, {
+          refreshUpstream: false,
+        });
+        const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
+
+        assert.equal(cachedStatus.behindCount, 0);
+        assert.equal(refreshedStatus.behindCount, 1);
+      }),
+    );
+
     it.effect("uses origin HEAD for default-branch detection with a non-origin upstream", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -4,6 +4,8 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { assert, it, describe } from "@effect/vitest";
 import * as Deferred from "effect/Deferred";
+import * as DateTime from "effect/DateTime";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
@@ -20,7 +22,13 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, type ReviewDiffFileContentsInput } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
-import { makeGitVcsDriverCore, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import {
+  isStaleGitStatusFetchDirectory,
+  isStaleGitTemporaryPackFile,
+  makeGitVcsDriverCore,
+  splitNullSeparatedGitStdoutPaths,
+  statusRemoteRefreshFailureKey,
+} from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
@@ -176,6 +184,79 @@ for (const location of ["root", "nested", "worktree"] as const) {
       }).pipe(Effect.provide(TestLayer)),
   );
 }
+describe("isStaleGitTemporaryPackFile", () => {
+  it("only selects temporary packs older than the cleanup grace period", () => {
+    const nowMs = 10_000;
+    const staleAfterMs = 1_000;
+
+    assert.isTrue(
+      isStaleGitTemporaryPackFile({
+        entry: "tmp_pack_stale",
+        modifiedAtMs: 9_000,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+    assert.isFalse(
+      isStaleGitTemporaryPackFile({
+        entry: "tmp_pack_active",
+        modifiedAtMs: 9_001,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+    assert.isFalse(
+      isStaleGitTemporaryPackFile({
+        entry: "pack-complete.pack",
+        modifiedAtMs: 1_000,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+    assert.isFalse(
+      isStaleGitTemporaryPackFile({
+        entry: "tmp_pack_unknown",
+        modifiedAtMs: null,
+        nowMs,
+        staleAfterMs,
+      }),
+    );
+  });
+});
+
+describe("isStaleGitStatusFetchDirectory", () => {
+  it("keeps active fetch directories past the cleanup grace period", () => {
+    const input = {
+      modifiedAtMs: 1_000,
+      nowMs: 10_000,
+      staleAfterMs: 1_000,
+    };
+
+    assert.isTrue(isStaleGitStatusFetchDirectory({ ...input, isActive: false }));
+    assert.isFalse(isStaleGitStatusFetchDirectory({ ...input, isActive: true }));
+  });
+});
+
+describe("statusRemoteRefreshFailureKey", () => {
+  it("isolates failure backoff across branch refreshes", () => {
+    const baseKey = {
+      gitCommonDir: "/repo/.git",
+      remoteName: "origin",
+      branchName: "main",
+      remoteRef: "refs/heads/main",
+      defaultBranchName: "main",
+    };
+
+    assert.notEqual(
+      statusRemoteRefreshFailureKey(baseKey),
+      statusRemoteRefreshFailureKey({
+        ...baseKey,
+        branchName: "feature",
+        remoteRef: "refs/heads/feature",
+      }),
+    );
+  });
+});
 
 it.effect("uses stable diagnostics for every parsed non-repository command", () => {
   const commands: Array<{ readonly args: ReadonlyArray<string>; readonly lcAll?: string }> = [];
@@ -1102,6 +1183,27 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("treats a deleted upstream tracking ref as no upstream", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", initialBranch]);
+        yield* git(cwd, ["checkout", "-b", "feature/deleted-upstream"]);
+        yield* git(cwd, ["push", "-u", "origin", "feature/deleted-upstream"]);
+        yield* git(cwd, ["push", "origin", "--delete", "feature/deleted-upstream"]);
+
+        const status = yield* (yield* GitVcsDriver.GitVcsDriver).statusDetailsRemote(cwd, {
+          refreshUpstream: false,
+        });
+
+        assert.equal(status.hasUpstream, false);
+        assert.equal(status.upstreamRef, null);
+      }),
+    );
+
     it.effect("reports remote status on unborn HEAD without failing", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();
@@ -1116,6 +1218,164 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(status.hasUpstream, false);
         assert.equal(status.aheadCount, 0);
         assert.equal(status.behindCount, 0);
+      }),
+    );
+
+    it.effect("keeps isolated fetch refs outside the shared repository", () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const cwd = yield* makeTmpDir();
+          const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+          const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+          const { initialBranch } = yield* initRepoWithCommit(cwd);
+          yield* git(remote, ["init", "--bare"]);
+          yield* git(cwd, ["remote", "add", "origin", remote]);
+          yield* git(cwd, ["push", "-u", "origin", initialBranch]);
+
+          yield* git(updater, ["clone", remote, "."]);
+          yield* git(updater, ["config", "user.email", "test@test.com"]);
+          yield* git(updater, ["config", "user.name", "Test"]);
+          yield* writeTextFile(updater, "remote.txt", "remote\n");
+          yield* git(updater, ["add", "remote.txt"]);
+          yield* git(updater, ["commit", "-m", "remote commit"]);
+          yield* git(updater, ["push", "origin", initialBranch]);
+          const concurrentCommit = yield* git(cwd, [
+            "commit-tree",
+            "HEAD^{tree}",
+            "-p",
+            "HEAD",
+            "-m",
+            "concurrent ref update",
+          ]);
+
+          const delegate = yield* ChildProcessSpawner.ChildProcessSpawner;
+          let isolatedFetchCount = 0;
+          const isolatedFetchExited = yield* Deferred.make<void>();
+          const releaseIsolatedFetch = yield* Deferred.make<void>();
+          yield* Effect.addFinalizer(() =>
+            Deferred.succeed(releaseIsolatedFetch, undefined).pipe(Effect.asVoid),
+          );
+          const blockingSpawner = ChildProcessSpawner.make((command) =>
+            Effect.gen(function* () {
+              const handle = yield* delegate.spawn(command);
+              if (
+                !ChildProcess.isStandardCommand(command) ||
+                !command.args.includes("--no-write-fetch-head") ||
+                command.options.env?.GIT_OBJECT_DIRECTORY === undefined
+              ) {
+                return handle;
+              }
+              isolatedFetchCount += 1;
+              return ChildProcessSpawner.makeHandle({
+                pid: handle.pid,
+                exitCode: handle.exitCode.pipe(
+                  Effect.tap(() => Deferred.succeed(isolatedFetchExited, undefined)),
+                  Effect.tap(() => Deferred.await(releaseIsolatedFetch)),
+                ),
+                isRunning: handle.isRunning,
+                kill: handle.kill,
+                unref: handle.unref,
+                stdin: handle.stdin,
+                stdout: handle.stdout,
+                stderr: handle.stderr,
+                all: handle.all,
+                getInputFd: handle.getInputFd,
+                getOutputFd: handle.getOutputFd,
+              });
+            }),
+          );
+          const driver = yield* makeGitVcsDriverCore().pipe(
+            Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, blockingSpawner),
+            Effect.provide(ServerConfigLayer),
+          );
+          const refresh = yield* driver
+            .statusDetailsRemote(cwd)
+            .pipe(Effect.forkChild({ startImmediately: true }));
+
+          yield* Deferred.await(isolatedFetchExited);
+          const sharedTemporaryRefs = yield* git(cwd, [
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/t3-status-fetch",
+          ]);
+          const fileSystem = yield* FileSystem.FileSystem;
+          const pathService = yield* Path.Path;
+          const gitCommonDirRaw = yield* git(cwd, ["rev-parse", "--git-common-dir"]);
+          const gitCommonDir = pathService.isAbsolute(gitCommonDirRaw)
+            ? gitCommonDirRaw
+            : pathService.resolve(cwd, gitCommonDirRaw);
+          const isolatedFetchRoot = pathService.join(gitCommonDir, "objects", "t3-status-fetch");
+          const [isolatedGitDir] = yield* fileSystem.readDirectory(isolatedFetchRoot, {
+            recursive: false,
+          });
+          if (isolatedGitDir === undefined) {
+            return yield* Effect.die("expected an isolated Git status fetch directory");
+          }
+          const privateTemporaryRefs = yield* git(cwd, [
+            "--git-dir",
+            pathService.join(isolatedFetchRoot, isolatedGitDir),
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/t3-status-fetch",
+          ]);
+
+          assert.equal(sharedTemporaryRefs, "");
+          assert.match(privateTemporaryRefs, /\/upstream$/u);
+
+          yield* git(cwd, ["update-ref", `refs/remotes/origin/${initialBranch}`, concurrentCommit]);
+          yield* Deferred.succeed(releaseIsolatedFetch, undefined);
+          const refreshedStatus = yield* Fiber.join(refresh);
+          assert.equal(refreshedStatus.behindCount, 1);
+
+          yield* TestClock.adjust("16 seconds");
+          yield* driver.statusDetailsRemote(cwd);
+          assert.equal(isolatedFetchCount, 2);
+        }),
+      ),
+    );
+
+    it.effect("cleans the isolated repository when alternate setup fails", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", initialBranch]);
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        const alternatesSuffix = pathService.join("objects", "info", "alternates");
+        const writeFailure = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "writeFileString",
+          pathOrDescriptor: alternatesSuffix,
+        });
+        const failingFileSystem = FileSystem.FileSystem.of({
+          ...fileSystem,
+          writeFileString: (filePath, data, options) =>
+            filePath.endsWith(alternatesSuffix)
+              ? Effect.fail(writeFailure)
+              : fileSystem.writeFileString(filePath, data, options),
+        });
+        const driver = yield* makeGitVcsDriverCore().pipe(
+          Effect.provideService(FileSystem.FileSystem, failingFileSystem),
+          Effect.provide(ServerConfigLayer),
+        );
+
+        yield* driver.statusDetailsRemote(cwd).pipe(Effect.ignore);
+
+        const gitCommonDirRaw = yield* git(cwd, ["rev-parse", "--git-common-dir"]);
+        const gitCommonDir = pathService.isAbsolute(gitCommonDirRaw)
+          ? gitCommonDirRaw
+          : pathService.resolve(cwd, gitCommonDirRaw);
+        const isolatedFetchRoot = pathService.join(gitCommonDir, "objects", "t3-status-fetch");
+        const isolatedFetchEntries = (yield* fileSystem.exists(isolatedFetchRoot))
+          ? yield* fileSystem.readDirectory(isolatedFetchRoot, { recursive: false })
+          : [];
+
+        assert.deepStrictEqual(isolatedFetchEntries, []);
       }),
     );
 
@@ -1136,6 +1396,154 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         yield* git(updater, ["add", "remote.txt"]);
         yield* git(updater, ["commit", "-m", "remote commit"]);
         yield* git(updater, ["push", "origin", initialBranch]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const cachedStatus = yield* driver.statusDetailsRemote(cwd, {
+          refreshUpstream: false,
+        });
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        const gitCommonDirRaw = yield* git(cwd, ["rev-parse", "--git-common-dir"]);
+        const gitCommonDir = pathService.isAbsolute(gitCommonDirRaw)
+          ? gitCommonDirRaw
+          : pathService.resolve(cwd, gitCommonDirRaw);
+        const isolatedFetchRoot = pathService.join(gitCommonDir, "objects", "t3-status-fetch");
+        const staleFetchRoot = pathService.join(isolatedFetchRoot, "stale-fetch");
+        yield* fileSystem.makeDirectory(pathService.join(staleFetchRoot, "objects"), {
+          recursive: true,
+        });
+        const now = yield* DateTime.now;
+        const staleTime = DateTime.toDateUtc(DateTime.subtractDuration(now, Duration.hours(2)));
+        yield* fileSystem.utimes(staleFetchRoot, staleTime, staleTime);
+
+        const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
+        const isolatedFetchEntries = (yield* fileSystem.exists(isolatedFetchRoot))
+          ? yield* fileSystem.readDirectory(isolatedFetchRoot, { recursive: false })
+          : [];
+        const temporaryRefs = yield* git(cwd, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/t3-status-fetch",
+        ]);
+
+        assert.equal(cachedStatus.behindCount, 0);
+        assert.equal(refreshedStatus.behindCount, 1);
+        assert.deepStrictEqual(isolatedFetchEntries, []);
+        assert.equal(temporaryRefs, "");
+      }),
+    );
+
+    it.effect("honors custom upstream fetch refspecs", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+        yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["checkout", "-b", "feature/custom-upstream"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["push", "origin", "HEAD:refs/pull/123/head"]);
+        yield* git(cwd, [
+          "config",
+          "remote.origin.fetch",
+          "+refs/pull/*/head:refs/remotes/origin/pr/*",
+        ]);
+        yield* git(cwd, ["fetch", "origin"]);
+        yield* git(cwd, ["config", "branch.feature/custom-upstream.remote", "origin"]);
+        yield* git(cwd, ["config", "branch.feature/custom-upstream.merge", "refs/pull/123/head"]);
+
+        yield* git(updater, ["init"]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* git(updater, ["remote", "add", "origin", remote]);
+        yield* git(updater, ["fetch", "origin", "refs/pull/123/head"]);
+        yield* git(updater, ["checkout", "-b", "custom-upstream", "FETCH_HEAD"]);
+        yield* writeTextFile(updater, "remote.txt", "remote\n");
+        yield* git(updater, ["add", "remote.txt"]);
+        yield* git(updater, ["commit", "-m", "remote commit"]);
+        yield* git(updater, ["push", "origin", "HEAD:refs/pull/123/head"]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const cachedStatus = yield* driver.statusDetailsRemote(cwd, {
+          refreshUpstream: false,
+        });
+        const refreshedStatus = yield* driver.statusDetailsRemote(cwd);
+
+        assert.equal(cachedStatus.behindCount, 0);
+        assert.equal(refreshedStatus.upstreamRef, "origin/pr/123");
+        assert.equal(refreshedStatus.behindCount, 1);
+      }),
+    );
+
+    it.effect("refreshes the default branch with a feature upstream", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+        yield* initRepoWithCommit(cwd);
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", "main"]);
+        yield* git(remote, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+        yield* git(cwd, ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+        yield* git(cwd, ["checkout", "-b", "feature/default-refresh"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["push", "-u", "origin", "feature/default-refresh"]);
+
+        yield* git(updater, ["clone", remote, "."]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* writeTextFile(updater, "remote.txt", "remote\n");
+        yield* git(updater, ["add", "remote.txt"]);
+        yield* git(updater, ["commit", "-m", "remote commit"]);
+        yield* git(updater, ["push", "origin", "main"]);
+        const remoteMain = yield* git(updater, ["rev-parse", "HEAD"]);
+
+        const localMainBefore = yield* git(cwd, ["rev-parse", "refs/remotes/origin/main"]);
+        yield* (yield* GitVcsDriver.GitVcsDriver).statusDetailsRemote(cwd);
+        const localMainAfter = yield* git(cwd, ["rev-parse", "refs/remotes/origin/main"]);
+
+        assert.notEqual(localMainBefore, remoteMain);
+        assert.equal(localMainAfter, remoteMain);
+      }),
+    );
+
+    it.effect("refreshes the upstream when the configured default branch is missing", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+        const updater = yield* makeTmpDir("git-vcs-driver-updater-");
+        yield* initRepoWithCommit(cwd);
+        yield* git(cwd, ["branch", "-M", "main"]);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", "main"]);
+        yield* git(remote, ["symbolic-ref", "HEAD", "refs/heads/main"]);
+        yield* git(cwd, [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/missing",
+        ]);
+        yield* git(cwd, ["checkout", "-b", "feature/missing-default"]);
+        yield* writeTextFile(cwd, "feature.txt", "feature\n");
+        yield* git(cwd, ["add", "feature.txt"]);
+        yield* git(cwd, ["commit", "-m", "feature commit"]);
+        yield* git(cwd, ["push", "-u", "origin", "feature/missing-default"]);
+
+        yield* git(updater, ["clone", remote, "."]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* git(updater, ["checkout", "feature/missing-default"]);
+        yield* writeTextFile(updater, "remote.txt", "remote\n");
+        yield* git(updater, ["add", "remote.txt"]);
+        yield* git(updater, ["commit", "-m", "remote commit"]);
+        yield* git(updater, ["push", "origin", "feature/missing-default"]);
 
         const driver = yield* GitVcsDriver.GitVcsDriver;
         const cachedStatus = yield* driver.statusDetailsRemote(cwd, {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -53,6 +53,7 @@ const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const GIT_TEMPORARY_PACK_PREFIX = "tmp_pack_";
+const GIT_TEMPORARY_PACK_STALE_AGE = Duration.hours(1);
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
   GCM_INTERACTIVE: "never",
   GIT_ASKPASS: "",
@@ -228,12 +229,16 @@ export function splitNullSeparatedGitStdoutPaths(
   return splitNullSeparatedPaths(result.stdout, result.stdoutTruncated);
 }
 
-export function findNewGitTemporaryPackFiles(
-  entries: ReadonlyArray<string>,
-  preexistingEntries: ReadonlySet<string>,
-): string[] {
-  return entries.filter(
-    (entry) => entry.startsWith(GIT_TEMPORARY_PACK_PREFIX) && !preexistingEntries.has(entry),
+export function isStaleGitTemporaryPackFile(input: {
+  entry: string;
+  modifiedAtMs: number | null;
+  nowMs: number;
+  staleAfterMs: number;
+}): boolean {
+  return (
+    input.entry.startsWith(GIT_TEMPORARY_PACK_PREFIX) &&
+    input.modifiedAtMs !== null &&
+    input.nowMs - input.modifiedAtMs >= input.staleAfterMs
   );
 }
 
@@ -944,34 +949,40 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       const fetchCwd =
         path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
       const packDirectory = path.join(gitCommonDir, "objects", "pack");
-      const preexistingEntries = yield* fileSystem.exists(packDirectory).pipe(
-        Effect.flatMap((exists) =>
-          exists
-            ? fileSystem
-                .readDirectory(packDirectory, { recursive: false })
-                .pipe(Effect.map((entries) => new Set(entries) as ReadonlySet<string>))
-            : Effect.succeed(new Set<string>() as ReadonlySet<string>),
-        ),
-        Effect.orElseSucceed(() => null),
-      );
-      const cleanupNewTemporaryPacks =
-        preexistingEntries === null
-          ? Effect.void
-          : fileSystem.readDirectory(packDirectory, { recursive: false }).pipe(
-              Effect.flatMap((entries) =>
-                Effect.forEach(
-                  findNewGitTemporaryPackFiles(entries, preexistingEntries),
-                  (entry) => fileSystem.remove(path.join(packDirectory, entry), { force: true }),
-                  { concurrency: "unbounded", discard: true },
-                ),
-              ),
-              Effect.catch((cause) =>
-                Effect.logWarning("Failed to clean temporary Git pack files after status fetch.", {
-                  cause,
-                }),
-              ),
+      const cleanupStaleTemporaryPacks = Effect.gen(function* () {
+        if (!(yield* fileSystem.exists(packDirectory))) return;
+        const now = yield* DateTime.now;
+        const nowMs = DateTime.toEpochMillis(now);
+        const entries = yield* fileSystem.readDirectory(packDirectory, { recursive: false });
+        yield* Effect.forEach(
+          entries,
+          (entry) => {
+            if (!entry.startsWith(GIT_TEMPORARY_PACK_PREFIX)) return Effect.void;
+            const temporaryPackPath = path.join(packDirectory, entry);
+            return fileSystem.stat(temporaryPackPath).pipe(
+              Effect.flatMap((info) => {
+                const modifiedAtMs = Option.getOrNull(info.mtime)?.getTime() ?? null;
+                return isStaleGitTemporaryPackFile({
+                  entry,
+                  modifiedAtMs,
+                  nowMs,
+                  staleAfterMs: Duration.toMillis(GIT_TEMPORARY_PACK_STALE_AGE),
+                })
+                  ? fileSystem.remove(temporaryPackPath, { force: true })
+                  : Effect.void;
+              }),
+              Effect.ignore,
             );
+          },
+          { concurrency: "unbounded", discard: true },
+        );
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logWarning("Failed to clean stale temporary Git pack files.", { cause }),
+        ),
+      );
 
+      yield* cleanupStaleTemporaryPacks;
       const result = yield* executeGit(
         "GitVcsDriver.fetchRemoteForStatus",
         fetchCwd,
@@ -981,10 +992,8 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           env: STATUS_UPSTREAM_REFRESH_ENV,
           timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
         },
-      ).pipe(Effect.tapError(() => cleanupNewTemporaryPacks));
-      if (result.exitCode !== 0) {
-        yield* cleanupNewTemporaryPacks;
-      }
+      ).pipe(Effect.ensuring(cleanupStaleTemporaryPacks));
+      if (result.exitCode !== 0) return;
     });
 
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -55,6 +55,7 @@ const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const GIT_TEMPORARY_PACK_PREFIX = "tmp_pack_";
 const GIT_TEMPORARY_PACK_STALE_AGE = Duration.hours(1);
 const GIT_STATUS_FETCH_OBJECT_DIRECTORY = "t3-status-fetch";
+const GIT_STATUS_FETCH_STALE_AGE = Duration.hours(1);
 const GIT_STATUS_FETCH_REF_PREFIX = "refs/t3-status-fetch";
 const GIT_ZERO_OID = "0".repeat(40);
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
@@ -99,6 +100,8 @@ class StatusRemoteRefreshCacheKey extends Data.Class<{
   gitCommonDir: string;
   remoteName: string;
   branchName: string;
+  remoteRef: string;
+  defaultBranchName: string | null;
 }> {}
 
 interface ExecuteGitOptions {
@@ -305,6 +308,16 @@ function parseUpstreamRefByFirstSeparator(
     remoteName,
     branchName,
   };
+}
+
+function parseCurrentUpstreamRemoteRef(stdout: string): string | null {
+  for (const line of stdout.split("\n")) {
+    const [headMarker = "", remoteRef = ""] = line.split("\t");
+    if (headMarker.trim() === "*" && remoteRef.trim().length > 0) {
+      return remoteRef.trim();
+    }
+  }
+  return null;
 }
 
 function parseTrackingBranchByUpstreamRef(stdout: string, upstreamRef: string): string | null {
@@ -939,22 +952,42 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       Effect.map(parseRemoteNames),
       Effect.orElseSucceed((): ReadonlyArray<string> => []),
     );
-    return (
+    const parsedUpstream =
       parseUpstreamRefWithRemoteNames(upstreamRef, remoteNames) ??
-      parseUpstreamRefByFirstSeparator(upstreamRef)
+      parseUpstreamRefByFirstSeparator(upstreamRef);
+    if (!parsedUpstream) {
+      return null;
+    }
+
+    const upstreamRemoteRef = yield* runGitStdout(
+      "GitVcsDriver.resolveCurrentUpstreamRemoteRef",
+      cwd,
+      ["for-each-ref", "--format=%(HEAD)%09%(upstream:remoteref)", "refs/heads"],
+      true,
+    ).pipe(
+      Effect.map(parseCurrentUpstreamRemoteRef),
+      Effect.orElseSucceed(() => null),
     );
+
+    return {
+      ...parsedUpstream,
+      remoteRef: upstreamRemoteRef ?? `refs/heads/${parsedUpstream.branchName}`,
+    };
   });
 
   const fetchRemoteForStatus = (
     gitCommonDir: string,
     remoteName: string,
     branchName: string,
+    remoteRef: string,
+    defaultBranchName: string | null,
   ): Effect.Effect<void, GitCommandError> =>
     Effect.gen(function* () {
       const fetchCwd =
         path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
       const objectDirectory = path.join(gitCommonDir, "objects");
       const packDirectory = path.join(objectDirectory, "pack");
+      const isolatedFetchRoot = path.join(objectDirectory, GIT_STATUS_FETCH_OBJECT_DIRECTORY);
       // Older builds wrote interrupted fetches into the shared pack directory.
       // New fetches use the isolated object directory below; this only reaps legacy leftovers.
       const cleanupStaleTemporaryPacks = Effect.gen(function* () {
@@ -990,7 +1023,38 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         ),
       );
 
-      yield* cleanupStaleTemporaryPacks;
+      const cleanupStaleIsolatedFetches = Effect.gen(function* () {
+        if (!(yield* fileSystem.exists(isolatedFetchRoot))) return;
+        const now = yield* DateTime.now;
+        const nowMs = DateTime.toEpochMillis(now);
+        const entries = yield* fileSystem.readDirectory(isolatedFetchRoot, { recursive: false });
+        yield* Effect.forEach(
+          entries,
+          (entry) => {
+            const entryPath = path.join(isolatedFetchRoot, entry);
+            return fileSystem.stat(entryPath).pipe(
+              Effect.flatMap((info) => {
+                const modifiedAtMs = Option.getOrNull(info.mtime)?.getTime() ?? null;
+                return modifiedAtMs !== null &&
+                  nowMs - modifiedAtMs >= Duration.toMillis(GIT_STATUS_FETCH_STALE_AGE)
+                  ? fileSystem.remove(entryPath, { recursive: true, force: true })
+                  : Effect.void;
+              }),
+              Effect.ignore,
+            );
+          },
+          { concurrency: "unbounded", discard: true },
+        );
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logWarning("Failed to clean stale isolated Git status fetches.", { cause }),
+        ),
+      );
+
+      yield* Effect.all([cleanupStaleTemporaryPacks, cleanupStaleIsolatedFetches], {
+        concurrency: "unbounded",
+        discard: true,
+      });
       const operationId = yield* crypto.randomUUIDv4.pipe(
         Effect.mapError(
           (cause) =>
@@ -1003,15 +1067,26 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             }),
         ),
       );
-      const temporaryRoot = path.join(
-        objectDirectory,
-        GIT_STATUS_FETCH_OBJECT_DIRECTORY,
-        operationId,
-      );
+      const temporaryRoot = path.join(isolatedFetchRoot, operationId);
       const temporaryObjectDirectory = path.join(temporaryRoot, "objects");
       const temporaryPackDirectory = path.join(temporaryObjectDirectory, "pack");
-      const temporaryRef = `${GIT_STATUS_FETCH_REF_PREFIX}/${operationId}`;
       const targetRef = `refs/remotes/${remoteName}/${branchName}`;
+      const fetchTargets = [
+        {
+          remoteRef,
+          temporaryRef: `${GIT_STATUS_FETCH_REF_PREFIX}/${operationId}/upstream`,
+          targetRef,
+        },
+      ];
+      const defaultTargetRef =
+        defaultBranchName === null ? null : `refs/remotes/${remoteName}/${defaultBranchName}`;
+      if (defaultTargetRef !== null && defaultTargetRef !== targetRef) {
+        fetchTargets.push({
+          remoteRef: `refs/heads/${defaultBranchName}`,
+          temporaryRef: `${GIT_STATUS_FETCH_REF_PREFIX}/${operationId}/default`,
+          targetRef: defaultTargetRef,
+        });
+      }
 
       yield* fileSystem.makeDirectory(temporaryPackDirectory, { recursive: true }).pipe(
         Effect.mapError(
@@ -1028,12 +1103,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
       const cleanupIsolatedFetch = Effect.all(
         [
-          executeGit(
-            "GitVcsDriver.fetchRemoteForStatus.cleanupRef",
-            fetchCwd,
-            ["--git-dir", gitCommonDir, "update-ref", "-d", temporaryRef],
-            { allowNonZeroExit: true, timeoutMs: 2_000 },
-          ).pipe(Effect.ignore),
+          Effect.forEach(
+            fetchTargets,
+            ({ temporaryRef }) =>
+              executeGit(
+                "GitVcsDriver.fetchRemoteForStatus.cleanupRef",
+                fetchCwd,
+                ["--git-dir", gitCommonDir, "update-ref", "-d", temporaryRef],
+                { allowNonZeroExit: true, timeoutMs: 2_000 },
+              ).pipe(Effect.ignore),
+            { concurrency: "unbounded", discard: true },
+          ),
           fileSystem.remove(temporaryRoot, { recursive: true, force: true }).pipe(Effect.ignore),
         ],
         { concurrency: "unbounded", discard: true },
@@ -1104,14 +1184,23 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       );
 
       yield* Effect.gen(function* () {
-        const previousTarget = yield* executeGit(
-          "GitVcsDriver.fetchRemoteForStatus.readTarget",
-          fetchCwd,
-          ["--git-dir", gitCommonDir, "rev-parse", "--verify", targetRef],
-          { allowNonZeroExit: true },
+        const targetsWithExpectedOids = yield* Effect.forEach(
+          fetchTargets,
+          Effect.fn("GitVcsDriver.fetchRemoteForStatus.readTarget")(function* (fetchTarget) {
+            const previousTarget = yield* executeGit(
+              "GitVcsDriver.fetchRemoteForStatus.readTarget",
+              fetchCwd,
+              ["--git-dir", gitCommonDir, "rev-parse", "--verify", fetchTarget.targetRef],
+              { allowNonZeroExit: true },
+            );
+            return {
+              ...fetchTarget,
+              expectedTarget:
+                previousTarget.exitCode === 0 ? previousTarget.stdout.trim() : GIT_ZERO_OID,
+            };
+          }),
+          { concurrency: "unbounded" },
         );
-        const expectedTarget =
-          previousTarget.exitCode === 0 ? previousTarget.stdout.trim() : GIT_ZERO_OID;
         const result = yield* executeGit(
           "GitVcsDriver.fetchRemoteForStatus",
           fetchCwd,
@@ -1126,7 +1215,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             "--no-write-fetch-head",
             "--refmap=",
             remoteName,
-            `+refs/heads/${branchName}:${temporaryRef}`,
+            ...fetchTargets.map(
+              ({ remoteRef: sourceRef, temporaryRef }) => `+${sourceRef}:${temporaryRef}`,
+            ),
           ],
           {
             allowNonZeroExit: true,
@@ -1153,19 +1244,29 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           ),
         );
         yield* promoteObjectFiles;
-        const fetchedCommit = yield* runGitStdout(
-          "GitVcsDriver.fetchRemoteForStatus.resolve",
-          fetchCwd,
-          ["--git-dir", gitCommonDir, "rev-parse", "--verify", temporaryRef],
-        ).pipe(Effect.map((stdout) => stdout.trim()));
-        yield* runGit("GitVcsDriver.fetchRemoteForStatus.promoteRef", fetchCwd, [
-          "--git-dir",
-          gitCommonDir,
-          "update-ref",
-          targetRef,
-          fetchedCommit,
-          expectedTarget,
-        ]);
+        yield* Effect.forEach(
+          targetsWithExpectedOids,
+          Effect.fn("GitVcsDriver.fetchRemoteForStatus.promoteRef")(function* ({
+            temporaryRef,
+            targetRef: destinationRef,
+            expectedTarget,
+          }) {
+            const fetchedCommit = yield* runGitStdout(
+              "GitVcsDriver.fetchRemoteForStatus.resolve",
+              fetchCwd,
+              ["--git-dir", gitCommonDir, "rev-parse", "--verify", temporaryRef],
+            ).pipe(Effect.map((stdout) => stdout.trim()));
+            yield* runGit("GitVcsDriver.fetchRemoteForStatus.promoteRef", fetchCwd, [
+              "--git-dir",
+              gitCommonDir,
+              "update-ref",
+              destinationRef,
+              fetchedCommit,
+              expectedTarget,
+            ]);
+          }),
+          { concurrency: 1, discard: true },
+        );
       }).pipe(Effect.ensuring(cleanupIsolatedFetch));
     });
 
@@ -1180,7 +1281,13 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const refreshStatusRemoteCacheEntry = Effect.fn("refreshStatusRemoteCacheEntry")(function* (
     cacheKey: StatusRemoteRefreshCacheKey,
   ) {
-    yield* fetchRemoteForStatus(cacheKey.gitCommonDir, cacheKey.remoteName, cacheKey.branchName);
+    yield* fetchRemoteForStatus(
+      cacheKey.gitCommonDir,
+      cacheKey.remoteName,
+      cacheKey.branchName,
+      cacheKey.remoteRef,
+      cacheKey.defaultBranchName,
+    );
     return true as const;
   });
 
@@ -1199,12 +1306,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const upstream = yield* resolveCurrentUpstream(cwd);
     if (!upstream) return;
     const gitCommonDir = yield* resolveGitCommonDir(cwd);
+    const defaultBranchName = yield* resolveDefaultBranchName(cwd, upstream.remoteName).pipe(
+      Effect.orElseSucceed(() => null),
+    );
     yield* Cache.get(
       statusRemoteRefreshCache,
       new StatusRemoteRefreshCacheKey({
         gitCommonDir,
         remoteName: upstream.remoteName,
         branchName: upstream.branchName,
+        remoteRef: upstream.remoteRef,
+        defaultBranchName,
       }),
     );
   });

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -52,6 +52,7 @@ const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 
 const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
+const GIT_TEMPORARY_PACK_PREFIX = "tmp_pack_";
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
   GCM_INTERACTIVE: "never",
   GIT_ASKPASS: "",
@@ -225,6 +226,15 @@ export function splitNullSeparatedGitStdoutPaths(
   result: Pick<GitVcsDriver.ExecuteGitResult, "stdout" | "stdoutTruncated">,
 ): string[] {
   return splitNullSeparatedPaths(result.stdout, result.stdoutTruncated);
+}
+
+export function findNewGitTemporaryPackFiles(
+  entries: ReadonlyArray<string>,
+  preexistingEntries: ReadonlySet<string>,
+): string[] {
+  return entries.filter(
+    (entry) => entry.startsWith(GIT_TEMPORARY_PACK_PREFIX) && !preexistingEntries.has(entry),
+  );
 }
 
 function sanitizeRemoteName(value: string): string {
@@ -929,20 +939,53 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const fetchRemoteForStatus = (
     gitCommonDir: string,
     remoteName: string,
-  ): Effect.Effect<void, GitCommandError> => {
-    const fetchCwd =
-      path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
-    return executeGit(
-      "GitVcsDriver.fetchRemoteForStatus",
-      fetchCwd,
-      ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
-      {
-        allowNonZeroExit: true,
-        env: STATUS_UPSTREAM_REFRESH_ENV,
-        timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
-      },
-    ).pipe(Effect.asVoid);
-  };
+  ): Effect.Effect<void, GitCommandError> =>
+    Effect.gen(function* () {
+      const fetchCwd =
+        path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
+      const packDirectory = path.join(gitCommonDir, "objects", "pack");
+      const preexistingEntries = yield* fileSystem.exists(packDirectory).pipe(
+        Effect.flatMap((exists) =>
+          exists
+            ? fileSystem
+                .readDirectory(packDirectory, { recursive: false })
+                .pipe(Effect.map((entries) => new Set(entries) as ReadonlySet<string>))
+            : Effect.succeed(new Set<string>() as ReadonlySet<string>),
+        ),
+        Effect.orElseSucceed(() => null),
+      );
+      const cleanupNewTemporaryPacks =
+        preexistingEntries === null
+          ? Effect.void
+          : fileSystem.readDirectory(packDirectory, { recursive: false }).pipe(
+              Effect.flatMap((entries) =>
+                Effect.forEach(
+                  findNewGitTemporaryPackFiles(entries, preexistingEntries),
+                  (entry) => fileSystem.remove(path.join(packDirectory, entry), { force: true }),
+                  { concurrency: "unbounded", discard: true },
+                ),
+              ),
+              Effect.catch((cause) =>
+                Effect.logWarning("Failed to clean temporary Git pack files after status fetch.", {
+                  cause,
+                }),
+              ),
+            );
+
+      const result = yield* executeGit(
+        "GitVcsDriver.fetchRemoteForStatus",
+        fetchCwd,
+        ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
+        {
+          allowNonZeroExit: true,
+          env: STATUS_UPSTREAM_REFRESH_ENV,
+          timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
+        },
+      ).pipe(Effect.tapError(() => cleanupNewTemporaryPacks));
+      if (result.exitCode !== 0) {
+        yield* cleanupNewTemporaryPacks;
+      }
+    });
 
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {
     const gitCommonDir = yield* runGitStdout("GitVcsDriver.resolveGitCommonDir", cwd, [

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -54,6 +54,9 @@ const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const GIT_TEMPORARY_PACK_PREFIX = "tmp_pack_";
 const GIT_TEMPORARY_PACK_STALE_AGE = Duration.hours(1);
+const GIT_STATUS_FETCH_OBJECT_DIRECTORY = "t3-status-fetch";
+const GIT_STATUS_FETCH_REF_PREFIX = "refs/t3-status-fetch";
+const GIT_ZERO_OID = "0".repeat(40);
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
   GCM_INTERACTIVE: "never",
   GIT_ASKPASS: "",
@@ -95,6 +98,7 @@ type TraceTailState = {
 class StatusRemoteRefreshCacheKey extends Data.Class<{
   gitCommonDir: string;
   remoteName: string;
+  branchName: string;
 }> {}
 
 interface ExecuteGitOptions {
@@ -944,11 +948,15 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const fetchRemoteForStatus = (
     gitCommonDir: string,
     remoteName: string,
+    branchName: string,
   ): Effect.Effect<void, GitCommandError> =>
     Effect.gen(function* () {
       const fetchCwd =
         path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
-      const packDirectory = path.join(gitCommonDir, "objects", "pack");
+      const objectDirectory = path.join(gitCommonDir, "objects");
+      const packDirectory = path.join(objectDirectory, "pack");
+      // Older builds wrote interrupted fetches into the shared pack directory.
+      // New fetches use the isolated object directory below; this only reaps legacy leftovers.
       const cleanupStaleTemporaryPacks = Effect.gen(function* () {
         if (!(yield* fileSystem.exists(packDirectory))) return;
         const now = yield* DateTime.now;
@@ -983,17 +991,182 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       );
 
       yield* cleanupStaleTemporaryPacks;
-      const result = yield* executeGit(
-        "GitVcsDriver.fetchRemoteForStatus",
-        fetchCwd,
-        ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
-        {
-          allowNonZeroExit: true,
-          env: STATUS_UPSTREAM_REFRESH_ENV,
-          timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
-        },
-      ).pipe(Effect.ensuring(cleanupStaleTemporaryPacks));
-      if (result.exitCode !== 0) return;
+      const operationId = yield* crypto.randomUUIDv4.pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitCommandError({
+              operation: "GitVcsDriver.fetchRemoteForStatus",
+              command: "crypto.randomUUIDv4",
+              cwd: fetchCwd,
+              detail: "Failed to create an isolated status fetch identifier.",
+              cause,
+            }),
+        ),
+      );
+      const temporaryRoot = path.join(
+        objectDirectory,
+        GIT_STATUS_FETCH_OBJECT_DIRECTORY,
+        operationId,
+      );
+      const temporaryObjectDirectory = path.join(temporaryRoot, "objects");
+      const temporaryPackDirectory = path.join(temporaryObjectDirectory, "pack");
+      const temporaryRef = `${GIT_STATUS_FETCH_REF_PREFIX}/${operationId}`;
+      const targetRef = `refs/remotes/${remoteName}/${branchName}`;
+
+      yield* fileSystem.makeDirectory(temporaryPackDirectory, { recursive: true }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitCommandError({
+              operation: "GitVcsDriver.fetchRemoteForStatus",
+              command: "filesystem.makeDirectory",
+              cwd: fetchCwd,
+              detail: "Failed to create an isolated Git object directory for status fetch.",
+              cause,
+            }),
+        ),
+      );
+
+      const cleanupIsolatedFetch = Effect.all(
+        [
+          executeGit(
+            "GitVcsDriver.fetchRemoteForStatus.cleanupRef",
+            fetchCwd,
+            ["--git-dir", gitCommonDir, "update-ref", "-d", temporaryRef],
+            { allowNonZeroExit: true, timeoutMs: 2_000 },
+          ).pipe(Effect.ignore),
+          fileSystem.remove(temporaryRoot, { recursive: true, force: true }).pipe(Effect.ignore),
+        ],
+        { concurrency: "unbounded", discard: true },
+      );
+
+      const promoteFile = (source: string, destination: string) =>
+        fileSystem
+          .rename(source, destination)
+          .pipe(
+            Effect.catch((cause) =>
+              fileSystem
+                .exists(destination)
+                .pipe(
+                  Effect.flatMap((exists) =>
+                    exists ? fileSystem.remove(source, { force: true }) : Effect.fail(cause),
+                  ),
+                ),
+            ),
+          );
+      const promoteObjectFiles = Effect.gen(function* () {
+        const objectEntries = yield* fileSystem.readDirectory(temporaryObjectDirectory, {
+          recursive: false,
+        });
+        for (const entry of objectEntries) {
+          if (entry === "pack") {
+            const packEntries = yield* fileSystem.readDirectory(temporaryPackDirectory, {
+              recursive: false,
+            });
+            yield* Effect.forEach(
+              packEntries.filter((packEntry) => packEntry.startsWith("pack-")),
+              (packEntry) =>
+                promoteFile(
+                  path.join(temporaryPackDirectory, packEntry),
+                  path.join(packDirectory, packEntry),
+                ),
+              { concurrency: 1, discard: true },
+            );
+            continue;
+          }
+          if (!/^[0-9a-f]{2}$/u.test(entry)) continue;
+          const sourceDirectory = path.join(temporaryObjectDirectory, entry);
+          const destinationDirectory = path.join(objectDirectory, entry);
+          yield* fileSystem.makeDirectory(destinationDirectory, { recursive: true });
+          const looseObjects = yield* fileSystem.readDirectory(sourceDirectory, {
+            recursive: false,
+          });
+          yield* Effect.forEach(
+            looseObjects,
+            (looseObject) =>
+              promoteFile(
+                path.join(sourceDirectory, looseObject),
+                path.join(destinationDirectory, looseObject),
+              ),
+            { concurrency: 1, discard: true },
+          );
+        }
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitCommandError({
+              operation: "GitVcsDriver.fetchRemoteForStatus",
+              command: "filesystem.rename",
+              cwd: fetchCwd,
+              detail: "Failed to promote isolated Git objects.",
+              cause,
+            }),
+        ),
+      );
+
+      yield* Effect.gen(function* () {
+        const previousTarget = yield* executeGit(
+          "GitVcsDriver.fetchRemoteForStatus.readTarget",
+          fetchCwd,
+          ["--git-dir", gitCommonDir, "rev-parse", "--verify", targetRef],
+          { allowNonZeroExit: true },
+        );
+        const expectedTarget =
+          previousTarget.exitCode === 0 ? previousTarget.stdout.trim() : GIT_ZERO_OID;
+        const result = yield* executeGit(
+          "GitVcsDriver.fetchRemoteForStatus",
+          fetchCwd,
+          [
+            "--git-dir",
+            gitCommonDir,
+            "-c",
+            "fetch.unpackLimit=0",
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-write-fetch-head",
+            "--refmap=",
+            remoteName,
+            `+refs/heads/${branchName}:${temporaryRef}`,
+          ],
+          {
+            allowNonZeroExit: true,
+            env: {
+              ...STATUS_UPSTREAM_REFRESH_ENV,
+              GIT_OBJECT_DIRECTORY: temporaryObjectDirectory,
+              GIT_ALTERNATE_OBJECT_DIRECTORIES: objectDirectory,
+            },
+            timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
+          },
+        );
+        if (result.exitCode !== 0) return;
+
+        yield* fileSystem.makeDirectory(packDirectory, { recursive: true }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new GitCommandError({
+                operation: "GitVcsDriver.fetchRemoteForStatus",
+                command: "filesystem.makeDirectory",
+                cwd: fetchCwd,
+                detail: "Failed to prepare the Git pack directory.",
+                cause,
+              }),
+          ),
+        );
+        yield* promoteObjectFiles;
+        const fetchedCommit = yield* runGitStdout(
+          "GitVcsDriver.fetchRemoteForStatus.resolve",
+          fetchCwd,
+          ["--git-dir", gitCommonDir, "rev-parse", "--verify", temporaryRef],
+        ).pipe(Effect.map((stdout) => stdout.trim()));
+        yield* runGit("GitVcsDriver.fetchRemoteForStatus.promoteRef", fetchCwd, [
+          "--git-dir",
+          gitCommonDir,
+          "update-ref",
+          targetRef,
+          fetchedCommit,
+          expectedTarget,
+        ]);
+      }).pipe(Effect.ensuring(cleanupIsolatedFetch));
     });
 
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {
@@ -1007,7 +1180,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const refreshStatusRemoteCacheEntry = Effect.fn("refreshStatusRemoteCacheEntry")(function* (
     cacheKey: StatusRemoteRefreshCacheKey,
   ) {
-    yield* fetchRemoteForStatus(cacheKey.gitCommonDir, cacheKey.remoteName);
+    yield* fetchRemoteForStatus(cacheKey.gitCommonDir, cacheKey.remoteName, cacheKey.branchName);
     return true as const;
   });
 
@@ -1031,6 +1204,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       new StatusRemoteRefreshCacheKey({
         gitCommonDir,
         remoteName: upstream.remoteName,
+        branchName: upstream.branchName,
       }),
     );
   });

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -273,49 +273,42 @@ function parseRemoteFetchUrls(stdout: string): Map<string, string> {
   return remotes;
 }
 
-function parseUpstreamRefWithRemoteNames(
-  upstreamRef: string,
-  remoteNames: ReadonlyArray<string>,
-): { upstreamRef: string; remoteName: string; branchName: string } | null {
-  const parsed = parseRemoteRefWithRemoteNames(upstreamRef, remoteNames);
-  if (!parsed) {
-    return null;
-  }
-
-  return {
-    upstreamRef,
-    remoteName: parsed.remoteName,
-    branchName: parsed.branchName,
-  };
-}
-
-function parseUpstreamRefByFirstSeparator(
-  upstreamRef: string,
-): { upstreamRef: string; remoteName: string; branchName: string } | null {
-  const separatorIndex = upstreamRef.indexOf("/");
-  if (separatorIndex <= 0 || separatorIndex === upstreamRef.length - 1) {
-    return null;
-  }
-
-  const remoteName = upstreamRef.slice(0, separatorIndex).trim();
-  const branchName = upstreamRef.slice(separatorIndex + 1).trim();
-  if (remoteName.length === 0 || branchName.length === 0) {
-    return null;
-  }
-
-  return {
-    upstreamRef,
-    remoteName,
-    branchName,
-  };
-}
-
-function parseCurrentUpstreamRemoteRef(stdout: string): string | null {
+function parseCurrentUpstream(stdout: string): {
+  upstreamRef: string;
+  remoteName: string;
+  branchName: string;
+  remoteRef: string;
+} | null {
   for (const line of stdout.split("\n")) {
-    const [headMarker = "", remoteRef = ""] = line.split("\t");
-    if (headMarker.trim() === "*" && remoteRef.trim().length > 0) {
-      return remoteRef.trim();
+    const [
+      headMarker = "",
+      upstreamRef = "",
+      upstreamTargetRef = "",
+      remoteName = "",
+      remoteRef = "",
+    ] = line.split("\t");
+    if (
+      headMarker.trim() !== "*" ||
+      upstreamRef.trim().length === 0 ||
+      remoteName.trim().length === 0 ||
+      remoteRef.trim().length === 0
+    ) {
+      continue;
     }
+
+    const normalizedRemoteName = remoteName.trim();
+    const remoteTrackingPrefix = `refs/remotes/${normalizedRemoteName}/`;
+    const normalizedUpstreamTargetRef = upstreamTargetRef.trim();
+    if (!normalizedUpstreamTargetRef.startsWith(remoteTrackingPrefix)) {
+      return null;
+    }
+
+    return {
+      upstreamRef: upstreamRef.trim(),
+      remoteName: normalizedRemoteName,
+      branchName: normalizedUpstreamTargetRef.slice(remoteTrackingPrefix.length),
+      remoteRef: remoteRef.trim(),
+    };
   }
   return null;
 }
@@ -937,42 +930,20 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   });
 
   const resolveCurrentUpstream = Effect.fn("resolveCurrentUpstream")(function* (cwd: string) {
-    const upstreamRef = yield* runGitStdout(
+    const upstream = yield* runGitStdout(
       "GitVcsDriver.resolveCurrentUpstream",
       cwd,
-      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
-      true,
-    ).pipe(Effect.map((stdout) => stdout.trim()));
-
-    if (upstreamRef.length === 0 || upstreamRef === "@{upstream}") {
-      return null;
-    }
-
-    const remoteNames = yield* runGitStdout("GitVcsDriver.listRemoteNames", cwd, ["remote"]).pipe(
-      Effect.map(parseRemoteNames),
-      Effect.orElseSucceed((): ReadonlyArray<string> => []),
-    );
-    const parsedUpstream =
-      parseUpstreamRefWithRemoteNames(upstreamRef, remoteNames) ??
-      parseUpstreamRefByFirstSeparator(upstreamRef);
-    if (!parsedUpstream) {
-      return null;
-    }
-
-    const upstreamRemoteRef = yield* runGitStdout(
-      "GitVcsDriver.resolveCurrentUpstreamRemoteRef",
-      cwd,
-      ["for-each-ref", "--format=%(HEAD)%09%(upstream:remoteref)", "refs/heads"],
+      [
+        "for-each-ref",
+        "--format=%(HEAD)%09%(upstream:short)%09%(upstream)%09%(upstream:remotename)%09%(upstream:remoteref)",
+        "refs/heads",
+      ],
       true,
     ).pipe(
-      Effect.map(parseCurrentUpstreamRemoteRef),
+      Effect.map(parseCurrentUpstream),
       Effect.orElseSucceed(() => null),
     );
-
-    return {
-      ...parsedUpstream,
-      remoteRef: upstreamRemoteRef ?? `refs/heads/${parsedUpstream.branchName}`,
-    };
+    return upstream;
   });
 
   const fetchRemoteForStatus = (
@@ -1183,53 +1154,52 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         ),
       );
 
-      yield* Effect.gen(function* () {
-        const targetsWithExpectedOids = yield* Effect.forEach(
-          fetchTargets,
-          Effect.fn("GitVcsDriver.fetchRemoteForStatus.readTarget")(function* (fetchTarget) {
-            const previousTarget = yield* executeGit(
-              "GitVcsDriver.fetchRemoteForStatus.readTarget",
-              fetchCwd,
-              ["--git-dir", gitCommonDir, "rev-parse", "--verify", fetchTarget.targetRef],
-              { allowNonZeroExit: true },
-            );
-            return {
-              ...fetchTarget,
-              expectedTarget:
-                previousTarget.exitCode === 0 ? previousTarget.stdout.trim() : GIT_ZERO_OID,
-            };
-          }),
-          { concurrency: "unbounded" },
-        );
-        const result = yield* executeGit(
-          "GitVcsDriver.fetchRemoteForStatus",
+      const fetchAndPromoteTarget = Effect.fn(
+        "GitVcsDriver.fetchRemoteForStatus.fetchAndPromoteTarget",
+      )(function* (fetchTarget: (typeof fetchTargets)[number]) {
+        const previousTarget = yield* executeGit(
+          "GitVcsDriver.fetchRemoteForStatus.readTarget",
           fetchCwd,
-          [
-            "--git-dir",
-            gitCommonDir,
-            "-c",
-            "fetch.unpackLimit=0",
-            "fetch",
-            "--quiet",
-            "--no-tags",
-            "--no-write-fetch-head",
-            "--refmap=",
-            remoteName,
-            ...fetchTargets.map(
-              ({ remoteRef: sourceRef, temporaryRef }) => `+${sourceRef}:${temporaryRef}`,
-            ),
-          ],
-          {
-            allowNonZeroExit: true,
-            env: {
-              ...STATUS_UPSTREAM_REFRESH_ENV,
-              GIT_OBJECT_DIRECTORY: temporaryObjectDirectory,
-              GIT_ALTERNATE_OBJECT_DIRECTORIES: objectDirectory,
-            },
-            timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
-          },
+          ["--git-dir", gitCommonDir, "rev-parse", "--verify", fetchTarget.targetRef],
+          { allowNonZeroExit: true },
         );
-        if (result.exitCode !== 0) return;
+        const expectedTarget =
+          previousTarget.exitCode === 0 ? previousTarget.stdout.trim() : GIT_ZERO_OID;
+        const fetchArgs = [
+          "--git-dir",
+          gitCommonDir,
+          "-c",
+          "fetch.unpackLimit=0",
+          "fetch",
+          "--quiet",
+          "--no-tags",
+          "--no-write-fetch-head",
+          "--refmap=",
+          remoteName,
+          `+${fetchTarget.remoteRef}:${fetchTarget.temporaryRef}`,
+        ];
+        const result = yield* executeGit("GitVcsDriver.fetchRemoteForStatus", fetchCwd, fetchArgs, {
+          allowNonZeroExit: true,
+          env: {
+            ...STATUS_UPSTREAM_REFRESH_ENV,
+            GIT_OBJECT_DIRECTORY: temporaryObjectDirectory,
+            GIT_ALTERNATE_OBJECT_DIRECTORIES: objectDirectory,
+          },
+          timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
+        });
+        if (result.exitCode !== 0) {
+          return yield* new GitCommandError({
+            ...gitCommandContext({
+              operation: "GitVcsDriver.fetchRemoteForStatus",
+              cwd: fetchCwd,
+              args: fetchArgs,
+            }),
+            detail: `Git status fetch failed for '${fetchTarget.remoteRef}'.`,
+            exitCode: result.exitCode,
+            stdoutLength: result.stdout.length,
+            stderrLength: result.stderr.length,
+          });
+        }
 
         yield* fileSystem.makeDirectory(packDirectory, { recursive: true }).pipe(
           Effect.mapError(
@@ -1244,27 +1214,38 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           ),
         );
         yield* promoteObjectFiles;
+        const fetchedCommit = yield* runGitStdout(
+          "GitVcsDriver.fetchRemoteForStatus.resolve",
+          fetchCwd,
+          ["--git-dir", gitCommonDir, "rev-parse", "--verify", fetchTarget.temporaryRef],
+        ).pipe(Effect.map((stdout) => stdout.trim()));
+        yield* runGit("GitVcsDriver.fetchRemoteForStatus.promoteRef", fetchCwd, [
+          "--git-dir",
+          gitCommonDir,
+          "update-ref",
+          fetchTarget.targetRef,
+          fetchedCommit,
+          expectedTarget,
+        ]);
+      });
+
+      yield* Effect.gen(function* () {
+        const [upstreamFetchTarget, ...optionalFetchTargets] = fetchTargets;
+        if (!upstreamFetchTarget) return;
+
+        yield* fetchAndPromoteTarget(upstreamFetchTarget);
         yield* Effect.forEach(
-          targetsWithExpectedOids,
-          Effect.fn("GitVcsDriver.fetchRemoteForStatus.promoteRef")(function* ({
-            temporaryRef,
-            targetRef: destinationRef,
-            expectedTarget,
-          }) {
-            const fetchedCommit = yield* runGitStdout(
-              "GitVcsDriver.fetchRemoteForStatus.resolve",
-              fetchCwd,
-              ["--git-dir", gitCommonDir, "rev-parse", "--verify", temporaryRef],
-            ).pipe(Effect.map((stdout) => stdout.trim()));
-            yield* runGit("GitVcsDriver.fetchRemoteForStatus.promoteRef", fetchCwd, [
-              "--git-dir",
-              gitCommonDir,
-              "update-ref",
-              destinationRef,
-              fetchedCommit,
-              expectedTarget,
-            ]);
-          }),
+          optionalFetchTargets,
+          (fetchTarget) =>
+            fetchAndPromoteTarget(fetchTarget).pipe(
+              Effect.catch((cause) =>
+                Effect.logWarning("Failed to refresh the default branch during Git status fetch.", {
+                  cause,
+                  remoteName,
+                  defaultBranchName,
+                }),
+              ),
+            ),
           { concurrency: 1, discard: true },
         );
       }).pipe(Effect.ensuring(cleanupIsolatedFetch));

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -74,6 +74,12 @@ const LIST_REFS_REFRESH_COALESCE_TTL = Duration.seconds(5);
 const LIST_REFS_REFRESH_FAILURE_COOLDOWN = Duration.seconds(30);
 const STATUS_DEFAULT_BRANCH_CACHE_TTL = Duration.minutes(5);
 const STATUS_ORIGIN_EXISTS_CACHE_TTL = Duration.minutes(5);
+const GIT_TEMPORARY_PACK_PREFIX = "tmp_pack_";
+const GIT_TEMPORARY_PACK_STALE_AGE = Duration.hours(1);
+const GIT_STATUS_FETCH_OBJECT_DIRECTORY = "t3-status-fetch";
+const GIT_STATUS_FETCH_STALE_AGE = Duration.hours(1);
+const GIT_STATUS_FETCH_REF_PREFIX = "refs/t3-status-fetch";
+const GIT_ZERO_OID = "0".repeat(40);
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
   GCM_INTERACTIVE: "never",
   GIT_ASKPASS: "",
@@ -116,6 +122,9 @@ type TraceTailState = {
 class StatusRemoteRefreshCacheKey extends Data.Class<{
   gitCommonDir: string;
   remoteName: string;
+  branchName: string;
+  remoteRef: string;
+  defaultBranchName: string | null;
 }> {}
 
 function statusUpstreamRefreshFailureCooldown(consecutiveFailures: number): Duration.Duration {
@@ -123,6 +132,21 @@ function statusUpstreamRefreshFailureCooldown(consecutiveFailures: number): Dura
   const cooldownMs =
     Duration.toMillis(STATUS_UPSTREAM_REFRESH_FAILURE_BASE_COOLDOWN) * Math.pow(2, exponent);
   return Duration.min(Duration.millis(cooldownMs), STATUS_UPSTREAM_REFRESH_FAILURE_MAX_COOLDOWN);
+}
+
+export function statusRemoteRefreshFailureKey(
+  cacheKey: Pick<
+    StatusRemoteRefreshCacheKey,
+    "gitCommonDir" | "remoteName" | "branchName" | "remoteRef" | "defaultBranchName"
+  >,
+): string {
+  return [
+    cacheKey.gitCommonDir,
+    cacheKey.remoteName,
+    cacheKey.branchName,
+    cacheKey.remoteRef,
+    cacheKey.defaultBranchName ?? "",
+  ].join("\0");
 }
 
 class GitRefsSnapshotCacheKey extends Data.Class<{
@@ -295,6 +319,32 @@ export function splitNullSeparatedGitStdoutPaths(
   return splitNullSeparatedPaths(result.stdout, result.stdoutTruncated);
 }
 
+export function isStaleGitTemporaryPackFile(input: {
+  entry: string;
+  modifiedAtMs: number | null;
+  nowMs: number;
+  staleAfterMs: number;
+}): boolean {
+  return (
+    input.entry.startsWith(GIT_TEMPORARY_PACK_PREFIX) &&
+    input.modifiedAtMs !== null &&
+    input.nowMs - input.modifiedAtMs >= input.staleAfterMs
+  );
+}
+
+export function isStaleGitStatusFetchDirectory(input: {
+  modifiedAtMs: number | null;
+  nowMs: number;
+  staleAfterMs: number;
+  isActive: boolean;
+}): boolean {
+  return (
+    !input.isActive &&
+    input.modifiedAtMs !== null &&
+    input.nowMs - input.modifiedAtMs >= input.staleAfterMs
+  );
+}
+
 function sanitizeRemoteName(value: string): string {
   const sanitized = value
     .trim()
@@ -319,41 +369,47 @@ function parseRemoteFetchUrls(stdout: string): Map<string, string> {
   return remotes;
 }
 
-function parseUpstreamRefWithRemoteNames(
-  upstreamRef: string,
-  remoteNames: ReadonlyArray<string>,
-): { upstreamRef: string; remoteName: string; branchName: string } | null {
-  const parsed = parseRemoteRefWithRemoteNames(upstreamRef, remoteNames);
-  if (!parsed) {
-    return null;
+function parseCurrentUpstream(stdout: string): {
+  upstreamRef: string;
+  remoteName: string;
+  branchName: string;
+  remoteRef: string;
+} | null {
+  for (const line of stdout.split("\n")) {
+    const [
+      headMarker = "",
+      upstreamRef = "",
+      upstreamTargetRef = "",
+      remoteName = "",
+      remoteRef = "",
+      upstreamTrackingStatus = "",
+    ] = line.split("\t");
+    if (
+      headMarker.trim() !== "*" ||
+      upstreamRef.trim().length === 0 ||
+      remoteName.trim().length === 0 ||
+      remoteRef.trim().length === 0 ||
+      upstreamTrackingStatus.trim().length === 0 ||
+      upstreamTrackingStatus.trim() === "[gone]"
+    ) {
+      continue;
+    }
+
+    const normalizedRemoteName = remoteName.trim();
+    const remoteTrackingPrefix = `refs/remotes/${normalizedRemoteName}/`;
+    const normalizedUpstreamTargetRef = upstreamTargetRef.trim();
+    if (!normalizedUpstreamTargetRef.startsWith(remoteTrackingPrefix)) {
+      return null;
+    }
+
+    return {
+      upstreamRef: upstreamRef.trim(),
+      remoteName: normalizedRemoteName,
+      branchName: normalizedUpstreamTargetRef.slice(remoteTrackingPrefix.length),
+      remoteRef: remoteRef.trim(),
+    };
   }
-
-  return {
-    upstreamRef,
-    remoteName: parsed.remoteName,
-    branchName: parsed.branchName,
-  };
-}
-
-function parseUpstreamRefByFirstSeparator(
-  upstreamRef: string,
-): { upstreamRef: string; remoteName: string; branchName: string } | null {
-  const separatorIndex = upstreamRef.indexOf("/");
-  if (separatorIndex <= 0 || separatorIndex === upstreamRef.length - 1) {
-    return null;
-  }
-
-  const remoteName = upstreamRef.slice(0, separatorIndex).trim();
-  const branchName = upstreamRef.slice(separatorIndex + 1).trim();
-  if (remoteName.length === 0 || branchName.length === 0) {
-    return null;
-  }
-
-  return {
-    upstreamRef,
-    remoteName,
-    branchName,
-  };
+  return null;
 }
 
 function parseTrackingBranchByUpstreamRef(stdout: string, upstreamRef: string): string | null {
@@ -996,44 +1052,323 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   });
 
   const resolveCurrentUpstream = Effect.fn("resolveCurrentUpstream")(function* (cwd: string) {
-    const upstreamRef = yield* runGitStdout(
+    const upstream = yield* runGitStdout(
       "GitVcsDriver.resolveCurrentUpstream",
       cwd,
-      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+      [
+        "for-each-ref",
+        "--format=%(HEAD)%09%(upstream:short)%09%(upstream)%09%(upstream:remotename)%09%(upstream:remoteref)%09%(upstream:trackshort)",
+        "refs/heads",
+      ],
       true,
-    ).pipe(Effect.map((stdout) => stdout.trim()));
-
-    if (upstreamRef.length === 0 || upstreamRef === "@{upstream}") {
-      return null;
-    }
-
-    const remoteNames = yield* runGitStdout("GitVcsDriver.listRemoteNames", cwd, ["remote"]).pipe(
-      Effect.map(parseRemoteNames),
-      Effect.orElseSucceed((): ReadonlyArray<string> => []),
+    ).pipe(
+      Effect.map(parseCurrentUpstream),
+      Effect.orElseSucceed(() => null),
     );
-    return (
-      parseUpstreamRefWithRemoteNames(upstreamRef, remoteNames) ??
-      parseUpstreamRefByFirstSeparator(upstreamRef)
-    );
+    return upstream;
   });
 
+  const activeStatusFetchOperationIds = new Set<string>();
   const fetchRemoteForStatus = (
     gitCommonDir: string,
     remoteName: string,
-  ): Effect.Effect<void, GitCommandError> => {
-    const fetchCwd =
-      path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
-    return executeGit(
-      "GitVcsDriver.fetchRemoteForStatus",
-      fetchCwd,
-      ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
-      {
-        env: STATUS_UPSTREAM_REFRESH_ENV,
-        fallbackErrorDetail: "Background Git fetch exited with a non-zero status.",
-        timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
-      },
-    ).pipe(Effect.asVoid);
-  };
+    branchName: string,
+    remoteRef: string,
+    defaultBranchName: string | null,
+  ): Effect.Effect<void, GitCommandError> =>
+    Effect.gen(function* () {
+      const fetchCwd =
+        path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
+      const objectDirectory = path.join(gitCommonDir, "objects");
+      const packDirectory = path.join(objectDirectory, "pack");
+      const isolatedFetchRoot = path.join(objectDirectory, GIT_STATUS_FETCH_OBJECT_DIRECTORY);
+      // Older builds wrote interrupted fetches into the shared pack directory.
+      // New fetches use the isolated object directory below; this only reaps legacy leftovers.
+      const cleanupStaleTemporaryPacks = Effect.gen(function* () {
+        if (!(yield* fileSystem.exists(packDirectory))) return;
+        const now = yield* DateTime.now;
+        const nowMs = DateTime.toEpochMillis(now);
+        const entries = yield* fileSystem.readDirectory(packDirectory, { recursive: false });
+        yield* Effect.forEach(
+          entries,
+          (entry) => {
+            if (!entry.startsWith(GIT_TEMPORARY_PACK_PREFIX)) return Effect.void;
+            const temporaryPackPath = path.join(packDirectory, entry);
+            return fileSystem.stat(temporaryPackPath).pipe(
+              Effect.flatMap((info) => {
+                const modifiedAtMs = Option.getOrNull(info.mtime)?.getTime() ?? null;
+                return isStaleGitTemporaryPackFile({
+                  entry,
+                  modifiedAtMs,
+                  nowMs,
+                  staleAfterMs: Duration.toMillis(GIT_TEMPORARY_PACK_STALE_AGE),
+                })
+                  ? fileSystem.remove(temporaryPackPath, { force: true })
+                  : Effect.void;
+              }),
+              Effect.ignore,
+            );
+          },
+          { concurrency: "unbounded", discard: true },
+        );
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logWarning("Failed to clean stale temporary Git pack files.", { cause }),
+        ),
+      );
+
+      const cleanupStaleIsolatedFetches = Effect.gen(function* () {
+        if (!(yield* fileSystem.exists(isolatedFetchRoot))) return;
+        const now = yield* DateTime.now;
+        const nowMs = DateTime.toEpochMillis(now);
+        const entries = yield* fileSystem.readDirectory(isolatedFetchRoot, { recursive: false });
+        yield* Effect.forEach(
+          entries,
+          (entry) => {
+            const entryPath = path.join(isolatedFetchRoot, entry);
+            return fileSystem.stat(entryPath).pipe(
+              Effect.flatMap((info) => {
+                const modifiedAtMs = Option.getOrNull(info.mtime)?.getTime() ?? null;
+                return isStaleGitStatusFetchDirectory({
+                  modifiedAtMs,
+                  nowMs,
+                  staleAfterMs: Duration.toMillis(GIT_STATUS_FETCH_STALE_AGE),
+                  isActive: activeStatusFetchOperationIds.has(entry),
+                })
+                  ? fileSystem.remove(entryPath, { recursive: true, force: true })
+                  : Effect.void;
+              }),
+              Effect.ignore,
+            );
+          },
+          { concurrency: "unbounded", discard: true },
+        );
+      }).pipe(
+        Effect.catch((cause) =>
+          Effect.logWarning("Failed to clean stale isolated Git status fetches.", { cause }),
+        ),
+      );
+
+      yield* Effect.all([cleanupStaleTemporaryPacks, cleanupStaleIsolatedFetches], {
+        concurrency: "unbounded",
+        discard: true,
+      });
+      const operationId = yield* crypto.randomUUIDv4.pipe(
+        Effect.mapError(
+          (cause) =>
+            new GitCommandError({
+              operation: "GitVcsDriver.fetchRemoteForStatus",
+              command: "crypto.randomUUIDv4",
+              cwd: fetchCwd,
+              detail: "Failed to create an isolated status fetch identifier.",
+              cause,
+            }),
+        ),
+      );
+      activeStatusFetchOperationIds.add(operationId);
+      const temporaryRoot = path.join(isolatedFetchRoot, operationId);
+      const temporaryObjectDirectory = path.join(temporaryRoot, "objects");
+      const targetRef = `refs/remotes/${remoteName}/${branchName}`;
+      const fetchTargets = [
+        {
+          remoteRef,
+          temporaryRef: `${GIT_STATUS_FETCH_REF_PREFIX}/${operationId}/upstream`,
+          targetRef,
+        },
+      ];
+      const defaultTargetRef =
+        defaultBranchName === null ? null : `refs/remotes/${remoteName}/${defaultBranchName}`;
+      if (defaultTargetRef !== null && defaultTargetRef !== targetRef) {
+        fetchTargets.push({
+          remoteRef: `refs/heads/${defaultBranchName}`,
+          temporaryRef: `${GIT_STATUS_FETCH_REF_PREFIX}/${operationId}/default`,
+          targetRef: defaultTargetRef,
+        });
+      }
+
+      const cleanupIsolatedFetch = fileSystem
+        .remove(temporaryRoot, { recursive: true, force: true })
+        .pipe(
+          Effect.ignore,
+          Effect.ensuring(
+            Effect.sync(() => {
+              activeStatusFetchOperationIds.delete(operationId);
+            }),
+          ),
+        );
+
+      yield* Effect.gen(function* () {
+        yield* runGit("GitVcsDriver.fetchRemoteForStatus.init", fetchCwd, [
+          "init",
+          "--bare",
+          "--quiet",
+          temporaryRoot,
+        ]);
+        yield* fileSystem
+          .writeFileString(
+            path.join(temporaryObjectDirectory, "info", "alternates"),
+            `${objectDirectory}\n`,
+          )
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitCommandError({
+                  operation: "GitVcsDriver.fetchRemoteForStatus",
+                  command: "filesystem.writeFileString",
+                  cwd: fetchCwd,
+                  detail: "Failed to configure isolated Git object alternates.",
+                  cause,
+                }),
+            ),
+          );
+
+        const fetchAndPromoteTarget = Effect.fn(
+          "GitVcsDriver.fetchRemoteForStatus.fetchAndPromoteTarget",
+        )(function* (fetchTarget: (typeof fetchTargets)[number]) {
+          const previousTarget = yield* executeGit(
+            "GitVcsDriver.fetchRemoteForStatus.readTarget",
+            fetchCwd,
+            ["--git-dir", gitCommonDir, "rev-parse", "--verify", fetchTarget.targetRef],
+            { allowNonZeroExit: true },
+          );
+          const expectedTarget =
+            previousTarget.exitCode === 0 ? previousTarget.stdout.trim() : GIT_ZERO_OID;
+          const fetchArgs = [
+            "--git-dir",
+            temporaryRoot,
+            "-c",
+            `include.path=${path.join(gitCommonDir, "config")}`,
+            "-c",
+            "fetch.unpackLimit=0",
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-write-fetch-head",
+            "--refmap=",
+            remoteName,
+            `+${fetchTarget.remoteRef}:${fetchTarget.temporaryRef}`,
+          ];
+          const result = yield* executeGit(
+            "GitVcsDriver.fetchRemoteForStatus",
+            fetchCwd,
+            fetchArgs,
+            {
+              allowNonZeroExit: true,
+              env: {
+                ...STATUS_UPSTREAM_REFRESH_ENV,
+                GIT_OBJECT_DIRECTORY: temporaryObjectDirectory,
+                GIT_ALTERNATE_OBJECT_DIRECTORIES: objectDirectory,
+              },
+              timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
+            },
+          );
+          if (result.exitCode !== 0) {
+            return yield* new GitCommandError({
+              ...gitCommandContext({
+                operation: "GitVcsDriver.fetchRemoteForStatus",
+                cwd: fetchCwd,
+                args: fetchArgs,
+              }),
+              detail: `Git status fetch failed for '${fetchTarget.remoteRef}'.`,
+              exitCode: result.exitCode,
+              stdoutLength: result.stdout.length,
+              stderrLength: result.stderr.length,
+            });
+          }
+
+          const fetchedCommit = yield* executeGit(
+            "GitVcsDriver.fetchRemoteForStatus.resolve",
+            fetchCwd,
+            ["--git-dir", temporaryRoot, "rev-parse", "--verify", fetchTarget.temporaryRef],
+            {
+              env: {
+                GIT_OBJECT_DIRECTORY: temporaryObjectDirectory,
+                GIT_ALTERNATE_OBJECT_DIRECTORIES: objectDirectory,
+              },
+            },
+          ).pipe(Effect.map((resolveResult) => resolveResult.stdout.trim()));
+
+          // Let Git install the complete pack set into the shared object store. This second fetch is
+          // local-only and uninterruptible so cancellation cannot strand a partially promoted pack.
+          yield* runGit(
+            "GitVcsDriver.fetchRemoteForStatus.promoteObjects",
+            fetchCwd,
+            [
+              "--git-dir",
+              gitCommonDir,
+              "-c",
+              "fetch.unpackLimit=0",
+              "fetch",
+              "--quiet",
+              "--no-tags",
+              "--no-write-fetch-head",
+              "--refmap=",
+              temporaryRoot,
+              fetchTarget.temporaryRef,
+            ],
+            {
+              timeoutMs: null,
+            },
+          ).pipe(Effect.uninterruptible);
+          const promoteRefArgs = [
+            "--git-dir",
+            gitCommonDir,
+            "update-ref",
+            fetchTarget.targetRef,
+            fetchedCommit,
+            expectedTarget,
+          ];
+          const promoteRefResult = yield* executeGit(
+            "GitVcsDriver.fetchRemoteForStatus.promoteRef",
+            fetchCwd,
+            promoteRefArgs,
+            { allowNonZeroExit: true },
+          );
+          if (promoteRefResult.exitCode === 0) return;
+
+          const currentTarget = yield* executeGit(
+            "GitVcsDriver.fetchRemoteForStatus.readPromotedTarget",
+            fetchCwd,
+            ["--git-dir", gitCommonDir, "rev-parse", "--verify", fetchTarget.targetRef],
+            { allowNonZeroExit: true },
+          );
+          const currentTargetOid =
+            currentTarget.exitCode === 0 ? currentTarget.stdout.trim() : GIT_ZERO_OID;
+          if (currentTargetOid !== expectedTarget) return;
+
+          return yield* new GitCommandError({
+            ...gitCommandContext({
+              operation: "GitVcsDriver.fetchRemoteForStatus.promoteRef",
+              cwd: fetchCwd,
+              args: promoteRefArgs,
+            }),
+            detail: `Git status ref promotion failed for '${fetchTarget.targetRef}'.`,
+            exitCode: promoteRefResult.exitCode,
+            stdoutLength: promoteRefResult.stdout.length,
+            stderrLength: promoteRefResult.stderr.length,
+          });
+        });
+
+        const [upstreamFetchTarget, ...optionalFetchTargets] = fetchTargets;
+        if (!upstreamFetchTarget) return;
+
+        yield* fetchAndPromoteTarget(upstreamFetchTarget);
+        yield* Effect.forEach(
+          optionalFetchTargets,
+          (fetchTarget) =>
+            fetchAndPromoteTarget(fetchTarget).pipe(
+              Effect.catch((cause) =>
+                Effect.logWarning("Failed to refresh the default branch during Git status fetch.", {
+                  cause,
+                  remoteName,
+                  defaultBranchName,
+                }),
+              ),
+            ),
+          { concurrency: 1, discard: true },
+        );
+      }).pipe(Effect.ensuring(cleanupIsolatedFetch));
+    });
 
   const resolveRepositoryPathsUncached = Effect.fn("resolveRepositoryPathsUncached")(function* (
     cwd: string,
@@ -1223,8 +1558,6 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   });
 
   const statusRemoteRefreshFailureCounts = new Map<string, number>();
-  const statusRemoteRefreshFailureKey = (cacheKey: StatusRemoteRefreshCacheKey) =>
-    `${cacheKey.gitCommonDir}\0${cacheKey.remoteName}`;
   const recordStatusRemoteRefreshFailure = (cacheKey: StatusRemoteRefreshCacheKey) => {
     const key = statusRemoteRefreshFailureKey(cacheKey);
     const nextCount = (statusRemoteRefreshFailureCounts.get(key) ?? 0) + 1;
@@ -1243,7 +1576,13 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const refreshStatusRemoteCacheEntry = Effect.fn("refreshStatusRemoteCacheEntry")(function* (
     cacheKey: StatusRemoteRefreshCacheKey,
   ) {
-    return yield* fetchRemoteForStatus(cacheKey.gitCommonDir, cacheKey.remoteName).pipe(
+    return yield* fetchRemoteForStatus(
+      cacheKey.gitCommonDir,
+      cacheKey.remoteName,
+      cacheKey.branchName,
+      cacheKey.remoteRef,
+      cacheKey.defaultBranchName,
+    ).pipe(
       Effect.tap(() => Effect.sync(() => clearStatusRemoteRefreshFailures(cacheKey))),
       Effect.tapError(() => Effect.sync(() => recordStatusRemoteRefreshFailure(cacheKey))),
       Effect.as(true as const),
@@ -1270,11 +1609,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const upstream = yield* resolveCurrentUpstream(cwd);
     if (!upstream) return;
     const gitCommonDir = yield* resolveGitCommonDir(cwd);
+    const defaultBranchName = yield* resolveDefaultBranchName(cwd, upstream.remoteName).pipe(
+      Effect.orElseSucceed(() => null),
+    );
     yield* Cache.get(
       statusRemoteRefreshCache,
       new StatusRemoteRefreshCacheKey({
         gitCommonDir,
         remoteName: upstream.remoteName,
+        branchName: upstream.branchName,
+        remoteRef: upstream.remoteRef,
+        defaultBranchName,
       }),
     );
   });


### PR DESCRIPTION
## What Changed

- Snapshot temporary pack entries before the status poller starts a remote fetch.
- Remove only newly created tmp_pack files when that fetch times out or exits unsuccessfully.
- Preserve pre-existing temporary packs and add focused regression coverage.

## Why

A status refresh that exceeded the five-second timeout could leave a full temporary pack behind every polling cycle, eventually filling the disk.

Closes #4296

## Checklist

- [x] Focused test passes: GitVcsDriverCore.test.ts
- [ ] Server typecheck deferred to CI; current local main has unrelated dependency diagnostics
- [x] Targeted lint and formatting pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites how Git status fetches write objects and remote-tracking refs in user repositories. Incorrect promotion or cleanup could leave stale packs, skip updates, or race concurrent ref changes.
> 
> **Overview**
> Background remote status refresh no longer fetches into the shared repository. It now uses a temporary bare repo under `objects/t3-status-fetch`, then promotes objects with a local fetch and `update-ref`, so a timed-out poll cannot leave `tmp_pack_*` files that fill the disk.
> 
> Housekeeping deletes stale `tmp_pack_*` leftovers (1h) and unused isolated fetch dirs. Upstream resolution now uses `for-each-ref` (including custom refspecs), failure backoff is per branch/ref, and the default branch can refresh alongside the tracked upstream. Isolated dirs are removed if alternates setup fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c755692437583ca7f9c5749cd8289dad616e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate background status fetch and clean stale temporary packs
> - Rewrites `fetchRemoteForStatus` in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/4338/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) to fetch into an isolated bare repo under `gitCommonDir/objects/t3-status-fetch/<op>` with alternates, avoiding writes to `FETCH_HEAD` or refs in the shared repo.
> - Adds `isStaleGitTemporaryPackFile` and `isStaleGitStatusFetchDirectory` predicates to clean stale `tmp_pack_*` files and inactive isolated fetch directories past `GIT_TEMPORARY_PACK_STALE_AGE` / `GIT_STATUS_FETCH_STALE_AGE`.
> - Replaces upstream resolution with `parseCurrentUpstream` using `git for-each-ref`, returning `remoteRef` alongside `remoteName` and `branchName`.
> - Broadens `statusRemoteRefreshFailureKey` to include `branchName`, `remoteRef`, and `defaultBranchName` so failure backoff is tracked per branch/ref tuple instead of per remote.
> - Behavioral Change: failure cache key shape changes from `gitCommonDir\0remoteName` to include branch and ref fields; existing in-memory backoff entries will not match the new key shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52c7556.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git status refresh reliability when upstream branches or tracking references change.
  - Correctly handles deleted upstream references and custom upstream configurations.
  - Improved default-branch refresh behavior when feature branches have their own upstreams.
  - Prevents refresh failures from affecting unrelated repositories or branches.
  - Automatically cleans up stale temporary Git data and incomplete refresh attempts.
- **Tests**
  - Added comprehensive coverage for upstream refresh, cleanup, isolation, and failure-recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->