### PR TITLE
Add optional Jude broker authentication for Codex

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -36,6 +36,7 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
+import { makeJudeCodexAuth } from "../Layers/JudeCodexAuth.ts";
 import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
@@ -116,10 +117,16 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const processEnv = mergeProviderInstanceEnvironment(environment);
+      const makeAuth = () =>
+        makeJudeCodexAuth(processEnv, {
+          fileSystem,
+          httpClient,
+        });
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
       const stampIdentity = withInstanceIdentity({
@@ -158,6 +165,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const adapter = yield* makeCodexAdapter(effectiveConfig, {
         instanceId,
         environment: processEnv,
+        makeAuth,
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       });
       const textGeneration = yield* makeCodexTextGeneration(effectiveConfig, processEnv);
@@ -166,7 +174,12 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // in as instance rebuilds from the registry rather than in-place
       // updates. Pre-provide `ChildProcessSpawner` so the check fits
       // `makeManagedServerProvider.checkProvider`'s `R = never`.
-      const checkProvider = checkCodexProviderStatus(effectiveConfig, undefined, processEnv).pipe(
+      const checkProvider = checkCodexProviderStatus(
+        effectiveConfig,
+        undefined,
+        processEnv,
+        makeAuth,
+      ).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       );

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -62,6 +62,7 @@ import {
 } from "./CodexSessionRuntime.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
+import type { CodexAppServerAuthFactory } from "./JudeCodexAuth.ts";
 const isCodexAppServerProcessExitedError = Schema.is(CodexErrors.CodexAppServerProcessExitedError);
 const isCodexAppServerTransportError = Schema.is(CodexErrors.CodexAppServerTransportError);
 const isCodexSessionRuntimeThreadIdMissingError = Schema.is(
@@ -83,6 +84,7 @@ export interface CodexAdapterLiveOptions {
   >;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly makeAuth?: CodexAppServerAuthFactory;
 }
 
 interface CodexAdapterSessionContext {
@@ -1395,6 +1397,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             ? getCodexServiceTierOptionValue(input.modelSelection)
             : undefined;
         const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+        const auth = options?.makeAuth?.();
         const runtimeInput: CodexSessionRuntimeOptions = {
           threadId: input.threadId,
           providerInstanceId: boundInstanceId,
@@ -1402,6 +1405,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           binaryPath: codexConfig.binaryPath,
           launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
           ...(options?.environment ? { environment: options.environment } : {}),
+          ...(auth ? { auth } : {}),
           ...(codexConfig.homePath ? { homePath: codexConfig.homePath } : {}),
           ...(isCodexResumeCursorSchema(input.resumeCursor)
             ? { resumeCursor: input.resumeCursor }

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -33,6 +33,7 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
+import type { CodexAppServerAuth, CodexAppServerAuthFactory } from "./JudeCodexAuth.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
@@ -320,6 +321,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   readonly cwd: string;
   readonly customModels?: ReadonlyArray<string>;
   readonly environment?: NodeJS.ProcessEnv;
+  readonly auth?: CodexAppServerAuth;
 }) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
   // so `CODEX_HOME=~/.codex_work` would reach codex verbatim and trip
@@ -374,6 +376,9 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     },
   });
   yield* client.notify("initialized", undefined);
+  if (input.auth) {
+    yield* input.auth.authenticate(client);
+  }
 
   // Extract the version string after the first '/' in userAgent, up to the next space or the end
   const versionMatch = initialize.userAgent.match(/\/([^\s]+)/);
@@ -503,12 +508,14 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     readonly cwd: string;
     readonly customModels: ReadonlyArray<string>;
     readonly environment?: NodeJS.ProcessEnv;
+    readonly auth?: CodexAppServerAuth;
   }) => Effect.Effect<
     CodexAppServerProviderSnapshot,
     CodexErrors.CodexAppServerError,
     ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
   > = probeCodexAppServerProvider,
   environment?: NodeJS.ProcessEnv,
+  makeAuth?: CodexAppServerAuthFactory,
 ): Effect.fn.Return<
   ServerProviderDraft,
   ServerSettingsError,
@@ -535,6 +542,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     });
   }
 
+  const auth = makeAuth?.();
   const probeResult = yield* probe({
     binaryPath: codexSettings.binaryPath,
     homePath: codexSettings.homePath,
@@ -542,6 +550,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
     environment: resolvedEnvironment,
+    ...(auth ? { auth } : {}),
   }).pipe(
     Effect.scoped,
     Effect.timeoutOption(Duration.millis(AUTH_PROBE_TIMEOUT_MS)),

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -38,6 +38,7 @@ import * as EffectCodexSchema from "effect-codex-app-server/schema";
 import { buildCodexInitializeParams } from "./CodexProvider.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
+import type { CodexAppServerAuth } from "./JudeCodexAuth.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
 const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
 
@@ -106,6 +107,7 @@ export interface CodexSessionRuntimeOptions {
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly resumeCursor?: CodexResumeCursor;
   readonly appServerArgs?: ReadonlyArray<string>;
+  readonly auth?: CodexAppServerAuth;
 }
 
 export interface CodexSessionRuntimeSendTurnInput {
@@ -1201,6 +1203,9 @@ export const makeCodexSessionRuntime = (
       yield* emitSessionEvent("session/connecting", "Starting Codex App Server session.");
       yield* client.request("initialize", buildCodexInitializeParams());
       yield* client.notify("initialized", undefined);
+      if (options.auth) {
+        yield* options.auth.authenticate(client);
+      }
 
       const requestedModel = normalizeCodexModelSlug(options.model);
 

--- a/apps/server/src/provider/Layers/JudeCodexAuth.test.ts
+++ b/apps/server/src/provider/Layers/JudeCodexAuth.test.ts
@@ -1,0 +1,125 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Schema from "effect/Schema";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import * as CodexClient from "effect-codex-app-server/client";
+import * as CodexRpc from "effect-codex-app-server/rpc";
+import { makeJudeCodexAuth } from "./JudeCodexAuth.ts";
+
+const decodeBrokerRequest = Schema.decodeSync(
+  Schema.fromJsonString(
+    Schema.Struct({
+      previousAccessTokenHash: Schema.String,
+    }),
+  ),
+);
+
+it.layer(NodeServices.layer)("JudeCodexAuth", (it) => {
+  it.effect("authenticates Codex and refreshes through the Jude broker", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serviceTokenFile = yield* fileSystem.makeTempFileScoped({ prefix: "jude-sa-token-" });
+      yield* fileSystem.writeFileString(serviceTokenFile, " service-account-token\n");
+
+      const brokerRequests: Array<{
+        readonly authorization: string | undefined;
+        readonly body: { readonly previousAccessTokenHash: string };
+      }> = [];
+      const httpClient = HttpClient.make((request) =>
+        Effect.sync(() => {
+          assert.strictEqual(request.body._tag, "Uint8Array");
+          if (request.body._tag !== "Uint8Array") {
+            return assert.fail("expected a JSON request body");
+          }
+          const body = decodeBrokerRequest(new TextDecoder().decode(request.body.body));
+          brokerRequests.push({
+            authorization: request.headers.authorization,
+            body,
+          });
+          const sequence = brokerRequests.length;
+          return HttpClientResponse.fromWeb(
+            request,
+            Response.json({
+              accessToken: `access-${sequence}`,
+              accessTokenHash: `hash-${sequence}`,
+              chatgptAccountId: "account-1",
+              chatgptPlanType: "pro",
+            }),
+          );
+        }),
+      );
+
+      let refreshHandler:
+        | (() => Effect.Effect<
+            CodexRpc.ServerRequestResponsesByMethod["account/chatgptAuthTokens/refresh"],
+            never
+          >)
+        | undefined;
+      const loginRequests: unknown[] = [];
+      const client = {
+        handleServerRequest: (_method: string, handler: () => Effect.Effect<unknown, never>) =>
+          Effect.sync(() => {
+            refreshHandler = handler as typeof refreshHandler;
+          }),
+        request: (_method: string, payload: unknown) =>
+          Effect.sync(() => {
+            loginRequests.push(payload);
+            return {};
+          }),
+      } as unknown as CodexClient.CodexAppServerClient["Service"];
+
+      const auth = makeJudeCodexAuth(
+        {
+          JUDE_OPENAI_AUTH_BROKER_URL: "https://jude.example.test/internal/openai-auth/token",
+          JUDE_OPENAI_AUTH_SERVICE_TOKEN_FILE: serviceTokenFile,
+        },
+        { fileSystem, httpClient },
+      );
+      assert.ok(auth);
+
+      yield* auth.authenticate(client);
+      assert.ok(refreshHandler);
+      const refreshed = yield* refreshHandler();
+
+      assert.deepStrictEqual(loginRequests, [
+        {
+          type: "chatgptAuthTokens",
+          accessToken: "access-1",
+          chatgptAccountId: "account-1",
+          chatgptPlanType: "pro",
+        },
+      ]);
+      assert.deepStrictEqual(refreshed, {
+        accessToken: "access-2",
+        chatgptAccountId: "account-1",
+        chatgptPlanType: "pro",
+      });
+      assert.deepStrictEqual(brokerRequests, [
+        {
+          authorization: "Bearer service-account-token",
+          body: { previousAccessTokenHash: "" },
+        },
+        {
+          authorization: "Bearer service-account-token",
+          body: { previousAccessTokenHash: "hash-1" },
+        },
+      ]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("stays disabled without a Jude broker URL", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const auth = makeJudeCodexAuth(
+        {},
+        {
+          fileSystem,
+          httpClient: HttpClient.make(() => Effect.die("unexpected broker request")),
+        },
+      );
+      assert.strictEqual(auth, undefined);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/JudeCodexAuth.ts
+++ b/apps/server/src/provider/Layers/JudeCodexAuth.ts
@@ -1,0 +1,90 @@
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Schema from "effect/Schema";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import * as CodexClient from "effect-codex-app-server/client";
+import * as CodexErrors from "effect-codex-app-server/errors";
+import * as CodexSchema from "effect-codex-app-server/schema";
+
+const DEFAULT_SERVICE_ACCOUNT_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+const JudeBrokerToken = Schema.Struct({
+  accessToken: Schema.String,
+  accessTokenHash: Schema.String,
+  chatgptAccountId: Schema.String,
+  chatgptPlanType: Schema.optionalKey(Schema.String),
+});
+
+type JudeBrokerToken = typeof JudeBrokerToken.Type;
+
+export interface CodexAppServerAuth {
+  readonly authenticate: (
+    client: CodexClient.CodexAppServerClient["Service"],
+  ) => Effect.Effect<void, CodexErrors.CodexAppServerError>;
+}
+
+export type CodexAppServerAuthFactory = () => CodexAppServerAuth | undefined;
+
+export function makeJudeCodexAuth(
+  environment: NodeJS.ProcessEnv,
+  dependencies: {
+    readonly fileSystem: FileSystem.FileSystem;
+    readonly httpClient: HttpClient.HttpClient;
+  },
+): CodexAppServerAuth | undefined {
+  const brokerUrl = environment.JUDE_OPENAI_AUTH_BROKER_URL?.trim();
+  if (!brokerUrl) {
+    return undefined;
+  }
+
+  const serviceTokenFile =
+    environment.JUDE_OPENAI_AUTH_SERVICE_TOKEN_FILE?.trim() || DEFAULT_SERVICE_ACCOUNT_TOKEN_FILE;
+  let previousAccessTokenHash = "";
+  const brokerError = () =>
+    CodexErrors.CodexAppServerRequestError.internalError(
+      "Failed to obtain Jude-managed Codex authentication tokens.",
+    );
+
+  const fetchToken = Effect.fn("JudeCodexAuth.fetchToken")(function* (refresh: boolean) {
+    const serviceToken = (yield* dependencies.fileSystem
+      .readFileString(serviceTokenFile)
+      .pipe(Effect.mapError(brokerError))).trim();
+    if (!serviceToken) {
+      return yield* brokerError();
+    }
+
+    const response = yield* HttpClientRequest.post(brokerUrl).pipe(
+      HttpClientRequest.bearerToken(serviceToken),
+      HttpClientRequest.bodyJson({
+        previousAccessTokenHash: refresh ? previousAccessTokenHash : "",
+      }),
+      Effect.flatMap(dependencies.httpClient.execute),
+      Effect.flatMap(HttpClientResponse.filterStatusOk),
+      Effect.flatMap(HttpClientResponse.schemaBodyJson(JudeBrokerToken)),
+      Effect.mapError(brokerError),
+    );
+    previousAccessTokenHash = response.accessTokenHash;
+    return response;
+  });
+
+  const toCodexTokenResponse = (
+    token: JudeBrokerToken,
+  ): CodexSchema.ChatgptAuthTokensRefreshResponse => ({
+    accessToken: token.accessToken,
+    chatgptAccountId: token.chatgptAccountId,
+    ...(token.chatgptPlanType ? { chatgptPlanType: token.chatgptPlanType } : {}),
+  });
+
+  return {
+    authenticate: Effect.fn("JudeCodexAuth.authenticate")(function* (client) {
+      yield* client.handleServerRequest("account/chatgptAuthTokens/refresh", () =>
+        fetchToken(true).pipe(Effect.map(toCodexTokenResponse)),
+      );
+      const token = yield* fetchToken(false);
+      yield* client.request("account/login/start", {
+        type: "chatgptAuthTokens",
+        ...toCodexTokenResponse(token),
+      });
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- add opt-in external Codex authentication backed by Jude's ServiceAccount-authenticated token broker
- authenticate both provider probes and long-lived Codex sessions
- retain only the previous access-token hash for unauthorized refreshes

The integration is dormant unless `JUDE_OPENAI_AUTH_BROKER_URL` is set. It never stores or exposes an OpenAI refresh credential.

## Verification
- `vp test run apps/server/src/provider/Layers/JudeCodexAuth.test.ts`
- `vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts apps/server/src/provider/Layers/ProviderRegistry.test.ts`
- `pnpm --filter t3 typecheck`
- focused `vp lint` on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication and token exchange for Codex app-server; mistakes could break login or mishandle credentials, though the path is env-gated and broker-mediated.
> 
> **Overview**
> Adds **opt-in Jude-managed ChatGPT/Codex authentication** that only activates when `JUDE_OPENAI_AUTH_BROKER_URL` is set; otherwise Codex behavior is unchanged.
> 
> New `makeJudeCodexAuth` reads a service-account token (default Kubernetes path or `JUDE_OPENAI_AUTH_SERVICE_TOKEN_FILE`), POSTs to the broker with `previousAccessTokenHash` on refresh, and wires Codex via `account/chatgptAuthTokens/refresh` plus `account/login/start` with broker-issued tokens—no long-lived OpenAI refresh secret is stored locally.
> 
> **CodexDriver** builds a `makeAuth` factory and passes it into the adapter and `checkCodexProviderStatus` so **provider health probes** and **long-lived session runtimes** both authenticate after `initialize`/`initialized`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b0327d93c3a0a769a3c669d7b50b1551fb16d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Jude broker authentication support to Codex provider
> - Adds a new `makeJudeCodexAuth` factory in [`JudeCodexAuth.ts`](https://github.com/pingdotgg/t3code/pull/4353/files#diff-ee2e1c96854d863548bbe564336a48863fa0a36762acc91bd4cdce88c1bd560a) that reads `JUDE_OPENAI_AUTH_BROKER_URL` and a service token file (defaulting to the Kubernetes SA token path) to fetch ChatGPT tokens from a Jude broker.
> - Wires auth into the Codex stack: `CodexSessionRuntime`, `CodexAdapter`, and `CodexProvider` each accept an optional `auth` object and call `auth.authenticate(client)` after the LSP `initialized` handshake.
> - `checkCodexProviderStatus` and `probeCodexAppServerProvider` are extended to accept and exercise the auth factory, so provider health checks also authenticate when configured.
> - Auth is inactive when `JUDE_OPENAI_AUTH_BROKER_URL` is unset, making this a no-op for deployments without Jude.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60b0327.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->