### PR TITLE
fix(server): parse CLI version in update preflight

### DIFF
--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -54,7 +54,7 @@ const makeRecordingRunnerLayer = (
           return {
             stdout:
               options?.stdoutFor?.(input.command, input.args) ??
-              (versionFromPath === undefined ? "" : `${versionFromPath}\n`),
+              (versionFromPath === undefined ? "" : `t3 v${versionFromPath}\n`),
             stderr: failed ? `${input.command} exploded` : "",
             code: ChildProcessSpawner.ExitCode(failed ? 1 : 0),
             timedOut: false,
@@ -427,7 +427,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
     Effect.gen(function* () {
       const context = yield* makeContext({
         stdoutFor: (command, args) =>
-          command === NODE_PATH && args[1] === "--version" ? "0.0.28\n" : undefined,
+          command === NODE_PATH && args[1] === "--version" ? "t3 v0.0.28\n" : undefined,
       });
       const versionDir = context.path.join(context.baseDir, "runtime", "versions", "0.0.29");
 

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -273,8 +273,10 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
             failWith(`Could not verify the installed t3@${targetVersion}.`, cause),
           ),
         );
-      const preflightVersion = preflight.stdout.trim();
-      if (preflight.code !== 0 || preflightVersion !== targetVersion) {
+      // Effect CLI's unstable formatVersion currently emits `${name} v${version}`.
+      // Extract the version token so surrounding presentation changes do not break updates.
+      const reportedVersion = /\bv(\S+)\s*$/.exec(preflight.stdout)?.[1];
+      if (preflight.code !== 0 || reportedVersion !== targetVersion) {
         // A completed npm install can still be unusable under this Node or on
         // this machine. Remove its sentinel and tree so a retry of the same
         // version performs a clean install instead of reusing a known-bad one.


### PR DESCRIPTION
## Summary

- verify pinned runtimes against the CLI’s actual `t3 v<version>` output
- make the self-update process-runner fake emit that same format
- keep wrong-version coverage realistic

## Verification

- `vp test run apps/server/src/cloud/selfUpdate.test.ts`
- `vp fmt --check apps/server/src/cloud/selfUpdate.ts apps/server/src/cloud/selfUpdate.test.ts`
- `vp lint apps/server/src/cloud/selfUpdate.ts apps/server/src/cloud/selfUpdate.test.ts`
- `vp run --filter t3 typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to post-install version verification and test doubles; no auth or data paths touched.
> 
> **Overview**
> **Self-update preflight** no longer treats `--version` stdout as a bare semver string. It **parses the trailing `v<version>` token** (e.g. from `t3 v0.0.29`) before comparing to the requested pin, so Effect CLI’s `formatVersion` output does not falsely fail installs.
> 
> **Tests** make the fake process runner and wrong-version case emit **`t3 v…`** so preflight behavior matches production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312fa3b31afb17628d5ce145d398b3a98f18e0c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix version parsing in update preflight to handle CLI `name v<version>` output
> The update preflight check was comparing the raw stdout of `--version` directly to the target version string, but Effect CLI emits output like `t3 v0.0.28` rather than a bare version number. The fix extracts the version token using `/\bv(\S+)\s*$/` before comparing, so installs are no longer incorrectly rejected and removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 312fa3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->