### PR TITLE
fix(web): warn before silent Windows updates

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3608,7 +3608,7 @@ export default function Sidebar() {
 
     if (desktopUpdateButtonAction === "install") {
       const confirmed = window.confirm(
-        getDesktopUpdateInstallConfirmationMessage(desktopUpdateState),
+        getDesktopUpdateInstallConfirmationMessage(desktopUpdateState, navigator.platform),
       );
       if (!confirmed) return;
       void bridge

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -225,6 +225,32 @@ describe("desktop update UI helpers", () => {
       }),
     ).toContain("Install update and restart T3 Code?");
   });
+
+  it("warns Windows users that a silent installation can take several minutes", () => {
+    const message = getDesktopUpdateInstallConfirmationMessage(
+      {
+        availableVersion: "1.1.0",
+        downloadedVersion: "1.1.0",
+      },
+      "Win32",
+    );
+
+    expect(message).toContain("may remain closed for several minutes");
+    expect(message).toContain("no installer window may appear");
+    expect(message).toContain("will reopen automatically");
+  });
+
+  it("keeps the additional silent installation warning Windows-specific", () => {
+    const message = getDesktopUpdateInstallConfirmationMessage(
+      {
+        availableVersion: "1.1.0",
+        downloadedVersion: "1.1.0",
+      },
+      "MacIntel",
+    );
+
+    expect(message).not.toContain("may remain closed for several minutes");
+  });
 });
 
 describe("canCheckForUpdate", () => {

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -1,4 +1,5 @@
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
+import { isWindowsPlatform } from "../lib/utils";
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
@@ -78,9 +79,13 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
 
 export function getDesktopUpdateInstallConfirmationMessage(
   state: Pick<DesktopUpdateState, "availableVersion" | "downloadedVersion">,
+  platform = "",
 ): string {
   const version = state.downloadedVersion ?? state.availableVersion;
-  return `Install update${version ? ` ${version}` : ""} and restart T3 Code?\n\nAny running tasks will be interrupted. Make sure you're ready before continuing.`;
+  const windowsInstallWarning = isWindowsPlatform(platform)
+    ? "\n\nOn Windows, T3 Code may remain closed for several minutes while the update installs, and no installer window may appear. T3 Code will reopen automatically when installation finishes."
+    : "";
+  return `Install update${version ? ` ${version}` : ""} and restart T3 Code?\n\nAny running tasks will be interrupted. Make sure you're ready before continuing.${windowsInstallWarning}`;
 }
 
 export function getDesktopUpdateActionError(result: DesktopUpdateActionResult): string | null {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -233,6 +233,7 @@ function AboutVersionSection() {
       const confirmed = window.confirm(
         getDesktopUpdateInstallConfirmationMessage(
           updateState ?? { availableVersion: null, downloadedVersion: null },
+          navigator.platform,
         ),
       );
       if (!confirmed) return;

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -110,7 +110,9 @@ export function SidebarUpdatePill() {
     }
 
     if (action === "install") {
-      const confirmed = window.confirm(getDesktopUpdateInstallConfirmationMessage(state));
+      const confirmed = window.confirm(
+        getDesktopUpdateInstallConfirmationMessage(state, navigator.platform),
+      );
       if (!confirmed) return;
       void bridge
         .installUpdate()


### PR DESCRIPTION
Closes #4328

## Summary
- warn Windows users that T3 Code can remain closed for several minutes during a silent update
- explain that no installer window may appear and that T3 Code will reopen automatically
- use the same confirmation copy across the legacy sidebar, sidebar update pill, and About settings entry points

## Verification
- `vp test run apps/web/src/components/desktopUpdate.logic.test.ts` (26 passed)
- `vp run --filter @t3tools/web typecheck`
- targeted lint for the changed files (one pre-existing array-index-key warning)
- `test-t3-app`: paired an isolated environment, launched the app, and opened the Settings panel successfully

The platform-specific copy is covered with explicit Win32 and MacIntel cases because the isolated web runner is not an Electron/Windows host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to install confirmation strings with platform gating; no updater or install logic modified.
> 
> **Overview**
> **Windows users** see extra copy in the desktop **install update** confirmation dialog explaining that T3 Code may stay closed for several minutes during a silent install, that no installer window may appear, and that the app will reopen when finished.
> 
> `getDesktopUpdateInstallConfirmationMessage` gains an optional **platform** argument (default empty) and uses `isWindowsPlatform` to append that paragraph only on Windows. **Sidebar**, **SidebarUpdatePill**, and **About** settings now pass `navigator.platform` so all install paths share the same message.
> 
> Unit tests cover **Win32** (warning present) vs **MacIntel** (warning absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ffba05eda1501819364f210295675fb8c1899d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn Windows users before silent desktop updates in confirmation dialogs
> Adds a Windows-specific warning to the update installation confirmation dialog shown in the sidebar and settings. `getDesktopUpdateInstallConfirmationMessage` in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/4350/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) now accepts an optional `platform` parameter and appends the warning when `isWindowsPlatform(platform)` is true. Callers in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4350/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/4350/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf), and [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/4350/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) pass `navigator.platform` as the second argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ffba05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->