### PR TITLE
Fix logical project grouping labels on mobile

### DIFF
--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -385,10 +385,6 @@ function IosHomeHeader(props: HomeHeaderProps) {
             title="Thread list options"
             separateBackground
           >
-            <NativeHeaderToolbar.MenuAction onPress={props.onOpenSettings}>
-              <NativeHeaderToolbar.Label>Settings</NativeHeaderToolbar.Label>
-            </NativeHeaderToolbar.MenuAction>
-
             <NativeHeaderToolbar.Menu title="Environment">
               <NativeHeaderToolbar.Label>Environment</NativeHeaderToolbar.Label>
               <NativeHeaderToolbar.MenuAction

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -4,7 +4,6 @@ import { useNavigation } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
 
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
-import { scopedProjectKey } from "../../lib/scopedEntities";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
@@ -16,6 +15,7 @@ import { AndroidHomeFabLayout } from "./AndroidHomeFab";
 import { HomeScreen } from "./HomeScreen";
 import { HomeHeader } from "./HomeHeader";
 import { useHomeListOptions } from "./home-list-options";
+import { buildHomeProjectScopes } from "./homeThreadList";
 import { usePendingTaskListActions } from "./usePendingTaskListActions";
 import { useThreadListActions } from "./useThreadListActions";
 
@@ -61,16 +61,15 @@ export function HomeRouteScreen() {
   const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
   const projectFilterOptions = useMemo(
     () =>
-      projects
-        .filter(
-          (project) =>
-            selectedEnvironmentId === null || project.environmentId === selectedEnvironmentId,
-        )
-        .map((project) => ({
-          key: scopedProjectKey(project.environmentId, project.id),
-          label: project.title,
-        })),
-    [projects, selectedEnvironmentId],
+      buildHomeProjectScopes({
+        projects,
+        environmentId: selectedEnvironmentId,
+        projectGroupingMode: listOptions.projectGroupingMode,
+      }).map((scope) => ({
+        key: scope.key,
+        label: scope.title,
+      })),
+    [listOptions.projectGroupingMode, projects, selectedEnvironmentId],
   );
   useEffect(() => {
     if (

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -372,6 +372,21 @@ export function HomeScreen(props: HomeScreenProps) {
           ) ?? null),
     [v2ProjectScopeKey, v2ScopeProjects],
   );
+  const v2ProjectTitleByProjectKey = useMemo(
+    () =>
+      new Map(
+        v2ScopeProjects.flatMap((scope) =>
+          scope.projectRefs.map(
+            (projectRef) =>
+              [
+                scopedProjectKey(projectRef.environmentId, projectRef.projectId),
+                scope.title,
+              ] as const,
+          ),
+        ),
+      ),
+    [v2ScopeProjects],
+  );
   const v2ScopedProjectKeys = useMemo(
     () =>
       v2ScopedProjectGroup === null
@@ -493,6 +508,9 @@ export function HomeScreen(props: HomeScreenProps) {
           projectByKey.get(scopedProjectKey(item.thread.environmentId, item.thread.projectId)) ??
           null
         }
+        projectTitle={v2ProjectTitleByProjectKey.get(
+          scopedProjectKey(item.thread.environmentId, item.thread.projectId),
+        )}
         providerDriver={
           serverConfigs
             .get(item.thread.environmentId)
@@ -536,6 +554,7 @@ export function HomeScreen(props: HomeScreenProps) {
       props.savedConnectionsById,
       serverConfigs,
       settlementEnvironmentIds,
+      v2ProjectTitleByProjectKey,
     ],
   );
   const v2KeyExtractor = useCallback(

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -245,43 +245,69 @@ export function HomeScreen(props: HomeScreenProps) {
     onScrollBeginDrag: handleScrollBeginDrag,
   });
 
-  const scopedProject = useMemo(
+  const projectScopes = useMemo(
+    () =>
+      buildHomeProjectScopes({
+        projects: props.projects,
+        environmentId: props.selectedEnvironmentId,
+        projectGroupingMode: props.projectGroupingMode,
+      }),
+    [props.projectGroupingMode, props.projects, props.selectedEnvironmentId],
+  );
+  const selectedProjectScope = useMemo(
     () =>
       props.selectedProjectKey === null
         ? null
-        : (props.projects.find(
-            (project) =>
-              scopedProjectKey(project.environmentId, project.id) === props.selectedProjectKey &&
-              (props.selectedEnvironmentId === null ||
-                project.environmentId === props.selectedEnvironmentId),
+        : (projectScopes.find(
+            (scope) =>
+              scope.key === props.selectedProjectKey ||
+              scope.projectRefs.some(
+                (projectRef) =>
+                  scopedProjectKey(projectRef.environmentId, projectRef.projectId) ===
+                  props.selectedProjectKey,
+              ),
           ) ?? null),
-    [props.projects, props.selectedEnvironmentId, props.selectedProjectKey],
+    [projectScopes, props.selectedProjectKey],
+  );
+  const selectedProjectRefKeys = useMemo(
+    () =>
+      selectedProjectScope === null
+        ? null
+        : new Set(
+            selectedProjectScope.projectRefs.map((projectRef) =>
+              scopedProjectKey(projectRef.environmentId, projectRef.projectId),
+            ),
+          ),
+    [selectedProjectScope],
   );
   const scopedProjects = useMemo(
-    () => (scopedProject === null ? props.projects : [scopedProject]),
-    [props.projects, scopedProject],
+    () =>
+      selectedProjectRefKeys === null
+        ? props.projects
+        : props.projects.filter((project) =>
+            selectedProjectRefKeys.has(scopedProjectKey(project.environmentId, project.id)),
+          ),
+    [props.projects, selectedProjectRefKeys],
   );
   const scopedThreads = useMemo(
     () =>
-      scopedProject === null
+      selectedProjectRefKeys === null
         ? props.threads
-        : props.threads.filter(
-            (thread) =>
-              thread.environmentId === scopedProject.environmentId &&
-              thread.projectId === scopedProject.id,
+        : props.threads.filter((thread) =>
+            selectedProjectRefKeys.has(scopedProjectKey(thread.environmentId, thread.projectId)),
           ),
-    [props.threads, scopedProject],
+    [props.threads, selectedProjectRefKeys],
   );
   const scopedPendingTasks = useMemo(
     () =>
-      scopedProject === null
+      selectedProjectRefKeys === null
         ? props.pendingTasks
-        : props.pendingTasks.filter(
-            (pendingTask) =>
-              pendingTask.message.environmentId === scopedProject.environmentId &&
-              pendingTask.creation.projectId === scopedProject.id,
+        : props.pendingTasks.filter((pendingTask) =>
+            selectedProjectRefKeys.has(
+              scopedProjectKey(pendingTask.message.environmentId, pendingTask.creation.projectId),
+            ),
           ),
-    [props.pendingTasks, scopedProject],
+    [props.pendingTasks, selectedProjectRefKeys],
   );
 
   const projectGroups = useMemo(
@@ -339,22 +365,18 @@ export function HomeScreen(props: HomeScreenProps) {
   const v2ScopeProjects = useMemo(
     () =>
       sortHomeProjectScopes({
-        scopes: buildHomeProjectScopes({
-          projects: props.projects,
-          environmentId: props.selectedEnvironmentId,
-          projectGroupingMode: props.projectGroupingMode,
-        }),
+        scopes: projectScopes,
         threads: props.threads,
         pendingTasks: props.pendingTasks,
         projectSortOrder: props.projectSortOrder,
       }),
     [
       props.pendingTasks,
-      props.projectGroupingMode,
       props.projects,
       props.projectSortOrder,
       props.selectedEnvironmentId,
       props.threads,
+      projectScopes,
     ],
   );
   const v2ScopedProjectGroup = useMemo(
@@ -774,9 +796,9 @@ export function HomeScreen(props: HomeScreenProps) {
   const listEmpty = !hasResults ? (
     hasSearchQuery ? (
       <EmptyState title="No results" detail={`No threads matching "${props.searchQuery}".`} />
-    ) : scopedProject !== null ? (
+    ) : selectedProjectScope !== null ? (
       <EmptyState
-        title={`No threads in ${scopedProject.title}`}
+        title={`No threads in ${selectedProjectScope.title}`}
         detail="Choose another project or create a new task."
       />
     ) : selectedEnvironmentLabel ? (

--- a/apps/mobile/src/features/home/home-list-filter-menu.test.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.test.ts
@@ -24,6 +24,7 @@ describe("buildHomeListFilterMenu", () => {
     const projectMenu = menu.items.find(
       (item) => item.type === "submenu" && item.title === "Project",
     );
+    expect(menu.items.some((item) => item.title === "Settings")).toBe(false);
     expect(projectMenu).toMatchObject({
       type: "submenu",
       items: [

--- a/apps/mobile/src/features/home/home-list-filter-menu.ts
+++ b/apps/mobile/src/features/home/home-list-filter-menu.ts
@@ -43,21 +43,12 @@ export function buildHomeListFilterMenu(props: {
   readonly onProjectChange: (projectKey: string | null) => void;
   readonly onProjectSortOrderChange: (sortOrder: HomeProjectSortOrder) => void;
   readonly onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
-  readonly onOpenSettings?: () => void;
   /** False hides the sort/group submenus. Thread List v2 uses a fixed
       creation-order layout, so offering those controls while it silently
       ignores them would be a lie; the environment filter still applies. */
   readonly listOrganization?: boolean;
 }): HomeListFilterMenu {
   const items: Array<HomeListFilterMenuAction | HomeListFilterMenuSubmenu> = [];
-
-  if (props.onOpenSettings) {
-    items.push({
-      type: "action",
-      title: "Settings",
-      onPress: props.onOpenSettings,
-    });
-  }
 
   items.push({
     type: "submenu",

--- a/apps/mobile/src/features/home/homeThreadList.test.ts
+++ b/apps/mobile/src/features/home/homeThreadList.test.ts
@@ -104,6 +104,7 @@ describe("buildHomeThreadGroups", () => {
     });
 
     expect(scopes).toHaveLength(1);
+    expect(scopes[0]?.title).toBe("t3code");
     expect(scopes[0]?.projects).toEqual(projects);
     expect(scopes[0]?.projectRefs).toEqual(
       projects.map((project) => ({
@@ -371,6 +372,31 @@ describe("buildHomeThreadGroups", () => {
         projectGroupingMode: "repository",
       }),
     ).toHaveLength(2);
+  });
+
+  it("uses the repository label for a singleton repository scope", () => {
+    const project = makeProject({
+      environmentId: EnvironmentId.make("environment-1"),
+      id: ProjectId.make("project-1"),
+      title: "local-worktree-name",
+      repositoryIdentity: {
+        canonicalKey: "github.com/pingdotgg/t3code",
+        displayName: "codething-mvp",
+        locator: {
+          source: "git-remote" as const,
+          remoteName: "origin",
+          remoteUrl: "git@github.com:pingdotgg/t3code.git",
+        },
+      },
+    });
+
+    expect(
+      buildHomeProjectScopes({
+        projects: [project],
+        environmentId: null,
+        projectGroupingMode: "repository",
+      })[0]?.title,
+    ).toBe("codething-mvp");
   });
 
   it("sorts the newest thread first regardless of snapshot order", () => {

--- a/apps/mobile/src/features/home/homeThreadList.test.ts
+++ b/apps/mobile/src/features/home/homeThreadList.test.ts
@@ -390,13 +390,25 @@ describe("buildHomeThreadGroups", () => {
       },
     });
 
-    expect(
-      buildHomeProjectScopes({
-        projects: [project],
-        environmentId: null,
-        projectGroupingMode: "repository",
-      })[0]?.title,
-    ).toBe("codething-mvp");
+    const scopes = buildHomeProjectScopes({
+      projects: [project],
+      environmentId: null,
+      projectGroupingMode: "repository",
+    });
+    const groups = buildGroups(
+      [project],
+      [
+        makeThread({
+          environmentId: project.environmentId,
+          id: ThreadId.make("thread-1"),
+          projectId: project.id,
+          title: "Thread",
+        }),
+      ],
+    );
+
+    expect(scopes[0]?.title).toBe("codething-mvp");
+    expect(groups[0]?.title).toBe("codething-mvp");
   });
 
   it("sorts the newest thread first regardless of snapshot order", () => {

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -343,10 +343,7 @@ export function buildHomeThreadGroups(input: {
       continue;
     }
 
-    const title =
-      group.projects.length > 1
-        ? deriveProjectGroupLabel({ representative, members: group.projects })
-        : representative.title;
+    const title = deriveProjectGroupLabel({ representative, members: group.projects });
     const groupMatches =
       query.length === 0 ||
       title.toLocaleLowerCase().includes(query) ||

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -113,10 +113,7 @@ export function buildHomeProjectScopes(input: {
     const representative = projects[0]!;
     return {
       key,
-      title:
-        projects.length > 1
-          ? deriveProjectGroupLabel({ representative, members: projects })
-          : representative.title,
+      title: deriveProjectGroupLabel({ representative, members: projects }),
       representative,
       projects,
       projectRefs: projectRefsByGroup.get(key) ?? [],

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -236,6 +236,21 @@ function ThreadNavigationSidebarPane(
       })),
     [projectScopes],
   );
+  const projectTitleByProjectKey = useMemo(
+    () =>
+      new Map(
+        projectScopes.flatMap((scope) =>
+          scope.projectRefs.map(
+            (projectRef) =>
+              [
+                scopedProjectKey(projectRef.environmentId, projectRef.projectId),
+                scope.title,
+              ] as const,
+          ),
+        ),
+      ),
+    [projectScopes],
+  );
   const selectedProjectScope = useMemo(
     () =>
       selectedProjectKey === null
@@ -728,6 +743,7 @@ function ThreadNavigationSidebarPane(
               variant={item.item.variant}
               showSettledDivider={item.item.showSettledDivider}
               project={projectByKey.get(scopeKey) ?? null}
+              projectTitle={projectTitleByProjectKey.get(scopeKey)}
               providerDriver={
                 serverConfigs
                   .get(thread.environmentId)
@@ -857,6 +873,7 @@ function ThreadNavigationSidebarPane(
       openPendingTask,
       projectByKey,
       projectCwdByKey,
+      projectTitleByProjectKey,
       props.onNewThreadInProject,
       props.selectedThreadKey,
       props.width,

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -90,6 +90,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
   readonly variant: "card" | "slim";
   readonly showSettledDivider: boolean;
   readonly project: EnvironmentProject | null;
+  readonly projectTitle?: string;
   readonly providerDriver: string | null;
   /** Which machine hosts the thread. Null when only one environment is
       connected — repeating the same label on every row is noise. Mirrors
@@ -219,7 +220,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
           <ProjectFavicon
             environmentId={thread.environmentId}
             size={15}
-            projectTitle={props.project.title}
+            projectTitle={props.projectTitle ?? props.project.title}
             workspaceRoot={props.project.workspaceRoot}
           />
         ) : null}
@@ -230,7 +231,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
           )}
           numberOfLines={1}
         >
-          {props.project?.title ?? ""}
+          {props.projectTitle ?? props.project?.title ?? ""}
         </Text>
         <Text
           className={cn(
@@ -393,7 +394,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 size={15}
-                projectTitle={props.project.title}
+                projectTitle={props.projectTitle ?? props.project.title}
                 workspaceRoot={props.project.workspaceRoot}
               />
             </View>


### PR DESCRIPTION
## Summary
- build the phone project filter from logical project scopes instead of raw project records
- show logical repository labels on Thread List V2 rows on phone and tablet
- use repository labels consistently for singleton repository scopes

## Verification
- `vp test run apps/mobile/src/features/home/homeThreadList.test.ts`
- targeted `vp lint --report-unused-disable-directives` on changed files
- `vp run --filter @t3tools/mobile typecheck`
- `vp run lint:mobile`
- iOS Simulator against disposable state with two physical projects from one repository

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and client-side list filtering only; no auth, API, or persistence changes.
> 
> **Overview**
> **Mobile home and sidebar thread lists now use logical project scope titles** (e.g. repository display names) instead of raw per-environment project titles when repository grouping is enabled.
> 
> `buildHomeProjectScopes` and thread group building **always** call `deriveProjectGroupLabel`, so a single project in a repo scope shows the repository label rather than a local worktree name. Project filter chips and menus are built from those scopes via `buildHomeProjectScopes`, respecting grouping mode.
> 
> Selecting a scope **filters threads and pending tasks across every `projectRef` in that scope** (not a single raw project). Thread List V2 rows receive an optional `projectTitle` so favicons and row text match the scope label on phone and tablet.
> 
> The thread-list filter menu **no longer includes a Settings action** (settings remain on the header); tests assert that removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a0ac5f1560a9f87dd83343714ad6c848ab37f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project grouping labels on mobile home screen to use repository display names
> - Updates `buildHomeProjectScopes` and `buildHomeThreadGroups` in [homeThreadList.ts](https://github.com/pingdotgg/t3code/pull/4391/files#diff-1f36b630d8d39dd1ca1be5a84d64ea082a69ffdf26be6759d3e6c9b705473796) to always derive scope/group titles via `deriveProjectGroupLabel`, even for single-project scopes, so repository display names appear instead of raw project titles.
> - Updates `HomeScreen` and `ThreadNavigationSidebarPane` to map project keys to scope-level titles and pass them to `ThreadListV2Row`, which now accepts an optional `projectTitle` prop with fallback to `project.title`.
> - Replaces per-project filter entries in `HomeRouteScreen` with `buildHomeProjectScopes`, so the Project submenu reflects grouped scopes and reacts to `projectGroupingMode`.
> - Removes the Settings action from the thread list options menu in `home-list-filter-menu.ts` and `HomeHeader`.
> - Behavioral Change: project filter selection now scopes threads and pending tasks across multiple projects within a grouped scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22a0ac5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->