### PR TITLE
Fix thread loading flash

### DIFF
--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -5,8 +5,15 @@ import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
 import { resolveThreadRouteRef, resolveThreadRouteRenderState } from "../threadRoutes";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "~/components/ui/empty";
 import { SidebarInset } from "~/components/ui/sidebar";
-import { useEnvironmentThreadRefs, useThreadDetail, useThreadShell } from "../state/entities";
+import {
+  useEnvironmentThreadRefs,
+  useThreadDetail,
+  useThreadError,
+  useThreadShell,
+  useThreadStatus,
+} from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
 import { environmentShell } from "../state/shell";
 
@@ -20,9 +27,10 @@ function ChatThreadRouteView() {
   );
   const serverThreadShell = useThreadShell(threadRef);
   const serverThreadDetail = useThreadDetail(threadRef);
+  const serverThreadStatus = useThreadStatus(threadRef);
+  const serverThreadError = useThreadError(threadRef);
   const environmentThreadRefs = useEnvironmentThreadRefs(threadRef?.environmentId ?? null);
   const bootstrapComplete = shell.data?.snapshot._tag === "Some";
-  const threadExists = serverThreadShell !== null || serverThreadDetail !== null;
   const environmentHasServerThreads = environmentThreadRefs.length > 0;
   const draftThreadExists = useComposerDraftStore((store) =>
     threadRef ? store.getDraftThreadByRef(threadRef) !== null : false,
@@ -36,11 +44,12 @@ function ChatThreadRouteView() {
     }
     return store.hasDraftThreadsInEnvironment(threadRef.environmentId);
   });
-  const routeThreadExists = threadExists || draftThreadExists;
   const renderState = resolveThreadRouteRenderState({
     bootstrapComplete,
     serverThreadShellExists: serverThreadShell !== null,
     serverThreadDetailExists: serverThreadDetail !== null,
+    serverThreadDetailDeleted: serverThreadStatus === "deleted",
+    serverThreadDetailFailed: serverThreadError !== null,
     draftThreadExists,
   });
   const serverThreadStarted = threadHasStarted(serverThreadDetail);
@@ -51,10 +60,10 @@ function ChatThreadRouteView() {
       return;
     }
 
-    if (!routeThreadExists && environmentHasAnyThreads) {
+    if (renderState === "missing" && environmentHasAnyThreads) {
       void navigate({ to: "/", replace: true });
     }
-  }, [bootstrapComplete, environmentHasAnyThreads, navigate, routeThreadExists, threadRef]);
+  }, [bootstrapComplete, environmentHasAnyThreads, navigate, renderState, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !serverThreadStarted || !draftThread) {
@@ -64,6 +73,9 @@ function ChatThreadRouteView() {
   }, [draftThread, serverThreadStarted, threadRef]);
 
   if (!threadRef || renderState !== "ready") {
+    if (renderState === "error") {
+      return <ThreadLoadErrorState error={serverThreadError} />;
+    }
     return null;
   }
 
@@ -74,6 +86,21 @@ function ChatThreadRouteView() {
         threadId={threadRef.threadId}
         routeKind="server"
       />
+    </SidebarInset>
+  );
+}
+
+function ThreadLoadErrorState({ error }: { error: string | null }) {
+  return (
+    <SidebarInset className="h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh">
+      <Empty className="flex-1">
+        <EmptyHeader>
+          <EmptyTitle>Couldn’t load thread</EmptyTitle>
+          <EmptyDescription>
+            {error ?? "T3 Code will keep trying to reconnect automatically."}
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
     </SidebarInset>
   );
 }

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -5,12 +5,10 @@ import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
 import { resolveThreadRouteRef, resolveThreadRouteRenderState } from "../threadRoutes";
-import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "~/components/ui/empty";
 import { SidebarInset } from "~/components/ui/sidebar";
 import {
   useEnvironmentThreadRefs,
   useThreadDetail,
-  useThreadError,
   useThreadShell,
   useThreadStatus,
 } from "../state/entities";
@@ -28,7 +26,6 @@ function ChatThreadRouteView() {
   const serverThreadShell = useThreadShell(threadRef);
   const serverThreadDetail = useThreadDetail(threadRef);
   const serverThreadStatus = useThreadStatus(threadRef);
-  const serverThreadError = useThreadError(threadRef);
   const environmentThreadRefs = useEnvironmentThreadRefs(threadRef?.environmentId ?? null);
   const bootstrapComplete = shell.data?.snapshot._tag === "Some";
   const environmentHasServerThreads = environmentThreadRefs.length > 0;
@@ -49,7 +46,6 @@ function ChatThreadRouteView() {
     serverThreadShellExists: serverThreadShell !== null,
     serverThreadDetailExists: serverThreadDetail !== null,
     serverThreadDetailDeleted: serverThreadStatus === "deleted",
-    serverThreadDetailFailed: serverThreadError !== null,
     draftThreadExists,
   });
   const serverThreadStarted = threadHasStarted(serverThreadDetail);
@@ -73,9 +69,6 @@ function ChatThreadRouteView() {
   }, [draftThread, serverThreadStarted, threadRef]);
 
   if (!threadRef || renderState !== "ready") {
-    if (renderState === "error") {
-      return <ThreadLoadErrorState error={serverThreadError} />;
-    }
     return null;
   }
 
@@ -86,21 +79,6 @@ function ChatThreadRouteView() {
         threadId={threadRef.threadId}
         routeKind="server"
       />
-    </SidebarInset>
-  );
-}
-
-function ThreadLoadErrorState({ error }: { error: string | null }) {
-  return (
-    <SidebarInset className="h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh">
-      <Empty className="flex-1">
-        <EmptyHeader>
-          <EmptyTitle>Couldn’t load thread</EmptyTitle>
-          <EmptyDescription>
-            {error ?? "T3 Code will keep trying to reconnect automatically."}
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
     </SidebarInset>
   );
 }

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
-import { resolveThreadRouteRef } from "../threadRoutes";
+import { resolveThreadRouteRef, resolveThreadRouteRenderState } from "../threadRoutes";
 import { SidebarInset } from "~/components/ui/sidebar";
 import { useEnvironmentThreadRefs, useThreadDetail, useThreadShell } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
@@ -37,6 +37,12 @@ function ChatThreadRouteView() {
     return store.hasDraftThreadsInEnvironment(threadRef.environmentId);
   });
   const routeThreadExists = threadExists || draftThreadExists;
+  const renderState = resolveThreadRouteRenderState({
+    bootstrapComplete,
+    serverThreadShellExists: serverThreadShell !== null,
+    serverThreadDetailExists: serverThreadDetail !== null,
+    draftThreadExists,
+  });
   const serverThreadStarted = threadHasStarted(serverThreadDetail);
   const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
 
@@ -57,7 +63,7 @@ function ChatThreadRouteView() {
     finalizePromotedDraftThreadByRef(threadRef);
   }, [draftThread, serverThreadStarted, threadRef]);
 
-  if (!threadRef || !bootstrapComplete || !routeThreadExists) {
+  if (!threadRef || renderState !== "ready") {
     return null;
   }
 

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -4,7 +4,10 @@ import type {
   EnvironmentThread,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
-import { mergeEnvironmentThread } from "@t3tools/client-runtime/state/threads";
+import {
+  type EnvironmentThreadStatus,
+  mergeEnvironmentThread,
+} from "@t3tools/client-runtime/state/threads";
 import type {
   OrchestrationMessage,
   OrchestrationProposedPlan,
@@ -43,6 +46,12 @@ const EMPTY_THREAD_SHELL_ATOM = Atom.make<EnvironmentThreadShell | null>(null).p
 );
 const EMPTY_THREAD_DETAIL_ATOM = Atom.make<EnvironmentThread | null>(null).pipe(
   Atom.withLabel("web-thread-detail:empty"),
+);
+const EMPTY_THREAD_STATUS_ATOM = Atom.make<EnvironmentThreadStatus>("empty").pipe(
+  Atom.withLabel("web-thread-status:empty"),
+);
+const EMPTY_THREAD_ERROR_ATOM = Atom.make<string | null>(null).pipe(
+  Atom.withLabel("web-thread-error:empty"),
 );
 const EMPTY_MESSAGES_ATOM = Atom.make(EMPTY_MESSAGES).pipe(
   Atom.withLabel("web-thread-messages:empty"),
@@ -137,6 +146,18 @@ export function useThreadShell(ref: ScopedThreadRef | null): EnvironmentThreadSh
 export function useThreadDetail(ref: ScopedThreadRef | null): EnvironmentThread | null {
   return useAtomValue(
     ref === null ? EMPTY_THREAD_DETAIL_ATOM : environmentThreadDetails.detailAtom(ref),
+  );
+}
+
+export function useThreadStatus(ref: ScopedThreadRef | null): EnvironmentThreadStatus {
+  return useAtomValue(
+    ref === null ? EMPTY_THREAD_STATUS_ATOM : environmentThreadDetails.statusAtom(ref),
+  );
+}
+
+export function useThreadError(ref: ScopedThreadRef | null): string | null {
+  return useAtomValue(
+    ref === null ? EMPTY_THREAD_ERROR_ATOM : environmentThreadDetails.errorAtom(ref),
   );
 }
 

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -50,9 +50,6 @@ const EMPTY_THREAD_DETAIL_ATOM = Atom.make<EnvironmentThread | null>(null).pipe(
 const EMPTY_THREAD_STATUS_ATOM = Atom.make<EnvironmentThreadStatus>("empty").pipe(
   Atom.withLabel("web-thread-status:empty"),
 );
-const EMPTY_THREAD_ERROR_ATOM = Atom.make<string | null>(null).pipe(
-  Atom.withLabel("web-thread-error:empty"),
-);
 const EMPTY_MESSAGES_ATOM = Atom.make(EMPTY_MESSAGES).pipe(
   Atom.withLabel("web-thread-messages:empty"),
 );
@@ -152,12 +149,6 @@ export function useThreadDetail(ref: ScopedThreadRef | null): EnvironmentThread 
 export function useThreadStatus(ref: ScopedThreadRef | null): EnvironmentThreadStatus {
   return useAtomValue(
     ref === null ? EMPTY_THREAD_STATUS_ATOM : environmentThreadDetails.statusAtom(ref),
-  );
-}
-
-export function useThreadError(ref: ScopedThreadRef | null): string | null {
-  return useAtomValue(
-    ref === null ? EMPTY_THREAD_ERROR_ATOM : environmentThreadDetails.errorAtom(ref),
   );
 }
 

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -7,6 +7,7 @@ import {
   buildDraftThreadRouteParams,
   buildThreadRouteParams,
   resolveActiveThreadRouteRef,
+  resolveThreadRouteRenderState,
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
 } from "./threadRoutes";
@@ -91,5 +92,54 @@ describe("threadRoutes", () => {
         promotedTo: null,
       }),
     ).toBeNull();
+  });
+
+  it("keeps shell-only server threads in the loading state", () => {
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: true,
+        serverThreadShellExists: true,
+        serverThreadDetailExists: false,
+        draftThreadExists: false,
+      }),
+    ).toBe("loading");
+  });
+
+  it("renders server details and local drafts when they are ready", () => {
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: true,
+        serverThreadShellExists: true,
+        serverThreadDetailExists: true,
+        draftThreadExists: false,
+      }),
+    ).toBe("ready");
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: true,
+        serverThreadShellExists: false,
+        serverThreadDetailExists: false,
+        draftThreadExists: true,
+      }),
+    ).toBe("ready");
+  });
+
+  it("distinguishes bootstrap loading from a missing thread", () => {
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: false,
+        serverThreadShellExists: false,
+        serverThreadDetailExists: false,
+        draftThreadExists: false,
+      }),
+    ).toBe("loading");
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: true,
+        serverThreadShellExists: false,
+        serverThreadDetailExists: false,
+        draftThreadExists: false,
+      }),
+    ).toBe("missing");
   });
 });

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -101,7 +101,6 @@ describe("threadRoutes", () => {
         serverThreadShellExists: true,
         serverThreadDetailExists: false,
         serverThreadDetailDeleted: false,
-        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("loading");
@@ -114,7 +113,6 @@ describe("threadRoutes", () => {
         serverThreadShellExists: true,
         serverThreadDetailExists: true,
         serverThreadDetailDeleted: false,
-        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("ready");
@@ -124,7 +122,6 @@ describe("threadRoutes", () => {
         serverThreadShellExists: false,
         serverThreadDetailExists: false,
         serverThreadDetailDeleted: false,
-        serverThreadDetailFailed: false,
         draftThreadExists: true,
       }),
     ).toBe("ready");
@@ -137,7 +134,6 @@ describe("threadRoutes", () => {
         serverThreadShellExists: false,
         serverThreadDetailExists: false,
         serverThreadDetailDeleted: false,
-        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("loading");
@@ -147,30 +143,18 @@ describe("threadRoutes", () => {
         serverThreadShellExists: false,
         serverThreadDetailExists: false,
         serverThreadDetailDeleted: false,
-        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("missing");
   });
 
-  it("does not leave failed or deleted shell-only threads loading", () => {
-    expect(
-      resolveThreadRouteRenderState({
-        bootstrapComplete: true,
-        serverThreadShellExists: true,
-        serverThreadDetailExists: false,
-        serverThreadDetailDeleted: false,
-        serverThreadDetailFailed: true,
-        draftThreadExists: false,
-      }),
-    ).toBe("error");
+  it("redirects deleted shell-only threads", () => {
     expect(
       resolveThreadRouteRenderState({
         bootstrapComplete: true,
         serverThreadShellExists: true,
         serverThreadDetailExists: false,
         serverThreadDetailDeleted: true,
-        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("missing");

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -100,6 +100,8 @@ describe("threadRoutes", () => {
         bootstrapComplete: true,
         serverThreadShellExists: true,
         serverThreadDetailExists: false,
+        serverThreadDetailDeleted: false,
+        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("loading");
@@ -111,6 +113,8 @@ describe("threadRoutes", () => {
         bootstrapComplete: true,
         serverThreadShellExists: true,
         serverThreadDetailExists: true,
+        serverThreadDetailDeleted: false,
+        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("ready");
@@ -119,6 +123,8 @@ describe("threadRoutes", () => {
         bootstrapComplete: true,
         serverThreadShellExists: false,
         serverThreadDetailExists: false,
+        serverThreadDetailDeleted: false,
+        serverThreadDetailFailed: false,
         draftThreadExists: true,
       }),
     ).toBe("ready");
@@ -130,6 +136,8 @@ describe("threadRoutes", () => {
         bootstrapComplete: false,
         serverThreadShellExists: false,
         serverThreadDetailExists: false,
+        serverThreadDetailDeleted: false,
+        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("loading");
@@ -138,6 +146,31 @@ describe("threadRoutes", () => {
         bootstrapComplete: true,
         serverThreadShellExists: false,
         serverThreadDetailExists: false,
+        serverThreadDetailDeleted: false,
+        serverThreadDetailFailed: false,
+        draftThreadExists: false,
+      }),
+    ).toBe("missing");
+  });
+
+  it("does not leave failed or deleted shell-only threads loading", () => {
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: true,
+        serverThreadShellExists: true,
+        serverThreadDetailExists: false,
+        serverThreadDetailDeleted: false,
+        serverThreadDetailFailed: true,
+        draftThreadExists: false,
+      }),
+    ).toBe("error");
+    expect(
+      resolveThreadRouteRenderState({
+        bootstrapComplete: true,
+        serverThreadShellExists: true,
+        serverThreadDetailExists: false,
+        serverThreadDetailDeleted: true,
+        serverThreadDetailFailed: false,
         draftThreadExists: false,
       }),
     ).toBe("missing");

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -18,14 +18,13 @@ type DraftThreadRouteState = {
   promotedTo?: ScopedThreadRef | null;
 };
 
-export type ThreadRouteRenderState = "loading" | "ready" | "missing" | "error";
+export type ThreadRouteRenderState = "loading" | "ready" | "missing";
 
 export function resolveThreadRouteRenderState(input: {
   bootstrapComplete: boolean;
   serverThreadShellExists: boolean;
   serverThreadDetailExists: boolean;
   serverThreadDetailDeleted: boolean;
-  serverThreadDetailFailed: boolean;
   draftThreadExists: boolean;
 }): ThreadRouteRenderState {
   if (!input.bootstrapComplete) {
@@ -36,9 +35,6 @@ export function resolveThreadRouteRenderState(input: {
   }
   if (input.serverThreadDetailDeleted) {
     return "missing";
-  }
-  if (input.serverThreadDetailFailed) {
-    return "error";
   }
   return input.serverThreadShellExists ? "loading" : "missing";
 }

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -18,12 +18,14 @@ type DraftThreadRouteState = {
   promotedTo?: ScopedThreadRef | null;
 };
 
-export type ThreadRouteRenderState = "loading" | "ready" | "missing";
+export type ThreadRouteRenderState = "loading" | "ready" | "missing" | "error";
 
 export function resolveThreadRouteRenderState(input: {
   bootstrapComplete: boolean;
   serverThreadShellExists: boolean;
   serverThreadDetailExists: boolean;
+  serverThreadDetailDeleted: boolean;
+  serverThreadDetailFailed: boolean;
   draftThreadExists: boolean;
 }): ThreadRouteRenderState {
   if (!input.bootstrapComplete) {
@@ -31,6 +33,12 @@ export function resolveThreadRouteRenderState(input: {
   }
   if (input.serverThreadDetailExists || input.draftThreadExists) {
     return "ready";
+  }
+  if (input.serverThreadDetailDeleted) {
+    return "missing";
+  }
+  if (input.serverThreadDetailFailed) {
+    return "error";
   }
   return input.serverThreadShellExists ? "loading" : "missing";
 }

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -18,6 +18,23 @@ type DraftThreadRouteState = {
   promotedTo?: ScopedThreadRef | null;
 };
 
+export type ThreadRouteRenderState = "loading" | "ready" | "missing";
+
+export function resolveThreadRouteRenderState(input: {
+  bootstrapComplete: boolean;
+  serverThreadShellExists: boolean;
+  serverThreadDetailExists: boolean;
+  draftThreadExists: boolean;
+}): ThreadRouteRenderState {
+  if (!input.bootstrapComplete) {
+    return "loading";
+  }
+  if (input.serverThreadDetailExists || input.draftThreadExists) {
+    return "ready";
+  }
+  return input.serverThreadShellExists ? "loading" : "missing";
+}
+
 export function buildThreadRouteParams(ref: ScopedThreadRef): {
   environmentId: EnvironmentId;
   threadId: ThreadId;


### PR DESCRIPTION
Waits for full thread detail before rendering a server thread, preventing the empty-thread state from flashing during navigation. Adds focused route-state coverage. Verified with the focused test, formatting, lint, and web typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized routing and render gating in the web chat UI with no auth, data persistence, or API contract changes.
> 
> **Overview**
> Fixes a brief **empty-thread flash** when opening a server thread by not mounting `ChatView` until thread data is actually ready.
> 
> The chat thread route now derives a **`loading` | `ready` | `missing`** state via new `resolveThreadRouteRenderState` in `threadRoutes.ts`, using bootstrap completion, shell/detail presence, draft existence, and **`useThreadStatus`** (including **`deleted`**). **Shell-only** threads stay in **loading** instead of rendering; **missing** threads still redirect home when the environment has other threads.
> 
> Unit tests in `threadRoutes.test.ts` cover loading vs ready vs missing, including deleted shell-only threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb3ad3009d33a67a315c29c96292c7cb8407d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread loading flash in chat thread route by deferring render until thread state is resolved
> - Introduces `resolveThreadRouteRenderState` in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/4396/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3) to centralize render state logic, returning `'loading'`, `'ready'`, or `'missing'` based on bootstrap status, server thread shell/detail existence, draft existence, and deletion status.
> - Adds `useThreadStatus` hook in [entities.ts](https://github.com/pingdotgg/t3code/pull/4396/files#diff-03d4a7bdd760faa2d76b1234f8bde0583a404e4647e6cc1f6c1d4a67e0eb6eba) to expose `EnvironmentThreadStatus` for a given thread ref, returning `'empty'` when ref is null.
> - The chat thread route now waits for `renderState === 'ready'` before rendering and redirects only when `renderState === 'missing'`, eliminating premature renders during loading.
> - Shell-only server threads (detail not yet loaded) are now treated as `'loading'` rather than `'missing'`, preventing a spurious redirect or blank render.
> - Behavioral Change: threads marked as deleted via `useThreadStatus` now trigger a redirect when other threads exist, instead of remaining on the deleted thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4eb3ad3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->