### PR TITLE
fix(web): roll back timed-out preview resizes

### DIFF
--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -56,6 +56,7 @@ import {
 import { previewAutomationOpenNeedsOverlay } from "./previewAutomationOpenReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
+import { resizePreviewViewportTransaction } from "./previewResizeTransaction";
 import {
   needsPreviewAutomationSessionSync,
   resolvePreviewAutomationOpenTab,
@@ -425,28 +426,36 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationResizeInput;
             const setting = resolvePreviewViewport(input);
-            const result = await resize({
-              environmentId,
-              input: {
-                threadId: request.threadId,
-                tabId: ready.tabId,
-                viewport: setting,
-              },
-            });
-            if (result._tag === "Failure") {
-              return raiseAtomCommandFailure(result);
-            }
-            updatePreviewServerSnapshot(threadRef, result.value);
-            const viewport = await waitForRenderedViewport(
-              ready.tabId,
+            const previousSetting =
+              resolvePreviewAutomationTarget(readThreadPreviewState(threadRef), ready.tabId)
+                .snapshot?.viewport ?? FILL_PREVIEW_VIEWPORT;
+            const timeoutMs = input.timeoutMs ?? request.timeoutMs;
+            const viewport = await resizePreviewViewportTransaction({
               setting,
-              input.timeoutMs ?? request.timeoutMs,
-              {
-                requestId: request.requestId,
-                environmentId,
-                threadId: request.threadId,
+              previousSetting,
+              timeoutMs,
+              applySetting: async (viewport) => {
+                const result = await resize({
+                  environmentId,
+                  input: {
+                    threadId: request.threadId,
+                    tabId: ready.tabId,
+                    viewport,
+                  },
+                });
+                if (result._tag === "Failure") {
+                  return raiseAtomCommandFailure(result);
+                }
+                return result.value;
               },
-            );
+              updateSnapshot: (snapshot) => updatePreviewServerSnapshot(threadRef, snapshot),
+              waitForViewport: (viewport, viewportTimeoutMs) =>
+                waitForRenderedViewport(ready.tabId, viewport, viewportTimeoutMs, {
+                  requestId: request.requestId,
+                  environmentId,
+                  threadId: request.threadId,
+                }),
+            });
             return {
               tabId: ready.tabId,
               setting,

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -56,13 +56,18 @@ import {
 import { previewAutomationOpenNeedsOverlay } from "./previewAutomationOpenReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
-import { resizePreviewViewportTransaction } from "./previewResizeTransaction";
+import {
+  createPreviewResizeTransactionQueue,
+  resizePreviewViewportTransaction,
+} from "./previewResizeTransaction";
 import {
   needsPreviewAutomationSessionSync,
   resolvePreviewAutomationOpenTab,
   resolvePreviewAutomationTarget,
 } from "./previewAutomationTarget";
 import { isPreviewViewportReady } from "./previewViewportReadiness";
+
+const previewResizeTransactionQueue = createPreviewResizeTransactionQueue();
 
 const waitForDesktopOverlay = async (
   threadRef: ScopedThreadRef,
@@ -426,35 +431,38 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationResizeInput;
             const setting = resolvePreviewViewport(input);
-            const previousSetting =
-              resolvePreviewAutomationTarget(readThreadPreviewState(threadRef), ready.tabId)
-                .snapshot?.viewport ?? FILL_PREVIEW_VIEWPORT;
             const timeoutMs = input.timeoutMs ?? request.timeoutMs;
-            const viewport = await resizePreviewViewportTransaction({
-              setting,
-              previousSetting,
-              timeoutMs,
-              applySetting: async (viewport) => {
-                const result = await resize({
-                  environmentId,
-                  input: {
+            const transactionKey = `${environmentId}:${request.threadId}:${ready.tabId}`;
+            const viewport = await previewResizeTransactionQueue.run(transactionKey, async () => {
+              const previousSetting =
+                resolvePreviewAutomationTarget(readThreadPreviewState(threadRef), ready.tabId)
+                  .snapshot?.viewport ?? FILL_PREVIEW_VIEWPORT;
+              return await resizePreviewViewportTransaction({
+                setting,
+                previousSetting,
+                timeoutMs,
+                applySetting: async (viewport) => {
+                  const result = await resize({
+                    environmentId,
+                    input: {
+                      threadId: request.threadId,
+                      tabId: ready.tabId,
+                      viewport,
+                    },
+                  });
+                  if (result._tag === "Failure") {
+                    return raiseAtomCommandFailure(result);
+                  }
+                  return result.value;
+                },
+                updateSnapshot: (snapshot) => updatePreviewServerSnapshot(threadRef, snapshot),
+                waitForViewport: (viewport, viewportTimeoutMs) =>
+                  waitForRenderedViewport(ready.tabId, viewport, viewportTimeoutMs, {
+                    requestId: request.requestId,
+                    environmentId,
                     threadId: request.threadId,
-                    tabId: ready.tabId,
-                    viewport,
-                  },
-                });
-                if (result._tag === "Failure") {
-                  return raiseAtomCommandFailure(result);
-                }
-                return result.value;
-              },
-              updateSnapshot: (snapshot) => updatePreviewServerSnapshot(threadRef, snapshot),
-              waitForViewport: (viewport, viewportTimeoutMs) =>
-                waitForRenderedViewport(ready.tabId, viewport, viewportTimeoutMs, {
-                  requestId: request.requestId,
-                  environmentId,
-                  threadId: request.threadId,
-                }),
+                  }),
+              });
             });
             return {
               tabId: ready.tabId,

--- a/apps/web/src/components/preview/previewResizeTransaction.test.ts
+++ b/apps/web/src/components/preview/previewResizeTransaction.test.ts
@@ -1,7 +1,10 @@
 import { FILL_PREVIEW_VIEWPORT, type PreviewViewportSetting } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { resizePreviewViewportTransaction } from "./previewResizeTransaction";
+import {
+  createPreviewResizeTransactionQueue,
+  resizePreviewViewportTransaction,
+} from "./previewResizeTransaction";
 
 const requestedSetting: PreviewViewportSetting = {
   _tag: "freeform",
@@ -85,5 +88,56 @@ describe("resizePreviewViewportTransaction", () => {
         }),
       }),
     ).rejects.toBe(timeout);
+  });
+});
+
+describe("createPreviewResizeTransactionQueue", () => {
+  it("serializes transactions for the same preview tab", async () => {
+    const queue = createPreviewResizeTransactionQueue();
+    const events: string[] = [];
+    let finishFirst = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+
+    const first = queue.run("tab-1", async () => {
+      events.push("first:start");
+      await firstGate;
+      events.push("first:end");
+    });
+    const second = queue.run("tab-1", async () => {
+      events.push("second:start");
+      events.push("second:end");
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(["first:start"]);
+
+    finishFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+  });
+
+  it("allows transactions for different preview tabs to run concurrently", async () => {
+    const queue = createPreviewResizeTransactionQueue();
+    const events: string[] = [];
+    let finishFirst = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+
+    const first = queue.run("tab-1", async () => {
+      events.push("first:start");
+      await firstGate;
+    });
+    const second = queue.run("tab-2", async () => {
+      events.push("second:start");
+    });
+
+    await second;
+    expect(events).toEqual(["first:start", "second:start"]);
+
+    finishFirst();
+    await first;
   });
 });

--- a/apps/web/src/components/preview/previewResizeTransaction.test.ts
+++ b/apps/web/src/components/preview/previewResizeTransaction.test.ts
@@ -1,0 +1,89 @@
+import { FILL_PREVIEW_VIEWPORT, type PreviewViewportSetting } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { resizePreviewViewportTransaction } from "./previewResizeTransaction";
+
+const requestedSetting: PreviewViewportSetting = {
+  _tag: "freeform",
+  width: 1_920,
+  height: 1_200,
+};
+
+describe("resizePreviewViewportTransaction", () => {
+  it("returns the rendered viewport without rolling back a successful resize", async () => {
+    const applySetting = vi.fn(async (setting: PreviewViewportSetting) => ({ viewport: setting }));
+    const updateSnapshot = vi.fn();
+    const waitForViewport = vi.fn(async () => ({ width: 1_920, height: 1_200 }));
+
+    await expect(
+      resizePreviewViewportTransaction({
+        setting: requestedSetting,
+        previousSetting: FILL_PREVIEW_VIEWPORT,
+        timeoutMs: 15_000,
+        applySetting,
+        updateSnapshot,
+        waitForViewport,
+      }),
+    ).resolves.toEqual({ width: 1_920, height: 1_200 });
+
+    expect(applySetting).toHaveBeenCalledTimes(1);
+    expect(updateSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the previous setting when the requested viewport times out", async () => {
+    const timeout = new Error("viewport timed out");
+    const applySetting = vi.fn(async (setting: PreviewViewportSetting) => ({ viewport: setting }));
+    const updateSnapshot = vi.fn();
+    const waitForViewport = vi
+      .fn<
+        (
+          setting: PreviewViewportSetting,
+          timeoutMs: number,
+        ) => Promise<{ width: number; height: number }>
+      >()
+      .mockRejectedValueOnce(timeout)
+      .mockResolvedValueOnce({ width: 1_280, height: 800 });
+
+    await expect(
+      resizePreviewViewportTransaction({
+        setting: requestedSetting,
+        previousSetting: FILL_PREVIEW_VIEWPORT,
+        timeoutMs: 15_000,
+        applySetting,
+        updateSnapshot,
+        waitForViewport,
+      }),
+    ).rejects.toBe(timeout);
+
+    expect(applySetting.mock.calls.map(([setting]) => setting)).toEqual([
+      requestedSetting,
+      FILL_PREVIEW_VIEWPORT,
+    ]);
+    expect(updateSnapshot.mock.calls.map(([snapshot]) => snapshot.viewport)).toEqual([
+      requestedSetting,
+      FILL_PREVIEW_VIEWPORT,
+    ]);
+    expect(waitForViewport).toHaveBeenLastCalledWith(FILL_PREVIEW_VIEWPORT, 2_000);
+  });
+
+  it("preserves the original timeout when rollback also fails", async () => {
+    const timeout = new Error("viewport timed out");
+    const applySetting = vi
+      .fn<(setting: PreviewViewportSetting) => Promise<{ viewport: PreviewViewportSetting }>>()
+      .mockResolvedValueOnce({ viewport: requestedSetting })
+      .mockRejectedValueOnce(new Error("rollback failed"));
+
+    await expect(
+      resizePreviewViewportTransaction({
+        setting: requestedSetting,
+        previousSetting: FILL_PREVIEW_VIEWPORT,
+        timeoutMs: 15_000,
+        applySetting,
+        updateSnapshot: vi.fn(),
+        waitForViewport: vi.fn(async () => {
+          throw timeout;
+        }),
+      }),
+    ).rejects.toBe(timeout);
+  });
+});

--- a/apps/web/src/components/preview/previewResizeTransaction.ts
+++ b/apps/web/src/components/preview/previewResizeTransaction.ts
@@ -1,0 +1,34 @@
+import type { PreviewRenderedViewportSize, PreviewViewportSetting } from "@t3tools/contracts";
+
+const MAX_ROLLBACK_WAIT_MS = 2_000;
+
+export async function resizePreviewViewportTransaction<Snapshot>(input: {
+  readonly setting: PreviewViewportSetting;
+  readonly previousSetting: PreviewViewportSetting;
+  readonly timeoutMs: number;
+  readonly applySetting: (setting: PreviewViewportSetting) => Promise<Snapshot>;
+  readonly updateSnapshot: (snapshot: Snapshot) => void;
+  readonly waitForViewport: (
+    setting: PreviewViewportSetting,
+    timeoutMs: number,
+  ) => Promise<PreviewRenderedViewportSize>;
+}): Promise<PreviewRenderedViewportSize> {
+  const snapshot = await input.applySetting(input.setting);
+  input.updateSnapshot(snapshot);
+
+  try {
+    return await input.waitForViewport(input.setting, input.timeoutMs);
+  } catch (error) {
+    try {
+      const previousSnapshot = await input.applySetting(input.previousSetting);
+      input.updateSnapshot(previousSnapshot);
+      await input.waitForViewport(
+        input.previousSetting,
+        Math.min(input.timeoutMs, MAX_ROLLBACK_WAIT_MS),
+      );
+    } catch {
+      // Preserve the original resize failure even when best-effort rollback cannot render.
+    }
+    throw error;
+  }
+}

--- a/apps/web/src/components/preview/previewResizeTransaction.ts
+++ b/apps/web/src/components/preview/previewResizeTransaction.ts
@@ -2,6 +2,36 @@ import type { PreviewRenderedViewportSize, PreviewViewportSetting } from "@t3too
 
 const MAX_ROLLBACK_WAIT_MS = 2_000;
 
+export interface PreviewResizeTransactionQueue {
+  readonly run: <Output>(key: string, transaction: () => Promise<Output>) => Promise<Output>;
+}
+
+export function createPreviewResizeTransactionQueue(): PreviewResizeTransactionQueue {
+  const tailByKey = new Map<string, Promise<void>>();
+
+  return {
+    async run<Output>(key: string, transaction: () => Promise<Output>): Promise<Output> {
+      const previous = tailByKey.get(key) ?? Promise.resolve();
+      let release = () => {};
+      const completion = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const tail = previous.then(() => completion);
+      tailByKey.set(key, tail);
+
+      await previous;
+      try {
+        return await transaction();
+      } finally {
+        release();
+        if (tailByKey.get(key) === tail) {
+          tailByKey.delete(key);
+        }
+      }
+    },
+  };
+}
+
 export async function resizePreviewViewportTransaction<Snapshot>(input: {
   readonly setting: PreviewViewportSetting;
   readonly previousSetting: PreviewViewportSetting;


### PR DESCRIPTION
## What Changed

- Capture the active preview viewport before applying an automation resize.
- Restore the previous server snapshot and rendered viewport when the requested viewport times out.
- Preserve the original timeout if the best-effort rollback also fails.

## Why

A timed-out preview_resize request updated the declared viewport before rendering completed, leaving preview_status and the live webview internally inconsistent.

Closes #3712

## UI Changes

No visual redesign. Failed automation resizes now return to the prior viewport instead of leaving partial state. The isolated web app pass authenticated and created a real thread successfully; the Browser surface is Electron-only and is intentionally unavailable in the web-only runner.

## Checklist

- [x] Focused transaction tests pass
- [x] Web typecheck passes
- [x] Targeted lint and formatting pass
- [x] Isolated test-t3-app smoke pass completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview automation resize semantics (rollback + serialization) in Electron-only paths; behavior is well-tested but affects automation status/viewport consistency on failure.
> 
> **Overview**
> **Preview automation `resize` no longer leaves a stale declared viewport when rendering times out.** The handler now records the tab’s current viewport (or `FILL_PREVIEW_VIEWPORT`), runs the resize through a per-tab transaction queue, and on `waitForRenderedViewport` failure reapplies that prior setting to the server snapshot and waits briefly (up to 2s) for rollback to render—while still surfacing the original timeout if rollback fails.
> 
> New helpers in `previewResizeTransaction.ts` implement the rollback transaction and serialize concurrent resizes per `environmentId:threadId:tabId` key; unit tests cover success, rollback on timeout, and queue behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584eaa383ee109fce94459ac443d53d9b8f4ec01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Roll back timed-out preview viewport resizes to their previous setting
> - Introduces `resizePreviewViewportTransaction` in [`previewResizeTransaction.ts`](https://github.com/pingdotgg/t3code/pull/4341/files#diff-6411813c21aac01c93e1239d36eaa7f986b3bfefcdc220c789c6dc2819630974) which applies a viewport setting, waits for it to render, and on timeout attempts a best-effort rollback to the previous setting (capped at 2000ms), preserving the original error if rollback also fails.
> - Adds `createPreviewResizeTransactionQueue` to serialize resize operations per preview tab (keyed by environment, thread, and tab ID), preventing concurrent conflicting resizes on the same tab.
> - Updates `PreviewAutomationHost` to wrap resize handling in the transaction queue and pass rollback context (previous setting defaulting to `FILL_PREVIEW_VIEWPORT`).
> - Behavioral Change: resize operations that previously fired-and-forgot on timeout now attempt rollback; concurrent resizes on the same tab are now serialized rather than running in parallel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 584eaa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->