### PR TITLE
fix(cli): publish nightly branded favicons

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -12,7 +12,8 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   DEVELOPMENT_ICON_OVERRIDES,
-  PUBLISH_ICON_OVERRIDES,
+  resolveWebAssetBrandForPackageVersion,
+  resolveWebIconOverrides,
 } from "../../../scripts/lib/brand-assets.ts";
 import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
 import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
@@ -81,50 +82,34 @@ const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.Stan
   }
 });
 
-interface PublishIconBackup {
-  readonly targetPath: string;
-  readonly backupPath: string;
-}
-
-const applyPublishIconOverrides = Effect.fn("applyPublishIconOverrides")(function* (
+const preparePublishIcons = Effect.fn("preparePublishIcons")(function* (
   repoRoot: string,
   serverDir: string,
+  version: string,
 ) {
   const path = yield* Path.Path;
   const fs = yield* FileSystem.FileSystem;
-  const backups: PublishIconBackup[] = [];
+  const brand = resolveWebAssetBrandForPackageVersion(version);
+  const icons = resolveWebIconOverrides(brand, "dist/client").map((override) => ({
+    sourcePath: path.join(repoRoot, override.sourceRelativePath),
+    targetPath: path.join(serverDir, override.targetRelativePath),
+  }));
 
-  for (const override of PUBLISH_ICON_OVERRIDES) {
-    const sourcePath = path.join(repoRoot, override.sourceRelativePath);
-    const targetPath = path.join(serverDir, override.targetRelativePath);
-    const backupPath = `${targetPath}.publish-bak`;
-
-    if (!(yield* fs.exists(sourcePath))) {
-      return yield* new ServerCliPublishIconSourceMissingError({ sourcePath });
+  for (const icon of icons) {
+    if (!(yield* fs.exists(icon.sourcePath))) {
+      return yield* new ServerCliPublishIconSourceMissingError({ sourcePath: icon.sourcePath });
     }
-    if (!(yield* fs.exists(targetPath))) {
-      return yield* new ServerCliPublishIconTargetMissingError({ targetPath });
+    if (!(yield* fs.exists(icon.targetPath))) {
+      return yield* new ServerCliPublishIconTargetMissingError({ targetPath: icon.targetPath });
     }
-
-    yield* fs.copyFile(targetPath, backupPath);
-    yield* fs.copyFile(sourcePath, targetPath);
-    backups.push({ targetPath, backupPath });
   }
 
-  yield* Effect.log("[cli] Applied publish icon overrides to dist/client");
-  return backups as ReadonlyArray<PublishIconBackup>;
-});
-
-const restorePublishIconOverrides = Effect.fn("restorePublishIconOverrides")(function* (
-  backups: ReadonlyArray<PublishIconBackup>,
-) {
-  const fs = yield* FileSystem.FileSystem;
-  for (const backup of backups) {
-    if (!(yield* fs.exists(backup.backupPath))) {
-      continue;
-    }
-    yield* fs.rename(backup.backupPath, backup.targetPath);
-  }
+  return yield* Effect.forEach(icons, (icon) =>
+    Effect.all({
+      original: fs.readFile(icon.targetPath),
+      publish: fs.readFile(icon.sourcePath),
+    }).pipe(Effect.map((contents) => ({ ...icon, ...contents }))),
+  );
 });
 
 const applyDevelopmentIconOverrides = Effect.fn("applyDevelopmentIconOverrides")(function* (
@@ -236,7 +221,6 @@ const publishCmd = Command.make(
       const repoRoot = yield* RepoRoot;
       const serverDir = path.join(repoRoot, "apps/server");
       const packageJsonPath = path.join(serverDir, "package.json");
-      const backupPath = `${packageJsonPath}.bak`;
 
       // Assert build assets exist
       for (const relPath of ["dist/bin.mjs", "dist/client/index.html"]) {
@@ -247,7 +231,7 @@ const publishCmd = Command.make(
       }
 
       yield* Effect.acquireUseRelease(
-        // Acquire: backup package.json, resolve catalog dependencies, and strip devDependencies/scripts
+        // Acquire: resolve publish metadata and read every original before mutation.
         Effect.gen(function* () {
           const version = Option.getOrElse(config.appVersion, () => serverPackageJson.version);
           const workspaceConfig = yield* readWorkspaceConfig();
@@ -273,19 +257,22 @@ const publishCmd = Command.make(
             ),
           };
 
-          const original = yield* fs.readFileString(packageJsonPath);
-          const packageJsonString = yield* encodePackageJson(pkg);
-          yield* fs.writeFileString(backupPath, original);
-          yield* fs.writeFileString(packageJsonPath, `${packageJsonString}\n`);
-          yield* Effect.log("[cli] Prepared package.json for publish");
-
-          const iconBackups = yield* applyPublishIconOverrides(repoRoot, serverDir);
-          return { iconBackups };
+          return {
+            packageJsonString: yield* encodePackageJson(pkg),
+            originalPackageJson: yield* fs.readFile(packageJsonPath),
+            icons: yield* preparePublishIcons(repoRoot, serverDir, version),
+          };
         }),
         // Use: pnpm publish from the workspace root so pnpm-only workspace
         // config, including override selectors, is interpreted correctly.
-        () =>
+        (resource) =>
           Effect.gen(function* () {
+            yield* fs.writeFileString(packageJsonPath, `${resource.packageJsonString}\n`);
+            for (const icon of resource.icons) {
+              yield* fs.writeFile(icon.targetPath, icon.publish);
+            }
+            yield* Effect.log("[cli] Applied package metadata and publish icon overrides");
+
             const args = createVpPmPublishArgs(config);
             const spawnCommand = yield* resolveSpawnCommand("vp", ["pm", ...args]);
 
@@ -299,16 +286,14 @@ const publishCmd = Command.make(
               }),
             );
           }),
-        // Release: restore
-        (resource: { readonly iconBackups: ReadonlyArray<PublishIconBackup> }) =>
+        // Release: restore every file even if applying overrides or publishing fails.
+        (resource) =>
           Effect.gen(function* () {
-            yield* restorePublishIconOverrides(resource.iconBackups).pipe(
-              Effect.catch((error) =>
-                Effect.logError(`[cli] Failed to restore publish icon overrides: ${String(error)}`),
-              ),
-            );
-            yield* fs.rename(backupPath, packageJsonPath);
-            if (config.verbose) yield* Effect.log("[cli] Restored original package.json");
+            yield* fs.writeFile(packageJsonPath, resource.originalPackageJson);
+            for (const icon of resource.icons) {
+              yield* fs.writeFile(icon.targetPath, icon.original);
+            }
+            if (config.verbose) yield* Effect.log("[cli] Restored original publish assets");
           }),
       );
     }),

--- a/scripts/lib/brand-assets.test.ts
+++ b/scripts/lib/brand-assets.test.ts
@@ -4,14 +4,14 @@ import {
   BRAND_ASSET_PATHS,
   DEVELOPMENT_ICON_OVERRIDES,
   DEVELOPMENT_PUBLIC_ICON_OVERRIDES,
-  PUBLISH_ICON_OVERRIDES,
   resolveWebAssetBrandForChannel,
+  resolveWebAssetBrandForPackageVersion,
   resolveWebIconOverrides,
 } from "./brand-assets.ts";
 
 describe("brand-assets", () => {
-  it("maps server publish web assets to production icons", () => {
-    expect(PUBLISH_ICON_OVERRIDES).toEqual([
+  it("maps production web assets into the server package", () => {
+    expect(resolveWebIconOverrides("production", "dist/client")).toEqual([
       {
         sourceRelativePath: BRAND_ASSET_PATHS.productionWebFaviconIco,
         targetRelativePath: "dist/client/favicon.ico",
@@ -76,6 +76,11 @@ describe("brand-assets", () => {
   it("maps hosted release channels to web asset brands", () => {
     expect(resolveWebAssetBrandForChannel("latest")).toBe("production");
     expect(resolveWebAssetBrandForChannel("nightly")).toBe("nightly");
+  });
+
+  it("maps package versions to web asset brands", () => {
+    expect(resolveWebAssetBrandForPackageVersion("0.0.29")).toBe("production");
+    expect(resolveWebAssetBrandForPackageVersion("0.0.29-nightly.20260723.882")).toBe("nightly");
   });
 
   it("keeps development, nightly, and production icon families separate", () => {

--- a/scripts/lib/brand-assets.ts
+++ b/scripts/lib/brand-assets.ts
@@ -41,6 +41,10 @@ export function resolveWebAssetBrandForChannel(channel: WebAssetChannel): WebAss
   return channel === "nightly" ? "nightly" : "production";
 }
 
+export function resolveWebAssetBrandForPackageVersion(version: string): WebAssetBrand {
+  return version.includes("-nightly.") ? "nightly" : "production";
+}
+
 export interface IconOverride {
   readonly sourceRelativePath: string;
   readonly targetRelativePath: string;
@@ -105,5 +109,3 @@ export const DEVELOPMENT_PUBLIC_ICON_OVERRIDES = resolveWebIconOverrides(
   "development",
   "apps/web/public",
 );
-
-export const PUBLISH_ICON_OVERRIDES = resolveWebIconOverrides("production", "dist/client");


### PR DESCRIPTION
## What Changed

- Select the packaged web icon family from the CLI package version.
- Use nightly favicons and the nightly Apple touch icon for `*-nightly.*` releases.
- Continue using production icons for stable releases.
- Store temporary publish backups outside `dist/client` so they are not included in npm tarballs.
- Add focused coverage for stable and nightly package-version branding.

## Why

The CLI publish step always applied the production icon overrides, regardless of the package version or npm distribution tag. As a result, `pnpx t3@nightly serve` served the stable production favicon even though the application otherwise identified itself as a nightly build.

The publish backups were also created inside `dist/client`, causing `*.publish-bak` files to be included in the published npm package.

This makes the packaged assets follow the release version and keeps temporary backup files out of published artifacts.

## UI Changes

| Before | After |
| --- | --- |
| Nightly CLI served the production favicon.<br><br>![Production favicon](https://raw.githubusercontent.com/pingdotgg/t3code/main/assets/prod/t3-black-web-favicon-32x32.png) | Nightly CLI serves the nightly branded favicon.<br><br>![Nightly favicon](https://raw.githubusercontent.com/pingdotgg/t3code/main/assets/nightly/nightly-web-favicon-32x32.png) |

## Validation

- `vp test run scripts/lib/brand-assets.test.ts`
- `vp run --filter @t3tools/scripts typecheck`
- `vp run --filter t3 typecheck`
- Targeted formatting check
- Full CLI build
- Nightly publish dry run

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable; this is a static favicon change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to publish-time asset swapping and branding helpers; no auth or runtime API changes, with tests for version-based brand selection.
> 
> **Overview**
> **Publish** now picks **production vs nightly** web favicons from the package **version** (`*-nightly.*` → nightly), so nightly npm releases no longer ship stable production icons.
> 
> The publish command **drops** the fixed `PUBLISH_ICON_OVERRIDES` path and **`preparePublishIcons`**, which uses `resolveWebAssetBrandForPackageVersion` and `resolveWebIconOverrides`. **`package.json` and icon overrides** are backed up **in memory** before write, then restored on release—replacing on-disk `*.publish-bak` files under `dist/client` that could end up in the tarball.
> 
> Tests cover version→brand mapping and assert production icons via `resolveWebIconOverrides("production", "dist/client")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a73926e5f482893883d0602974210ac49d26d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish nightly-branded favicons based on package version in the CLI publish command
> - Adds `resolveWebAssetBrandForPackageVersion` in [`scripts/lib/brand-assets.ts`](https://github.com/pingdotgg/t3code/pull/4372/files#diff-b73b620b017c1a849abeae456edae96b0683ad451284af25dbc3295f01a8f0af) to return `"nightly"` for versions containing `-nightly.`, otherwise `"production"`.
> - The publish command in [`apps/server/scripts/cli.ts`](https://github.com/pingdotgg/t3code/pull/4372/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) now selects icon overrides based on the detected brand, writing overrides just-in-time and restoring originals afterward.
> - Removes the old `PUBLISH_ICON_OVERRIDES` constant and the `applyPublishIconOverrides`/`restorePublishIconOverrides` helpers that relied on `.publish-bak` files on disk.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a73926.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->