### PR TITLE
perf(web): coalesce streaming Markdown renders

### DIFF
--- a/apps/web/src/components/ChatMarkdown.logic.test.ts
+++ b/apps/web/src/components/ChatMarkdown.logic.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  STREAMING_MARKDOWN_RENDER_INTERVAL_MS,
+  streamingMarkdownRenderDelay,
+} from "./ChatMarkdown.logic";
+
+describe("streamingMarkdownRenderDelay", () => {
+  it("coalesces updates inside the render interval", () => {
+    expect(streamingMarkdownRenderDelay({ lastRenderedAt: 1_000, now: 1_020 })).toBe(30);
+  });
+
+  it("allows an immediate refresh once the interval elapsed", () => {
+    expect(
+      streamingMarkdownRenderDelay({
+        lastRenderedAt: 1_000,
+        now: 1_000 + STREAMING_MARKDOWN_RENDER_INTERVAL_MS,
+      }),
+    ).toBe(0);
+    expect(streamingMarkdownRenderDelay({ lastRenderedAt: 1_000, now: 2_000 })).toBe(0);
+  });
+
+  it("handles a clock moving backwards without exceeding the interval", () => {
+    expect(streamingMarkdownRenderDelay({ lastRenderedAt: 1_000, now: 900 })).toBe(
+      STREAMING_MARKDOWN_RENDER_INTERVAL_MS,
+    );
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.logic.ts
+++ b/apps/web/src/components/ChatMarkdown.logic.ts
@@ -1,0 +1,9 @@
+export const STREAMING_MARKDOWN_RENDER_INTERVAL_MS = 50;
+
+export function streamingMarkdownRenderDelay(input: {
+  lastRenderedAt: number;
+  now: number;
+}): number {
+  const elapsed = Math.max(0, input.now - input.lastRenderedAt);
+  return Math.max(0, STREAMING_MARKDOWN_RENDER_INTERVAL_MS - elapsed);
+}

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -8,6 +8,7 @@ import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { GitHubIcon } from "./Icons";
 import { Button } from "./ui/button";
 import { setMarkdownTaskChecked } from "./files/filePreviewMode";
+import { STREAMING_MARKDOWN_RENDER_INTERVAL_MS } from "./ChatMarkdown.logic";
 
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
 vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -121,6 +122,7 @@ describe("ChatMarkdown streaming", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     let renderer: ReactTestRenderer | undefined;
 
     try {
@@ -144,11 +146,15 @@ describe("ChatMarkdown streaming", () => {
           <ChatMarkdown cwd="/tmp/project" text={"```text\nrecovered\n```"} isStreaming />,
         );
       });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(STREAMING_MARKDOWN_RENDER_INTERVAL_MS);
+      });
       expect(mounted.root.findAllByProps({ className: "chat-markdown-shiki" })).toHaveLength(1);
       expect(mounted.root.findByProps({ "data-language": "text" })).toBe(codeBlock);
       expect(codeBlock.props["data-wrap"]).toBe(String(!initialWrap));
     } finally {
       await act(async () => renderer?.unmount());
+      vi.useRealTimers();
       vi.unstubAllGlobals();
       vi.restoreAllMocks();
     }
@@ -221,6 +227,9 @@ describe("ChatMarkdown streaming", () => {
             isStreaming
           />,
         );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(STREAMING_MARKDOWN_RENDER_INTERVAL_MS);
       });
       const copyUpdated = codeButton(mounted, "Copied");
       await act(async () => {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1318,17 +1318,11 @@ function ChatMarkdown({
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
   const renderedTextRef = useRef(renderedText);
-  const isStreamingRef = useRef(isStreaming);
   const markdownFileLinkMetaByHrefRef = useRef(markdownFileLinkMetaByHref);
   const fileLinkParentSuffixByPathRef = useRef(fileLinkParentSuffixByPath);
-  const resolvedThemeRef = useRef(resolvedTheme);
-  const diffThemeNameRef = useRef(diffThemeName);
   renderedTextRef.current = renderedText;
-  isStreamingRef.current = isStreaming;
   markdownFileLinkMetaByHrefRef.current = markdownFileLinkMetaByHref;
   fileLinkParentSuffixByPathRef.current = fileLinkParentSuffixByPath;
-  resolvedThemeRef.current = resolvedTheme;
-  diffThemeNameRef.current = diffThemeName;
   // Re-emit highlighted content as markdown so copying out of the rendered
   // view keeps links, emphasis, lists, and code fences intact.
   const handleCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
@@ -1521,7 +1515,7 @@ function ChatMarkdown({
             line={fileLinkMeta.line}
             label={labelParts.join(" · ")}
             copyMarkdown={`[${fileLinkMeta.basename}](${normalizedHref})`}
-            theme={resolvedThemeRef.current}
+            theme={resolvedTheme}
             threadRef={threadRef}
             onOpen={openInPreferredEditor}
             onOpenInBrowser={
@@ -1554,15 +1548,15 @@ function ChatMarkdown({
             code={codeBlock.code}
             language={language}
             fenceTitle={fenceTitle}
-            theme={resolvedThemeRef.current}
+            theme={resolvedTheme}
           >
             <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
               <Suspense fallback={<pre {...props}>{children}</pre>}>
                 <SuspenseShikiCodeBlock
                   className={codeBlock.className}
                   code={codeBlock.code}
-                  themeName={diffThemeNameRef.current}
-                  isStreaming={isStreamingRef.current}
+                  themeName={diffThemeName}
+                  isStreaming={isStreaming}
                 />
               </Suspense>
             </CodeHighlightErrorBoundary>
@@ -1571,10 +1565,13 @@ function ChatMarkdown({
       },
     }),
     [
+      diffThemeName,
+      isStreaming,
       onTaskListChange,
       openInPreferredEditor,
       openExternalLinkInPreview,
       openMarkdownFileInPreview,
+      resolvedTheme,
       skills,
       threadRef,
     ],

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -88,6 +88,7 @@ import {
   openUrlInPreview,
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
+import { streamingMarkdownRenderDelay } from "./ChatMarkdown.logic";
 
 class CodeHighlightErrorBoundary extends React.Component<
   { fallback: ReactNode; children: ReactNode },
@@ -146,6 +147,33 @@ const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
 const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
+
+function useStreamingMarkdownText(text: string, isStreaming: boolean): string {
+  const [renderedText, setRenderedText] = useState(text);
+  const lastRenderedAtRef = useRef(Date.now());
+
+  useEffect(() => {
+    if (!isStreaming) {
+      lastRenderedAtRef.current = Date.now();
+      setRenderedText((current) => (current === text ? current : text));
+      return;
+    }
+
+    const delay = streamingMarkdownRenderDelay({
+      lastRenderedAt: lastRenderedAtRef.current,
+      now: Date.now(),
+    });
+    const timeout = setTimeout(() => {
+      lastRenderedAtRef.current = Date.now();
+      setRenderedText(text);
+    }, delay);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [isStreaming, text]);
+
+  return isStreaming ? renderedText : text;
+}
 
 function findTaskListMarkerOffset(markdown: string, listItemStart: number): number | null {
   const firstLineEnd = markdown.indexOf("\n", listItemStart);
@@ -1251,6 +1279,7 @@ function ChatMarkdown({
   className,
   lineBreaks = false,
 }: ChatMarkdownProps) {
+  const renderedText = useStreamingMarkdownText(text, isStreaming);
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
     reportFailure: false,
@@ -1271,7 +1300,7 @@ function ChatMarkdown({
       string,
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
-    for (const href of extractMarkdownLinkHrefs(text)) {
+    for (const href of extractMarkdownLinkHrefs(renderedText)) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
@@ -1280,7 +1309,7 @@ function ChatMarkdown({
       }
     }
     return metaByHref;
-  }, [cwd, text]);
+  }, [cwd, renderedText]);
   const fileLinkParentSuffixByPath = useMemo(() => {
     const filePaths = [...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath);
     return buildFileLinkParentSuffixByPath(filePaths);
@@ -1288,6 +1317,18 @@ function ChatMarkdown({
   const markdownUrlTransform = useCallback((href: string) => {
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
+  const renderedTextRef = useRef(renderedText);
+  const isStreamingRef = useRef(isStreaming);
+  const markdownFileLinkMetaByHrefRef = useRef(markdownFileLinkMetaByHref);
+  const fileLinkParentSuffixByPathRef = useRef(fileLinkParentSuffixByPath);
+  const resolvedThemeRef = useRef(resolvedTheme);
+  const diffThemeNameRef = useRef(diffThemeName);
+  renderedTextRef.current = renderedText;
+  isStreamingRef.current = isStreaming;
+  markdownFileLinkMetaByHrefRef.current = markdownFileLinkMetaByHref;
+  fileLinkParentSuffixByPathRef.current = fileLinkParentSuffixByPath;
+  resolvedThemeRef.current = resolvedTheme;
+  diffThemeNameRef.current = diffThemeName;
   // Re-emit highlighted content as markdown so copying out of the rendered
   // view keeps links, emphasis, lists, and code fences intact.
   const handleCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
@@ -1347,7 +1388,9 @@ function ChatMarkdown({
       li({ node, children, ...props }) {
         const listItemStart = node?.position?.start.offset;
         const markerOffset =
-          typeof listItemStart === "number" ? findTaskListMarkerOffset(text, listItemStart) : null;
+          typeof listItemStart === "number"
+            ? findTaskListMarkerOffset(renderedTextRef.current, listItemStart)
+            : null;
         return (
           <li {...props} data-task-marker-offset={markerOffset ?? undefined}>
             {renderSkillInlineMarkdownChildren(children, skills)}
@@ -1385,7 +1428,9 @@ function ChatMarkdown({
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const fileLinkMeta = normalizedHref
+          ? markdownFileLinkMetaByHrefRef.current.get(normalizedHref)
+          : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1455,7 +1500,7 @@ function ChatMarkdown({
           );
         }
 
-        const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
+        const parentSuffix = fileLinkParentSuffixByPathRef.current.get(fileLinkMeta.filePath);
         const labelParts = [fileLinkMeta.basename];
         if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
           labelParts.push(parentSuffix);
@@ -1476,7 +1521,7 @@ function ChatMarkdown({
             line={fileLinkMeta.line}
             label={labelParts.join(" · ")}
             copyMarkdown={`[${fileLinkMeta.basename}](${normalizedHref})`}
-            theme={resolvedTheme}
+            theme={resolvedThemeRef.current}
             threadRef={threadRef}
             onOpen={openInPreferredEditor}
             onOpenInBrowser={
@@ -1509,15 +1554,15 @@ function ChatMarkdown({
             code={codeBlock.code}
             language={language}
             fenceTitle={fenceTitle}
-            theme={resolvedTheme}
+            theme={resolvedThemeRef.current}
           >
             <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
               <Suspense fallback={<pre {...props}>{children}</pre>}>
                 <SuspenseShikiCodeBlock
                   className={codeBlock.className}
                   code={codeBlock.code}
-                  themeName={diffThemeName}
-                  isStreaming={isStreaming}
+                  themeName={diffThemeNameRef.current}
+                  isStreaming={isStreamingRef.current}
                 />
               </Suspense>
             </CodeHighlightErrorBoundary>
@@ -1526,19 +1571,28 @@ function ChatMarkdown({
       },
     }),
     [
-      diffThemeName,
-      fileLinkParentSuffixByPath,
-      isStreaming,
-      markdownFileLinkMetaByHref,
       onTaskListChange,
       openInPreferredEditor,
       openExternalLinkInPreview,
       openMarkdownFileInPreview,
-      resolvedTheme,
       skills,
-      text,
       threadRef,
     ],
+  );
+  const renderedMarkdown = useMemo(
+    () => (
+      <ReactMarkdown
+        remarkPlugins={
+          lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
+        }
+        rehypePlugins={CHAT_MARKDOWN_REHYPE_PLUGINS}
+        components={markdownComponents}
+        urlTransform={markdownUrlTransform}
+      >
+        {renderedText}
+      </ReactMarkdown>
+    ),
+    [lineBreaks, markdownComponents, markdownUrlTransform, renderedText],
   );
 
   return (
@@ -1549,16 +1603,7 @@ function ChatMarkdown({
       )}
       onCopy={handleCopy}
     >
-      <ReactMarkdown
-        remarkPlugins={
-          lineBreaks ? CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS : CHAT_MARKDOWN_REMARK_PLUGINS
-        }
-        rehypePlugins={CHAT_MARKDOWN_REHYPE_PLUGINS}
-        components={markdownComponents}
-        urlTransform={markdownUrlTransform}
-      >
-        {text}
-      </ReactMarkdown>
+      {renderedMarkdown}
     </div>
   );
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -181,6 +181,7 @@ import {
 } from "../browser/openFileInPreview";
 import { resolveLinkTarget } from "../browser/browserLinkTarget";
 import { PullRequestLinkPreview } from "./pullRequest/PullRequestLinkPreview";
+import { streamingMarkdownRenderDelay } from "./ChatMarkdown.logic";
 
 interface ChatMarkdownProps {
   text: string;
@@ -323,6 +324,33 @@ const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_ENTRIES,
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
+
+function useStreamingMarkdownText(text: string, isStreaming: boolean): string {
+  const [renderedText, setRenderedText] = useState(text);
+  const lastRenderedAtRef = useRef(Date.now());
+
+  useEffect(() => {
+    if (!isStreaming) {
+      lastRenderedAtRef.current = Date.now();
+      setRenderedText((current) => (current === text ? current : text));
+      return;
+    }
+
+    const delay = streamingMarkdownRenderDelay({
+      lastRenderedAt: lastRenderedAtRef.current,
+      now: Date.now(),
+    });
+    const timeout = setTimeout(() => {
+      lastRenderedAtRef.current = Date.now();
+      setRenderedText(text);
+    }, delay);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [isStreaming, text]);
+
+  return isStreaming ? renderedText : text;
+}
 
 function findTaskListMarkerOffset(markdown: string, listItemStart: number): number | null {
   const firstLineEnd = markdown.indexOf("\n", listItemStart);
@@ -2168,6 +2196,7 @@ function useChatMarkdownState({
   imageBaseDir,
   onImageExpand,
 }: ChatMarkdownProps) {
+  const renderedText = useStreamingMarkdownText(text, isStreaming);
   const { resolvedTheme } = useTheme();
   const [localMediaPreview, setLocalMediaPreview] = useState<ExpandedImagePreview | null>(null);
   const expandMedia = onImageExpand ?? setLocalMediaPreview;
@@ -2588,7 +2617,7 @@ function useChatMarkdownState({
       resolvedTheme,
       serverConfig,
       skills,
-      text,
+      text: renderedText,
       threadRef,
       updateThreadPullRequestLink,
     }),
@@ -2614,7 +2643,7 @@ function useChatMarkdownState({
       resolvedTheme,
       serverConfig,
       skills,
-      text,
+      renderedText,
       threadRef,
       updateThreadPullRequestLink,
     ],
@@ -2624,6 +2653,7 @@ function useChatMarkdownState({
     handleCopy,
     markdownUrlTransform,
     localMediaPreview,
+    renderedText,
     setLocalMediaPreview,
   };
 }
@@ -3110,6 +3140,7 @@ function ChatMarkdown({
     handleCopy,
     markdownUrlTransform,
     localMediaPreview,
+    renderedText,
     setLocalMediaPreview,
   } = useChatMarkdownState({ text, ...props });
   const remarkPlugins = useMemo(
@@ -3139,7 +3170,7 @@ function ChatMarkdown({
           components={CHAT_MARKDOWN_COMPONENTS}
           urlTransform={markdownUrlTransform}
         >
-          {text}
+          {renderedText}
         </ReactMarkdown>
       </ChatMarkdownRendererContext>
       {localMediaPreview ? (


### PR DESCRIPTION
Closes #4074

## Summary
- coalesce streaming assistant Markdown updates to a 50ms rendering cadence
- keep Markdown component identities stable while text deltas arrive
- flush the final response immediately without splitting whole-document Markdown semantics

## Verification
- `vp test run apps/web/src/components/ChatMarkdown.logic.test.ts apps/web/src/components/markdown-list-indentation.test.tsx apps/web/src/components/markdown-links.test.ts` (27 passed)
- `vp run --filter @t3tools/web typecheck`
- targeted lint for the changed files (only pre-existing nested-component warnings)
- `test-t3-app`: streamed a live Codex response containing paragraphs, bullet/task lists, a table, and a fenced TypeScript block; all rendered after completion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI performance tuning in chat markdown rendering only; behavior change is limited to update cadence during streaming, with immediate flush when streaming stops.
> 
> **Overview**
> **Streaming assistant messages** no longer trigger a full `react-markdown` parse on every token. While `isStreaming` is true, `useStreamingMarkdownText` applies the latest text on a **50ms** cadence via `streamingMarkdownRenderDelay`, canceling superseded timers so rapid deltas coalesce.
> 
> `ChatMarkdown` now drives link metadata, inline-code file links, task-list marker offsets, and the memoized `ReactMarkdown` tree from that throttled **`renderedText`**. When streaming ends, the hook **syncs immediately** to the final `text` (no artificial delay on the completed message).
> 
> A small **`ChatMarkdown.logic`** helper plus unit tests cover interval math, including backward clock jumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73ad50a300dd77553a43c5b3ee2289b23113989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce streaming Markdown renders in `ChatMarkdown` to a 50ms interval
> - Adds `useStreamingMarkdownText` hook in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/4349/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) that throttles text updates during streaming to at most one render per 50ms, clearing superseded timers and recording render timestamps
> - Adds `streamingMarkdownRenderDelay` util in [ChatMarkdown.logic.ts](https://github.com/pingdotgg/t3code/pull/4349/files#diff-45fe209df11ee8e2f3895cd5aa02e6de9980d6fa1d96d7a8600cc6b098f34e5c) that computes the non-negative remaining delay since the last render, clamping elapsed time to zero when the clock moves backwards
> - `ChatMarkdown` now uses throttled `renderedText` for file-link extraction, inline-code extraction, task-list markers, and the memoized `ReactMarkdown` output; non-streaming renders sync immediately
> - Behavioral Change: streaming `ChatMarkdown` no longer re-parses and re-renders on every incoming text value; output updates at most every 50ms while streaming is active
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a73ad50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streaming markdown messages now update at a controlled pace, reducing visual flicker and unnecessary redraws while content is received.
  * Markdown refreshes remain responsive, including when updates arrive after a rendering interval or when timing changes unexpectedly.

* **Tests**
  * Added coverage for streaming update timing and markdown rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->