### PR TITLE
feat(web): share project actions via t3.json

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -15,6 +15,7 @@ import {
   type ThreadId,
   type TurnId,
   type KeybindingCommand,
+  T3_PROJECT_FILE_NAME,
   OrchestrationThreadActivity,
   ProviderInteractionMode,
   ProviderDriverKind,
@@ -144,6 +145,8 @@ import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
+import { getProjectFileQueryData, setProjectFileQueryData } from "./files/projectFilesQueryState";
+import { upsertT3ProjectFileScript } from "~/t3ProjectFileScripts";
 import {
   buildProjectScript,
   commandForProjectScript,
@@ -1106,6 +1109,9 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
+  const writeProjectFile = useAtomCommand(projectEnvironment.writeFile, {
+    reportFailure: false,
+  });
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
     reportFailure: false,
   });
@@ -2799,6 +2805,36 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [environmentId, updateProject, upsertKeybinding],
   );
+  const shareProjectScript = useCallback(
+    async (input: {
+      readonly script: ProjectScript;
+      readonly previousScript?: ProjectScript;
+    }): Promise<void> => {
+      if (!activeProject) return;
+      const cwd = activeProject.workspaceRoot;
+      const existingContents =
+        getProjectFileQueryData(activeProject.environmentId, cwd, T3_PROJECT_FILE_NAME)?.contents ??
+        null;
+      const contents = upsertT3ProjectFileScript({
+        contents: existingContents,
+        script: input.script,
+        ...(input.previousScript ? { previousScript: input.previousScript } : {}),
+      });
+      const result = await writeProjectFile({
+        environmentId: activeProject.environmentId,
+        input: {
+          cwd,
+          relativePath: T3_PROJECT_FILE_NAME,
+          contents,
+        },
+      });
+      if (result._tag === "Failure") {
+        throw squashAtomCommandFailure(result);
+      }
+      setProjectFileQueryData(activeProject.environmentId, cwd, T3_PROJECT_FILE_NAME, contents);
+    },
+    [activeProject, writeProjectFile],
+  );
   const saveProjectScript = useCallback(
     async (input: NewProjectScriptInput): Promise<AtomCommandResult<void, unknown>> => {
       if (!activeProject) {
@@ -2818,7 +2854,7 @@ function ChatViewContent(props: ChatViewProps) {
           ]
         : [...activeProject.scripts, nextScript];
 
-      return persistProjectScripts({
+      const result = await persistProjectScripts({
         projectId: activeProject.id,
         projectCwd: activeProject.workspaceRoot,
         previousScripts: activeProject.scripts,
@@ -2826,8 +2862,22 @@ function ChatViewContent(props: ChatViewProps) {
         keybinding: input.keybinding,
         keybindingCommand: commandForProjectScript(nextId),
       });
+      if (result._tag === "Success" && input.shareWithProject) {
+        try {
+          await shareProjectScript({ script: nextScript });
+        } catch (error) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Action saved, but could not be shared",
+              description: error instanceof Error ? error.message : "Could not update t3.json.",
+            }),
+          );
+        }
+      }
+      return result;
     },
-    [activeProject, persistProjectScripts],
+    [activeProject, persistProjectScripts, shareProjectScript],
   );
   const updateProjectScript = useCallback(
     async (
@@ -2851,7 +2901,7 @@ function ChatViewContent(props: ChatViewProps) {
             : script,
       );
 
-      return persistProjectScripts({
+      const result = await persistProjectScripts({
         projectId: activeProject.id,
         projectCwd: activeProject.workspaceRoot,
         previousScripts: activeProject.scripts,
@@ -2859,8 +2909,25 @@ function ChatViewContent(props: ChatViewProps) {
         keybinding: input.keybinding,
         keybindingCommand: commandForProjectScript(scriptId),
       });
+      if (result._tag === "Success" && input.shareWithProject) {
+        try {
+          await shareProjectScript({
+            script: updatedScript,
+            previousScript: existingScript,
+          });
+        } catch (error) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Action saved, but could not be shared",
+              description: error instanceof Error ? error.message : "Could not update t3.json.",
+            }),
+          );
+        }
+      }
+      return result;
     },
-    [activeProject, persistProjectScripts],
+    [activeProject, persistProjectScripts, shareProjectScript],
   );
   const deleteProjectScript = useCallback(
     async (scriptId: string): Promise<AtomCommandResult<void, unknown>> => {

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -100,6 +100,8 @@ export interface NewProjectScriptInput {
   command: string;
   icon: ProjectScriptIcon;
   runOnWorktreeCreate: boolean;
+  /** When true, also add this action to the repository's checked-in t3.json. */
+  shareWithProject: boolean;
   keybinding: string | null;
   /** Optional URL to open in the in-app preview when this script runs. */
   previewUrl: string | null;
@@ -144,6 +146,7 @@ export default function ProjectScriptsControl({
   const [icon, setIcon] = useState<ProjectScriptIcon>("play");
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [runOnWorktreeCreate, setRunOnWorktreeCreate] = useState(false);
+  const [shareWithProject, setShareWithProject] = useState(false);
   const [keybinding, setKeybinding] = useState("");
   const [previewUrl, setPreviewUrl] = useState("");
   const [autoOpenPreview, setAutoOpenPreview] = useState(false);
@@ -217,6 +220,7 @@ export default function ProjectScriptsControl({
         command: trimmedCommand,
         icon,
         runOnWorktreeCreate,
+        shareWithProject,
         keybinding: keybindingRule?.key ?? null,
         previewUrl: trimmedPreviewUrl.length > 0 ? trimmedPreviewUrl : null,
         autoOpenPreview: trimmedPreviewUrl.length > 0 ? autoOpenPreview : false,
@@ -247,6 +251,7 @@ export default function ProjectScriptsControl({
     setIcon("play");
     setIconPickerOpen(false);
     setRunOnWorktreeCreate(false);
+    setShareWithProject(false);
     setKeybinding("");
     setPreviewUrl("");
     setAutoOpenPreview(false);
@@ -261,6 +266,7 @@ export default function ProjectScriptsControl({
     setIcon(script.icon);
     setIconPickerOpen(false);
     setRunOnWorktreeCreate(script.runOnWorktreeCreate);
+    setShareWithProject(false);
     setKeybinding(keybindingValueForCommand(keybindings, commandForProjectScript(script.id)) ?? "");
     setPreviewUrl(script.previewUrl ?? "");
     setAutoOpenPreview(script.autoOpenPreview ?? false);
@@ -281,6 +287,7 @@ export default function ProjectScriptsControl({
       command: fileScript.command,
       icon: fileScript.icon ?? "play",
       runOnWorktreeCreate: fileScript.runOnWorktreeCreate ?? false,
+      shareWithProject: false,
       keybinding: null,
       previewUrl: fileScript.previewUrl ?? null,
       autoOpenPreview: fileScript.previewUrl ? (fileScript.autoOpenPreview ?? false) : false,
@@ -296,6 +303,7 @@ export default function ProjectScriptsControl({
       setIcon(payload.icon);
       setIconPickerOpen(false);
       setRunOnWorktreeCreate(payload.runOnWorktreeCreate);
+      setShareWithProject(false);
       setKeybinding("");
       setPreviewUrl(payload.previewUrl ?? "");
       setAutoOpenPreview(payload.autoOpenPreview);
@@ -454,6 +462,7 @@ export default function ProjectScriptsControl({
           setCommand("");
           setIcon("play");
           setRunOnWorktreeCreate(false);
+          setShareWithProject(false);
           setKeybinding("");
           setPreviewUrl("");
           setAutoOpenPreview(false);
@@ -560,6 +569,18 @@ export default function ProjectScriptsControl({
                 <Switch
                   checked={runOnWorktreeCreate}
                   onCheckedChange={(checked) => setRunOnWorktreeCreate(Boolean(checked))}
+                />
+              </label>
+              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2 text-sm dark:border-transparent dark:bg-white/[0.035]">
+                <span className="flex flex-col gap-0.5">
+                  <span>Share with everyone on this project</span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    Adds this action to the repository&apos;s t3.json file.
+                  </span>
+                </span>
+                <Switch
+                  checked={shareWithProject}
+                  onCheckedChange={(checked) => setShareWithProject(Boolean(checked))}
                 />
               </label>
               <label

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -68,6 +68,17 @@ export function getOptimisticProjectFileQueryData(
   return appAtomRegistry.get(optimisticFileAtom(environmentId, cwd, relativePath))?.data ?? null;
 }
 
+export function getProjectFileQueryData(
+  environmentId: EnvironmentId,
+  cwd: string,
+  relativePath: string,
+): ProjectReadFileResult | null {
+  const optimistic = getOptimisticProjectFileQueryData(environmentId, cwd, relativePath);
+  if (optimistic !== null) return optimistic;
+  const result = appAtomRegistry.get(getProjectFileQueryAtom(environmentId, cwd, relativePath));
+  return Option.getOrNull(AsyncResult.value(result));
+}
+
 export function confirmProjectFileQueryData(
   environmentId: EnvironmentId,
   cwd: string,

--- a/apps/web/src/t3ProjectFileScripts.test.ts
+++ b/apps/web/src/t3ProjectFileScripts.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { upsertT3ProjectFileScript } from "./t3ProjectFileScripts";
+
+const script = {
+  id: "script-test",
+  name: "Test",
+  command: "vp test",
+  icon: "test" as const,
+  runOnWorktreeCreate: false,
+  autoOpenPreview: false,
+};
+
+describe("upsertT3ProjectFileScript", () => {
+  it("creates a project file for the first shared action", () => {
+    const result = JSON.parse(
+      upsertT3ProjectFileScript({
+        contents: null,
+        script,
+      }),
+    );
+
+    expect(result).toEqual({
+      $schema: "https://t3.codes/schema/t3.json",
+      scripts: [
+        {
+          name: "Test",
+          command: "vp test",
+          icon: "test",
+          runOnWorktreeCreate: false,
+        },
+      ],
+    });
+  });
+
+  it("appends an action while preserving existing project settings", () => {
+    const result = JSON.parse(
+      upsertT3ProjectFileScript({
+        contents: JSON.stringify({
+          $schema: "https://t3.codes/schema/t3.json",
+          iconPath: "assets/logo.svg",
+          futureSetting: { enabled: true },
+          scripts: [{ name: "Dev", command: "vp dev" }],
+        }),
+        script,
+      }),
+    );
+
+    expect(result.iconPath).toBe("assets/logo.svg");
+    expect(result.futureSetting).toEqual({ enabled: true });
+    expect(result.scripts).toEqual([
+      { name: "Dev", command: "vp dev" },
+      {
+        name: "Test",
+        command: "vp test",
+        icon: "test",
+        runOnWorktreeCreate: false,
+      },
+    ]);
+  });
+
+  it("updates an edited shared action instead of duplicating it", () => {
+    const previousScript = { ...script, name: "Checks", command: "vp check" };
+    const result = JSON.parse(
+      upsertT3ProjectFileScript({
+        contents: JSON.stringify({
+          scripts: [{ name: "Checks", command: "vp check" }],
+        }),
+        previousScript,
+        script,
+      }),
+    );
+
+    expect(result.scripts).toHaveLength(1);
+    expect(result.scripts[0]).toMatchObject({ name: "Test", command: "vp test" });
+  });
+
+  it("rejects an invalid existing project file", () => {
+    expect(() =>
+      upsertT3ProjectFileScript({
+        contents: "{ invalid",
+        script,
+      }),
+    ).toThrow("t3.json is invalid");
+  });
+
+  it("does not exceed the shared action limit", () => {
+    expect(() =>
+      upsertT3ProjectFileScript({
+        contents: JSON.stringify({
+          scripts: Array.from({ length: 50 }, (_, index) => ({
+            name: `Action ${index}`,
+            command: `echo ${index}`,
+          })),
+        }),
+        script,
+      }),
+    ).toThrow("maximum of 50 shared actions");
+  });
+});

--- a/apps/web/src/t3ProjectFileScripts.ts
+++ b/apps/web/src/t3ProjectFileScripts.ts
@@ -1,0 +1,94 @@
+import {
+  T3_PROJECT_FILE_SCHEMA_URL,
+  type ProjectScript,
+  type T3ProjectFile,
+  type T3ProjectFileScript,
+} from "@t3tools/contracts";
+import { fromLenientJson } from "@t3tools/shared/schemaJson";
+import { T3ProjectFileFromJson } from "@t3tools/shared/t3ProjectFile";
+import * as Schema from "effect/Schema";
+
+const decodeT3ProjectFile = Schema.decodeUnknownSync(T3ProjectFileFromJson);
+const decodeLenientJson = Schema.decodeUnknownSync(fromLenientJson(Schema.Unknown));
+const MAX_PROJECT_FILE_SCRIPTS = 50;
+
+function isSameScript(
+  fileScript: T3ProjectFileScript,
+  script: Pick<ProjectScript, "name" | "command">,
+): boolean {
+  return (
+    fileScript.command === script.command ||
+    fileScript.name.toLowerCase() === script.name.toLowerCase()
+  );
+}
+
+export function projectFileScriptFromProjectScript(script: ProjectScript): T3ProjectFileScript {
+  return {
+    name: script.name,
+    command: script.command,
+    icon: script.icon,
+    runOnWorktreeCreate: script.runOnWorktreeCreate,
+    ...(script.previewUrl ? { previewUrl: script.previewUrl } : {}),
+    ...(script.previewUrl ? { autoOpenPreview: script.autoOpenPreview ?? false } : {}),
+  };
+}
+
+/**
+ * Adds or updates an action in a checked-in t3.json document.
+ *
+ * An edited action is matched against its previous values first. Matching the
+ * next name or command as a fallback keeps repeated share attempts idempotent.
+ */
+export function upsertT3ProjectFileScript(input: {
+  readonly contents: string | null;
+  readonly script: ProjectScript;
+  readonly previousScript?: ProjectScript;
+}): string {
+  let projectFile: T3ProjectFile;
+  let rawProjectFile: Record<string, unknown>;
+  try {
+    if (input.contents === null) {
+      projectFile = { $schema: T3_PROJECT_FILE_SCHEMA_URL };
+      rawProjectFile = {};
+    } else {
+      projectFile = decodeT3ProjectFile(input.contents);
+      const raw = decodeLenientJson(input.contents);
+      rawProjectFile =
+        typeof raw === "object" && raw !== null && !Array.isArray(raw)
+          ? (raw as Record<string, unknown>)
+          : {};
+    }
+  } catch {
+    throw new Error("t3.json is invalid. Fix the file before sharing this action.");
+  }
+
+  const nextFileScript = projectFileScriptFromProjectScript(input.script);
+  const decodedScripts = projectFile.scripts ?? [];
+  const existingIndex = decodedScripts.findIndex(
+    (fileScript) =>
+      (input.previousScript !== undefined && isSameScript(fileScript, input.previousScript)) ||
+      isSameScript(fileScript, input.script),
+  );
+  if (existingIndex === -1 && decodedScripts.length >= MAX_PROJECT_FILE_SCRIPTS) {
+    throw new Error("t3.json already contains the maximum of 50 shared actions.");
+  }
+
+  const scripts = Array.isArray(rawProjectFile.scripts)
+    ? [...rawProjectFile.scripts]
+    : [...decodedScripts];
+  if (existingIndex === -1) {
+    scripts.push(nextFileScript);
+  } else {
+    scripts[existingIndex] = nextFileScript;
+  }
+
+  return `${JSON.stringify(
+    {
+      ...rawProjectFile,
+      $schema: projectFile.$schema ?? T3_PROJECT_FILE_SCHEMA_URL,
+      scripts,
+    },
+    null,
+    2,
+  )}\n`;
+}


### PR DESCRIPTION
## What Changed

- add an off-by-default “Share with everyone on this project” switch to the add/edit action dialog
- create `t3.json` with the published schema when the first action is shared
- merge new or edited actions into an existing `t3.json` without duplicating matching actions or dropping unrelated project settings
- keep personal keybindings local and show a non-blocking error toast if the local action saves but `t3.json` cannot be updated
- cover create, append, edit, invalid-file, forward-compatible-field, and script-limit behavior with focused tests

## Why

`t3.json` already lets teammates import repository-defined actions, but sharing a newly configured action currently requires manually editing JSON. This keeps personal actions local by default while making the existing checked-in sharing workflow available directly from the action form.

This builds on #4317.

## UI Changes

**Before:** Actions created in the dialog were stored only in the local project configuration; sharing required a manual `t3.json` edit.

**After:** The same dialog includes an off-by-default sharing switch with explanatory copy. Enabling it writes the saved action to the repository's `t3.json`.

The requester manually verified the complete add-and-share flow in the live development app.

## Verification

- `pnpm --filter @t3tools/web typecheck`
- `pnpm exec vp lint apps/web/src/components/ChatView.tsx apps/web/src/components/ProjectScriptsControl.tsx apps/web/src/components/files/projectFilesQueryState.ts apps/web/src/t3ProjectFileScripts.ts apps/web/src/t3ProjectFileScripts.test.ts`
- `pnpm exec vp test run apps/web/src/t3ProjectFileScripts.test.ts apps/web/src/components/files/projectFilesQueryState.test.ts` (6 tests)
- targeted formatting check for the five changed files
- integrated web flow manually verified by the requester

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] No animation or motion behavior was changed, so a video is not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in writes to version-controlled `t3.json` in the workspace; validation and partial-failure handling limit blast radius, but teammates can still pick up unintended shared actions if misused.
> 
> **Overview**
> Adds an **off-by-default “Share with everyone on this project”** switch to the add/edit action dialog so a saved action can be written into the repo’s checked-in `t3.json`, not only local project config.
> 
> After a successful local save, optional sharing reads current `t3.json` (via new `getProjectFileQueryData`), merges the action with **`upsertT3ProjectFileScript`** (create file, append, or update by name/command; keeps unrelated keys; 50-script cap; invalid JSON errors), then persists through **`writeProjectFile`**. Keybindings stay local. If sharing fails, the user gets a **non-blocking toast** (“Action saved, but could not be shared”).
> 
> Includes unit tests for the merge helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98df4fdde2794c31431b6a8697dd14007faf423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share project actions via t3.json when saving or updating scripts
> - Adds a "Share with everyone on this project" toggle to the add/edit action dialog in [`ProjectScriptsControl`](https://github.com/pingdotgg/t3code/pull/4363/files#diff-e891caffa18ba1b7506cceb8fe52ad48887e3161ef59bee56d37cd57b61c511b), exposing a new `shareWithProject` flag on `NewProjectScriptInput`.
> - When `shareWithProject` is true, [`ChatViewContent`](https://github.com/pingdotgg/t3code/pull/4363/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) writes or updates the action in the project's `t3.json` file after saving, using the new `upsertT3ProjectFileScript` utility in [`t3ProjectFileScripts.ts`](https://github.com/pingdotgg/t3code/pull/4363/files#diff-7a572fe58eb4085cbb2729d525474cc88802aa8bfa804c4206bd72f149c94759).
> - `upsertT3ProjectFileScript` preserves unrelated `t3.json` fields, matches existing entries by command or case-insensitive name, enforces a 50-script limit, and returns pretty-printed JSON.
> - On success, the in-memory query cache is updated via `setProjectFileQueryData`. If writing `t3.json` fails, the action still saves locally and an error toast is shown.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d98df4f. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->