### PR TITLE
Fix Codex Desktop detection on Windows

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -57,6 +57,7 @@ import {
   materializeCodexShadowHome,
   resolveCodexHomeLayout,
 } from "./CodexHomeLayout.ts";
+import { resolveCodexExecutablePath } from "./CodexExecutable.ts";
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
@@ -120,6 +121,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const processEnv = mergeProviderInstanceEnvironment(environment);
+      const binaryPath = yield* resolveCodexExecutablePath(config.binaryPath, processEnv);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
       const stampIdentity = withInstanceIdentity({
@@ -142,6 +144,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const effectiveConfig = {
         ...config,
         enabled,
+        binaryPath,
         homePath: homeLayout.effectiveHomePath ?? "",
       } satisfies CodexSettings;
       const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {

--- a/apps/server/src/provider/Drivers/CodexExecutable.test.ts
+++ b/apps/server/src/provider/Drivers/CodexExecutable.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { SpawnExecutableResolution } from "@t3tools/shared/shell";
+import * as Effect from "effect/Effect";
+
+import {
+  CodexDesktopBinaryDiscovery,
+  type CodexDesktopFileSystem,
+  findCodexDesktopBinary,
+  resolveCodexExecutablePath,
+} from "./CodexExecutable.ts";
+
+const LOCAL_APP_DATA = "C:\\Users\\dev\\AppData\\Local";
+const DESKTOP_BINARY = "C:\\Users\\dev\\AppData\\Local\\OpenAI\\Codex\\bin\\new-runtime\\codex.exe";
+
+function withWindowsResolution(input: {
+  readonly resolvedCommand?: string;
+  readonly desktopBinary?: string;
+}) {
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provideService(HostProcessPlatform, "win32"),
+      Effect.provideService(SpawnExecutableResolution, () => input.resolvedCommand),
+      Effect.provideService(CodexDesktopBinaryDiscovery, () => input.desktopBinary),
+    );
+}
+
+describe("findCodexDesktopBinary", () => {
+  it("selects the newest executable from versioned runtime directories", () => {
+    const root = `${LOCAL_APP_DATA}\\OpenAI\\Codex\\bin`;
+    const files = new Map([
+      [`${root}\\old-runtime\\codex.exe`, { isFile: true, modifiedAt: 100 }],
+      [`${root}\\new-runtime\\codex.exe`, { isFile: true, modifiedAt: 200 }],
+    ]);
+    const fileSystem: CodexDesktopFileSystem = {
+      readDirectory: () => [
+        { name: "old-runtime", isDirectory: true },
+        { name: "ignored-file", isDirectory: false },
+        { name: "new-runtime", isDirectory: true },
+        { name: "empty-runtime", isDirectory: true },
+      ],
+      statFile: (filePath) => files.get(filePath),
+    };
+
+    expect(findCodexDesktopBinary(LOCAL_APP_DATA, fileSystem)).toBe(DESKTOP_BINARY);
+  });
+
+  it("returns undefined when no runtime contains codex.exe", () => {
+    const fileSystem: CodexDesktopFileSystem = {
+      readDirectory: () => [{ name: "empty-runtime", isDirectory: true }],
+      statFile: () => undefined,
+    };
+
+    expect(findCodexDesktopBinary(LOCAL_APP_DATA, fileSystem)).toBeUndefined();
+  });
+});
+
+describe("resolveCodexExecutablePath", () => {
+  it.effect("returns the configured path unchanged on non-Windows platforms", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* resolveCodexExecutablePath("codex", {}).pipe(
+          Effect.provideService(HostProcessPlatform, "darwin"),
+          Effect.provideService(SpawnExecutableResolution, () => {
+            throw new Error("must not resolve on non-Windows platforms");
+          }),
+          Effect.provideService(CodexDesktopBinaryDiscovery, () => {
+            throw new Error("must not inspect Codex Desktop on non-Windows platforms");
+          }),
+        ),
+      ).toBe("codex");
+    }),
+  );
+
+  it.effect("prefers a normal PATH installation", () =>
+    Effect.gen(function* () {
+      const installedBinary = "C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd";
+      expect(
+        yield* resolveCodexExecutablePath("codex", {
+          LOCALAPPDATA: LOCAL_APP_DATA,
+        }).pipe(
+          withWindowsResolution({
+            resolvedCommand: installedBinary,
+            desktopBinary: DESKTOP_BINARY,
+          }),
+        ),
+      ).toBe(installedBinary);
+    }),
+  );
+
+  it.effect("falls back to Codex Desktop for the default Windows command", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* resolveCodexExecutablePath("codex", {
+          LOCALAPPDATA: LOCAL_APP_DATA,
+        }).pipe(withWindowsResolution({ desktopBinary: DESKTOP_BINARY })),
+      ).toBe(DESKTOP_BINARY);
+    }),
+  );
+
+  it.effect("respects an explicit binary path when it cannot be resolved", () =>
+    Effect.gen(function* () {
+      const explicitBinary = "C:\\custom\\codex.exe";
+      expect(
+        yield* resolveCodexExecutablePath(explicitBinary, {
+          LOCALAPPDATA: LOCAL_APP_DATA,
+        }).pipe(withWindowsResolution({ desktopBinary: DESKTOP_BINARY })),
+      ).toBe(explicitBinary);
+    }),
+  );
+
+  it.effect("keeps the default command when Codex Desktop is unavailable", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* resolveCodexExecutablePath("codex", {
+          LOCALAPPDATA: LOCAL_APP_DATA,
+        }).pipe(withWindowsResolution({})),
+      ).toBe("codex");
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/CodexExecutable.ts
+++ b/apps/server/src/provider/Drivers/CodexExecutable.ts
@@ -1,0 +1,122 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { SpawnExecutableResolution } from "@t3tools/shared/shell";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+
+const DEFAULT_CODEX_COMMANDS: ReadonlySet<string> = new Set(["codex", "codex.exe"]);
+
+interface CodexDesktopDirectoryEntry {
+  readonly name: string;
+  readonly isDirectory: boolean;
+}
+
+interface CodexDesktopFileInfo {
+  readonly isFile: boolean;
+  readonly modifiedAt: number;
+}
+
+export interface CodexDesktopFileSystem {
+  readonly readDirectory: (directoryPath: string) => ReadonlyArray<CodexDesktopDirectoryEntry>;
+  readonly statFile: (filePath: string) => CodexDesktopFileInfo | undefined;
+}
+
+const nodeCodexDesktopFileSystem: CodexDesktopFileSystem = {
+  readDirectory: (directoryPath) => {
+    try {
+      return NodeFS.readdirSync(directoryPath, { withFileTypes: true }).map((entry) => ({
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+      }));
+    } catch {
+      return [];
+    }
+  },
+  statFile: (filePath) => {
+    try {
+      const stat = NodeFS.statSync(filePath);
+      return {
+        isFile: stat.isFile(),
+        modifiedAt: stat.mtimeMs,
+      };
+    } catch {
+      return undefined;
+    }
+  },
+};
+
+/**
+ * Finds the newest usable Codex CLI extracted by Codex Desktop.
+ *
+ * Microsoft Store installs do not expose their packaged executable on the
+ * normal user PATH. Codex Desktop keeps a launchable copy under the user's
+ * local app data directory, with a version-specific directory name.
+ */
+export function findCodexDesktopBinary(
+  localAppData: string,
+  fileSystem: CodexDesktopFileSystem = nodeCodexDesktopFileSystem,
+): string | undefined {
+  const binaryRoot = NodePath.win32.join(localAppData, "OpenAI", "Codex", "bin");
+  const candidates = fileSystem
+    .readDirectory(binaryRoot)
+    .filter((entry) => entry.isDirectory)
+    .flatMap((entry) => {
+      const binaryPath = NodePath.win32.join(binaryRoot, entry.name, "codex.exe");
+      const info = fileSystem.statFile(binaryPath);
+      return info?.isFile ? [{ binaryPath, modifiedAt: info.modifiedAt }] : [];
+    })
+    .sort(
+      (left, right) =>
+        right.modifiedAt - left.modifiedAt || left.binaryPath.localeCompare(right.binaryPath),
+    );
+
+  return candidates[0]?.binaryPath;
+}
+
+export type CodexDesktopBinaryDiscovery = (localAppData: string) => string | undefined;
+
+/** Injectable discovery hook so resolver tests never inspect the host machine. */
+export const CodexDesktopBinaryDiscovery = Context.Reference<CodexDesktopBinaryDiscovery>(
+  "server/provider/Drivers/CodexDesktopBinaryDiscovery",
+  {
+    defaultValue: () => findCodexDesktopBinary,
+  },
+);
+
+/**
+ * Resolves Codex exactly once for every provider instance so probes, sessions,
+ * and text generation all use the same executable.
+ *
+ * A configured path or normal PATH installation always wins. The Codex
+ * Desktop runtime is only considered for the default bare command on Windows.
+ */
+export const resolveCodexExecutablePath = Effect.fn("resolveCodexExecutablePath")(function* (
+  binaryPath: string,
+  environment: NodeJS.ProcessEnv,
+): Effect.fn.Return<string> {
+  const platform = yield* HostProcessPlatform;
+  if (platform !== "win32") {
+    return binaryPath;
+  }
+
+  const resolveExecutable = yield* SpawnExecutableResolution;
+  const resolved = resolveExecutable(binaryPath, platform, environment);
+  if (resolved) {
+    return resolved;
+  }
+
+  if (!DEFAULT_CODEX_COMMANDS.has(binaryPath.trim().toLowerCase())) {
+    return binaryPath;
+  }
+
+  const localAppData = environment.LOCALAPPDATA?.trim();
+  if (!localAppData) {
+    return binaryPath;
+  }
+
+  const discoverDesktopBinary = yield* CodexDesktopBinaryDiscovery;
+  return discoverDesktopBinary(localAppData) ?? binaryPath;
+});

--- a/docs/getting-started/codex-prerequisites.md
+++ b/docs/getting-started/codex-prerequisites.md
@@ -1,5 +1,7 @@
 # Codex prerequisites
 
 - Install Codex CLI so `codex` is on your PATH.
+- On Windows, T3 Code can fall back to the CLI extracted by Codex Desktop when the default
+  `codex` command is unavailable. A standalone PATH installation is still preferred.
 - Authenticate Codex before running T3 Code (for example via API key or ChatGPT auth supported by Codex).
 - T3 Code starts the server via `codex app-server` per session.


### PR DESCRIPTION
On Windows, T3 Code currently assumes `codex` is available on PATH. That works for standalone npm installs, but Codex Desktop and Microsoft Store installs keep their CLI under `%LOCALAPPDATA%\OpenAI\Codex\bin\<runtime>\codex.exe`, so the provider reports "not installed" even though Codex is present. This adds a Windows-only fallback that first respects explicit binary paths and normal PATH resolution, then selects the newest valid Desktop runtime; the resolved path is captured once so probes, sessions, and text generation all use the same executable. Non-Windows behavior is unchanged, and standalone CLI installs still win. I added focused coverage for PATH priority, explicit overrides, missing runtimes, platform isolation, and runtime selection, plus a prerequisite note. Validation: 7 focused tests, a read-only smoke test against a real Microsoft Store installation (`codex-cli 0.145.0-alpha.18`), server and full-workspace typechecks, and `vp check` (0 errors; 14 unrelated existing warnings).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex Desktop CLI detection on Windows by resolving executable path from `LOCALAPPDATA`
> - On Windows, `resolveCodexExecutablePath` first checks if `codex`/`codex.exe` resolves via PATH; if not, it searches `%LOCALAPPDATA%/OpenAI/Codex/bin` for the newest versioned `codex.exe` unpacked by Codex Desktop.
> - The `CodexDriver` factory now calls `resolveCodexExecutablePath` at creation time and stores the resolved path in `effectiveConfig`, which is also passed to maintenance capability checks.
> - `findCodexDesktopBinary` selects the newest binary by modified time across versioned subdirectories, with path as a tiebreaker.
> - Non-Windows platforms and non-default binary paths are returned unchanged.
> - Behavioral Change: on Windows with no `codex` on PATH, the provider may silently switch to the Codex Desktop-extracted binary instead of failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a5bfc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->