### PR TITLE
perf(web): skip large sidebar collapse animations

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -22,6 +22,7 @@ import {
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
+  shouldSuspendSidebarThreadListAnimation,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
   sortThreadsForSidebarV2,
@@ -45,6 +46,29 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("shouldSuspendSidebarThreadListAnimation", () => {
+  it("skips expensive collapse animations only for large expanded lists", () => {
+    expect(
+      shouldSuspendSidebarThreadListAnimation({
+        projectExpanded: true,
+        renderedThreadCount: 31,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuspendSidebarThreadListAnimation({
+        projectExpanded: true,
+        renderedThreadCount: 30,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuspendSidebarThreadListAnimation({
+        projectExpanded: false,
+        renderedThreadCount: 100,
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -15,6 +15,7 @@ import { resolveServerBackedAppStageLabel } from "../branding.logic";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
+export const SIDEBAR_THREAD_LIST_ANIMATION_LIMIT = 30;
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
@@ -44,6 +45,13 @@ type LogicalSidebarProject = SidebarProject & {
 };
 
 export type ThreadTraversalDirection = "previous" | "next";
+
+export function shouldSuspendSidebarThreadListAnimation(input: {
+  projectExpanded: boolean;
+  renderedThreadCount: number;
+}): boolean {
+  return input.projectExpanded && input.renderedThreadCount > SIDEBAR_THREAD_LIST_ANIMATION_LIMIT;
+}
 
 export async function archiveSelectedThreadEntries<
   TEntry extends { readonly threadKey: string },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -23,7 +23,7 @@ import {
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { useAtomValue } from "@effect/atom-react";
-import { autoAnimate } from "@formkit/auto-animate";
+import { autoAnimate, type AnimationController } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -181,6 +181,7 @@ import {
   resolveThreadStatusPill,
   orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
+  shouldSuspendSidebarThreadListAnimation,
   sortProjectsForSidebar,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
@@ -1062,7 +1063,7 @@ interface SidebarProjectItemProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
-  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
+  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => AnimationController | null;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
   dragInProgressRef: React.RefObject<boolean>;
@@ -1210,6 +1211,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
   const confirmArchiveButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const threadListAnimationControllerRef = useRef<AnimationController | null>(null);
   const memberProjectByScopedKey = useMemo(
     () =>
       new Map(
@@ -1344,6 +1346,32 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     visibleProjectThreads,
   ]);
 
+  const attachProjectThreadListAutoAnimateRef = useCallback(
+    (node: HTMLElement | null) => {
+      threadListAnimationControllerRef.current = attachThreadListAutoAnimateRef(node);
+    },
+    [attachThreadListAutoAnimateRef],
+  );
+
+  const toggleProjectExpanded = useCallback(() => {
+    const animationController = threadListAnimationControllerRef.current;
+    const shouldSuspendAnimation = shouldSuspendSidebarThreadListAnimation({
+      projectExpanded,
+      renderedThreadCount: renderedThreads.length,
+    });
+    if (shouldSuspendAnimation) {
+      animationController?.disable();
+    }
+
+    setProjectExpanded(projectPreferenceKeys, !projectExpanded);
+
+    if (shouldSuspendAnimation && animationController) {
+      requestAnimationFrame(() => {
+        animationController.enable();
+      });
+    }
+  }, [projectExpanded, projectPreferenceKeys, renderedThreads.length, setProjectExpanded]);
+
   const handleProjectButtonClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (suppressProjectClickForContextMenuRef.current) {
@@ -1366,16 +1394,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       if (useThreadSelectionStore.getState().hasSelection()) {
         clearSelection();
       }
-      setProjectExpanded(projectPreferenceKeys, !projectExpanded);
+      toggleProjectExpanded();
     },
     [
       clearSelection,
       dragInProgressRef,
-      projectExpanded,
-      projectPreferenceKeys,
-      setProjectExpanded,
       suppressProjectClickAfterDragRef,
       suppressProjectClickForContextMenuRef,
+      toggleProjectExpanded,
     ],
   );
 
@@ -1386,9 +1412,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       if (dragInProgressRef.current) {
         return;
       }
-      setProjectExpanded(projectPreferenceKeys, !projectExpanded);
+      toggleProjectExpanded();
     },
-    [dragInProgressRef, projectExpanded, projectPreferenceKeys, setProjectExpanded],
+    [dragInProgressRef, toggleProjectExpanded],
   );
 
   const handleProjectButtonPointerDownCapture = useCallback(
@@ -2345,7 +2371,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         confirmingArchiveThreadKey={confirmingArchiveThreadKey}
         setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
         confirmArchiveButtonRefs={confirmArchiveButtonRefs}
-        attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
+        attachThreadListAutoAnimateRef={attachProjectThreadListAutoAnimateRef}
         handleThreadClick={handleThreadClick}
         navigateToThread={navigateToThread}
         handleMultiSelectContextMenu={handleMultiSelectContextMenu}
@@ -2753,7 +2779,7 @@ interface SidebarProjectsContentProps {
   newThreadShortcutLabel: string | null;
   commandPaletteShortcutLabel: string | null;
   threadJumpLabelByKey: ReadonlyMap<string, string>;
-  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
+  attachThreadListAutoAnimateRef: (node: HTMLElement | null) => AnimationController | null;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
   dragInProgressRef: React.RefObject<boolean>;
@@ -3249,13 +3275,18 @@ export default function Sidebar() {
     animatedProjectListsRef.current.add(node);
   }, []);
 
-  const animatedThreadListsRef = useRef(new WeakSet<HTMLElement>());
+  const animatedThreadListsRef = useRef(new WeakMap<HTMLElement, AnimationController>());
   const attachThreadListAutoAnimateRef = useCallback((node: HTMLElement | null) => {
-    if (!node || animatedThreadListsRef.current.has(node)) {
-      return;
+    if (!node) {
+      return null;
     }
-    autoAnimate(node, SIDEBAR_LIST_ANIMATION_OPTIONS);
-    animatedThreadListsRef.current.add(node);
+    const existingController = animatedThreadListsRef.current.get(node);
+    if (existingController) {
+      return existingController;
+    }
+    const controller = autoAnimate(node, SIDEBAR_LIST_ANIMATION_OPTIONS);
+    animatedThreadListsRef.current.set(node, controller);
+    return controller;
   }, []);
 
   const visibleThreads = useMemo(


### PR DESCRIPTION
Closes #3962

## Summary
- suspend per-row auto-animation before collapsing a project with more than 30 rendered threads
- re-enable animation on the next frame so later sidebar interactions retain their existing motion
- add focused coverage for the large-list threshold

## Verification
- `./node_modules/.bin/vp test run apps/web/src/components/Sidebar.logic.test.ts` (76 passed)
- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- targeted lint and formatting for the changed files
- isolated `test-t3-app` run with a disposable 31-thread fixture: expanded all rows, collapsed with zero retained exit rows, then reopened the project successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance tweak in sidebar expand/collapse with unit tests for the threshold; no auth, data, or API changes.
> 
> **Overview**
> **Collapsing a project with more than 30 visible threads no longer runs per-row auto-animate exit animations**, avoiding jank when many rows disappear at once.
> 
> Adds `shouldSuspendSidebarThreadListAnimation` and `SIDEBAR_THREAD_LIST_ANIMATION_LIMIT` (30) in `Sidebar.logic.ts`. Suspension applies only when the project is **expanded** and `renderedThreadCount` exceeds the limit; smaller lists and already-collapsed projects behave as before.
> 
> `Sidebar.tsx` now keeps a per-DOM-node `AnimationController` from `@formkit/auto-animate` (WeakMap instead of WeakSet). Project expand/collapse goes through `toggleProjectExpanded`, which **disables** animation before updating expansion state and **re-enables** it on the next frame when suspension applies, so later sidebar motion is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2b417db1287aa69e6df408e9b3093d39d885cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip collapse animations in sidebar project thread lists exceeding 30 items
> - Adds `shouldSuspendSidebarThreadListAnimation` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/4345/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) that returns true when a project is expanded and its rendered thread count exceeds 30 (`SIDEBAR_THREAD_LIST_ANIMATION_LIMIT`).
> - Reworks `attachThreadListAutoAnimateRef` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4345/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to use a `WeakMap` instead of `WeakSet`, returning a cached `AnimationController` per DOM node.
> - `SidebarProjectItem` stores the controller and disables animation before toggling expansion, re-enabling it on the next animation frame — only when suspension applies.
> - Lists with 30 or fewer items and collapsed projects continue animating as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a2b417.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->