### PR TITLE
feat(web): reveal project delete button only on row hover

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1597,7 +1597,7 @@ export default function SidebarV2() {
                           key={scopeKey}
                           value={scopeKey}
                           closeOnClick
-                          className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                          className="group/project-row h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
                         >
                           <ProjectFavicon
                             environmentId={project.environmentId}
@@ -1609,7 +1609,7 @@ export default function SidebarV2() {
                             type="button"
                             aria-label={`Remove project ${project.title}`}
                             title={`Remove ${project.title}`}
-                            className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground/55 outline-none transition-colors hover:bg-destructive/12 hover:text-destructive focus-visible:bg-destructive/12 focus-visible:text-destructive focus-visible:ring-2 focus-visible:ring-destructive/40"
+                            className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground/55 opacity-0 outline-none transition-colors hover:bg-destructive/12 hover:text-destructive focus-visible:bg-destructive/12 focus-visible:text-destructive focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-destructive/40 group-hover/project-row:opacity-100"
                             onPointerDown={(event) => event.stopPropagation()}
                             onClick={(event) => {
                               event.preventDefault();


### PR DESCRIPTION
## What Changed

In the sidebar project switcher, the trash/delete button on each project row was always visible. It is now hidden by default and revealed only while hovering that project's row (and on keyboard focus, so it stays reachable without a mouse).

Implementation is two class-list edits in `apps/web/src/components/SidebarV2.tsx`, using the same named-group hover pattern the thread rows in this file already use (`group/<name>` + `group-hover/<name>:opacity-100`): the `MenuRadioItem` row gets `group/project-row`, and the delete button gets `opacity-0` with `group-hover/project-row:opacity-100` and `focus-visible:opacity-100`.

## Why

With every row showing a trash can, the project list reads as a column of destructive actions and gets visually noisy as the list grows. Revealing the delete affordance only on the hovered row keeps the list calm while keeping deletion exactly one hover away — and matches the hover-reveal behavior the thread list already has, so the sidebar behaves consistently.

## UI Changes

| Before (always visible) | After (idle) | After (row hovered) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/before-idle.png) | ![after idle](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/after-idle.png) | ![after hover](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/after-hover.png) |

Hover interaction:

| Before | After |
| --- | --- |
| ![before hover interaction](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/before-hover.gif) | ![after hover interaction](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/after-hover.gif) |

MP4 versions: [before.mp4](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/before.mp4) · [after.mp4](https://raw.githubusercontent.com/shivamhwp/t3code/pr-assets-project-delete-hover/after.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only visibility tweak in the sidebar; no changes to delete logic or data handling.
> 
> **Overview**
> In the sidebar **project filter** menu, each project row’s **remove (trash)** control is **hidden by default** and shown only when that row is hovered or when the button has keyboard focus.
> 
> This mirrors the existing thread-row hover-reveal pattern in `SidebarV2` (`group/project-row` on the `MenuRadioItem`, `opacity-0` plus `group-hover/project-row:opacity-100` and `focus-visible:opacity-100` on the delete button). Removal behavior and confirm dialog are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735449c72927958b64d4ad4b4f8df0809322a35a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide project delete button in sidebar until row hover
> The remove button on each project row in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4357/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) is now hidden by default (`opacity-0`) and revealed on row hover or keyboard focus (`focus-visible`). This is a CSS-only change using Tailwind group hover utilities; no logic or event handling is modified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 735449c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->