### PR TITLE
Keep Android new task composer above keyboard

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1068,74 +1068,76 @@ export function NewTaskDraftScreen(props: {
         <NativeStackScreenOptions options={{ headerShown: false }} />
         <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
 
-        <KeyboardStickyView
-          style={ANDROID_DRAFT_COMPOSER_STICKY_STYLE}
-          offset={ANDROID_DRAFT_COMPOSER_KEYBOARD_OFFSET}
-        >
-          <View
-            className="px-4 pt-2"
-            style={{
-              paddingBottom: controlsBottomPadding,
-              experimental_backgroundImage: isDarkMode
-                ? "linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 100%)"
-                : "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 40%, rgba(255,255,255,0.95) 100%)",
-            }}
+        <View className="relative min-h-0 flex-1">
+          <KeyboardStickyView
+            style={ANDROID_DRAFT_COMPOSER_STICKY_STYLE}
+            offset={ANDROID_DRAFT_COMPOSER_KEYBOARD_OFFSET}
           >
-            <ComposerSurface
-              isDarkMode={isDarkMode}
-              style={
-                isExpanded
-                  ? {
-                      borderRadius: 20,
-                      overflow: "hidden",
-                      paddingHorizontal: 14,
-                      paddingVertical: 12,
-                    }
-                  : {
-                      borderRadius: 999,
-                      overflow: "hidden",
-                      flexDirection: "row",
-                      alignItems: "center",
-                      paddingLeft: 18,
-                      paddingRight: 5,
-                      paddingVertical: 5,
-                    }
-              }
+            <View
+              className="px-4 pt-2"
+              style={{
+                paddingBottom: controlsBottomPadding,
+                experimental_backgroundImage: isDarkMode
+                  ? "linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 100%)"
+                  : "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 40%, rgba(255,255,255,0.95) 100%)",
+              }}
             >
-              {isExpanded && flow.attachments.length > 0 ? (
-                <View className="pb-2.5">
-                  <ComposerAttachmentStrip
-                    attachments={flow.attachments}
-                    onRemove={
-                      isIncomingShareTransferPending ? () => undefined : flow.removeAttachment
-                    }
+              <ComposerSurface
+                isDarkMode={isDarkMode}
+                style={
+                  isExpanded
+                    ? {
+                        borderRadius: 20,
+                        overflow: "hidden",
+                        paddingHorizontal: 14,
+                        paddingVertical: 12,
+                      }
+                    : {
+                        borderRadius: 999,
+                        overflow: "hidden",
+                        flexDirection: "row",
+                        alignItems: "center",
+                        paddingLeft: 18,
+                        paddingRight: 5,
+                        paddingVertical: 5,
+                      }
+                }
+              >
+                {isExpanded && flow.attachments.length > 0 ? (
+                  <View className="pb-2.5">
+                    <ComposerAttachmentStrip
+                      attachments={flow.attachments}
+                      onRemove={
+                        isIncomingShareTransferPending ? () => undefined : flow.removeAttachment
+                      }
+                    />
+                  </View>
+                ) : null}
+                <View className={isExpanded ? undefined : "min-w-0 flex-1"}>{promptEditor}</View>
+                {!isExpanded ? (
+                  <ControlPill
+                    icon="arrow.up"
+                    variant="primary"
+                    disabled={!canStart}
+                    onPress={() => void handleStart()}
                   />
-                </View>
-              ) : null}
-              <View className={isExpanded ? undefined : "min-w-0 flex-1"}>{promptEditor}</View>
-              {!isExpanded ? (
-                <ControlPill
-                  icon="arrow.up"
-                  variant="primary"
-                  disabled={!canStart}
-                  onPress={() => void handleStart()}
-                />
-              ) : null}
-            </ComposerSurface>
+                ) : null}
+              </ComposerSurface>
 
-            {isExpanded ? (
-              <ComposerToolbarRow paddingBottom={8} paddingHorizontal={0} paddingTop={8}>
-                <ComposerToolbarScroller
-                  fadeOpaque={isDarkMode ? "rgba(0,0,0,0.95)" : "rgba(255,255,255,0.95)"}
-                  fadeTransparent={isDarkMode ? "rgba(0,0,0,0)" : "rgba(255,255,255,0)"}
-                >
-                  {toolbarPills}
-                </ComposerToolbarScroller>
-                {startButton}
-              </ComposerToolbarRow>
-            ) : null}
-          </View>
-        </KeyboardStickyView>
+              {isExpanded ? (
+                <ComposerToolbarRow paddingBottom={8} paddingHorizontal={0} paddingTop={8}>
+                  <ComposerToolbarScroller
+                    fadeOpaque={isDarkMode ? "rgba(0,0,0,0.95)" : "rgba(255,255,255,0.95)"}
+                    fadeTransparent={isDarkMode ? "rgba(0,0,0,0)" : "rgba(255,255,255,0)"}
+                  >
+                    {toolbarPills}
+                  </ComposerToolbarScroller>
+                  {startButton}
+                </ComposerToolbarRow>
+              ) : null}
+            </View>
+          </KeyboardStickyView>
+        </View>
       </View>
     );
   }

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -2,7 +2,11 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, usePreventRemove } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, InteractionManager, Platform, View, useColorScheme } from "react-native";
-import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
+import {
+  KeyboardAvoidingView,
+  KeyboardStickyView,
+  useKeyboardState,
+} from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useFontFamily } from "../../lib/useFontFamily";
@@ -50,6 +54,14 @@ import { useRemoteConnectionStatus } from "../../state/use-remote-environment-re
 import { branchBadgeLabel, useNewTaskFlow } from "./new-task-flow-provider";
 import { useCreateProjectThread } from "./use-project-actions";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
+
+const ANDROID_DRAFT_COMPOSER_STICKY_STYLE = {
+  position: "absolute",
+  bottom: 0,
+  left: 0,
+  right: 0,
+} as const;
+const ANDROID_DRAFT_COMPOSER_KEYBOARD_OFFSET = { closed: 0, opened: 0 } as const;
 
 function formatWorkspaceLabel(input: {
   readonly workspaceMode: string;
@@ -1048,14 +1060,18 @@ export function NewTaskDraftScreen(props: {
     // The draft is a thread that doesn't exist yet, so it mirrors the thread
     // page: in-screen header, empty feed canvas above, and the same floating
     // composer chrome as ThreadComposer (collapsed pill → expanded card).
+    // Keep the composer bottom-anchored to the IME so its focus-driven height
+    // expansion grows upward instead of racing a padding-based relayout and
+    // leaving the toolbar underneath the keyboard.
     return (
       <View className="flex-1 bg-screen">
         <NativeStackScreenOptions options={{ headerShown: false }} />
         <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
 
-        <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
-          <View className="flex-1" />
-
+        <KeyboardStickyView
+          style={ANDROID_DRAFT_COMPOSER_STICKY_STYLE}
+          offset={ANDROID_DRAFT_COMPOSER_KEYBOARD_OFFSET}
+        >
           <View
             className="px-4 pt-2"
             style={{
@@ -1119,7 +1135,7 @@ export function NewTaskDraftScreen(props: {
               </ComposerToolbarRow>
             ) : null}
           </View>
-        </KeyboardAvoidingView>
+        </KeyboardStickyView>
       </View>
     );
   }


### PR DESCRIPTION
## What Changed

- Replace the Android new-task screen’s padding-based keyboard avoidance with a bottom-anchored `KeyboardStickyView`.
- Keep the draft composer attached to the IME while its focused editor expands upward.
- Preserve the existing iOS keyboard-avoidance behavior.

## Why

The Android new-task composer changes height as focus expands the collapsed prompt pill into a multiline editor with toolbar controls. The padding-based keyboard relayout could race that height change, leaving part of the editor and toolbar underneath Gboard.

Anchoring the Android composer directly to the keyboard makes the expansion grow upward and keeps the complete composer accessible while typing.

## UI Changes

**Before:** With Gboard open and a multiline prompt, the lower portion of the composer can remain hidden behind the keyboard.

**After:** The expanded editor and its model/configuration/action row remain fully above Gboard, including at the editor’s maximum height.

Verified on a physical Pixel 9 Pro XL through wireless debugging, plus an Android 35 emulator. On the phone, the toolbar bottom moved from `1628` (inside Gboard) to `1363` (fully above Gboard’s `1399` top edge).

### Physical-device evidence

| Before | After |
| --- | --- |
| ![Before: composer obscured by Gboard](https://raw.githubusercontent.com/colonelpanic8/t3code/b508b44ecb9efba9e808b862b3e4a47e1d02b1d3/before.png) | ![After: complete composer above Gboard](https://raw.githubusercontent.com/colonelpanic8/t3code/b508b44ecb9efba9e808b862b3e4a47e1d02b1d3/after.png) |

[Watch the wireless-debugging interaction recording](https://raw.githubusercontent.com/colonelpanic8/t3code/b508b44ecb9efba9e808b862b3e4a47e1d02b1d3/after.mp4)

## Validation

- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`
- `vp run --filter @t3tools/mobile test` — 92 files, 538 tests passed
- Android 35 emulator with Gboard and a maximum-height multiline prompt

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] I included a short video for the keyboard interaction change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Android UI/layout change in one screen, following an existing `KeyboardStickyView` pattern elsewhere in mobile; no auth, data, or API impact.
> 
> **Overview**
> On **Android**, the new-thread draft screen no longer uses `KeyboardAvoidingView` with padding to lift the composer. The draft composer (surface, toolbar, gradient chrome) is wrapped in **`KeyboardStickyView`** with absolute bottom anchoring so it tracks the IME.
> 
> That change targets a race when the collapsed pill expands into a multiline editor: padding-based avoidance could leave the editor and toolbar under Gboard. Sticky anchoring lets height growth move **upward** while the bar stays above the keyboard.
> 
> **iOS** still uses the existing `KeyboardAvoidingView` layout; only the Android branch in `NewTaskDraftScreen` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5846bf0146be27ff54d451a1f085f9d5963aaa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep Android new task composer above the keyboard using `KeyboardStickyView`
> On Android, the draft composer was previously laid out with `KeyboardAvoidingView`, which could leave the toolbar obscured by the keyboard. The composer is now wrapped in a `KeyboardStickyView` with absolute bottom positioning so it anchors to the bottom and rises with the IME. The non-Android path using `KeyboardAvoidingView` is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5846bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->