### PR TITLE
Recover stranded provider turns

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -304,6 +304,7 @@ export const makeOrchestrationIntegrationHarness = (
       ProjectionPendingApprovalRepositoryLive,
       checkpointStoreLayer,
       providerLayer,
+      providerSessionDirectoryLayer,
       RuntimeReceiptBusTest,
     );
     const serverSettingsLayer = ServerSettingsService.layerTest();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -161,6 +161,10 @@ describe("ProviderCommandReactor", () => {
     readonly runtimeBindingsByRead?: ReadonlyArray<
       ReadonlyArray<ProviderRuntimeBindingWithMetadata>
     >;
+    readonly sessionUpdateOnRuntimeBindingRead?: {
+      readonly readIndex: number;
+      readonly session: OrchestrationSession;
+    };
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -366,6 +370,7 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(SqlitePersistenceMemory),
     );
     let runtimeBindingReadCount = 0;
+    let engineForRuntimeBindingRead: OrchestrationEngineService["Service"] | undefined;
     const providerSessionDirectoryLayer = Layer.succeed(ProviderSessionDirectory, {
       upsert: () => Effect.void,
       getProvider: () =>
@@ -373,8 +378,23 @@ describe("ProviderCommandReactor", () => {
       getBinding: () => Effect.succeed(Option.none()),
       listThreadIds: () => Effect.succeed([]),
       listBindings: () =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
           const readIndex = runtimeBindingReadCount++;
+          if (
+            engineForRuntimeBindingRead &&
+            input?.sessionUpdateOnRuntimeBindingRead?.readIndex === readIndex
+          ) {
+            const session = input.sessionUpdateOnRuntimeBindingRead.session;
+            yield* engineForRuntimeBindingRead
+              .dispatch({
+                type: "thread.session.set",
+                commandId: CommandId.make(`cmd-session-update-on-binding-read-${readIndex}`),
+                threadId: session.threadId,
+                session,
+                createdAt: session.updatedAt,
+              })
+              .pipe(Effect.orDie);
+          }
           const bindingsByRead = input?.runtimeBindingsByRead;
           if (bindingsByRead && bindingsByRead.length > 0) {
             return bindingsByRead[Math.min(readIndex, bindingsByRead.length - 1)]!;
@@ -417,6 +437,7 @@ describe("ProviderCommandReactor", () => {
     runtime = ManagedRuntime.make(layer);
 
     const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
+    engineForRuntimeBindingRead = engine;
     const snapshotQuery = await runtime.runPromise(Effect.service(ProjectionSnapshotQuery));
     const reactor = await runtime.runPromise(Effect.service(ProviderCommandReactor));
     const drain = () => Effect.runPromise(reactor.drain);
@@ -643,6 +664,48 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.session?.status).toBe("running");
     expect(thread?.session?.activeTurnId).toBe("orchestration-turn-1");
+  });
+
+  it("checks the projected session again immediately before settling it", async () => {
+    const runningAt = "2026-01-01T00:01:00.000Z";
+    const stoppedAt = "2026-01-01T00:02:00.000Z";
+    const recoveredAt = "2026-01-01T00:03:00.000Z";
+    const initialSession: OrchestrationSession = {
+      threadId: ThreadId.make("thread-1"),
+      status: "running",
+      providerName: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      runtimeMode: "approval-required",
+      activeTurnId: asTurnId("orchestration-turn-1"),
+      lastError: null,
+      updatedAt: runningAt,
+    };
+    const stoppedBinding: ProviderRuntimeBindingWithMetadata = {
+      threadId: ThreadId.make("thread-1"),
+      provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      status: "stopped",
+      runtimeMode: "approval-required",
+      lastSeenAt: stoppedAt,
+    };
+    const harness = await createHarness({
+      initialSession,
+      runtimeBindings: [stoppedBinding],
+      sessionUpdateOnRuntimeBindingRead: {
+        readIndex: 2,
+        session: {
+          ...initialSession,
+          activeTurnId: asTurnId("orchestration-turn-recovered"),
+          updatedAt: recoveredAt,
+        },
+      },
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("running");
+    expect(thread?.session?.activeTurnId).toBe("orchestration-turn-recovered");
+    expect(thread?.session?.updatedAt).toBe(recoveredAt);
   });
 
   it("reacts to thread.turn.start by ensuring session and sending provider turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -5,6 +5,7 @@ import * as NodePath from "node:path";
 
 import {
   ModelSelection,
+  type OrchestrationSession,
   ProviderRuntimeEvent,
   ProviderSession,
   ProviderDriverKind,
@@ -26,6 +27,7 @@ import * as Deferred from "effect/Deferred";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
+import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
@@ -35,6 +37,10 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { deriveServerPaths, ServerConfig } from "../../config.ts";
 import { TextGenerationError } from "@t3tools/contracts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
+import {
+  ProviderSessionDirectory,
+  type ProviderRuntimeBindingWithMetadata,
+} from "../../provider/Services/ProviderSessionDirectory.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
@@ -149,6 +155,8 @@ describe("ProviderCommandReactor", () => {
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
+    readonly initialSession?: OrchestrationSession;
+    readonly runtimeBindings?: ReadonlyArray<ProviderRuntimeBindingWithMetadata>;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -353,10 +361,19 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(RepositoryIdentityResolver.layer),
       Layer.provide(SqlitePersistenceMemory),
     );
+    const providerSessionDirectoryLayer = Layer.succeed(ProviderSessionDirectory, {
+      upsert: () => Effect.void,
+      getProvider: () =>
+        Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in this test")),
+      getBinding: () => Effect.succeed(Option.none()),
+      listThreadIds: () => Effect.succeed([]),
+      listBindings: () => Effect.succeed(input?.runtimeBindings ?? []),
+    });
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
+      Layer.provideMerge(providerSessionDirectoryLayer),
       Layer.provideMerge(makeProviderRegistryLayer(providerSnapshots as never)),
       Layer.provideMerge(
         Layer.mock(GitWorkflowService.GitWorkflowService)({
@@ -387,8 +404,6 @@ describe("ProviderCommandReactor", () => {
     const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
     const snapshotQuery = await runtime.runPromise(Effect.service(ProjectionSnapshotQuery));
     const reactor = await runtime.runPromise(Effect.service(ProviderCommandReactor));
-    scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
     const drain = () => Effect.runPromise(reactor.drain);
 
     await Effect.runPromise(
@@ -417,6 +432,19 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
       }),
     );
+    if (input?.initialSession) {
+      await Effect.runPromise(
+        engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-initial-session-set"),
+          threadId: ThreadId.make("thread-1"),
+          session: input.initialSession,
+          createdAt: input.initialSession.updatedAt,
+        }),
+      );
+    }
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
 
     return {
       engine,
@@ -436,6 +464,71 @@ describe("ProviderCommandReactor", () => {
       drain,
     };
   }
+
+  it("settles a projected running turn when its persisted runtime already stopped", async () => {
+    const runningAt = "2026-01-01T00:01:00.000Z";
+    const stoppedAt = "2026-01-01T00:02:00.000Z";
+    const harness = await createHarness({
+      initialSession: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "approval-required",
+        activeTurnId: asTurnId("orchestration-turn-1"),
+        lastError: null,
+        updatedAt: runningAt,
+      },
+      runtimeBindings: [
+        {
+          threadId: ThreadId.make("thread-1"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          status: "stopped",
+          runtimeMode: "approval-required",
+          lastSeenAt: stoppedAt,
+        },
+      ],
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("stopped");
+    expect(thread?.session?.activeTurnId).toBeNull();
+  });
+
+  it("does not settle a newer running projection from an older stopped binding", async () => {
+    const stoppedAt = "2026-01-01T00:01:00.000Z";
+    const runningAt = "2026-01-01T00:02:00.000Z";
+    const harness = await createHarness({
+      initialSession: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "approval-required",
+        activeTurnId: asTurnId("orchestration-turn-1"),
+        lastError: null,
+        updatedAt: runningAt,
+      },
+      runtimeBindings: [
+        {
+          threadId: ThreadId.make("thread-1"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          status: "stopped",
+          runtimeMode: "approval-required",
+          lastSeenAt: stoppedAt,
+        },
+      ],
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("running");
+    expect(thread?.session?.activeTurnId).toBe("orchestration-turn-1");
+    expect(thread?.latestTurn?.state).toBe("running");
+  });
 
   it("reacts to thread.turn.start by ensuring session and sending provider turn", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -158,6 +158,9 @@ describe("ProviderCommandReactor", () => {
     readonly initialSession?: OrchestrationSession;
     readonly runtimeBindings?: ReadonlyArray<ProviderRuntimeBindingWithMetadata>;
     readonly runtimeBindingsAfterInitialRead?: ReadonlyArray<ProviderRuntimeBindingWithMetadata>;
+    readonly runtimeBindingsByRead?: ReadonlyArray<
+      ReadonlyArray<ProviderRuntimeBindingWithMetadata>
+    >;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -370,11 +373,16 @@ describe("ProviderCommandReactor", () => {
       getBinding: () => Effect.succeed(Option.none()),
       listThreadIds: () => Effect.succeed([]),
       listBindings: () =>
-        Effect.succeed(
-          runtimeBindingReadCount++ > 0 && input?.runtimeBindingsAfterInitialRead
+        Effect.sync(() => {
+          const readIndex = runtimeBindingReadCount++;
+          const bindingsByRead = input?.runtimeBindingsByRead;
+          if (bindingsByRead && bindingsByRead.length > 0) {
+            return bindingsByRead[Math.min(readIndex, bindingsByRead.length - 1)]!;
+          }
+          return readIndex > 0 && input?.runtimeBindingsAfterInitialRead
             ? input.runtimeBindingsAfterInitialRead
-            : (input?.runtimeBindings ?? []),
-        ),
+            : (input?.runtimeBindings ?? []);
+        }),
     });
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(orchestrationLayer),
@@ -593,6 +601,42 @@ describe("ProviderCommandReactor", () => {
       initialSession,
       runtimeBindings: [stoppedBinding],
       runtimeBindingsAfterInitialRead: [{ ...stoppedBinding, status: "running" }],
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("running");
+    expect(thread?.session?.activeTurnId).toBe("orchestration-turn-1");
+  });
+
+  it("checks the binding again immediately before settling the projected session", async () => {
+    const runningAt = "2026-01-01T00:01:00.000Z";
+    const stoppedAt = "2026-01-01T00:02:00.000Z";
+    const initialSession: OrchestrationSession = {
+      threadId: ThreadId.make("thread-1"),
+      status: "running",
+      providerName: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      runtimeMode: "approval-required",
+      activeTurnId: asTurnId("orchestration-turn-1"),
+      lastError: null,
+      updatedAt: runningAt,
+    };
+    const stoppedBinding: ProviderRuntimeBindingWithMetadata = {
+      threadId: ThreadId.make("thread-1"),
+      provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      status: "stopped",
+      runtimeMode: "approval-required",
+      lastSeenAt: stoppedAt,
+    };
+    const harness = await createHarness({
+      initialSession,
+      runtimeBindingsByRead: [
+        [stoppedBinding],
+        [stoppedBinding],
+        [{ ...stoppedBinding, status: "running" }],
+      ],
     });
 
     const readModel = await harness.readModel();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -537,6 +537,37 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.latestTurn?.state).toBe("running");
   });
 
+  it("settles the projection when the stopped binding shares the session timestamp", async () => {
+    const sharedAt = "2026-01-01T00:01:00.000Z";
+    const harness = await createHarness({
+      initialSession: {
+        threadId: ThreadId.make("thread-1"),
+        status: "running",
+        providerName: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "approval-required",
+        activeTurnId: asTurnId("orchestration-turn-1"),
+        lastError: null,
+        updatedAt: sharedAt,
+      },
+      runtimeBindings: [
+        {
+          threadId: ThreadId.make("thread-1"),
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          status: "stopped",
+          runtimeMode: "approval-required",
+          lastSeenAt: sharedAt,
+        },
+      ],
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("stopped");
+    expect(thread?.session?.activeTurnId).toBeNull();
+  });
+
   it("rechecks a stopped binding before settling the projected session", async () => {
     const runningAt = "2026-01-01T00:01:00.000Z";
     const stoppedAt = "2026-01-01T00:02:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -157,6 +157,7 @@ describe("ProviderCommandReactor", () => {
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
     readonly initialSession?: OrchestrationSession;
     readonly runtimeBindings?: ReadonlyArray<ProviderRuntimeBindingWithMetadata>;
+    readonly runtimeBindingsAfterInitialRead?: ReadonlyArray<ProviderRuntimeBindingWithMetadata>;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -361,13 +362,19 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(RepositoryIdentityResolver.layer),
       Layer.provide(SqlitePersistenceMemory),
     );
+    let runtimeBindingReadCount = 0;
     const providerSessionDirectoryLayer = Layer.succeed(ProviderSessionDirectory, {
       upsert: () => Effect.void,
       getProvider: () =>
         Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in this test")),
       getBinding: () => Effect.succeed(Option.none()),
       listThreadIds: () => Effect.succeed([]),
-      listBindings: () => Effect.succeed(input?.runtimeBindings ?? []),
+      listBindings: () =>
+        Effect.succeed(
+          runtimeBindingReadCount++ > 0 && input?.runtimeBindingsAfterInitialRead
+            ? input.runtimeBindingsAfterInitialRead
+            : (input?.runtimeBindings ?? []),
+        ),
     });
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(orchestrationLayer),
@@ -528,6 +535,39 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.status).toBe("running");
     expect(thread?.session?.activeTurnId).toBe("orchestration-turn-1");
     expect(thread?.latestTurn?.state).toBe("running");
+  });
+
+  it("rechecks a stopped binding before settling the projected session", async () => {
+    const runningAt = "2026-01-01T00:01:00.000Z";
+    const stoppedAt = "2026-01-01T00:02:00.000Z";
+    const initialSession: OrchestrationSession = {
+      threadId: ThreadId.make("thread-1"),
+      status: "running",
+      providerName: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      runtimeMode: "approval-required",
+      activeTurnId: asTurnId("orchestration-turn-1"),
+      lastError: null,
+      updatedAt: runningAt,
+    };
+    const stoppedBinding: ProviderRuntimeBindingWithMetadata = {
+      threadId: ThreadId.make("thread-1"),
+      provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex"),
+      status: "stopped",
+      runtimeMode: "approval-required",
+      lastSeenAt: stoppedAt,
+    };
+    const harness = await createHarness({
+      initialSession,
+      runtimeBindings: [stoppedBinding],
+      runtimeBindingsAfterInitialRead: [{ ...stoppedBinding, status: "running" }],
+    });
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("running");
+    expect(thread?.session?.activeTurnId).toBe("orchestration-turn-1");
   });
 
   it("reacts to thread.turn.start by ensuring session and sending provider turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -469,7 +469,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
     if (input?.initialSession) {
-      await Effect.runPromise(
+      await runtime.runPromise(
         engine.dispatch({
           type: "thread.session.set",
           commandId: CommandId.make("cmd-initial-session-set"),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -341,24 +341,34 @@ const make = Effect.gen(function* () {
               return;
             }
 
+            // Re-read immediately before dispatch. Runtime recovery can update
+            // the persisted binding while projection/session checks are in
+            // flight; never settle from a stopped snapshot that has already
+            // been replaced by a live binding.
+            const finalBindings = yield* providerSessionDirectory.listBindings();
+            const finalBinding = finalBindings.find((entry) => entry.threadId === thread.id);
+            if (!finalBinding || !canReconcileStoppedRuntimeBinding(latestSession, finalBinding)) {
+              return;
+            }
+
             yield* setThreadSession({
               threadId: thread.id,
               session: {
                 ...latestSession,
                 status: "stopped",
                 activeTurnId: null,
-                updatedAt: latestBinding.lastSeenAt,
+                updatedAt: finalBinding.lastSeenAt,
               },
-              createdAt: latestBinding.lastSeenAt,
+              createdAt: finalBinding.lastSeenAt,
             }).pipe(
               Effect.tap(() =>
                 Effect.logWarning("provider.session.reconciled-stopped-runtime", {
                   threadId: thread.id,
                   previousStatus: latestSession.status,
                   activeTurnId: latestSession.activeTurnId,
-                  provider: latestBinding.provider,
-                  providerInstanceId: latestBinding.providerInstanceId,
-                  stoppedAt: latestBinding.lastSeenAt,
+                  provider: finalBinding.provider,
+                  providerInstanceId: finalBinding.providerInstanceId,
+                  stoppedAt: finalBinding.lastSeenAt,
                 }),
               ),
             );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -32,6 +32,7 @@ import type { ProviderServiceError } from "../../provider/Errors.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
+import { ProviderSessionDirectory } from "../../provider/Services/ProviderSessionDirectory.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
@@ -195,6 +196,7 @@ const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
   const providerRegistry = yield* ProviderRegistry;
+  const providerSessionDirectory = yield* ProviderSessionDirectory;
   const gitWorkflow = yield* GitWorkflowService;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
@@ -284,6 +286,61 @@ const make = Effect.gen(function* () {
         }),
       ),
     );
+
+  const reconcileStoppedRuntimeBindings = Effect.fn("reconcileStoppedRuntimeBindings")(
+    function* () {
+      const [snapshot, bindings] = yield* Effect.all([
+        projectionSnapshotQuery.getShellSnapshot(),
+        providerSessionDirectory.listBindings(),
+      ]);
+      const bindingByThreadId = new Map(bindings.map((binding) => [binding.threadId, binding]));
+
+      yield* Effect.forEach(
+        snapshot.threads,
+        (thread) => {
+          const session = thread.session;
+          const binding = bindingByThreadId.get(thread.id);
+          const bindingLastSeenAt = binding ? Date.parse(binding.lastSeenAt) : Number.NaN;
+          const sessionUpdatedAt = session ? Date.parse(session.updatedAt) : Number.NaN;
+          if (
+            (session?.status !== "running" && session?.status !== "starting") ||
+            binding?.status !== "stopped" ||
+            (session.providerName !== null && session.providerName !== binding.provider) ||
+            (session.providerInstanceId !== undefined &&
+              session.providerInstanceId !== binding.providerInstanceId) ||
+            Number.isNaN(bindingLastSeenAt) ||
+            Number.isNaN(sessionUpdatedAt) ||
+            bindingLastSeenAt < sessionUpdatedAt
+          ) {
+            return Effect.void;
+          }
+
+          return setThreadSession({
+            threadId: thread.id,
+            session: {
+              ...session,
+              status: "stopped",
+              activeTurnId: null,
+              updatedAt: binding.lastSeenAt,
+            },
+            createdAt: binding.lastSeenAt,
+          }).pipe(
+            Effect.tap(() =>
+              Effect.logWarning("provider.session.reconciled-stopped-runtime", {
+                threadId: thread.id,
+                previousStatus: session.status,
+                activeTurnId: session.activeTurnId,
+                provider: binding.provider,
+                providerInstanceId: binding.providerInstanceId,
+                stoppedAt: binding.lastSeenAt,
+              }),
+            ),
+          );
+        },
+        { concurrency: 1, discard: true },
+      );
+    },
+  );
 
   const setThreadSessionErrorOnTurnStartFailure = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
@@ -1109,6 +1166,13 @@ const make = Effect.gen(function* () {
 
     yield* Effect.forkScoped(
       Stream.runForEach(orchestrationEngine.streamDomainEvents, processEvent),
+    );
+    yield* reconcileStoppedRuntimeBindings().pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("provider.session.startup-reconciliation-failed", {
+          cause: Cause.pretty(cause),
+        }),
+      ),
     );
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -347,14 +347,22 @@ const make = Effect.gen(function* () {
             // been replaced by a live binding.
             const finalBindings = yield* providerSessionDirectory.listBindings();
             const finalBinding = finalBindings.find((entry) => entry.threadId === thread.id);
-            if (!finalBinding || !canReconcileStoppedRuntimeBinding(latestSession, finalBinding)) {
+            const finalThread = yield* projectionSnapshotQuery
+              .getThreadShellById(thread.id)
+              .pipe(Effect.map(Option.getOrUndefined));
+            const finalSession = finalThread?.session;
+            if (
+              !finalSession ||
+              !finalBinding ||
+              !canReconcileStoppedRuntimeBinding(finalSession, finalBinding)
+            ) {
               return;
             }
 
             yield* setThreadSession({
               threadId: thread.id,
               session: {
-                ...latestSession,
+                ...finalSession,
                 status: "stopped",
                 activeTurnId: null,
                 updatedAt: finalBinding.lastSeenAt,
@@ -364,8 +372,8 @@ const make = Effect.gen(function* () {
               Effect.tap(() =>
                 Effect.logWarning("provider.session.reconciled-stopped-runtime", {
                   threadId: thread.id,
-                  previousStatus: latestSession.status,
-                  activeTurnId: latestSession.activeTurnId,
+                  previousStatus: finalSession.status,
+                  activeTurnId: finalSession.activeTurnId,
                   provider: finalBinding.provider,
                   providerInstanceId: finalBinding.providerInstanceId,
                   stoppedAt: finalBinding.lastSeenAt,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -32,7 +32,10 @@ import type { ProviderServiceError } from "../../provider/Errors.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
-import { ProviderSessionDirectory } from "../../provider/Services/ProviderSessionDirectory.ts";
+import {
+  ProviderSessionDirectory,
+  type ProviderRuntimeBindingWithMetadata,
+} from "../../provider/Services/ProviderSessionDirectory.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
@@ -117,6 +120,24 @@ function canReplaceThreadTitle(currentTitle: string, titleSeed?: string): boolea
   return trimmedTitleSeed !== undefined && trimmedTitleSeed.length > 0
     ? trimmedCurrentTitle === trimmedTitleSeed
     : false;
+}
+
+function canReconcileStoppedRuntimeBinding(
+  session: OrchestrationSession,
+  binding: ProviderRuntimeBindingWithMetadata,
+): boolean {
+  const bindingLastSeenAt = Date.parse(binding.lastSeenAt);
+  const sessionUpdatedAt = Date.parse(session.updatedAt);
+  return (
+    (session.status === "running" || session.status === "starting") &&
+    binding.status === "stopped" &&
+    (session.providerName === null || session.providerName === binding.provider) &&
+    (session.providerInstanceId === undefined ||
+      session.providerInstanceId === binding.providerInstanceId) &&
+    !Number.isNaN(bindingLastSeenAt) &&
+    !Number.isNaN(sessionUpdatedAt) &&
+    bindingLastSeenAt >= sessionUpdatedAt
+  );
 }
 
 function findProviderAdapterRequestError(
@@ -300,42 +321,48 @@ const make = Effect.gen(function* () {
         (thread) => {
           const session = thread.session;
           const binding = bindingByThreadId.get(thread.id);
-          const bindingLastSeenAt = binding ? Date.parse(binding.lastSeenAt) : Number.NaN;
-          const sessionUpdatedAt = session ? Date.parse(session.updatedAt) : Number.NaN;
-          if (
-            (session?.status !== "running" && session?.status !== "starting") ||
-            binding?.status !== "stopped" ||
-            (session.providerName !== null && session.providerName !== binding.provider) ||
-            (session.providerInstanceId !== undefined &&
-              session.providerInstanceId !== binding.providerInstanceId) ||
-            Number.isNaN(bindingLastSeenAt) ||
-            Number.isNaN(sessionUpdatedAt) ||
-            bindingLastSeenAt < sessionUpdatedAt
-          ) {
+          if (!session || !binding || !canReconcileStoppedRuntimeBinding(session, binding)) {
             return Effect.void;
           }
 
-          return setThreadSession({
-            threadId: thread.id,
-            session: {
-              ...session,
-              status: "stopped",
-              activeTurnId: null,
-              updatedAt: binding.lastSeenAt,
-            },
-            createdAt: binding.lastSeenAt,
-          }).pipe(
-            Effect.tap(() =>
-              Effect.logWarning("provider.session.reconciled-stopped-runtime", {
-                threadId: thread.id,
-                previousStatus: session.status,
-                activeTurnId: session.activeTurnId,
-                provider: binding.provider,
-                providerInstanceId: binding.providerInstanceId,
-                stoppedAt: binding.lastSeenAt,
-              }),
-            ),
-          );
+          return Effect.gen(function* () {
+            const [latestThreadOption, latestBindings] = yield* Effect.all([
+              projectionSnapshotQuery.getThreadShellById(thread.id),
+              providerSessionDirectory.listBindings(),
+            ]);
+            const latestThread = Option.getOrUndefined(latestThreadOption);
+            const latestSession = latestThread?.session;
+            const latestBinding = latestBindings.find((entry) => entry.threadId === thread.id);
+            if (
+              !latestSession ||
+              !latestBinding ||
+              !canReconcileStoppedRuntimeBinding(latestSession, latestBinding)
+            ) {
+              return;
+            }
+
+            yield* setThreadSession({
+              threadId: thread.id,
+              session: {
+                ...latestSession,
+                status: "stopped",
+                activeTurnId: null,
+                updatedAt: latestBinding.lastSeenAt,
+              },
+              createdAt: latestBinding.lastSeenAt,
+            }).pipe(
+              Effect.tap(() =>
+                Effect.logWarning("provider.session.reconciled-stopped-runtime", {
+                  threadId: thread.id,
+                  previousStatus: latestSession.status,
+                  activeTurnId: latestSession.activeTurnId,
+                  provider: latestBinding.provider,
+                  providerInstanceId: latestBinding.providerInstanceId,
+                  stoppedAt: latestBinding.lastSeenAt,
+                }),
+              ),
+            );
+          });
         },
         { concurrency: 1, discard: true },
       );
@@ -1164,15 +1191,15 @@ const make = Effect.gen(function* () {
       }
     });
 
-    yield* Effect.forkScoped(
-      Stream.runForEach(orchestrationEngine.streamDomainEvents, processEvent),
-    );
     yield* reconcileStoppedRuntimeBindings().pipe(
       Effect.catchCause((cause) =>
         Effect.logWarning("provider.session.startup-reconciliation-failed", {
           cause: Cause.pretty(cause),
         }),
       ),
+    );
+    yield* Effect.forkScoped(
+      Stream.runForEach(orchestrationEngine.streamDomainEvents, processEvent),
     );
   });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -12,6 +12,7 @@ import {
   ProviderItemId,
   type ProviderApprovalDecision,
   type ProviderEvent,
+  type ProviderRuntimeEvent,
   type ProviderSession,
   type ProviderTurnStartResult,
   type ProviderUserInputAnswers,
@@ -23,15 +24,18 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, vi } from "@effect/vitest";
 
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import * as CodexErrors from "effect-codex-app-server/errors";
 
 import { ServerConfig } from "../../config.ts";
@@ -44,6 +48,7 @@ import {
   type CodexSessionRuntimeSendTurnInput,
   type CodexSessionRuntimeShape,
   type CodexThreadSnapshot,
+  type CodexTurnCompletionReconciliation,
 } from "./CodexSessionRuntime.ts";
 import { makeCodexAdapter } from "./CodexAdapter.ts";
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
@@ -95,6 +100,11 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
       }),
   );
 
+  public readonly reconcileTurnCompletionImpl = vi.fn(
+    (_turnId: TurnId): Effect.Effect<CodexTurnCompletionReconciliation> =>
+      Effect.succeed("obsolete"),
+  );
+
   public readonly rollbackThreadImpl = vi.fn(
     (_numTurns: number): Promise<CodexThreadSnapshot> =>
       Promise.resolve({
@@ -136,6 +146,10 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
   }
 
   readThread = Effect.promise(() => this.readThreadImpl());
+
+  reconcileTurnCompletion(turnId: TurnId) {
+    return this.reconcileTurnCompletionImpl(turnId);
+  }
 
   rollbackThread(numTurns: number) {
     return Effect.promise(() => this.rollbackThreadImpl(numTurns));
@@ -512,6 +526,77 @@ function startLifecycleRuntime() {
 }
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
+  it.effect("recovers terminal turns from provider state and suppresses late completion", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const receivedRef = yield* Ref.make<Array<ProviderRuntimeEvent>>([]);
+      const firstReceived = yield* Deferred.make<void>();
+      const consumer = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Ref.update(receivedRef, (events) => [...events, event]).pipe(
+          Effect.andThen(Deferred.succeed(firstReceived, undefined).pipe(Effect.ignore)),
+        ),
+      ).pipe(Effect.forkChild);
+
+      runtime.reconcileTurnCompletionImpl.mockImplementation((turnId) =>
+        runtime
+          .emit({
+            id: asEventId("evt-recovered-completion"),
+            kind: "notification",
+            provider: ProviderDriverKind.make("codex"),
+            createdAt: "2026-01-01T00:00:30.000Z",
+            method: "turn/completed",
+            threadId: asThreadId("thread-1"),
+            turnId,
+            payload: {
+              threadId: "provider-thread-1",
+              turn: {
+                id: turnId,
+                items: [],
+                status: "completed",
+              },
+            },
+          })
+          .pipe(Effect.as("settled" as const)),
+      );
+
+      yield* adapter.sendTurn({
+        threadId: asThreadId("thread-1"),
+        input: "recover me",
+        attachments: [],
+      });
+      yield* TestClock.adjust("30 seconds");
+      yield* Deferred.await(firstReceived);
+
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 1);
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls[0]?.[0], "turn-1");
+
+      yield* runtime.emit({
+        id: asEventId("evt-late-completion"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:31.000Z",
+        method: "turn/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        payload: {
+          threadId: "provider-thread-1",
+          turn: {
+            id: "turn-1",
+            items: [],
+            status: "completed",
+          },
+        },
+      });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      const received = yield* Ref.get(receivedRef);
+      NodeAssert.equal(received.length, 1);
+      NodeAssert.equal(received[0]?.type, "turn.completed");
+      yield* Fiber.interrupt(consumer);
+    }),
+  );
+
   it.effect("maps completed agent message items to canonical item.completed events", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -597,6 +597,30 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("abandons completion polling after three consecutive provider read failures", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      runtime.reconcileTurnCompletionImpl.mockImplementation(() =>
+        Effect.die(new Error("thread/read unavailable")),
+      );
+
+      yield* adapter.sendTurn({
+        threadId: asThreadId("thread-1"),
+        input: "poll carefully",
+        attachments: [],
+      });
+
+      yield* TestClock.adjust("30 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 1);
+      yield* TestClock.adjust("10 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 2);
+      yield* TestClock.adjust("10 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 3);
+      yield* TestClock.adjust("1 minute");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 3);
+    }),
+  );
+
   it.effect("maps completed agent message items to canonical item.completed events", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -621,6 +621,91 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("backs off completion polling geometrically while the turn stays active", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      runtime.reconcileTurnCompletionImpl.mockImplementation(() =>
+        Effect.succeed("active" as const),
+      );
+
+      yield* adapter.sendTurn({
+        threadId: asThreadId("thread-1"),
+        input: "long turn",
+        attachments: [],
+      });
+
+      // Grace period, then delays of 10s, 20s, 40s, capped at 60s.
+      yield* TestClock.adjust("30 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 1);
+      yield* TestClock.adjust("10 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 2);
+      yield* TestClock.adjust("10 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 2);
+      yield* TestClock.adjust("10 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 3);
+      yield* TestClock.adjust("40 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 4);
+      yield* TestClock.adjust("60 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 5);
+      yield* TestClock.adjust("60 seconds");
+      NodeAssert.equal(runtime.reconcileTurnCompletionImpl.mock.calls.length, 6);
+    }),
+  );
+
+  it.effect("recovers a failed turn as a failed completion with its error message", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const receivedRef = yield* Ref.make<Array<ProviderRuntimeEvent>>([]);
+      const firstReceived = yield* Deferred.make<void>();
+      const consumer = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Ref.update(receivedRef, (events) => [...events, event]).pipe(
+          Effect.andThen(Deferred.succeed(firstReceived, undefined).pipe(Effect.ignore)),
+        ),
+      ).pipe(Effect.forkChild);
+
+      runtime.reconcileTurnCompletionImpl.mockImplementation((turnId) =>
+        runtime
+          .emit({
+            id: asEventId("evt-recovered-failure"),
+            kind: "notification",
+            provider: ProviderDriverKind.make("codex"),
+            createdAt: "2026-01-01T00:00:30.000Z",
+            method: "turn/completed",
+            threadId: asThreadId("thread-1"),
+            turnId,
+            payload: {
+              threadId: "provider-thread-1",
+              turn: {
+                id: turnId,
+                items: [],
+                status: "failed",
+                error: { message: "provider exploded" },
+              },
+            },
+          })
+          .pipe(Effect.as("settled" as const)),
+      );
+
+      yield* adapter.sendTurn({
+        threadId: asThreadId("thread-1"),
+        input: "fail me",
+        attachments: [],
+      });
+      yield* TestClock.adjust("30 seconds");
+      yield* Deferred.await(firstReceived);
+
+      const received = yield* Ref.get(receivedRef);
+      NodeAssert.equal(received.length, 1);
+      const event = received[0];
+      NodeAssert.equal(event?.type, "turn.completed");
+      if (event?.type === "turn.completed") {
+        NodeAssert.equal(event.payload.state, "failed");
+        NodeAssert.equal(event.payload.errorMessage, "provider exploded");
+      }
+      yield* Fiber.interrupt(consumer);
+    }),
+  );
+
   it.effect("maps completed agent message items to canonical item.completed events", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -71,6 +71,7 @@ const isCodexSessionRuntimeThreadIdMissingError = Schema.is(
 const isCodexResumeCursorSchema = Schema.is(CodexResumeCursorSchema);
 
 const PROVIDER = ProviderDriverKind.make("codex");
+const MAX_TURN_COMPLETION_RECONCILIATION_FAILURES = 3;
 
 export interface CodexAdapterLiveOptions {
   readonly instanceId?: ProviderInstanceId;
@@ -1582,26 +1583,40 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       })
       .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
 
-    const pollTurnCompletion = (): Effect.Effect<void> =>
+    const pollTurnCompletion = (consecutiveFailures = 0): Effect.Effect<void> =>
       Effect.gen(function* () {
         const currentSession = sessions.get(input.threadId);
         if (currentSession !== session || session.stopped) {
           return;
         }
-        const result = yield* session.runtime.reconcileTurnCompletion(turn.turnId).pipe(
-          Effect.catchCause((cause) =>
-            Effect.logWarning("codex.turn-completion.reconciliation-failed", {
+        const outcome = yield* session.runtime
+          .reconcileTurnCompletion(turn.turnId)
+          .pipe(Effect.exit);
+        if (Exit.isFailure(outcome)) {
+          const failureCount = consecutiveFailures + 1;
+          yield* Effect.logWarning("codex.turn-completion.reconciliation-failed", {
+            threadId: input.threadId,
+            turnId: turn.turnId,
+            failureCount,
+            maxFailures: MAX_TURN_COMPLETION_RECONCILIATION_FAILURES,
+            cause: outcome.cause,
+          });
+          if (failureCount >= MAX_TURN_COMPLETION_RECONCILIATION_FAILURES) {
+            yield* Effect.logWarning("codex.turn-completion.reconciliation-abandoned", {
               threadId: input.threadId,
               turnId: turn.turnId,
-              cause,
-            }).pipe(Effect.as("active" as const)),
-          ),
-        );
-        if (result !== "active") {
+              failureCount,
+            });
+            return;
+          }
+          yield* Effect.sleep(Duration.millis(turnCompletionRecoveryPollMs));
+          return yield* pollTurnCompletion(failureCount);
+        }
+        if (outcome.value !== "active") {
           return;
         }
         yield* Effect.sleep(Duration.millis(turnCompletionRecoveryPollMs));
-        return yield* pollTurnCompletion();
+        return yield* pollTurnCompletion(0);
       });
 
     yield* Effect.sleep(Duration.millis(turnCompletionRecoveryGraceMs)).pipe(

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -87,6 +87,7 @@ export interface CodexAdapterLiveOptions {
   readonly nativeEventLogger?: EventNdjsonLogger;
   readonly turnCompletionRecoveryGraceMs?: number;
   readonly turnCompletionRecoveryPollMs?: number;
+  readonly turnCompletionRecoveryMaxPollMs?: number;
 }
 
 interface CodexAdapterSessionContext {
@@ -1382,6 +1383,10 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     options?.turnCompletionRecoveryGraceMs ?? 30_000,
   );
   const turnCompletionRecoveryPollMs = Math.max(1, options?.turnCompletionRecoveryPollMs ?? 10_000);
+  const turnCompletionRecoveryMaxPollMs = Math.max(
+    turnCompletionRecoveryPollMs,
+    options?.turnCompletionRecoveryMaxPollMs ?? 60_000,
+  );
 
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
@@ -1583,7 +1588,13 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       })
       .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
 
-    const pollTurnCompletion = (consecutiveFailures = 0): Effect.Effect<void> =>
+    // Each "active" poll costs a full `thread/read` (there is no lighter
+    // provider read), so the cadence backs off geometrically for legitimately
+    // long turns instead of holding the initial interval.
+    const pollTurnCompletion = (
+      consecutiveFailures = 0,
+      pollDelayMs = turnCompletionRecoveryPollMs,
+    ): Effect.Effect<void> =>
       Effect.gen(function* () {
         const currentSession = sessions.get(input.threadId);
         if (currentSession !== session || session.stopped) {
@@ -1609,14 +1620,17 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             });
             return;
           }
-          yield* Effect.sleep(Duration.millis(turnCompletionRecoveryPollMs));
-          return yield* pollTurnCompletion(failureCount);
+          yield* Effect.sleep(Duration.millis(pollDelayMs));
+          return yield* pollTurnCompletion(failureCount, pollDelayMs);
         }
         if (outcome.value !== "active") {
           return;
         }
-        yield* Effect.sleep(Duration.millis(turnCompletionRecoveryPollMs));
-        return yield* pollTurnCompletion(0);
+        yield* Effect.sleep(Duration.millis(pollDelayMs));
+        return yield* pollTurnCompletion(
+          0,
+          Math.min(pollDelayMs * 2, turnCompletionRecoveryMaxPollMs),
+        );
       });
 
     yield* Effect.sleep(Duration.millis(turnCompletionRecoveryGraceMs)).pipe(

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -26,6 +26,7 @@ import {
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Crypto from "effect/Crypto";
+import * as Duration from "effect/Duration";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
@@ -83,6 +84,8 @@ export interface CodexAdapterLiveOptions {
   >;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly turnCompletionRecoveryGraceMs?: number;
+  readonly turnCompletionRecoveryPollMs?: number;
 }
 
 interface CodexAdapterSessionContext {
@@ -1373,6 +1376,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
+  const turnCompletionRecoveryGraceMs = Math.max(
+    1,
+    options?.turnCompletionRecoveryGraceMs ?? 30_000,
+  );
+  const turnCompletionRecoveryPollMs = Math.max(1, options?.turnCompletionRecoveryPollMs ?? 10_000);
 
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
@@ -1447,10 +1455,23 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           ),
         );
 
+        const settledTurnIds = new Set<string>();
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
             yield* writeNativeEvent(event);
-            const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
+            const runtimeEvents = mapToRuntimeEvents(event, event.threadId).filter(
+              (runtimeEvent) => {
+                if (runtimeEvent.type !== "turn.completed") {
+                  return true;
+                }
+                const turnId = String(runtimeEvent.turnId);
+                if (settledTurnIds.has(turnId)) {
+                  return false;
+                }
+                settledTurnIds.add(turnId);
+                return true;
+              },
+            );
             if (runtimeEvents.length === 0) {
               yield* Effect.logDebug("ignoring unhandled Codex provider event", {
                 method: event.method,
@@ -1544,7 +1565,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getCodexServiceTierOptionValue(input.modelSelection)
         : undefined;
-    return yield* session.runtime
+    const turn = yield* session.runtime
       .sendTurn({
         ...(input.input !== undefined ? { input: input.input } : {}),
         ...(input.modelSelection?.instanceId === boundInstanceId
@@ -1560,6 +1581,34 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
       })
       .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
+
+    const pollTurnCompletion = (): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const currentSession = sessions.get(input.threadId);
+        if (currentSession !== session || session.stopped) {
+          return;
+        }
+        const result = yield* session.runtime.reconcileTurnCompletion(turn.turnId).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("codex.turn-completion.reconciliation-failed", {
+              threadId: input.threadId,
+              turnId: turn.turnId,
+              cause,
+            }).pipe(Effect.as("active" as const)),
+          ),
+        );
+        if (result !== "active") {
+          return;
+        }
+        yield* Effect.sleep(Duration.millis(turnCompletionRecoveryPollMs));
+        return yield* pollTurnCompletion();
+      });
+
+    yield* Effect.sleep(Duration.millis(turnCompletionRecoveryGraceMs)).pipe(
+      Effect.andThen(pollTurnCompletion()),
+      Effect.forkIn(session.scope),
+    );
+    return turn;
   });
 
   const requireSession = Effect.fn("requireSession")(function* (threadId: ThreadId) {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1623,6 +1623,26 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           yield* Effect.sleep(Duration.millis(pollDelayMs));
           return yield* pollTurnCompletion(failureCount, pollDelayMs);
         }
+        if (outcome.value === "missing") {
+          const missingCount = consecutiveFailures + 1;
+          yield* Effect.logWarning("codex.turn-completion.turn-missing", {
+            threadId: input.threadId,
+            turnId: turn.turnId,
+            missingCount,
+            maxMissing: MAX_TURN_COMPLETION_RECONCILIATION_FAILURES,
+          });
+          if (missingCount >= MAX_TURN_COMPLETION_RECONCILIATION_FAILURES) {
+            yield* Effect.logWarning("codex.turn-completion.reconciliation-abandoned", {
+              threadId: input.threadId,
+              turnId: turn.turnId,
+              missingCount,
+              reason: "turn-missing",
+            });
+            return;
+          }
+          yield* Effect.sleep(Duration.millis(pollDelayMs));
+          return yield* pollTurnCompletion(missingCount, pollDelayMs);
+        }
         if (outcome.value !== "active") {
           return;
         }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1592,7 +1592,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     // provider read), so the cadence backs off geometrically for legitimately
     // long turns instead of holding the initial interval.
     const pollTurnCompletion = (
-      consecutiveFailures = 0,
+      consecutiveReadFailures = 0,
+      consecutiveMissing = 0,
       pollDelayMs = turnCompletionRecoveryPollMs,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
@@ -1604,7 +1605,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           .reconcileTurnCompletion(turn.turnId)
           .pipe(Effect.exit);
         if (Exit.isFailure(outcome)) {
-          const failureCount = consecutiveFailures + 1;
+          const failureCount = consecutiveReadFailures + 1;
           yield* Effect.logWarning("codex.turn-completion.reconciliation-failed", {
             threadId: input.threadId,
             turnId: turn.turnId,
@@ -1621,10 +1622,10 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             return;
           }
           yield* Effect.sleep(Duration.millis(pollDelayMs));
-          return yield* pollTurnCompletion(failureCount, pollDelayMs);
+          return yield* pollTurnCompletion(failureCount, 0, pollDelayMs);
         }
         if (outcome.value === "missing") {
-          const missingCount = consecutiveFailures + 1;
+          const missingCount = consecutiveMissing + 1;
           yield* Effect.logWarning("codex.turn-completion.turn-missing", {
             threadId: input.threadId,
             turnId: turn.turnId,
@@ -1641,13 +1642,14 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             return;
           }
           yield* Effect.sleep(Duration.millis(pollDelayMs));
-          return yield* pollTurnCompletion(missingCount, pollDelayMs);
+          return yield* pollTurnCompletion(0, missingCount, pollDelayMs);
         }
         if (outcome.value !== "active") {
           return;
         }
         yield* Effect.sleep(Duration.millis(pollDelayMs));
         return yield* pollTurnCompletion(
+          0,
           0,
           Math.min(pollDelayMs * 2, turnCompletionRecoveryMaxPollMs),
         );

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -4,7 +4,13 @@ import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { describe } from "vite-plus/test";
-import { DEFAULT_MODEL, ThreadId } from "@t3tools/contracts";
+import {
+  DEFAULT_MODEL,
+  ProviderDriverKind,
+  type ProviderSession,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 
@@ -15,12 +21,54 @@ import {
 } from "../CodexDeveloperInstructions.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
+  applyTurnCompletionToSession,
   buildTurnStartParams,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+
+describe("applyTurnCompletionToSession", () => {
+  const makeRunningSession = (activeTurnId: TurnId): ProviderSession => ({
+    provider: ProviderDriverKind.make("codex"),
+    status: "running",
+    runtimeMode: "full-access",
+    threadId: ThreadId.make("thread-1"),
+    activeTurnId,
+    createdAt: "2026-04-18T00:00:00.000Z",
+    updatedAt: "2026-04-18T00:01:00.000Z",
+  });
+
+  it("ignores a delayed completion for an older turn", () => {
+    const session = makeRunningSession(TurnId.make("turn-new"));
+    const updated = applyTurnCompletionToSession({
+      session,
+      turnId: TurnId.make("turn-old"),
+      status: "completed",
+      updatedAt: "2026-04-18T00:02:00.000Z",
+    });
+
+    NodeAssert.strictEqual(updated, session);
+    NodeAssert.equal(updated.status, "running");
+    NodeAssert.equal(updated.activeTurnId, "turn-new");
+  });
+
+  it("settles only the matching active turn", () => {
+    const updated = applyTurnCompletionToSession({
+      session: makeRunningSession(TurnId.make("turn-1")),
+      turnId: TurnId.make("turn-1"),
+      status: "failed",
+      errorMessage: "provider failed",
+      updatedAt: "2026-04-18T00:02:00.000Z",
+    });
+
+    NodeAssert.equal(updated.status, "error");
+    NodeAssert.equal(updated.activeTurnId, undefined);
+    NodeAssert.equal(updated.lastError, "provider failed");
+    NodeAssert.equal(updated.updatedAt, "2026-04-18T00:02:00.000Z");
+  });
+});
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1308,6 +1308,9 @@ export const makeCodexSessionRuntime = (
         return "active";
       }
 
+      // Recovery settles only the turn's terminal state. Item notifications
+      // missed alongside the completion are not replayed, so content produced
+      // during the outage may be absent from the projection.
       yield* emitEvent({
         kind: "notification",
         threadId: options.threadId,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -123,12 +123,17 @@ export interface CodexSessionRuntimeSendTurnInput {
 export interface CodexThreadTurnSnapshot {
   readonly id: TurnId;
   readonly items: ReadonlyArray<CodexThreadItem>;
+  readonly status: EffectCodexSchema.V2ThreadReadResponse__TurnStatus;
+  readonly completedAt?: number | null;
+  readonly errorMessage?: string;
 }
 
 export interface CodexThreadSnapshot {
   readonly threadId: string;
   readonly turns: ReadonlyArray<CodexThreadTurnSnapshot>;
 }
+
+export type CodexTurnCompletionReconciliation = "active" | "settled" | "obsolete";
 
 export interface CodexSessionRuntimeShape {
   readonly start: () => Effect.Effect<ProviderSession, CodexSessionRuntimeError>;
@@ -138,6 +143,9 @@ export interface CodexSessionRuntimeShape {
   ) => Effect.Effect<ProviderTurnStartResult, CodexSessionRuntimeError>;
   readonly interruptTurn: (turnId?: TurnId) => Effect.Effect<void, CodexSessionRuntimeError>;
   readonly readThread: Effect.Effect<CodexThreadSnapshot, CodexSessionRuntimeError>;
+  readonly reconcileTurnCompletion: (
+    turnId: TurnId,
+  ) => Effect.Effect<CodexTurnCompletionReconciliation, CodexSessionRuntimeError>;
   readonly rollbackThread: (
     numTurns: number,
   ) => Effect.Effect<CodexThreadSnapshot, CodexSessionRuntimeError>;
@@ -703,6 +711,9 @@ function parseThreadSnapshot(
     turns: response.thread.turns.map((turn) => ({
       id: TurnId.make(turn.id),
       items: turn.items,
+      status: turn.status,
+      ...(turn.completedAt !== undefined ? { completedAt: turn.completedAt } : {}),
+      ...(turn.error?.message ? { errorMessage: turn.error.message } : {}),
     })),
   };
 }
@@ -1253,6 +1264,64 @@ export const makeCodexSessionRuntime = (
       return providerThreadId;
     });
 
+    const reconcileTurnCompletion: CodexSessionRuntimeShape["reconcileTurnCompletion"] = Effect.fn(
+      "CodexSessionRuntime.reconcileTurnCompletion",
+    )(function* (turnId) {
+      const sessionBeforeRead = yield* Ref.get(sessionRef);
+      if (sessionBeforeRead.status !== "running" || sessionBeforeRead.activeTurnId !== turnId) {
+        return "obsolete";
+      }
+
+      const providerThreadId = yield* readProviderThreadId;
+      const response = yield* client.request("thread/read", {
+        threadId: providerThreadId,
+        includeTurns: true,
+      });
+      const turn = response.thread.turns.find((candidate) => candidate.id === turnId);
+      if (!turn || turn.status === "inProgress") {
+        return "active";
+      }
+
+      const recoveredAt = yield* nowIso;
+      const claimed = yield* Ref.modify(sessionRef, (session) => {
+        if (session.status !== "running" || session.activeTurnId !== turnId) {
+          return [false, session] as const;
+        }
+        const lastError = turn.status === "failed" ? turn.error?.message : undefined;
+        return [
+          true,
+          {
+            ...session,
+            status: turn.status === "failed" ? ("error" as const) : ("ready" as const),
+            activeTurnId: undefined,
+            ...(lastError ? { lastError } : {}),
+            updatedAt: recoveredAt,
+          },
+        ] as const;
+      });
+      if (!claimed) {
+        return "obsolete";
+      }
+
+      yield* emitEvent({
+        kind: "notification",
+        threadId: options.threadId,
+        method: "turn/completed",
+        turnId,
+        payload: {
+          threadId: providerThreadId,
+          turn,
+        },
+      });
+      yield* Effect.logWarning("codex.turn-completion.recovered", {
+        threadId: options.threadId,
+        providerThreadId,
+        turnId,
+        turnStatus: turn.status,
+      });
+      return "settled";
+    });
+
     const close = Effect.gen(function* () {
       const alreadyClosed = yield* Ref.getAndSet(closedRef, true);
       if (alreadyClosed) {
@@ -1348,6 +1417,7 @@ export const makeCodexSessionRuntime = (
         });
         return parseThreadSnapshot(response);
       }),
+      reconcileTurnCompletion,
       rollbackThread: (numTurns) =>
         Effect.gen(function* () {
           const providerThreadId = yield* readProviderThreadId;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -703,6 +703,25 @@ function updateSession(
   });
 }
 
+export function applyTurnCompletionToSession(input: {
+  readonly session: ProviderSession;
+  readonly turnId: TurnId;
+  readonly status: EffectCodexSchema.V2ThreadReadResponse__TurnStatus;
+  readonly errorMessage?: string;
+  readonly updatedAt: string;
+}): ProviderSession {
+  if (input.status === "inProgress" || input.session.activeTurnId !== input.turnId) {
+    return input.session;
+  }
+  return {
+    ...input.session,
+    status: input.status === "failed" ? "error" : "ready",
+    activeTurnId: undefined,
+    ...(input.errorMessage ? { lastError: input.errorMessage } : {}),
+    updatedAt: input.updatedAt,
+  };
+}
+
 function parseThreadSnapshot(
   response: EffectCodexSchema.V2ThreadReadResponse | EffectCodexSchema.V2ThreadRollbackResponse,
 ): CodexThreadSnapshot {
@@ -941,20 +960,27 @@ export const makeCodexSessionRuntime = (
 
     yield* client.handleServerNotification("turn/completed", (payload) =>
       currentSessionProviderThreadId.pipe(
-        Effect.flatMap((providerThreadId) => {
-          if (providerThreadId && payload.threadId !== providerThreadId) {
-            return Effect.void;
-          }
-          const lastError =
-            payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
-              ? payload.turn.error.message
-              : undefined;
-          return updateSession(sessionRef, {
-            status: payload.turn.status === "failed" ? "error" : "ready",
-            activeTurnId: undefined,
-            ...(lastError ? { lastError } : {}),
-          });
-        }),
+        Effect.flatMap((providerThreadId) =>
+          Effect.gen(function* () {
+            if (providerThreadId && payload.threadId !== providerThreadId) {
+              return;
+            }
+            const errorMessage =
+              payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
+                ? payload.turn.error.message
+                : undefined;
+            const updatedAt = yield* nowIso;
+            yield* Ref.update(sessionRef, (session) =>
+              applyTurnCompletionToSession({
+                session,
+                turnId: TurnId.make(payload.turn.id),
+                status: payload.turn.status,
+                ...(errorMessage ? { errorMessage } : {}),
+                updatedAt,
+              }),
+            );
+          }),
+        ),
       ),
     );
 
@@ -1282,27 +1308,6 @@ export const makeCodexSessionRuntime = (
         return "active";
       }
 
-      const recoveredAt = yield* nowIso;
-      const claimed = yield* Ref.modify(sessionRef, (session) => {
-        if (session.status !== "running" || session.activeTurnId !== turnId) {
-          return [false, session] as const;
-        }
-        const lastError = turn.status === "failed" ? turn.error?.message : undefined;
-        return [
-          true,
-          {
-            ...session,
-            status: turn.status === "failed" ? ("error" as const) : ("ready" as const),
-            activeTurnId: undefined,
-            ...(lastError ? { lastError } : {}),
-            updatedAt: recoveredAt,
-          },
-        ] as const;
-      });
-      if (!claimed) {
-        return "obsolete";
-      }
-
       yield* emitEvent({
         kind: "notification",
         threadId: options.threadId,
@@ -1313,6 +1318,16 @@ export const makeCodexSessionRuntime = (
           turn,
         },
       });
+      const recoveredAt = yield* nowIso;
+      yield* Ref.update(sessionRef, (session) =>
+        applyTurnCompletionToSession({
+          session,
+          turnId,
+          status: turn.status,
+          ...(turn.error?.message ? { errorMessage: turn.error.message } : {}),
+          updatedAt: recoveredAt,
+        }),
+      );
       yield* Effect.logWarning("codex.turn-completion.recovered", {
         threadId: options.threadId,
         providerThreadId,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -133,7 +133,7 @@ export interface CodexThreadSnapshot {
   readonly turns: ReadonlyArray<CodexThreadTurnSnapshot>;
 }
 
-export type CodexTurnCompletionReconciliation = "active" | "settled" | "obsolete";
+export type CodexTurnCompletionReconciliation = "active" | "missing" | "settled" | "obsolete";
 
 export interface CodexSessionRuntimeShape {
   readonly start: () => Effect.Effect<ProviderSession, CodexSessionRuntimeError>;
@@ -1304,7 +1304,10 @@ export const makeCodexSessionRuntime = (
         includeTurns: true,
       });
       const turn = response.thread.turns.find((candidate) => candidate.id === turnId);
-      if (!turn || turn.status === "inProgress") {
+      if (!turn) {
+        return "missing";
+      }
+      if (turn.status === "inProgress") {
         return "active";
       }
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -366,6 +366,85 @@ it.effect("ProviderServiceLive catches stopAll failures during shutdown", () =>
   }),
 );
 
+it.effect("ProviderServiceLive stops only sessions owned by this process during shutdown", () =>
+  Effect.gen(function* () {
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [CODEX_DRIVER]: codex.adapter,
+    });
+    const providerAdapterLayer = Layer.succeed(
+      ProviderAdapterRegistry.ProviderAdapterRegistry,
+      registry,
+    );
+    const bindings = new Map<
+      ThreadId,
+      ProviderSessionDirectory.ProviderRuntimeBindingWithMetadata
+    >();
+    const foreignThreadId = asThreadId("thread-owned-by-another-process");
+    bindings.set(foreignThreadId, {
+      threadId: foreignThreadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: codexInstanceId,
+      status: "running",
+      runtimeMode: "full-access",
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+    });
+    const directoryLayer = Layer.succeed(ProviderSessionDirectory.ProviderSessionDirectory, {
+      upsert: (binding: ProviderSessionDirectory.ProviderRuntimeBinding) =>
+        Effect.sync(() => {
+          const existing = bindings.get(binding.threadId);
+          bindings.set(binding.threadId, {
+            ...existing,
+            ...binding,
+            lastSeenAt: "2026-01-01T00:01:00.000Z",
+          });
+        }),
+      getProvider: (threadId: ThreadId) =>
+        Effect.sync(() => bindings.get(threadId)?.provider ?? CODEX_DRIVER),
+      getBinding: (threadId: ThreadId) =>
+        Effect.sync(() => {
+          const binding = bindings.get(threadId);
+          return binding === undefined
+            ? Option.none<ProviderSessionDirectory.ProviderRuntimeBinding>()
+            : Option.some(binding);
+        }),
+      listThreadIds: () => Effect.sync(() => Array.from(bindings.keys())),
+      listBindings: () => Effect.sync(() => Array.from(bindings.values())),
+    });
+    const providerLayer = Layer.mergeAll(
+      makeProviderServiceLive().pipe(
+        Layer.provide(providerAdapterLayer),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provideMerge(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      ),
+      directoryLayer,
+      NodeServices.layer,
+    );
+    const scope = yield* Scope.make();
+    const runtimeServices = yield* Layer.build(providerLayer).pipe(Scope.provide(scope));
+    const provider = yield* ProviderService.ProviderService.pipe(Effect.provide(runtimeServices));
+    const ownedThreadId = asThreadId("thread-owned-by-this-process");
+
+    yield* provider.startSession(ownedThreadId, {
+      provider: CODEX_DRIVER,
+      providerInstanceId: codexInstanceId,
+      threadId: ownedThreadId,
+      runtimeMode: "full-access",
+    });
+    yield* Scope.close(scope, Exit.void);
+
+    assert.equal(bindings.get(ownedThreadId)?.status, "stopped");
+    assert.equal(bindings.get(foreignThreadId)?.status, "running");
+  }),
+);
+
 it.effect("ProviderServiceLive rejects new sessions for disabled providers", () =>
   Effect.gen(function* () {
     const codex = makeFakeCodexAdapter();

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -445,6 +445,108 @@ it.effect("ProviderServiceLive stops only sessions owned by this process during 
   }),
 );
 
+it.effect("ProviderServiceLive stops orphaned bindings whose owner process is gone", () =>
+  Effect.gen(function* () {
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [CODEX_DRIVER]: codex.adapter,
+    });
+    const providerAdapterLayer = Layer.succeed(
+      ProviderAdapterRegistry.ProviderAdapterRegistry,
+      registry,
+    );
+    const ownerProcessId = 4242;
+    const alivePid = 1111;
+    const deadPid = 2222;
+    const bindings = new Map<
+      ThreadId,
+      ProviderSessionDirectory.ProviderRuntimeBindingWithMetadata
+    >();
+    const makeBinding = (
+      threadId: ThreadId,
+      status: "running" | "stopped",
+      ownerPid?: number,
+    ): ProviderSessionDirectory.ProviderRuntimeBindingWithMetadata => ({
+      threadId,
+      provider: CODEX_DRIVER,
+      providerInstanceId: codexInstanceId,
+      status,
+      runtimeMode: "full-access",
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+      ...(ownerPid !== undefined ? { runtimePayload: { ownerPid } } : {}),
+    });
+    const deadOwnerThreadId = asThreadId("thread-dead-owner");
+    const aliveOwnerThreadId = asThreadId("thread-alive-owner");
+    const legacyThreadId = asThreadId("thread-no-owner-recorded");
+    const recycledOwnThreadId = asThreadId("thread-recycled-own-pid");
+    bindings.set(deadOwnerThreadId, makeBinding(deadOwnerThreadId, "running", deadPid));
+    bindings.set(aliveOwnerThreadId, makeBinding(aliveOwnerThreadId, "running", alivePid));
+    bindings.set(legacyThreadId, makeBinding(legacyThreadId, "running"));
+    bindings.set(recycledOwnThreadId, makeBinding(recycledOwnThreadId, "running", ownerProcessId));
+    const directoryLayer = Layer.succeed(ProviderSessionDirectory.ProviderSessionDirectory, {
+      upsert: (binding: ProviderSessionDirectory.ProviderRuntimeBinding) =>
+        Effect.sync(() => {
+          const existing = bindings.get(binding.threadId);
+          bindings.set(binding.threadId, {
+            ...existing,
+            ...binding,
+            lastSeenAt: "2026-01-01T00:01:00.000Z",
+          });
+        }),
+      getProvider: (threadId: ThreadId) =>
+        Effect.sync(() => bindings.get(threadId)?.provider ?? CODEX_DRIVER),
+      getBinding: (threadId: ThreadId) =>
+        Effect.sync(() => {
+          const binding = bindings.get(threadId);
+          return binding === undefined
+            ? Option.none<ProviderSessionDirectory.ProviderRuntimeBinding>()
+            : Option.some(binding);
+        }),
+      listThreadIds: () => Effect.sync(() => Array.from(bindings.keys())),
+      listBindings: () => Effect.sync(() => Array.from(bindings.values())),
+    });
+    const providerLayer = Layer.mergeAll(
+      makeProviderServiceLive({
+        ownerProcessId,
+        isProcessAlive: (pid) => pid === alivePid,
+      }).pipe(
+        Layer.provide(providerAdapterLayer),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provideMerge(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      ),
+      directoryLayer,
+      NodeServices.layer,
+    );
+    const scope = yield* Scope.make();
+    const runtimeServices = yield* Layer.build(providerLayer).pipe(Scope.provide(scope));
+    const provider = yield* ProviderService.ProviderService.pipe(Effect.provide(runtimeServices));
+
+    assert.equal(bindings.get(deadOwnerThreadId)?.status, "stopped");
+    assert.equal(bindings.get(aliveOwnerThreadId)?.status, "running");
+    assert.equal(bindings.get(legacyThreadId)?.status, "running");
+    assert.equal(bindings.get(recycledOwnThreadId)?.status, "stopped");
+
+    const ownedThreadId = asThreadId("thread-owned-by-this-process");
+    yield* provider.startSession(ownedThreadId, {
+      provider: CODEX_DRIVER,
+      providerInstanceId: codexInstanceId,
+      threadId: ownedThreadId,
+      runtimeMode: "full-access",
+    });
+    const ownedPayload = bindings.get(ownedThreadId)?.runtimePayload;
+    assert.ok(ownedPayload && typeof ownedPayload === "object" && !Array.isArray(ownedPayload));
+    assert.equal((ownedPayload as Record<string, unknown>).ownerPid, ownerProcessId);
+    yield* Scope.close(scope, Exit.void);
+  }),
+);
+
 it.effect("ProviderServiceLive rejects new sessions for disabled providers", () =>
   Effect.gen(function* () {
     const codex = makeFakeCodexAdapter();

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -64,6 +64,15 @@ const isModelSelection = Schema.is(ModelSelection);
  */
 export interface ProviderServiceLiveOptions {
   readonly canonicalEventLogger?: EventNdjsonLogger;
+  /**
+   * Identity of the process that owns sessions started by this service.
+   * Recorded into persisted runtime bindings so a later startup can tell
+   * whether a "running" binding belongs to a process that no longer exists.
+   * Tests override these; production wiring uses the real pid and a
+   * `process.kill(pid, 0)` liveness probe.
+   */
+  readonly ownerProcessId?: number;
+  readonly isProcessAlive?: (pid: number) => boolean;
 }
 
 type ProviderServiceMethod<Name extends keyof ProviderService.ProviderService["Service"]> =
@@ -150,6 +159,28 @@ function readPersistedModelSelection(
   return isModelSelection(raw) ? raw : undefined;
 }
 
+function readPersistedOwnerPid(
+  runtimePayload: ProviderSessionDirectory.ProviderRuntimeBinding["runtimePayload"],
+): number | undefined {
+  if (!runtimePayload || typeof runtimePayload !== "object" || Array.isArray(runtimePayload)) {
+    return undefined;
+  }
+  const raw = "ownerPid" in runtimePayload ? runtimePayload.ownerPid : undefined;
+  return typeof raw === "number" && Number.isInteger(raw) && raw > 0 ? raw : undefined;
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // Only a definitive ESRCH proves the owner is gone. EPERM (or any other
+    // failure) means a process with this pid may still exist, so we must not
+    // treat its bindings as orphaned.
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
 function readPersistedCwd(
   runtimePayload: ProviderSessionDirectory.ProviderRuntimeBinding["runtimePayload"],
 ): string | undefined {
@@ -214,6 +245,8 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
   const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
   const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+  const ownerProcessId = options?.ownerProcessId ?? process.pid;
+  const isProcessAlive = options?.isProcessAlive ?? defaultIsProcessAlive;
   const prepareMcpSession = (threadId: ThreadId, providerInstanceId: ProviderInstanceId) =>
     McpSessionRegistry.issueActiveMcpCredential({ threadId, providerInstanceId }).pipe(
       Effect.tap((credential) =>
@@ -277,7 +310,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         runtimeMode: session.runtimeMode,
         status: toRuntimeStatus(session),
         ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
-        runtimePayload: toRuntimePayloadFromSession(session, extra),
+        runtimePayload: {
+          ...toRuntimePayloadFromSession(session, extra),
+          ownerPid: ownerProcessId,
+        },
       });
     });
 
@@ -1057,6 +1093,67 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     });
     yield* analytics.flush;
   });
+
+  // Crash recovery: a process that dies without running `runStopAll` leaves
+  // its bindings persisted as "running" forever, and the projection-level
+  // startup reconciliation only settles threads whose binding is "stopped".
+  // Sweep bindings whose recorded owner process verifiably no longer exists.
+  // A pid recycled to another live process makes us skip the sweep (fail-safe:
+  // no worse than before), never stop a live foreign session. Our own pid at
+  // construction time is also stale — this process has not started sessions yet.
+  const reconcileOrphanedRuntimeBindings = Effect.fn("reconcileOrphanedRuntimeBindings")(
+    function* () {
+      const bindings = yield* directory.listBindings();
+      yield* Effect.forEach(
+        bindings,
+        (binding) =>
+          Effect.gen(function* () {
+            if (binding.status !== "running" && binding.status !== "starting") {
+              return;
+            }
+            const ownerPid = readPersistedOwnerPid(binding.runtimePayload);
+            if (
+              ownerPid === undefined ||
+              (ownerPid !== ownerProcessId && isProcessAlive(ownerPid))
+            ) {
+              return;
+            }
+            const providerInstanceId = dieOnMissingBindingInstanceId(
+              "ProviderService.reconcileOrphanedRuntimeBindings",
+              binding,
+            );
+            const lastRuntimeEventAt = yield* nowIso;
+            yield* directory.upsert({
+              threadId: binding.threadId,
+              provider: binding.provider,
+              providerInstanceId,
+              status: "stopped",
+              runtimePayload: {
+                activeTurnId: null,
+                lastRuntimeEvent: "provider.owner-process-gone",
+                lastRuntimeEventAt,
+              },
+            });
+            yield* Effect.logWarning("provider.session.orphaned-binding-stopped", {
+              threadId: binding.threadId,
+              provider: binding.provider,
+              providerInstanceId,
+              ownerPid,
+              previousStatus: binding.status,
+            });
+          }),
+        { concurrency: 1, discard: true },
+      );
+    },
+  );
+
+  yield* reconcileOrphanedRuntimeBindings().pipe(
+    Effect.catchCause((cause) =>
+      Effect.logWarning("provider.session.orphan-reconciliation-failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+  );
 
   yield* Effect.addFinalizer(() =>
     runStopAll().pipe(

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1015,7 +1015,6 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   });
 
   const runStopAll = Effect.fn("runStopAll")(function* () {
-    const threadIds = yield* directory.listThreadIds();
     const currentAdapters = yield* getAdapterEntries;
     const activeSessions = yield* Effect.forEach(currentAdapters, ([instanceId, adapter]) =>
       adapter.listSessions().pipe(
@@ -1038,28 +1037,23 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     yield* Effect.forEach(currentAdapters, ([, adapter]) => adapter.stopAll()).pipe(Effect.asVoid);
     yield* McpSessionRegistry.revokeAllActiveMcpCredentials();
     McpProviderSession.clearAllMcpProviderSessions();
-    const bindings = yield* directory.listBindings().pipe(Effect.orElseSucceed(() => []));
-    yield* Effect.forEach(bindings, (binding) =>
-      Effect.gen(function* () {
-        const providerInstanceId = dieOnMissingBindingInstanceId(
-          "ProviderService.stopAll",
-          binding,
-        );
-        return yield* directory.upsert({
-          threadId: binding.threadId,
-          provider: binding.provider,
-          providerInstanceId,
+    yield* Effect.forEach(activeSessions, (session) =>
+      Effect.flatMap(nowIso, (lastRuntimeEventAt) =>
+        directory.upsert({
+          threadId: session.threadId,
+          provider: session.provider,
+          providerInstanceId: session.providerInstanceId,
           status: "stopped",
           runtimePayload: {
             activeTurnId: null,
             lastRuntimeEvent: "provider.stopAll",
-            lastRuntimeEventAt: yield* nowIso,
+            lastRuntimeEventAt,
           },
-        });
-      }),
+        }),
+      ),
     ).pipe(Effect.asVoid);
     yield* analytics.record("provider.sessions.stopped_all", {
-      sessionCount: threadIds.length,
+      sessionCount: activeSessions.length,
     });
     yield* analytics.flush;
   });


### PR DESCRIPTION
## Summary

- poll Codex thread state after a running-turn grace period and recover terminal turns when the realtime completion notification is missing
- suppress a delayed duplicate completion after recovery
- stop only provider sessions owned by the current process during shutdown instead of rewriting every persisted binding
- reconcile running or starting projections from newer matching stopped runtime bindings on startup, rechecking the latest projection and binding state before settling
- record the owning process id in persisted bindings and, on startup, stop orphaned bindings whose owner process verifiably no longer exists (crash recovery; pid recycling can only skip the sweep, never stop a live foreign session)
- back off completion polling geometrically (10s doubling to a 60s cap) since each poll costs a full `thread/read`, and abandon polling after three consecutive read failures

## Why

This addresses the defensive recovery proposed in #917 and the restart variant reproduced locally. A desktop backend and a headless backend can share the same state database; the old shutdown finalizer marked every persisted provider binding stopped without emitting the corresponding orchestration lifecycle event. That left durable thread projections running indefinitely and could also disturb sessions owned by the other process.

The startup reconciliation is guarded by provider identity and timestamp ordering so an older stopped binding cannot overwrite a newer running projection.

Known limitation: turn recovery settles only the turn's terminal state; item notifications missed alongside the completion are not replayed, so content produced during the outage may be absent from the projection.

Closes #917.

## Verification

- `vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts apps/server/src/provider/Layers/ProviderService.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts` — 119 tests passed
- server package TypeScript check passed
- focused formatting and lint passed for changed sources and tests; the reactor test file retains one pre-existing manual-runtime lint violation outside this change
- isolated web stack launched, migrated, and completed browser pairing against disposable state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes orchestration session projection, persisted runtime bindings, and multi-process shutdown semantics—incorrect reconciliation could stop live sessions or leave turns stuck running.
> 
> **Overview**
> **Recovers provider turns and session state** when realtime Codex completion notifications are lost or a backend dies without a clean shutdown—especially when multiple processes share the same state DB.
> 
> **Codex:** After `sendTurn`, the adapter waits a grace period then polls `reconcileTurnCompletion` via `thread/read`, with geometric backoff (10s → 60s cap) and abandonment after three consecutive failures. Recovery emits a synthetic `turn/completed` and settles session state via `applyTurnCompletionToSession`; duplicate late completions for the same turn are dropped. Missed item notifications are **not** replayed.
> 
> **ProviderService:** Persists `ownerPid` on bindings; on startup marks running/starting bindings stopped when the owner process is gone (with conservative liveness checks). Shutdown/`stopAll` now stops in-process sessions and updates only those bindings instead of rewriting every persisted binding.
> 
> **ProviderCommandReactor:** On startup, reconciles threads still projected as running/starting against stopped runtime bindings when `lastSeenAt >= session.updatedAt`, with double re-read of projection and bindings before dispatching `thread.session.set` to stopped.
> 
> Extensive tests cover polling, reconciliation guards, and multi-process shutdown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14c025db47501c7c2f56294091b92e993dda048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover stranded provider turns on startup via runtime reconciliation and orphan detection
> - `ProviderService` now records `ownerPid` on session bindings, reconciles orphaned bindings (dead or missing owner process) to `stopped` at startup, and only stops sessions owned by the current process on shutdown.
> - `CodexAdapter` polls `reconcileTurnCompletion` in the background after sending a turn, using geometric backoff up to a cap, and suppresses duplicate `turn.completed` events for the same turn.
> - `CodexSessionRuntime` exposes `reconcileTurnCompletion` to query provider state and settle the active turn if the completion event was missed; a new `applyTurnCompletionToSession` helper ensures consistent session state transitions.
> - `ProviderCommandReactor` runs a reconciliation pass at startup to settle projected sessions to `stopped` when a corresponding persisted runtime binding confirms the runtime has stopped and timestamps are consistent.
> - Risk: Reconciliation logic depends on timestamp comparisons between `binding.lastSeenAt` and `session.updatedAt`; clock skew or delayed writes could cause sessions to be incorrectly left un-reconciled or prematurely settled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c14c025.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
