### PR TITLE
Polish iOS git progress overlay with glass effects

### DIFF
--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -1,5 +1,5 @@
 import { GlassView, isGlassEffectAPIAvailable } from "expo-glass-effect";
-import { forwardRef, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   Platform,
   useColorScheme,
@@ -17,10 +17,14 @@ export interface GlassSurfaceProps extends Omit<ViewProps, "className"> {
   readonly chrome?: "default" | "none";
 }
 
-export const GlassSurface = forwardRef<View, GlassSurfaceProps>(function GlassSurface(
-  { children, glassEffectStyle = "regular", chrome = "default", tintColor, style, ...props },
-  ref,
-) {
+export function GlassSurface({
+  children,
+  glassEffectStyle = "regular",
+  chrome = "default",
+  tintColor,
+  style,
+  ...props
+}: GlassSurfaceProps) {
   const isDarkMode = useColorScheme() === "dark";
   const borderColor = useThemeColor("--color-border");
   const glassSurface = useThemeColor("--color-glass-surface");
@@ -52,7 +56,6 @@ export const GlassSurface = forwardRef<View, GlassSurfaceProps>(function GlassSu
     return (
       <GlassView
         {...props}
-        ref={ref}
         glassEffectStyle={glassEffectStyle}
         tintColor={String(tintColor ?? glassTint)}
         colorScheme={isDarkMode ? "dark" : "light"}
@@ -64,8 +67,8 @@ export const GlassSurface = forwardRef<View, GlassSurfaceProps>(function GlassSu
   }
 
   return (
-    <View {...props} ref={ref} style={[surfaceStyle, style]}>
+    <View {...props} style={[surfaceStyle, style]}>
       {children}
     </View>
   );
-});
+}

--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -1,5 +1,5 @@
 import { GlassView, isGlassEffectAPIAvailable } from "expo-glass-effect";
-import type { ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 import {
   Platform,
   useColorScheme,
@@ -17,14 +17,10 @@ export interface GlassSurfaceProps extends Omit<ViewProps, "className"> {
   readonly chrome?: "default" | "none";
 }
 
-export function GlassSurface({
-  children,
-  glassEffectStyle = "regular",
-  chrome = "default",
-  tintColor,
-  style,
-  ...props
-}: GlassSurfaceProps) {
+export const GlassSurface = forwardRef<View, GlassSurfaceProps>(function GlassSurface(
+  { children, glassEffectStyle = "regular", chrome = "default", tintColor, style, ...props },
+  ref,
+) {
   const isDarkMode = useColorScheme() === "dark";
   const borderColor = useThemeColor("--color-border");
   const glassSurface = useThemeColor("--color-glass-surface");
@@ -56,6 +52,7 @@ export function GlassSurface({
     return (
       <GlassView
         {...props}
+        ref={ref}
         glassEffectStyle={glassEffectStyle}
         tintColor={String(tintColor ?? glassTint)}
         colorScheme={isDarkMode ? "dark" : "light"}
@@ -67,8 +64,8 @@ export function GlassSurface({
   }
 
   return (
-    <View {...props} style={[surfaceStyle, style]}>
+    <View {...props} ref={ref} style={[surfaceStyle, style]}>
       {children}
     </View>
   );
-}
+});

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -1,14 +1,19 @@
 import * as Haptics from "expo-haptics";
 import { SymbolView } from "../../components/AppSymbol";
 import { useCallback, useEffect, useRef } from "react";
-import { ActivityIndicator, Pressable, View } from "react-native";
-import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import { ActivityIndicator, Platform, Pressable, View } from "react-native";
+import Animated, { FadeIn, FadeOut, LinearTransition } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { isGlassEffectAPIAvailable } from "expo-glass-effect";
 
 import { AppText as Text } from "../../components/AppText";
+import { GlassSurface } from "../../components/GlassSurface";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
+
+const OVERLAY_LAYOUT_TRANSITION = LinearTransition.duration(220);
+const AnimatedGlassSurface = Animated.createAnimatedComponent(GlassSurface);
 
 export function GitActionProgressOverlay(props: {
   readonly progress: GitActionProgress;
@@ -61,16 +66,9 @@ export function GitActionProgressOverlay(props: {
 function OverlayContent(props: { readonly progress: GitActionProgress }) {
   const { progress } = props;
   const iconColor = useThemeColor("--color-icon");
-
-  const bgClass =
-    progress.phase === "error"
-      ? "bg-red-50 dark:bg-red-950/80 border-red-200 dark:border-red-800"
-      : "bg-card border-border";
-
-  return (
-    <View
-      className={`flex-row items-center gap-2.5 rounded-2xl border px-3.5 py-3 shadow-lg shadow-black/10 ${bgClass}`}
-    >
+  const supportsGlass = Platform.OS === "ios" && isGlassEffectAPIAvailable();
+  const content = (
+    <>
       <OverlayIcon phase={progress.phase} iconColor={iconColor} />
 
       <View className="flex-1 gap-0.5">
@@ -89,7 +87,37 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
       {progress.prUrl ? (
         <SymbolView name="arrow.up.right" size={13} tintColor={iconColor} type="monochrome" />
       ) : null}
-    </View>
+    </>
+  );
+
+  if (supportsGlass) {
+    return (
+      <AnimatedGlassSurface
+        chrome="none"
+        glassEffectStyle="regular"
+        layout={OVERLAY_LAYOUT_TRANSITION}
+        style={{
+          borderCurve: "continuous",
+          borderRadius: 26,
+        }}
+      >
+        <View className="flex-row items-center gap-2.5 px-3.5 py-3">{content}</View>
+      </AnimatedGlassSurface>
+    );
+  }
+
+  const bgClass =
+    progress.phase === "error"
+      ? "bg-red-50 dark:bg-red-950/80 border-red-200 dark:border-red-800"
+      : "bg-card border-border";
+
+  return (
+    <Animated.View
+      layout={OVERLAY_LAYOUT_TRANSITION}
+      className={`flex-row items-center gap-2.5 rounded-[26px] border border-continuous px-3.5 py-3 shadow-lg shadow-black/10 ${bgClass}`}
+    >
+      {content}
+    </Animated.View>
   );
 }
 

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -1,19 +1,18 @@
 import * as Haptics from "expo-haptics";
+import { isLiquidGlassSupported, LiquidGlassView } from "@callstack/liquid-glass";
 import { SymbolView } from "../../components/AppSymbol";
 import { useCallback, useEffect, useRef } from "react";
-import { ActivityIndicator, Platform, Pressable, View } from "react-native";
+import { ActivityIndicator, Pressable, StyleSheet, useColorScheme, View } from "react-native";
 import Animated, { FadeIn, FadeOut, LinearTransition } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { isGlassEffectAPIAvailable } from "expo-glass-effect";
 
 import { AppText as Text } from "../../components/AppText";
-import { GlassSurface } from "../../components/GlassSurface";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
 
 const OVERLAY_LAYOUT_TRANSITION = LinearTransition.duration(220);
-const AnimatedGlassSurface = Animated.createAnimatedComponent(GlassSurface);
+const AnimatedLiquidGlassView = Animated.createAnimatedComponent(LiquidGlassView);
 
 export function GitActionProgressOverlay(props: {
   readonly progress: GitActionProgress;
@@ -50,7 +49,7 @@ export function GitActionProgressOverlay(props: {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(200)}
+      entering={isLiquidGlassSupported ? undefined : FadeIn.duration(200)}
       exiting={FadeOut.duration(150)}
       className="absolute inset-x-3 z-[100]"
       style={{ top: insets.top + 48 }}
@@ -66,7 +65,9 @@ export function GitActionProgressOverlay(props: {
 function OverlayContent(props: { readonly progress: GitActionProgress }) {
   const { progress } = props;
   const iconColor = useThemeColor("--color-icon");
-  const supportsGlass = Platform.OS === "ios" && isGlassEffectAPIAvailable();
+  const glassBorder = useThemeColor("--color-header-border");
+  const glassTint = useThemeColor("--color-glass-tint");
+  const isDarkMode = useColorScheme() === "dark";
   const content = (
     <>
       <OverlayIcon phase={progress.phase} iconColor={iconColor} />
@@ -90,19 +91,38 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
     </>
   );
 
-  if (supportsGlass) {
+  if (isLiquidGlassSupported) {
     return (
-      <AnimatedGlassSurface
-        chrome="none"
-        glassEffectStyle="regular"
+      <Animated.View
         layout={OVERLAY_LAYOUT_TRANSITION}
         style={{
+          backgroundColor: glassTint,
+          borderColor: glassBorder,
           borderCurve: "continuous",
           borderRadius: 26,
+          borderWidth: StyleSheet.hairlineWidth,
+          overflow: "hidden",
         }}
       >
-        <View className="flex-row items-center gap-2.5 px-3.5 py-3">{content}</View>
-      </AnimatedGlassSurface>
+        <AnimatedLiquidGlassView
+          colorScheme={isDarkMode ? "dark" : "light"}
+          effect="regular"
+          interactive
+          layout={OVERLAY_LAYOUT_TRANSITION}
+          style={{
+            borderCurve: "continuous",
+            borderRadius: 26,
+            overflow: "hidden",
+          }}
+        >
+          <Animated.View
+            entering={FadeIn.delay(60).duration(140)}
+            className="flex-row items-center gap-2.5 px-3.5 py-3"
+          >
+            {content}
+          </Animated.View>
+        </AnimatedLiquidGlassView>
+      </Animated.View>
     );
   }
 


### PR DESCRIPTION
## Summary
- Add ref forwarding to `GlassSurface` for animated glass overlays.
- Use iOS glass effects and layout transitions for the git action progress overlay.
- Preserve the existing bordered fallback styling on unsupported platforms and APIs.

## Testing
- Not run (not provided).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to a progress toast; no git, auth, or data-path changes.
> 
> **Overview**
> **Git action progress overlay** gets an iOS liquid-glass treatment when `@callstack/liquid-glass` is supported, while other platforms keep the existing card/error styling.
> 
> On supported devices, `OverlayContent` wraps shared label/icon UI in an animated `LiquidGlassView` with theme-driven tint and border (`--color-glass-tint`, `--color-header-border`), ~26px continuous corners, and a short inner fade-in. The outer overlay skips its fade-in on glass so the effect reads cleanly.
> 
> Both glass and fallback paths use a **220ms `LinearTransition`** on layout so the banner resizes smoothly as phase text changes. The non-glass branch still uses phase-based red/card classes but matches the updated corner radius.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8041bd80495325449edd0b38bb010443e54d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish iOS git progress overlay with LiquidGlass effects
> - On devices supporting LiquidGlass (iOS 26+), `OverlayContent` in [GitActionProgressOverlay.tsx](https://github.com/pingdotgg/t3code/pull/4387/files#diff-676fe607184008943cedbcbd21f43bbf678b3617b5934ad9c366823c90e4e2f4) renders with an interactive glass effect, theme-derived tint/border, and a short delayed `FadeIn` on content.
> - On non-supporting devices, the overlay uses a 26px continuous border radius and switches from a static `View` to an `Animated.View`.
> - Layout changes within the overlay now animate over 220ms using `LinearTransition`.
> - The outer container skips `FadeIn` on entry when LiquidGlass is supported; otherwise retains the 200ms fade.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb8041b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->