### PR TITLE
feat(desktop): open SSH worktrees in local Zed

### DIFF
--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -37,6 +37,7 @@ import {
   getLocalEnvironmentBearerToken,
   getWindowFullscreenState,
   openExternal,
+  openRemoteZed,
   pickFolder,
   setTheme,
   showContextMenu,
@@ -82,6 +83,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(confirm);
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
+  yield* ipc.handle(openRemoteZed);
   yield* ipc.handle(openExternal);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -2,6 +2,7 @@ export const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 export const CONFIRM_CHANNEL = "desktop:confirm";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
+export const OPEN_REMOTE_ZED_CHANNEL = "desktop:open-remote-zed";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -2,6 +2,7 @@ import {
   ContextMenuItemSchema,
   DesktopAppBrandingSchema,
   DesktopEnvironmentBootstrapSchema,
+  DesktopOpenRemoteZedInputSchema,
   DesktopThemeSchema,
   PickFolderOptionsSchema,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
@@ -17,6 +18,7 @@ import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
 import * as DesktopWslBackend from "../../wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "../../wsl/DesktopWslEnvironment.ts";
+import * as DesktopZedLauncher from "../../shell/DesktopZedLauncher.ts";
 import * as ElectronDialog from "../../electron/ElectronDialog.ts";
 import * as ElectronMenu from "../../electron/ElectronMenu.ts";
 import * as ElectronShell from "../../electron/ElectronShell.ts";
@@ -266,5 +268,15 @@ export const openExternal = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.window.openExternal")(function* (url) {
     const shell = yield* ElectronShell.ElectronShell;
     return yield* shell.openExternal(url);
+  }),
+});
+
+export const openRemoteZed = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.OPEN_REMOTE_ZED_CHANNEL,
+  payload: DesktopOpenRemoteZedInputSchema,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.openRemoteZed")(function* (input) {
+    const launcher = yield* DesktopZedLauncher.DesktopZedLauncher;
+    yield* launcher.openRemoteWorkspace(input);
   }),
 });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -51,6 +51,7 @@ import * as DesktopClientSettings from "./settings/DesktopClientSettings.ts";
 import * as DesktopSavedEnvironments from "./settings/DesktopSavedEnvironments.ts";
 import * as DesktopAppSettings from "./settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "./shell/DesktopShellEnvironment.ts";
+import * as DesktopZedLauncher from "./shell/DesktopZedLauncher.ts";
 import * as DesktopSshEnvironment from "./ssh/DesktopSshEnvironment.ts";
 import * as DesktopSshPasswordPrompts from "./ssh/DesktopSshPasswordPrompts.ts";
 import * as DesktopState from "./app/DesktopState.ts";
@@ -184,6 +185,7 @@ const desktopApplicationLayer = Layer.mergeAll(
   DesktopApplicationMenu.layer,
   DesktopLinuxUrlHandler.layer,
   DesktopShellEnvironment.layer,
+  DesktopZedLauncher.layer,
   desktopSshLayer,
 ).pipe(
   Layer.provideMerge(DesktopUpdates.layer),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -104,6 +104,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       items,
       ...(position === undefined ? {} : { position }),
     }),
+  openRemoteZed: (input) => ipcRenderer.invoke(IpcChannels.OPEN_REMOTE_ZED_CHANNEL, input),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {

--- a/apps/desktop/src/shell/DesktopZedLauncher.test.ts
+++ b/apps/desktop/src/shell/DesktopZedLauncher.test.ts
@@ -31,7 +31,7 @@ function makeDetachedHandle(onUnref: () => void): ChildProcessSpawner.ChildProce
 }
 
 describe("DesktopZedLauncher", () => {
-  it("builds Zed's encoded SSH URI from the connection alias", () => {
+  it("builds Zed's encoded SSH URI from the connection target", () => {
     assert.equal(
       DesktopZedLauncher.remoteZedSshUri({
         target: {
@@ -42,7 +42,19 @@ describe("DesktopZedLauncher", () => {
         },
         path: "~/code/project alpha",
       }),
-      "ssh://devbox/~/code/project%20alpha",
+      "ssh://declan@devbox:2222/~/code/project%20alpha",
+    );
+    assert.equal(
+      DesktopZedLauncher.remoteZedSshUri({
+        target: {
+          alias: "",
+          hostname: "devbox.example.com",
+          username: null,
+          port: null,
+        },
+        path: "/srv/project",
+      }),
+      "ssh://devbox.example.com/srv/project",
     );
   });
 

--- a/apps/desktop/src/shell/DesktopZedLauncher.test.ts
+++ b/apps/desktop/src/shell/DesktopZedLauncher.test.ts
@@ -1,0 +1,109 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import * as DesktopZedLauncher from "./DesktopZedLauncher.ts";
+
+function makeDetachedHandle(onUnref: () => void): ChildProcessSpawner.ChildProcessHandle {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+    isRunning: Effect.succeed(true),
+    kill: () => Effect.void,
+    unref: Effect.sync(() => {
+      onUnref();
+      return Effect.void;
+    }),
+    stdin: Sink.drain,
+    stdout: Stream.empty,
+    stderr: Stream.empty,
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+}
+
+describe("DesktopZedLauncher", () => {
+  it("builds Zed's encoded SSH URI from the connection alias", () => {
+    assert.equal(
+      DesktopZedLauncher.remoteZedSshUri({
+        target: {
+          alias: "devbox",
+          hostname: "devbox.example.com",
+          username: "declan",
+          port: 2222,
+        },
+        path: "~/code/project alpha",
+      }),
+      "ssh://devbox/~/code/project%20alpha",
+    );
+  });
+
+  it.effect("launches and detaches the local Zed CLI for a remote workspace", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-zed-" });
+      const zedPath = path.join(binDir, "zed");
+      yield* fileSystem.writeFileString(zedPath, "#!/bin/sh\n");
+      yield* fileSystem.chmod(zedPath, 0o755);
+
+      let spawned: ChildProcess.StandardCommand | undefined;
+      let didUnref = false;
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make((command) =>
+          Effect.sync(() => {
+            assert.equal(ChildProcess.isStandardCommand(command), true);
+            if (!ChildProcess.isStandardCommand(command)) {
+              throw new Error("Expected a standard command");
+            }
+            spawned = command;
+            return makeDetachedHandle(() => {
+              didUnref = true;
+            });
+          }),
+        ),
+      );
+      const previousPath = process.env.PATH;
+      process.env.PATH = binDir;
+
+      yield* Effect.gen(function* () {
+        const launcher = yield* DesktopZedLauncher.DesktopZedLauncher;
+        yield* launcher.openRemoteWorkspace({
+          target: {
+            alias: "devbox",
+            hostname: "devbox.example.com",
+            username: null,
+            port: null,
+          },
+          path: "/srv/project",
+        });
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            process.env.PATH = previousPath;
+          }),
+        ),
+        Effect.provide(
+          DesktopZedLauncher.layer.pipe(
+            Layer.provide(Layer.merge(NodeServices.layer, spawnerLayer)),
+          ),
+        ),
+      );
+
+      assert.ok(spawned);
+      assert.equal(spawned.command, "zed");
+      assert.deepEqual(spawned.args, ["-r", "ssh://devbox/srv/project"]);
+      assert.equal(spawned.options.detached, true);
+      assert.equal(didUnref, true);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/desktop/src/shell/DesktopZedLauncher.test.ts
+++ b/apps/desktop/src/shell/DesktopZedLauncher.test.ts
@@ -56,40 +56,111 @@ describe("DesktopZedLauncher", () => {
       }),
       "ssh://devbox.example.com/srv/project",
     );
+    assert.equal(
+      DesktopZedLauncher.remoteZedSshUri({
+        target: {
+          alias: "",
+          hostname: "2001:db8::1",
+          username: "declan",
+          port: 2222,
+        },
+        path: "/srv/project",
+      }),
+      "ssh://declan@[2001:db8::1]:2222/srv/project",
+    );
   });
 
-  it.effect("launches and detaches the local Zed CLI for a remote workspace", () =>
+  it.effect.each<{
+    availableCommands: ReadonlyArray<"zed" | "zeditor">;
+    expectedCommand: "zed" | "zeditor";
+  }>([
+    { availableCommands: ["zed", "zeditor"], expectedCommand: "zed" },
+    { availableCommands: ["zeditor"], expectedCommand: "zeditor" },
+  ])(
+    "launches and detaches $expectedCommand when available",
+    ({ availableCommands, expectedCommand }) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-zed-" });
+        for (const command of availableCommands) {
+          const commandPath = path.join(binDir, command);
+          yield* fileSystem.writeFileString(commandPath, "#!/bin/sh\n");
+          yield* fileSystem.chmod(commandPath, 0o755);
+        }
+
+        let spawned: ChildProcess.StandardCommand | undefined;
+        let didUnref = false;
+        const spawnerLayer = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make((command) =>
+            Effect.sync(() => {
+              assert.equal(ChildProcess.isStandardCommand(command), true);
+              if (!ChildProcess.isStandardCommand(command)) {
+                throw new Error("Expected a standard command");
+              }
+              spawned = command;
+              return makeDetachedHandle(() => {
+                didUnref = true;
+              });
+            }),
+          ),
+        );
+        const previousPath = process.env.PATH;
+        process.env.PATH = binDir;
+
+        yield* Effect.gen(function* () {
+          const launcher = yield* DesktopZedLauncher.DesktopZedLauncher;
+          yield* launcher.openRemoteWorkspace({
+            target: {
+              alias: "devbox",
+              hostname: "devbox.example.com",
+              username: null,
+              port: null,
+            },
+            path: "/srv/project",
+          });
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              process.env.PATH = previousPath;
+            }),
+          ),
+          Effect.provide(
+            DesktopZedLauncher.layer.pipe(
+              Layer.provide(Layer.merge(NodeServices.layer, spawnerLayer)),
+            ),
+          ),
+        );
+
+        assert.ok(spawned);
+        assert.equal(spawned.command, expectedCommand);
+        assert.deepEqual(spawned.args, ["-r", "ssh://devbox/srv/project"]);
+        assert.equal(spawned.options.detached, true);
+        assert.equal(didUnref, true);
+      }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it("keeps launch errors free of SSH connection details", () => {
+    const error = new DesktopZedLauncher.DesktopZedLaunchError({
+      argumentCount: 2,
+      cause: new Error("spawn failed"),
+    });
+
+    assert.equal(error.message, "Failed to open remote workspace in Zed.");
+    assert.equal(error.argumentCount, 2);
+  });
+
+  it.effect("fails clearly when no local Zed CLI is available", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-zed-" });
-      const zedPath = path.join(binDir, "zed");
-      yield* fileSystem.writeFileString(zedPath, "#!/bin/sh\n");
-      yield* fileSystem.chmod(zedPath, 0o755);
-
-      let spawned: ChildProcess.StandardCommand | undefined;
-      let didUnref = false;
-      const spawnerLayer = Layer.succeed(
-        ChildProcessSpawner.ChildProcessSpawner,
-        ChildProcessSpawner.make((command) =>
-          Effect.sync(() => {
-            assert.equal(ChildProcess.isStandardCommand(command), true);
-            if (!ChildProcess.isStandardCommand(command)) {
-              throw new Error("Expected a standard command");
-            }
-            spawned = command;
-            return makeDetachedHandle(() => {
-              didUnref = true;
-            });
-          }),
-        ),
-      );
+      const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-no-zed-" });
       const previousPath = process.env.PATH;
       process.env.PATH = binDir;
 
-      yield* Effect.gen(function* () {
+      const error = yield* Effect.gen(function* () {
         const launcher = yield* DesktopZedLauncher.DesktopZedLauncher;
-        yield* launcher.openRemoteWorkspace({
+        return yield* launcher.openRemoteWorkspace({
           target: {
             alias: "devbox",
             hostname: "devbox.example.com",
@@ -99,23 +170,17 @@ describe("DesktopZedLauncher", () => {
           path: "/srv/project",
         });
       }).pipe(
+        Effect.flip,
         Effect.ensuring(
           Effect.sync(() => {
             process.env.PATH = previousPath;
           }),
         ),
-        Effect.provide(
-          DesktopZedLauncher.layer.pipe(
-            Layer.provide(Layer.merge(NodeServices.layer, spawnerLayer)),
-          ),
-        ),
+        Effect.provide(DesktopZedLauncher.layer.pipe(Layer.provide(NodeServices.layer))),
       );
 
-      assert.ok(spawned);
-      assert.equal(spawned.command, "zed");
-      assert.deepEqual(spawned.args, ["-r", "ssh://devbox/srv/project"]);
-      assert.equal(spawned.options.detached, true);
-      assert.equal(didUnref, true);
+      assert.equal(error._tag, "DesktopZedCommandNotFoundError");
+      assert.equal(error.message, "Zed CLI not found.");
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/desktop/src/shell/DesktopZedLauncher.ts
+++ b/apps/desktop/src/shell/DesktopZedLauncher.ts
@@ -1,0 +1,128 @@
+import {
+  type DesktopOpenRemoteZedInput,
+  type DesktopSshEnvironmentTarget,
+} from "@t3tools/contracts";
+import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+const ZED_COMMANDS = ["zed", "zeditor"] as const;
+
+export class DesktopZedCommandNotFoundError extends Schema.TaggedErrorClass<DesktopZedCommandNotFoundError>()(
+  "DesktopZedCommandNotFoundError",
+  {},
+) {
+  override get message(): string {
+    return "Zed CLI not found.";
+  }
+}
+
+export class DesktopZedLaunchError extends Schema.TaggedErrorClass<DesktopZedLaunchError>()(
+  "DesktopZedLaunchError",
+  {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to open remote workspace in Zed with '${[this.command, ...this.args].join(" ")}'.`;
+  }
+}
+
+function remoteAuthority(target: DesktopSshEnvironmentTarget): string {
+  const alias = target.alias.trim();
+  if (alias.length > 0) {
+    return alias;
+  }
+
+  const username = target.username?.trim();
+  const hostname = target.hostname.trim();
+  const port = target.port === null ? "" : `:${target.port}`;
+  return `${username ? `${username}@` : ""}${hostname}${port}`;
+}
+
+function remoteUriPath(path: string): string {
+  const normalized = path === "~" ? "/~" : path.startsWith("~/") ? `/~/${path.slice(2)}` : path;
+  const absolute = normalized.startsWith("/") ? normalized : `/${normalized}`;
+  return absolute
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+export function remoteZedSshUri(input: DesktopOpenRemoteZedInput): string {
+  return `ssh://${remoteAuthority(input.target)}${remoteUriPath(input.path)}`;
+}
+
+export class DesktopZedLauncher extends Context.Service<
+  DesktopZedLauncher,
+  {
+    readonly openRemoteWorkspace: (
+      input: DesktopOpenRemoteZedInput,
+    ) => Effect.Effect<void, DesktopZedCommandNotFoundError | DesktopZedLaunchError>;
+  }
+>()("@t3tools/desktop/shell/DesktopZedLauncher") {}
+
+export const make = Effect.gen(function* () {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const openRemoteWorkspace = Effect.fn("desktop.zed.openRemoteWorkspace")(function* (
+    input: DesktopOpenRemoteZedInput,
+  ) {
+    let command = Option.none<string>();
+    for (const candidate of ZED_COMMANDS) {
+      if (
+        yield* isCommandAvailable(candidate).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+          Effect.provideService(Path.Path, path),
+        )
+      ) {
+        command = Option.some(candidate);
+        break;
+      }
+    }
+    if (Option.isNone(command)) {
+      return yield* new DesktopZedCommandNotFoundError();
+    }
+
+    const args = ["-r", remoteZedSshUri(input)];
+    const resolved = yield* resolveSpawnCommand(command.value, args).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+    );
+    const process = ChildProcess.make(resolved.command, resolved.args, {
+      detached: true,
+      shell: resolved.shell,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    yield* spawner.spawn(process).pipe(
+      Effect.flatMap((handle) => handle.unref),
+      Effect.asVoid,
+      Effect.scoped,
+      Effect.mapError(
+        (cause) =>
+          new DesktopZedLaunchError({
+            command: resolved.command,
+            args: resolved.args,
+            cause,
+          }),
+      ),
+    );
+  });
+
+  return DesktopZedLauncher.of({ openRemoteWorkspace });
+});
+
+export const layer = Layer.effect(DesktopZedLauncher, make);

--- a/apps/desktop/src/shell/DesktopZedLauncher.ts
+++ b/apps/desktop/src/shell/DesktopZedLauncher.ts
@@ -38,15 +38,10 @@ export class DesktopZedLaunchError extends Schema.TaggedErrorClass<DesktopZedLau
 }
 
 function remoteAuthority(target: DesktopSshEnvironmentTarget): string {
-  const alias = target.alias.trim();
-  if (alias.length > 0) {
-    return alias;
-  }
-
+  const host = target.alias.trim() || target.hostname.trim();
   const username = target.username?.trim();
-  const hostname = target.hostname.trim();
   const port = target.port === null ? "" : `:${target.port}`;
-  return `${username ? `${username}@` : ""}${hostname}${port}`;
+  return `${username ? `${username}@` : ""}${host}${port}`;
 }
 
 function remoteUriPath(path: string): string {

--- a/apps/desktop/src/shell/DesktopZedLauncher.ts
+++ b/apps/desktop/src/shell/DesktopZedLauncher.ts
@@ -27,18 +27,18 @@ export class DesktopZedCommandNotFoundError extends Schema.TaggedErrorClass<Desk
 export class DesktopZedLaunchError extends Schema.TaggedErrorClass<DesktopZedLaunchError>()(
   "DesktopZedLaunchError",
   {
-    command: Schema.String,
-    args: Schema.Array(Schema.String),
+    argumentCount: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to open remote workspace in Zed with '${[this.command, ...this.args].join(" ")}'.`;
+    return "Failed to open remote workspace in Zed.";
   }
 }
 
 function remoteAuthority(target: DesktopSshEnvironmentTarget): string {
-  const host = target.alias.trim() || target.hostname.trim();
+  const rawHost = target.alias.trim() || target.hostname.trim();
+  const host = rawHost.includes(":") && !rawHost.startsWith("[") ? `[${rawHost}]` : rawHost;
   const username = target.username?.trim();
   const port = target.port === null ? "" : `:${target.port}`;
   return `${username ? `${username}@` : ""}${host}${port}`;
@@ -109,8 +109,7 @@ export const make = Effect.gen(function* () {
       Effect.mapError(
         (cause) =>
           new DesktopZedLaunchError({
-            command: resolved.command,
-            args: resolved.args,
+            argumentCount: resolved.args.length,
             cause,
           }),
       ),

--- a/apps/web/src/components/chat/ChatHeader.test.ts
+++ b/apps/web/src/components/chat/ChatHeader.test.ts
@@ -36,6 +36,28 @@ describe("shouldShowOpenInPicker", () => {
     ).toBe(false);
   });
 
+  it("shows the picker for SSH environments with local Zed launch support", () => {
+    expect(
+      shouldShowOpenInPicker({
+        activeProjectName: "codething-mvp",
+        activeThreadEnvironmentId: EnvironmentId.make("environment-remote"),
+        primaryEnvironmentId,
+        remoteZedAvailable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the picker for SSH environments without local Zed launch support", () => {
+    expect(
+      shouldShowOpenInPicker({
+        activeProjectName: "codething-mvp",
+        activeThreadEnvironmentId: EnvironmentId.make("environment-remote"),
+        primaryEnvironmentId,
+        remoteZedAvailable: false,
+      }),
+    ).toBe(false);
+  });
+
   it("hides the picker when there is no active project", () => {
     expect(
       shouldShowOpenInPicker({

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -6,6 +6,7 @@ import {
   type ThreadId,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import * as Option from "effect/Option";
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
@@ -15,7 +16,7 @@ import ProjectScriptsControl, {
   type ProjectScriptActionResult,
 } from "../ProjectScriptsControl";
 import { OpenInPicker } from "./OpenInPicker";
-import { usePrimaryEnvironmentId } from "../../state/environments";
+import { useEnvironment, usePrimaryEnvironmentId } from "../../state/environments";
 import { useT3ProjectFileScripts } from "~/hooks/useT3ProjectFileScripts";
 import { ProjectFavicon } from "../ProjectFavicon";
 import { cn } from "~/lib/utils";
@@ -48,11 +49,13 @@ export function shouldShowOpenInPicker(input: {
   readonly activeProjectName: string | undefined;
   readonly activeThreadEnvironmentId: EnvironmentId;
   readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly remoteZedAvailable?: boolean;
 }): boolean {
   return (
     Boolean(input.activeProjectName) &&
-    input.primaryEnvironmentId !== null &&
-    input.activeThreadEnvironmentId === input.primaryEnvironmentId
+    ((input.primaryEnvironmentId !== null &&
+      input.activeThreadEnvironmentId === input.primaryEnvironmentId) ||
+      input.remoteZedAvailable === true)
   );
 }
 
@@ -81,11 +84,21 @@ export const ChatHeader = memo(function ChatHeader({
     activeThreadEnvironmentId,
     activeProjectScripts ? activeProjectCwd : null,
   );
+  const activeEnvironment = useEnvironment(activeThreadEnvironmentId);
+  const sshProfile =
+    activeEnvironment &&
+    Option.isSome(activeEnvironment.entry.profile) &&
+    activeEnvironment.entry.profile.value._tag === "SshConnectionProfile"
+      ? activeEnvironment.entry.profile.value
+      : null;
+  const remoteZedAvailable = sshProfile !== null && window.desktopBridge !== undefined;
   const showOpenInPicker = shouldShowOpenInPicker({
     activeProjectName,
     activeThreadEnvironmentId,
     primaryEnvironmentId,
+    remoteZedAvailable,
   });
+  const openInEditors = sshProfile ? (["zed"] as const) : availableEditors;
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
@@ -156,8 +169,9 @@ export const ChatHeader = memo(function ChatHeader({
           <OpenInPicker
             environmentId={activeThreadEnvironmentId}
             keybindings={keybindings}
-            availableEditors={availableEditors}
+            availableEditors={openInEditors}
             openInCwd={openInCwd}
+            {...(sshProfile ? { remoteZedTarget: sshProfile.target } : {})}
           />
         )}
         {activeProjectName && (

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -1,4 +1,9 @@
-import { EditorId, type EnvironmentId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import {
+  EditorId,
+  type DesktopSshEnvironmentTarget,
+  type EnvironmentId,
+  type ResolvedKeybindingsConfig,
+} from "@t3tools/contracts";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
 import { usePreferredEditor } from "../../editorPreferences";
@@ -6,6 +11,7 @@ import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Group, GroupSeparator } from "../ui/group";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu";
+import { toastManager } from "../ui/toast";
 import {
   AntigravityIcon,
   CursorIcon,
@@ -188,6 +194,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   keybindings,
   availableEditors,
   openInCwd,
+  remoteZedTarget,
   compact = false,
   enableShortcut = true,
 }: {
@@ -195,6 +202,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
   openInCwd: string | null;
+  remoteZedTarget?: DesktopSshEnvironmentTarget;
   compact?: boolean;
   enableShortcut?: boolean;
 }) {
@@ -211,6 +219,23 @@ export const OpenInPicker = memo(function OpenInPicker({
       if (!openInCwd) return;
       const editor = editorId ?? preferredEditor;
       if (!editor) return;
+      if (remoteZedTarget) {
+        if (editor !== "zed" || !window.desktopBridge) return;
+        const result = window.desktopBridge
+          .openRemoteZed({
+            target: remoteZedTarget,
+            path: openInCwd,
+          })
+          .catch((error: unknown) => {
+            toastManager.add({
+              type: "error",
+              title: "Unable to open remote workspace in Zed",
+              description: error instanceof Error ? error.message : "Zed launch failed.",
+            });
+          });
+        setPreferredEditor(editor);
+        return result;
+      }
       const result = openInEditorMutation({
         environmentId,
         input: {
@@ -221,7 +246,14 @@ export const OpenInPicker = memo(function OpenInPicker({
       setPreferredEditor(editor);
       return result;
     },
-    [environmentId, openInCwd, openInEditorMutation, preferredEditor, setPreferredEditor],
+    [
+      environmentId,
+      openInCwd,
+      openInEditorMutation,
+      preferredEditor,
+      remoteZedTarget,
+      setPreferredEditor,
+    ],
   );
 
   const openFavoriteEditorShortcutLabel = useMemo(
@@ -237,24 +269,11 @@ export const OpenInPicker = memo(function OpenInPicker({
       if (!preferredEditor) return;
 
       e.preventDefault();
-      void openInEditorMutation({
-        environmentId,
-        input: {
-          cwd: openInCwd,
-          editor: preferredEditor,
-        },
-      });
+      void openInEditor(preferredEditor);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [
-    enableShortcut,
-    environmentId,
-    keybindings,
-    openInCwd,
-    openInEditorMutation,
-    preferredEditor,
-  ]);
+  }, [enableShortcut, keybindings, openInCwd, openInEditor, preferredEditor]);
 
   return (
     <Group aria-label="Open in editor">

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -292,6 +292,12 @@ export const DesktopSshEnvironmentTargetSchema = Schema.Struct({
 });
 export type DesktopSshEnvironmentTarget = typeof DesktopSshEnvironmentTargetSchema.Type;
 
+export const DesktopOpenRemoteZedInputSchema = Schema.Struct({
+  target: DesktopSshEnvironmentTargetSchema,
+  path: Schema.String.check(Schema.isTrimmed()).check(Schema.isNonEmpty()),
+});
+export type DesktopOpenRemoteZedInput = typeof DesktopOpenRemoteZedInputSchema.Type;
+
 export type DesktopSshHostSource = "ssh-config" | "known-hosts";
 export const DesktopSshHostSourceSchema = Schema.Literals(["ssh-config", "known-hosts"]);
 
@@ -1006,6 +1012,7 @@ export interface DesktopBridge {
     items: readonly ContextMenuItem<T>[],
     position?: { x: number; y: number },
   ) => Promise<T | null>;
+  openRemoteZed: (input: DesktopOpenRemoteZedInput) => Promise<void>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getWindowFullscreenState: () => boolean;


### PR DESCRIPTION
Fixes #4361

## What Changed

- Show the Open control for SSH-backed threads in the desktop app, limited to Zed.
- Launch the local `zed` or `zeditor` CLI through desktop IPC with an encoded SSH workspace URI.
- Preserve SSH aliases, usernames, custom ports, IPv6 literals, and home-relative paths.
- Route Ctrl+O through the same remote launch path and show a toast when launch fails.
- Keep launch errors free of SSH connection details.
- Add focused coverage for URI construction, IPv6, command preference, `zeditor` fallback, detached launching, missing CLI behavior, and picker visibility.

## Why

The existing Open action runs in the environment that owns the worktree. For an SSH-backed thread, that environment is remote and cannot launch the user's local graphical editor.

Zed supports opening a remote project from its local CLI through an SSH URL. Launching Zed from the desktop process extends the existing Open and Ctrl+O workflow without changing server-side editor launching.

## UI Changes

### Before

<!-- Add the screenshot showing the missing Open control on an SSH-backed thread. -->

### After

<img width="561" height="719" alt="Open control available for an SSH-backed worktree" src="https://github.com/user-attachments/assets/5283a425-9ff5-4d46-8c3f-477d317082a6" />

### Interaction

https://github.com/user-attachments/assets/7be8f765-4a81-4b20-969d-67b8bc211813

## Validation

- `vp test run apps/desktop/src/shell/DesktopZedLauncher.test.ts apps/web/src/components/chat/ChatHeader.test.ts`
- `vp run --filter @t3tools/desktop typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/contracts typecheck`
- Targeted formatting and lint checks for changed files
- Manually verified against an SSH-backed worktree with local Zed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a bounded desktop-only path that spawns a local Zed CLI with SSH targets from IPC; no auth or server changes, and user-facing launch errors stay generic.
> 
> **Overview**
> Adds **Open in Zed** for SSH-backed projects in the desktop app when the thread has an active project cwd and `desktopBridge` is available.
> 
> A new **`DesktopZedLauncher`** resolves `zed` / `zeditor` on PATH, builds an encoded `ssh://` URI from the SSH connection target and workspace path, and spawns a detached `zed -r …` process. Launch failures surface generic messages (no SSH details in the launch error path).
> 
> The feature is wired through **`openRemoteZed`** on the desktop IPC bridge (`DesktopOpenRemoteZedInput` in contracts). **`ChatHeader`** extends **`shouldShowOpenInPicker`** so the picker appears on SSH environments (not only the primary local env) and limits editor choices to Zed when an SSH profile is active. **`OpenInPicker`** routes those opens to `desktopBridge.openRemoteZed` instead of the usual shell `openInEditor` mutation, with error toasts on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b3f5cca3f23c0fab5238797ad006ac5db4a036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Open in Zed' support for SSH worktrees via local Zed CLI
> - Adds a `DesktopZedLauncher` service that searches PATH for `zed` or `zeditor`, builds an `ssh://` URI from the active SSH environment, and spawns the CLI in detached mode to open the remote workspace.
> - Exposes the launcher via a new `openRemoteZed` IPC channel, bridged to the renderer as `window.desktopBridge.openRemoteZed(input)`.
> - Updates `ChatHeader` to detect SSH environments in desktop context and restrict the 'Open in' picker to Zed, routing clicks through the desktop bridge instead of the local editor flow.
> - `OpenInPicker` handles the `remoteZedTarget` prop by calling the bridge and showing an error toast on failure.
> - Risk: if neither `zed` nor `zeditor` is on PATH, the operation fails with `DesktopZedCommandNotFoundError` and surfaces an error toast to the user.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50b3f5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->