### PR TITLE
perf(server): bound OpenCode history hydration

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -67,6 +67,7 @@ const runtimeMock = {
     messageCalls: [] as Array<{ sessionID: string; limit?: number; before?: string }>,
     messageReadHangs: false,
     messageReadAbortCount: 0,
+    overlapMessagePages: false,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
     closeError: null as Error | null,
@@ -90,6 +91,7 @@ const runtimeMock = {
     this.state.messageCalls.length = 0;
     this.state.messageReadHangs = false;
     this.state.messageReadAbortCount = 0;
+    this.state.overlapMessagePages = false;
     this.state.promptCalls.length = 0;
     this.state.promptAsyncError = null;
     this.state.closeError = null;
@@ -212,9 +214,24 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             : runtimeMock.state.messages.length;
           const resolvedEndIndex = endIndex < 0 ? runtimeMock.state.messages.length : endIndex;
           const startIndex =
-            input.limit === undefined ? 0 : Math.max(0, resolvedEndIndex - input.limit);
+            input.limit === undefined
+              ? 0
+              : Math.max(
+                  0,
+                  resolvedEndIndex -
+                    (runtimeMock.state.overlapMessagePages && input.before
+                      ? input.limit - 1
+                      : input.limit),
+                );
+          const page = runtimeMock.state.messages.slice(startIndex, resolvedEndIndex);
+          if (runtimeMock.state.overlapMessagePages && input.before) {
+            const overlappingBoundary = runtimeMock.state.messages[resolvedEndIndex];
+            if (overlappingBoundary) {
+              page.push(overlappingBoundary);
+            }
+          }
           return {
-            data: runtimeMock.state.messages.slice(startIndex, resolvedEndIndex),
+            data: page,
           };
         },
         revert: async ({ sessionID, messageID }: { sessionID: string; messageID?: string }) => {
@@ -1039,6 +1056,54 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           sessionID: "http://127.0.0.1:9999/session",
           limit: 100,
           before: "user-6",
+        },
+      ]);
+      NodeAssert.deepEqual(runtimeMock.state.revertCalls, [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          messageID: "assistant-5",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("continues rollback pagination when a full page overlaps the previous page", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-rollback-overlap");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      runtimeMock.state.overlapMessagePages = true;
+      runtimeMock.state.messages = Array.from({ length: 105 }, (_, index) => [
+        {
+          info: { id: `user-${index + 1}`, role: "user" as const },
+          parts: [],
+        },
+        {
+          info: { id: `assistant-${index + 1}`, role: "assistant" as const },
+          parts: [],
+        },
+      ]).flat();
+
+      yield* adapter.rollbackThread(threadId, 100);
+
+      NodeAssert.deepEqual(runtimeMock.state.messageCalls.slice(0, 3), [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+        },
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+          before: "user-56",
+        },
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+          before: "assistant-6",
         },
       ]);
       NodeAssert.deepEqual(runtimeMock.state.revertCalls, [

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -2,6 +2,7 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Context from "effect/Context";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -63,6 +64,9 @@ const runtimeMock = {
     abortCalls: [] as string[],
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
+    messageCalls: [] as Array<{ sessionID: string; limit?: number; before?: string }>,
+    messageReadHangs: false,
+    messageReadAbortCount: 0,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
     closeError: null as Error | null,
@@ -83,6 +87,9 @@ const runtimeMock = {
     this.state.abortCalls.length = 0;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
+    this.state.messageCalls.length = 0;
+    this.state.messageReadHangs = false;
+    this.state.messageReadAbortCount = 0;
     this.state.promptCalls.length = 0;
     this.state.promptAsyncError = null;
     this.state.closeError = null;
@@ -183,7 +190,33 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             throw runtimeMock.state.promptAsyncError;
           }
         },
-        messages: async () => ({ data: runtimeMock.state.messages }),
+        messages: async (
+          input: { sessionID: string; limit?: number; before?: string },
+          options?: { signal?: AbortSignal },
+        ) => {
+          runtimeMock.state.messageCalls.push(input);
+          if (runtimeMock.state.messageReadHangs) {
+            return await new Promise<never>((_resolve, reject) => {
+              options?.signal?.addEventListener(
+                "abort",
+                () => {
+                  runtimeMock.state.messageReadAbortCount += 1;
+                  reject(options.signal?.reason);
+                },
+                { once: true },
+              );
+            });
+          }
+          const endIndex = input.before
+            ? runtimeMock.state.messages.findIndex((entry) => entry.info.id === input.before)
+            : runtimeMock.state.messages.length;
+          const resolvedEndIndex = endIndex < 0 ? runtimeMock.state.messages.length : endIndex;
+          const startIndex =
+            input.limit === undefined ? 0 : Math.max(0, resolvedEndIndex - input.limit);
+          return {
+            data: runtimeMock.state.messages.slice(startIndex, resolvedEndIndex),
+          };
+        },
         revert: async ({ sessionID, messageID }: { sessionID: string; messageID?: string }) => {
           runtimeMock.state.revertCalls.push({
             sessionID,
@@ -942,6 +975,104 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.deepEqual(runtimeMock.state.promptCalls, []);
     }).pipe(Effect.provide(adapterLayer));
   });
+
+  it.effect("bounds readThread to the latest OpenCode message page", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-read-page");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      runtimeMock.state.messages = Array.from({ length: 250 }, (_, index) => ({
+        info: { id: `assistant-${index + 1}`, role: "assistant" as const },
+        parts: [],
+      }));
+
+      const snapshot = yield* adapter.readThread(threadId);
+
+      NodeAssert.deepEqual(runtimeMock.state.messageCalls, [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+        },
+      ]);
+      NodeAssert.equal(snapshot.turns.length, 100);
+      NodeAssert.equal(snapshot.turns[0]?.id, "assistant-151");
+    }),
+  );
+
+  it.effect("pages older OpenCode messages only when rollback needs them", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-rollback-pages");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      runtimeMock.state.messages = Array.from({ length: 105 }, (_, index) => [
+        {
+          info: { id: `user-${index + 1}`, role: "user" as const },
+          parts: [],
+        },
+        {
+          info: { id: `assistant-${index + 1}`, role: "assistant" as const },
+          parts: [],
+        },
+      ]).flat();
+
+      yield* adapter.rollbackThread(threadId, 100);
+
+      NodeAssert.deepEqual(runtimeMock.state.messageCalls.slice(0, 3), [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+        },
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+          before: "user-56",
+        },
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          limit: 100,
+          before: "user-6",
+        },
+      ]);
+      NodeAssert.deepEqual(runtimeMock.state.revertCalls, [
+        {
+          sessionID: "http://127.0.0.1:9999/session",
+          messageID: "assistant-5",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("times out and aborts a stalled OpenCode history read", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-read-timeout");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      runtimeMock.state.messageReadHangs = true;
+
+      const readFiber = yield* Effect.forkChild(Effect.exit(adapter.readThread(threadId)));
+      yield* Effect.yieldNow;
+      yield* advanceTestClock(15_000);
+      const readExit = yield* Fiber.join(readFiber);
+
+      NodeAssert.equal(Exit.isFailure(readExit), true);
+      if (Exit.isFailure(readExit)) {
+        NodeAssert.match(Cause.pretty(readExit.cause), /timed out after 15000ms/u);
+      }
+      NodeAssert.equal(runtimeMock.state.messageReadAbortCount, 1);
+    }),
+  );
 
   it.effect("reverts the full thread when rollback removes every assistant turn", () =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -23,7 +23,13 @@ import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
+import type {
+  Message,
+  OpencodeClient,
+  Part,
+  PermissionRequest,
+  QuestionRequest,
+} from "@opencode-ai/sdk/v2";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -54,6 +60,8 @@ import {
 import * as Option from "effect/Option";
 
 const PROVIDER = ProviderDriverKind.make("opencode");
+const OPENCODE_THREAD_MESSAGE_PAGE_SIZE = 100;
+const OPENCODE_THREAD_MESSAGE_TIMEOUT_MS = 15_000;
 
 /**
  * Version tag stamped into the OpenCode resume cursor. Bump if the cursor
@@ -385,6 +393,65 @@ const ensureSessionContext = Effect.fn("ensureSessionContext")(function* (
     });
   }
   return session;
+});
+
+const readOpenCodeMessagePage = Effect.fn("readOpenCodeMessagePage")(function* (
+  context: OpenCodeSessionContext,
+  before?: string,
+) {
+  const result = yield* runOpenCodeSdk("session.messages", (signal) =>
+    context.client.session.messages(
+      {
+        sessionID: context.openCodeSessionId,
+        limit: OPENCODE_THREAD_MESSAGE_PAGE_SIZE,
+        ...(before ? { before } : {}),
+      },
+      { signal },
+    ),
+  ).pipe(Effect.timeoutOption(OPENCODE_THREAD_MESSAGE_TIMEOUT_MS));
+
+  return yield* Option.match(result, {
+    onNone: () =>
+      Effect.fail(
+        new OpenCodeRuntimeError({
+          operation: "session.messages",
+          detail: `OpenCode session history timed out after ${OPENCODE_THREAD_MESSAGE_TIMEOUT_MS}ms.`,
+        }),
+      ),
+    onSome: Effect.succeed,
+  });
+});
+
+const readOpenCodeMessagesForRollback = Effect.fn("readOpenCodeMessagesForRollback")(function* (
+  context: OpenCodeSessionContext,
+  numTurns: number,
+) {
+  let before: string | undefined;
+  const messages: Array<{ info: Message; parts: Array<Part> }> = [];
+  const seenMessageIds = new Set<string>();
+
+  while (true) {
+    const page = yield* readOpenCodeMessagePage(context, before);
+    const pageMessages = (page.data ?? []).filter((entry) => {
+      if (seenMessageIds.has(entry.info.id)) {
+        return false;
+      }
+      seenMessageIds.add(entry.info.id);
+      return true;
+    });
+    messages.unshift(...pageMessages);
+
+    const assistantCount = messages.filter((entry) => entry.info.role === "assistant").length;
+    if (assistantCount > numTurns || pageMessages.length < OPENCODE_THREAD_MESSAGE_PAGE_SIZE) {
+      return messages;
+    }
+
+    const nextBefore = pageMessages[0]?.info.id;
+    if (!nextBefore || nextBefore === before) {
+      return messages;
+    }
+    before = nextBefore;
+  }
 });
 
 function normalizeQuestionRequest(request: QuestionRequest): ReadonlyArray<UserInputQuestion> {
@@ -1634,11 +1701,9 @@ export function makeOpenCodeAdapter(
     const readThread: OpenCodeAdapterShape["readThread"] = Effect.fn("readThread")(
       function* (threadId) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        const messages = yield* runOpenCodeSdk("session.messages", () =>
-          context.client.session.messages({
-            sessionID: context.openCodeSessionId,
-          }),
-        ).pipe(Effect.mapError(toRequestError));
+        const messages = yield* readOpenCodeMessagePage(context).pipe(
+          Effect.mapError(toRequestError),
+        );
 
         const turns: Array<OpenCodeTurnSnapshot> = [];
         for (const entry of messages.data ?? []) {
@@ -1660,15 +1725,11 @@ export function makeOpenCodeAdapter(
     const rollbackThread: OpenCodeAdapterShape["rollbackThread"] = Effect.fn("rollbackThread")(
       function* (threadId, numTurns) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        const messages = yield* runOpenCodeSdk("session.messages", () =>
-          context.client.session.messages({
-            sessionID: context.openCodeSessionId,
-          }),
-        ).pipe(Effect.mapError(toRequestError));
-
-        const assistantMessages = (messages.data ?? []).filter(
-          (entry) => entry.info.role === "assistant",
+        const messageEntries = yield* readOpenCodeMessagesForRollback(context, numTurns).pipe(
+          Effect.mapError(toRequestError),
         );
+
+        const assistantMessages = messageEntries.filter((entry) => entry.info.role === "assistant");
         const targetIndex = assistantMessages.length - numTurns - 1;
         const target = targetIndex >= 0 ? assistantMessages[targetIndex] : null;
         yield* runOpenCodeSdk("session.revert", () =>

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -432,7 +432,8 @@ const readOpenCodeMessagesForRollback = Effect.fn("readOpenCodeMessagesForRollba
 
   while (true) {
     const page = yield* readOpenCodeMessagePage(context, before);
-    const pageMessages = (page.data ?? []).filter((entry) => {
+    const rawPageMessages = page.data ?? [];
+    const pageMessages = rawPageMessages.filter((entry) => {
       if (seenMessageIds.has(entry.info.id)) {
         return false;
       }
@@ -442,11 +443,11 @@ const readOpenCodeMessagesForRollback = Effect.fn("readOpenCodeMessagesForRollba
     messages.unshift(...pageMessages);
 
     const assistantCount = messages.filter((entry) => entry.info.role === "assistant").length;
-    if (assistantCount > numTurns || pageMessages.length < OPENCODE_THREAD_MESSAGE_PAGE_SIZE) {
+    if (assistantCount > numTurns || rawPageMessages.length < OPENCODE_THREAD_MESSAGE_PAGE_SIZE) {
       return messages;
     }
 
-    const nextBefore = pageMessages[0]?.info.id;
+    const nextBefore = rawPageMessages[0]?.info.id;
     if (!nextBefore || nextBefore === before) {
       return messages;
     }

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -84,7 +84,7 @@ export function openCodeRuntimeErrorDetail(cause: unknown): string {
 
 export const runOpenCodeSdk = <A>(
   operation: string,
-  fn: () => Promise<A>,
+  fn: (signal: AbortSignal) => Promise<A>,
 ): Effect.Effect<A, OpenCodeRuntimeError> =>
   Effect.tryPromise({
     try: fn,


### PR DESCRIPTION
Closes #3601

## Summary
- cap routine OpenCode thread hydration at the latest 100 messages instead of materializing the full session
- page older messages on demand when rollback needs more assistant turns
- impose a 15-second per-page timeout and pass cancellation through to the SDK request
- preserve rollback semantics across multiple history pages

## Verification
- `./node_modules/.bin/vp test run apps/server/src/provider/Layers/OpenCodeAdapter.test.ts` (33 passed)
- `./node_modules/.bin/vp run --filter t3 typecheck` (passes; three unrelated existing Effect suggestions remain in `orchestration/decider.ts`)
- targeted lint and formatting for the changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how thread snapshots are built and how rollback resolves targets across paginated history; incorrect paging could mis-revert long threads, though behavior is covered by new adapter tests.
> 
> **Overview**
> **OpenCode thread hydration is capped** so routine reads no longer pull the entire session history from the SDK.
> 
> `readThread` now loads a single page of **100** messages via `session.messages` (`limit` / optional `before`) instead of unbounded history. **`readThread` therefore exposes at most the 100 most recent assistant turns**—a deliberate behavior change for performance.
> 
> `rollbackThread` uses **`readOpenCodeMessagesForRollback`** to walk older pages only until it has enough assistant messages to pick the revert target, with **deduplication** and extra pagination when a full page **overlaps** the previous cursor.
> 
> Each history page goes through **`readOpenCodeMessagePage`**: **15s** timeout, **`AbortSignal`** passed into the SDK call, and a clear timeout error on stall. **`runOpenCodeSdk`** now takes a callback `(signal) => Promise<...>` so cancellation can reach the client.
> 
> Tests extend the runtime mock for paged `messages`, hang/abort, and overlap, and add coverage for read bounds, rollback paging, overlap continuation, and timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e48e6dfbb88bcf6b4ef1d6bbf36ee2a6c7e22d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound OpenCode history hydration to paginated reads with a 15s timeout
> - `readThread` now reads only the latest 100 messages (one page) instead of the full session history, with a 15-second timeout per request.
> - `rollbackThread` uses a new `readOpenCodeMessagesForRollback` helper that pages backwards through history only as far as needed to locate the target assistant message, deduplicating overlapping page boundaries.
> - `runOpenCodeSdk` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/4348/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) now passes an `AbortSignal` to the SDK callback so timed-out reads are cleanly cancelled.
> - New tests in [OpenCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/4348/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) cover page bounding, paginated rollback, overlapping-page deduplication, and timeout/abort behaviour.
> - Behavioral Change: `readThread` no longer returns messages beyond the most recent 100; sessions with long histories will see a truncated turn list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e48e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->