### PR TITLE
[codex] restore Sidebar V2 project actions

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
-  buildSidebarV2ProjectActionItems,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -37,73 +36,6 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 
-describe("buildSidebarV2ProjectActionItems", () => {
-  it("targets each physical member and makes remove-all explicit for grouped projects", () => {
-    expect(
-      buildSidebarV2ProjectActionItems([
-        {
-          physicalProjectKey: "local:/repo",
-          title: "Local title",
-          workspaceRoot: "/repo",
-          environmentLabel: "Grouping Local",
-        },
-        {
-          physicalProjectKey: "remote:/repo",
-          title: "Remote title",
-          workspaceRoot: "/repo",
-          environmentLabel: "Grouping Remote",
-        },
-      ]),
-    ).toEqual([
-      {
-        id: "rename:submenu",
-        label: "Rename project entry",
-        children: [
-          { id: "rename:local:/repo", label: "Grouping Local — /repo" },
-          { id: "rename:remote:/repo", label: "Grouping Remote — /repo" },
-        ],
-      },
-      {
-        id: "grouping:submenu",
-        label: "Group into…",
-        children: [
-          { id: "grouping:local:/repo", label: "Grouping Local — /repo" },
-          { id: "grouping:remote:/repo", label: "Grouping Remote — /repo" },
-        ],
-      },
-      {
-        id: "copy-path:submenu",
-        label: "Copy Path",
-        children: [
-          { id: "copy-path:local:/repo", label: "Grouping Local — /repo" },
-          { id: "copy-path:remote:/repo", label: "Grouping Remote — /repo" },
-        ],
-      },
-      {
-        id: "remove:submenu",
-        label: "Remove",
-        children: [
-          {
-            id: "remove:local:/repo",
-            label: "Grouping Local — /repo",
-            destructive: true,
-          },
-          {
-            id: "remove:remote:/repo",
-            label: "Grouping Remote — /repo",
-            destructive: true,
-          },
-        ],
-      },
-      {
-        id: "remove-all",
-        label: "Remove all grouped entries…",
-        destructive: true,
-        icon: "trash",
-      },
-    ]);
-  });
-});
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
+  buildSidebarV2ProjectActionItems,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -35,6 +36,74 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
+
+describe("buildSidebarV2ProjectActionItems", () => {
+  it("targets each physical member and makes remove-all explicit for grouped projects", () => {
+    expect(
+      buildSidebarV2ProjectActionItems([
+        {
+          physicalProjectKey: "local:/repo",
+          title: "Local title",
+          workspaceRoot: "/repo",
+          environmentLabel: "Grouping Local",
+        },
+        {
+          physicalProjectKey: "remote:/repo",
+          title: "Remote title",
+          workspaceRoot: "/repo",
+          environmentLabel: "Grouping Remote",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "rename:submenu",
+        label: "Rename project entry",
+        children: [
+          { id: "rename:local:/repo", label: "Grouping Local — /repo" },
+          { id: "rename:remote:/repo", label: "Grouping Remote — /repo" },
+        ],
+      },
+      {
+        id: "grouping:submenu",
+        label: "Group into…",
+        children: [
+          { id: "grouping:local:/repo", label: "Grouping Local — /repo" },
+          { id: "grouping:remote:/repo", label: "Grouping Remote — /repo" },
+        ],
+      },
+      {
+        id: "copy-path:submenu",
+        label: "Copy Path",
+        children: [
+          { id: "copy-path:local:/repo", label: "Grouping Local — /repo" },
+          { id: "copy-path:remote:/repo", label: "Grouping Remote — /repo" },
+        ],
+      },
+      {
+        id: "remove:submenu",
+        label: "Remove",
+        children: [
+          {
+            id: "remove:local:/repo",
+            label: "Grouping Local — /repo",
+            destructive: true,
+          },
+          {
+            id: "remove:remote:/repo",
+            label: "Grouping Remote — /repo",
+            destructive: true,
+          },
+        ],
+      },
+      {
+        id: "remove-all",
+        label: "Remove all grouped entries…",
+        destructive: true,
+        icon: "trash",
+      },
+    ]);
+  });
+});
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -44,63 +44,6 @@ type LogicalSidebarProject = SidebarProject & {
   }[];
 };
 
-type ProjectActionMember = {
-  readonly physicalProjectKey: string;
-  readonly title: string;
-  readonly workspaceRoot: string;
-  readonly environmentLabel: string | null;
-};
-
-export function buildSidebarV2ProjectActionItems(
-  members: readonly ProjectActionMember[],
-): ContextMenuItem<string>[] {
-  const memberLabel = (member: ProjectActionMember) =>
-    members.length > 1
-      ? member.environmentLabel
-        ? `${member.environmentLabel} — ${member.workspaceRoot}`
-        : member.workspaceRoot
-      : member.title;
-  const targetedItem = (
-    action: "rename" | "grouping" | "copy-path" | "remove",
-    label: string,
-    destructive = false,
-  ): ContextMenuItem<string> => {
-    if (members.length === 1) {
-      return {
-        id: `${action}:${members[0]!.physicalProjectKey}`,
-        label,
-        ...(destructive ? { destructive: true, icon: "trash" as const } : {}),
-      };
-    }
-    return {
-      id: `${action}:submenu`,
-      label,
-      children: members.map((member) => ({
-        id: `${action}:${member.physicalProjectKey}`,
-        label: memberLabel(member),
-        ...(destructive ? { destructive: true } : {}),
-      })),
-    };
-  };
-
-  return [
-    targetedItem("rename", members.length > 1 ? "Rename project entry" : "Rename"),
-    targetedItem("grouping", "Group into…"),
-    targetedItem("copy-path", "Copy Path"),
-    targetedItem("remove", "Remove", true),
-    ...(members.length > 1
-      ? [
-          {
-            id: "remove-all",
-            label: "Remove all grouped entries…",
-            destructive: true,
-            icon: "trash" as const,
-          },
-        ]
-      : []),
-  ];
-}
-
 export type ThreadTraversalDirection = "previous" | "next";
 
 export async function archiveSelectedThreadEntries<

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -44,6 +44,63 @@ type LogicalSidebarProject = SidebarProject & {
   }[];
 };
 
+type ProjectActionMember = {
+  readonly physicalProjectKey: string;
+  readonly title: string;
+  readonly workspaceRoot: string;
+  readonly environmentLabel: string | null;
+};
+
+export function buildSidebarV2ProjectActionItems(
+  members: readonly ProjectActionMember[],
+): ContextMenuItem<string>[] {
+  const memberLabel = (member: ProjectActionMember) =>
+    members.length > 1
+      ? member.environmentLabel
+        ? `${member.environmentLabel} — ${member.workspaceRoot}`
+        : member.workspaceRoot
+      : member.title;
+  const targetedItem = (
+    action: "rename" | "grouping" | "copy-path" | "remove",
+    label: string,
+    destructive = false,
+  ): ContextMenuItem<string> => {
+    if (members.length === 1) {
+      return {
+        id: `${action}:${members[0]!.physicalProjectKey}`,
+        label,
+        ...(destructive ? { destructive: true, icon: "trash" as const } : {}),
+      };
+    }
+    return {
+      id: `${action}:submenu`,
+      label,
+      children: members.map((member) => ({
+        id: `${action}:${member.physicalProjectKey}`,
+        label: memberLabel(member),
+        ...(destructive ? { destructive: true } : {}),
+      })),
+    };
+  };
+
+  return [
+    targetedItem("rename", members.length > 1 ? "Rename project entry" : "Rename"),
+    targetedItem("grouping", "Group into…"),
+    targetedItem("copy-path", "Copy Path"),
+    targetedItem("remove", "Remove", true),
+    ...(members.length > 1
+      ? [
+          {
+            id: "remove-all",
+            label: "Remove all grouped entries…",
+            destructive: true,
+            icon: "trash" as const,
+          },
+        ]
+      : []),
+  ];
+}
+
 export type ThreadTraversalDirection = "previous" | "next";
 
 export async function archiveSelectedThreadEntries<

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -7,7 +7,7 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef } from "@t3tools/contracts";
+import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -17,12 +17,12 @@ import {
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
+  EllipsisIcon,
   MessageSquareIcon,
   PlusIcon,
   SearchIcon,
   ServerIcon,
   SquarePenIcon,
-  Trash2Icon,
   Undo2Icon,
 } from "lucide-react";
 import {
@@ -58,9 +58,14 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { isMacPlatform } from "~/lib/utils";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { readLocalApi } from "../localApi";
-import { getProjectOrderKey, selectProjectGroupingSettings } from "../logicalProject";
+import {
+  deriveProjectGroupingOverrideKey,
+  getProjectOrderKey,
+  selectProjectGroupingSettings,
+} from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
+  type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
@@ -69,7 +74,8 @@ import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
-import { useClientSettings } from "../hooks/useSettings";
+import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
@@ -84,6 +90,7 @@ import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import {
   firstValidTimestampMs,
+  buildSidebarV2ProjectActionItems,
   hasUnseenCompletion,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
@@ -102,8 +109,20 @@ import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../pr
 import { primaryServerProvidersAtom } from "../state/server";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { CommandDialogTrigger } from "./ui/command";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
 import { Kbd } from "./ui/kbd";
 import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
@@ -113,6 +132,22 @@ import { useComposerDraftStore } from "../composerDraftStore";
 // stays behind an explicit Show more.
 const SETTLED_TAIL_INITIAL_COUNT = 10;
 const SETTLED_TAIL_PAGE_COUNT = 25;
+const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
+  repository: "Group by repository",
+  repository_path: "Group by repository path",
+  separate: "Keep separate",
+};
+
+function projectGroupingModeDescription(mode: SidebarProjectGroupingMode): string {
+  switch (mode) {
+    case "repository":
+      return "Projects from the same repository share one sidebar row.";
+    case "repository_path":
+      return "Projects group only when both the repository and repo-relative path match.";
+    case "separate":
+      return "This project always appears as its own sidebar entry.";
+  }
+}
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -736,6 +771,37 @@ export default function SidebarV2() {
   const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
+  const updateProject = useAtomCommand(projectEnvironment.update, {
+    reportFailure: false,
+  });
+  const updateSettings = useUpdateClientSettings();
+  const { copyToClipboard: copyProjectPath } = useCopyToClipboard<{ path: string }>({
+    onCopy: ({ path }) => {
+      toastManager.add({
+        type: "success",
+        title: "Path copied",
+        description: path,
+      });
+    },
+    onError: (error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to copy path",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    },
+  });
+  const [projectRenameTarget, setProjectRenameTarget] = useState<SidebarProjectGroupMember | null>(
+    null,
+  );
+  const [projectRenameTitle, setProjectRenameTitle] = useState("");
+  const [projectGroupingTarget, setProjectGroupingTarget] =
+    useState<SidebarProjectGroupMember | null>(null);
+  const [projectGroupingSelection, setProjectGroupingSelection] = useState<
+    SidebarProjectGroupingMode | "inherit"
+  >("inherit");
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
@@ -893,41 +959,50 @@ export default function SidebarV2() {
     clearSelection();
   }, [clearSelection, projectScopeKey]);
 
-  const handleRemoveProject = useCallback(
-    async (projectGroup: SidebarProjectSnapshot) => {
+  const handleRemoveProjectMembers = useCallback(
+    async (projectGroup: SidebarProjectSnapshot, members: readonly SidebarProjectGroupMember[]) => {
       const api = readLocalApi();
       if (!api) return;
 
-      const memberKeys = new Set(
-        projectGroup.memberProjectRefs.map(
-          (projectRef) => `${projectRef.environmentId}:${projectRef.projectId}`,
-        ),
-      );
+      const memberKeys = new Set(members.map((member) => `${member.environmentId}:${member.id}`));
       const projectThreads = threads.filter((thread) =>
         memberKeys.has(`${thread.environmentId}:${thread.projectId}`),
       );
+      const isWholeGroup = members.length === projectGroup.memberProjects.length;
+      const singleMember = members.length === 1 ? members[0]! : null;
+      const targetLabel = singleMember?.title ?? projectGroup.displayName;
       const confirmed = await settlePromise(() =>
         api.dialogs.confirm(
           projectThreads.length > 0
             ? [
-                `Remove project "${projectGroup.displayName}" and delete its ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}?`,
-                ...(projectGroup.memberProjects.length === 1
-                  ? [`Path: ${projectGroup.workspaceRoot}`]
-                  : [
-                      `This removes ${projectGroup.memberProjects.length} grouped project entries.`,
-                    ]),
+                `Remove project "${targetLabel}" and delete its ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}?`,
+                ...(singleMember
+                  ? [
+                      `Path: ${singleMember.workspaceRoot}`,
+                      ...(singleMember.environmentLabel
+                        ? [`Environment: ${singleMember.environmentLabel}`]
+                        : []),
+                    ]
+                  : [`This removes ${members.length} grouped project entries.`]),
                 "This permanently clears conversation history for those threads.",
-                "This removes only the project entries, not the files on disk.",
+                isWholeGroup
+                  ? "This removes only the project entries, not the files on disk."
+                  : "Other entries in this grouped project are unaffected.",
                 "This action cannot be undone.",
               ].join("\n")
             : [
-                `Remove project "${projectGroup.displayName}"?`,
-                ...(projectGroup.memberProjects.length === 1
-                  ? [`Path: ${projectGroup.workspaceRoot}`]
-                  : [
-                      `This removes ${projectGroup.memberProjects.length} grouped project entries.`,
-                    ]),
-                "This removes only the project entries, not the files on disk.",
+                `Remove project "${targetLabel}"?`,
+                ...(singleMember
+                  ? [
+                      `Path: ${singleMember.workspaceRoot}`,
+                      ...(singleMember.environmentLabel
+                        ? [`Environment: ${singleMember.environmentLabel}`]
+                        : []),
+                    ]
+                  : [`This removes ${members.length} grouped project entries.`]),
+                isWholeGroup
+                  ? "This removes only the project entries, not the files on disk."
+                  : "Other entries in this grouped project are unaffected.",
               ].join("\n"),
         ),
       );
@@ -935,7 +1010,7 @@ export default function SidebarV2() {
 
       const draftStore = useComposerDraftStore.getState();
       let shouldNavigate = false;
-      for (const project of projectGroup.memberProjects) {
+      for (const project of members) {
         const memberThreads = projectThreads.filter(
           (thread) =>
             thread.environmentId === project.environmentId && thread.projectId === project.id,
@@ -984,6 +1059,103 @@ export default function SidebarV2() {
       }
     },
     [deleteProject, router, threads],
+  );
+
+  const closeProjectRenameDialog = useCallback(() => {
+    setProjectRenameTarget(null);
+    setProjectRenameTitle("");
+  }, []);
+  const submitProjectRename = useCallback(async () => {
+    if (!projectRenameTarget) return;
+    const title = projectRenameTitle.trim();
+    if (!title) {
+      toastManager.add({ type: "warning", title: "Project title cannot be empty" });
+      return;
+    }
+    if (title === projectRenameTarget.title) {
+      closeProjectRenameDialog();
+      return;
+    }
+    const result = await updateProject({
+      environmentId: projectRenameTarget.environmentId,
+      input: { projectId: projectRenameTarget.id, title },
+    });
+    if (result._tag === "Success") {
+      closeProjectRenameDialog();
+    } else if (!isAtomCommandInterrupted(result)) {
+      const error = squashAtomCommandFailure(result);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to rename project",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    }
+  }, [closeProjectRenameDialog, projectRenameTarget, projectRenameTitle, updateProject]);
+
+  const closeProjectGroupingDialog = useCallback(() => {
+    setProjectGroupingTarget(null);
+    setProjectGroupingSelection("inherit");
+  }, []);
+  const saveProjectGroupingPreference = useCallback(() => {
+    if (!projectGroupingTarget) return;
+    const overrideKey = deriveProjectGroupingOverrideKey(projectGroupingTarget);
+    const nextOverrides = { ...projectGroupingSettings.sidebarProjectGroupingOverrides };
+    if (projectGroupingSelection === "inherit") {
+      delete nextOverrides[overrideKey];
+    } else {
+      nextOverrides[overrideKey] = projectGroupingSelection;
+    }
+    updateSettings({ sidebarProjectGroupingOverrides: nextOverrides });
+    closeProjectGroupingDialog();
+  }, [
+    closeProjectGroupingDialog,
+    projectGroupingSelection,
+    projectGroupingSettings.sidebarProjectGroupingOverrides,
+    projectGroupingTarget,
+    updateSettings,
+  ]);
+
+  const handleProjectActions = useCallback(
+    async (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const api = readLocalApi();
+      if (!api) return;
+      const clicked = await api.contextMenu.show(
+        buildSidebarV2ProjectActionItems(projectGroup.memberProjects),
+        { x: event.clientX, y: event.clientY },
+      );
+      if (!clicked) return;
+      if (clicked === "remove-all") {
+        await handleRemoveProjectMembers(projectGroup, projectGroup.memberProjects);
+        return;
+      }
+      const member = projectGroup.memberProjects.find((candidate) =>
+        clicked.endsWith(`:${candidate.physicalProjectKey}`),
+      );
+      if (!member) return;
+      if (clicked.startsWith("rename:")) {
+        setProjectRenameTarget(member);
+        setProjectRenameTitle(member.title);
+      } else if (clicked.startsWith("grouping:")) {
+        const overrideKey = deriveProjectGroupingOverrideKey(member);
+        setProjectGroupingTarget(member);
+        setProjectGroupingSelection(
+          projectGroupingSettings.sidebarProjectGroupingOverrides?.[overrideKey] ?? "inherit",
+        );
+      } else if (clicked.startsWith("copy-path:")) {
+        copyProjectPath(member.workspaceRoot, { path: member.workspaceRoot });
+      } else if (clicked.startsWith("remove:")) {
+        await handleRemoveProjectMembers(projectGroup, [member]);
+      }
+    },
+    [
+      copyProjectPath,
+      handleRemoveProjectMembers,
+      projectGroupingSettings.sidebarProjectGroupingOverrides,
+    ],
   );
 
   // Settled threads stay in the live shell stream (settled ≠ archived), so
@@ -1677,17 +1849,15 @@ export default function SidebarV2() {
                           <span className="min-w-0 truncate text-sm">{project.displayName}</span>
                           <button
                             type="button"
-                            aria-label={`Remove project ${project.displayName}`}
-                            title={`Remove ${project.displayName}`}
-                            className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground/55 outline-none transition-colors hover:bg-destructive/12 hover:text-destructive focus-visible:bg-destructive/12 focus-visible:text-destructive focus-visible:ring-2 focus-visible:ring-destructive/40"
+                            aria-label={`Project actions for ${project.displayName}`}
+                            title={`Project actions for ${project.displayName}`}
+                            className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground/55 outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
                             onPointerDown={(event) => event.stopPropagation()}
                             onClick={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                              void handleRemoveProject(project);
+                              void handleProjectActions(event, project);
                             }}
                           >
-                            <Trash2Icon className="size-3.5" />
+                            <EllipsisIcon className="size-3.5" />
                           </button>
                         </MenuRadioItem>
                       );
@@ -1845,6 +2015,131 @@ export default function SidebarV2() {
           ) : null}
         </SidebarGroup>
       </SidebarContent>
+      <Dialog
+        open={projectRenameTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) closeProjectRenameDialog();
+        }}
+      >
+        <DialogPopup className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {projectRenameTarget &&
+              projectGroups.some(
+                (group) =>
+                  group.memberProjects.length > 1 &&
+                  group.memberProjects.some(
+                    (member) =>
+                      member.environmentId === projectRenameTarget.environmentId &&
+                      member.id === projectRenameTarget.id,
+                  ),
+              )
+                ? "Rename project entry"
+                : "Rename project"}
+            </DialogTitle>
+            <DialogDescription>
+              {projectRenameTarget
+                ? `Update the title for ${projectRenameTarget.workspaceRoot}. Repository-grouped labels still use repository identity.`
+                : "Update the project title."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <div className="grid gap-1.5">
+              <span className="text-xs font-medium text-foreground">Project title</span>
+              <Input
+                aria-label="Project title"
+                value={projectRenameTitle}
+                onChange={(event) => setProjectRenameTitle(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    void submitProjectRename();
+                  }
+                }}
+              />
+            </div>
+            {projectRenameTarget?.environmentLabel ? (
+              <p className="text-xs text-muted-foreground">
+                Environment: {projectRenameTarget.environmentLabel}
+              </p>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeProjectRenameDialog}>
+              Cancel
+            </Button>
+            <Button onClick={() => void submitProjectRename()}>Save</Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+      <Dialog
+        open={projectGroupingTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) closeProjectGroupingDialog();
+        }}
+      >
+        <DialogPopup className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Project grouping</DialogTitle>
+            <DialogDescription>
+              {projectGroupingTarget
+                ? `Choose how ${projectGroupingTarget.workspaceRoot} should be grouped in the sidebar.`
+                : "Choose how this project should be grouped in the sidebar."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <div className="grid gap-1.5">
+              <span className="text-xs font-medium text-foreground">Grouping rule</span>
+              <Select
+                value={projectGroupingSelection}
+                onValueChange={(value) => {
+                  if (
+                    value === "inherit" ||
+                    value === "repository" ||
+                    value === "repository_path" ||
+                    value === "separate"
+                  ) {
+                    setProjectGroupingSelection(value);
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full" aria-label="Project grouping rule">
+                  <SelectValue>
+                    {projectGroupingSelection === "inherit"
+                      ? `Use global default (${PROJECT_GROUPING_MODE_LABELS[projectGroupingSettings.sidebarProjectGroupingMode]})`
+                      : PROJECT_GROUPING_MODE_LABELS[projectGroupingSelection]}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="inherit">
+                    Use global default
+                  </SelectItem>
+                  <SelectItem hideIndicator value="repository">
+                    {PROJECT_GROUPING_MODE_LABELS.repository}
+                  </SelectItem>
+                  <SelectItem hideIndicator value="repository_path">
+                    {PROJECT_GROUPING_MODE_LABELS.repository_path}
+                  </SelectItem>
+                  <SelectItem hideIndicator value="separate">
+                    {PROJECT_GROUPING_MODE_LABELS.separate}
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {projectGroupingSelection === "inherit"
+                ? projectGroupingModeDescription(projectGroupingSettings.sidebarProjectGroupingMode)
+                : projectGroupingModeDescription(projectGroupingSelection)}
+            </p>
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeProjectGroupingDialog}>
+              Cancel
+            </Button>
+            <Button onClick={saveProjectGroupingPreference}>Save</Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
       <SidebarChromeFooter />
     </>
   );

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -90,7 +90,6 @@ import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import {
   firstValidTimestampMs,
-  buildSidebarV2ProjectActionItems,
   hasUnseenCompletion,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
@@ -797,6 +796,9 @@ export default function SidebarV2() {
     null,
   );
   const [projectRenameTitle, setProjectRenameTitle] = useState("");
+  const [projectActionsTarget, setProjectActionsTarget] = useState<SidebarProjectSnapshot | null>(
+    null,
+  );
   const [projectGroupingTarget, setProjectGroupingTarget] =
     useState<SidebarProjectGroupMember | null>(null);
   const [projectGroupingSelection, setProjectGroupingSelection] = useState<
@@ -1118,44 +1120,12 @@ export default function SidebarV2() {
   ]);
 
   const handleProjectActions = useCallback(
-    async (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
+    (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
       event.preventDefault();
       event.stopPropagation();
-      const api = readLocalApi();
-      if (!api) return;
-      const clicked = await api.contextMenu.show(
-        buildSidebarV2ProjectActionItems(projectGroup.memberProjects),
-        { x: event.clientX, y: event.clientY },
-      );
-      if (!clicked) return;
-      if (clicked === "remove-all") {
-        await handleRemoveProjectMembers(projectGroup, projectGroup.memberProjects);
-        return;
-      }
-      const member = projectGroup.memberProjects.find((candidate) =>
-        clicked.endsWith(`:${candidate.physicalProjectKey}`),
-      );
-      if (!member) return;
-      if (clicked.startsWith("rename:")) {
-        setProjectRenameTarget(member);
-        setProjectRenameTitle(member.title);
-      } else if (clicked.startsWith("grouping:")) {
-        const overrideKey = deriveProjectGroupingOverrideKey(member);
-        setProjectGroupingTarget(member);
-        setProjectGroupingSelection(
-          projectGroupingSettings.sidebarProjectGroupingOverrides?.[overrideKey] ?? "inherit",
-        );
-      } else if (clicked.startsWith("copy-path:")) {
-        copyProjectPath(member.workspaceRoot, { path: member.workspaceRoot });
-      } else if (clicked.startsWith("remove:")) {
-        await handleRemoveProjectMembers(projectGroup, [member]);
-      }
+      setProjectActionsTarget(projectGroup);
     },
-    [
-      copyProjectPath,
-      handleRemoveProjectMembers,
-      projectGroupingSettings.sidebarProjectGroupingOverrides,
-    ],
+    [],
   );
 
   // Settled threads stay in the live shell stream (settled ≠ archived), so
@@ -2015,6 +1985,123 @@ export default function SidebarV2() {
           ) : null}
         </SidebarGroup>
       </SidebarContent>
+      <Dialog
+        open={projectActionsTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setProjectActionsTarget(null);
+        }}
+      >
+        <DialogPopup className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Manage {projectActionsTarget?.displayName ?? "project"}</DialogTitle>
+            <DialogDescription>
+              {projectActionsTarget && projectActionsTarget.memberProjects.length > 1
+                ? "Manage each environment's project entry independently."
+                : "Rename, regroup, copy, or remove this project entry."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-3">
+            {projectActionsTarget?.memberProjects.map((member) => (
+              <div
+                key={member.physicalProjectKey}
+                className="rounded-lg border border-border/70 bg-muted/20 p-3"
+              >
+                <div className="flex min-w-0 items-start gap-2">
+                  <ProjectFavicon
+                    environmentId={member.environmentId}
+                    cwd={member.workspaceRoot}
+                    className="mt-0.5 size-4 shrink-0"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium text-foreground">
+                      {member.title}
+                    </div>
+                    <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {member.environmentLabel
+                        ? `${member.environmentLabel} · ${member.workspaceRoot}`
+                        : member.workspaceRoot}
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setProjectActionsTarget(null);
+                      setProjectRenameTarget(member);
+                      setProjectRenameTitle(member.title);
+                    }}
+                  >
+                    Rename
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setProjectActionsTarget(null);
+                      setProjectGroupingTarget(member);
+                      setProjectGroupingSelection(
+                        projectGroupingSettings.sidebarProjectGroupingOverrides?.[
+                          deriveProjectGroupingOverrideKey(member)
+                        ] ?? "inherit",
+                      );
+                    }}
+                  >
+                    Grouping
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      copyProjectPath(member.workspaceRoot, { path: member.workspaceRoot })
+                    }
+                  >
+                    Copy path
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="ml-auto"
+                    onClick={() => {
+                      const projectGroup = projectActionsTarget;
+                      if (!projectGroup) return;
+                      setProjectActionsTarget(null);
+                      void handleRemoveProjectMembers(projectGroup, [member]);
+                    }}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+            {projectActionsTarget && projectActionsTarget.memberProjects.length > 1 ? (
+              <div className="flex items-center justify-between gap-4 border-t border-border/70 pt-3">
+                <p className="text-xs text-muted-foreground">
+                  Removes every grouped entry and its conversation history.
+                </p>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="shrink-0"
+                  onClick={() => {
+                    const projectGroup = projectActionsTarget;
+                    setProjectActionsTarget(null);
+                    void handleRemoveProjectMembers(projectGroup, projectGroup.memberProjects);
+                  }}
+                >
+                  Remove all entries
+                </Button>
+              </div>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setProjectActionsTarget(null)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
       <Dialog
         open={projectRenameTarget !== null}
         onOpenChange={(open) => {

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -14,6 +14,7 @@ import {
   CircleAlertIcon,
   CircleCheckIcon,
   CircleDashedIcon,
+  CopyIcon,
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
@@ -23,6 +24,7 @@ import {
   SearchIcon,
   ServerIcon,
   SquarePenIcon,
+  Trash2Icon,
   Undo2Icon,
 } from "lucide-react";
 import {
@@ -136,17 +138,6 @@ const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> =
   repository_path: "Group by repository path",
   separate: "Keep separate",
 };
-
-function projectGroupingModeDescription(mode: SidebarProjectGroupingMode): string {
-  switch (mode) {
-    case "repository":
-      return "Projects from the same repository share one sidebar row.";
-    case "repository_path":
-      return "Projects group only when both the repository and repo-relative path match.";
-    case "separate":
-      return "This project always appears as its own sidebar entry.";
-  }
-}
 
 function compactSidebarTimeLabel(label: string): string {
   if (label === "just now") return "now";
@@ -792,18 +783,10 @@ export default function SidebarV2() {
       );
     },
   });
-  const [projectRenameTarget, setProjectRenameTarget] = useState<SidebarProjectGroupMember | null>(
-    null,
-  );
-  const [projectRenameTitle, setProjectRenameTitle] = useState("");
   const [projectActionsTarget, setProjectActionsTarget] = useState<SidebarProjectSnapshot | null>(
     null,
   );
-  const [projectGroupingTarget, setProjectGroupingTarget] =
-    useState<SidebarProjectGroupMember | null>(null);
-  const [projectGroupingSelection, setProjectGroupingSelection] = useState<
-    SidebarProjectGroupingMode | "inherit"
-  >("inherit");
+  const [projectScopeMenuOpen, setProjectScopeMenuOpen] = useState(false);
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
@@ -1063,67 +1046,52 @@ export default function SidebarV2() {
     [deleteProject, router, threads],
   );
 
-  const closeProjectRenameDialog = useCallback(() => {
-    setProjectRenameTarget(null);
-    setProjectRenameTitle("");
-  }, []);
-  const submitProjectRename = useCallback(async () => {
-    if (!projectRenameTarget) return;
-    const title = projectRenameTitle.trim();
-    if (!title) {
-      toastManager.add({ type: "warning", title: "Project title cannot be empty" });
-      return;
-    }
-    if (title === projectRenameTarget.title) {
-      closeProjectRenameDialog();
-      return;
-    }
-    const result = await updateProject({
-      environmentId: projectRenameTarget.environmentId,
-      input: { projectId: projectRenameTarget.id, title },
-    });
-    if (result._tag === "Success") {
-      closeProjectRenameDialog();
-    } else if (!isAtomCommandInterrupted(result)) {
-      const error = squashAtomCommandFailure(result);
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Failed to rename project",
-          description: error instanceof Error ? error.message : "An error occurred.",
-        }),
-      );
-    }
-  }, [closeProjectRenameDialog, projectRenameTarget, projectRenameTitle, updateProject]);
+  const renameProjectMember = useCallback(
+    async (member: SidebarProjectGroupMember, nextTitle: string) => {
+      const title = nextTitle.trim();
+      if (!title) {
+        toastManager.add({ type: "warning", title: "Project title cannot be empty" });
+        return;
+      }
+      if (title === member.title) return;
+      const result = await updateProject({
+        environmentId: member.environmentId,
+        input: { projectId: member.id, title },
+      });
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to rename project",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    },
+    [updateProject],
+  );
 
-  const closeProjectGroupingDialog = useCallback(() => {
-    setProjectGroupingTarget(null);
-    setProjectGroupingSelection("inherit");
-  }, []);
-  const saveProjectGroupingPreference = useCallback(() => {
-    if (!projectGroupingTarget) return;
-    const overrideKey = deriveProjectGroupingOverrideKey(projectGroupingTarget);
-    const nextOverrides = { ...projectGroupingSettings.sidebarProjectGroupingOverrides };
-    if (projectGroupingSelection === "inherit") {
-      delete nextOverrides[overrideKey];
-    } else {
-      nextOverrides[overrideKey] = projectGroupingSelection;
-    }
-    updateSettings({ sidebarProjectGroupingOverrides: nextOverrides });
-    closeProjectGroupingDialog();
-  }, [
-    closeProjectGroupingDialog,
-    projectGroupingSelection,
-    projectGroupingSettings.sidebarProjectGroupingOverrides,
-    projectGroupingTarget,
-    updateSettings,
-  ]);
+  const updateProjectGroupingPreference = useCallback(
+    (member: SidebarProjectGroupMember, selection: SidebarProjectGroupingMode | "inherit") => {
+      const overrideKey = deriveProjectGroupingOverrideKey(member);
+      const nextOverrides = { ...projectGroupingSettings.sidebarProjectGroupingOverrides };
+      if (selection === "inherit") {
+        delete nextOverrides[overrideKey];
+      } else {
+        nextOverrides[overrideKey] = selection;
+      }
+      updateSettings({ sidebarProjectGroupingOverrides: nextOverrides });
+    },
+    [projectGroupingSettings.sidebarProjectGroupingOverrides, updateSettings],
+  );
 
   const handleProjectActions = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
       event.preventDefault();
       event.stopPropagation();
-      setProjectActionsTarget(projectGroup);
+      setProjectScopeMenuOpen(false);
+      window.requestAnimationFrame(() => setProjectActionsTarget(projectGroup));
     },
     [],
   );
@@ -1768,7 +1736,7 @@ export default function SidebarV2() {
         {projectGroups.length > 0 ? (
           <SidebarGroup className="px-2 pb-2 pt-0">
             <div className="flex items-center gap-1">
-              <Menu>
+              <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
                 <MenuTrigger
                   aria-label="Filter threads by project"
                   className="flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 text-left text-sm font-medium text-sidebar-muted-foreground outline-none hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
@@ -1991,98 +1959,154 @@ export default function SidebarV2() {
           if (!open) setProjectActionsTarget(null);
         }}
       >
-        <DialogPopup className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Manage {projectActionsTarget?.displayName ?? "project"}</DialogTitle>
+        <DialogPopup className="max-w-xl">
+          <DialogHeader className="gap-1.5">
+            <DialogTitle className="text-balance">Project settings</DialogTitle>
             <DialogDescription>
               {projectActionsTarget && projectActionsTarget.memberProjects.length > 1
-                ? "Manage each environment's project entry independently."
-                : "Rename, regroup, copy, or remove this project entry."}
+                ? `${projectActionsTarget.displayName} has an entry in each environment. Changes apply only to the entry you choose.`
+                : `Manage ${projectActionsTarget?.displayName ?? "this project"} in this environment.`}
             </DialogDescription>
           </DialogHeader>
-          <DialogPanel className="space-y-3">
-            {projectActionsTarget?.memberProjects.map((member) => (
-              <div
-                key={member.physicalProjectKey}
-                className="rounded-lg border border-border/70 bg-muted/20 p-3"
-              >
-                <div className="flex min-w-0 items-start gap-2">
-                  <ProjectFavicon
-                    environmentId={member.environmentId}
-                    cwd={member.workspaceRoot}
-                    className="mt-0.5 size-4 shrink-0"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-medium text-foreground">
-                      {member.title}
-                    </div>
-                    <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                      {member.environmentLabel
-                        ? `${member.environmentLabel} · ${member.workspaceRoot}`
-                        : member.workspaceRoot}
+          <DialogPanel className="p-0">
+            <div className="divide-y divide-border/60">
+              {projectActionsTarget?.memberProjects.map((member) => (
+                <section
+                  key={member.physicalProjectKey}
+                  className="flex min-w-0 flex-col gap-4 px-6 py-5 sm:gap-3 sm:py-4"
+                >
+                  <div className="flex min-w-0 items-start gap-3">
+                    <ProjectFavicon
+                      environmentId={member.environmentId}
+                      cwd={member.workspaceRoot}
+                      className="size-5 shrink-0 sm:size-4"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 items-center gap-1.5 text-base text-muted-foreground sm:text-sm">
+                        <ServerIcon className="size-4 shrink-0 stroke-muted-foreground" />
+                        <p className="min-w-0 truncate">
+                          {member.environmentLabel ?? "Current environment"}
+                        </p>
+                      </div>
+                      <p
+                        className="truncate font-mono text-base text-muted-foreground/72 sm:text-sm"
+                        title={member.workspaceRoot}
+                      >
+                        {member.workspaceRoot}
+                      </p>
                     </div>
                   </div>
-                </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setProjectActionsTarget(null);
-                      setProjectRenameTarget(member);
-                      setProjectRenameTitle(member.title);
-                    }}
-                  >
-                    Rename
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setProjectActionsTarget(null);
-                      setProjectGroupingTarget(member);
-                      setProjectGroupingSelection(
-                        projectGroupingSettings.sidebarProjectGroupingOverrides?.[
-                          deriveProjectGroupingOverrideKey(member)
-                        ] ?? "inherit",
-                      );
-                    }}
-                  >
-                    Grouping
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() =>
-                      copyProjectPath(member.workspaceRoot, { path: member.workspaceRoot })
-                    }
-                  >
-                    Copy path
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    className="ml-auto"
-                    onClick={() => {
-                      const projectGroup = projectActionsTarget;
-                      if (!projectGroup) return;
-                      setProjectActionsTarget(null);
-                      void handleRemoveProjectMembers(projectGroup, [member]);
-                    }}
-                  >
-                    Remove
-                  </Button>
-                </div>
-              </div>
-            ))}
+                  <div className="grid gap-4 sm:grid-cols-2 sm:gap-3 sm:pl-7">
+                    <label className="grid min-w-0 gap-1.5">
+                      <span className="font-medium text-foreground">Project name</span>
+                      <Input
+                        key={`${member.physicalProjectKey}:${member.title}`}
+                        size="sm"
+                        aria-label={`Project name in ${member.environmentLabel ?? "current environment"}`}
+                        defaultValue={member.title}
+                        onBlur={(event) => {
+                          void renameProjectMember(member, event.currentTarget.value);
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") event.currentTarget.blur();
+                        }}
+                      />
+                    </label>
+                    <label className="grid min-w-0 gap-1.5">
+                      <span className="font-medium text-foreground">Grouping rule</span>
+                      <Select
+                        value={
+                          projectGroupingSettings.sidebarProjectGroupingOverrides?.[
+                            deriveProjectGroupingOverrideKey(member)
+                          ] ?? "inherit"
+                        }
+                        onValueChange={(value) => {
+                          if (
+                            value === "inherit" ||
+                            value === "repository" ||
+                            value === "repository_path" ||
+                            value === "separate"
+                          ) {
+                            updateProjectGroupingPreference(member, value);
+                          }
+                        }}
+                      >
+                        <SelectTrigger
+                          size="sm"
+                          className="w-full"
+                          aria-label={`Grouping rule for ${member.environmentLabel ?? "current environment"}`}
+                        >
+                          <SelectValue>
+                            {(() => {
+                              const selection =
+                                projectGroupingSettings.sidebarProjectGroupingOverrides?.[
+                                  deriveProjectGroupingOverrideKey(member)
+                                ] ?? "inherit";
+                              return selection === "inherit"
+                                ? `Default (${PROJECT_GROUPING_MODE_LABELS[projectGroupingSettings.sidebarProjectGroupingMode]})`
+                                : PROJECT_GROUPING_MODE_LABELS[selection];
+                            })()}
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectPopup align="start" alignItemWithTrigger={false}>
+                          <SelectItem hideIndicator value="inherit">
+                            Use global default
+                          </SelectItem>
+                          <SelectItem hideIndicator value="repository">
+                            {PROJECT_GROUPING_MODE_LABELS.repository}
+                          </SelectItem>
+                          <SelectItem hideIndicator value="repository_path">
+                            {PROJECT_GROUPING_MODE_LABELS.repository_path}
+                          </SelectItem>
+                          <SelectItem hideIndicator value="separate">
+                            {PROJECT_GROUPING_MODE_LABELS.separate}
+                          </SelectItem>
+                        </SelectPopup>
+                      </Select>
+                    </label>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 sm:pl-7">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() =>
+                        copyProjectPath(member.workspaceRoot, { path: member.workspaceRoot })
+                      }
+                    >
+                      <CopyIcon />
+                      Copy path
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive-foreground hover:bg-destructive/8 hover:text-destructive-foreground sm:ml-auto"
+                      onClick={() => {
+                        const projectGroup = projectActionsTarget;
+                        if (!projectGroup) return;
+                        setProjectActionsTarget(null);
+                        void handleRemoveProjectMembers(projectGroup, [member]);
+                      }}
+                    >
+                      <Trash2Icon />
+                      Remove
+                    </Button>
+                  </div>
+                </section>
+              ))}
+            </div>
             {projectActionsTarget && projectActionsTarget.memberProjects.length > 1 ? (
-              <div className="flex items-center justify-between gap-4 border-t border-border/70 pt-3">
-                <p className="text-xs text-muted-foreground">
-                  Removes every grouped entry and its conversation history.
-                </p>
+              <div className="flex flex-col gap-3 border-t border-border/60 bg-muted/32 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <p className="text-base font-medium text-foreground sm:text-sm">
+                    Remove this project everywhere
+                  </p>
+                  <p className="text-base text-pretty text-muted-foreground sm:text-sm">
+                    Deletes all grouped entries and their conversation history.
+                  </p>
+                </div>
                 <Button
                   size="sm"
-                  variant="destructive"
+                  variant="destructive-outline"
                   className="shrink-0"
                   onClick={() => {
                     const projectGroup = projectActionsTarget;
@@ -2090,140 +2114,14 @@ export default function SidebarV2() {
                     void handleRemoveProjectMembers(projectGroup, projectGroup.memberProjects);
                   }}
                 >
+                  <Trash2Icon />
                   Remove all entries
                 </Button>
               </div>
             ) : null}
           </DialogPanel>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setProjectActionsTarget(null)}>
-              Done
-            </Button>
-          </DialogFooter>
-        </DialogPopup>
-      </Dialog>
-      <Dialog
-        open={projectRenameTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) closeProjectRenameDialog();
-        }}
-      >
-        <DialogPopup className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>
-              {projectRenameTarget &&
-              projectGroups.some(
-                (group) =>
-                  group.memberProjects.length > 1 &&
-                  group.memberProjects.some(
-                    (member) =>
-                      member.environmentId === projectRenameTarget.environmentId &&
-                      member.id === projectRenameTarget.id,
-                  ),
-              )
-                ? "Rename project entry"
-                : "Rename project"}
-            </DialogTitle>
-            <DialogDescription>
-              {projectRenameTarget
-                ? `Update the title for ${projectRenameTarget.workspaceRoot}. Repository-grouped labels still use repository identity.`
-                : "Update the project title."}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogPanel className="space-y-4">
-            <div className="grid gap-1.5">
-              <span className="text-xs font-medium text-foreground">Project title</span>
-              <Input
-                aria-label="Project title"
-                value={projectRenameTitle}
-                onChange={(event) => setProjectRenameTitle(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    void submitProjectRename();
-                  }
-                }}
-              />
-            </div>
-            {projectRenameTarget?.environmentLabel ? (
-              <p className="text-xs text-muted-foreground">
-                Environment: {projectRenameTarget.environmentLabel}
-              </p>
-            ) : null}
-          </DialogPanel>
-          <DialogFooter>
-            <Button variant="outline" onClick={closeProjectRenameDialog}>
-              Cancel
-            </Button>
-            <Button onClick={() => void submitProjectRename()}>Save</Button>
-          </DialogFooter>
-        </DialogPopup>
-      </Dialog>
-      <Dialog
-        open={projectGroupingTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) closeProjectGroupingDialog();
-        }}
-      >
-        <DialogPopup className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Project grouping</DialogTitle>
-            <DialogDescription>
-              {projectGroupingTarget
-                ? `Choose how ${projectGroupingTarget.workspaceRoot} should be grouped in the sidebar.`
-                : "Choose how this project should be grouped in the sidebar."}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogPanel className="space-y-4">
-            <div className="grid gap-1.5">
-              <span className="text-xs font-medium text-foreground">Grouping rule</span>
-              <Select
-                value={projectGroupingSelection}
-                onValueChange={(value) => {
-                  if (
-                    value === "inherit" ||
-                    value === "repository" ||
-                    value === "repository_path" ||
-                    value === "separate"
-                  ) {
-                    setProjectGroupingSelection(value);
-                  }
-                }}
-              >
-                <SelectTrigger className="w-full" aria-label="Project grouping rule">
-                  <SelectValue>
-                    {projectGroupingSelection === "inherit"
-                      ? `Use global default (${PROJECT_GROUPING_MODE_LABELS[projectGroupingSettings.sidebarProjectGroupingMode]})`
-                      : PROJECT_GROUPING_MODE_LABELS[projectGroupingSelection]}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectItem hideIndicator value="inherit">
-                    Use global default
-                  </SelectItem>
-                  <SelectItem hideIndicator value="repository">
-                    {PROJECT_GROUPING_MODE_LABELS.repository}
-                  </SelectItem>
-                  <SelectItem hideIndicator value="repository_path">
-                    {PROJECT_GROUPING_MODE_LABELS.repository_path}
-                  </SelectItem>
-                  <SelectItem hideIndicator value="separate">
-                    {PROJECT_GROUPING_MODE_LABELS.separate}
-                  </SelectItem>
-                </SelectPopup>
-              </Select>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {projectGroupingSelection === "inherit"
-                ? projectGroupingModeDescription(projectGroupingSettings.sidebarProjectGroupingMode)
-                : projectGroupingModeDescription(projectGroupingSelection)}
-            </p>
-          </DialogPanel>
-          <DialogFooter>
-            <Button variant="outline" onClick={closeProjectGroupingDialog}>
-              Cancel
-            </Button>
-            <Button onClick={saveProjectGroupingPreference}>Save</Button>
+          <DialogFooter variant="bare">
+            <Button onClick={() => setProjectActionsTarget(null)}>Done</Button>
           </DialogFooter>
         </DialogPopup>
       </Dialog>


### PR DESCRIPTION
## What changed

Sidebar V2 now exposes the project-entry actions that were available in Sidebar V1 without treating a logical project group as one indivisible destructive target.

The project ellipsis closes the scope menu, then opens one project settings dialog. Each physical entry is clearly labeled by environment and workspace path, with its project name and grouping rule editable inline. Copy path and Remove stay available per entry; removing every member remains an explicit, secondary Remove all entries action.

Single projects use the same dialog with one entry. Rename uses the existing server update command, while grouping changes update the existing grouping override settings directly.

## Why

The previous Sidebar V2 trash button immediately targeted the entire logical group. Once local and remote project records were grouped, users could no longer rename, regroup, copy, or remove one physical project independently, and the default removal confirmation could delete every grouped entry and its conversation history.

## Verification

- `vp lint apps/web/src/components/SidebarV2.tsx`
- `vp test run apps/web/src/components/Sidebar.logic.test.ts apps/web/src/environmentGrouping.test.ts`
- `vp run --filter @t3tools/web typecheck`
- React Doctor review of the changed web scope (reported pre-existing Sidebar V2/compiler diagnostics; no new dialog-specific issue)
- Integrated browser verification against two disposable environments labeled Grouping Remote and Grouping Local
- Verified the scope menu is dismissed before the dialog mounts
- Verified the desktop dialog exposes both inline project-name inputs and grouping selects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive project removal UX and adds server-backed rename plus client grouping overrides, but reuses existing commands and settings patterns from Sidebar V1.
> 
> **Overview**
> Sidebar V2’s project scope menu no longer removes an entire logical group from a trash icon. Each project row gets an **ellipsis** that dismisses the scope menu and opens a **Project settings** dialog.
> 
> The dialog is **per physical entry** (environment + path): inline **rename** via `projectEnvironment.update`, **grouping rule** overrides via client settings, **copy path**, and **remove** for that entry only. Multi-member groups also show an explicit **Remove all entries** footer.
> 
> Removal logic is refactored to `handleRemoveProjectMembers` with a member subset, so confirmations name the specific entry (path/environment) and clarify when other grouped entries stay untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef27faff12898f8868940f6548e1b1b3c447eb84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore project actions in Sidebar V2 with logical project grouping
> - Adds `sortLogicalProjectsForSidebar` to sort grouped cross-environment projects by manual order or recent activity, ignoring archived threads.
> - Updates [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4373/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) to group projects by logical key, filter threads by scoped project membership, and apply manual ordering when the sort order is `'manual'`.
> - Replaces the direct trash-icon delete with an ellipsis actions menu that opens a dialog supporting per-environment rename, grouping rule override, copy path, single-entry removal, and bulk removal of all grouped entries.
> - Extends `buildSidebarProjectSnapshots` so `memberProjectRefs` includes all scoped project references mapping to a logical group, and adds `buildSidebarProjectPickerEntries` to select a preferred-environment target per group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d596b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->