### PR TITLE
fix(mobile): keep Android new-task composer above keyboard

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -1053,7 +1053,16 @@ export function NewTaskDraftScreen(props: {
         <NativeStackScreenOptions options={{ headerShown: false }} />
         <AndroidScreenHeader title="New Thread" onBack={() => navigation.goBack()} />
 
-        <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
+        <KeyboardAvoidingView
+          automaticOffset
+          behavior="padding"
+          className="flex-1"
+          // Android lays this screen through the edge-to-edge navigation area,
+          // but the IME overlap reported to KeyboardAvoidingView stops above
+          // it. Include that inset so the expanded editor and its toolbar both
+          // remain above the keyboard.
+          keyboardVerticalOffset={insets.bottom}
+        >
           <View className="flex-1" />
 
           <View


### PR DESCRIPTION
## Summary

- keep the Android New Thread composer above the software keyboard
- include the edge-to-edge bottom navigation inset in the keyboard avoidance offset
- preserve the existing iOS and composer layout behavior

## Problem

On Android devices using edge-to-edge layout, focusing the New Thread composer expands the editor while opening the IME. The keyboard overlap reported to `KeyboardAvoidingView` stops above the system navigation area, even though the composer is laid out through that area. As a result, the top of the keyboard can cover the bottom of the editor and hide the composer toolbar.

## Fix

Pass the safe-area bottom inset as `keyboardVerticalOffset` for the Android New Thread `KeyboardAvoidingView`. This accounts for the edge-to-edge navigation area and lifts the complete expanded composer—including its toolbar—above the keyboard.

## Validation

- manually verified on a physical Samsung Android device with Gboard; the focused composer and action controls remain visible above the keyboard
- `vp fmt --check apps/mobile/src/features/threads/NewTaskDraftScreen.tsx`
- `vp lint apps/mobile/src/features/threads/NewTaskDraftScreen.tsx --report-unused-disable-directives`
- `vp run --filter @t3tools/mobile typecheck`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android new-task composer staying above keyboard in `NewTaskDraftScreen`
> Adds `keyboardVerticalOffset={insets.bottom}` to the `KeyboardAvoidingView` in the Android render path of [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/4393/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2). This ensures the editor and toolbar stay visible above the keyboard and bottom navigation area.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca8be3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Android-only layout offset in NewTaskDraftScreen; no auth, data, or shared logic changes.
> 
> **Overview**
> On **Android** edge-to-edge layouts, the New Thread screen’s `KeyboardAvoidingView` now uses **`keyboardVerticalOffset={insets.bottom}`** so keyboard avoidance accounts for the system navigation inset.
> 
> That lifts the expanded composer and toolbar when the IME opens, instead of the keyboard overlapping the bottom of the editor. **iOS** and the rest of the composer layout are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8be3e2d5af470a1163f60fc50d72f10558a15f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->