### PR TITLE
Fix thread tooltip folder icon color

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -186,7 +186,7 @@ function SidebarV2ThreadTooltip({
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={projectCwd ?? ""}
-                className="size-4 shrink-0"
+                className="size-4 shrink-0 stroke-muted-foreground"
               />
               <div className="min-w-0 wrap-break-word text-foreground/90">{projectTitle}</div>
             </div>


### PR DESCRIPTION
## Summary
- Match the thread tooltip folder icon stroke color to the other metadata icons.

## Why
The project favicon fallback used a dimmer inherited color than the server, branch, and provider icons.

## Verification
- `vp fmt apps/web/src/components/SidebarV2.tsx --check`
- `vp lint apps/web/src/components/SidebarV2.tsx --report-unused-disable-directives`
- `vp run --filter @t3tools/web typecheck`

Browser testing was skipped at the requester’s direction.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix folder icon stroke color in thread tooltip sidebar
> Adds `stroke-muted-foreground` to the `ProjectFavicon` element in `SidebarV2ThreadTooltip` so the folder icon renders with the correct muted color instead of the default stroke.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7fcd8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a sidebar tooltip icon; no logic, data, or API changes.
> 
> **Overview**
> In **Sidebar V2** thread hover tooltips, the project row’s `ProjectFavicon` now includes **`stroke-muted-foreground`** so the folder fallback stroke matches the server, branch, and other metadata icons instead of looking dimmer from inherited stroke color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7fcd8e4a389381a95fffa06f110f301821d6178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->