### PR TITLE
fix(server): resolve orphaned OpenCode permissions on session error

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1374,4 +1374,64 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.deepEqual(closeCallsDuringRun, []);
     }),
   );
+
+  it.effect(
+    "resolves an orphaned pending permission as cancelled when the session errors out",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-opencode-orphaned-permission");
+        runtimeMock.state.subscribedEvents = [
+          {
+            type: "permission.asked",
+            properties: {
+              id: "perm-orphaned",
+              sessionID: "http://127.0.0.1:9999/session",
+              permission: "bash",
+              patterns: [],
+              metadata: {},
+              always: [],
+            },
+          },
+          {
+            type: "session.error",
+            properties: {
+              sessionID: "http://127.0.0.1:9999/session",
+              error: {
+                name: "MessageAbortedError",
+                data: { message: "Aborted" },
+              },
+            },
+          },
+        ];
+
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.threadId === threadId),
+          // session.started, thread.started, request.opened, request.resolved, runtime.error
+          Stream.take(5),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        });
+
+        const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+
+        // Nothing ever answered the permission request — before this fix, no
+        // event ever resolved it and the request stayed pending forever.
+        const opened = events.find((event) => event.type === "request.opened");
+        const resolved = events.find((event) => event.type === "request.resolved");
+        NodeAssert.ok(opened, "expected a request.opened event for the pending permission");
+        NodeAssert.ok(resolved, "expected the orphaned permission to be resolved");
+        NodeAssert.equal(String(opened?.requestId), "perm-orphaned");
+        NodeAssert.equal(String(resolved?.requestId), "perm-orphaned");
+        if (resolved?.type === "request.resolved") {
+          NodeAssert.equal(resolved.payload.decision, "cancel");
+        }
+      }),
+  );
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1078,6 +1078,27 @@ export function makeOpenCodeAdapter(
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
           context.activeTurnId = undefined;
+          // A session error abandons any tool call awaiting approval — the
+          // opencode subprocess won't send a matching `permission.replied`
+          // for it, so without this the request stays "pending" forever and
+          // blocks the thread from ever settling.
+          const orphanedPermissions = Array.from(context.pendingPermissions.entries());
+          context.pendingPermissions.clear();
+          for (const [requestId, permission] of orphanedPermissions) {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId: activeTurnId,
+                requestId,
+                raw: event,
+              })),
+              type: "request.resolved",
+              payload: {
+                requestType: mapPermissionToRequestType(permission.permission),
+                decision: "cancel",
+              },
+            });
+          }
           yield* updateProviderSession(
             context,
             {


### PR DESCRIPTION
## What Changed

I was trying the new sidebar and had an issue when an OpenCode session got a fatal `session.error` (I think it was a rate-limit in a free provider I was playing with) and the approval of that session got stuck for ever, left the "action needed" pill on the sidebar and didn't allow me to "settle" it. 

I thought it was related to the "auto approval" option in opencode, which I don't think it exists in the opencode provider, but after looking a bit it doesn't seem related. 

 `OpenCodeAdapter.ts` now drains any tool permission requests still awaiting a reply and emits a synthetic `request.resolved` (`decision: "cancel"`) for each, instead of leaving them pending forever.

## Why

The opencode subprocess never sends a matching `permission.replied` for a turn that already died, so today no `request.resolved` event is ever emitted for a permission request orphaned by a session error. That leaves the thread's `pending_approval_count` stuck above zero, which permanently blocks the "Settle" action with "This thread still needs attention." The only way out today is a direct database edit.

This mirrors the same "cancel pending approvals on abnormal termination" pattern already used elsewhere in the codebase: `ClaudeAdapter.stopSessionInternal`, `CodexSessionRuntime.settlePendingApprovals("cancel")`, and `CursorAdapter.settlePendingApprovalsAsCancelled`. OpenCode's adapter was missing the equivalent safeguard.

Repro steps that hit this in practice:
1. Start an OpenCode thread and let the model request a tool permission (e.g. `bash`/`grep`).
2. Have the underlying provider call fail/abort before the permission is answered (rate limiting is one trigger).
3. The thread is now permanently stuck: `pending_approval_count` never returns to 0, and "Settle" fails forever.

Added a regression test (`OpenCodeAdapter.test.ts`) that reproduces this exact sequence and asserts the orphaned permission is resolved with `decision: "cancel"`. Verified it fails without the fix (timeout waiting for the resolution) and passes with it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a — no UI changes)
- [x] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized OpenCode adapter event handling with a regression test; no auth, persistence schema, or UI changes.
> 
> **Overview**
> Fixes threads that stay permanently blocked when an OpenCode session dies (e.g. rate limit / abort) while a tool permission is still waiting for a reply. OpenCode never sends `permission.replied` in that case, so **`pending_approval_count` never drops** and Settle keeps failing.
> 
> On **`session.error`**, `OpenCodeAdapter` now **drains `pendingPermissions`**, clears the map, and emits **`request.resolved` with `decision: "cancel"`** for each orphaned request (with the correct approval type from the stored permission). Session error handling (status, turn failure, runtime error) is unchanged aside from this cleanup.
> 
> Adds a regression test that simulates `permission.asked` followed by `session.error` and asserts the permission is resolved as cancelled—matching the cancel-on-abnormal-termination pattern used by other provider adapters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2a2a60cdc6e7cd274fba1cc4081404109c065d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve orphaned pending permissions as cancelled on OpenCode session error
> When a `session.error` event is received, any pending permission requests that have not been resolved are now emitted as `request.resolved` events with decision `cancel` before the session transitions to error state. Previously, these permissions would remain indefinitely pending. A new test in [OpenCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/4381/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) covers this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a2a2a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->