### PR TITLE
fix(web): restore dark composer toolbar styling

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -248,7 +248,7 @@ export const BranchToolbar = memo(function BranchToolbar({
   if (!hasActiveThread || !activeProject) return null;
 
   return (
-    <div className="flex w-full items-center gap-2 border-t border-border/60 px-3 py-2">
+    <div className="chat-composer-context-strip -mt-4 mx-auto flex w-[calc(100%-1.5rem)] max-w-[calc(48rem-1.5rem)] items-center gap-2 pt-5 pb-1 ps-1">
       {isMobile ? (
         <MobileRunContextSelector
           envLocked={envLocked}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5592,7 +5592,7 @@ function ChatViewContent(props: ChatViewProps) {
                         : undefined
                     }
                   >
-                    <div className="chat-composer-glass-host mx-auto w-full max-w-3xl rounded-[22px]">
+                    <div className="chat-composer-glass-host relative z-10 mx-auto w-full max-w-3xl rounded-[22px]">
                       <div ref={attachDraftHeroComposerAnchorRef} className="relative z-10">
                         <ChatComposer
                           composerRef={composerRef}
@@ -5670,41 +5670,41 @@ function ChatViewContent(props: ChatViewProps) {
                           onExpandImage={onExpandTimelineImage}
                         />
                       </div>
-                      <div className="min-h-0">
-                        <div
-                          data-terminal-open={terminalUiState.terminalOpen ? "true" : undefined}
-                          className="relative z-0"
-                        >
-                          {isGitRepo && (
-                            <div className="pointer-events-auto">
-                              <BranchToolbar
-                                environmentId={activeThread.environmentId}
-                                threadId={activeThread.id}
-                                {...(routeKind === "draft" && draftId ? { draftId } : {})}
-                                onEnvModeChange={onEnvModeChange}
-                                startFromOrigin={startFromOrigin}
-                                onStartFromOriginChange={onStartFromOriginChange}
-                                {...(canOverrideServerThreadEnvMode
-                                  ? { effectiveEnvModeOverride: envMode }
-                                  : {})}
-                                {...(canOverrideServerThreadEnvMode
-                                  ? {
-                                      activeThreadBranchOverride: activeThreadBranch,
-                                      onActiveThreadBranchOverrideChange:
-                                        setPendingServerThreadBranch,
-                                    }
-                                  : {})}
-                                envLocked={envLocked}
-                                onComposerFocusRequest={scheduleComposerFocus}
-                                {...(canCheckoutPullRequestIntoThread
-                                  ? { onCheckoutPullRequestRequest: openPullRequestDialog }
-                                  : {})}
-                                {...(hasMultipleEnvironments ? { onEnvironmentChange } : {})}
-                                availableEnvironments={logicalProjectEnvironments}
-                              />
-                            </div>
-                          )}
-                        </div>
+                    </div>
+                    <div className="min-h-0">
+                      <div
+                        data-terminal-open={terminalUiState.terminalOpen ? "true" : undefined}
+                        className="relative z-0"
+                      >
+                        {isGitRepo && (
+                          <div className="pointer-events-auto">
+                            <BranchToolbar
+                              environmentId={activeThread.environmentId}
+                              threadId={activeThread.id}
+                              {...(routeKind === "draft" && draftId ? { draftId } : {})}
+                              onEnvModeChange={onEnvModeChange}
+                              startFromOrigin={startFromOrigin}
+                              onStartFromOriginChange={onStartFromOriginChange}
+                              {...(canOverrideServerThreadEnvMode
+                                ? { effectiveEnvModeOverride: envMode }
+                                : {})}
+                              {...(canOverrideServerThreadEnvMode
+                                ? {
+                                    activeThreadBranchOverride: activeThreadBranch,
+                                    onActiveThreadBranchOverrideChange:
+                                      setPendingServerThreadBranch,
+                                  }
+                                : {})}
+                              envLocked={envLocked}
+                              onComposerFocusRequest={scheduleComposerFocus}
+                              {...(canCheckoutPullRequestIntoThread
+                                ? { onCheckoutPullRequestRequest: openPullRequestDialog }
+                                : {})}
+                              {...(hasMultipleEnvironments ? { onEnvironmentChange } : {})}
+                              availableEnvironments={logicalProjectEnvironments}
+                            />
+                          </div>
+                        )}
                       </div>
                     </div>
                     <div

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -402,10 +402,39 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     content: "";
   }
 
-  .dark .chat-composer-glass-host {
-    --chat-composer-glass-surface: color-mix(in srgb, var(--background) 84%, var(--color-white));
+  .chat-composer-context-strip {
+    --chat-composer-context-surface: var(--card);
 
-    box-shadow: 0 0 0 1px rgb(255 255 255 / 10%);
+    position: relative;
+    isolation: isolate;
+  }
+
+  .chat-composer-context-strip::before {
+    position: absolute;
+    z-index: -1;
+    inset: 0;
+    border-radius: 0 0 16px 16px;
+    background: color-mix(
+      in srgb,
+      var(--chat-composer-context-surface) var(--glass-opacity),
+      transparent
+    );
+    -webkit-mask-image: linear-gradient(to bottom, transparent 0 1rem, black 1rem);
+    mask-image: linear-gradient(to bottom, transparent 0 1rem, black 1rem);
+    box-shadow: 0 12px 28px -18px rgb(0 0 0 / 40%);
+    content: "";
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturation));
+    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturation));
+  }
+
+  .dark .chat-composer-glass-host {
+    --chat-composer-glass-surface: color-mix(in srgb, var(--background) 96%, var(--color-white));
+
+    box-shadow: none;
+  }
+
+  .dark .chat-composer-context-strip::before {
+    box-shadow: 0 14px 32px -18px rgb(0 0 0 / 75%);
   }
 
   .alert-glass {


### PR DESCRIPTION
## What Changed

- Restore the subtler dark-mode composer colors from the original surface redesign.
- Remove the dark composer outline and shadow that increased contrast against the workspace.
- Reintroduce the inset workspace toolbar beneath the composer.
- Align the toolbar controls with the composer controls.
- Connect the toolbar surface to the glass-opacity setting.
- Mask the toolbar overlap so it does not show through the translucent composer.

## Why

A follow-up contrast adjustment made the dark composer appear significantly brighter and visually heavier than the surrounding workspace.

The workspace toolbar was also merged into the composer surface, removing the inset hierarchy from the original redesign. This restores that separation while preserving the newer overlay behavior and ensuring the glass-opacity control affects both surfaces consistently.

## UI Changes

before
<img width="792" height="198" alt="image" src="https://github.com/user-attachments/assets/f558fc41-19d1-41d4-9a77-77ed5298c281" />
after
<img width="783" height="192" alt="image" src="https://github.com/user-attachments/assets/0c5fb25a-81b1-435b-94d3-5e181045b2a9" />

(100% glass opacity)

## Validation

- `vp fmt --check apps/web/src/components/BranchToolbar.tsx apps/web/src/components/ChatView.tsx apps/web/src/index.css`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation changes require a video

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and composer-overlay layout only; no behavior or API changes to thread/git controls.
> 
> **Overview**
> Restores the **inset branch/workspace toolbar** under the chat composer instead of treating it as a full-width bordered strip merged into the composer chrome.
> 
> **Layout:** `BranchToolbar` moves to a sibling below the `chat-composer-glass-host` (still in the composer overlay). The glass host gets `z-10` so the rounded composer sits above the toolbar. The toolbar uses `chat-composer-context-strip` with negative top margin and width/max-width matched to the composer inset so controls line up with the input.
> 
> **Styling:** New CSS gives the toolbar its own glass surface via `--glass-opacity` (same control as the composer), with a **top mask** so the strip doesn’t bleed through the translucent composer. **Dark mode** softens the composer (higher background mix, no outline/shadow on the glass host) and applies shadow on the context strip instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebd8e444d37c3503c521da4d33b9aa6b1585272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore dark mode styling for the composer toolbar
> - Moves `BranchToolbar` outside the `chat-composer-glass-host` container in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4375/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) so it renders as a sibling, fixing z-index stacking in dark mode.
> - Adds a `.chat-composer-context-strip` class to [BranchToolbar.tsx](https://github.com/pingdotgg/t3code/pull/4375/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) with updated spacing and no top border.
> - Introduces a `::before` pseudo-element in [index.css](https://github.com/pingdotgg/t3code/pull/4375/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) that renders a blurred, semi-transparent glass effect behind the toolbar strip, and removes the outline box-shadow from the dark glass host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ebd8e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->