### PR TITLE
fix: preserve unsaved keybindings

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import type {
+  KeybindingCommand,
+  ResolvedKeybindingRule,
+  ResolvedKeybindingsConfig,
+} from "@t3tools/contracts";
 
 import {
   buildKeybindingRows,
@@ -13,6 +17,20 @@ import {
   unknownWhenVariables,
   whenAstToExpression,
 } from "./KeybindingsSettings.logic";
+
+function resolvedKeybinding(command: KeybindingCommand, key: string): ResolvedKeybindingRule {
+  return {
+    command,
+    shortcut: {
+      key,
+      modKey: true,
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    },
+  };
+}
 
 describe("KeybindingsSettings.logic", () => {
   it("builds searchable rows with readable key and when values", () => {
@@ -197,6 +215,39 @@ describe("KeybindingsSettings.logic", () => {
     );
 
     expect(rows.map((row) => row.source)).toEqual(["Default", "Default"]);
+  });
+
+  it("keeps unaffected row ids stable when another binding is replaced and appended", () => {
+    const originalRows = buildKeybindingRows(
+      [
+        resolvedKeybinding("chat.new", "n"),
+        resolvedKeybinding("chat.newLocal", "l"),
+        resolvedKeybinding("terminal.toggle", "j"),
+      ],
+      "",
+    );
+    const refreshedRows = buildKeybindingRows(
+      [
+        resolvedKeybinding("chat.newLocal", "l"),
+        resolvedKeybinding("terminal.toggle", "j"),
+        resolvedKeybinding("chat.new", "k"),
+      ],
+      "",
+    );
+    const originalIds = new Map(originalRows.map((row) => [row.command, row.id]));
+    const refreshedIds = new Map(refreshedRows.map((row) => [row.command, row.id]));
+
+    expect(refreshedIds.get("chat.newLocal")).toBe(originalIds.get("chat.newLocal"));
+    expect(refreshedIds.get("terminal.toggle")).toBe(originalIds.get("terminal.toggle"));
+    expect(refreshedIds.get("chat.new")).not.toBe(originalIds.get("chat.new"));
+  });
+
+  it("assigns distinct row ids to exact duplicate bindings", () => {
+    const duplicate = resolvedKeybinding("terminal.toggle", "j");
+    const rows = buildKeybindingRows([duplicate, duplicate], "");
+
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.id)).size).toBe(2);
   });
 
   it("reports conflicting shortcuts that share an active when context", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -158,12 +158,16 @@ export function buildKeybindingRows(
   query: string,
 ): ReadonlyArray<KeybindingRow> {
   const normalizedQuery = query.trim().toLowerCase();
-  const rows = keybindings.map((binding, index) => {
+  const rowIdOccurrences = new Map<string, number>();
+  const rows = keybindings.map((binding) => {
     const defaultBinding = defaultBindingForBinding(binding);
     const key = shortcutToKeybindingInput(binding.shortcut);
     const when = whenAstToExpression(binding.whenAst);
+    const baseRowId = keybindingRowId(binding.command, key, when);
+    const rowIdOccurrence = rowIdOccurrences.get(baseRowId) ?? 0;
+    rowIdOccurrences.set(baseRowId, rowIdOccurrence + 1);
     return {
-      id: `${keybindingRowId(binding.command, key, when)}\u0000${index}`,
+      id: `${baseRowId}\u0000${rowIdOccurrence}`,
       command: binding.command,
       key,
       when,


### PR DESCRIPTION
Hey, I just downloaded T3 Code and found this nasty bug

if I change multiple keybindings without saving them, then save an earlier row first, all the unsaved changes below it are lost. Saving from the bottom upward happens to work, so the result incorrectly depends on the order in which the bindings are saved

This small PR fixes the issue, lmk if there is anything wrong with this PR, but should be a quick review

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix row id generation in `buildKeybindingRows` to preserve unsaved keybindings
> Previously, row ids were derived from a base id plus the array index, causing ids to shift when bindings were reordered or inserted. The function now tracks occurrences of each base id in a `Map` and appends an occurrence counter instead, making ids stable for unchanged bindings and distinct for exact duplicates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ba472e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->