### PR TITLE
fix(cursor): reject desktop launcher forwarders

### DIFF
--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -524,6 +524,8 @@ describe("isCursorDesktopAgentForwarderScript", () => {
   it("recognizes shell wrappers that invoke the desktop CLI's agent argument", () => {
     expect(isCursorDesktopAgentForwarderScript("@echo off\r\ncursor agent %*\r\n")).toBe(true);
     expect(isCursorDesktopAgentForwarderScript('exec "/opt/Cursor/cursor" agent "$@"')).toBe(true);
+    expect(isCursorDesktopAgentForwarderScript('exec /usr/local/bin/cursor agent "$@"')).toBe(true);
+    expect(isCursorDesktopAgentForwarderScript("C:\\tools\\cursor.exe agent %*")).toBe(true);
     expect(isCursorDesktopAgentForwarderScript("cursor-agent about")).toBe(false);
     expect(isCursorDesktopAgentForwarderScript('# cursor agent "$@"')).toBe(false);
   });

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -4,11 +4,13 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
-import type * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { describe, expect, it } from "vite-plus/test";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import type { CursorSettings } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelCapabilities } from "@t3tools/shared/model";
 
 import {
@@ -18,6 +20,7 @@ import {
   discoverCursorModelsViaAcp,
   getCursorFallbackModels,
   getCursorParameterizedModelPickerUnsupportedMessage,
+  isCursorDesktopAgentForwarderScript,
   parseCursorAboutOutput,
   parseCursorCliConfigChannel,
   parseCursorVersionDate,
@@ -156,6 +159,27 @@ const makeExitLogFixture = Effect.fn("makeExitLogFixture")(function* (prefix: st
       T3_ACP_EXIT_LOG_PATH: exitLogPath,
     }),
   };
+});
+
+const makeCursorDesktopForwarder = Effect.fn("makeCursorDesktopForwarder")(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const platform = yield* HostProcessPlatform;
+  const path = yield* Path.Path;
+  const tempDir = yield* fileSystem.makeTempDirectory({
+    directory: NodeOS.tmpdir(),
+    prefix: "cursor-desktop-forwarder-",
+  });
+  const wrapperPath = path.join(
+    tempDir,
+    platform === "win32" ? "cursor-agent.cmd" : "cursor-agent",
+  );
+  const script =
+    platform === "win32"
+      ? "@echo off\r\ncursor agent %*\r\n"
+      : '#!/bin/sh\nexec cursor agent "$@"\n';
+  yield* fileSystem.writeFileString(wrapperPath, script);
+  yield* fileSystem.chmod(wrapperPath, 0o755);
+  return wrapperPath;
 });
 
 const parameterizedGpt54ConfigOptions = [
@@ -428,6 +452,28 @@ describe("buildCursorCapabilitiesFromConfigOptions", () => {
 });
 
 describe("checkCursorProviderStatus", () => {
+  it("rejects desktop forwarder shims without spawning them", async () => {
+    const wrapperPath = await runNode(makeCursorDesktopForwarder());
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.die("Cursor desktop forwarder must not be spawned"),
+    );
+    const provider = await runNode(
+      checkCursorProviderStatus({
+        enabled: true,
+        binaryPath: wrapperPath,
+        apiEndpoint: "",
+        customModels: [],
+      }).pipe(Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner))),
+    );
+
+    expect(provider).toMatchObject({
+      installed: false,
+      status: "error",
+      auth: { status: "unknown" },
+    });
+    expect(provider.message).toContain("forwards to the Cursor desktop launcher");
+  });
+
   it("reports the install docs when the Cursor CLI command is missing", async () => {
     const provider = await runNode(
       checkCursorProviderStatus({
@@ -471,6 +517,15 @@ describe("checkCursorProviderStatus", () => {
       "claude-opus-4-6",
     ]);
     await expect(runNode(waitForFileContent(requestLogPath))).resolves.toContain("initialize");
+  });
+});
+
+describe("isCursorDesktopAgentForwarderScript", () => {
+  it("recognizes shell wrappers that invoke the desktop CLI's agent argument", () => {
+    expect(isCursorDesktopAgentForwarderScript("@echo off\r\ncursor agent %*\r\n")).toBe(true);
+    expect(isCursorDesktopAgentForwarderScript('exec "/opt/Cursor/cursor" agent "$@"')).toBe(true);
+    expect(isCursorDesktopAgentForwarderScript("cursor-agent about")).toBe(false);
+    expect(isCursorDesktopAgentForwarderScript('# cursor agent "$@"')).toBe(false);
   });
 });
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -629,7 +629,7 @@ function buildCursorCliCommandMissingMessage(binaryPath: string): string {
 }
 
 export function isCursorDesktopAgentForwarderScript(script: string): boolean {
-  return /^[^\S\r\n]*(?!(?:#|::|rem(?:[^\S\r\n]|$)))(?:(?:exec|@?call|&)[^\S\r\n]+)?@?(?:"[^"\r\n]*[\\/]cursor(?:\.exe|\.cmd|\.bat)?"|cursor(?:\.exe|\.cmd|\.bat)?)[^\S\r\n]+agent(?:[^\S\r\n]|$)/im.test(
+  return /^[^\S\r\n]*(?!(?:#|::|rem(?:[^\S\r\n]|$)))(?:(?:exec|@?call|&)[^\S\r\n]+)?@?(?:"[^"\r\n]*[\\/]cursor(?:\.exe|\.cmd|\.bat)?"|(?:[^\s"'&|<>]+[\\/])?cursor(?:\.exe|\.cmd|\.bat)?)[^\S\r\n]+agent(?:[^\S\r\n]|$)/im.test(
     script,
   );
 }

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -28,7 +28,7 @@ import {
   getProviderOptionBooleanSelectionValue,
   getProviderOptionStringSelectionValue,
 } from "@t3tools/shared/model";
-import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import { resolveCommandPath, resolveSpawnCommand } from "@t3tools/shared/shell";
 
 import {
   buildBooleanOptionDescriptor,
@@ -579,6 +579,12 @@ export function getCursorFallbackModels(
 
 /** Timeout for `agent about` — it's slower than a simple `--version` probe. */
 const ABOUT_TIMEOUT_MS = 8_000;
+const CURSOR_FORWARDER_INSPECTION_MAX_BYTES = 64n * 1024n;
+const CURSOR_DESKTOP_FORWARDER_MESSAGE = [
+  "The configured Cursor Agent command forwards to the Cursor desktop launcher, which cannot provide ACP and may open editor windows.",
+  "Install the standalone Cursor CLI and set the binary path to `cursor-agent`.",
+  `See ${CURSOR_CLI_INSTALLATION_DOCS_URL}.`,
+].join(" ");
 
 /** Strip ANSI escape sequences so we can parse plain key-value lines. */
 function stripAnsi(text: string): string {
@@ -621,6 +627,40 @@ function buildCursorCliCommandMissingMessage(binaryPath: string): string {
     `See ${CURSOR_CLI_INSTALLATION_DOCS_URL}.`,
   ].join(" ");
 }
+
+export function isCursorDesktopAgentForwarderScript(script: string): boolean {
+  return /^[^\S\r\n]*(?!(?:#|::|rem(?:[^\S\r\n]|$)))(?:(?:exec|@?call|&)[^\S\r\n]+)?@?(?:"[^"\r\n]*[\\/]cursor(?:\.exe|\.cmd|\.bat)?"|cursor(?:\.exe|\.cmd|\.bat)?)[^\S\r\n]+agent(?:[^\S\r\n]|$)/im.test(
+    script,
+  );
+}
+
+const isCursorDesktopAgentForwarder = Effect.fn("isCursorDesktopAgentForwarder")(function* (
+  binaryPath: string,
+  environment?: NodeJS.ProcessEnv,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const resolvedPath = yield* resolveCommandPath(
+    binaryPath,
+    environment ? { env: environment } : {},
+  ).pipe(Effect.option);
+  if (Option.isNone(resolvedPath)) {
+    return false;
+  }
+
+  const info = yield* fileSystem.stat(resolvedPath.value).pipe(Effect.option);
+  if (
+    Option.isNone(info) ||
+    info.value.type !== "File" ||
+    info.value.size > CURSOR_FORWARDER_INSPECTION_MAX_BYTES
+  ) {
+    return false;
+  }
+
+  const script = yield* fileSystem
+    .readFileString(resolvedPath.value)
+    .pipe(Effect.orElseSucceed(() => ""));
+  return isCursorDesktopAgentForwarderScript(script);
+});
 
 export function buildCursorProviderSnapshot(input: {
   readonly checkedAt: string;
@@ -1007,6 +1047,22 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
         status: "warning",
         auth: { status: "unknown" },
         message: "Cursor is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  if (yield* isCursorDesktopAgentForwarder(cursorSettings.binaryPath, environment)) {
+    return buildServerProvider({
+      presentation: CURSOR_PRESENTATION,
+      enabled: cursorSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: false,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: CURSOR_DESKTOP_FORWARDER_MESSAGE,
       },
     });
   }


### PR DESCRIPTION
## What Changed

- Resolve the configured Cursor Agent command before provider health checks.
- Inspect only small wrapper scripts and reject shims that forward to `cursor agent`, the desktop editor launcher.
- Return a clear standalone-CLI setup error without spawning the shim.
- Add regression coverage for Windows batch and POSIX shell forwarders, including a no-spawn assertion.

## Why

Cursor's supported standalone command is `cursor-agent`. A local shim such as `cursor-agent.cmd` containing `cursor agent %*` launches the desktop editor instead of ACP. T3's five-minute provider refresh then opens Cursor repeatedly and can leave expensive editor processes running.

This is a follow-up safety guard to #4094 and covers the desktop-launcher failure mode reported in #2516. Correct standalone Cursor CLI binaries and ordinary wrappers remain unchanged.

Official CLI installation: https://cursor.com/docs/cli/installation

## Verification

- `vp test run apps/server/src/provider/Layers/CursorProvider.test.ts -t 'rejects desktop forwarder|recognizes shell wrappers'`
- `vp lint apps/server/src/provider/Layers/CursorProvider.ts apps/server/src/provider/Layers/CursorProvider.test.ts --report-unused-disable-directives`
- `vp fmt --check apps/server/src/provider/Layers/CursorProvider.ts apps/server/src/provider/Layers/CursorProvider.test.ts`
- `vp run --filter t3 typecheck`

The full Cursor provider test file also runs 22/25 tests on native Windows; its three existing ACP fixture tests fail with `spawn EFTYPE` because they execute `.sh` wrappers directly. The new tests pass on native Windows.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped guard in Cursor provider status checks with file-size limits; legitimate standalone CLI binaries are unchanged.
> 
> **Overview**
> **Cursor provider health checks now block desktop-launcher shims** so periodic refreshes no longer spawn wrappers that open the editor instead of ACP.
> 
> Before `agent about`, `checkCursorProviderStatus` resolves the configured binary with `resolveCommandPath`, reads only small regular files (≤64 KiB), and uses `isCursorDesktopAgentForwarderScript` to detect batch/shell scripts that forward to `cursor agent`. Matches return `installed: false`, `status: "error"`, and a message pointing users to the standalone `cursor-agent` CLI—**without** executing the shim.
> 
> Regression tests cover POSIX/Windows forwarder patterns, the script predicate (including commented lines), and a no-spawn assertion when a forwarder is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1069cd70599f96ffb0916a745dad5bf5b27b341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject desktop launcher forwarder scripts in `checkCursorProviderStatus`
> - Adds `isCursorDesktopAgentForwarderScript` to detect shell/batch wrappers that forward to the `cursor agent` desktop launcher via a case-insensitive regex.
> - Adds an early guard in `checkCursorProviderStatus` that reads the configured binary, checks if it is a forwarder script, and returns an error probe with `installed=false` without spawning any subprocess.
> - Behavioral Change: configs pointing to a desktop forwarder shim now immediately fail with a user-facing message instead of attempting to spawn the agent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1069cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->