### PR TITLE
fix(desktop): recover zoom from the upper limit

### DIFF
--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -10,6 +10,7 @@ import type * as Electron from "electron";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopApplicationMenu from "./DesktopApplicationMenu.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
@@ -91,12 +92,36 @@ const makeElectronMenuLayer = (
     showContextMenu: () => Effect.succeed(Option.none()),
   } satisfies ElectronMenu.ElectronMenu["Service"]);
 
+const makeElectronWindowLayer = (zoomLevel: { value: number }) =>
+  Layer.succeed(ElectronWindow.ElectronWindow, {
+    create: () => Effect.die("unexpected create"),
+    main: Effect.succeed(Option.none()),
+    currentMainOrFirst: Effect.succeed(Option.none()),
+    focusedMainOrFirst: Effect.succeed(
+      Option.some({
+        webContents: {
+          getZoomLevel: () => zoomLevel.value,
+          setZoomLevel: (value: number) => {
+            zoomLevel.value = value;
+          },
+        },
+      } as Electron.BrowserWindow),
+    ),
+    setMain: () => Effect.void,
+    clearMain: () => Effect.void,
+    reveal: () => Effect.void,
+    sendAll: () => Effect.void,
+    destroyAll: Effect.void,
+    syncAllAppearance: () => Effect.void,
+  } satisfies ElectronWindow.ElectronWindow["Service"]);
+
 describe("DesktopApplicationMenu", () => {
   it.effect("installs the native menu and routes Settings through DesktopWindow", () =>
     Effect.gen(function* () {
       const selectedAction = yield* Deferred.make<string>();
       const applicationMenuTemplate =
         yield* Deferred.make<readonly Electron.MenuItemConstructorOptions[]>();
+      const zoomLevel = { value: 9 };
 
       yield* Effect.gen(function* () {
         const menu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
@@ -105,6 +130,7 @@ describe("DesktopApplicationMenu", () => {
         Effect.provide(
           DesktopApplicationMenu.layer.pipe(
             Layer.provideMerge(makeElectronMenuLayer(applicationMenuTemplate)),
+            Layer.provideMerge(makeElectronWindowLayer(zoomLevel)),
             Layer.provideMerge(makeDesktopWindowLayer(selectedAction)),
             Layer.provideMerge(desktopUpdatesLayer),
             Layer.provideMerge(electronDialogLayer),
@@ -133,6 +159,21 @@ describe("DesktopApplicationMenu", () => {
 
       settingsClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
       assert.equal(yield* Deferred.await(selectedAction), "open-settings");
+
+      const viewMenu = template.find((item) => item.label === "View");
+      assert.isDefined(viewMenu);
+      if (!Array.isArray(viewMenu.submenu)) {
+        throw new Error("Expected View menu submenu to be an array.");
+      }
+      const zoomOutItem = viewMenu.submenu.find((item) => item.label === "Zoom Out");
+      assert.isDefined(zoomOutItem);
+      const zoomOutClick = zoomOutItem.click;
+      if (typeof zoomOutClick !== "function") {
+        throw new Error("Expected Zoom Out menu item to have a click handler.");
+      }
+      zoomOutClick({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent);
+      yield* Effect.yieldNow;
+      assert.equal(zoomLevel.value, 8);
     }),
   );
 });

--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -10,6 +10,7 @@ import { makeComponentLogger } from "../app/DesktopObservability.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
@@ -36,7 +37,8 @@ export class DesktopApplicationMenu extends Context.Service<
 type DesktopApplicationMenuRuntimeServices =
   | DesktopUpdates.DesktopUpdates
   | DesktopWindow.DesktopWindow
-  | ElectronDialog.ElectronDialog;
+  | ElectronDialog.ElectronDialog
+  | ElectronWindow.ElectronWindow;
 
 const { logInfo: logUpdaterInfo } = makeComponentLogger("desktop-updater");
 
@@ -47,6 +49,18 @@ const dispatchMenuAction = Effect.fn("desktop.menu.dispatchMenuAction")(function
 ): Effect.fn.Return<void, DesktopWindow.DesktopWindowError, DesktopWindow.DesktopWindow> {
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   yield* desktopWindow.dispatchMenuAction(action);
+});
+
+const setApplicationZoom = Effect.fn("desktop.menu.setApplicationZoom")(function* (
+  transform: (current: number) => number,
+) {
+  const electronWindow = yield* ElectronWindow.ElectronWindow;
+  const focusedWindow = yield* electronWindow.focusedMainOrFirst;
+  if (Option.isNone(focusedWindow)) return;
+  yield* Effect.sync(() => {
+    const webContents = focusedWindow.value.webContents;
+    webContents.setZoomLevel(transform(webContents.getZoomLevel()));
+  });
 });
 
 const checkForUpdatesFromMenu = Effect.gen(function* () {
@@ -127,6 +141,24 @@ export const make = Effect.gen(function* () {
     const settingsClick = () => {
       runMenuEffect("open-settings", dispatchMenuAction("open-settings"));
     };
+    const resetZoomClick = () => {
+      runMenuEffect(
+        "reset-zoom",
+        setApplicationZoom(() => 0),
+      );
+    };
+    const zoomInClick = () => {
+      runMenuEffect(
+        "zoom-in",
+        setApplicationZoom((current) => current + 1),
+      );
+    };
+    const zoomOutClick = () => {
+      runMenuEffect(
+        "zoom-out",
+        setApplicationZoom((current) => current - 1),
+      );
+    };
     const template: Electron.MenuItemConstructorOptions[] = [];
 
     if (environment.platform === "darwin") {
@@ -181,10 +213,15 @@ export const make = Effect.gen(function* () {
           { role: "forceReload" },
           { role: "toggleDevTools" },
           { type: "separator" },
-          { role: "resetZoom" },
-          { role: "zoomIn", accelerator: "CmdOrCtrl+=" },
-          { role: "zoomIn", accelerator: "CmdOrCtrl+Plus", visible: false },
-          { role: "zoomOut" },
+          { label: "Actual Size", accelerator: "CmdOrCtrl+0", click: resetZoomClick },
+          { label: "Zoom In", accelerator: "CmdOrCtrl+=", click: zoomInClick },
+          {
+            label: "Zoom In",
+            accelerator: "CmdOrCtrl+Plus",
+            visible: false,
+            click: zoomInClick,
+          },
+          { label: "Zoom Out", accelerator: "CmdOrCtrl+-", click: zoomOutClick },
           { type: "separator" },
           { role: "togglefullscreen" },
         ],


### PR DESCRIPTION
## What Changed

- Replace Electron built-in zoom menu roles with explicit focused-window zoom handlers.
- Decrement the current zoom level directly, including when the upper limit has been reached.
- Keep the existing shortcuts and add focused menu regression coverage.

## Why

On Linux and Windows, Electron could leave the built-in Zoom Out role ineffective after reaching maximum UI zoom. Reset still worked, but users could otherwise become stuck at an unusable scale.

Closes #4238

## Checklist

- [x] Focused desktop menu test passes
- [x] Desktop typecheck passes
- [x] Targeted lint and formatting pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop menu behavior with a regression test; no auth, data, or shared API surface changes.
> 
> **Overview**
> Fixes **Zoom Out** becoming a no-op on Linux/Windows after UI zoom hits Electron’s built-in maximum, while **Actual Size** still worked.
> 
> The **View** menu no longer uses Electron `resetZoom` / `zoomIn` / `zoomOut` roles. **Actual Size**, **Zoom In**, and **Zoom Out** now call custom handlers that read and write `webContents` zoom on the focused main window via `setApplicationZoom`, including decrementing from a high level (e.g. 9 → 8). Shortcuts are unchanged (`CmdOrCtrl+0`, `+=`, `-`, hidden `Plus`).
> 
> Tests add an `ElectronWindow` stub and assert **Zoom Out** lowers the mocked zoom level after menu configure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cec1f5b6869bff18b320a40eda0e3d6c77bd46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix zoom recovery from upper limit by replacing role-based zoom menu items with custom handlers
> - Replaces Electron's built-in role-based zoom menu items in the View menu with custom `click` handlers that read and set `webContents` zoom level directly via the `ElectronWindow` service.
> - Adds a `setApplicationZoom` effect that applies a transform (increment, decrement, or reset) to the focused window's zoom level; if no window is focused, the action is a no-op.
> - Behavioral Change: zoom controls no longer rely on Electron's default role behavior, so any role-specific side effects (e.g. native OS integration) are lost in favor of direct `webContents` zoom control.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cec1f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->