### PR TITLE
[codex] Deduplicate connection failure messaging

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -22,7 +22,7 @@ import {
   TerminalOpenInput,
 } from "@t3tools/contracts";
 import {
-  connectionStatusText,
+  connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
 import {
@@ -1815,7 +1815,7 @@ function ChatViewContent(props: ChatViewProps) {
         id: `environment-unavailable:${activeEnvironmentUnavailableState.environmentId}`,
         variant: connection.phase === "error" ? "error" : "warning",
         icon: <WifiOffIcon />,
-        title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusText(connection)}`,
+        title: `${activeEnvironmentUnavailableState.label}: ${connectionStatusTitle(connection)}`,
         description:
           connection.error ??
           "Reconnect this environment before sending messages or running actions.",

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -18,10 +18,7 @@ import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
-import {
-  connectionStatusText,
-  type EnvironmentConnectionPresentation,
-} from "@t3tools/client-runtime/connection";
+import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
@@ -2577,15 +2574,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                         ? "Add feedback to refine the plan, or leave this blank to implement it"
                         : projectSelectionRequired
                           ? "Choose a project above to start a thread"
-                          : environmentUnavailable
-                            ? `${environmentUnavailable.label}: ${connectionStatusText(
-                                environmentUnavailable.connection,
-                              )}`
-                            : noProviderAvailable
-                              ? "Enable a provider in Settings to send a message"
-                              : phase === "disconnected"
-                                ? "Ask for follow-up changes or attach images"
-                                : "Ask anything, @tag files/folders, $use skills, or / for commands"
+                          : noProviderAvailable
+                            ? "Enable a provider in Settings to send a message"
+                            : phase === "disconnected"
+                              ? "Ask for follow-up changes or attach images"
+                              : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}
               />

--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -12,6 +12,7 @@ import {
   connectionCatalogDisplayUrl,
   connectionPhaseMessage,
   connectionStatusText,
+  connectionStatusTitle,
   presentEnvironmentConnection,
   presentConnectionState,
 } from "./presentation.ts";
@@ -123,13 +124,15 @@ describe("connection presentation", () => {
   });
 
   it("combines reconnect progress with the latest failure", () => {
-    expect(
-      connectionStatusText({
-        phase: "reconnecting",
-        error: "Relay request timed out.",
-        traceId: "trace-retry",
-      }),
-    ).toBe("Failed to connect. Reconnecting... Reason: Relay request timed out.");
+    const connection = {
+      phase: "reconnecting",
+      error: "Relay request timed out.",
+      traceId: "trace-retry",
+    } as const;
+    expect(connectionStatusText(connection)).toBe(
+      "Failed to connect. Reconnecting... Reason: Relay request timed out.",
+    );
+    expect(connectionStatusTitle(connection)).toBe("Failed to connect. Reconnecting...");
   });
 
   it("presents the supervisor's offline state without consulting shell state", () => {

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -76,6 +76,13 @@ export function connectionStatusText(connection: EnvironmentConnectionPresentati
   }
 }
 
+export function connectionStatusTitle(connection: EnvironmentConnectionPresentation): string {
+  if (connection.phase === "reconnecting" && connection.error) {
+    return "Failed to connect. Reconnecting...";
+  }
+  return connectionStatusText({ ...connection, error: null });
+}
+
 export function presentEnvironmentConnection(
   state: SupervisorConnectionState,
 ): EnvironmentConnectionPresentation {


### PR DESCRIPTION
Connection failures currently repeat the same supervisor error in the composer banner title, banner body, and disabled composer placeholder. This makes the failure state noisy and makes the actual reason harder to scan.

The banner title used `connectionStatusText`, which intentionally includes the latest low-level reason, while the banner description also rendered that reason. The composer independently reused the same combined status string as its placeholder.

This change adds a concise connection-status title presentation, keeps the underlying failure reason in the banner description, and leaves the normal composer placeholder unchanged while sending remains unavailable.

Verification:

- `vp lint --report-unused-disable-directives` on the changed files
- client-runtime and web typechecks
- focused connection presentation tests (8 passing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to connection messaging in the web UI; no changes to connection logic or send gating beyond placeholder copy.
> 
> **Overview**
> Connection failure copy was repeated in the composer banner title, banner body, and disabled composer placeholder. This PR adds **`connectionStatusTitle`** in client-runtime so titles stay short (e.g. reconnecting omits the `Reason: …` line that **`connectionStatusText`** still includes).
> 
> **`ChatView`** uses the new helper for the environment-unavailable banner title while the description still shows **`connection.error`**. **`ChatComposer`** no longer injects connection status into the textarea placeholder when the environment is down—it uses the usual placeholders instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221377f09444c6effca49f42f6dcba52402627b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate connection failure messaging in chat banner and composer
> - Introduces `connectionStatusTitle` in [presentation.ts](https://github.com/pingdotgg/t3code/pull/4367/files#diff-696aa7c2bcbe229bb02c6650bd93c240a3bf10020da226e64d7158f5dd4da6b3), which returns a concise title (e.g. `Failed to connect. Reconnecting...`) that suppresses error details, delegating to `connectionStatusText` with error forced to null otherwise.
> - Updates the system composer banner in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4367/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to use `connectionStatusTitle` instead of `connectionStatusText`, removing the redundant error reason from the banner title.
> - Removes the `environmentUnavailable` placeholder branch from [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/4367/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), so the composer no longer shows connection status text in the textarea placeholder when the environment is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 221377f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->