### PR TITLE
fix(web): surface Claude snake-case file paths

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5503,6 +5503,7 @@ function ChatViewContent(props: ChatViewProps) {
                 activeThreadEnvironmentId={activeThread.environmentId}
                 routeThreadKey={routeThreadKey}
                 onOpenTurnDiff={onOpenTurnDiff}
+                onOpenFile={openFileSurface}
                 revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
                 onRevertUserMessage={onRevertUserMessage}
                 isRevertingCheckpoint={isRevertingCheckpoint}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -535,7 +535,7 @@ describe("MessagesTimeline", () => {
               createdAt: "2026-03-17T19:12:28.000Z",
               label: "Updated files",
               tone: "tool",
-              changedFiles: ["C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts"],
+              changedFiles: ["/C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts"],
             },
           },
         ]}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -603,7 +603,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("git status");
     expect(markup).not.toContain(">git status</button>");
     expect(markup).toContain('aria-label="Open file inside.ts"');
-    expect(markup).toContain(">inside.ts</button>");
+    expect(markup).toContain("lucide-file-text");
+    expect(markup).toContain('<span class="truncate">inside.ts</span>');
   });
 
   it("keeps detail text separate from its associated file link", () => {
@@ -632,7 +633,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Wrote requested content");
     expect(markup).not.toContain(">Wrote requested content</button>");
     expect(markup).toContain('aria-label="Open file inside.ts"');
-    expect(markup).toContain(">inside.ts</button>");
+    expect(markup).toContain("lucide-file-text");
+    expect(markup).toContain('<span class="truncate">inside.ts</span>');
   });
 
   it("renders review comment contexts as structured cards instead of raw tags", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -548,6 +548,89 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Open file apps/web/src/session-logic.ts"');
   });
 
+  it("rejects case-mismatched POSIX paths outside the workspace", () => {
+    const renderChangedFile = (filePath: string) =>
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          timelineEntries={[
+            {
+              id: "entry-1",
+              kind: "work",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              entry: {
+                id: "work-1",
+                createdAt: "2026-03-17T19:12:28.000Z",
+                label: "Updated file",
+                tone: "tool",
+                changedFiles: [filePath],
+              },
+            },
+          ]}
+          workspaceRoot="/home/alice/Repo"
+        />,
+      );
+
+    expect(renderChangedFile("/home/alice/Repo/inside.ts")).toContain(
+      'aria-label="Open file inside.ts"',
+    );
+    expect(renderChangedFile("/home/alice/repo/outside.ts")).not.toContain('aria-label="Open file');
+  });
+
+  it("does not make command text open an associated changed file", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Ran command",
+              tone: "tool",
+              command: "git status",
+              changedFiles: ["/home/alice/Repo/inside.ts"],
+            },
+          },
+        ]}
+        workspaceRoot="/home/alice/Repo"
+      />,
+    );
+
+    expect(markup).toContain("git status");
+    expect(markup).not.toContain('aria-label="Open file');
+  });
+
+  it("does not make detail text open an associated changed file", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Updated file",
+              tone: "tool",
+              detail: "Wrote requested content",
+              changedFiles: ["/home/alice/Repo/inside.ts"],
+            },
+          },
+        ]}
+        workspaceRoot="/home/alice/Repo"
+      />,
+    );
+
+    expect(markup).toContain("Wrote requested content");
+    expect(markup).not.toContain('aria-label="Open file');
+  });
+
   it("renders review comment contexts as structured cards instead of raw tags", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -549,28 +549,93 @@ describe("MessagesTimeline", () => {
   });
 
   it("rejects absolute Windows paths while the workspace root is unavailable", () => {
-    const markup = renderToStaticMarkup(
-      <MessagesTimeline
-        {...buildProps()}
-        timelineEntries={[
-          {
-            id: "entry-1",
-            kind: "work",
-            createdAt: "2026-03-17T19:12:28.000Z",
-            entry: {
-              id: "work-1",
+    const renderChangedFile = (filePath: string) =>
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          timelineEntries={[
+            {
+              id: "entry-1",
+              kind: "work",
               createdAt: "2026-03-17T19:12:28.000Z",
-              label: "Updated file",
-              tone: "tool",
-              changedFiles: ["C:\\repo\\outside.ts"],
+              entry: {
+                id: "work-1",
+                createdAt: "2026-03-17T19:12:28.000Z",
+                label: "Updated file",
+                tone: "tool",
+                changedFiles: [filePath],
+              },
             },
-          },
-        ]}
-        workspaceRoot={undefined}
-      />,
-    );
+          ]}
+          workspaceRoot={undefined}
+        />,
+      );
 
-    expect(markup).not.toContain('aria-label="Open file');
+    expect(renderChangedFile("C:\\repo\\outside.ts")).not.toContain('aria-label="Open file');
+    expect(renderChangedFile("C:outside.ts")).not.toContain('aria-label="Open file');
+  });
+
+  it("handles Windows drive roots and UNC workspaces case-insensitively", () => {
+    const renderChangedFile = (filePath: string, workspaceRoot: string) =>
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          timelineEntries={[
+            {
+              id: "entry-1",
+              kind: "work",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              entry: {
+                id: "work-1",
+                createdAt: "2026-03-17T19:12:28.000Z",
+                label: "Updated file",
+                tone: "tool",
+                changedFiles: [filePath],
+              },
+            },
+          ]}
+          workspaceRoot={workspaceRoot}
+        />,
+      );
+
+    expect(renderChangedFile("/c:/inside.ts", "C:/")).toContain('aria-label="Open file inside.ts"');
+    expect(
+      renderChangedFile("\\\\SERVER\\SHARE\\Repo\\.scratch\\inside.ts", "\\\\server\\share\\repo"),
+    ).toContain('aria-label="Open file .scratch/inside.ts"');
+    expect(
+      renderChangedFile("\\\\server\\share\\repo-other\\outside.ts", "\\\\server\\share\\repo"),
+    ).not.toContain('aria-label="Open file');
+  });
+
+  it("rejects relative paths that escape the workspace", () => {
+    const renderChangedFile = (filePath: string) =>
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          timelineEntries={[
+            {
+              id: "entry-1",
+              kind: "work",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              entry: {
+                id: "work-1",
+                createdAt: "2026-03-17T19:12:28.000Z",
+                label: "Updated file",
+                tone: "tool",
+                changedFiles: [filePath],
+              },
+            },
+          ]}
+          workspaceRoot="/home/alice/Repo"
+        />,
+      );
+
+    expect(renderChangedFile("../outside.ts")).not.toContain('aria-label="Open file');
+    expect(renderChangedFile("..\\outside.ts")).not.toContain('aria-label="Open file');
+    expect(renderChangedFile("/home/alice/Repo/dir/../../outside.ts")).not.toContain(
+      'aria-label="Open file',
+    );
+    expect(renderChangedFile("src/../inside.ts")).toContain('aria-label="Open file inside.ts"');
   });
 
   it("rejects case-mismatched POSIX paths outside the workspace", () => {
@@ -628,6 +693,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("git status");
     expect(markup).not.toContain(">git status</button>");
     expect(markup).toContain('aria-label="Open file inside.ts"');
+    expect(markup).toContain('aria-label="Expand Ran command"');
+    expect(markup).not.toContain('role="button" tabindex="0" aria-label="Ran command');
     expect(markup).toContain("lucide-file-text");
     expect(markup).toContain('<span class="truncate">inside.ts</span>');
   });
@@ -658,6 +725,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Wrote requested content");
     expect(markup).not.toContain(">Wrote requested content</button>");
     expect(markup).toContain('aria-label="Open file inside.ts"');
+    expect(markup).toContain('aria-label="Expand Updated file"');
+    expect(markup).not.toContain('role="button" tabindex="0" aria-label="Updated file');
     expect(markup).toContain("lucide-file-text");
     expect(markup).toContain('<span class="truncate">inside.ts</span>');
   });

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -548,6 +548,31 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Open file apps/web/src/session-logic.ts"');
   });
 
+  it("rejects absolute Windows paths while the workspace root is unavailable", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Updated file",
+              tone: "tool",
+              changedFiles: ["C:\\repo\\outside.ts"],
+            },
+          },
+        ]}
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).not.toContain('aria-label="Open file');
+  });
+
   it("rejects case-mismatched POSIX paths outside the workspace", () => {
     const renderChangedFile = (filePath: string) =>
       renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -181,6 +181,7 @@ function buildProps() {
     turnDiffSummaryByAssistantMessageId: new Map(),
     routeThreadKey: "environment-local:thread-1",
     onOpenTurnDiff: () => {},
+    onOpenFile: () => {},
     revertTurnCountByUserMessageId: new Map(),
     onRevertUserMessage: () => {},
     isRevertingCheckpoint: false,
@@ -544,6 +545,7 @@ describe("MessagesTimeline", () => {
 
     expect(markup).toContain("t3code/apps/web/src/session-logic.ts");
     expect(markup).not.toContain("C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts");
+    expect(markup).toContain('aria-label="Open file apps/web/src/session-logic.ts"');
   });
 
   it("renders review comment contexts as structured cards instead of raw tags", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -577,7 +577,7 @@ describe("MessagesTimeline", () => {
     expect(renderChangedFile("/home/alice/repo/outside.ts")).not.toContain('aria-label="Open file');
   });
 
-  it("does not make command text open an associated changed file", () => {
+  it("keeps command text separate from its associated file link", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline
         {...buildProps()}
@@ -601,10 +601,12 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("git status");
-    expect(markup).not.toContain('aria-label="Open file');
+    expect(markup).not.toContain(">git status</button>");
+    expect(markup).toContain('aria-label="Open file inside.ts"');
+    expect(markup).toContain(">inside.ts</button>");
   });
 
-  it("does not make detail text open an associated changed file", () => {
+  it("keeps detail text separate from its associated file link", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline
         {...buildProps()}
@@ -628,7 +630,9 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Wrote requested content");
-    expect(markup).not.toContain('aria-label="Open file');
+    expect(markup).not.toContain(">Wrote requested content</button>");
+    expect(markup).toContain('aria-label="Open file inside.ts"');
+    expect(markup).toContain(">inside.ts</button>");
   });
 
   it("renders review comment contexts as structured cards instead of raw tags", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1882,17 +1882,27 @@ function workToneIcon(tone: TimelineWorkEntry["tone"]): {
 function workEntryPreview(
   workEntry: Pick<TimelineWorkEntry, "detail" | "command" | "changedFiles">,
   workspaceRoot: string | undefined,
-): { text: string; changedFilePath: string | null } | null {
-  if (workEntry.command) return { text: workEntry.command, changedFilePath: null };
-  if (workEntry.detail) return { text: workEntry.detail, changedFilePath: null };
+): {
+  text: string;
+  source: "command" | "detail" | "changed-files";
+  changedFilePath: string | null;
+} | null {
   const changedFiles = workEntry.changedFiles ?? [];
   const [firstPath] = changedFiles;
+  const changedFilePath = changedFiles.length === 1 ? (firstPath ?? null) : null;
+  if (workEntry.command) {
+    return { text: workEntry.command, source: "command", changedFilePath };
+  }
+  if (workEntry.detail) {
+    return { text: workEntry.detail, source: "detail", changedFilePath };
+  }
   if (!firstPath) return null;
   const displayPath = formatWorkspaceRelativePath(firstPath, workspaceRoot);
   const singleChangedFile = changedFiles.length === 1;
   return {
     text: singleChangedFile ? displayPath : `${displayPath} +${changedFiles.length - 1} more`,
-    changedFilePath: singleChangedFile ? firstPath : null,
+    source: "changed-files",
+    changedFilePath,
   };
 }
 
@@ -2030,6 +2040,9 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const openableFilePath = resolvedPreview?.changedFilePath
     ? toWorkspaceRelativeFilePath(resolvedPreview.changedFilePath, workspaceRoot)
     : null;
+  const previewIsOpenableFile =
+    openableFilePath !== null && resolvedPreview?.source === "changed-files";
+  const fileButtonText = previewIsOpenableFile ? rawPreview : openableFilePath;
   const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
   const canExpand = expandedBody !== null;
   const showFailedIndicator = workEntryIndicatesToolFailure(workEntry);
@@ -2091,26 +2104,27 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           <div className="min-w-0 flex-1 overflow-hidden">
             <p className="flex min-w-0 w-full items-baseline gap-1.5 text-[12px] leading-5">
               <span className={cn("min-w-0 shrink truncate", headingClass)}>{heading}</span>
-              {preview &&
-                (openableFilePath ? (
-                  <button
-                    type="button"
-                    className="min-w-0 flex-1 cursor-pointer truncate text-left text-muted-foreground/55 hover:text-foreground hover:underline"
-                    aria-label={`Open file ${openableFilePath}`}
-                    onKeyDown={stopRowToggle}
-                    onPointerDown={stopRowToggle}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onOpenFile(openableFilePath);
-                    }}
-                  >
-                    {preview}
-                  </button>
-                ) : (
-                  <span className="min-w-0 flex-1 truncate text-muted-foreground/55">
-                    {preview}
-                  </span>
-                ))}
+              {preview && !previewIsOpenableFile ? (
+                <span className="min-w-0 flex-1 truncate text-muted-foreground/55">{preview}</span>
+              ) : null}
+              {openableFilePath && fileButtonText ? (
+                <button
+                  type="button"
+                  className={cn(
+                    "min-w-0 cursor-pointer truncate text-left text-muted-foreground/55 hover:text-foreground hover:underline",
+                    previewIsOpenableFile ? "flex-1" : "max-w-[45%] shrink-0",
+                  )}
+                  aria-label={`Open file ${openableFilePath}`}
+                  onKeyDown={stopRowToggle}
+                  onPointerDown={stopRowToggle}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOpenFile(openableFilePath);
+                  }}
+                >
+                  {fileButtonText}
+                </button>
+              ) : null}
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-px text-muted-foreground/55">

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1882,16 +1882,18 @@ function workToneIcon(tone: TimelineWorkEntry["tone"]): {
 function workEntryPreview(
   workEntry: Pick<TimelineWorkEntry, "detail" | "command" | "changedFiles">,
   workspaceRoot: string | undefined,
-) {
-  if (workEntry.command) return workEntry.command;
-  if (workEntry.detail) return workEntry.detail;
-  if ((workEntry.changedFiles?.length ?? 0) === 0) return null;
-  const [firstPath] = workEntry.changedFiles ?? [];
+): { text: string; changedFilePath: string | null } | null {
+  if (workEntry.command) return { text: workEntry.command, changedFilePath: null };
+  if (workEntry.detail) return { text: workEntry.detail, changedFilePath: null };
+  const changedFiles = workEntry.changedFiles ?? [];
+  const [firstPath] = changedFiles;
   if (!firstPath) return null;
   const displayPath = formatWorkspaceRelativePath(firstPath, workspaceRoot);
-  return workEntry.changedFiles!.length === 1
-    ? displayPath
-    : `${displayPath} +${workEntry.changedFiles!.length - 1} more`;
+  const singleChangedFile = changedFiles.length === 1;
+  return {
+    text: singleChangedFile ? displayPath : `${displayPath} +${changedFiles.length - 1} more`,
+    changedFilePath: singleChangedFile ? firstPath : null,
+  };
 }
 
 function workEntryRawCommand(
@@ -1991,7 +1993,12 @@ function toWorkspaceRelativeFilePath(
 
   const normalizedRoot = workspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
   const rootWithSeparator = `${normalizedRoot}/`;
-  if (normalizedPath.toLowerCase().startsWith(rootWithSeparator.toLowerCase())) {
+  const usesCaseInsensitiveComparison =
+    /^[A-Za-z]:\//.test(normalizedRoot) || normalizedRoot.startsWith("//");
+  const isInsideWorkspace = usesCaseInsensitiveComparison
+    ? normalizedPath.toLowerCase().startsWith(rootWithSeparator.toLowerCase())
+    : normalizedPath.startsWith(rootWithSeparator);
+  if (isInsideWorkspace) {
     return normalizedPath.slice(rootWithSeparator.length);
   }
   return normalizedPath.startsWith("/") || /^[A-Za-z]:\//.test(normalizedPath)
@@ -2011,7 +2018,8 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
   const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
-  const rawPreview = workEntryPreview(workEntry, workspaceRoot);
+  const resolvedPreview = workEntryPreview(workEntry, workspaceRoot);
+  const rawPreview = resolvedPreview?.text ?? null;
   const preview =
     rawPreview &&
     normalizeCompactToolLabel(rawPreview).toLowerCase() ===
@@ -2019,10 +2027,8 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
       ? null
       : rawPreview;
   const displayText = preview ? `${heading} - ${preview}` : heading;
-  const singleChangedFile =
-    workEntry.changedFiles?.length === 1 ? workEntry.changedFiles[0] : undefined;
-  const openableFilePath = singleChangedFile
-    ? toWorkspaceRelativeFilePath(singleChangedFile, workspaceRoot)
+  const openableFilePath = resolvedPreview?.changedFilePath
+    ? toWorkspaceRelativeFilePath(resolvedPreview.changedFilePath, workspaceRoot)
     : null;
   const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
   const canExpand = expandedBody !== null;
@@ -2091,6 +2097,8 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                     type="button"
                     className="min-w-0 flex-1 cursor-pointer truncate text-left text-muted-foreground/55 hover:text-foreground hover:underline"
                     aria-label={`Open file ${openableFilePath}`}
+                    onKeyDown={stopRowToggle}
+                    onPointerDown={stopRowToggle}
                     onClick={(event) => {
                       event.stopPropagation();
                       onOpenFile(openableFilePath);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1998,8 +1998,11 @@ function toWorkspaceRelativeFilePath(
   workspaceRoot: string | undefined,
 ): string | null {
   const normalizedPath = filePath.replaceAll("\\", "/").replace(/^\/(?=[A-Za-z]:\/)/, "");
+  const isAbsoluteWindowsPath = /^[A-Za-z]:\//.test(normalizedPath);
   if (!workspaceRoot) {
-    return normalizedPath.startsWith("/") ? null : normalizedPath.replace(/^\.\/+/, "");
+    return normalizedPath.startsWith("/") || isAbsoluteWindowsPath
+      ? null
+      : normalizedPath.replace(/^\.\/+/, "");
   }
 
   const normalizedRoot = workspaceRoot
@@ -2015,7 +2018,7 @@ function toWorkspaceRelativeFilePath(
   if (isInsideWorkspace) {
     return normalizedPath.slice(rootWithSeparator.length);
   }
-  return normalizedPath.startsWith("/") || /^[A-Za-z]:\//.test(normalizedPath)
+  return normalizedPath.startsWith("/") || isAbsoluteWindowsPath
     ? null
     : normalizedPath.replace(/^\.\/+/, "");
 }

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1993,16 +1993,30 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
 
+function normalizeWorkspaceRelativeFilePath(filePath: string): string | null {
+  const segments: string[] = [];
+  for (const segment of filePath.replace(/^\.\/+/, "").split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) return null;
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.length > 0 ? segments.join("/") : null;
+}
+
 function toWorkspaceRelativeFilePath(
   filePath: string,
   workspaceRoot: string | undefined,
 ): string | null {
   const normalizedPath = filePath.replaceAll("\\", "/").replace(/^\/(?=[A-Za-z]:\/)/, "");
-  const isAbsoluteWindowsPath = /^[A-Za-z]:\//.test(normalizedPath);
+  const hasWindowsDrivePrefix = /^[A-Za-z]:/.test(normalizedPath);
   if (!workspaceRoot) {
-    return normalizedPath.startsWith("/") || isAbsoluteWindowsPath
+    return normalizedPath.startsWith("/") || hasWindowsDrivePrefix
       ? null
-      : normalizedPath.replace(/^\.\/+/, "");
+      : normalizeWorkspaceRelativeFilePath(normalizedPath);
   }
 
   const normalizedRoot = workspaceRoot
@@ -2011,16 +2025,16 @@ function toWorkspaceRelativeFilePath(
     .replace(/\/+$/, "");
   const rootWithSeparator = `${normalizedRoot}/`;
   const usesCaseInsensitiveComparison =
-    /^[A-Za-z]:\//.test(normalizedRoot) || normalizedRoot.startsWith("//");
+    /^[A-Za-z]:(?:\/|$)/.test(normalizedRoot) || normalizedRoot.startsWith("//");
   const isInsideWorkspace = usesCaseInsensitiveComparison
     ? normalizedPath.toLowerCase().startsWith(rootWithSeparator.toLowerCase())
     : normalizedPath.startsWith(rootWithSeparator);
   if (isInsideWorkspace) {
-    return normalizedPath.slice(rootWithSeparator.length);
+    return normalizeWorkspaceRelativeFilePath(normalizedPath.slice(rootWithSeparator.length));
   }
-  return normalizedPath.startsWith("/") || isAbsoluteWindowsPath
+  return normalizedPath.startsWith("/") || hasWindowsDrivePrefix
     ? null
-    : normalizedPath.replace(/^\.\/+/, "");
+    : normalizeWorkspaceRelativeFilePath(normalizedPath);
 }
 
 const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
@@ -2076,26 +2090,28 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const showSuccessIndicator =
     workEntryIndicatesToolSuccess(workEntry) ||
     (turnSettled && workEntryIndicatesToolNeutralStatus(workEntry));
-  const rowToggleProps = canExpand
-    ? {
-        role: "button" as const,
-        tabIndex: 0 as const,
-        "aria-label": displayText,
-        onClick: () => setExpanded((v) => !v),
-        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            setExpanded((v) => !v);
-          }
-        },
-      }
-    : {};
+  const rowToggleProps =
+    canExpand && !openableFilePath
+      ? {
+          role: "button" as const,
+          tabIndex: 0 as const,
+          "aria-label": displayText,
+          onClick: () => setExpanded((v) => !v),
+          onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setExpanded((v) => !v);
+            }
+          },
+        }
+      : {};
 
   return (
     <div
       className={cn(
         "flex flex-col rounded-md px-0.5 py-0.5 transition-colors",
         canExpand &&
+          !openableFilePath &&
           "cursor-pointer hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
       )}
       {...rowToggleProps}
@@ -2136,11 +2152,14 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-px text-muted-foreground/55">
-            <span
-              className="flex size-4 shrink-0 items-center justify-center"
-              aria-hidden={!canExpand}
-            >
-              {canExpand ? (
+            {canExpand && openableFilePath ? (
+              <button
+                type="button"
+                className="flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
+                aria-expanded={expanded}
+                aria-label={`${expanded ? "Collapse" : "Expand"} ${heading}`}
+                onClick={() => setExpanded((value) => !value)}
+              >
                 <ChevronDownIcon
                   className={cn(
                     "size-3 shrink-0 opacity-70 transition-transform duration-200",
@@ -2148,8 +2167,23 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                   )}
                   aria-hidden
                 />
-              ) : null}
-            </span>
+              </button>
+            ) : (
+              <span
+                className="flex size-4 shrink-0 items-center justify-center"
+                aria-hidden={!canExpand}
+              >
+                {canExpand ? (
+                  <ChevronDownIcon
+                    className={cn(
+                      "size-3 shrink-0 opacity-70 transition-transform duration-200",
+                      expanded && "rotate-180",
+                    )}
+                    aria-hidden
+                  />
+                ) : null}
+              </span>
+            )}
             <span className="flex size-4 shrink-0 items-center justify-center">
               {showFailedIndicator ? (
                 <Tooltip>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1997,12 +1997,15 @@ function toWorkspaceRelativeFilePath(
   filePath: string,
   workspaceRoot: string | undefined,
 ): string | null {
-  const normalizedPath = filePath.replaceAll("\\", "/");
+  const normalizedPath = filePath.replaceAll("\\", "/").replace(/^\/(?=[A-Za-z]:\/)/, "");
   if (!workspaceRoot) {
     return normalizedPath.startsWith("/") ? null : normalizedPath.replace(/^\.\/+/, "");
   }
 
-  const normalizedRoot = workspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
+  const normalizedRoot = workspaceRoot
+    .replaceAll("\\", "/")
+    .replace(/^\/(?=[A-Za-z]:\/)/, "")
+    .replace(/\/+$/, "");
   const rootWithSeparator = `${normalizedRoot}/`;
   const usesCaseInsensitiveComparison =
     /^[A-Za-z]:\//.test(normalizedRoot) || normalizedRoot.startsWith("//");

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -137,6 +137,7 @@ interface TimelineRowSharedState {
   onRevertUserMessage: (messageId: MessageId) => void;
   onImageExpand: (preview: ExpandedImagePreview) => void;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  onOpenFile: (relativePath: string) => void;
   onToggleTurnFold: (turnId: TurnId) => void;
   onToggleWorkGroup: (groupId: string, anchorElement?: HTMLElement) => void;
 }
@@ -169,6 +170,7 @@ interface MessagesTimelineProps {
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   routeThreadKey: string;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  onOpenFile: (relativePath: string) => void;
   revertTurnCountByUserMessageId: Map<MessageId, number>;
   onRevertUserMessage: (messageId: MessageId) => void;
   isRevertingCheckpoint: boolean;
@@ -204,6 +206,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   turnDiffSummaryByAssistantMessageId,
   routeThreadKey,
   onOpenTurnDiff,
+  onOpenFile,
   revertTurnCountByUserMessageId,
   onRevertUserMessage,
   isRevertingCheckpoint,
@@ -431,6 +434,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onRevertUserMessage,
       onImageExpand,
       onOpenTurnDiff,
+      onOpenFile,
       onToggleTurnFold,
       onToggleWorkGroup,
     }),
@@ -445,6 +449,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onRevertUserMessage,
       onImageExpand,
       onOpenTurnDiff,
+      onOpenFile,
       onToggleTurnFold,
       onToggleWorkGroup,
     ],
@@ -1155,7 +1160,7 @@ const WorkGroupSection = memo(function WorkGroupSection({
 }: {
   groupedEntries: Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"];
 }) {
-  const { workspaceRoot } = use(TimelineRowCtx);
+  const { onOpenFile, workspaceRoot } = use(TimelineRowCtx);
   const nonEmptyEntries = useMemo(
     () => groupedEntries.filter((entry) => !workEntryIndicatesToolNeutralStatus(entry)),
     [groupedEntries],
@@ -1182,6 +1187,7 @@ const WorkGroupSection = memo(function WorkGroupSection({
             key={workEntry.id}
             workEntry={workEntry}
             workspaceRoot={workspaceRoot}
+            onOpenFile={onOpenFile}
           />
         ))}
       </div>
@@ -1974,11 +1980,31 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
 
+function toWorkspaceRelativeFilePath(
+  filePath: string,
+  workspaceRoot: string | undefined,
+): string | null {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  if (!workspaceRoot) {
+    return normalizedPath.startsWith("/") ? null : normalizedPath.replace(/^\.\/+/, "");
+  }
+
+  const normalizedRoot = workspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
+  const rootWithSeparator = `${normalizedRoot}/`;
+  if (normalizedPath.toLowerCase().startsWith(rootWithSeparator.toLowerCase())) {
+    return normalizedPath.slice(rootWithSeparator.length);
+  }
+  return normalizedPath.startsWith("/") || /^[A-Za-z]:\//.test(normalizedPath)
+    ? null
+    : normalizedPath.replace(/^\.\/+/, "");
+}
+
 const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   workEntry: TimelineWorkEntry;
   workspaceRoot: string | undefined;
+  onOpenFile: (relativePath: string) => void;
 }) {
-  const { workEntry, workspaceRoot } = props;
+  const { workEntry, workspaceRoot, onOpenFile } = props;
   const activity = use(TimelineRowActivityCtx);
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
@@ -1993,6 +2019,11 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
       ? null
       : rawPreview;
   const displayText = preview ? `${heading} - ${preview}` : heading;
+  const singleChangedFile =
+    workEntry.changedFiles?.length === 1 ? workEntry.changedFiles[0] : undefined;
+  const openableFilePath = singleChangedFile
+    ? toWorkspaceRelativeFilePath(singleChangedFile, workspaceRoot)
+    : null;
   const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
   const canExpand = expandedBody !== null;
   const showFailedIndicator = workEntryIndicatesToolFailure(workEntry);
@@ -2054,9 +2085,24 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           <div className="min-w-0 flex-1 overflow-hidden">
             <p className="flex min-w-0 w-full items-baseline gap-1.5 text-[12px] leading-5">
               <span className={cn("min-w-0 shrink truncate", headingClass)}>{heading}</span>
-              {preview && (
-                <span className="min-w-0 flex-1 truncate text-muted-foreground/55">{preview}</span>
-              )}
+              {preview &&
+                (openableFilePath ? (
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 cursor-pointer truncate text-left text-muted-foreground/55 hover:text-foreground hover:underline"
+                    aria-label={`Open file ${openableFilePath}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onOpenFile(openableFilePath);
+                    }}
+                  >
+                    {preview}
+                  </button>
+                ) : (
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground/55">
+                    {preview}
+                  </span>
+                ))}
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-px text-muted-foreground/55">

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -49,6 +49,7 @@ import {
   CircleAlertIcon,
   EyeIcon,
   FileDiffIcon,
+  FileTextIcon,
   GlobeIcon,
   HammerIcon,
   MessageCircleIcon,
@@ -2111,7 +2112,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                 <button
                   type="button"
                   className={cn(
-                    "min-w-0 cursor-pointer truncate text-left text-muted-foreground/55 hover:text-foreground hover:underline",
+                    "inline-flex min-w-0 cursor-pointer items-center gap-1 truncate text-left font-medium text-foreground/70 underline decoration-foreground/25 underline-offset-2 hover:text-foreground hover:decoration-foreground/60",
                     previewIsOpenableFile ? "flex-1" : "max-w-[45%] shrink-0",
                   )}
                   aria-label={`Open file ${openableFilePath}`}
@@ -2122,7 +2123,8 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                     onOpenFile(openableFilePath);
                   }}
                 >
-                  {fileButtonText}
+                  <FileTextIcon className="size-3 shrink-0" aria-hidden />
+                  <span className="truncate">{fileButtonText}</span>
                 </button>
               ) : null}
             </p>

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1146,6 +1146,30 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("extracts Claude snake-case file paths from tool activities", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "claude-file-tool",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            toolName: "Write",
+            input: {
+              file_path: "/home/deploy/ALS/.scratch/handoffs/wave-18/coordination-assessment.md",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities);
+    expect(entry?.changedFiles).toEqual([
+      "/home/deploy/ALS/.scratch/handoffs/wave-18/coordination-assessment.md",
+    ]);
+  });
+
   it("drops duplicated tool detail when it only repeats the title", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1262,6 +1262,7 @@ function collectChangedFiles(value: unknown, target: string[], seen: Set<string>
 
   pushChangedFile(target, seen, record.path);
   pushChangedFile(target, seen, record.filePath);
+  pushChangedFile(target, seen, record.file_path);
   pushChangedFile(target, seen, record.relativePath);
   pushChangedFile(target, seen, record.filename);
   pushChangedFile(target, seen, record.newPath);


### PR DESCRIPTION
## What changed

- Recognize Claude Code's snake-case `file_path` field when deriving changed files from tool activity payloads.
- Make a single changed-file entry open the existing file preview, including files omitted from the Files index because they are gitignored.
- Normalize absolute Windows and POSIX workspace paths before opening them.
- Render an unmistakable file action with a file icon, persistent underline, and accessible `Open file …` label while keeping command/detail text separate.
- Add regression coverage for Claude's `data.input.file_path` shape and the timeline click-through.

## Why

Codex file-change events expose paths as `data.item.changes[].path`, which the timeline already recognizes. Claude Code emits equivalent file paths as `data.input.file_path`.

The shared extractor handled `path`, `filePath`, `relativePath`, and related keys, but not `file_path`. Claude could read or write the file and the server retained the absolute path, but the web client discarded it while deriving `changedFiles`. This was particularly visible for gitignored paths such as `.scratch/`, because they are also absent from the shared Files index.

This keeps gitignore behavior unchanged. It normalizes the provider payload already stored by T3 Code and uses the existing file-preview surface.

## Validation

- `vp test run apps/web/src/session-logic.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx` — 80 tests passed
- Adversarial path coverage includes POSIX/Windows/UNC roots, slash-prefixed drives, drive-relative paths, case boundaries, dot-segment normalization, traversal rejection, and missing-workspace-root behavior
- Accessibility coverage verifies separate file and expand/collapse controls without nested interactive semantics
- Targeted formatting and lint checks passed for all changed files
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/web build`
- `pnpm --filter t3 build:bundle`
- Live Claude desktop test in an isolated local Alpha instance:
  - Claude's actual `Write`/`Read` events carried an absolute Windows `file_path` for gitignored `.scratch/proof.md`.
  - T3 rendered `.scratch/proof.md` as the separate file action while preserving the tool detail.
  - Activating the file action opened the existing file-preview surface and displayed `PASS-005e475`.
  - The preview exposed the existing **Open** action for the preferred external editor.
  - The isolated instance used separate app data, backend data, and ports from the installed Nightly build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and path-normalization changes in the web client; workspace containment checks limit what can be opened, with no auth or server behavior changes.
> 
> **Overview**
> Claude Code tool activities now contribute **changed files** from snake-case `file_path` in payloads, and the chat **work log** can open a single in-workspace file via the existing file preview (including gitignored paths not in the Files index).
> 
> **Session logic** adds `file_path` to changed-file extraction. **Timeline** threads `onOpenFile` from `ChatView` into work rows, normalizes absolute Windows/UNC/POSIX paths against `workspaceRoot` (rejecting escapes and out-of-root absolutes), and renders a dedicated **Open file** control with icon and underline while keeping command/detail text non-clickable. Expand/collapse is split out when a file link is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6315377a9d553942708402886402d859a859f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Claude snake_case `file_path` fields and add clickable file links in work log entries
> - Extends `collectChangedFiles` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/4340/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to extract `file_path` (snake_case) from tool activity payloads, alongside existing keys like `filePath` and `path`.
> - Refactors `workEntryPreview` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/4340/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) to return a structured object with `text`, `source`, and `changedFilePath`, enabling `SimpleWorkEntryRow` to render a clickable file-open button when a single in-workspace file is present.
> - Adds `toWorkspaceRelativeFilePath` and `normalizeWorkspaceRelativeFilePath` helpers that validate and normalize file paths, rejecting absolute, out-of-workspace, or path-traversal paths before they can be opened.
> - When a file link is present, row expansion moves to a dedicated chevron button; the full row is no longer the toggle target.
> - Behavioral Change: work log rows with a single changed file now render a file icon button instead of plain text, and row-click no longer toggles expansion when a file link is shown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href=https://app.macroscope.com>Macroscope</a> summarized e631537.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->