### PR TITLE
Navigate open selections with Ctrl-N and Ctrl-P

### DIFF
--- a/apps/web/src/AppRoot.test.tsx
+++ b/apps/web/src/AppRoot.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
+import { SelectionNavigationBindings } from "./components/SelectionNavigationBindings";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
 import type { AppRouter } from "./router";
 import { AppRoot } from "./AppRoot";
@@ -16,9 +17,10 @@ describe("AppRoot", () => {
     const children = Children.toArray(
       (root as ReactElement<{ readonly children: ReactNode }>).props.children,
     );
-    expect(children).toHaveLength(3);
-    expect(isValidElement(children[0]) && children[0].type).toBe(RouterProvider);
-    expect(isValidElement(children[1]) && children[1].type).toBe(PreviewAutomationHosts);
-    expect(isValidElement(children[2]) && children[2].type).toBe(ElectronBrowserHost);
+    expect(children).toHaveLength(4);
+    expect(isValidElement(children[0]) && children[0].type).toBe(SelectionNavigationBindings);
+    expect(isValidElement(children[1]) && children[1].type).toBe(RouterProvider);
+    expect(isValidElement(children[2]) && children[2].type).toBe(PreviewAutomationHosts);
+    expect(isValidElement(children[3]) && children[3].type).toBe(ElectronBrowserHost);
   });
 });

--- a/apps/web/src/AppRoot.tsx
+++ b/apps/web/src/AppRoot.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from "@tanstack/react-router";
 
 import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
+import { SelectionNavigationBindings } from "./components/SelectionNavigationBindings";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
 import type { AppRouter } from "./router";
 
@@ -13,6 +14,7 @@ import type { AppRouter } from "./router";
 export function AppRoot({ router }: { readonly router: AppRouter }) {
   return (
     <AppAtomRegistryProvider>
+      <SelectionNavigationBindings />
       <RouterProvider router={router} />
       <PreviewAutomationHosts />
       <ElectronBrowserHost />

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -9,7 +9,7 @@ import {
   HistoryIcon,
   MonitorIcon,
 } from "lucide-react";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { useProject, useThread, useThreadShellsForProjectRefs } from "../state/entities";
@@ -89,6 +89,11 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
   onUsePreviousWorktree,
   onSelectionComplete,
 }: MobileRunContextSelectorProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const completeSelection = useCallback(() => {
+    setIsMenuOpen(false);
+    onSelectionComplete?.();
+  }, [onSelectionComplete]);
   const activeEnvironment = useMemo(
     () => availableEnvironments?.find((env) => env.environmentId === environmentId) ?? null,
     [availableEnvironments, environmentId],
@@ -134,7 +139,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
   }
 
   return (
-    <Menu>
+    <Menu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
       <MenuTrigger
         render={<Button variant="ghost" size="xs" />}
         className="min-w-0 max-w-[48%] flex-1 justify-start text-muted-foreground/70 hover:text-foreground/80 md:hidden"
@@ -151,7 +156,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                 value={environmentId}
                 onValueChange={(value) => {
                   onEnvironmentChange(value as EnvironmentId);
-                  onSelectionComplete?.();
+                  completeSelection();
                 }}
               >
                 {availableEnvironments.map((env) => {
@@ -159,6 +164,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                   return (
                     <MenuRadioItem
                       key={env.environmentId}
+                      closeOnClick
                       disabled={envLocked}
                       value={env.environmentId}
                     >
@@ -181,14 +187,14 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
             onValueChange={(value) => {
               if (value === "previous-worktree") {
                 onUsePreviousWorktree();
-                onSelectionComplete?.();
+                completeSelection();
                 return;
               }
               onEnvModeChange(value as EnvMode);
-              onSelectionComplete?.();
+              completeSelection();
             }}
           >
-            <MenuRadioItem disabled={envModeLocked} value="local">
+            <MenuRadioItem closeOnClick disabled={envModeLocked} value="local">
               <span className="flex min-w-0 items-center gap-1.5">
                 {activeWorktreePath ? (
                   <FolderGitIcon className="size-3" />
@@ -200,14 +206,14 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                 </span>
               </span>
             </MenuRadioItem>
-            <MenuRadioItem disabled={envModeLocked} value="worktree">
+            <MenuRadioItem closeOnClick disabled={envModeLocked} value="worktree">
               <span className="flex min-w-0 items-center gap-1.5">
                 <FolderGit2Icon className="size-3" />
                 <span className="min-w-0 truncate">{resolveEnvModeLabel("worktree")}</span>
               </span>
             </MenuRadioItem>
             {previousWorktreeLabel ? (
-              <MenuRadioItem disabled={envModeLocked} value="previous-worktree">
+              <MenuRadioItem closeOnClick disabled={envModeLocked} value="previous-worktree">
                 <span className="flex min-w-0 items-center gap-1.5">
                   <HistoryIcon className="size-3" />
                   <span className="min-w-0 truncate">{previousWorktreeLabel}</span>

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -71,6 +71,7 @@ interface MobileRunContextSelectorProps {
   onEnvModeChange: (mode: EnvMode) => void;
   previousWorktreeLabel: string | null;
   onUsePreviousWorktree: () => void;
+  onSelectionComplete?: () => void;
 }
 
 const MobileRunContextSelector = memo(function MobileRunContextSelector({
@@ -86,6 +87,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
   onEnvModeChange,
   previousWorktreeLabel,
   onUsePreviousWorktree,
+  onSelectionComplete,
 }: MobileRunContextSelectorProps) {
   const activeEnvironment = useMemo(
     () => availableEnvironments?.find((env) => env.environmentId === environmentId) ?? null,
@@ -147,7 +149,10 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
               <MenuGroupLabel>Run on</MenuGroupLabel>
               <MenuRadioGroup
                 value={environmentId}
-                onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
+                onValueChange={(value) => {
+                  onEnvironmentChange(value as EnvironmentId);
+                  onSelectionComplete?.();
+                }}
               >
                 {availableEnvironments.map((env) => {
                   const Icon = env.isPrimary ? MonitorIcon : CloudIcon;
@@ -176,9 +181,11 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
             onValueChange={(value) => {
               if (value === "previous-worktree") {
                 onUsePreviousWorktree();
+                onSelectionComplete?.();
                 return;
               }
               onEnvModeChange(value as EnvMode);
+              onSelectionComplete?.();
             }}
           >
             <MenuRadioItem disabled={envModeLocked} value="local">
@@ -319,6 +326,7 @@ export const BranchToolbar = memo(function BranchToolbar({
           onEnvModeChange={onEnvModeChange}
           previousWorktreeLabel={previousWorktreeLabel}
           onUsePreviousWorktree={onUsePreviousWorktree}
+          {...(onComposerFocusRequest ? { onSelectionComplete: onComposerFocusRequest } : {})}
         />
       ) : (
         <div className="flex min-w-0 flex-1 items-center gap-1">
@@ -328,6 +336,7 @@ export const BranchToolbar = memo(function BranchToolbar({
                 envLocked={envLocked}
                 environmentId={environmentId}
                 availableEnvironments={availableEnvironments}
+                {...(onComposerFocusRequest ? { onSelectionComplete: onComposerFocusRequest } : {})}
                 {...(showEnvironmentPicker && onEnvironmentChange ? { onEnvironmentChange } : {})}
               />
               <Separator orientation="vertical" className="mx-0.5 h-3.5!" />
@@ -340,6 +349,7 @@ export const BranchToolbar = memo(function BranchToolbar({
             onEnvModeChange={onEnvModeChange}
             previousWorktreeLabel={previousWorktreeLabel}
             onUsePreviousWorktree={onUsePreviousWorktree}
+            {...(onComposerFocusRequest ? { onSelectionComplete: onComposerFocusRequest } : {})}
           />
         </div>
       )}

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -26,6 +26,7 @@ interface BranchToolbarEnvModeSelectorProps {
   onEnvModeChange: (mode: EnvMode) => void;
   previousWorktreeLabel?: string | null;
   onUsePreviousWorktree?: () => void;
+  onSelectionComplete?: () => void;
 }
 
 export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSelector({
@@ -35,6 +36,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   onEnvModeChange,
   previousWorktreeLabel,
   onUsePreviousWorktree,
+  onSelectionComplete,
 }: BranchToolbarEnvModeSelectorProps) {
   const showPreviousWorktree = Boolean(previousWorktreeLabel && onUsePreviousWorktree);
   const envModeItems = useMemo(
@@ -73,9 +75,11 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
       onValueChange={(value: string | null) => {
         if (value === PREVIOUS_WORKTREE_SELECT_VALUE) {
           onUsePreviousWorktree?.();
+          onSelectionComplete?.();
           return;
         }
         onEnvModeChange(value as EnvMode);
+        onSelectionComplete?.();
       }}
       items={envModeItems}
     >

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -20,6 +20,7 @@ interface BranchToolbarEnvironmentSelectorProps {
   // Absent when there is only one environment to show: the indicator still
   // renders (as a static label) so remote projects are always identifiable.
   onEnvironmentChange?: (environmentId: EnvironmentId) => void;
+  onSelectionComplete?: () => void;
 }
 
 export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvironmentSelector({
@@ -27,6 +28,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
   environmentId,
   availableEnvironments,
   onEnvironmentChange,
+  onSelectionComplete,
 }: BranchToolbarEnvironmentSelectorProps) {
   const activeEnvironment = useMemo(() => {
     return availableEnvironments.find((env) => env.environmentId === environmentId) ?? null;
@@ -58,7 +60,10 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
     <Select
       modal={false}
       value={environmentId}
-      onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
+      onValueChange={(value) => {
+        onEnvironmentChange(value as EnvironmentId);
+        onSelectionComplete?.();
+      }}
       items={environmentItems}
     >
       <SelectTrigger

--- a/apps/web/src/components/SelectionNavigationBindings.tsx
+++ b/apps/web/src/components/SelectionNavigationBindings.tsx
@@ -1,0 +1,12 @@
+import { useLayoutEffect } from "react";
+
+import { handleSelectionNavigationKeyDown } from "../selectionNavigation";
+
+export function SelectionNavigationBindings() {
+  useLayoutEffect(() => {
+    window.addEventListener("keydown", handleSelectionNavigationKeyDown, true);
+    return () => window.removeEventListener("keydown", handleSelectionNavigationKeyDown, true);
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -348,6 +348,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
                 size="sm"
                 className="font-medium"
                 aria-label="Runtime mode"
+                data-chat-runtime-mode-picker="true"
               />
             }
           >

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -286,6 +286,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   onToggleInteractionMode: () => void;
   onRuntimeModeChange: (mode: RuntimeMode) => void;
   onTogglePlanSidebar: () => void;
+  onSelectionComplete: () => void;
 }) {
   const runtimeModeOption = runtimeModeConfig[props.runtimeMode];
   const RuntimeModeIcon = runtimeModeOption.icon;
@@ -339,7 +340,10 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
       <Tooltip>
         <Select
           value={props.runtimeMode}
-          onValueChange={(value) => props.onRuntimeModeChange(value!)}
+          onValueChange={(value) => {
+            props.onRuntimeModeChange(value!);
+            props.onSelectionComplete();
+          }}
         >
           <TooltipTrigger
             render={
@@ -1224,6 +1228,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     modelOptions: composerModelOptions?.[selectedInstanceId],
     prompt,
     onPromptChange: setPromptFromTraits,
+    onSelectionComplete: scheduleComposerFocus,
   });
   const providerTraitsPicker = renderProviderTraitsPicker({
     provider: selectedProvider,
@@ -1235,6 +1240,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     modelOptions: composerModelOptions?.[selectedInstanceId],
     prompt,
     onPromptChange: setPromptFromTraits,
+    onSelectionComplete: scheduleComposerFocus,
   });
   const pendingPrimaryAction = useMemo(
     () =>
@@ -3117,6 +3123,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     }}
                     getModelDisabledReason={getModelDisabledReason}
                     onInstanceModelChange={onProviderModelSelect}
+                    onSelectionComplete={scheduleComposerFocus}
                   />
                 )}
 
@@ -3132,6 +3139,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onToggleInteractionMode={toggleInteractionMode}
                     onTogglePlanSidebar={togglePlanSidebar}
                     onRuntimeModeChange={handleRuntimeModeChange}
+                    onSelectionComplete={scheduleComposerFocus}
                   />
                 ) : (
                   <>
@@ -3151,6 +3159,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       onToggleInteractionMode={toggleInteractionMode}
                       onRuntimeModeChange={handleRuntimeModeChange}
                       onTogglePlanSidebar={togglePlanSidebar}
+                      onSelectionComplete={scheduleComposerFocus}
                     />
                   </>
                 )}

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -23,6 +23,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   onToggleInteractionMode: () => void;
   onTogglePlanSidebar: () => void;
   onRuntimeModeChange: (mode: RuntimeMode) => void;
+  onSelectionComplete: () => void;
 }) {
   return (
     <Menu>
@@ -53,6 +54,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
               onValueChange={(value) => {
                 if (!value || value === props.interactionMode) return;
                 props.onToggleInteractionMode();
+                props.onSelectionComplete();
               }}
             >
               <MenuRadioItem value="default">Chat</MenuRadioItem>
@@ -67,6 +69,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
           onValueChange={(value) => {
             if (!value || value === props.runtimeMode) return;
             props.onRuntimeModeChange(value as RuntimeMode);
+            props.onSelectionComplete();
           }}
         >
           <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
@@ -77,7 +80,12 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
         {props.activePlan ? (
           <>
             <MenuDivider />
-            <MenuItem onClick={props.onTogglePlanSidebar}>
+            <MenuItem
+              onClick={() => {
+                props.onTogglePlanSidebar();
+                props.onSelectionComplete();
+              }}
+            >
               <ListTodoIcon className="size-4 shrink-0" />
               {props.planSidebarOpen
                 ? `Hide ${props.planSidebarLabel.toLowerCase()} sidebar`

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -1,5 +1,5 @@
 import { ProviderInteractionMode, RuntimeMode } from "@t3tools/contracts";
-import { memo, type ReactNode } from "react";
+import { cloneElement, memo, type ReactElement, useCallback, useState } from "react";
 import { EllipsisIcon, ListTodoIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import {
@@ -19,14 +19,25 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   planSidebarOpen: boolean;
   runtimeMode: RuntimeMode;
   showInteractionModeToggle: boolean;
-  traitsMenuContent?: ReactNode;
+  traitsMenuContent?: ReactElement | null;
   onToggleInteractionMode: () => void;
   onTogglePlanSidebar: () => void;
   onRuntimeModeChange: (mode: RuntimeMode) => void;
   onSelectionComplete: () => void;
 }) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const completeSelection = useCallback(() => {
+    setIsMenuOpen(false);
+    props.onSelectionComplete();
+  }, [props.onSelectionComplete]);
+  const traitsMenuContent = props.traitsMenuContent
+    ? cloneElement(props.traitsMenuContent as ReactElement<{ onSelectionComplete?: () => void }>, {
+        onSelectionComplete: completeSelection,
+      })
+    : null;
+
   return (
-    <Menu>
+    <Menu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
       <MenuTrigger
         render={
           <Button
@@ -40,9 +51,9 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
         <EllipsisIcon aria-hidden="true" className="size-4" />
       </MenuTrigger>
       <MenuPopup align="start">
-        {props.traitsMenuContent ? (
+        {traitsMenuContent ? (
           <>
-            {props.traitsMenuContent}
+            {traitsMenuContent}
             <MenuDivider />
           </>
         ) : null}
@@ -54,11 +65,15 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
               onValueChange={(value) => {
                 if (!value || value === props.interactionMode) return;
                 props.onToggleInteractionMode();
-                props.onSelectionComplete();
+                completeSelection();
               }}
             >
-              <MenuRadioItem value="default">Chat</MenuRadioItem>
-              <MenuRadioItem value="plan">Plan</MenuRadioItem>
+              <MenuRadioItem closeOnClick value="default">
+                Chat
+              </MenuRadioItem>
+              <MenuRadioItem closeOnClick value="plan">
+                Plan
+              </MenuRadioItem>
             </MenuRadioGroup>
             <MenuDivider />
           </>
@@ -69,13 +84,21 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
           onValueChange={(value) => {
             if (!value || value === props.runtimeMode) return;
             props.onRuntimeModeChange(value as RuntimeMode);
-            props.onSelectionComplete();
+            completeSelection();
           }}
         >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="auto">Auto</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          <MenuRadioItem closeOnClick value="approval-required">
+            Supervised
+          </MenuRadioItem>
+          <MenuRadioItem closeOnClick value="auto-accept-edits">
+            Auto-accept edits
+          </MenuRadioItem>
+          <MenuRadioItem closeOnClick value="auto">
+            Auto
+          </MenuRadioItem>
+          <MenuRadioItem closeOnClick value="full-access">
+            Full access
+          </MenuRadioItem>
         </MenuRadioGroup>
         {props.activePlan ? (
           <>
@@ -83,7 +106,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             <MenuItem
               onClick={() => {
                 props.onTogglePlanSidebar();
-                props.onSelectionComplete();
+                completeSelection();
               }}
             >
               <ListTodoIcon className="size-4 shrink-0" />

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -63,8 +63,10 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             <MenuRadioGroup
               value={props.interactionMode}
               onValueChange={(value) => {
-                if (!value || value === props.interactionMode) return;
-                props.onToggleInteractionMode();
+                if (!value) return;
+                if (value !== props.interactionMode) {
+                  props.onToggleInteractionMode();
+                }
                 completeSelection();
               }}
             >
@@ -82,8 +84,10 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
         <MenuRadioGroup
           value={props.runtimeMode}
           onValueChange={(value) => {
-            if (!value || value === props.runtimeMode) return;
-            props.onRuntimeModeChange(value as RuntimeMode);
+            if (!value) return;
+            if (value !== props.runtimeMode) {
+              props.onRuntimeModeChange(value as RuntimeMode);
+            }
             completeSelection();
           }}
         >

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -141,7 +141,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
     >
       <div
         ref={listRef}
-        data-composer-command-menu=""
+        data-composer-command-menu={props.items.length > 0 ? "" : undefined}
         className="dropdown-glass relative w-full overflow-hidden rounded-[20px]"
       >
         {props.items.length > 0 ? (

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -139,7 +139,11 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
         );
       }}
     >
-      <div ref={listRef} className="dropdown-glass relative w-full overflow-hidden rounded-[20px]">
+      <div
+        ref={listRef}
+        data-composer-command-menu=""
+        className="dropdown-glass relative w-full overflow-hidden rounded-[20px]"
+      >
         {props.items.length > 0 ? (
           <CommandList className="max-h-72">
             {groups.map((group, groupIndex) => (

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -43,6 +43,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   onOpenChange?: (open: boolean) => void;
   getModelDisabledReason?: (instanceId: ProviderInstanceId, model: string) => string | null;
   onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
+  onSelectionComplete?: () => void;
 }) {
   const [uncontrolledIsMenuOpen, setUncontrolledIsMenuOpen] = useState(false);
   const isMenuOpen = props.open ?? uncontrolledIsMenuOpen;
@@ -131,6 +132,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     if (props.disabled) return;
     props.onInstanceModelChange(instanceId, model);
     setIsMenuOpen(false);
+    props.onSelectionComplete?.();
   };
 
   return (

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -439,6 +439,10 @@ export const TraitsPicker = memo(function TraitsPicker({
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const completeSelection = useCallback(() => {
+    setIsMenuOpen(false);
+    onSelectionComplete?.();
+  }, [onSelectionComplete]);
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled, fastModeEnabled } =
     getTraitsSectionVisibility({
       provider,
@@ -522,7 +526,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           onPromptChange={onPromptChange}
           modelOptions={modelOptions}
           allowPromptInjectedEffort={allowPromptInjectedEffort}
-          {...(onSelectionComplete ? { onSelectionComplete } : {})}
+          onSelectionComplete={completeSelection}
           {...persistence}
         />
       </MenuPopup>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -482,6 +482,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           <Button
             size="sm"
             variant={triggerVariant ?? "ghost"}
+            data-chat-provider-traits-picker="true"
             className={cn(
               isCodexStyle
                 ? "min-w-0 max-w-40 shrink justify-start overflow-hidden whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:max-w-48 sm:px-3 [&_svg]:mx-0"

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -218,6 +218,7 @@ export interface TraitsMenuContentProps {
   allowPromptInjectedEffort?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
+  onSelectionComplete?: () => void;
 }
 
 export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
@@ -229,6 +230,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  onSelectionComplete,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
@@ -281,6 +283,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           ? ULTRATHINK_PROMPT_PREFIX
           : applyClaudePromptEffortPrefix(prompt, "ultrathink");
       onPromptChange(nextPrompt);
+      onSelectionComplete?.();
       return;
     }
     if (ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id) return;
@@ -289,6 +292,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       onPromptChange(stripped);
     }
     updateDescriptors(replaceDescriptorCurrentValue(descriptors, descriptor.id, value));
+    onSelectionComplete?.();
   };
 
   if (!hasAnyControls) {
@@ -361,6 +365,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                   updateDescriptors(
                     replaceDescriptorCurrentValue(descriptors, descriptor.id, value === "on"),
                   );
+                  onSelectionComplete?.();
                 }}
               >
                 {(["on", "off"] as const).map((value) => (
@@ -430,6 +435,7 @@ export const TraitsPicker = memo(function TraitsPicker({
   allowPromptInjectedEffort = true,
   triggerVariant,
   triggerClassName,
+  onSelectionComplete,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -516,6 +522,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           onPromptChange={onPromptChange}
           modelOptions={modelOptions}
           allowPromptInjectedEffort={allowPromptInjectedEffort}
+          {...(onSelectionComplete ? { onSelectionComplete } : {})}
           {...persistence}
         />
       </MenuPopup>

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -46,6 +46,7 @@ type TraitsRenderInput = {
   modelOptions: ReadonlyArray<ProviderOptionSelection> | undefined;
   prompt: string;
   onPromptChange: (prompt: string) => void;
+  onSelectionComplete?: () => void;
 };
 
 export function getComposerPromptInjectionState(prompt: string): ComposerPromptInjectionState {
@@ -94,6 +95,7 @@ function renderTraitsControl(
     modelOptions,
     prompt,
     onPromptChange,
+    onSelectionComplete,
   } = input;
   const hasTarget = threadRef !== undefined || draftId !== undefined;
   if (
@@ -113,6 +115,7 @@ function renderTraitsControl(
       modelOptions={modelOptions}
       prompt={prompt}
       onPromptChange={onPromptChange}
+      {...(onSelectionComplete ? { onSelectionComplete } : {})}
     />
   );
 }

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -11,7 +11,7 @@ import {
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
 } from "@t3tools/shared/model";
-import type { ReactNode } from "react";
+import type { ReactElement } from "react";
 
 import type { DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
@@ -84,7 +84,7 @@ export function getComposerProviderState(input: ComposerProviderStateInput): Com
 function renderTraitsControl(
   Component: typeof TraitsMenuContent | typeof TraitsPicker,
   input: TraitsRenderInput,
-): ReactNode {
+): ReactElement | null {
   const {
     provider,
     instanceId,
@@ -120,10 +120,10 @@ function renderTraitsControl(
   );
 }
 
-export function renderProviderTraitsMenuContent(input: TraitsRenderInput): ReactNode {
+export function renderProviderTraitsMenuContent(input: TraitsRenderInput): ReactElement | null {
   return renderTraitsControl(TraitsMenuContent, input);
 }
 
-export function renderProviderTraitsPicker(input: TraitsRenderInput): ReactNode {
+export function renderProviderTraitsPicker(input: TraitsRenderInput): ReactElement | null {
   return renderTraitsControl(TraitsPicker, input);
 }

--- a/apps/web/src/selectionNavigation.test.ts
+++ b/apps/web/src/selectionNavigation.test.ts
@@ -132,6 +132,76 @@ describe("selection navigation", () => {
     expect(dispatchedKeys).toEqual(["ArrowDown"]);
   });
 
+  it("routes navigation in the model picker search input", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const searchInput = new TestElement();
+    searchInput.attributes.set("data-slot", "combobox-input");
+    searchInput.attributes.set("aria-controls", "model-picker-options");
+    const modelPickerPopup = new TestElement();
+    modelPickerPopup.id = "model-picker-options";
+    modelPickerPopup.attributes.set("data-slot", "combobox-popup");
+    testDocument(searchInput, [modelPickerPopup]);
+
+    const dispatchedKeys: string[] = [];
+    searchInput.addEventListener("keydown", (event) => {
+      dispatchedKeys.push((event as TestKeyboardEvent).key);
+    });
+
+    handleSelectionNavigationKeyDown(keyboardEvent(searchInput, { key: "n", ctrlKey: true }));
+    handleSelectionNavigationKeyDown(keyboardEvent(searchInput, { key: "p", ctrlKey: true }));
+
+    expect(dispatchedKeys).toEqual(["ArrowDown", "ArrowUp"]);
+  });
+
+  it.each([
+    ["project picker", "menu-trigger", "menu-popup"],
+    ["submenu", "menu-sub-trigger", "menu-sub-content"],
+  ] as const)(
+    "routes the first chord after opening a %s without an aria-controls link",
+    (_label, triggerSlot, popupSlot) => {
+      vi.stubGlobal("Element", TestElement);
+      vi.stubGlobal("HTMLElement", TestElement);
+
+      const trigger = new TestElement();
+      trigger.attributes.set("aria-expanded", "true");
+      trigger.attributes.set("data-slot", triggerSlot);
+      const popup = new TestElement();
+      popup.attributes.set("data-slot", popupSlot);
+      testDocument(trigger, [popup]);
+
+      const dispatchedKeys: string[] = [];
+      trigger.addEventListener("keydown", (event) => {
+        dispatchedKeys.push((event as TestKeyboardEvent).key);
+      });
+
+      handleSelectionNavigationKeyDown(keyboardEvent(trigger, { key: "n", ctrlKey: true }));
+
+      expect(dispatchedKeys).toEqual(["ArrowDown"]);
+    },
+  );
+
+  it("routes navigation while focus is inside the project picker popup", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const projectPickerPopup = new TestElement();
+    projectPickerPopup.attributes.set("data-slot", "menu-popup");
+    const focusedItem = new TestElement();
+    focusedItem.parentElement = projectPickerPopup;
+    testDocument(focusedItem, [projectPickerPopup]);
+
+    const dispatchedKeys: string[] = [];
+    focusedItem.addEventListener("keydown", (event) => {
+      dispatchedKeys.push((event as TestKeyboardEvent).key);
+    });
+
+    handleSelectionNavigationKeyDown(keyboardEvent(focusedItem, { key: "p", ctrlKey: true }));
+
+    expect(dispatchedKeys).toEqual(["ArrowUp"]);
+  });
+
   it("routes navigation to the portaled composer suggestion menu", () => {
     vi.stubGlobal("Element", TestElement);
     vi.stubGlobal("HTMLElement", TestElement);

--- a/apps/web/src/selectionNavigation.test.ts
+++ b/apps/web/src/selectionNavigation.test.ts
@@ -111,26 +111,33 @@ describe("selection navigation", () => {
     expect(event.stopImmediatePropagation).toHaveBeenCalledOnce();
   });
 
-  it("routes the first chord after opening the prompt runtime/access picker", () => {
-    vi.stubGlobal("Element", TestElement);
-    vi.stubGlobal("HTMLElement", TestElement);
+  it.each([
+    ["runtime/access", "data-chat-runtime-mode-picker", "select-popup"],
+    ["effort and provider options", "data-chat-provider-traits-picker", "menu-popup"],
+  ] as const)(
+    "routes the first chord after a tooltip replaces the %s picker trigger slot",
+    (_label, triggerMarker, popupSlot) => {
+      vi.stubGlobal("Element", TestElement);
+      vi.stubGlobal("HTMLElement", TestElement);
 
-    const target = new TestElement();
-    target.attributes.set("aria-expanded", "true");
-    target.attributes.set("data-slot", "select-trigger");
-    const surface = new TestElement();
-    surface.attributes.set("data-slot", "select-popup");
-    testDocument(target, [surface]);
+      const target = new TestElement();
+      target.attributes.set("aria-expanded", "true");
+      target.attributes.set("data-slot", "tooltip-trigger");
+      target.attributes.set(triggerMarker, "true");
+      const surface = new TestElement();
+      surface.attributes.set("data-slot", popupSlot);
+      testDocument(target, [surface]);
 
-    const dispatchedKeys: string[] = [];
-    target.addEventListener("keydown", (event) => {
-      dispatchedKeys.push((event as TestKeyboardEvent).key);
-    });
+      const dispatchedKeys: string[] = [];
+      target.addEventListener("keydown", (event) => {
+        dispatchedKeys.push((event as TestKeyboardEvent).key);
+      });
 
-    handleSelectionNavigationKeyDown(keyboardEvent(target, { key: "n", ctrlKey: true }));
+      handleSelectionNavigationKeyDown(keyboardEvent(target, { key: "n", ctrlKey: true }));
 
-    expect(dispatchedKeys).toEqual(["ArrowDown"]);
-  });
+      expect(dispatchedKeys).toEqual(["ArrowDown"]);
+    },
+  );
 
   it("routes navigation in the model picker search input", () => {
     vi.stubGlobal("Element", TestElement);

--- a/apps/web/src/selectionNavigation.test.ts
+++ b/apps/web/src/selectionNavigation.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { handleSelectionNavigationKeyDown } from "./selectionNavigation";
+
+class TestElement extends EventTarget {
+  ownerDocument!: Document;
+  parentElement: TestElement | null = null;
+  hidden = false;
+  id = "";
+  attributes = new Map<string, string>();
+
+  contains(candidate: unknown): boolean {
+    for (let current = candidate as TestElement | null; current; current = current.parentElement) {
+      if (current === this) return true;
+    }
+    return false;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+
+  closest(selector: string): TestElement | null {
+    if (
+      (selector === '[data-chat-composer-form="true"]' &&
+        this.attributes.get("data-chat-composer-form") === "true") ||
+      (selector === "[data-terminal-owner]" && this.attributes.has("data-terminal-owner")) ||
+      (selector === "[data-keybinding-capture]" && this.attributes.has("data-keybinding-capture"))
+    ) {
+      return this;
+    }
+    return this.parentElement?.closest(selector) ?? null;
+  }
+}
+
+class TestKeyboardEvent extends Event {
+  readonly key: string;
+  readonly repeat: boolean;
+
+  constructor(type: string, init: KeyboardEventInit) {
+    super(type, init);
+    this.key = init.key ?? "";
+    this.repeat = init.repeat ?? false;
+  }
+}
+
+function keyboardEvent(
+  target: TestElement,
+  input: Partial<KeyboardEvent> & Pick<KeyboardEvent, "key">,
+): KeyboardEvent {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    isComposing: false,
+    metaKey: false,
+    repeat: false,
+    shiftKey: false,
+    stopImmediatePropagation: vi.fn(),
+    preventDefault: vi.fn(),
+    target,
+    ...input,
+  } as unknown as KeyboardEvent;
+}
+
+function testDocument(target: TestElement, surfaces: TestElement[]): Document {
+  const body = new TestElement();
+  const document = {
+    activeElement: target,
+    body,
+    defaultView: { KeyboardEvent: TestKeyboardEvent },
+    querySelectorAll: () => surfaces,
+  } as unknown as Document;
+  target.ownerDocument = document;
+  for (const surface of surfaces) surface.ownerDocument = document;
+  return document;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("selection navigation", () => {
+  it.each([
+    ["n", "ArrowDown"],
+    ["p", "ArrowUp"],
+  ] as const)("routes Control-%s to %s in an owned listbox", (key, expected) => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const target = new TestElement();
+    const surface = new TestElement();
+    surface.id = "project-options";
+    target.attributes.set("aria-controls", surface.id);
+    testDocument(target, [surface]);
+
+    const dispatchedKeys: string[] = [];
+    target.addEventListener("keydown", (event) => {
+      dispatchedKeys.push((event as TestKeyboardEvent).key);
+    });
+    const event = keyboardEvent(target, { key, ctrlKey: true });
+
+    handleSelectionNavigationKeyDown(event);
+
+    expect(dispatchedKeys).toEqual([expected]);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopImmediatePropagation).toHaveBeenCalledOnce();
+  });
+
+  it("routes the first chord after opening a select whose popup has no aria-controls link", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const target = new TestElement();
+    target.attributes.set("aria-expanded", "true");
+    target.attributes.set("data-slot", "select-trigger");
+    const surface = new TestElement();
+    surface.attributes.set("data-slot", "select-popup");
+    testDocument(target, [surface]);
+
+    const dispatchedKeys: string[] = [];
+    target.addEventListener("keydown", (event) => {
+      dispatchedKeys.push((event as TestKeyboardEvent).key);
+    });
+
+    handleSelectionNavigationKeyDown(keyboardEvent(target, { key: "n", ctrlKey: true }));
+
+    expect(dispatchedKeys).toEqual(["ArrowDown"]);
+  });
+
+  it("routes navigation to the portaled composer suggestion menu", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const composer = new TestElement();
+    composer.attributes.set("data-chat-composer-form", "true");
+    const target = new TestElement();
+    target.parentElement = composer;
+    const surface = new TestElement();
+    surface.attributes.set("data-composer-command-menu", "");
+    testDocument(target, [surface]);
+
+    const dispatchedKeys: string[] = [];
+    target.addEventListener("keydown", (event) => {
+      dispatchedKeys.push((event as TestKeyboardEvent).key);
+    });
+
+    handleSelectionNavigationKeyDown(keyboardEvent(target, { key: "p", ctrlKey: true }));
+
+    expect(dispatchedKeys).toEqual(["ArrowUp"]);
+  });
+
+  it("does not claim navigation for an unrelated visible picker", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const body = new TestElement();
+    const targetContainer = new TestElement();
+    targetContainer.parentElement = body;
+    const target = new TestElement();
+    target.parentElement = targetContainer;
+    const pickerContainer = new TestElement();
+    pickerContainer.parentElement = body;
+    const surface = new TestElement();
+    surface.parentElement = pickerContainer;
+    const document = testDocument(target, [surface]);
+    (document as unknown as { body: TestElement }).body = body;
+    const event = keyboardEvent(target, { key: "n", ctrlKey: true });
+
+    handleSelectionNavigationKeyDown(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  it("ignores modified chords, terminals, and keybinding capture fields", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const target = new TestElement();
+    const surface = new TestElement();
+    surface.id = "owned-options";
+    target.attributes.set("aria-controls", surface.id);
+    testDocument(target, [surface]);
+
+    for (const event of [
+      keyboardEvent(target, { key: "n", ctrlKey: true, shiftKey: true }),
+      keyboardEvent(target, { key: "p", metaKey: true }),
+    ]) {
+      handleSelectionNavigationKeyDown(event);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+
+    target.attributes.set("data-terminal-owner", "");
+    const terminalEvent = keyboardEvent(target, { key: "n", ctrlKey: true });
+    handleSelectionNavigationKeyDown(terminalEvent);
+    expect(terminalEvent.preventDefault).not.toHaveBeenCalled();
+
+    target.attributes.delete("data-terminal-owner");
+    target.attributes.set("data-keybinding-capture", "");
+    const captureEvent = keyboardEvent(target, { key: "p", ctrlKey: true });
+    handleSelectionNavigationKeyDown(captureEvent);
+    expect(captureEvent.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/selectionNavigation.test.ts
+++ b/apps/web/src/selectionNavigation.test.ts
@@ -111,7 +111,7 @@ describe("selection navigation", () => {
     expect(event.stopImmediatePropagation).toHaveBeenCalledOnce();
   });
 
-  it("routes the first chord after opening a select whose popup has no aria-controls link", () => {
+  it("routes the first chord after opening the prompt runtime/access picker", () => {
     vi.stubGlobal("Element", TestElement);
     vi.stubGlobal("HTMLElement", TestElement);
 
@@ -157,6 +157,9 @@ describe("selection navigation", () => {
 
   it.each([
     ["project picker", "menu-trigger", "menu-popup"],
+    ["effort and provider options picker", "menu-trigger", "menu-popup"],
+    ["compact composer controls picker", "menu-trigger", "menu-popup"],
+    ["implementation actions menu", "menu-trigger", "menu-popup"],
     ["submenu", "menu-sub-trigger", "menu-sub-content"],
   ] as const)(
     "routes the first chord after opening a %s without an aria-controls link",

--- a/apps/web/src/selectionNavigation.test.ts
+++ b/apps/web/src/selectionNavigation.test.ts
@@ -154,6 +154,24 @@ describe("selection navigation", () => {
     expect(dispatchedKeys).toEqual(["ArrowUp"]);
   });
 
+  it("does not claim navigation for an empty composer suggestion menu", () => {
+    vi.stubGlobal("Element", TestElement);
+    vi.stubGlobal("HTMLElement", TestElement);
+
+    const composer = new TestElement();
+    composer.attributes.set("data-chat-composer-form", "true");
+    const target = new TestElement();
+    target.parentElement = composer;
+    const emptySurface = new TestElement();
+    testDocument(target, [emptySurface]);
+    const event = keyboardEvent(target, { key: "n", ctrlKey: true });
+
+    handleSelectionNavigationKeyDown(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
   it("does not claim navigation for an unrelated visible picker", () => {
     vi.stubGlobal("Element", TestElement);
     vi.stubGlobal("HTMLElement", TestElement);

--- a/apps/web/src/selectionNavigation.test.ts
+++ b/apps/web/src/selectionNavigation.test.ts
@@ -112,6 +112,7 @@ describe("selection navigation", () => {
   });
 
   it.each([
+    ["model", "data-chat-provider-model-picker", "combobox-list"],
     ["runtime/access", "data-chat-runtime-mode-picker", "select-popup"],
     ["effort and provider options", "data-chat-provider-traits-picker", "menu-popup"],
   ] as const)(

--- a/apps/web/src/selectionNavigation.ts
+++ b/apps/web/src/selectionNavigation.ts
@@ -20,6 +20,11 @@ const SURFACE_SLOT_BY_TRIGGER_SLOT: Readonly<Record<string, string>> = {
   "select-trigger": "select-popup",
 };
 
+const SURFACE_SLOT_BY_TRIGGER_MARKER: Readonly<Record<string, string>> = {
+  "data-chat-provider-traits-picker": "menu-popup",
+  "data-chat-runtime-mode-picker": "select-popup",
+};
+
 function resolveSelectionNavigationKey(event: KeyboardEvent): SelectionNavigationKey | null {
   if (
     event.defaultPrevented ||
@@ -57,6 +62,14 @@ function candidateSurfaceBelongsToFocus(
     surfaceSlot === SURFACE_SLOT_BY_TRIGGER_SLOT[triggerSlot]
   ) {
     return true;
+  }
+
+  if (focusedElement.getAttribute("aria-expanded") === "true") {
+    for (const [triggerMarker, popupSlot] of Object.entries(SURFACE_SLOT_BY_TRIGGER_MARKER)) {
+      if (focusedElement.hasAttribute(triggerMarker) && surfaceSlot === popupSlot) {
+        return true;
+      }
+    }
   }
 
   if (

--- a/apps/web/src/selectionNavigation.ts
+++ b/apps/web/src/selectionNavigation.ts
@@ -1,0 +1,130 @@
+const CANDIDATE_SURFACE_SELECTOR = [
+  "[data-composer-command-menu]",
+  '[data-slot="command-dialog-popup"]',
+  '[data-slot="command-list"]',
+  '[data-slot="combobox-popup"]',
+  '[data-slot="autocomplete-popup"]',
+  '[data-slot="select-popup"]',
+  '[data-slot="menu-popup"]',
+  '[role="listbox"]',
+].join(",");
+
+type SelectionNavigationKey = "ArrowDown" | "ArrowUp";
+
+const SURFACE_SLOT_BY_TRIGGER_SLOT: Readonly<Record<string, string>> = {
+  "autocomplete-trigger": "autocomplete-popup",
+  "combobox-trigger": "combobox-popup",
+  "menu-trigger": "menu-popup",
+  "select-trigger": "select-popup",
+};
+
+function resolveSelectionNavigationKey(event: KeyboardEvent): SelectionNavigationKey | null {
+  if (
+    event.defaultPrevented ||
+    event.isComposing ||
+    !event.ctrlKey ||
+    event.altKey ||
+    event.metaKey ||
+    event.shiftKey
+  ) {
+    return null;
+  }
+
+  const key = event.key.toLowerCase();
+  if (key === "n") return "ArrowDown";
+  if (key === "p") return "ArrowUp";
+  return null;
+}
+
+function candidateSurfaceBelongsToFocus(
+  surface: HTMLElement,
+  focusedElement: Element | null,
+  document: Document,
+): boolean {
+  if (!focusedElement) return false;
+  if (surface.contains(focusedElement)) return true;
+
+  const controlledIds = focusedElement.getAttribute("aria-controls")?.split(/\s+/) ?? [];
+  if (surface.id && controlledIds.includes(surface.id)) return true;
+
+  const triggerSlot = focusedElement.getAttribute("data-slot");
+  const surfaceSlot = surface.getAttribute("data-slot");
+  if (
+    focusedElement.getAttribute("aria-expanded") === "true" &&
+    triggerSlot !== null &&
+    surfaceSlot === SURFACE_SLOT_BY_TRIGGER_SLOT[triggerSlot]
+  ) {
+    return true;
+  }
+
+  if (
+    surface.hasAttribute("data-composer-command-menu") &&
+    focusedElement.closest('[data-chat-composer-form="true"]') !== null
+  ) {
+    return true;
+  }
+
+  // Some non-portaled pickers render beside their controlling input without
+  // an aria-controls relationship. Accept a nearby shared container, but do
+  // not climb as far as body where an unrelated open picker could match.
+  let container = surface.parentElement;
+  for (let depth = 0; container && depth < 6; depth += 1) {
+    if (container === document.body) return false;
+    if (container.contains(focusedElement)) return true;
+    container = container.parentElement;
+  }
+  return false;
+}
+
+function isCandidateSelectionOpen(document: Document, eventTarget: EventTarget | null): boolean {
+  const focusedElement =
+    document.activeElement instanceof Element
+      ? document.activeElement
+      : eventTarget instanceof Element
+        ? eventTarget
+        : null;
+
+  return Array.from(document.querySelectorAll<HTMLElement>(CANDIDATE_SURFACE_SELECTOR)).some(
+    (surface) =>
+      !surface.hidden &&
+      surface.getAttribute("aria-hidden") !== "true" &&
+      candidateSurfaceBelongsToFocus(surface, focusedElement, document),
+  );
+}
+
+function dispatchSelectionNavigation(event: KeyboardEvent, key: SelectionNavigationKey): void {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+
+  const document = (event.target as Node | null)?.ownerDocument ?? globalThis.document;
+  const target =
+    document.activeElement instanceof HTMLElement ? document.activeElement : event.target;
+  if (!(target instanceof EventTarget)) return;
+
+  const KeyboardEventConstructor = document.defaultView?.KeyboardEvent ?? KeyboardEvent;
+  target.dispatchEvent(
+    new KeyboardEventConstructor("keydown", {
+      bubbles: true,
+      cancelable: true,
+      code: key,
+      key,
+      repeat: event.repeat,
+    }),
+  );
+}
+
+export function handleSelectionNavigationKeyDown(event: KeyboardEvent): void {
+  const key = resolveSelectionNavigationKey(event);
+  if (!key || !(event.target instanceof Element)) return;
+  if (
+    event.target.closest("[data-terminal-owner]") !== null ||
+    event.target.closest("[data-keybinding-capture]") !== null
+  ) {
+    return;
+  }
+
+  const document = (event.target as Node).ownerDocument;
+  if (!document) return;
+  if (!isCandidateSelectionOpen(document, event.target)) return;
+  dispatchSelectionNavigation(event, key);
+}

--- a/apps/web/src/selectionNavigation.ts
+++ b/apps/web/src/selectionNavigation.ts
@@ -6,6 +6,7 @@ const CANDIDATE_SURFACE_SELECTOR = [
   '[data-slot="autocomplete-popup"]',
   '[data-slot="select-popup"]',
   '[data-slot="menu-popup"]',
+  '[data-slot="menu-sub-content"]',
   '[role="listbox"]',
 ].join(",");
 
@@ -15,6 +16,7 @@ const SURFACE_SLOT_BY_TRIGGER_SLOT: Readonly<Record<string, string>> = {
   "autocomplete-trigger": "autocomplete-popup",
   "combobox-trigger": "combobox-popup",
   "menu-trigger": "menu-popup",
+  "menu-sub-trigger": "menu-sub-content",
   "select-trigger": "select-popup",
 };
 

--- a/apps/web/src/selectionNavigation.ts
+++ b/apps/web/src/selectionNavigation.ts
@@ -21,6 +21,7 @@ const SURFACE_SLOT_BY_TRIGGER_SLOT: Readonly<Record<string, string>> = {
 };
 
 const SURFACE_SLOT_BY_TRIGGER_MARKER: Readonly<Record<string, string>> = {
+  "data-chat-provider-model-picker": "combobox-list",
   "data-chat-provider-traits-picker": "menu-popup",
   "data-chat-runtime-mode-picker": "select-popup",
 };


### PR DESCRIPTION
## What Changed

- Preserve the prompt pickers' native Arrow Up/Down, Enter, and type-to-search behavior across model, effort, access, machine, checkout/worktree, and branch selection.
- Translate `Ctrl-N`/`Ctrl-P` to Down/Up while the focused control owns an open command palette, combobox, autocomplete, select, menu, listbox, or composer suggestion menu.
- Run selection arbitration before application shortcuts, so `Ctrl-N` navigates an open picker instead of opening a new thread.
- Route tooltip-wrapped effort and access triggers to their owned popup surfaces.
- Return focus to prompt entry after a prompt-picker selection completes.
- Leave ordinary text editing, terminals, keybinding capture fields, and unrelated visible pickers untouched.
- Add focused coverage for every prompt picker, portaled composer suggestions, modifier exclusions, empty menus, tooltip trigger ownership, and app-root registration.

## Why

Prompt controls should behave consistently as keyboard-first selection surfaces. Readline-style `Ctrl-N`/`Ctrl-P` navigation must take precedence over global shortcuts while a picker is open, and completing a selection should return the user directly to prompt entry.

## UI Changes

Interaction-only; there are no layout or styling changes.

Verified in an isolated authenticated web environment:

1. Opened the command palette from the sidebar.
2. Pressed `Ctrl-N`; highlight moved from **Add project** to **Open settings** while the query stayed empty and the palette stayed open.
3. Pressed `Ctrl-P`; highlight moved back to **Add project**.
4. Confirmed no new-thread action fired.

[Interaction recording](https://raw.githubusercontent.com/colonelpanic8/t3code/ed324053043c2b517a97a31df66203312bb946a0/pr-assets/4394/ctrl-n-p-selection-navigation.mp4)

The follow-up prompt-focus flow was also launched in an isolated environment. API authentication succeeded, but the collaborative preview remained on its pairing route, so that pass could not reach the prompt surface for a second recording.

## Checklist

- [x] `vp test run apps/web/src/selectionNavigation.test.ts apps/web/src/AppRoot.test.tsx apps/web/src/components/chat/composerProviderState.test.tsx` (26 tests pass)
- [x] `vp check` (0 errors; 11 unrelated existing warnings)
- [x] Focused formatting and lint for all changed prompt-picker files
- [x] Integrated Ctrl-N/Ctrl-P web verification and interaction recording
- [ ] `vp run typecheck` — existing `@effect/vitest` export errors in `oxlint-plugin-t3code`; no errors in changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Capture-phase global key handling can interact with other shortcuts when pickers are open; behavior is heavily tested but still touches many composer and toolbar entry points.
> 
> **Overview**
> Adds **readline-style `Ctrl-N` / `Ctrl-P`** navigation while a relevant picker or list is open. A new capture-phase handler in `selectionNavigation.ts` maps those chords to `ArrowDown` / `ArrowUp` when focus owns an open menu, select, combobox, command list, or composer suggestion surface, and **stops the event before global shortcuts** (e.g. new thread on `Ctrl-N`). `SelectionNavigationBindings` registers that listener from `AppRoot`.
> 
> Picker triggers gain **`data-*` markers** so tooltip-wrapped controls still link to their popups; the composer command menu sets `data-composer-command-menu` only when it has items. Terminals and keybinding-capture fields are excluded.
> 
> **After a selection**, composer and branch-toolbar controls call **`onSelectionComplete`** (wired to `scheduleComposerFocus` / `onComposerFocusRequest`) so menus close and focus returns to the prompt. Mobile branch menus use controlled `open` state and `closeOnClick` on radio items; compact composer controls clone traits menu content with the same callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8310181b0a3dcd4f4f4b2a7a9f4e50266bd059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ctrl-N/Ctrl-P keyboard navigation for open selection menus and pickers
> - Adds [`handleSelectionNavigationKeyDown`](https://github.com/pingdotgg/t3code/pull/4394/files#diff-fe96d707ce901699f19e193e2c2f1558103f739403449619468c42f01b71200a) which maps Ctrl-N/Ctrl-P to ArrowDown/ArrowUp for open selection surfaces (menus, popovers, command lists), dispatching a synthetic keydown to the focused element.
> - [`SelectionNavigationBindings`](https://github.com/pingdotgg/t3code/pull/4394/files#diff-f896a6b43509168977bb319a1f1d76343b5a67d8347a66e7fd2c31e10d1948e4) mounts the global capture-phase keydown listener with `AppRoot`, so it is active for the full app lifetime.
> - Picker and menu components (traits picker, model picker, runtime mode, compact controls, branch toolbar selectors) are marked with `data-*` attributes and wired with `onSelectionComplete` callbacks that close their menus and schedule composer focus after a selection.
> - The handler ignores events with modifier keys and skips terminal or keybinding-capture fields to avoid conflicts.
> - Behavioral Change: Ctrl-N and Ctrl-P are now intercepted globally at capture phase when a recognized selection surface is open, which may suppress default browser behavior for those keys in those contexts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f83101.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->