### PR TITLE
perf(server): reduce Windows WMI polling

### DIFF
--- a/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
@@ -220,6 +220,60 @@ describe("ProcessDiagnostics", () => {
     }),
   );
 
+  it.effect("queries Windows performance counters once per sample", () =>
+    Effect.gen(function* () {
+      const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> =
+        [];
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make((command) => {
+          const childProcess = command as unknown as {
+            readonly command: string;
+            readonly args: ReadonlyArray<string>;
+          };
+          commands.push({ command: childProcess.command, args: childProcess.args });
+          return Effect.succeed(
+            mockHandle({
+              stdout: JSON.stringify({
+                ProcessId: 4242,
+                ParentProcessId: process.pid,
+                Name: "agent.exe",
+                CommandLine: "agent.exe --serve",
+                Status: null,
+                WorkingSetSize: 2048,
+                PercentProcessorTime: 1.5,
+              }),
+            }),
+          );
+        }),
+      );
+
+      const rows = yield* ProcessDiagnostics.readProcessRows.pipe(
+        Effect.provide(spawnerLayer),
+        Effect.provideService(HostProcessPlatform, "win32"),
+      );
+
+      expect(rows).toEqual([
+        {
+          pid: 4242,
+          ppid: process.pid,
+          pgid: null,
+          status: "Live",
+          cpuPercent: 1.5,
+          rssBytes: 2048,
+          elapsed: "",
+          command: "agent.exe --serve",
+        },
+      ]);
+      expect(commands).toHaveLength(1);
+      expect(commands[0]?.command).toBe("powershell.exe");
+      const powershellCommand = commands[0]?.args.at(-1) ?? "";
+      expect(powershellCommand.match(/Get-CimInstance/g)).toHaveLength(2);
+      expect(powershellCommand).not.toContain("-Filter");
+      expect(powershellCommand).toContain("$perfById[[int]$_.ProcessId]");
+    }),
+  );
+
   it.effect("keeps bounded command diagnostics when the process query exits unsuccessfully", () =>
     Effect.gen(function* () {
       const spawnerLayer = Layer.succeed(

--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -443,9 +443,11 @@ function readWindowsProcessRows(): Effect.Effect<
   ChildProcessSpawner.ChildProcessSpawner
 > {
   const command = [
+    "$perfById = @{};",
+    "Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -ErrorAction SilentlyContinue | ForEach-Object { $perfById[[int]$_.IDProcess] = $_.PercentProcessorTime };",
     "$processes = Get-CimInstance Win32_Process | ForEach-Object {",
-    '$perf = Get-CimInstance Win32_PerfFormattedData_PerfProc_Process -Filter "IDProcess = $($_.ProcessId)" -ErrorAction SilentlyContinue;',
-    "[pscustomobject]@{ ProcessId = $_.ProcessId; ParentProcessId = $_.ParentProcessId; Name = $_.Name; CommandLine = $_.CommandLine; Status = $_.Status; WorkingSetSize = $_.WorkingSetSize; PercentProcessorTime = if ($perf) { $perf.PercentProcessorTime } else { 0 } }",
+    "$cpu = $perfById[[int]$_.ProcessId];",
+    "[pscustomobject]@{ ProcessId = $_.ProcessId; ParentProcessId = $_.ParentProcessId; Name = $_.Name; CommandLine = $_.CommandLine; Status = $_.Status; WorkingSetSize = $_.WorkingSetSize; PercentProcessorTime = if ($null -ne $cpu) { $cpu } else { 0 } }",
     "};",
     "$processes | ConvertTo-Json -Compress -Depth 3",
   ].join(" ");

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
@@ -118,8 +118,8 @@ describe("ProcessResourceMonitor", () => {
       expect(result.topProcesses).toHaveLength(1);
       expect(result.topProcesses[0]?.avgCpuPercent).toBe(20);
       expect(result.topProcesses[0]?.maxCpuPercent).toBe(30);
-      expect(result.topProcesses[0]?.cpuSecondsApprox).toBe(2);
-      expect(result.totalCpuSecondsApprox).toBe(2);
+      expect(result.topProcesses[0]?.cpuSecondsApprox).toBe(6);
+      expect(result.totalCpuSecondsApprox).toBe(6);
       expect(result.buckets.some((bucket) => bucket.maxCpuPercent === 30)).toBe(true);
     }),
   );

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.ts
@@ -17,7 +17,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import * as ProcessDiagnostics from "./ProcessDiagnostics.ts";
 
-const SAMPLE_INTERVAL_MS = 5_000;
+const SAMPLE_INTERVAL_MS = 15_000;
 const RETENTION_MS = 60 * 60_000;
 const MAX_RETAINED_SAMPLES = 20_000;
 


### PR DESCRIPTION
## What Changed

- Replace the per-process performance counter lookup with two bulk WMI queries and an in-memory PID map.
- Slow background resource sampling from every 5 seconds to every 15 seconds.
- Add focused coverage that prevents the N+1 WMI query pattern from returning.

## Why

The diagnostics poller issued one additional WMI query for every process on every sample. On Windows this caused sustained WmiPrvSE CPU usage and repeated failed IDProcess queries.

Closes #4024

## Checklist

- [x] Focused diagnostics tests pass
- [x] Server typecheck passes
- [x] Targeted lint and formatting pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only changes on Windows WMI and slower background sampling; no auth, data, or API contract changes beyond approximate CPU rollup timing.
> 
> **Overview**
> Cuts **Windows process diagnostics** cost by replacing per-process WMI performance lookups with **two bulk `Get-CimInstance` queries** and a PID→CPU map in the PowerShell one-liner, instead of an N+1 `-Filter` query per process.
> 
> **Background resource sampling** interval moves from **5s to 15s**; rollup tests now expect higher `cpuSecondsApprox` because that metric uses the new interval.
> 
> A **regression test** asserts a single `powershell.exe` spawn per sample, exactly two `Get-CimInstance` calls, no `-Filter`, and use of `$perfById`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4fe0927addbb424234b92f086bd5ffa55f2b9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce Windows WMI polling frequency and eliminate per-process CIM queries
> - Rewrites the PowerShell command in `readWindowsProcessRows` ([ProcessDiagnostics.ts](https://github.com/pingdotgg/t3code/pull/4339/files#diff-3976428399caa24c646f345343c779cdea0f12d571dd49a947e677d81f460ced)) to fetch all `Win32_PerfFormattedData_PerfProc_Process` data in a single `Get-CimInstance` call, building a `$perfById` lookup instead of issuing a filtered query per process.
> - Increases `SAMPLE_INTERVAL_MS` in [ProcessResourceMonitor.ts](https://github.com/pingdotgg/t3code/pull/4339/files#diff-531add2e9c8cf312f695a676a24b959ff83264a563fac3914620ab8e1f516d6b) from 5,000 ms to 15,000 ms, tripling the time between samples.
> - Behavioral Change: CPU metrics on Windows now reflect a single bulk snapshot rather than per-process filtered queries; processes missing from the perf snapshot fall back to 0% CPU.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4fe092.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->