### PR TITLE
feat(web): add and manage reusable chat labels

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,6 +14,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolveSelectedThreadEntries,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveSidebarStageBadgeLabel,
@@ -168,6 +169,32 @@ describe("buildMultiSelectThreadContextMenuItems", () => {
     expect(
       buildMultiSelectThreadContextMenuItems({ count: 2, hasRunningThread: true }),
     ).toContainEqual({ id: "archive", label: "Archive (2)", disabled: true });
+  });
+});
+
+describe("resolveSelectedThreadEntries", () => {
+  it("keeps only entries that still resolve so bulk counts match actionable threads", () => {
+    const entries = resolveSelectedThreadEntries(
+      ["thread-one", "stale-thread", "thread-two"],
+      (threadKey) =>
+        threadKey === "stale-thread"
+          ? null
+          : {
+              threadKey,
+            },
+    );
+
+    expect(entries).toEqual([{ threadKey: "thread-one" }, { threadKey: "thread-two" }]);
+    expect(
+      buildMultiSelectThreadContextMenuItems({
+        count: entries.length,
+        hasRunningThread: false,
+      }),
+    ).toContainEqual({ id: "add-label", label: "Add label (2)" });
+  });
+
+  it("returns an empty actionable set when every selected thread is stale", () => {
+    expect(resolveSelectedThreadEntries(["stale-thread"], () => null)).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -152,6 +152,12 @@ describe("archiveSelectedThreadEntries", () => {
 });
 
 describe("buildMultiSelectThreadContextMenuItems", () => {
+  it("offers bulk labels with the selected count", () => {
+    expect(
+      buildMultiSelectThreadContextMenuItems({ count: 3, hasRunningThread: false }),
+    ).toContainEqual({ id: "add-label", label: "Add label (3)" });
+  });
+
   it("offers bulk archive with the selected count", () => {
     expect(
       buildMultiSelectThreadContextMenuItems({ count: 3, hasRunningThread: false }),

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -83,8 +83,9 @@ export async function archiveSelectedThreadEntries<
 export function buildMultiSelectThreadContextMenuItems(input: {
   count: number;
   hasRunningThread: boolean;
-}): readonly ContextMenuItem<"mark-unread" | "archive" | "delete">[] {
+}): readonly ContextMenuItem<"add-label" | "mark-unread" | "archive" | "delete">[] {
   return [
+    { id: "add-label", label: `Add label (${input.count})` },
     { id: "mark-unread", label: `Mark unread (${input.count})` },
     {
       id: "archive",

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -46,6 +46,20 @@ type LogicalSidebarProject = SidebarProject & {
 
 export type ThreadTraversalDirection = "previous" | "next";
 
+export function resolveSelectedThreadEntries<TEntry>(
+  threadKeys: Iterable<string>,
+  resolveEntry: (threadKey: string) => TEntry | null | undefined,
+): TEntry[] {
+  const entries: TEntry[] = [];
+  for (const threadKey of threadKeys) {
+    const entry = resolveEntry(threadKey);
+    if (entry != null) {
+      entries.push(entry);
+    }
+  }
+  return entries;
+}
+
 export async function archiveSelectedThreadEntries<
   TEntry extends { readonly threadKey: string },
   TResult extends { readonly _tag: "Success" | "Failure" },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { ThreadLabelBadgesForThread, ThreadLabelPickerDialog } from "./ThreadLabels";
 import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
@@ -729,6 +730,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               </TooltipPopup>
             </Tooltip>
           )}
+          {renamingThreadKey === threadKey ? null : (
+            <ThreadLabelBadgesForThread threadKey={threadKey} compact maxVisible={1} />
+          )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           {discoveredPorts.length > 0 && (
@@ -1201,6 +1205,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
   const [confirmingArchiveThreadKey, setConfirmingArchiveThreadKey] = useState<string | null>(null);
+  const [threadLabelPickerTarget, setThreadLabelPickerTarget] = useState<{
+    threadKeys: readonly string[];
+    targetLabel: string;
+  } | null>(null);
   const [projectRenameTarget, setProjectRenameTarget] = useState<SidebarProjectGroupMember | null>(
     null,
   );
@@ -1780,6 +1788,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         position,
       );
 
+      if (clicked === "add-label") {
+        setThreadLabelPickerTarget({
+          threadKeys: selectedThreadEntries.map(({ threadKey }) => threadKey),
+          targetLabel: `${count} selected chats`,
+        });
+        return;
+      }
+
       if (clicked === "mark-unread") {
         for (const { threadKey, thread } of selectedThreadEntries) {
           markThreadUnread(threadKey, thread.latestTurn?.completedAt);
@@ -2165,6 +2181,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       const clicked = await api.contextMenu.show(
         [
           { id: "rename", label: "Rename thread" },
+          { id: "add-label", label: "Add label" },
           { id: "mark-unread", label: "Mark unread" },
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
@@ -2175,6 +2192,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
       if (clicked === "rename") {
         startThreadRename(threadKey, thread.title);
+        return;
+      }
+
+      if (clicked === "add-label") {
+        setThreadLabelPickerTarget({
+          threadKeys: [threadKey],
+          targetLabel: `“${thread.title}”`,
+        });
         return;
       }
 
@@ -2379,6 +2404,17 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         openPrLink={openPrLink}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
+      />
+
+      <ThreadLabelPickerDialog
+        open={threadLabelPickerTarget !== null}
+        threadKeys={threadLabelPickerTarget?.threadKeys ?? []}
+        targetLabel={threadLabelPickerTarget?.targetLabel ?? "this chat"}
+        onOpenChange={(open) => {
+          if (!open) {
+            setThreadLabelPickerTarget(null);
+          }
+        }}
       />
 
       <Dialog

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -178,6 +178,7 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   resolveProjectStatusIndicator,
+  resolveSelectedThreadEntries,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
@@ -1773,12 +1774,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       if (!api) return;
       const threadKeys = [...useThreadSelectionStore.getState().selectedThreadKeys];
       if (threadKeys.length === 0) return;
-      const count = threadKeys.length;
-      const selectedThreadEntries = threadKeys.flatMap((threadKey) => {
+      const selectedThreadEntries = resolveSelectedThreadEntries(threadKeys, (threadKey) => {
         const threadRef = parseScopedThreadKey(threadKey);
         const thread = threadRef ? readThreadShell(threadRef) : null;
-        return threadRef && thread ? [{ threadKey, threadRef, thread }] : [];
+        return threadRef && thread ? { threadKey, threadRef, thread } : null;
       });
+      if (selectedThreadEntries.length === 0) return;
+      const count = selectedThreadEntries.length;
       const hasRunningThread = selectedThreadEntries.some(
         ({ thread }) => thread.session?.status === "running" && thread.session.activeTurnId != null,
       );

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -107,6 +107,7 @@ import {
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { ThreadLabelBadgesForThread, ThreadLabelPickerDialog } from "./ThreadLabels";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
@@ -633,6 +634,9 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               />
             </span>
             {title}
+            {isRenaming ? null : (
+              <ThreadLabelBadgesForThread threadKey={threadKey} compact maxVisible={1} />
+            )}
             {/* The PR badge stays outside the hover-fading slot: it must
               remain visible AND clickable while the row is hovered. Only
               the time/jump label yields to the settle affordance. */}
@@ -755,7 +759,12 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 ) : null}
               </span>
             </div>
-            <div className="mt-1 flex min-w-0">{title}</div>
+            <div className="mt-1 flex min-w-0 items-center gap-1">
+              {title}
+              {isRenaming ? null : (
+                <ThreadLabelBadgesForThread threadKey={threadKey} maxVisible={2} />
+              )}
+            </div>
             <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
               {thread.branch ? (
                 <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
@@ -863,6 +872,10 @@ export default function SidebarV2() {
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((s) => s.rangeSelectTo);
   const markThreadUnread = useUiStateStore((s) => s.markThreadUnread);
+  const [threadLabelPickerTarget, setThreadLabelPickerTarget] = useState<{
+    threadKeys: readonly string[];
+    targetLabel: string;
+  } | null>(null);
   const routeTarget = useParams({
     strict: false,
     select: (params) => resolveThreadRouteTarget(params),
@@ -1474,6 +1487,7 @@ export default function SidebarV2() {
         api.contextMenu.show(
           [
             { id: "settle", label: `Settle (${count})` },
+            { id: "add-label", label: `Add label (${count})` },
             { id: "mark-unread", label: `Mark unread (${count})` },
             { id: "delete", label: `Delete (${count})`, destructive: true },
           ],
@@ -1481,6 +1495,13 @@ export default function SidebarV2() {
         ),
       );
       if (clicked._tag === "Failure") return;
+      if (clicked.value === "add-label") {
+        setThreadLabelPickerTarget({
+          threadKeys,
+          targetLabel: `${count} selected chats`,
+        });
+        return;
+      }
       if (clicked.value === "settle") {
         // Post-settle navigation must skip threads settling in this same
         // batch — they are all leaving the card block together. Rows that
@@ -1585,6 +1606,7 @@ export default function SidebarV2() {
                   ]
                 : []),
               { id: "rename", label: "Rename thread" },
+              { id: "add-label", label: "Add label" },
               { id: "mark-unread", label: "Mark unread" },
               { id: "delete", label: "Delete", destructive: true, icon: "trash" },
             ],
@@ -1601,6 +1623,12 @@ export default function SidebarV2() {
             return;
           case "rename":
             startThreadRename(threadRef, thread.title);
+            return;
+          case "add-label":
+            setThreadLabelPickerTarget({
+              threadKeys: [threadKey],
+              targetLabel: `“${thread.title}”`,
+            });
             return;
           case "mark-unread":
             markThreadUnread(threadKey, thread.latestTurn?.completedAt);
@@ -2192,6 +2220,16 @@ export default function SidebarV2() {
           </DialogFooter>
         </DialogPopup>
       </Dialog>
+      <ThreadLabelPickerDialog
+        open={threadLabelPickerTarget !== null}
+        threadKeys={threadLabelPickerTarget?.threadKeys ?? []}
+        targetLabel={threadLabelPickerTarget?.targetLabel ?? "this chat"}
+        onOpenChange={(open) => {
+          if (!open) {
+            setThreadLabelPickerTarget(null);
+          }
+        }}
+      />
       <SidebarChromeFooter />
     </>
   );

--- a/apps/web/src/components/ThreadLabels.tsx
+++ b/apps/web/src/components/ThreadLabels.tsx
@@ -15,6 +15,7 @@ import { useShallow } from "zustand/react/shallow";
 
 import {
   normalizeThreadLabelName,
+  resolveAssignedThreadLabels,
   THREAD_LABEL_COLORS,
   THREAD_LABEL_NAME_MAX_LENGTH,
   type ThreadLabel,
@@ -78,9 +79,7 @@ export function ThreadLabelBadgesForThread(props: {
   const labels = useUiStateStore(
     useShallow((state) => {
       const assignedIds = state.threadLabelIdsByThreadKey[threadKey] ?? [];
-      if (assignedIds.length === 0) return [];
-      const assignedSet = new Set(assignedIds);
-      return state.threadLabels.filter((label) => assignedSet.has(label.id));
+      return resolveAssignedThreadLabels(state.threadLabels, assignedIds);
     }),
   );
   if (labels.length === 0) {

--- a/apps/web/src/components/ThreadLabels.tsx
+++ b/apps/web/src/components/ThreadLabels.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { CheckIcon, ChevronLeftIcon, MinusIcon, PlusIcon, SearchIcon, TagIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import {
+  normalizeThreadLabelName,
+  THREAD_LABEL_COLORS,
+  THREAD_LABEL_NAME_MAX_LENGTH,
+  type ThreadLabel,
+} from "../threadLabels";
+import { useUiStateStore } from "../uiStateStore";
+import { cn } from "../lib/utils";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+
+const DEFAULT_THREAD_LABEL_COLOR = THREAD_LABEL_COLORS[0];
+
+function ThreadLabelBadge({ label, compact = false }: { label: ThreadLabel; compact?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 shrink-0 items-center gap-1 rounded-full border font-medium text-foreground/85",
+        compact ? "h-4 max-w-18 px-1 text-[9px]" : "h-5 max-w-24 px-1.5 text-[10px]",
+      )}
+      style={{
+        backgroundColor: `${label.color}18`,
+        borderColor: `${label.color}66`,
+      }}
+      title={label.name}
+      data-testid={`thread-label-badge-${label.id}`}
+    >
+      <span
+        aria-hidden
+        className={cn("shrink-0 rounded-full", compact ? "size-1.5" : "size-2")}
+        style={{ backgroundColor: label.color }}
+      />
+      <span className="truncate">{label.name}</span>
+    </span>
+  );
+}
+
+export function ThreadLabelBadgesForThread(props: {
+  readonly threadKey: string;
+  readonly compact?: boolean;
+  readonly maxVisible?: number;
+  readonly className?: string;
+}) {
+  const { compact = false, maxVisible = 2, threadKey } = props;
+  const labels = useUiStateStore(
+    useShallow((state) => {
+      const assignedIds = state.threadLabelIdsByThreadKey[threadKey] ?? [];
+      if (assignedIds.length === 0) return [];
+      const assignedSet = new Set(assignedIds);
+      return state.threadLabels.filter((label) => assignedSet.has(label.id));
+    }),
+  );
+  if (labels.length === 0) {
+    return null;
+  }
+  const visibleLabels = labels.slice(0, maxVisible);
+  const hiddenCount = labels.length - visibleLabels.length;
+
+  return (
+    <span
+      className={cn("inline-flex min-w-0 shrink-0 items-center gap-1", props.className)}
+      aria-label={`Labels: ${labels.map((label) => label.name).join(", ")}`}
+    >
+      {visibleLabels.map((label) => (
+        <ThreadLabelBadge key={label.id} label={label} compact={compact} />
+      ))}
+      {hiddenCount > 0 ? (
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center justify-center rounded-full border border-border bg-background/70 font-medium text-muted-foreground",
+            compact ? "h-4 min-w-4 px-1 text-[9px]" : "h-5 min-w-5 px-1 text-[10px]",
+          )}
+          title={labels
+            .slice(visibleLabels.length)
+            .map((label) => label.name)
+            .join(", ")}
+        >
+          +{hiddenCount}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+interface ThreadLabelPickerDialogProps {
+  readonly open: boolean;
+  readonly threadKeys: readonly string[];
+  readonly targetLabel: string;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function ThreadLabelPickerDialog({
+  onOpenChange,
+  open,
+  targetLabel,
+  threadKeys,
+}: ThreadLabelPickerDialogProps) {
+  const [mode, setMode] = useState<"pick" | "create">("pick");
+  const [search, setSearch] = useState("");
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string>(DEFAULT_THREAD_LABEL_COLOR);
+  const labels = useUiStateStore((state) => state.threadLabels);
+  const threadLabelIdsByThreadKey = useUiStateStore((state) => state.threadLabelIdsByThreadKey);
+  const createThreadLabel = useUiStateStore((state) => state.createThreadLabel);
+  const setThreadLabelAssigned = useUiStateStore((state) => state.setThreadLabelAssigned);
+
+  useEffect(() => {
+    if (!open) return;
+    setMode("pick");
+    setSearch("");
+    setName("");
+    setColor(
+      THREAD_LABEL_COLORS[labels.length % THREAD_LABEL_COLORS.length] ?? DEFAULT_THREAD_LABEL_COLOR,
+    );
+  }, [labels.length, open]);
+
+  const filteredLabels = useMemo(() => {
+    const query = search.trim().toLocaleLowerCase();
+    return query.length === 0
+      ? labels
+      : labels.filter((label) => label.name.toLocaleLowerCase().includes(query));
+  }, [labels, search]);
+  const normalizedName = normalizeThreadLabelName(name);
+  const duplicateLabel = labels.find(
+    (label) => label.name.toLocaleLowerCase() === normalizedName.toLocaleLowerCase(),
+  );
+
+  const selectedCountForLabel = (labelId: string) =>
+    threadKeys.reduce(
+      (count, threadKey) =>
+        count + (threadLabelIdsByThreadKey[threadKey]?.includes(labelId) ? 1 : 0),
+      0,
+    );
+
+  const handleCreate = () => {
+    if (!normalizedName) return;
+    const labelId = createThreadLabel(normalizedName, color);
+    if (!labelId) return;
+    setThreadLabelAssigned(threadKeys, labelId, true);
+    setMode("pick");
+    setSearch(normalizedName);
+    setName("");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-md overflow-hidden" data-testid="thread-label-picker">
+        <DialogHeader className="border-b border-border/70 pb-4">
+          <DialogTitle>{mode === "create" ? "Create label" : "Add label"}</DialogTitle>
+          <DialogDescription>
+            {mode === "create"
+              ? "Labels are reusable across chats in this browser."
+              : `Choose labels for ${targetLabel}.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {mode === "pick" ? (
+          <>
+            <DialogPanel className="space-y-3">
+              <div className="relative">
+                <SearchIcon
+                  aria-hidden
+                  className="pointer-events-none absolute top-1/2 left-2.5 z-10 size-4 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  type="search"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search labels"
+                  aria-label="Search labels"
+                  className="[&_input]:pl-8"
+                />
+              </div>
+              <div className="grid max-h-72 gap-1 overflow-y-auto" role="list">
+                {filteredLabels.map((label) => {
+                  const selectedCount = selectedCountForLabel(label.id);
+                  const allSelected = threadKeys.length > 0 && selectedCount === threadKeys.length;
+                  const partlySelected = selectedCount > 0 && !allSelected;
+                  return (
+                    <button
+                      key={label.id}
+                      type="button"
+                      role="checkbox"
+                      aria-checked={partlySelected ? "mixed" : allSelected}
+                      className="group flex min-h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+                      onClick={() => setThreadLabelAssigned(threadKeys, label.id, !allSelected)}
+                      data-testid={`thread-label-option-${label.id}`}
+                    >
+                      <span
+                        aria-hidden
+                        className="size-3 shrink-0 rounded-full border border-black/10 dark:border-white/20"
+                        style={{ backgroundColor: label.color }}
+                      />
+                      <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                        {label.name}
+                      </span>
+                      <span
+                        className={cn(
+                          "inline-flex size-5 shrink-0 items-center justify-center rounded border",
+                          allSelected || partlySelected
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-input bg-background",
+                        )}
+                      >
+                        {partlySelected ? (
+                          <MinusIcon className="size-3" aria-hidden />
+                        ) : allSelected ? (
+                          <CheckIcon className="size-3" aria-hidden />
+                        ) : null}
+                      </span>
+                    </button>
+                  );
+                })}
+                {filteredLabels.length === 0 ? (
+                  <div className="flex flex-col items-center gap-2 py-8 text-center text-sm text-muted-foreground">
+                    <TagIcon className="size-5 opacity-60" aria-hidden />
+                    <span>{labels.length === 0 ? "No labels yet" : "No matching labels"}</span>
+                  </div>
+                ) : null}
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full justify-start"
+                onClick={() => {
+                  setName(search);
+                  setMode("create");
+                }}
+                data-testid="create-thread-label"
+              >
+                <PlusIcon />
+                Create new label
+              </Button>
+            </DialogPanel>
+            <DialogFooter>
+              <Button onClick={() => onOpenChange(false)}>Done</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogPanel className="space-y-5">
+              <label className="grid gap-2">
+                <span className="text-xs font-medium text-foreground">Label text</span>
+                <Input
+                  autoFocus
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && normalizedName) {
+                      event.preventDefault();
+                      handleCreate();
+                    }
+                  }}
+                  maxLength={THREAD_LABEL_NAME_MAX_LENGTH}
+                  placeholder="e.g. Research"
+                  aria-label="Label text"
+                  data-testid="thread-label-name"
+                />
+                <span className="text-[11px] text-muted-foreground">
+                  {duplicateLabel
+                    ? `“${duplicateLabel.name}” already exists and will be applied.`
+                    : `${name.length}/${THREAD_LABEL_NAME_MAX_LENGTH} characters`}
+                </span>
+              </label>
+
+              <div className="grid gap-2">
+                <span className="text-xs font-medium text-foreground">Color</span>
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <input
+                    type="color"
+                    value={color}
+                    onChange={(event) => setColor(event.target.value.toLowerCase())}
+                    aria-label="Custom label color"
+                    className="h-8 w-10 cursor-pointer rounded-xl border border-input bg-background p-0.5"
+                  />
+                  <div className="flex flex-wrap gap-1.5">
+                    {THREAD_LABEL_COLORS.map((swatch) => {
+                      const selected = color === swatch;
+                      return (
+                        <button
+                          key={swatch}
+                          type="button"
+                          className={cn(
+                            "size-6 cursor-pointer rounded-full border transition",
+                            selected
+                              ? "scale-110 border-foreground ring-2 ring-ring ring-offset-1 ring-offset-background"
+                              : "border-black/10 hover:scale-105 dark:border-white/20",
+                          )}
+                          style={{ backgroundColor: swatch }}
+                          onClick={() => setColor(swatch)}
+                          aria-label={`Use ${swatch} label color`}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                <span className="text-xs font-medium text-foreground">Preview</span>
+                {normalizedName ? (
+                  <ThreadLabelBadge label={{ id: "preview", name: normalizedName, color }} />
+                ) : (
+                  <span className="text-sm text-muted-foreground">Enter label text</span>
+                )}
+              </div>
+            </DialogPanel>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setMode("pick");
+                  setName("");
+                }}
+              >
+                <ChevronLeftIcon />
+                Back
+              </Button>
+              <Button disabled={!normalizedName} onClick={handleCreate}>
+                {duplicateLabel ? "Apply label" : "Create and apply"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ThreadLabels.tsx
+++ b/apps/web/src/components/ThreadLabels.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { CheckIcon, ChevronLeftIcon, MinusIcon, PlusIcon, SearchIcon, TagIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  MinusIcon,
+  PencilIcon,
+  PlusIcon,
+  SearchIcon,
+  TagIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import {
@@ -13,6 +22,15 @@ import {
 import { useUiStateStore } from "../uiStateStore";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
 import {
   Dialog,
   DialogDescription,
@@ -110,20 +128,29 @@ export function ThreadLabelPickerDialog({
   targetLabel,
   threadKeys,
 }: ThreadLabelPickerDialogProps) {
-  const [mode, setMode] = useState<"pick" | "create">("pick");
+  const [mode, setMode] = useState<"pick" | "create" | "edit">("pick");
   const [search, setSearch] = useState("");
   const [name, setName] = useState("");
   const [color, setColor] = useState<string>(DEFAULT_THREAD_LABEL_COLOR);
+  const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const wasOpenRef = useRef(false);
   const labels = useUiStateStore((state) => state.threadLabels);
   const threadLabelIdsByThreadKey = useUiStateStore((state) => state.threadLabelIdsByThreadKey);
   const createThreadLabel = useUiStateStore((state) => state.createThreadLabel);
+  const updateThreadLabel = useUiStateStore((state) => state.updateThreadLabel);
+  const deleteThreadLabel = useUiStateStore((state) => state.deleteThreadLabel);
   const setThreadLabelAssigned = useUiStateStore((state) => state.setThreadLabelAssigned);
 
   useEffect(() => {
-    if (!open) return;
+    const justOpened = open && !wasOpenRef.current;
+    wasOpenRef.current = open;
+    if (!justOpened) return;
     setMode("pick");
     setSearch("");
     setName("");
+    setEditingLabelId(null);
+    setDeleteConfirmOpen(false);
     setColor(
       THREAD_LABEL_COLORS[labels.length % THREAD_LABEL_COLORS.length] ?? DEFAULT_THREAD_LABEL_COLOR,
     );
@@ -135,10 +162,16 @@ export function ThreadLabelPickerDialog({
       ? labels
       : labels.filter((label) => label.name.toLocaleLowerCase().includes(query));
   }, [labels, search]);
+  const editingLabel = labels.find((label) => label.id === editingLabelId) ?? null;
   const normalizedName = normalizeThreadLabelName(name);
   const duplicateLabel = labels.find(
-    (label) => label.name.toLocaleLowerCase() === normalizedName.toLocaleLowerCase(),
+    (label) =>
+      label.id !== editingLabelId &&
+      label.name.toLocaleLowerCase() === normalizedName.toLocaleLowerCase(),
   );
+  const hasEditorChanges =
+    editingLabel !== null &&
+    (editingLabel.name !== normalizedName || editingLabel.color !== color.toLocaleLowerCase());
 
   const selectedCountForLabel = (labelId: string) =>
     threadKeys.reduce(
@@ -157,187 +190,311 @@ export function ThreadLabelPickerDialog({
     setName("");
   };
 
+  const handleSave = () => {
+    if (!editingLabelId || !normalizedName || duplicateLabel || !hasEditorChanges) return;
+    if (!updateThreadLabel(editingLabelId, normalizedName, color)) return;
+    setMode("pick");
+    setEditingLabelId(null);
+    setName("");
+  };
+
+  const handleDelete = () => {
+    if (!editingLabelId) return;
+    deleteThreadLabel(editingLabelId);
+    setDeleteConfirmOpen(false);
+    setMode("pick");
+    setEditingLabelId(null);
+    setName("");
+  };
+
+  const startCreate = () => {
+    setEditingLabelId(null);
+    setName(search);
+    setColor(
+      THREAD_LABEL_COLORS[labels.length % THREAD_LABEL_COLORS.length] ?? DEFAULT_THREAD_LABEL_COLOR,
+    );
+    setMode("create");
+  };
+
+  const startEdit = (label: ThreadLabel) => {
+    setEditingLabelId(label.id);
+    setName(label.name);
+    setColor(label.color);
+    setMode("edit");
+  };
+
+  const returnToPicker = () => {
+    setMode("pick");
+    setEditingLabelId(null);
+    setName("");
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setDeleteConfirmOpen(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const isEditing = mode === "edit";
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogPopup className="max-w-md overflow-hidden" data-testid="thread-label-picker">
-        <DialogHeader className="border-b border-border/70 pb-4">
-          <DialogTitle>{mode === "create" ? "Create label" : "Add label"}</DialogTitle>
-          <DialogDescription>
-            {mode === "create"
-              ? "Labels are reusable across chats in this browser."
-              : `Choose labels for ${targetLabel}.`}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogPopup className="max-w-sm overflow-hidden" data-testid="thread-label-picker">
+          <DialogHeader className="gap-1 px-4 pt-4 pr-12 pb-2">
+            <DialogTitle className="text-base leading-5">
+              {mode === "pick" ? "Add label" : isEditing ? "Edit label" : "Create label"}
+            </DialogTitle>
+            <DialogDescription className="truncate text-xs" title={targetLabel}>
+              {mode === "pick"
+                ? `Choose labels for ${targetLabel}.`
+                : isEditing
+                  ? "Rename the label or change its color."
+                  : "Create a reusable label for your chats."}
+            </DialogDescription>
+          </DialogHeader>
 
-        {mode === "pick" ? (
-          <>
-            <DialogPanel className="space-y-3">
-              <div className="relative">
-                <SearchIcon
-                  aria-hidden
-                  className="pointer-events-none absolute top-1/2 left-2.5 z-10 size-4 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  type="search"
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  placeholder="Search labels"
-                  aria-label="Search labels"
-                  className="[&_input]:pl-8"
-                />
-              </div>
-              <div className="grid max-h-72 gap-1 overflow-y-auto" role="list">
-                {filteredLabels.map((label) => {
-                  const selectedCount = selectedCountForLabel(label.id);
-                  const allSelected = threadKeys.length > 0 && selectedCount === threadKeys.length;
-                  const partlySelected = selectedCount > 0 && !allSelected;
-                  return (
-                    <button
-                      key={label.id}
-                      type="button"
-                      role="checkbox"
-                      aria-checked={partlySelected ? "mixed" : allSelected}
-                      className="group flex min-h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
-                      onClick={() => setThreadLabelAssigned(threadKeys, label.id, !allSelected)}
-                      data-testid={`thread-label-option-${label.id}`}
-                    >
-                      <span
-                        aria-hidden
-                        className="size-3 shrink-0 rounded-full border border-black/10 dark:border-white/20"
-                        style={{ backgroundColor: label.color }}
-                      />
-                      <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                        {label.name}
-                      </span>
-                      <span
-                        className={cn(
-                          "inline-flex size-5 shrink-0 items-center justify-center rounded border",
-                          allSelected || partlySelected
-                            ? "border-primary bg-primary text-primary-foreground"
-                            : "border-input bg-background",
-                        )}
-                      >
-                        {partlySelected ? (
-                          <MinusIcon className="size-3" aria-hidden />
-                        ) : allSelected ? (
-                          <CheckIcon className="size-3" aria-hidden />
-                        ) : null}
-                      </span>
-                    </button>
-                  );
-                })}
-                {filteredLabels.length === 0 ? (
-                  <div className="flex flex-col items-center gap-2 py-8 text-center text-sm text-muted-foreground">
-                    <TagIcon className="size-5 opacity-60" aria-hidden />
-                    <span>{labels.length === 0 ? "No labels yet" : "No matching labels"}</span>
-                  </div>
-                ) : null}
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full justify-start"
-                onClick={() => {
-                  setName(search);
-                  setMode("create");
-                }}
-                data-testid="create-thread-label"
-              >
-                <PlusIcon />
-                Create new label
-              </Button>
-            </DialogPanel>
-            <DialogFooter>
-              <Button onClick={() => onOpenChange(false)}>Done</Button>
-            </DialogFooter>
-          </>
-        ) : (
-          <>
-            <DialogPanel className="space-y-5">
-              <label className="grid gap-2">
-                <span className="text-xs font-medium text-foreground">Label text</span>
-                <Input
-                  autoFocus
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" && normalizedName) {
-                      event.preventDefault();
-                      handleCreate();
-                    }
-                  }}
-                  maxLength={THREAD_LABEL_NAME_MAX_LENGTH}
-                  placeholder="e.g. Research"
-                  aria-label="Label text"
-                  data-testid="thread-label-name"
-                />
-                <span className="text-[11px] text-muted-foreground">
-                  {duplicateLabel
-                    ? `“${duplicateLabel.name}” already exists and will be applied.`
-                    : `${name.length}/${THREAD_LABEL_NAME_MAX_LENGTH} characters`}
-                </span>
-              </label>
-
-              <div className="grid gap-2">
-                <span className="text-xs font-medium text-foreground">Color</span>
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                  <input
-                    type="color"
-                    value={color}
-                    onChange={(event) => setColor(event.target.value.toLowerCase())}
-                    aria-label="Custom label color"
-                    className="h-8 w-10 cursor-pointer rounded-xl border border-input bg-background p-0.5"
+          {mode === "pick" ? (
+            <>
+              <DialogPanel className="space-y-2 px-3 pt-1 pb-3" scrollFade={false}>
+                <div className="relative">
+                  <SearchIcon
+                    aria-hidden
+                    className="pointer-events-none absolute top-1/2 left-2.5 z-10 size-3.5 -translate-y-1/2 text-muted-foreground"
                   />
-                  <div className="flex flex-wrap gap-1.5">
-                    {THREAD_LABEL_COLORS.map((swatch) => {
-                      const selected = color === swatch;
-                      return (
+                  <Input
+                    type="search"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search labels"
+                    aria-label="Search labels"
+                    size="sm"
+                    className="[&_input]:pl-8"
+                  />
+                </div>
+                <div className="grid max-h-64 gap-0.5 overflow-y-auto" role="list">
+                  {filteredLabels.map((label) => {
+                    const selectedCount = selectedCountForLabel(label.id);
+                    const allSelected =
+                      threadKeys.length > 0 && selectedCount === threadKeys.length;
+                    const partlySelected = selectedCount > 0 && !allSelected;
+                    return (
+                      <div
+                        key={label.id}
+                        className="group flex min-h-8 items-center rounded-md transition-colors hover:bg-accent focus-within:bg-accent"
+                      >
                         <button
-                          key={swatch}
                           type="button"
-                          className={cn(
-                            "size-6 cursor-pointer rounded-full border transition",
-                            selected
-                              ? "scale-110 border-foreground ring-2 ring-ring ring-offset-1 ring-offset-background"
-                              : "border-black/10 hover:scale-105 dark:border-white/20",
-                          )}
-                          style={{ backgroundColor: swatch }}
-                          onClick={() => setColor(swatch)}
-                          aria-label={`Use ${swatch} label color`}
-                        />
-                      );
-                    })}
+                          role="checkbox"
+                          aria-checked={partlySelected ? "mixed" : allSelected}
+                          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 self-stretch rounded-md px-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          onClick={() => setThreadLabelAssigned(threadKeys, label.id, !allSelected)}
+                          data-testid={`thread-label-option-${label.id}`}
+                        >
+                          <span
+                            aria-hidden
+                            className="size-2.5 shrink-0 rounded-full border border-black/10 dark:border-white/20"
+                            style={{ backgroundColor: label.color }}
+                          />
+                          <span className="min-w-0 flex-1 truncate text-sm">{label.name}</span>
+                          <span
+                            className={cn(
+                              "inline-flex size-4 shrink-0 items-center justify-center rounded-[5px] border",
+                              allSelected || partlySelected
+                                ? "border-primary bg-primary text-primary-foreground"
+                                : "border-input bg-background/80",
+                            )}
+                          >
+                            {partlySelected ? (
+                              <MinusIcon className="size-2.5" aria-hidden />
+                            ) : allSelected ? (
+                              <CheckIcon className="size-2.5" aria-hidden />
+                            ) : null}
+                          </span>
+                        </button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          className="mr-1 opacity-55 group-hover:opacity-100 focus-visible:opacity-100"
+                          onClick={() => startEdit(label)}
+                          aria-label={`Edit label ${label.name}`}
+                          title={`Edit ${label.name}`}
+                          data-testid={`edit-thread-label-${label.id}`}
+                        >
+                          <PencilIcon />
+                        </Button>
+                      </div>
+                    );
+                  })}
+                  {filteredLabels.length === 0 ? (
+                    <div className="flex items-center justify-center gap-2 py-5 text-center text-xs text-muted-foreground">
+                      <TagIcon className="size-4 opacity-60" aria-hidden />
+                      <span>{labels.length === 0 ? "No labels yet" : "No matching labels"}</span>
+                    </div>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  className="flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-md border-t border-border/60 px-2 pt-1.5 text-left text-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={startCreate}
+                  data-testid="create-thread-label"
+                >
+                  <PlusIcon className="size-4 text-muted-foreground" />
+                  Create label
+                </button>
+              </DialogPanel>
+              <DialogFooter className="flex-row justify-end px-3 py-2">
+                <Button size="sm" onClick={() => handleOpenChange(false)}>
+                  Done
+                </Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <DialogPanel className="space-y-3 px-4 pt-1 pb-4" scrollFade={false}>
+                <label className="grid gap-1.5">
+                  <span className="text-xs font-medium text-foreground">Label text</span>
+                  <Input
+                    autoFocus
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (
+                        event.key === "Enter" &&
+                        normalizedName &&
+                        (!isEditing || (!duplicateLabel && hasEditorChanges))
+                      ) {
+                        event.preventDefault();
+                        if (isEditing) {
+                          handleSave();
+                        } else {
+                          handleCreate();
+                        }
+                      }
+                    }}
+                    size="sm"
+                    maxLength={THREAD_LABEL_NAME_MAX_LENGTH}
+                    placeholder="e.g. Research"
+                    aria-label="Label text"
+                    data-testid="thread-label-name"
+                  />
+                  <span
+                    className={cn(
+                      "text-[11px]",
+                      duplicateLabel ? "text-destructive" : "text-muted-foreground",
+                    )}
+                  >
+                    {duplicateLabel
+                      ? isEditing
+                        ? `“${duplicateLabel.name}” already exists.`
+                        : `“${duplicateLabel.name}” already exists and will be applied.`
+                      : `${name.length}/${THREAD_LABEL_NAME_MAX_LENGTH} characters`}
+                  </span>
+                </label>
+
+                <div className="grid gap-1.5">
+                  <span className="text-xs font-medium text-foreground">Color</span>
+                  <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                    <input
+                      type="color"
+                      value={color}
+                      onChange={(event) => setColor(event.target.value.toLowerCase())}
+                      aria-label="Custom label color"
+                      className="size-7 cursor-pointer rounded-md border border-input bg-background p-0.5"
+                    />
+                    <div className="flex flex-wrap gap-1">
+                      {THREAD_LABEL_COLORS.map((swatch) => {
+                        const selected = color === swatch;
+                        return (
+                          <button
+                            key={swatch}
+                            type="button"
+                            className={cn(
+                              "size-5 cursor-pointer rounded-full border transition-shadow",
+                              selected
+                                ? "border-foreground ring-2 ring-ring ring-offset-1 ring-offset-background"
+                                : "border-black/10 hover:ring-2 hover:ring-ring/40 dark:border-white/20",
+                            )}
+                            style={{ backgroundColor: swatch }}
+                            onClick={() => setColor(swatch)}
+                            aria-label={`Use ${swatch} label color`}
+                          />
+                        );
+                      })}
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div className="grid gap-2">
-                <span className="text-xs font-medium text-foreground">Preview</span>
-                {normalizedName ? (
-                  <ThreadLabelBadge label={{ id: "preview", name: normalizedName, color }} />
-                ) : (
-                  <span className="text-sm text-muted-foreground">Enter label text</span>
-                )}
-              </div>
-            </DialogPanel>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => {
-                  setMode("pick");
-                  setName("");
-                }}
-              >
-                <ChevronLeftIcon />
-                Back
-              </Button>
-              <Button disabled={!normalizedName} onClick={handleCreate}>
-                {duplicateLabel ? "Apply label" : "Create and apply"}
-              </Button>
-            </DialogFooter>
-          </>
-        )}
-      </DialogPopup>
-    </Dialog>
+                <div className="flex min-h-6 items-center justify-between gap-3 border-t border-border/60 pt-3">
+                  <span className="text-xs font-medium text-foreground">Preview</span>
+                  {normalizedName ? (
+                    <ThreadLabelBadge label={{ id: "preview", name: normalizedName, color }} />
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Enter label text</span>
+                  )}
+                </div>
+              </DialogPanel>
+              <DialogFooter className="flex-row items-center px-3 py-2">
+                {isEditing ? (
+                  <Button
+                    size="sm"
+                    variant="destructive-outline"
+                    className="mr-auto"
+                    onClick={() => setDeleteConfirmOpen(true)}
+                    data-testid="delete-thread-label"
+                  >
+                    <Trash2Icon />
+                    Delete
+                  </Button>
+                ) : null}
+                <Button size="sm" variant="outline" onClick={returnToPicker}>
+                  <ChevronLeftIcon />
+                  Back
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={
+                    !normalizedName ||
+                    (isEditing ? Boolean(duplicateLabel) || !hasEditorChanges : false)
+                  }
+                  onClick={isEditing ? handleSave : handleCreate}
+                  data-testid={isEditing ? "save-thread-label" : "submit-thread-label"}
+                >
+                  {isEditing ? "Save" : duplicateLabel ? "Apply" : "Create & apply"}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogPopup>
+      </Dialog>
+
+      <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <AlertDialogPopup className="max-w-sm">
+          <AlertDialogHeader className="gap-1 px-4 py-4">
+            <AlertDialogTitle className="text-base leading-5">
+              Delete “{editingLabel?.name ?? "label"}”?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-xs">
+              This removes the label from every chat. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-row justify-end px-4 py-3">
+            <AlertDialogClose render={<Button size="sm" variant="outline" />}>
+              Cancel
+            </AlertDialogClose>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={handleDelete}
+              data-testid="confirm-delete-thread-label"
+            >
+              Delete label
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/web/src/threadLabels.test.ts
+++ b/apps/web/src/threadLabels.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveAssignedThreadLabels, type ThreadLabel } from "./threadLabels";
+
+const labels: readonly ThreadLabel[] = [
+  { id: "label-first-created", name: "First created", color: "#2563eb" },
+  { id: "label-second-created", name: "Second created", color: "#7c3aed" },
+  { id: "label-third-created", name: "Third created", color: "#db2777" },
+];
+
+describe("resolveAssignedThreadLabels", () => {
+  it("preserves each thread's assignment order instead of catalog order", () => {
+    expect(
+      resolveAssignedThreadLabels(labels, [
+        "label-third-created",
+        "label-first-created",
+        "label-second-created",
+      ]).map((label) => label.id),
+    ).toEqual(["label-third-created", "label-first-created", "label-second-created"]);
+  });
+
+  it("ignores stale assignment ids without disturbing the remaining order", () => {
+    expect(
+      resolveAssignedThreadLabels(labels, [
+        "label-second-created",
+        "label-deleted",
+        "label-second-created",
+        "label-first-created",
+      ]).map((label) => label.id),
+    ).toEqual(["label-second-created", "label-first-created"]);
+  });
+});

--- a/apps/web/src/threadLabels.ts
+++ b/apps/web/src/threadLabels.ts
@@ -17,6 +17,30 @@ export interface ThreadLabel {
   readonly color: string;
 }
 
+export function resolveAssignedThreadLabels(
+  labels: readonly ThreadLabel[],
+  assignedIds: readonly string[],
+): ThreadLabel[] {
+  if (assignedIds.length === 0) {
+    return [];
+  }
+
+  const labelsById = new Map(labels.map((label) => [label.id, label]));
+  const resolved: ThreadLabel[] = [];
+  const seenIds = new Set<string>();
+  for (const labelId of assignedIds) {
+    if (seenIds.has(labelId)) {
+      continue;
+    }
+    seenIds.add(labelId);
+    const label = labelsById.get(labelId);
+    if (label) {
+      resolved.push(label);
+    }
+  }
+  return resolved;
+}
+
 let nextThreadLabelId = 0;
 
 export function normalizeThreadLabelName(value: string): string {

--- a/apps/web/src/threadLabels.ts
+++ b/apps/web/src/threadLabels.ts
@@ -1,0 +1,66 @@
+export const THREAD_LABEL_NAME_MAX_LENGTH = 32;
+
+export const THREAD_LABEL_COLORS = [
+  "#2563eb",
+  "#7c3aed",
+  "#db2777",
+  "#dc2626",
+  "#ea580c",
+  "#ca8a04",
+  "#16a34a",
+  "#0891b2",
+] as const;
+
+export interface ThreadLabel {
+  readonly id: string;
+  readonly name: string;
+  readonly color: string;
+}
+
+let nextThreadLabelId = 0;
+
+export function normalizeThreadLabelName(value: string): string {
+  return value.trim().replace(/\s+/g, " ").slice(0, THREAD_LABEL_NAME_MAX_LENGTH);
+}
+
+export function normalizeThreadLabelColor(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return /^#[\da-f]{6}$/.test(normalized) ? normalized : null;
+}
+
+export function sanitizeThreadLabels(value: unknown): ThreadLabel[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const labels: ThreadLabel[] = [];
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const id = "id" in candidate && typeof candidate.id === "string" ? candidate.id.trim() : "";
+    const name =
+      "name" in candidate && typeof candidate.name === "string"
+        ? normalizeThreadLabelName(candidate.name)
+        : "";
+    const color =
+      "color" in candidate && typeof candidate.color === "string"
+        ? normalizeThreadLabelColor(candidate.color)
+        : null;
+    const normalizedName = name.toLocaleLowerCase();
+    if (!id || !name || !color || seenIds.has(id) || seenNames.has(normalizedName)) {
+      continue;
+    }
+    seenIds.add(id);
+    seenNames.add(normalizedName);
+    labels.push({ id, name, color });
+  }
+  return labels;
+}
+
+export function createThreadLabelId(): string {
+  const sequence = nextThreadLabelId++;
+  return `label-${Date.now().toString(36)}-${sequence.toString(36)}`;
+}

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -2,6 +2,7 @@ import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  addThreadLabel,
   legacyProjectCwdPreferenceKey,
   markThreadUnread,
   markThreadVisited,
@@ -13,6 +14,7 @@ import {
   resolveProjectExpanded,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
+  setThreadLabelAssigned,
   setThreadChangedFilesExpanded,
   type UiState,
 } from "./uiStateStore";
@@ -23,6 +25,8 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
+    threadLabels: [],
+    threadLabelIdsByThreadKey: {},
     defaultAdvertisedEndpointKey: null,
     ...overrides,
   };
@@ -140,6 +144,55 @@ describe("uiStateStore pure functions", () => {
       defaultAdvertisedEndpointKey: null,
     });
   });
+
+  it("creates reusable labels and assigns them to multiple scoped threads", () => {
+    const label = { id: "label-research", name: "  Research  ", color: "#2563EB" };
+    const withLabel = addThreadLabel(makeUiState(), label);
+    const assigned = setThreadLabelAssigned(
+      withLabel,
+      ["environment-a:thread-1", "environment-b:thread-1"],
+      "label-research",
+      true,
+    );
+
+    expect(assigned.threadLabels).toEqual([
+      { id: "label-research", name: "Research", color: "#2563eb" },
+    ]);
+    expect(assigned.threadLabelIdsByThreadKey).toEqual({
+      "environment-a:thread-1": ["label-research"],
+      "environment-b:thread-1": ["label-research"],
+    });
+    expect(
+      setThreadLabelAssigned(assigned, "environment-a:thread-1", "label-research", false)
+        .threadLabelIdsByThreadKey,
+    ).toEqual({
+      "environment-b:thread-1": ["label-research"],
+    });
+  });
+
+  it("rejects invalid or duplicate labels and unknown assignments", () => {
+    const state = addThreadLabel(makeUiState(), {
+      id: "label-research",
+      name: "Research",
+      color: "#2563eb",
+    });
+
+    expect(
+      addThreadLabel(state, {
+        id: "label-duplicate",
+        name: "research",
+        color: "#16a34a",
+      }),
+    ).toBe(state);
+    expect(
+      addThreadLabel(state, {
+        id: "label-invalid",
+        name: "Invalid",
+        color: "blue",
+      }),
+    ).toBe(state);
+    expect(setThreadLabelAssigned(state, "environment:thread-1", "missing", true)).toBe(state);
+  });
 });
 
 describe("parsePersistedState", () => {
@@ -161,6 +214,13 @@ describe("parsePersistedState", () => {
           "turn-2": true,
         },
       },
+      threadLabels: [
+        { id: "label-research", name: "Research", color: "#2563EB" },
+        { id: "label-invalid", name: "Invalid", color: "blue" },
+      ],
+      threadLabelIdsByThreadKey: {
+        "environment:thread-1": ["label-research", "label-research", "label-invalid"],
+      },
     });
 
     expect(parsed).toEqual({
@@ -176,6 +236,10 @@ describe("parsePersistedState", () => {
         "environment:thread-1": {
           "turn-1": false,
         },
+      },
+      threadLabels: [{ id: "label-research", name: "Research", color: "#2563eb" }],
+      threadLabelIdsByThreadKey: {
+        "environment:thread-1": ["label-research"],
       },
     });
   });
@@ -261,6 +325,10 @@ describe("uiStateStore persistence", () => {
           "turn-2": true,
         },
       },
+      threadLabels: [{ id: "label-research", name: "Research", color: "#2563eb" }],
+      threadLabelIdsByThreadKey: {
+        "environment:thread-1": ["label-research"],
+      },
       defaultAdvertisedEndpointKey: "desktop-core:lan:http",
     });
 
@@ -282,6 +350,10 @@ describe("uiStateStore persistence", () => {
         "environment:thread-1": {
           "turn-1": false,
         },
+      },
+      threadLabels: [{ id: "label-research", name: "Research", color: "#2563eb" }],
+      threadLabelIdsByThreadKey: {
+        "environment:thread-1": ["label-research"],
       },
     });
     expect(parsePersistedState(persisted)).toEqual({

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import {
   addThreadLabel,
+  deleteThreadLabel,
   legacyProjectCwdPreferenceKey,
   markThreadUnread,
   markThreadVisited,
@@ -17,6 +18,7 @@ import {
   setThreadLabelAssigned,
   setThreadChangedFilesExpanded,
   type UiState,
+  updateThreadLabel,
 } from "./uiStateStore";
 
 function makeUiState(overrides: Partial<UiState> = {}): UiState {
@@ -192,6 +194,81 @@ describe("uiStateStore pure functions", () => {
       }),
     ).toBe(state);
     expect(setThreadLabelAssigned(state, "environment:thread-1", "missing", true)).toBe(state);
+  });
+
+  it("renames and recolors an existing label without changing its assignments", () => {
+    const assigned = setThreadLabelAssigned(
+      addThreadLabel(makeUiState(), {
+        id: "label-research",
+        name: "Research",
+        color: "#2563eb",
+      }),
+      "environment:thread-1",
+      "label-research",
+      true,
+    );
+
+    const updated = updateThreadLabel(assigned, "label-research", "  Deep research  ", "#16A34A");
+
+    expect(updated.threadLabels).toEqual([
+      { id: "label-research", name: "Deep research", color: "#16a34a" },
+    ]);
+    expect(updated.threadLabelIdsByThreadKey).toEqual(assigned.threadLabelIdsByThreadKey);
+  });
+
+  it("rejects invalid or duplicate label updates", () => {
+    const withLabels = addThreadLabel(
+      addThreadLabel(makeUiState(), {
+        id: "label-research",
+        name: "Research",
+        color: "#2563eb",
+      }),
+      {
+        id: "label-review",
+        name: "Review",
+        color: "#16a34a",
+      },
+    );
+
+    expect(updateThreadLabel(withLabels, "label-review", "research", "#dc2626")).toBe(withLabels);
+    expect(updateThreadLabel(withLabels, "label-review", "Review", "red")).toBe(withLabels);
+    expect(updateThreadLabel(withLabels, "missing", "Review", "#dc2626")).toBe(withLabels);
+  });
+
+  it("deletes a label and removes it from every thread assignment", () => {
+    const withLabels = addThreadLabel(
+      addThreadLabel(makeUiState(), {
+        id: "label-research",
+        name: "Research",
+        color: "#2563eb",
+      }),
+      {
+        id: "label-review",
+        name: "Review",
+        color: "#16a34a",
+      },
+    );
+    const assigned = setThreadLabelAssigned(
+      setThreadLabelAssigned(
+        setThreadLabelAssigned(withLabels, "environment:thread-1", "label-research", true),
+        "environment:thread-1",
+        "label-review",
+        true,
+      ),
+      "environment:thread-2",
+      "label-research",
+      true,
+    );
+
+    const deleted = deleteThreadLabel(assigned, "label-research");
+
+    expect(deleted.threadLabels).toEqual([
+      { id: "label-review", name: "Review", color: "#16a34a" },
+    ]);
+    expect(deleted.threadLabelIdsByThreadKey).toEqual({
+      "environment:thread-1": ["label-review"],
+    });
+    expect(deleteThreadLabel(deleted, "missing")).toBe(deleted);
   });
 });
 

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -408,6 +408,59 @@ export function addThreadLabel(state: UiState, label: ThreadLabel): UiState {
   };
 }
 
+export function updateThreadLabel(
+  state: UiState,
+  labelId: string,
+  name: string,
+  color: string,
+): UiState {
+  const labelIndex = state.threadLabels.findIndex((label) => label.id === labelId);
+  const normalizedName = normalizeThreadLabelName(name);
+  const normalizedColor = normalizeThreadLabelColor(color);
+  if (labelIndex < 0 || !normalizedName || !normalizedColor) {
+    return state;
+  }
+  const duplicateName = state.threadLabels.some(
+    (label) =>
+      label.id !== labelId && label.name.toLocaleLowerCase() === normalizedName.toLocaleLowerCase(),
+  );
+  if (duplicateName) {
+    return state;
+  }
+  const currentLabel = state.threadLabels[labelIndex]!;
+  if (currentLabel.name === normalizedName && currentLabel.color === normalizedColor) {
+    return state;
+  }
+  const threadLabels = [...state.threadLabels];
+  threadLabels[labelIndex] = {
+    ...currentLabel,
+    name: normalizedName,
+    color: normalizedColor,
+  };
+  return {
+    ...state,
+    threadLabels,
+  };
+}
+
+export function deleteThreadLabel(state: UiState, labelId: string): UiState {
+  if (!state.threadLabels.some((label) => label.id === labelId)) {
+    return state;
+  }
+  const threadLabelIdsByThreadKey: Record<string, string[]> = {};
+  for (const [threadKey, labelIds] of Object.entries(state.threadLabelIdsByThreadKey)) {
+    const nextLabelIds = labelIds.filter((candidate) => candidate !== labelId);
+    if (nextLabelIds.length > 0) {
+      threadLabelIdsByThreadKey[threadKey] = nextLabelIds;
+    }
+  }
+  return {
+    ...state,
+    threadLabels: state.threadLabels.filter((label) => label.id !== labelId),
+    threadLabelIdsByThreadKey,
+  };
+}
+
 export function setThreadLabelAssigned(
   state: UiState,
   threadKeys: string | readonly string[],
@@ -530,6 +583,8 @@ interface UiStateStore extends UiState {
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   createThreadLabel: (name: string, color: string) => string | null;
+  updateThreadLabel: (labelId: string, name: string, color: string) => boolean;
+  deleteThreadLabel: (labelId: string) => void;
   setThreadLabelAssigned: (
     threadKeys: string | readonly string[],
     labelId: string,
@@ -569,6 +624,16 @@ export const useUiStateStore = create<UiStateStore>((set, get) => ({
     set((state) => addThreadLabel(state, { id, name: normalizedName, color: normalizedColor }));
     return id;
   },
+  updateThreadLabel: (labelId, name, color) => {
+    const currentState = get();
+    const nextState = updateThreadLabel(currentState, labelId, name, color);
+    if (nextState === currentState) {
+      return false;
+    }
+    set(nextState);
+    return true;
+  },
+  deleteThreadLabel: (labelId) => set((state) => deleteThreadLabel(state, labelId)),
   setThreadLabelAssigned: (threadKeys, labelId, assigned) =>
     set((state) => setThreadLabelAssigned(state, threadKeys, labelId, assigned)),
   setProjectExpanded: (projectIds, expanded) =>

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,6 +1,13 @@
 import { Debouncer } from "@tanstack/react-pacer";
 import { create } from "zustand";
 import { normalizeProjectPathForComparison } from "./lib/projectPaths";
+import {
+  createThreadLabelId,
+  normalizeThreadLabelColor,
+  normalizeThreadLabelName,
+  sanitizeThreadLabels,
+  type ThreadLabel,
+} from "./threadLabels";
 
 export const PERSISTED_STATE_KEY = "t3code:ui-state:v1";
 const LEGACY_PERSISTED_STATE_KEYS = [
@@ -25,6 +32,8 @@ export interface PersistedUiState {
   projectOrderCwds?: string[];
   defaultAdvertisedEndpointKey?: string | null;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  threadLabels?: ThreadLabel[];
+  threadLabelIdsByThreadKey?: Record<string, string[]>;
 }
 
 export interface UiProjectState {
@@ -37,17 +46,25 @@ export interface UiThreadState {
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
 }
 
+export interface UiThreadLabelState {
+  threadLabels: ThreadLabel[];
+  threadLabelIdsByThreadKey: Record<string, string[]>;
+}
+
 export interface UiEndpointState {
   defaultAdvertisedEndpointKey: string | null;
 }
 
-export interface UiState extends UiProjectState, UiThreadState, UiEndpointState {}
+export interface UiState
+  extends UiProjectState, UiThreadState, UiThreadLabelState, UiEndpointState {}
 
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
+  threadLabels: [],
+  threadLabelIdsByThreadKey: {},
   defaultAdvertisedEndpointKey: null,
 };
 
@@ -96,6 +113,34 @@ function sanitizeTimestampRecord(value: unknown): Record<string, string> {
   );
 }
 
+function sanitizeThreadLabelAssignments(
+  value: unknown,
+  labels: readonly ThreadLabel[],
+): Record<string, string[]> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const knownLabelIds = new Set(labels.map((label) => label.id));
+  const assignments: Record<string, string[]> = {};
+  for (const [threadKey, candidateIds] of Object.entries(value)) {
+    if (!threadKey || !Array.isArray(candidateIds)) {
+      continue;
+    }
+    const labelIds = [
+      ...new Set(
+        candidateIds.filter(
+          (candidate): candidate is string =>
+            typeof candidate === "string" && knownLabelIds.has(candidate),
+        ),
+      ),
+    ];
+    if (labelIds.length > 0) {
+      assignments[threadKey] = labelIds;
+    }
+  }
+  return assignments;
+}
+
 export function parsePersistedState(parsed: PersistedUiState): UiState {
   const projectExpandedById =
     parsed.projectExpandedById === undefined
@@ -119,6 +164,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     parsed.projectOrder === undefined
       ? sanitizeStringArray(parsed.projectOrderCwds).map(legacyProjectCwdPreferenceKey)
       : sanitizeStringArray(parsed.projectOrder);
+  const threadLabels = sanitizeThreadLabels(parsed.threadLabels);
 
   return {
     projectExpandedById,
@@ -126,6 +172,11 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
     threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
       parsed.threadChangedFilesExpandedById,
+    ),
+    threadLabels,
+    threadLabelIdsByThreadKey: sanitizeThreadLabelAssignments(
+      parsed.threadLabelIdsByThreadKey,
+      threadLabels,
     ),
     defaultAdvertisedEndpointKey:
       typeof parsed.defaultAdvertisedEndpointKey === "string" &&
@@ -211,6 +262,8 @@ export function persistState(state: UiState): void {
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpandedById,
+        threadLabels: state.threadLabels,
+        threadLabelIdsByThreadKey: state.threadLabelIdsByThreadKey,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -334,6 +387,66 @@ export function setDefaultAdvertisedEndpointKey(state: UiState, key: string | nu
   };
 }
 
+export function addThreadLabel(state: UiState, label: ThreadLabel): UiState {
+  const id = label.id.trim();
+  const name = normalizeThreadLabelName(label.name);
+  const color = normalizeThreadLabelColor(label.color);
+  if (!id || !name || !color) {
+    return state;
+  }
+  const normalizedName = name.toLocaleLowerCase();
+  if (
+    state.threadLabels.some(
+      (existing) => existing.id === id || existing.name.toLocaleLowerCase() === normalizedName,
+    )
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    threadLabels: [...state.threadLabels, { id, name, color }],
+  };
+}
+
+export function setThreadLabelAssigned(
+  state: UiState,
+  threadKeys: string | readonly string[],
+  labelId: string,
+  assigned: boolean,
+): UiState {
+  if (!state.threadLabels.some((label) => label.id === labelId)) {
+    return state;
+  }
+  const keys = [
+    ...new Set((typeof threadKeys === "string" ? [threadKeys] : threadKeys).filter(Boolean)),
+  ];
+  if (keys.length === 0) {
+    return state;
+  }
+
+  let changed = false;
+  const threadLabelIdsByThreadKey = { ...state.threadLabelIdsByThreadKey };
+  for (const threadKey of keys) {
+    const currentIds = threadLabelIdsByThreadKey[threadKey] ?? [];
+    const currentlyAssigned = currentIds.includes(labelId);
+    if (currentlyAssigned === assigned) {
+      continue;
+    }
+    changed = true;
+    if (assigned) {
+      threadLabelIdsByThreadKey[threadKey] = [...currentIds, labelId];
+      continue;
+    }
+    const nextIds = currentIds.filter((candidate) => candidate !== labelId);
+    if (nextIds.length === 0) {
+      delete threadLabelIdsByThreadKey[threadKey];
+    } else {
+      threadLabelIdsByThreadKey[threadKey] = nextIds;
+    }
+  }
+  return changed ? { ...state, threadLabelIdsByThreadKey } : state;
+}
+
 export function resolveProjectExpanded(
   projectExpandedById: Readonly<Record<string, boolean>>,
   preferenceKeys: readonly string[],
@@ -416,6 +529,12 @@ interface UiStateStore extends UiState {
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
+  createThreadLabel: (name: string, color: string) => string | null;
+  setThreadLabelAssigned: (
+    threadKeys: string | readonly string[],
+    labelId: string,
+    assigned: boolean,
+  ) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
   reorderProjects: (
     currentProjectOrder: readonly string[],
@@ -424,7 +543,7 @@ interface UiStateStore extends UiState {
   ) => void;
 }
 
-export const useUiStateStore = create<UiStateStore>((set) => ({
+export const useUiStateStore = create<UiStateStore>((set, get) => ({
   ...readPersistedState(),
   markThreadVisited: (threadId, visitedAt) =>
     set((state) => markThreadVisited(state, threadId, visitedAt)),
@@ -434,6 +553,24 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
   setDefaultAdvertisedEndpointKey: (key) =>
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
+  createThreadLabel: (name, color) => {
+    const normalizedName = normalizeThreadLabelName(name);
+    const normalizedColor = normalizeThreadLabelColor(color);
+    if (!normalizedName || !normalizedColor) {
+      return null;
+    }
+    const existing = get().threadLabels.find(
+      (label) => label.name.toLocaleLowerCase() === normalizedName.toLocaleLowerCase(),
+    );
+    if (existing) {
+      return existing.id;
+    }
+    const id = createThreadLabelId();
+    set((state) => addThreadLabel(state, { id, name: normalizedName, color: normalizedColor }));
+    return id;
+  },
+  setThreadLabelAssigned: (threadKeys, labelId, assigned) =>
+    set((state) => setThreadLabelAssigned(state, threadKeys, labelId, assigned)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>


### PR DESCRIPTION
## What Changed

- Added reusable thread labels with create, rename, recolor, delete, assign, and remove actions.
- Added label badges to sidebar rows and label controls to single-thread and bulk context menus.
- Persisted the label catalog and per-thread assignments in UI state.
- Preserved each thread's label assignment order when choosing visible badges.
- Made bulk-label counts and targets use only currently resolvable selected threads.
- Ignored stale or duplicate label IDs without disturbing valid badge order.

## Why

Labels provide a lightweight way to organize chats across projects without changing provider or project metadata.

## UI Changes

Thread rows can show compact colored label badges. Context menus expose focused label management and assignment flows for one or many selected threads.

## Verification

- 80 focused label/sidebar tests passed on the PR branch.
- Web TypeScript, scoped lint, formatting, and diff checks passed.
- Regression coverage includes stale bulk selections, empty actionable selections, per-thread assignment order, stale IDs, and duplicate IDs.

## Checklist

- [x] This PR is focused on thread labels
- [x] I explained what changed and why
- [x] I documented the UI behavior
- [x] Bulk and ordering edge cases have focused regression coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI state in localStorage; no auth or server data paths. Scope is sidebar labeling with solid unit test coverage.
> 
> **Overview**
> Introduces **reusable thread labels** for organizing chats: a label catalog and per-thread assignments live in persisted UI state (`threadLabels`, `threadLabelIdsByThreadKey`), with create/rename/recolor/delete and assign/remove flows.
> 
> **Sidebar UX:** Both `Sidebar` and `SidebarV2` show compact colored label badges on thread rows and expose **Add label** on single-thread and multi-select context menus. Bulk actions open a shared `ThreadLabelPickerDialog` for one or many threads, with mixed-selection checkboxes for partial bulk assignment.
> 
> **Logic:** `resolveSelectedThreadEntries` filters multi-select to threads that still resolve, so bulk menu counts and label targets match actionable selections. `resolveAssignedThreadLabels` keeps badge order aligned with each thread’s assignment order and drops stale or duplicate label IDs.
> 
> **Tests** cover label store/persistence, assignment ordering, and bulk-selection edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0c60746b8b7571ad4cc9f32b9b7717c115ab50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->