### PR TITLE
fix(web): preserve Claude insight line breaks

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -5,7 +5,19 @@ import {
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  shouldPreserveAssistantLineBreaks,
 } from "./MessagesTimeline.logic";
+
+describe("shouldPreserveAssistantLineBreaks", () => {
+  it("preserves Claude insight formatting without changing regular markdown", () => {
+    expect(
+      shouldPreserveAssistantLineBreaks(
+        "★ Insight ─────────────────\\nFirst observation\\nSecond observation\\n─────────────────",
+      ),
+    ).toBe(true);
+    expect(shouldPreserveAssistantLineBreaks("A normal\\nmarkdown paragraph")).toBe(false);
+  });
+});
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -25,6 +25,10 @@ export function resolveTimelineIsAtEnd(state: TimelineEndState | undefined): boo
   return state?.isNearEnd ?? state?.isAtEnd;
 }
 
+export function shouldPreserveAssistantLineBreaks(text: string): boolean {
+  return /^★ Insight(?:\s|─)/mu.test(text);
+}
+
 export function resolveTimelineMinimapHeightStyle(itemCount: number): string {
   const naturalHeight = Math.max(1, (itemCount - 1) * TIMELINE_MINIMAP_ITEM_SPACING);
   return `min(${naturalHeight}px, ${TIMELINE_MINIMAP_MAX_HEIGHT_CSS})`;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -80,6 +80,7 @@ import {
   resolveTimelineMinimapIndexFromPointer,
   resolveTimelineMinimapInteractiveWidth,
   resolveTimelineMinimapTopPercent,
+  shouldPreserveAssistantLineBreaks,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
   TIMELINE_MINIMAP_MIN_ITEMS,
@@ -1029,6 +1030,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           cwd={ctx.markdownCwd}
           threadRef={ctx.threadRef ?? undefined}
           isStreaming={Boolean(row.message.streaming)}
+          lineBreaks={shouldPreserveAssistantLineBreaks(messageText)}
           skills={ctx.skills}
         />
         <AssistantChangedFilesSection


### PR DESCRIPTION
Closes #3652

## Summary
- detect Claude `★ Insight` assistant blocks before Markdown rendering
- preserve soft line breaks for Insight content without changing normal Markdown wrapping
- add focused coverage for Insight and regular assistant text

## Verification
- `./node_modules/.bin/vp test run apps/web/src/components/chat/MessagesTimeline.logic.test.ts` (29 passed)
- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- targeted lint and formatting for the changed files
- isolated `test-t3-app` launch, pairing, project creation, and thread flow; the configured Claude model returned an invalid-model API error before a live assistant response could be rendered

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only assistant markdown rendering gated by a narrow content prefix; no auth, data, or API changes.
> 
> **Overview**
> Fixes **Claude `★ Insight` blocks** collapsing to a single paragraph in the chat timeline by turning on hard line breaks only for that pattern.
> 
> Adds **`shouldPreserveAssistantLineBreaks`** in timeline logic (regex on text starting with `★ Insight` followed by space or box-drawing). **`AssistantTimelineRow`** passes the result into **`ChatMarkdown`** as `lineBreaks`, which switches in the remark plugin that treats single newlines as breaks. Normal assistant markdown stays on the default renderer.
> 
> Unit tests cover Insight-formatted text vs ordinary multi-line markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d59d6221a8d7b5e25d3c2998c6f7730400de88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve line breaks in Claude insight messages in chat timeline
> Adds a `shouldPreserveAssistantLineBreaks` utility in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/4344/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) that detects assistant messages starting with `★ Insight` followed by whitespace or `─`. The `AssistantTimelineRow` component passes this as the `lineBreaks` prop to `ChatMarkdown`, so insight messages render with preserved line breaks while other messages are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c0d59d6. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->