### PR TITLE
Add user-local project icons

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -1,5 +1,5 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ThreadId } from "@t3tools/contracts";
+import { DEFAULT_SERVER_SETTINGS, ThreadId } from "@t3tools/contracts";
 import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -7,10 +7,12 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import * as Stream from "effect/Stream";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import { ASSET_ROUTE_PREFIX, issueAssetUrl, resolveAsset } from "./AssetAccess.ts";
@@ -25,6 +27,7 @@ const testLayer = Layer.mergeAll(
     Layer.provide(WorkspacePaths.layer),
     Layer.provide(T3ProjectFileLoader.layer),
   ),
+  ServerSettings.ServerSettingsService.layerTest(),
   ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
 ).pipe(Layer.provideMerge(NodeServices.layer));
 
@@ -242,6 +245,42 @@ describe("AssetAccess", () => {
           fallbackSuffix.slice(fallbackSeparatorIndex + 1),
         ),
       ).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("issues exact capabilities for configured project icons outside the workspace", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-root-",
+      });
+      const iconDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-custom-",
+      });
+      const iconPath = path.join(iconDirectory, "custom.svg");
+      yield* fileSystem.writeFileString(iconPath, "<svg />");
+      const canonicalIconPath = yield* fileSystem.realPath(iconPath);
+      const settings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Effect.succeed({
+          ...DEFAULT_SERVER_SETTINGS,
+          projectIcons: { [root]: iconPath },
+        }),
+        updateSettings: () => Effect.die("not implemented"),
+        streamChanges: Stream.empty,
+      });
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root, revision: iconPath },
+      }).pipe(Effect.provideService(ServerSettings.ServerSettingsService, settings));
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+
+      expect(
+        yield* resolveAsset(suffix.slice(0, separatorIndex), suffix.slice(separatorIndex + 1)),
+      ).toEqual({ kind: "file", path: canonicalIconPath });
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -286,6 +286,60 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("finds workspace icon settings keyed by the unnormalized request root", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-raw-root-",
+      });
+      const requestedRoot = `${root}/.`;
+      const iconDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-raw-custom-",
+      });
+      const iconPath = path.join(iconDirectory, "custom.svg");
+      yield* fileSystem.writeFileString(iconPath, "<svg />");
+      const settings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Effect.succeed({
+          ...DEFAULT_SERVER_SETTINGS,
+          projectIcons: { [requestedRoot]: iconPath },
+        }),
+        updateSettings: () => Effect.die("not implemented"),
+        streamChanges: Stream.empty,
+      });
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: requestedRoot, revision: iconPath },
+      }).pipe(Effect.provideService(ServerSettings.ServerSettingsService, settings));
+
+      expect(result.relativeUrl.endsWith("/custom.svg")).toBe(true);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects automatically discovered icon symlinks outside the workspace", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-auto-symlink-root-",
+      });
+      const outsideDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-auto-symlink-outside-",
+      });
+      const outsidePath = path.join(outsideDirectory, "secret.svg");
+      yield* fileSystem.writeFileString(outsidePath, "<svg>secret</svg>");
+      yield* fileSystem.symlink(outsidePath, path.join(root, "favicon.svg"));
+
+      const error = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root },
+      }).pipe(Effect.flip);
+
+      expect(error._tag).toBe("AssetProjectFaviconNotFoundError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("rejects a configured project icon replaced by a symlink after signing", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -399,6 +453,7 @@ describe("AssetAccess", () => {
         cause: platformCause,
       });
       const resolver = ProjectFaviconResolver.ProjectFaviconResolver.of({
+        resolve: () => Effect.fail(resolutionCause),
         resolvePath: () => Effect.fail(resolutionCause),
       });
 

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -286,6 +286,48 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("rejects a configured project icon replaced by a symlink after signing", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-symlink-root-",
+      });
+      const iconDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-symlink-custom-",
+      });
+      const outsideDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-symlink-outside-",
+      });
+      const iconPath = path.join(iconDirectory, "custom.svg");
+      const outsidePath = path.join(outsideDirectory, "secret.svg");
+      yield* fileSystem.writeFileString(iconPath, "<svg>icon</svg>");
+      yield* fileSystem.writeFileString(outsidePath, "<svg>secret</svg>");
+      const settings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Effect.succeed({
+          ...DEFAULT_SERVER_SETTINGS,
+          projectIcons: { [root]: iconPath },
+        }),
+        updateSettings: () => Effect.die("not implemented"),
+        streamChanges: Stream.empty,
+      });
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root, revision: iconPath },
+      }).pipe(Effect.provideService(ServerSettings.ServerSettingsService, settings));
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      yield* fileSystem.remove(iconPath);
+      yield* fileSystem.symlink(outsidePath, iconPath);
+
+      expect(yield* resolveAsset(token, suffix.slice(separatorIndex + 1))).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("uses a configured git-remote icon across clone paths", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -12,6 +12,7 @@ import * as Stream from "effect/Stream";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
+import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
@@ -27,6 +28,7 @@ const testLayer = Layer.mergeAll(
     Layer.provide(WorkspacePaths.layer),
     Layer.provide(T3ProjectFileLoader.layer),
   ),
+  RepositoryIdentityResolver.layer,
   ServerSettings.ServerSettingsService.layerTest(),
   ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
 ).pipe(Layer.provideMerge(NodeServices.layer));
@@ -275,6 +277,59 @@ describe("AssetAccess", () => {
       const result = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root, revision: iconPath },
       }).pipe(Effect.provideService(ServerSettings.ServerSettingsService, settings));
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+
+      expect(
+        yield* resolveAsset(suffix.slice(0, separatorIndex), suffix.slice(separatorIndex + 1)),
+      ).toEqual({ kind: "file", path: canonicalIconPath });
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("uses a configured git-remote icon across clone paths", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-remote-root-",
+      });
+      const iconDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-remote-custom-",
+      });
+      const iconPath = path.join(iconDirectory, "custom.svg");
+      yield* fileSystem.writeFileString(iconPath, "<svg />");
+      const canonicalIconPath = yield* fileSystem.realPath(iconPath);
+      const settings = ServerSettings.ServerSettingsService.of({
+        start: Effect.void,
+        ready: Effect.void,
+        getSettings: Effect.succeed({
+          ...DEFAULT_SERVER_SETTINGS,
+          projectIconsByGitRemote: { "github.com/t3tools/t3code": iconPath },
+        }),
+        updateSettings: () => Effect.die("not implemented"),
+        streamChanges: Stream.empty,
+      });
+      const repositoryIdentityResolver = RepositoryIdentityResolver.RepositoryIdentityResolver.of({
+        resolve: () =>
+          Effect.succeed({
+            canonicalKey: "github.com/t3tools/t3code",
+            locator: {
+              source: "git-remote",
+              remoteName: "origin",
+              remoteUrl: "git@github.com:T3Tools/T3Code.git",
+            },
+          }),
+      });
+
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "project-favicon", cwd: root, revision: iconPath },
+      }).pipe(
+        Effect.provideService(ServerSettings.ServerSettingsService, settings),
+        Effect.provideService(
+          RepositoryIdentityResolver.RepositoryIdentityResolver,
+          repositoryIdentityResolver,
+        ),
+      );
       const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
       const separatorIndex = suffix.indexOf("/");
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -38,6 +38,7 @@ import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { resolveAttachmentPathById } from "../attachmentStore.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
+import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
@@ -300,9 +301,17 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         ),
       );
       const faviconResolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
-      const customIconPath = serverSettings.projectIcons[workspaceRoot];
+      const repositoryIdentityResolver =
+        yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+      const repositoryIdentity = yield* repositoryIdentityResolver.resolve(workspaceRoot);
+      const customIconPaths = [
+        serverSettings.projectIcons[workspaceRoot],
+        ...(repositoryIdentity
+          ? [serverSettings.projectIconsByGitRemote[repositoryIdentity.canonicalKey]]
+          : []),
+      ].filter((iconPath): iconPath is string => iconPath !== undefined);
       const faviconPath = yield* faviconResolver
-        .resolvePath(workspaceRoot, customIconPath === undefined ? undefined : { customIconPath })
+        .resolvePath(workspaceRoot, customIconPaths.length === 0 ? undefined : { customIconPaths })
         .pipe(
           Effect.mapError(
             (cause) =>

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -305,13 +305,14 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
       const repositoryIdentity = yield* repositoryIdentityResolver.resolve(workspaceRoot);
       const customIconPaths = [
-        serverSettings.projectIcons[workspaceRoot],
+        serverSettings.projectIcons[workspaceRoot] ??
+          serverSettings.projectIcons[input.resource.cwd],
         ...(repositoryIdentity
           ? [serverSettings.projectIconsByGitRemote[repositoryIdentity.canonicalKey]]
           : []),
       ].filter((iconPath): iconPath is string => iconPath !== undefined);
-      const faviconPath = yield* faviconResolver
-        .resolvePath(workspaceRoot, customIconPaths.length === 0 ? undefined : { customIconPaths })
+      const resolvedFavicon = yield* faviconResolver
+        .resolve(workspaceRoot, customIconPaths.length === 0 ? undefined : { customIconPaths })
         .pipe(
           Effect.mapError(
             (cause) =>
@@ -321,18 +322,34 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
               }),
           ),
         );
-      const canonicalFaviconPath = faviconPath
-        ? yield* optionOnNotFound(fileSystem.realPath(faviconPath)).pipe(
-            Effect.mapError(
-              (cause) =>
-                new AssetProjectFaviconInspectionError({
-                  resource: input.resource,
-                  cause,
-                }),
-            ),
-          )
+      const canonicalFaviconPath = resolvedFavicon
+        ? resolvedFavicon.source === "custom-setting"
+          ? yield* optionOnNotFound(fileSystem.realPath(resolvedFavicon.path)).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new AssetProjectFaviconInspectionError({
+                    resource: input.resource,
+                    cause,
+                  }),
+              ),
+            )
+          : yield* Effect.gen(function* () {
+              const canonicalPath = yield* resolveCanonicalWorkspaceFile({
+                workspaceRoot,
+                relativePath: path.relative(workspaceRoot, resolvedFavicon.path),
+              }).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new AssetProjectFaviconInspectionError({
+                      resource: input.resource,
+                      cause,
+                    }),
+                ),
+              );
+              return canonicalPath === null ? Option.none<string>() : Option.some(canonicalPath);
+            })
         : Option.none<string>();
-      if (faviconPath && Option.isNone(canonicalFaviconPath)) {
+      if (resolvedFavicon && Option.isNone(canonicalFaviconPath)) {
         return yield* new AssetProjectFaviconNotFoundError({ resource: input.resource });
       }
       claims = {
@@ -341,7 +358,9 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         absolutePath: Option.getOrNull(canonicalFaviconPath),
         expiresAt,
       };
-      fileName = faviconPath ? path.basename(faviconPath) : PROJECT_FAVICON_FALLBACK_MARKER;
+      fileName = resolvedFavicon
+        ? path.basename(resolvedFavicon.path)
+        : PROJECT_FAVICON_FALLBACK_MARKER;
       break;
     }
   }

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -38,6 +38,7 @@ import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { resolveAttachmentPathById } from "../attachmentStore.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
 export const ASSET_ROUTE_PREFIX = "/api/assets";
@@ -82,6 +83,12 @@ const AssetClaimsSchema = Schema.Union([
     kind: Schema.Literal("project-favicon"),
     workspaceRoot: Schema.String,
     relativePath: Schema.NullOr(Schema.String),
+    expiresAt: Schema.Number,
+  }),
+  Schema.Struct({
+    version: Schema.Literal(2),
+    kind: Schema.Literal("project-icon"),
+    absolutePath: Schema.NullOr(Schema.String),
     expiresAt: Schema.Number,
   }),
 ]);
@@ -282,8 +289,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      const faviconResolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
-      const faviconPath = yield* faviconResolver.resolvePath(workspaceRoot).pipe(
+      const settings = yield* ServerSettings.ServerSettingsService;
+      const serverSettings = yield* settings.getSettings.pipe(
         Effect.mapError(
           (cause) =>
             new AssetProjectFaviconResolutionError({
@@ -292,39 +299,40 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      const relativePath = faviconPath ? path.relative(workspaceRoot, faviconPath) : null;
-      if (
-        relativePath &&
-        !(yield* resolveCanonicalWorkspaceFile({ workspaceRoot, relativePath }).pipe(
+      const faviconResolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+      const customIconPath = serverSettings.projectIcons[workspaceRoot];
+      const faviconPath = yield* faviconResolver
+        .resolvePath(workspaceRoot, customIconPath === undefined ? undefined : { customIconPath })
+        .pipe(
           Effect.mapError(
             (cause) =>
-              new AssetProjectFaviconInspectionError({
+              new AssetProjectFaviconResolutionError({
                 resource: input.resource,
                 cause,
               }),
           ),
-        ))
-      ) {
-        return yield* new AssetProjectFaviconNotFoundError({
-          resource: input.resource,
-        });
+        );
+      const canonicalFaviconPath = faviconPath
+        ? yield* optionOnNotFound(fileSystem.realPath(faviconPath)).pipe(
+            Effect.mapError(
+              (cause) =>
+                new AssetProjectFaviconInspectionError({
+                  resource: input.resource,
+                  cause,
+                }),
+            ),
+          )
+        : Option.none<string>();
+      if (faviconPath && Option.isNone(canonicalFaviconPath)) {
+        return yield* new AssetProjectFaviconNotFoundError({ resource: input.resource });
       }
       claims = {
-        version: 1,
-        kind: "project-favicon",
-        workspaceRoot: yield* fileSystem.realPath(workspaceRoot).pipe(
-          Effect.mapError(
-            (cause) =>
-              new AssetWorkspaceResolutionError({
-                resource: input.resource,
-                cause,
-              }),
-          ),
-        ),
-        relativePath,
+        version: 2,
+        kind: "project-icon",
+        absolutePath: Option.getOrNull(canonicalFaviconPath),
         expiresAt,
       };
-      fileName = relativePath ? path.basename(relativePath) : PROJECT_FAVICON_FALLBACK_MARKER;
+      fileName = faviconPath ? path.basename(faviconPath) : PROJECT_FAVICON_FALLBACK_MARKER;
       break;
     }
   }
@@ -395,6 +403,22 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       relativePath: claims.relativePath,
     });
     return faviconPath ? ({ kind: "file", path: faviconPath } satisfies ResolvedAsset) : null;
+  }
+  if (claims.kind === "project-icon") {
+    if (claims.absolutePath === null) return null;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const info = yield* optionOnNotFound(fileSystem.stat(claims.absolutePath)).pipe(
+      Effect.tapError((cause) =>
+        Effect.logError("Failed to inspect configured project icon.", {
+          path: claims.absolutePath,
+          cause,
+        }),
+      ),
+      Effect.orElseSucceed(() => Option.none()),
+    );
+    return Option.isSome(info) && info.value.type === "File"
+      ? ({ kind: "file", path: claims.absolutePath } satisfies ResolvedAsset)
+      : null;
   }
 
   const decodedPath = decodeRelativePath(relativePath);

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -416,17 +416,27 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   if (claims.kind === "project-icon") {
     if (claims.absolutePath === null) return null;
     const fileSystem = yield* FileSystem.FileSystem;
-    const info = yield* optionOnNotFound(fileSystem.stat(claims.absolutePath)).pipe(
+    const canonicalPath = yield* optionOnNotFound(fileSystem.realPath(claims.absolutePath)).pipe(
       Effect.tapError((cause) =>
-        Effect.logError("Failed to inspect configured project icon.", {
+        Effect.logError("Failed to canonicalize configured project icon.", {
           path: claims.absolutePath,
           cause,
         }),
       ),
       Effect.orElseSucceed(() => Option.none()),
     );
+    if (Option.isNone(canonicalPath) || canonicalPath.value !== claims.absolutePath) return null;
+    const info = yield* optionOnNotFound(fileSystem.stat(canonicalPath.value)).pipe(
+      Effect.tapError((cause) =>
+        Effect.logError("Failed to inspect configured project icon.", {
+          path: canonicalPath.value,
+          cause,
+        }),
+      ),
+      Effect.orElseSucceed(() => Option.none()),
+    );
     return Option.isSome(info) && info.value.type === "File"
-      ? ({ kind: "file", path: claims.absolutePath } satisfies ResolvedAsset)
+      ? ({ kind: "file", path: canonicalPath.value } satisfies ResolvedAsset)
       : null;
   }
 

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -86,7 +86,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
 
         const resolved = yield* resolver.resolvePath(cwd, {
-          customIconPath: `${iconDirectory}/custom.svg`,
+          customIconPaths: [`${iconDirectory}/custom.svg`],
         });
 
         expect(resolved).toBe(`${iconDirectory}/custom.svg`);
@@ -100,7 +100,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         yield* writeTextFile(cwd, ".local/icon.svg", "<svg>custom</svg>");
 
         const resolved = yield* resolver.resolvePath(cwd, {
-          customIconPath: ".local/icon.svg",
+          customIconPaths: [".local/icon.svg"],
         });
 
         expect(resolved).toBe(`${cwd}/.local/icon.svg`);
@@ -114,10 +114,26 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
         yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
 
         const resolved = yield* resolver.resolvePath(cwd, {
-          customIconPath: "/missing/custom.svg",
+          customIconPaths: ["/missing/custom.svg"],
         });
 
         expect(resolved).toBe(`${cwd}/favicon.svg`);
+      }),
+    );
+
+    it.effect("uses the next configured icon when a higher-priority path is missing", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        const iconDirectory = yield* makeTempDir;
+        yield* writeTextFile(iconDirectory, "remote.svg", "<svg>remote</svg>");
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd, {
+          customIconPaths: ["/missing/path-specific.svg", `${iconDirectory}/remote.svg`],
+        });
+
+        expect(resolved).toBe(`${iconDirectory}/remote.svg`);
       }),
     );
 

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -77,6 +77,50 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("prefers a configured icon outside the workspace", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        const iconDirectory = yield* makeTempDir;
+        yield* writeTextFile(iconDirectory, "custom.svg", "<svg>custom</svg>");
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd, {
+          customIconPath: `${iconDirectory}/custom.svg`,
+        });
+
+        expect(resolved).toBe(`${iconDirectory}/custom.svg`);
+      }),
+    );
+
+    it.effect("resolves configured relative paths from the workspace", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, ".local/icon.svg", "<svg>custom</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd, {
+          customIconPath: ".local/icon.svg",
+        });
+
+        expect(resolved).toBe(`${cwd}/.local/icon.svg`);
+      }),
+    );
+
+    it.effect("falls back to discovery when the configured icon does not exist", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd, {
+          customIconPath: "/missing/custom.svg",
+        });
+
+        expect(resolved).toBe(`${cwd}/favicon.svg`);
+      }),
+    );
+
     it.effect("falls back to well-known files when the t3.json iconPath does not exist", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -93,7 +93,7 @@ export class ProjectFaviconResolver extends Context.Service<
      */
     readonly resolvePath: (
       cwd: string,
-      options?: { readonly customIconPath?: string },
+      options?: { readonly customIconPaths?: ReadonlyArray<string> },
     ) => Effect.Effect<string | null, ProjectFaviconResolutionError>;
   }
 >()("t3/project/ProjectFaviconResolver") {}
@@ -195,8 +195,8 @@ export const make = Effect.gen(function* () {
     // User-local settings override checked-in metadata and automatic discovery.
     // Relative paths are resolved from the workspace; absolute and home-relative
     // paths may point at a central icon directory outside the repository.
-    if (options?.customIconPath !== undefined) {
-      const expandedIconPath = expandHomePath(options.customIconPath.trim(), path);
+    for (const configuredPath of options?.customIconPaths ?? []) {
+      const expandedIconPath = expandHomePath(configuredPath.trim(), path);
       const customIconPath = path.isAbsolute(expandedIconPath)
         ? path.resolve(expandedIconPath)
         : path.resolve(projectCwd, expandedIconPath);

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -6,6 +6,8 @@
  *
  * @module ProjectFaviconResolver
  */
+import * as NodeOS from "node:os";
+
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -91,6 +93,7 @@ export class ProjectFaviconResolver extends Context.Service<
      */
     readonly resolvePath: (
       cwd: string,
+      options?: { readonly customIconPath?: string },
     ) => Effect.Effect<string | null, ProjectFaviconResolutionError>;
   }
 >()("t3/project/ProjectFaviconResolver") {}
@@ -101,6 +104,16 @@ function extractIconHref(source: string): string | null {
   const objMatch = source.match(LINK_ICON_OBJ_RE);
   if (objMatch?.[1]) return objMatch[1];
   return null;
+}
+
+function expandHomePath(input: string, path: Path.Path): string {
+  if (input === "~") {
+    return NodeOS.homedir();
+  }
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return path.join(NodeOS.homedir(), input.slice(2));
+  }
+  return input;
 }
 
 const optionOnNotFound = <A, R>(
@@ -168,7 +181,7 @@ export const make = Effect.gen(function* () {
 
   const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
     "ProjectFaviconResolver.resolvePath",
-  )(function* (cwd) {
+  )(function* (cwd, options) {
     const projectCwd = yield* workspacePaths.normalizeWorkspaceRoot(cwd).pipe(
       Effect.mapError(
         (cause) =>
@@ -179,6 +192,30 @@ export const make = Effect.gen(function* () {
           }),
       ),
     );
+    // User-local settings override checked-in metadata and automatic discovery.
+    // Relative paths are resolved from the workspace; absolute and home-relative
+    // paths may point at a central icon directory outside the repository.
+    if (options?.customIconPath !== undefined) {
+      const expandedIconPath = expandHomePath(options.customIconPath.trim(), path);
+      const customIconPath = path.isAbsolute(expandedIconPath)
+        ? path.resolve(expandedIconPath)
+        : path.resolve(projectCwd, expandedIconPath);
+      const customIconStats = yield* optionOnNotFound(fileSystem.stat(customIconPath)).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectFaviconResolutionError({
+              operation: "stat-candidate",
+              workspaceRoot: projectCwd,
+              absolutePath: customIconPath,
+              cause,
+            }),
+        ),
+      );
+      if (Option.isSome(customIconStats) && customIconStats.value.type === "File") {
+        return customIconPath;
+      }
+    }
+
     // A t3.json iconPath takes precedence over the well-known locations.
     const projectFile = yield* projectFileLoader.load(projectCwd);
     if (Option.isSome(projectFile) && projectFile.value.iconPath !== undefined) {

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -87,6 +87,22 @@ export class ProjectFaviconResolver extends Context.Service<
   ProjectFaviconResolver,
   {
     /**
+     * Resolve a favicon together with the trust boundary that selected it.
+     *
+     * Explicit user settings may intentionally point outside the workspace,
+     * while project metadata and automatic discovery must remain contained.
+     */
+    readonly resolve: (
+      cwd: string,
+      options?: { readonly customIconPaths?: ReadonlyArray<string> },
+    ) => Effect.Effect<
+      {
+        readonly path: string;
+        readonly source: "custom-setting" | "workspace";
+      } | null,
+      ProjectFaviconResolutionError
+    >;
+    /**
      * Resolve a favicon or icon file path for the provided workspace root.
      *
      * Returns `null` when no candidate icon file can be found.
@@ -179,8 +195,8 @@ export const make = Effect.gen(function* () {
     return null;
   });
 
-  const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
-    "ProjectFaviconResolver.resolvePath",
+  const resolve: ProjectFaviconResolver["Service"]["resolve"] = Effect.fn(
+    "ProjectFaviconResolver.resolve",
   )(function* (cwd, options) {
     const projectCwd = yield* workspacePaths.normalizeWorkspaceRoot(cwd).pipe(
       Effect.mapError(
@@ -212,7 +228,7 @@ export const make = Effect.gen(function* () {
         ),
       );
       if (Option.isSome(customIconStats) && customIconStats.value.type === "File") {
-        return customIconPath;
+        return { path: customIconPath, source: "custom-setting" as const };
       }
     }
 
@@ -221,14 +237,14 @@ export const make = Effect.gen(function* () {
     if (Option.isSome(projectFile) && projectFile.value.iconPath !== undefined) {
       const existing = yield* findExistingFile(projectCwd, [projectFile.value.iconPath]);
       if (existing) {
-        return existing;
+        return { path: existing, source: "workspace" as const };
       }
     }
 
     for (const candidate of FAVICON_CANDIDATES) {
       const existing = yield* findExistingFile(projectCwd, [candidate]);
       if (existing) {
-        return existing;
+        return { path: existing, source: "workspace" as const };
       }
     }
 
@@ -272,14 +288,17 @@ export const make = Effect.gen(function* () {
       }
       const existing = yield* findExistingFile(projectCwd, resolveIconHref(href));
       if (existing) {
-        return existing;
+        return { path: existing, source: "workspace" as const };
       }
     }
 
     return null;
   });
 
-  return ProjectFaviconResolver.of({ resolvePath });
+  const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = (cwd, options) =>
+    resolve(cwd, options).pipe(Effect.map((resolved) => resolved?.path ?? null));
+
+  return ProjectFaviconResolver.of({ resolve, resolvePath });
 });
 
 export const layer = Layer.effect(ProjectFaviconResolver, make);

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -558,6 +558,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         projectIcons: {
           "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
         },
+        projectIconsByGitRemote: {
+          "github.com/t3tools/t3code": "~/.config/t3code/icons/t3code.svg",
+        },
         observability: {
           otlpTracesUrl: "http://localhost:4318/v1/traces",
           otlpMetricsUrl: "http://localhost:4318/v1/metrics",
@@ -582,6 +585,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         addProjectBaseDirectory: "~/Development",
         projectIcons: {
           "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
+        },
+        projectIconsByGitRemote: {
+          "github.com/t3tools/t3code": "~/.config/t3code/icons/t3code.svg",
         },
         observability: {
           otlpTracesUrl: "http://localhost:4318/v1/traces",

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -555,6 +555,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       const fileSystem = yield* FileSystem.FileSystem;
       const next = yield* serverSettings.updateSettings({
         addProjectBaseDirectory: "~/Development",
+        projectIcons: {
+          "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
+        },
         observability: {
           otlpTracesUrl: "http://localhost:4318/v1/traces",
           otlpMetricsUrl: "http://localhost:4318/v1/metrics",
@@ -577,6 +580,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       // @effect-diagnostics-next-line preferSchemaOverJson:off
       assert.deepEqual(JSON.parse(raw), {
         addProjectBaseDirectory: "~/Development",
+        projectIcons: {
+          "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
+        },
         observability: {
           otlpTracesUrl: "http://localhost:4318/v1/traces",
           otlpMetricsUrl: "http://localhost:4318/v1/metrics",

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1093,6 +1093,7 @@ const makeWsRpcLayer = (
           auth,
           cwd: config.cwd,
           keybindingsConfigPath: config.keybindingsConfigPath,
+          settingsConfigPath: config.settingsPath,
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
           providers,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -797,6 +797,7 @@ function OpenCommandPaletteDialog(props: {
           <ProjectFavicon
             environmentId={project.environmentId}
             cwd={project.workspaceRoot}
+            repositoryKey={project.repositoryIdentity?.canonicalKey}
             className={ITEM_ICON_CLASS}
           />
         ),
@@ -821,6 +822,7 @@ function OpenCommandPaletteDialog(props: {
             <ProjectFavicon
               environmentId={project.environmentId}
               cwd={project.workspaceRoot}
+              repositoryKey={project.repositoryIdentity?.canonicalKey}
               className={ITEM_ICON_CLASS}
             />
           ),

--- a/apps/web/src/components/ProjectFavicon.test.ts
+++ b/apps/web/src/components/ProjectFavicon.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { projectFaviconSettingsRevision } from "./ProjectFavicon";
+
+describe("projectFaviconSettingsRevision", () => {
+  it("stays bounded for large remote icon maps", () => {
+    const projectIconsByGitRemote = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `github.com/example/${"r".repeat(900)}-${index}`,
+        `/icons/${"i".repeat(900)}-${index}.svg`,
+      ]),
+    );
+
+    const revision = projectFaviconSettingsRevision(
+      { projectIcons: {}, projectIconsByGitRemote },
+      "/workspace/project",
+    );
+
+    expect(revision).toBeDefined();
+    expect(revision?.length).toBeLessThanOrEqual(1024);
+  });
+
+  it("is stable across remote map insertion order and changes with icon settings", () => {
+    const first = projectFaviconSettingsRevision(
+      {
+        projectIcons: {},
+        projectIconsByGitRemote: {
+          "github.com/example/two": "/icons/two.svg",
+          "github.com/example/one": "/icons/one.svg",
+        },
+      },
+      "/workspace/project",
+    );
+    const reordered = projectFaviconSettingsRevision(
+      {
+        projectIcons: {},
+        projectIconsByGitRemote: {
+          "github.com/example/one": "/icons/one.svg",
+          "github.com/example/two": "/icons/two.svg",
+        },
+      },
+      "/workspace/project",
+    );
+    const changed = projectFaviconSettingsRevision(
+      {
+        projectIcons: {},
+        projectIconsByGitRemote: {
+          "github.com/example/one": "/icons/one-next.svg",
+          "github.com/example/two": "/icons/two.svg",
+        },
+      },
+      "/workspace/project",
+    );
+
+    expect(first).toBe(reordered);
+    expect(changed).not.toBe(first);
+  });
+
+  it("uses only the higher-precedence workspace icon when configured", () => {
+    const first = projectFaviconSettingsRevision(
+      {
+        projectIcons: { "/workspace/project": "/icons/local.svg" },
+        projectIconsByGitRemote: { "github.com/example/one": "/icons/one.svg" },
+      },
+      "/workspace/project",
+    );
+    const remoteChanged = projectFaviconSettingsRevision(
+      {
+        projectIcons: { "/workspace/project": "/icons/local.svg" },
+        projectIconsByGitRemote: { "github.com/example/one": "/icons/one-next.svg" },
+      },
+      "/workspace/project",
+    );
+
+    expect(remoteChanged).toBe(first);
+  });
+});

--- a/apps/web/src/components/ProjectFavicon.test.ts
+++ b/apps/web/src/components/ProjectFavicon.test.ts
@@ -56,7 +56,7 @@ describe("projectFaviconSettingsRevision", () => {
     expect(changed).not.toBe(first);
   });
 
-  it("uses only the higher-precedence workspace icon when configured", () => {
+  it("changes when remote settings change even with a workspace override", () => {
     const first = projectFaviconSettingsRevision(
       {
         projectIcons: { "/workspace/project": "/icons/local.svg" },
@@ -72,6 +72,24 @@ describe("projectFaviconSettingsRevision", () => {
       "/workspace/project",
     );
 
-    expect(remoteChanged).toBe(first);
+    expect(remoteChanged).not.toBe(first);
+  });
+
+  it("changes when repository identity becomes available", () => {
+    const settings = {
+      projectIcons: {},
+      projectIconsByGitRemote: {
+        "github.com/example/one": "/icons/one.svg",
+      },
+    };
+
+    const unresolved = projectFaviconSettingsRevision(settings, "/workspace/project");
+    const resolved = projectFaviconSettingsRevision(
+      settings,
+      "/workspace/project",
+      "github.com/example/one",
+    );
+
+    expect(resolved).not.toBe(unresolved);
   });
 });

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -8,18 +8,42 @@ import { useEnvironmentSettings } from "../hooks/useSettings";
 
 const loadedProjectFaviconSrcs = new Set<string>();
 
+function hashProjectFaviconRevision(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+export function projectFaviconSettingsRevision(
+  settings: {
+    readonly projectIcons: Readonly<Record<string, string>>;
+    readonly projectIconsByGitRemote: Readonly<Record<string, string>>;
+  },
+  cwd: string,
+): string | undefined {
+  const pathIcon = settings.projectIcons[cwd];
+  const remoteEntries = Object.entries(settings.projectIconsByGitRemote);
+  if (!pathIcon && remoteEntries.length === 0) return undefined;
+  const revisionSource = JSON.stringify(
+    pathIcon
+      ? ["path", pathIcon]
+      : ["remotes", remoteEntries.sort(([left], [right]) => left.localeCompare(right))],
+  );
+  return `icons:${revisionSource.length}:${hashProjectFaviconRevision(revisionSource)}`;
+}
+
 export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
   cwd: string;
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
-  const configuredIconRevision = useEnvironmentSettings(input.environmentId, (settings) => {
-    const pathIcon = settings.projectIcons[input.cwd];
-    if (pathIcon) return `path:${pathIcon}`;
-    const remoteEntries = Object.entries(settings.projectIconsByGitRemote);
-    return remoteEntries.length === 0 ? undefined : `remotes:${JSON.stringify(remoteEntries)}`;
-  });
+  const configuredIconRevision = useEnvironmentSettings(input.environmentId, (settings) =>
+    projectFaviconSettingsRevision(settings, input.cwd),
+  );
   const src = useAssetUrl(input.environmentId, {
     _tag: "project-favicon",
     cwd: input.cwd,

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -14,14 +14,16 @@ export function ProjectFavicon(input: {
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
-  const configuredIconPath = useEnvironmentSettings(
-    input.environmentId,
-    (settings) => settings.projectIcons[input.cwd],
-  );
+  const configuredIconRevision = useEnvironmentSettings(input.environmentId, (settings) => {
+    const pathIcon = settings.projectIcons[input.cwd];
+    if (pathIcon) return `path:${pathIcon}`;
+    const remoteEntries = Object.entries(settings.projectIconsByGitRemote);
+    return remoteEntries.length === 0 ? undefined : `remotes:${JSON.stringify(remoteEntries)}`;
+  });
   const src = useAssetUrl(input.environmentId, {
     _tag: "project-favicon",
     cwd: input.cwd,
-    ...(configuredIconPath ? { revision: configuredIconPath } : {}),
+    ...(configuredIconRevision ? { revision: configuredIconRevision } : {}),
   });
   const FallbackIcon = input.fallbackIcon ?? FolderIcon;
 

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -4,6 +4,7 @@ import { FolderIcon } from "lucide-react";
 import type { ComponentType } from "react";
 import { useState } from "react";
 import { useAssetUrl } from "../assets/assetUrls";
+import { useEnvironmentSettings } from "../hooks/useSettings";
 
 const loadedProjectFaviconSrcs = new Set<string>();
 
@@ -13,9 +14,14 @@ export function ProjectFavicon(input: {
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
+  const configuredIconPath = useEnvironmentSettings(
+    input.environmentId,
+    (settings) => settings.projectIcons[input.cwd],
+  );
   const src = useAssetUrl(input.environmentId, {
     _tag: "project-favicon",
     cwd: input.cwd,
+    ...(configuredIconPath ? { revision: configuredIconPath } : {}),
   });
   const FallbackIcon = input.fallbackIcon ?? FolderIcon;
 

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -23,26 +23,31 @@ export function projectFaviconSettingsRevision(
     readonly projectIconsByGitRemote: Readonly<Record<string, string>>;
   },
   cwd: string,
+  repositoryKey?: string | null,
 ): string | undefined {
   const pathIcon = settings.projectIcons[cwd];
   const remoteEntries = Object.entries(settings.projectIconsByGitRemote);
-  if (!pathIcon && remoteEntries.length === 0) return undefined;
-  const revisionSource = JSON.stringify(
-    pathIcon
-      ? ["path", pathIcon]
-      : ["remotes", remoteEntries.sort(([left], [right]) => left.localeCompare(right))],
-  );
+  if (!pathIcon && remoteEntries.length === 0 && !repositoryKey) return undefined;
+  const revisionSource = JSON.stringify([
+    "path",
+    pathIcon ?? null,
+    "repository",
+    repositoryKey ?? null,
+    "remotes",
+    remoteEntries.sort(([left], [right]) => left.localeCompare(right)),
+  ]);
   return `icons:${revisionSource.length}:${hashProjectFaviconRevision(revisionSource)}`;
 }
 
 export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
   cwd: string;
+  repositoryKey?: string | null | undefined;
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
   const configuredIconRevision = useEnvironmentSettings(input.environmentId, (settings) =>
-    projectFaviconSettingsRevision(settings, input.cwd),
+    projectFaviconSettingsRevision(settings, input.cwd, input.repositoryKey),
   );
   const src = useAssetUrl(input.environmentId, {
     _tag: "project-favicon",

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -25,12 +25,14 @@ export function projectFaviconSettingsRevision(
   cwd: string,
   repositoryKey?: string | null,
 ): string | undefined {
-  const pathIcon = settings.projectIcons[cwd];
+  const pathEntries = Object.entries(settings.projectIcons);
   const remoteEntries = Object.entries(settings.projectIconsByGitRemote);
-  if (!pathIcon && remoteEntries.length === 0 && !repositoryKey) return undefined;
+  if (pathEntries.length === 0 && remoteEntries.length === 0 && !repositoryKey) return undefined;
   const revisionSource = JSON.stringify([
-    "path",
-    pathIcon ?? null,
+    "workspace",
+    cwd,
+    "paths",
+    pathEntries.sort(([left], [right]) => left.localeCompare(right)),
     "repository",
     repositoryKey ?? null,
     "remotes",

--- a/apps/web/src/components/ProjectIconSettings.test.ts
+++ b/apps/web/src/components/ProjectIconSettings.test.ts
@@ -6,13 +6,20 @@ describe("replaceProjectIconSetting", () => {
   it("sets and trims a project icon without changing other projects", () => {
     expect(
       replaceProjectIconSetting(
-        { "/workspace/one": "/icons/one.svg" },
-        "/workspace/two",
+        {
+          projectIcons: { "/workspace/one": "/icons/one.svg" },
+          projectIconsByGitRemote: {},
+        },
+        { workspaceRoot: "/workspace/two" },
+        "workspace",
         "  ~/icons/two.svg  ",
       ),
     ).toEqual({
-      "/workspace/one": "/icons/one.svg",
-      "/workspace/two": "~/icons/two.svg",
+      projectIcons: {
+        "/workspace/one": "/icons/one.svg",
+        "/workspace/two": "~/icons/two.svg",
+      },
+      projectIconsByGitRemote: {},
     });
   });
 
@@ -20,12 +27,64 @@ describe("replaceProjectIconSetting", () => {
     expect(
       replaceProjectIconSetting(
         {
-          "/workspace/one": "/icons/one.svg",
-          "/workspace/two": "/icons/two.svg",
+          projectIcons: {
+            "/workspace/one": "/icons/one.svg",
+            "/workspace/two": "/icons/two.svg",
+          },
+          projectIconsByGitRemote: {},
         },
-        "/workspace/one",
+        { workspaceRoot: "/workspace/one" },
+        "workspace",
         " ",
       ),
-    ).toEqual({ "/workspace/two": "/icons/two.svg" });
+    ).toEqual({
+      projectIcons: { "/workspace/two": "/icons/two.svg" },
+      projectIconsByGitRemote: {},
+    });
+  });
+
+  it("sets a portable git-remote icon and removes the local path override", () => {
+    expect(
+      replaceProjectIconSetting(
+        {
+          projectIcons: {
+            "/workspace/one": "/icons/local.svg",
+            "/workspace/two": "/icons/two.svg",
+          },
+          projectIconsByGitRemote: {
+            "github.com/example/other": "/icons/other.svg",
+          },
+        },
+        {
+          workspaceRoot: "/workspace/one",
+          repositoryKey: "github.com/example/one",
+        },
+        "git-remote",
+        " ~/icons/one.svg ",
+      ),
+    ).toEqual({
+      projectIcons: { "/workspace/two": "/icons/two.svg" },
+      projectIconsByGitRemote: {
+        "github.com/example/other": "/icons/other.svg",
+        "github.com/example/one": "~/icons/one.svg",
+      },
+    });
+  });
+
+  it("falls back to a workspace setting when the project has no git remote", () => {
+    expect(
+      replaceProjectIconSetting(
+        {
+          projectIcons: {},
+          projectIconsByGitRemote: {},
+        },
+        { workspaceRoot: "/workspace/one" },
+        "git-remote",
+        "/icons/one.svg",
+      ),
+    ).toEqual({
+      projectIcons: { "/workspace/one": "/icons/one.svg" },
+      projectIconsByGitRemote: {},
+    });
   });
 });

--- a/apps/web/src/components/ProjectIconSettings.test.ts
+++ b/apps/web/src/components/ProjectIconSettings.test.ts
@@ -87,4 +87,64 @@ describe("replaceProjectIconSetting", () => {
       projectIconsByGitRemote: {},
     });
   });
+
+  it("removes the portable icon when switching back to workspace scope", () => {
+    expect(
+      replaceProjectIconSetting(
+        {
+          projectIcons: {
+            "/workspace/two": "/icons/two.svg",
+          },
+          projectIconsByGitRemote: {
+            "github.com/example/one": "/icons/one-remote.svg",
+            "github.com/example/two": "/icons/two-remote.svg",
+          },
+        },
+        {
+          workspaceRoot: "/workspace/one",
+          repositoryKey: "github.com/example/one",
+        },
+        "workspace",
+        "/icons/one-local.svg",
+      ),
+    ).toEqual({
+      projectIcons: {
+        "/workspace/one": "/icons/one-local.svg",
+        "/workspace/two": "/icons/two.svg",
+      },
+      projectIconsByGitRemote: {
+        "github.com/example/two": "/icons/two-remote.svg",
+      },
+    });
+  });
+
+  it("removes both scoped overrides when resetting from workspace scope", () => {
+    expect(
+      replaceProjectIconSetting(
+        {
+          projectIcons: {
+            "/workspace/one": "/icons/one-local.svg",
+            "/workspace/two": "/icons/two.svg",
+          },
+          projectIconsByGitRemote: {
+            "github.com/example/one": "/icons/one-remote.svg",
+            "github.com/example/two": "/icons/two-remote.svg",
+          },
+        },
+        {
+          workspaceRoot: "/workspace/one",
+          repositoryKey: "github.com/example/one",
+        },
+        "workspace",
+        " ",
+      ),
+    ).toEqual({
+      projectIcons: {
+        "/workspace/two": "/icons/two.svg",
+      },
+      projectIconsByGitRemote: {
+        "github.com/example/two": "/icons/two-remote.svg",
+      },
+    });
+  });
 });

--- a/apps/web/src/components/ProjectIconSettings.test.ts
+++ b/apps/web/src/components/ProjectIconSettings.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { replaceProjectIconSetting } from "./ProjectIconSettings";
+
+describe("replaceProjectIconSetting", () => {
+  it("sets and trims a project icon without changing other projects", () => {
+    expect(
+      replaceProjectIconSetting(
+        { "/workspace/one": "/icons/one.svg" },
+        "/workspace/two",
+        "  ~/icons/two.svg  ",
+      ),
+    ).toEqual({
+      "/workspace/one": "/icons/one.svg",
+      "/workspace/two": "~/icons/two.svg",
+    });
+  });
+
+  it("removes only the selected project when the path is blank", () => {
+    expect(
+      replaceProjectIconSetting(
+        {
+          "/workspace/one": "/icons/one.svg",
+          "/workspace/two": "/icons/two.svg",
+        },
+        "/workspace/one",
+        " ",
+      ),
+    ).toEqual({ "/workspace/two": "/icons/two.svg" });
+  });
+});

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -11,6 +11,7 @@ import { environmentServerConfigsAtom, serverEnvironment } from "../state/server
 import { useAtomCommand } from "../state/use-atom-command";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { Button } from "./ui/button";
+import { Checkbox } from "./ui/checkbox";
 import {
   Dialog,
   DialogDescription,
@@ -28,21 +29,57 @@ export interface ProjectIconTarget {
   readonly environmentLabel: string | null;
   readonly title: string;
   readonly workspaceRoot: string;
+  readonly repositoryKey?: string | undefined;
 }
 
-export function replaceProjectIconSetting(
+export type ProjectIconScope = "workspace" | "git-remote";
+
+function replaceIconInMap(
   projectIcons: Readonly<Record<string, string>>,
-  workspaceRoot: string,
+  key: string,
   iconPath: string,
 ): Record<string, string> {
   const next = { ...projectIcons };
   const trimmedPath = iconPath.trim();
   if (trimmedPath.length === 0) {
-    delete next[workspaceRoot];
+    delete next[key];
   } else {
-    next[workspaceRoot] = trimmedPath;
+    next[key] = trimmedPath;
   }
   return next;
+}
+
+export function replaceProjectIconSetting(
+  input: {
+    readonly projectIcons: Readonly<Record<string, string>>;
+    readonly projectIconsByGitRemote: Readonly<Record<string, string>>;
+  },
+  target: Pick<ProjectIconTarget, "workspaceRoot" | "repositoryKey">,
+  scope: ProjectIconScope,
+  iconPath: string,
+): {
+  readonly projectIcons: Record<string, string>;
+  readonly projectIconsByGitRemote: Record<string, string>;
+} {
+  if (scope === "git-remote" && target.repositoryKey) {
+    const projectIcons = { ...input.projectIcons };
+    // A path-specific icon has higher precedence. Remove it when the user
+    // explicitly chooses the portable repository setting so the new value is
+    // immediately visible for this clone as well as other clones.
+    delete projectIcons[target.workspaceRoot];
+    return {
+      projectIcons,
+      projectIconsByGitRemote: replaceIconInMap(
+        input.projectIconsByGitRemote,
+        target.repositoryKey,
+        iconPath,
+      ),
+    };
+  }
+  return {
+    projectIcons: replaceIconInMap(input.projectIcons, target.workspaceRoot, iconPath),
+    projectIconsByGitRemote: { ...input.projectIconsByGitRemote },
+  };
 }
 
 function useProjectIconSetting(target: ProjectIconTarget) {
@@ -50,30 +87,46 @@ function useProjectIconSetting(target: ProjectIconTarget) {
     target.environmentId,
     (settings) => settings.projectIcons,
   );
+  const projectIconsByGitRemote = useEnvironmentSettings(
+    target.environmentId,
+    (settings) => settings.projectIconsByGitRemote,
+  );
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   const updateServerSettings = useAtomCommand(serverEnvironment.updateSettings, {
     reportFailure: false,
   });
-  const iconPath = projectIcons[target.workspaceRoot] ?? "";
+  const workspaceIconPath = projectIcons[target.workspaceRoot] ?? "";
+  const repositoryIconPath = target.repositoryKey
+    ? (projectIconsByGitRemote[target.repositoryKey] ?? "")
+    : "";
+  const initialScope: ProjectIconScope =
+    workspaceIconPath || !target.repositoryKey ? "workspace" : "git-remote";
+  const iconPath = workspaceIconPath || repositoryIconPath;
   const settingsPath =
     serverConfigs.get(target.environmentId)?.settingsConfigPath ?? "settings.json";
 
   const saveIconPath = useCallback(
-    async (nextPath: string): Promise<boolean> => {
-      const nextProjectIcons = replaceProjectIconSetting(
-        projectIcons,
-        target.workspaceRoot,
+    async (nextPath: string, scope: ProjectIconScope): Promise<boolean> => {
+      const next = replaceProjectIconSetting(
+        { projectIcons, projectIconsByGitRemote },
+        target,
+        scope,
         nextPath,
       );
       if (
-        nextProjectIcons[target.workspaceRoot] === projectIcons[target.workspaceRoot] &&
-        Object.keys(nextProjectIcons).length === Object.keys(projectIcons).length
+        JSON.stringify(next.projectIcons) === JSON.stringify(projectIcons) &&
+        JSON.stringify(next.projectIconsByGitRemote) === JSON.stringify(projectIconsByGitRemote)
       ) {
         return true;
       }
       const result = await updateServerSettings({
         environmentId: target.environmentId,
-        input: { patch: { projectIcons: nextProjectIcons } },
+        input: {
+          patch: {
+            projectIcons: next.projectIcons,
+            projectIconsByGitRemote: next.projectIconsByGitRemote,
+          },
+        },
       });
       if (result._tag === "Success") {
         return true;
@@ -90,31 +143,57 @@ function useProjectIconSetting(target: ProjectIconTarget) {
       }
       return false;
     },
-    [projectIcons, target.environmentId, target.workspaceRoot, updateServerSettings],
+    [projectIcons, projectIconsByGitRemote, target, updateServerSettings],
   );
 
-  return { iconPath, saveIconPath, settingsPath };
+  return {
+    iconPath,
+    initialScope,
+    repositoryIconPath,
+    saveIconPath,
+    settingsPath,
+    workspaceIconPath,
+  };
 }
 
 export function ProjectIconPathField({ target }: { readonly target: ProjectIconTarget }) {
-  const { iconPath, saveIconPath, settingsPath } = useProjectIconSetting(target);
+  const { iconPath, initialScope, saveIconPath, settingsPath } = useProjectIconSetting(target);
+  const [draftPath, setDraftPath] = useState(iconPath);
+  const [scope, setScope] = useState<ProjectIconScope>(initialScope);
 
   return (
     <label className="grid min-w-0 gap-1.5 sm:col-span-2">
       <span className="font-medium text-foreground">Custom icon path</span>
       <Input
-        key={`${target.environmentId}:${target.workspaceRoot}:${iconPath}`}
         size="sm"
         aria-label={`Custom icon path for ${target.title}`}
-        defaultValue={iconPath}
+        value={draftPath}
         placeholder="~/icons/project.svg"
+        onChange={(event) => setDraftPath(event.currentTarget.value)}
         onBlur={(event) => {
-          void saveIconPath(event.currentTarget.value);
+          void saveIconPath(event.currentTarget.value, scope);
         }}
         onKeyDown={(event) => {
           if (event.key === "Enter") event.currentTarget.blur();
         }}
       />
+      {target.repositoryKey ? (
+        <span className="flex min-w-0 items-start gap-2 text-xs text-muted-foreground">
+          <Checkbox
+            aria-label={`Use icon for all clones of ${target.repositoryKey}`}
+            checked={scope === "git-remote"}
+            onCheckedChange={(checked) => {
+              const nextScope = checked ? "git-remote" : "workspace";
+              setScope(nextScope);
+              void saveIconPath(draftPath, nextScope);
+            }}
+          />
+          <span className="min-w-0">
+            Use for all clones of{" "}
+            <span className="font-mono text-[11px]">{target.repositoryKey}</span>
+          </span>
+        </span>
+      ) : null}
       <span className="truncate text-xs text-muted-foreground" title={settingsPath}>
         Absolute, ~/…, or project-relative. Stored in {settingsPath}.
       </span>
@@ -129,10 +208,11 @@ function ProjectIconDialogContent({
   readonly target: ProjectIconTarget;
   readonly onClose: () => void;
 }) {
-  const { iconPath, saveIconPath, settingsPath } = useProjectIconSetting(target);
+  const { iconPath, initialScope, saveIconPath, settingsPath } = useProjectIconSetting(target);
   const [draftPath, setDraftPath] = useState(iconPath);
+  const [scope, setScope] = useState<ProjectIconScope>(initialScope);
   const submit = async (nextPath: string) => {
-    if (await saveIconPath(nextPath)) {
+    if (await saveIconPath(nextPath, scope)) {
       toastManager.add({
         type: "success",
         title: nextPath.trim() ? "Project icon updated" : "Project icon reset",
@@ -177,6 +257,22 @@ function ProjectIconDialogContent({
             }}
           />
         </label>
+        {target.repositoryKey ? (
+          <label className="flex items-start gap-2 rounded-md border border-border/70 bg-muted/20 p-3">
+            <Checkbox
+              checked={scope === "git-remote"}
+              onCheckedChange={(checked) => setScope(checked ? "git-remote" : "workspace")}
+            />
+            <span className="grid min-w-0 gap-0.5">
+              <span className="font-medium text-foreground">Use for every clone</span>
+              <span className="text-sm text-muted-foreground">
+                Match the normalized git remote{" "}
+                <span className="font-mono text-xs">{target.repositoryKey}</span> on other machines
+                and at other paths.
+              </span>
+            </span>
+          </label>
+        ) : null}
         <p className="text-sm text-muted-foreground">
           Use an absolute path, ~/…, or a path relative to the project. The setting is stored in{" "}
           <span className="font-mono text-xs">{settingsPath}</span>.

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -1,0 +1,221 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import { useCallback, useState } from "react";
+
+import { useEnvironmentSettings } from "../hooks/useSettings";
+import { environmentServerConfigsAtom, serverEnvironment } from "../state/server";
+import { useAtomCommand } from "../state/use-atom-command";
+import { ProjectFavicon } from "./ProjectFavicon";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+
+export interface ProjectIconTarget {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string | null;
+  readonly title: string;
+  readonly workspaceRoot: string;
+}
+
+export function replaceProjectIconSetting(
+  projectIcons: Readonly<Record<string, string>>,
+  workspaceRoot: string,
+  iconPath: string,
+): Record<string, string> {
+  const next = { ...projectIcons };
+  const trimmedPath = iconPath.trim();
+  if (trimmedPath.length === 0) {
+    delete next[workspaceRoot];
+  } else {
+    next[workspaceRoot] = trimmedPath;
+  }
+  return next;
+}
+
+function useProjectIconSetting(target: ProjectIconTarget) {
+  const projectIcons = useEnvironmentSettings(
+    target.environmentId,
+    (settings) => settings.projectIcons,
+  );
+  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
+  const updateServerSettings = useAtomCommand(serverEnvironment.updateSettings, {
+    reportFailure: false,
+  });
+  const iconPath = projectIcons[target.workspaceRoot] ?? "";
+  const settingsPath =
+    serverConfigs.get(target.environmentId)?.settingsConfigPath ?? "settings.json";
+
+  const saveIconPath = useCallback(
+    async (nextPath: string): Promise<boolean> => {
+      const nextProjectIcons = replaceProjectIconSetting(
+        projectIcons,
+        target.workspaceRoot,
+        nextPath,
+      );
+      if (
+        nextProjectIcons[target.workspaceRoot] === projectIcons[target.workspaceRoot] &&
+        Object.keys(nextProjectIcons).length === Object.keys(projectIcons).length
+      ) {
+        return true;
+      }
+      const result = await updateServerSettings({
+        environmentId: target.environmentId,
+        input: { patch: { projectIcons: nextProjectIcons } },
+      });
+      if (result._tag === "Success") {
+        return true;
+      }
+      if (!isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to update project icon",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+      return false;
+    },
+    [projectIcons, target.environmentId, target.workspaceRoot, updateServerSettings],
+  );
+
+  return { iconPath, saveIconPath, settingsPath };
+}
+
+export function ProjectIconPathField({ target }: { readonly target: ProjectIconTarget }) {
+  const { iconPath, saveIconPath, settingsPath } = useProjectIconSetting(target);
+
+  return (
+    <label className="grid min-w-0 gap-1.5 sm:col-span-2">
+      <span className="font-medium text-foreground">Custom icon path</span>
+      <Input
+        key={`${target.environmentId}:${target.workspaceRoot}:${iconPath}`}
+        size="sm"
+        aria-label={`Custom icon path for ${target.title}`}
+        defaultValue={iconPath}
+        placeholder="~/icons/project.svg"
+        onBlur={(event) => {
+          void saveIconPath(event.currentTarget.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") event.currentTarget.blur();
+        }}
+      />
+      <span className="truncate text-xs text-muted-foreground" title={settingsPath}>
+        Absolute, ~/…, or project-relative. Stored in {settingsPath}.
+      </span>
+    </label>
+  );
+}
+
+function ProjectIconDialogContent({
+  target,
+  onClose,
+}: {
+  readonly target: ProjectIconTarget;
+  readonly onClose: () => void;
+}) {
+  const { iconPath, saveIconPath, settingsPath } = useProjectIconSetting(target);
+  const [draftPath, setDraftPath] = useState(iconPath);
+  const submit = async (nextPath: string) => {
+    if (await saveIconPath(nextPath)) {
+      toastManager.add({
+        type: "success",
+        title: nextPath.trim() ? "Project icon updated" : "Project icon reset",
+        description: target.title,
+      });
+      onClose();
+    }
+  };
+
+  return (
+    <DialogPopup className="max-w-lg">
+      <DialogHeader>
+        <DialogTitle>Project icon</DialogTitle>
+        <DialogDescription>
+          Set a user-local icon for {target.title} without changing the project repository.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogPanel className="space-y-4">
+        <div className="flex min-w-0 items-center gap-3 rounded-lg border border-border/70 bg-muted/25 p-3">
+          <ProjectFavicon
+            environmentId={target.environmentId}
+            cwd={target.workspaceRoot}
+            className="size-8"
+          />
+          <div className="min-w-0">
+            <p className="truncate font-medium text-foreground">{target.title}</p>
+            <p className="truncate font-mono text-xs text-muted-foreground">
+              {target.workspaceRoot}
+            </p>
+          </div>
+        </div>
+        <label className="grid gap-1.5">
+          <span className="font-medium text-foreground">Icon path</span>
+          <Input
+            autoFocus
+            aria-label={`Custom icon path for ${target.title}`}
+            value={draftPath}
+            placeholder="~/icons/project.svg"
+            onChange={(event) => setDraftPath(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void submit(draftPath);
+            }}
+          />
+        </label>
+        <p className="text-sm text-muted-foreground">
+          Use an absolute path, ~/…, or a path relative to the project. The setting is stored in{" "}
+          <span className="font-mono text-xs">{settingsPath}</span>.
+        </p>
+        {target.environmentLabel ? (
+          <p className="text-sm text-muted-foreground">Environment: {target.environmentLabel}</p>
+        ) : null}
+      </DialogPanel>
+      <DialogFooter>
+        {iconPath ? (
+          <Button variant="ghost" className="mr-auto" onClick={() => void submit("")}>
+            Reset to automatic
+          </Button>
+        ) : null}
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={() => void submit(draftPath)}>Save</Button>
+      </DialogFooter>
+    </DialogPopup>
+  );
+}
+
+export function ProjectIconDialog({
+  target,
+  onOpenChange,
+}: {
+  readonly target: ProjectIconTarget | null;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={target !== null} onOpenChange={onOpenChange}>
+      {target ? (
+        <ProjectIconDialogContent
+          key={`${target.environmentId}:${target.workspaceRoot}`}
+          target={target}
+          onClose={() => onOpenChange(false)}
+        />
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -4,6 +4,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { applyProjectIconUpdate } from "@t3tools/shared/serverSettings";
 import { useCallback, useState } from "react";
 
 import { useEnvironmentSettings } from "../hooks/useSettings";
@@ -34,21 +35,6 @@ export interface ProjectIconTarget {
 
 export type ProjectIconScope = "workspace" | "git-remote";
 
-function replaceIconInMap(
-  projectIcons: Readonly<Record<string, string>>,
-  key: string,
-  iconPath: string,
-): Record<string, string> {
-  const next = { ...projectIcons };
-  const trimmedPath = iconPath.trim();
-  if (trimmedPath.length === 0) {
-    delete next[key];
-  } else {
-    next[key] = trimmedPath;
-  }
-  return next;
-}
-
 export function replaceProjectIconSetting(
   input: {
     readonly projectIcons: Readonly<Record<string, string>>;
@@ -61,25 +47,23 @@ export function replaceProjectIconSetting(
   readonly projectIcons: Record<string, string>;
   readonly projectIconsByGitRemote: Record<string, string>;
 } {
-  if (scope === "git-remote" && target.repositoryKey) {
-    const projectIcons = { ...input.projectIcons };
-    // A path-specific icon has higher precedence. Remove it when the user
-    // explicitly chooses the portable repository setting so the new value is
-    // immediately visible for this clone as well as other clones.
-    delete projectIcons[target.workspaceRoot];
-    return {
-      projectIcons,
-      projectIconsByGitRemote: replaceIconInMap(
-        input.projectIconsByGitRemote,
-        target.repositoryKey,
-        iconPath,
-      ),
-    };
-  }
-  return {
-    projectIcons: replaceIconInMap(input.projectIcons, target.workspaceRoot, iconPath),
-    projectIconsByGitRemote: { ...input.projectIconsByGitRemote },
-  };
+  const trimmedPath = iconPath.trim();
+  return applyProjectIconUpdate(
+    input,
+    scope === "git-remote" && target.repositoryKey
+      ? {
+          scope,
+          workspaceRoot: target.workspaceRoot,
+          repositoryKey: target.repositoryKey,
+          iconPath: trimmedPath,
+        }
+      : {
+          scope: "workspace",
+          workspaceRoot: target.workspaceRoot,
+          ...(target.repositoryKey ? { repositoryKey: target.repositoryKey } : {}),
+          iconPath: trimmedPath,
+        },
+  );
 }
 
 function useProjectIconSetting(target: ProjectIconTarget) {
@@ -107,24 +91,25 @@ function useProjectIconSetting(target: ProjectIconTarget) {
 
   const saveIconPath = useCallback(
     async (nextPath: string, scope: ProjectIconScope): Promise<boolean> => {
-      const next = replaceProjectIconSetting(
-        { projectIcons, projectIconsByGitRemote },
-        target,
-        scope,
-        nextPath,
-      );
-      if (
-        JSON.stringify(next.projectIcons) === JSON.stringify(projectIcons) &&
-        JSON.stringify(next.projectIconsByGitRemote) === JSON.stringify(projectIconsByGitRemote)
-      ) {
-        return true;
-      }
+      const trimmedPath = nextPath.trim();
       const result = await updateServerSettings({
         environmentId: target.environmentId,
         input: {
           patch: {
-            projectIcons: next.projectIcons,
-            projectIconsByGitRemote: next.projectIconsByGitRemote,
+            projectIconUpdate:
+              scope === "git-remote" && target.repositoryKey
+                ? {
+                    scope,
+                    workspaceRoot: target.workspaceRoot,
+                    repositoryKey: target.repositoryKey,
+                    iconPath: trimmedPath,
+                  }
+                : {
+                    scope: "workspace",
+                    workspaceRoot: target.workspaceRoot,
+                    ...(target.repositoryKey ? { repositoryKey: target.repositoryKey } : {}),
+                    iconPath: trimmedPath,
+                  },
           },
         },
       });
@@ -143,7 +128,7 @@ function useProjectIconSetting(target: ProjectIconTarget) {
       }
       return false;
     },
-    [projectIcons, projectIconsByGitRemote, target, updateServerSettings],
+    [target, updateServerSettings],
   );
 
   return {

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -5,7 +5,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { applyProjectIconUpdate } from "@t3tools/shared/serverSettings";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useEnvironmentSettings } from "../hooks/useSettings";
 import { environmentServerConfigsAtom, serverEnvironment } from "../state/server";
@@ -145,6 +145,25 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
   const { iconPath, initialScope, saveIconPath, settingsPath } = useProjectIconSetting(target);
   const [draftPath, setDraftPath] = useState(iconPath);
   const [scope, setScope] = useState<ProjectIconScope>(initialScope);
+  const saveQueueRef = useRef(Promise.resolve());
+  const queueSave = useCallback(
+    (nextPath: string, nextScope: ProjectIconScope) => {
+      const save = saveQueueRef.current.then(() => saveIconPath(nextPath, nextScope));
+      saveQueueRef.current = save.then(
+        () => undefined,
+        () => undefined,
+      );
+      return save;
+    },
+    [saveIconPath],
+  );
+
+  useEffect(() => {
+    setDraftPath(iconPath);
+  }, [iconPath]);
+  useEffect(() => {
+    setScope(initialScope);
+  }, [initialScope]);
 
   return (
     <label className="grid min-w-0 gap-1.5 sm:col-span-2">
@@ -156,7 +175,7 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
         placeholder="~/icons/project.svg"
         onChange={(event) => setDraftPath(event.currentTarget.value)}
         onBlur={(event) => {
-          void saveIconPath(event.currentTarget.value, scope);
+          void queueSave(event.currentTarget.value, scope);
         }}
         onKeyDown={(event) => {
           if (event.key === "Enter") event.currentTarget.blur();
@@ -170,7 +189,7 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
             onCheckedChange={(checked) => {
               const nextScope = checked ? "git-remote" : "workspace";
               setScope(nextScope);
-              void saveIconPath(draftPath, nextScope);
+              void queueSave(draftPath, nextScope);
             }}
           />
           <span className="min-w-0">
@@ -220,6 +239,7 @@ function ProjectIconDialogContent({
           <ProjectFavicon
             environmentId={target.environmentId}
             cwd={target.workspaceRoot}
+            repositoryKey={target.repositoryKey}
             className="size-8"
           />
           <div className="min-w-0">

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -163,8 +163,12 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
       latestSaveIdRef.current = id;
       const path = nextPath.trim();
       const observableScope = path.length === 0 || !target.repositoryKey ? "workspace" : nextScope;
+      if (observableScope !== nextScope) {
+        setScope(observableScope);
+        setScopeDirty(true);
+      }
       setPendingSave({ id, path, scope: observableScope, status: "pending" });
-      const save = saveQueueRef.current.then(() => saveIconPath(nextPath, nextScope));
+      const save = saveQueueRef.current.then(() => saveIconPath(nextPath, observableScope));
       saveQueueRef.current = save.then(
         () => undefined,
         () => undefined,

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -145,6 +145,10 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
   const { iconPath, initialScope, saveIconPath, settingsPath } = useProjectIconSetting(target);
   const [draftPath, setDraftPath] = useState(iconPath);
   const [scope, setScope] = useState<ProjectIconScope>(initialScope);
+  const [pathDirty, setPathDirty] = useState(false);
+  const [scopeDirty, setScopeDirty] = useState(false);
+  const draftPathRef = useRef(draftPath);
+  const scopeRef = useRef(scope);
   const saveQueueRef = useRef(Promise.resolve());
   const queueSave = useCallback(
     (nextPath: string, nextScope: ProjectIconScope) => {
@@ -153,17 +157,30 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
         () => undefined,
         () => undefined,
       );
+      void save.then((saved) => {
+        if (!saved) return;
+        if (draftPathRef.current === nextPath) {
+          setPathDirty(false);
+        }
+        if (scopeRef.current === nextScope) {
+          setScopeDirty(false);
+        }
+      });
       return save;
     },
     [saveIconPath],
   );
 
   useEffect(() => {
+    if (pathDirty) return;
+    draftPathRef.current = iconPath;
     setDraftPath(iconPath);
-  }, [iconPath]);
+  }, [iconPath, pathDirty]);
   useEffect(() => {
+    if (scopeDirty) return;
+    scopeRef.current = initialScope;
     setScope(initialScope);
-  }, [initialScope]);
+  }, [initialScope, scopeDirty]);
 
   return (
     <label className="grid min-w-0 gap-1.5 sm:col-span-2">
@@ -173,7 +190,12 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
         aria-label={`Custom icon path for ${target.title}`}
         value={draftPath}
         placeholder="~/icons/project.svg"
-        onChange={(event) => setDraftPath(event.currentTarget.value)}
+        onChange={(event) => {
+          const nextPath = event.currentTarget.value;
+          draftPathRef.current = nextPath;
+          setDraftPath(nextPath);
+          setPathDirty(true);
+        }}
         onBlur={(event) => {
           void queueSave(event.currentTarget.value, scope);
         }}
@@ -188,7 +210,9 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
             checked={scope === "git-remote"}
             onCheckedChange={(checked) => {
               const nextScope = checked ? "git-remote" : "workspace";
+              scopeRef.current = nextScope;
               setScope(nextScope);
+              setScopeDirty(true);
               void queueSave(draftPath, nextScope);
             }}
           />

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -35,6 +35,13 @@ export interface ProjectIconTarget {
 
 export type ProjectIconScope = "workspace" | "git-remote";
 
+interface PendingProjectIconSave {
+  readonly id: number;
+  readonly path: string;
+  readonly scope: ProjectIconScope;
+  readonly status: "pending" | "awaiting-stream";
+}
+
 export function replaceProjectIconSetting(
   input: {
     readonly projectIcons: Readonly<Record<string, string>>;
@@ -147,37 +154,58 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
   const [scope, setScope] = useState<ProjectIconScope>(initialScope);
   const [pathDirty, setPathDirty] = useState(false);
   const [scopeDirty, setScopeDirty] = useState(false);
+  const [pendingSave, setPendingSave] = useState<PendingProjectIconSave | null>(null);
   const saveQueueRef = useRef(Promise.resolve());
+  const latestSaveIdRef = useRef(0);
   const queueSave = useCallback(
     (nextPath: string, nextScope: ProjectIconScope) => {
+      const id = latestSaveIdRef.current + 1;
+      latestSaveIdRef.current = id;
+      const path = nextPath.trim();
+      const observableScope = path.length === 0 || !target.repositoryKey ? "workspace" : nextScope;
+      setPendingSave({ id, path, scope: observableScope, status: "pending" });
       const save = saveQueueRef.current.then(() => saveIconPath(nextPath, nextScope));
       saveQueueRef.current = save.then(
         () => undefined,
         () => undefined,
       );
+      void save.then((saved) => {
+        if (latestSaveIdRef.current !== id) return;
+        setPendingSave((current) =>
+          current?.id === id && saved
+            ? { ...current, status: "awaiting-stream" }
+            : current?.id === id
+              ? null
+              : current,
+        );
+      });
       return save;
     },
-    [saveIconPath],
+    [saveIconPath, target.repositoryKey],
   );
 
   useEffect(() => {
-    if (pathDirty) {
-      if (iconPath === draftPath.trim()) {
-        setPathDirty(false);
-      }
-      return;
-    }
+    if (pathDirty || pendingSave !== null) return;
     setDraftPath(iconPath);
-  }, [draftPath, iconPath, pathDirty]);
+  }, [iconPath, pathDirty, pendingSave]);
   useEffect(() => {
-    if (scopeDirty) {
-      if (initialScope === scope) {
-        setScopeDirty(false);
-      }
+    if (scopeDirty || pendingSave !== null) return;
+    setScope(initialScope);
+  }, [initialScope, pendingSave, scopeDirty]);
+  useEffect(() => {
+    if (
+      pendingSave?.status !== "awaiting-stream" ||
+      iconPath !== pendingSave.path ||
+      initialScope !== pendingSave.scope ||
+      draftPath.trim() !== pendingSave.path ||
+      scope !== pendingSave.scope
+    ) {
       return;
     }
-    setScope(initialScope);
-  }, [initialScope, scope, scopeDirty]);
+    setPendingSave(null);
+    setPathDirty(false);
+    setScopeDirty(false);
+  }, [draftPath, iconPath, initialScope, pendingSave, scope]);
 
   return (
     <label className="grid min-w-0 gap-1.5 sm:col-span-2">

--- a/apps/web/src/components/ProjectIconSettings.tsx
+++ b/apps/web/src/components/ProjectIconSettings.tsx
@@ -147,8 +147,6 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
   const [scope, setScope] = useState<ProjectIconScope>(initialScope);
   const [pathDirty, setPathDirty] = useState(false);
   const [scopeDirty, setScopeDirty] = useState(false);
-  const draftPathRef = useRef(draftPath);
-  const scopeRef = useRef(scope);
   const saveQueueRef = useRef(Promise.resolve());
   const queueSave = useCallback(
     (nextPath: string, nextScope: ProjectIconScope) => {
@@ -157,30 +155,29 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
         () => undefined,
         () => undefined,
       );
-      void save.then((saved) => {
-        if (!saved) return;
-        if (draftPathRef.current === nextPath) {
-          setPathDirty(false);
-        }
-        if (scopeRef.current === nextScope) {
-          setScopeDirty(false);
-        }
-      });
       return save;
     },
     [saveIconPath],
   );
 
   useEffect(() => {
-    if (pathDirty) return;
-    draftPathRef.current = iconPath;
+    if (pathDirty) {
+      if (iconPath === draftPath.trim()) {
+        setPathDirty(false);
+      }
+      return;
+    }
     setDraftPath(iconPath);
-  }, [iconPath, pathDirty]);
+  }, [draftPath, iconPath, pathDirty]);
   useEffect(() => {
-    if (scopeDirty) return;
-    scopeRef.current = initialScope;
+    if (scopeDirty) {
+      if (initialScope === scope) {
+        setScopeDirty(false);
+      }
+      return;
+    }
     setScope(initialScope);
-  }, [initialScope, scopeDirty]);
+  }, [initialScope, scope, scopeDirty]);
 
   return (
     <label className="grid min-w-0 gap-1.5 sm:col-span-2">
@@ -192,7 +189,6 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
         placeholder="~/icons/project.svg"
         onChange={(event) => {
           const nextPath = event.currentTarget.value;
-          draftPathRef.current = nextPath;
           setDraftPath(nextPath);
           setPathDirty(true);
         }}
@@ -210,7 +206,6 @@ export function ProjectIconPathField({ target }: { readonly target: ProjectIconT
             checked={scope === "git-remote"}
             onCheckedChange={(checked) => {
               const nextScope = checked ? "git-remote" : "workspace";
-              scopeRef.current = nextScope;
               setScope(nextScope);
               setScopeDirty(true);
               void queueSave(draftPath, nextScope);

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,6 +14,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveProjectStatusIndicator,
+  resolveProjectRepositoryKey,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarV2Status,
@@ -45,6 +46,21 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("resolveProjectRepositoryKey", () => {
+  it("preserves a repository identity for sidebar favicon cache revisions", () => {
+    expect(
+      resolveProjectRepositoryKey({
+        repositoryIdentity: { canonicalKey: "github.com/pingdotgg/t3code" },
+      }),
+    ).toBe("github.com/pingdotgg/t3code");
+  });
+
+  it("returns null while repository identity is unavailable", () => {
+    expect(resolveProjectRepositoryKey(undefined)).toBeNull();
+    expect(resolveProjectRepositoryKey({ repositoryIdentity: null })).toBeNull();
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -18,6 +18,16 @@ export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
+
+export function resolveProjectRepositoryKey(
+  project:
+    | { readonly repositoryIdentity?: { readonly canonicalKey: string } | null | undefined }
+    | null
+    | undefined,
+): string | null {
+  return project?.repositoryIdentity?.canonicalKey ?? null;
+}
+
 type SidebarProject = {
   id: string;
   title: string;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { ProjectIconDialog, type ProjectIconTarget } from "./ProjectIconSettings";
 import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
@@ -1203,6 +1204,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const [projectRenameTitle, setProjectRenameTitle] = useState("");
   const [projectGroupingTarget, setProjectGroupingTarget] =
     useState<SidebarProjectGroupMember | null>(null);
+  const [projectIconTarget, setProjectIconTarget] = useState<ProjectIconTarget | null>(null);
   const [projectGroupingSelection, setProjectGroupingSelection] = useState<
     SidebarProjectGroupingMode | "inherit"
   >("inherit");
@@ -1586,7 +1588,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
         const actionHandlers = new Map<string, () => Promise<void> | void>();
         const makeLeaf = (
-          action: "rename" | "grouping" | "copy-path" | "delete",
+          action: "rename" | "grouping" | "icon" | "copy-path" | "delete",
           member: SidebarProjectGroupMember,
           options?: {
             destructive?: boolean;
@@ -1601,6 +1603,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                 return;
               case "grouping":
                 openProjectGroupingDialog(member);
+                return;
+              case "icon":
+                setProjectIconTarget({
+                  environmentId: member.environmentId,
+                  environmentLabel: member.environmentLabel,
+                  title: member.title,
+                  workspaceRoot: member.workspaceRoot,
+                });
                 return;
               case "copy-path":
                 copyPathToClipboard(member.workspaceRoot, { path: member.workspaceRoot });
@@ -1619,7 +1629,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         };
 
         const buildTargetedItem = (
-          action: "rename" | "grouping" | "copy-path" | "delete",
+          action: "rename" | "grouping" | "icon" | "copy-path" | "delete",
           label: string,
           options?: {
             destructive?: boolean;
@@ -1655,6 +1665,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           [
             buildTargetedItem("rename", "Rename"),
             buildTargetedItem("grouping", "Group into..."),
+            buildTargetedItem("icon", "Project icon..."),
             buildTargetedItem("copy-path", "Copy Path"),
             buildTargetedItem("delete", "Remove", {
               destructive: true,
@@ -2404,6 +2415,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           </DialogFooter>
         </DialogPopup>
       </Dialog>
+
+      <ProjectIconDialog
+        target={projectIconTarget}
+        onOpenChange={(open) => {
+          if (!open) setProjectIconTarget(null);
+        }}
+      />
 
       <Dialog
         open={projectGroupingTarget !== null}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1610,6 +1610,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                   environmentLabel: member.environmentLabel,
                   title: member.title,
                   workspaceRoot: member.workspaceRoot,
+                  repositoryKey: member.repositoryIdentity?.canonicalKey,
                 });
                 return;
               case "copy-path":

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2269,7 +2269,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
               }`}
             />
           )}
-          <ProjectFavicon environmentId={project.environmentId} cwd={project.workspaceRoot} />
+          <ProjectFavicon
+            environmentId={project.environmentId}
+            cwd={project.workspaceRoot}
+            repositoryKey={project.repositoryIdentity?.canonicalKey}
+          />
           <span className="flex min-w-0 flex-1 items-center gap-2">
             <span className="truncate text-sm font-medium text-sidebar-foreground/90">
               {project.displayName}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -2360,6 +2360,7 @@ export default function SidebarV2() {
                     <ProjectFavicon
                       environmentId={scopedProjectGroup.environmentId}
                       cwd={scopedProjectGroup.workspaceRoot}
+                      repositoryKey={scopedProjectGroup.repositoryIdentity?.canonicalKey}
                       className="size-4 shrink-0"
                     />
                   ) : (
@@ -2397,6 +2398,7 @@ export default function SidebarV2() {
                           <ProjectFavicon
                             environmentId={project.environmentId}
                             cwd={project.workspaceRoot}
+                            repositoryKey={project.repositoryIdentity?.canonicalKey}
                             className="size-4 shrink-0"
                           />
                           <span className="min-w-0 truncate text-sm">{project.displayName}</span>
@@ -2670,6 +2672,7 @@ export default function SidebarV2() {
                     <ProjectFavicon
                       environmentId={member.environmentId}
                       cwd={member.workspaceRoot}
+                      repositoryKey={member.repositoryIdentity?.canonicalKey}
                       className="size-5 shrink-0 sm:size-4"
                     />
                     <div className="min-w-0 flex-1">

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -132,6 +132,11 @@ import {
   type SnoozePreset,
 } from "./Sidebar.snooze";
 import { ProjectFavicon } from "./ProjectFavicon";
+import {
+  ProjectIconDialog,
+  ProjectIconPathField,
+  type ProjectIconTarget,
+} from "./ProjectIconSettings";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
@@ -385,6 +390,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   isRenaming: boolean;
   renamingTitle: string;
   onContextMenu: (threadRef: ScopedThreadRef, position: { x: number; y: number }) => void;
+  onProjectIconContextMenu: (
+    threadRef: ScopedThreadRef,
+    position: { x: number; y: number },
+  ) => void;
   onSettle: (threadRef: ScopedThreadRef) => void;
   onUnsettle: (threadRef: ScopedThreadRef) => void;
   onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
@@ -551,6 +560,17 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       onContextMenu(threadRef, { x: event.clientX, y: event.clientY });
     },
     [onContextMenu, threadRef],
+  );
+  const handleProjectIconContextMenu = useCallback(
+    (event: ReactMouseEvent<HTMLSpanElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      props.onProjectIconContextMenu(threadRef, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+    },
+    [props.onProjectIconContextMenu, threadRef],
   );
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent) => {
@@ -759,6 +779,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 !props.isActive &&
                   "opacity-40 grayscale group-hover/v2-row:opacity-100 group-hover/v2-row:grayscale-0",
               )}
+              onContextMenu={handleProjectIconContextMenu}
             >
               <ProjectFavicon
                 environmentId={thread.environmentId}
@@ -862,11 +883,13 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
         >
           <div className="relative z-10 h-[4.875rem] px-2.5 py-2">
             <div className="flex h-5 min-w-0 items-center gap-1.5">
-              <ProjectFavicon
-                environmentId={thread.environmentId}
-                cwd={props.projectCwd ?? ""}
-                className="size-4 shrink-0"
-              />
+              <span className="shrink-0" onContextMenu={handleProjectIconContextMenu}>
+                <ProjectFavicon
+                  environmentId={thread.environmentId}
+                  cwd={props.projectCwd ?? ""}
+                  className="size-4 shrink-0"
+                />
+              </span>
               {props.projectTitle ? (
                 <span
                   className={cn(
@@ -1039,6 +1062,7 @@ export default function SidebarV2() {
   const [projectActionsTarget, setProjectActionsTarget] = useState<SidebarProjectSnapshot | null>(
     null,
   );
+  const [projectIconTarget, setProjectIconTarget] = useState<ProjectIconTarget | null>(null);
   const [projectScopeMenuOpen, setProjectScopeMenuOpen] = useState(false);
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
@@ -1144,6 +1168,19 @@ export default function SidebarV2() {
       ),
     [projectGroups],
   );
+  const projectMemberByKey = useMemo(
+    () =>
+      new Map(
+        projectGroups.flatMap((group) =>
+          group.memberProjects.map(
+            (member) => [`${member.environmentId}:${member.id}`, member] as const,
+          ),
+        ),
+      ),
+    [projectGroups],
+  );
+  const projectMemberByKeyRef = useRef(projectMemberByKey);
+  projectMemberByKeyRef.current = projectMemberByKey;
 
   // now is quantized to the minute so effectiveSettled memoization doesn't
   // churn on every render; auto-settle thresholds are day-granular anyway.
@@ -1542,6 +1579,42 @@ export default function SidebarV2() {
   // event and defeat row memoization during streaming.
   const threadByKeyRef = useRef(threadByKey);
   threadByKeyRef.current = threadByKey;
+  const handleProjectIconContextMenu = useCallback(
+    (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
+      void (async () => {
+        const api = readLocalApi();
+        if (!api) return;
+        const thread = threadByKeyRef.current.get(scopedThreadKey(threadRef));
+        if (!thread) return;
+        const member = projectMemberByKeyRef.current.get(
+          `${thread.environmentId}:${thread.projectId}`,
+        );
+        if (!member) return;
+        const configuredIcon = serverConfigs.get(member.environmentId)?.settings.projectIcons[
+          member.workspaceRoot
+        ];
+        const clicked = await settlePromise(() =>
+          api.contextMenu.show(
+            [
+              {
+                id: "configure-project-icon",
+                label: configuredIcon ? "Change project icon..." : "Set project icon...",
+              },
+            ],
+            position,
+          ),
+        );
+        if (clicked._tag === "Failure" || clicked.value !== "configure-project-icon") return;
+        setProjectIconTarget({
+          environmentId: member.environmentId,
+          environmentLabel: member.environmentLabel,
+          title: member.title,
+          workspaceRoot: member.workspaceRoot,
+        });
+      })();
+    },
+    [serverConfigs],
+  );
   // handleNewThread is inherently unstable (depends on the projects list);
   // a ref keeps it out of attemptSettle's dependency array.
   const handleNewThreadRef = useRef(newThreadContext.handleNewThread);
@@ -2447,6 +2520,7 @@ export default function SidebarV2() {
                       isRenaming={renamingThreadKey === threadKey}
                       renamingTitle={renamingThreadKey === threadKey ? renamingTitle : ""}
                       onContextMenu={handleThreadContextMenu}
+                      onProjectIconContextMenu={handleProjectIconContextMenu}
                       onSettle={attemptSettle}
                       onUnsettle={attemptUnsettle}
                       onSnooze={attemptSnooze}
@@ -2560,6 +2634,12 @@ export default function SidebarV2() {
           ) : null}
         </SidebarGroup>
       </SidebarContent>
+      <ProjectIconDialog
+        target={projectIconTarget}
+        onOpenChange={(open) => {
+          if (!open) setProjectIconTarget(null);
+        }}
+      />
       <Dialog
         open={projectActionsTarget !== null}
         onOpenChange={(open) => {
@@ -2671,6 +2751,14 @@ export default function SidebarV2() {
                         </SelectPopup>
                       </Select>
                     </label>
+                    <ProjectIconPathField
+                      target={{
+                        environmentId: member.environmentId,
+                        environmentLabel: member.environmentLabel,
+                        title: member.title,
+                        workspaceRoot: member.workspaceRoot,
+                      }}
+                    />
                   </div>
                   <div className="flex flex-wrap items-center gap-2 sm:pl-7">
                     <Button

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -111,6 +111,7 @@ import {
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
   resolveAdjacentThreadId,
+  resolveProjectRepositoryKey,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
   resolveWorkingStartedAt,
@@ -225,6 +226,7 @@ function SidebarV2ThreadTooltip({
   thread,
   projectTitle,
   projectCwd,
+  projectRepositoryKey,
   environmentLabel,
   driverKind,
   modelInstanceId,
@@ -234,6 +236,7 @@ function SidebarV2ThreadTooltip({
   thread: SidebarThreadSummary;
   projectTitle: string | null;
   projectCwd: string | null;
+  projectRepositoryKey: string | null;
   environmentLabel: string | null;
   driverKind: ProviderInstanceEntry["driverKind"] | null;
   modelInstanceId: string;
@@ -259,6 +262,7 @@ function SidebarV2ThreadTooltip({
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={projectCwd ?? ""}
+                repositoryKey={projectRepositoryKey}
                 className="size-4 shrink-0 stroke-muted-foreground"
               />
               <div className="min-w-0 wrap-break-word text-foreground/90">{projectTitle}</div>
@@ -379,6 +383,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   currentEnvironmentId: string | null;
   environmentLabel: string | null;
   projectCwd: string | null;
+  projectRepositoryKey: string | null;
   projectTitle: string | null;
   providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
   onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
@@ -540,6 +545,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       thread={thread}
       projectTitle={props.projectTitle}
       projectCwd={props.projectCwd}
+      projectRepositoryKey={props.projectRepositoryKey}
       environmentLabel={props.environmentLabel}
       driverKind={driverKind}
       modelInstanceId={modelInstanceId}
@@ -784,6 +790,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
+                repositoryKey={props.projectRepositoryKey}
                 className="size-4"
                 fallbackIcon={MessageSquareIcon}
               />
@@ -887,6 +894,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 <ProjectFavicon
                   environmentId={thread.environmentId}
                   cwd={props.projectCwd ?? ""}
+                  repositoryKey={props.projectRepositoryKey}
                   className="size-4 shrink-0"
                 />
               </span>
@@ -2511,6 +2519,9 @@ export default function SidebarV2() {
                       projectCwd={
                         projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
                       }
+                      projectRepositoryKey={resolveProjectRepositoryKey(
+                        projectMemberByKey.get(`${thread.environmentId}:${thread.projectId}`),
+                      )}
                       projectTitle={
                         projectDisplayNameByKey.get(
                           `${thread.environmentId}:${thread.projectId}`,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1590,9 +1590,12 @@ export default function SidebarV2() {
           `${thread.environmentId}:${thread.projectId}`,
         );
         if (!member) return;
-        const configuredIcon = serverConfigs.get(member.environmentId)?.settings.projectIcons[
-          member.workspaceRoot
-        ];
+        const settings = serverConfigs.get(member.environmentId)?.settings;
+        const configuredIcon =
+          settings?.projectIcons[member.workspaceRoot] ??
+          (member.repositoryIdentity
+            ? settings?.projectIconsByGitRemote[member.repositoryIdentity.canonicalKey]
+            : undefined);
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
             [
@@ -1610,6 +1613,7 @@ export default function SidebarV2() {
           environmentLabel: member.environmentLabel,
           title: member.title,
           workspaceRoot: member.workspaceRoot,
+          repositoryKey: member.repositoryIdentity?.canonicalKey,
         });
       })();
     },
@@ -2757,6 +2761,7 @@ export default function SidebarV2() {
                         environmentLabel: member.environmentLabel,
                         title: member.title,
                         workspaceRoot: member.workspaceRoot,
+                        repositoryKey: member.repositoryIdentity?.canonicalKey,
                       }}
                     />
                   </div>

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -14,6 +14,9 @@ export const AssetResource = Schema.Union([
   }),
   Schema.TaggedStruct("project-favicon", {
     cwd: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
+    revision: Schema.optional(
+      TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
+    ),
   }),
 ]);
 export type AssetResource = typeof AssetResource.Type;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -412,6 +412,7 @@ export const ServerConfig = Schema.Struct({
   auth: ServerAuthDescriptor,
   cwd: TrimmedNonEmptyString,
   keybindingsConfigPath: TrimmedNonEmptyString,
+  settingsConfigPath: Schema.optionalKey(TrimmedNonEmptyString),
   keybindings: ResolvedKeybindingsConfig,
   issues: ServerConfigIssues,
   providers: ServerProviders,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -166,26 +166,44 @@ describe("ServerSettings.sourceControlWritingStyle", () => {
 describe("ServerSettings project icons", () => {
   it("defaults to an empty map for existing settings files", () => {
     expect(decodeServerSettings({}).projectIcons).toEqual({});
+    expect(decodeServerSettings({}).projectIconsByGitRemote).toEqual({});
   });
 
-  it("trims project roots and icon paths in settings and patches", () => {
+  it("trims project roots, git remotes, and icon paths in settings and patches", () => {
     const input = {
       projectIcons: {
         "  /workspace/t3code  ": "  ~/.config/t3code/icons/t3code.svg  ",
+      },
+      projectIconsByGitRemote: {
+        "  github.com/t3tools/t3code  ": "  ~/.config/t3code/icons/t3code.svg  ",
       },
     };
 
     expect(decodeServerSettings(input).projectIcons).toEqual({
       "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
     });
+    expect(decodeServerSettings(input).projectIconsByGitRemote).toEqual({
+      "github.com/t3tools/t3code": "~/.config/t3code/icons/t3code.svg",
+    });
     expect(decodeServerSettingsPatch(input).projectIcons).toEqual({
       "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
     });
+    expect(decodeServerSettingsPatch(input).projectIconsByGitRemote).toEqual({
+      "github.com/t3tools/t3code": "~/.config/t3code/icons/t3code.svg",
+    });
   });
 
-  it("rejects empty project roots and icon paths", () => {
+  it("rejects empty project roots, git remotes, and icon paths", () => {
     expect(() => decodeServerSettings({ projectIcons: { "": "/icons/project.svg" } })).toThrow();
     expect(() => decodeServerSettingsPatch({ projectIcons: { "/workspace": "  " } })).toThrow();
+    expect(() =>
+      decodeServerSettings({ projectIconsByGitRemote: { "": "/icons/project.svg" } }),
+    ).toThrow();
+    expect(() =>
+      decodeServerSettingsPatch({
+        projectIconsByGitRemote: { "github.com/example/project": "  " },
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -163,6 +163,32 @@ describe("ServerSettings.sourceControlWritingStyle", () => {
   });
 });
 
+describe("ServerSettings project icons", () => {
+  it("defaults to an empty map for existing settings files", () => {
+    expect(decodeServerSettings({}).projectIcons).toEqual({});
+  });
+
+  it("trims project roots and icon paths in settings and patches", () => {
+    const input = {
+      projectIcons: {
+        "  /workspace/t3code  ": "  ~/.config/t3code/icons/t3code.svg  ",
+      },
+    };
+
+    expect(decodeServerSettings(input).projectIcons).toEqual({
+      "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
+    });
+    expect(decodeServerSettingsPatch(input).projectIcons).toEqual({
+      "/workspace/t3code": "~/.config/t3code/icons/t3code.svg",
+    });
+  });
+
+  it("rejects empty project roots and icon paths", () => {
+    expect(() => decodeServerSettings({ projectIcons: { "": "/icons/project.svg" } })).toThrow();
+    expect(() => decodeServerSettingsPatch({ projectIcons: { "/workspace": "  " } })).toThrow();
+  });
+});
+
 describe("ServerSettingsPatch.providerInstances", () => {
   it("treats providerInstances as an optional whole-map replacement", () => {
     const patch = decodeServerSettingsPatch({});

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -205,6 +205,34 @@ describe("ServerSettings project icons", () => {
       }),
     ).toThrow();
   });
+
+  it("decodes atomic project icon updates and permits a blank reset path", () => {
+    expect(
+      decodeServerSettingsPatch({
+        projectIconUpdate: {
+          scope: "workspace",
+          workspaceRoot: "  /workspace/t3code  ",
+          repositoryKey: "  github.com/t3tools/t3code  ",
+          iconPath: "  ",
+        },
+      }).projectIconUpdate,
+    ).toEqual({
+      scope: "workspace",
+      workspaceRoot: "/workspace/t3code",
+      repositoryKey: "github.com/t3tools/t3code",
+      iconPath: "",
+    });
+
+    expect(() =>
+      decodeServerSettingsPatch({
+        projectIconUpdate: {
+          scope: "git-remote",
+          workspaceRoot: "/workspace/t3code",
+          iconPath: "/icons/project.svg",
+        },
+      }),
+    ).toThrow();
+  });
 });
 
 describe("ServerSettingsPatch.providerInstances", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -418,6 +418,7 @@ export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 const ProjectIconPath = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
 const ProjectIconWorkspaceRoot = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
 const ProjectIconGitRemote = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
+const ProjectIconUpdatePath = TrimmedString.check(Schema.isMaxLength(1024));
 
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -570,6 +571,22 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+export const ProjectIconUpdate = Schema.Union([
+  Schema.Struct({
+    scope: Schema.Literal("workspace"),
+    workspaceRoot: ProjectIconWorkspaceRoot,
+    repositoryKey: Schema.optionalKey(ProjectIconGitRemote),
+    iconPath: ProjectIconUpdatePath,
+  }),
+  Schema.Struct({
+    scope: Schema.Literal("git-remote"),
+    workspaceRoot: ProjectIconWorkspaceRoot,
+    repositoryKey: ProjectIconGitRemote,
+    iconPath: ProjectIconUpdatePath,
+  }),
+]);
+export type ProjectIconUpdate = typeof ProjectIconUpdate.Type;
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
@@ -583,6 +600,9 @@ export const ServerSettingsPatch = Schema.Struct({
   // Whole-map replacement. Keys are normalized repository identities such as
   // github.com/t3tools/t3code, independent of clone URL or local path.
   projectIconsByGitRemote: Schema.optionalKey(Schema.Record(ProjectIconGitRemote, ProjectIconPath)),
+  // Atomic single-project update. The server applies this against the latest
+  // icon maps so concurrent edits cannot replace unrelated entries.
+  projectIconUpdate: Schema.optionalKey(ProjectIconUpdate),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(
     Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -415,6 +415,9 @@ export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyle
 
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 
+const ProjectIconPath = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
+const ProjectIconWorkspaceRoot = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
+
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
@@ -430,6 +433,9 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  projectIcons: Schema.Record(ProjectIconWorkspaceRoot, ProjectIconPath).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
       Effect.succeed({
@@ -568,6 +574,8 @@ export const ServerSettingsPatch = Schema.Struct({
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
+  // Whole-map replacement. Omitting a key removes that project's override.
+  projectIcons: Schema.optionalKey(Schema.Record(ProjectIconWorkspaceRoot, ProjectIconPath)),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(
     Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -417,6 +417,7 @@ export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 
 const ProjectIconPath = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
 const ProjectIconWorkspaceRoot = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
+const ProjectIconGitRemote = TrimmedNonEmptyString.check(Schema.isMaxLength(1024));
 
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -434,6 +435,9 @@ export const ServerSettings = Schema.Struct({
   ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   projectIcons: Schema.Record(ProjectIconWorkspaceRoot, ProjectIconPath).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
+  projectIconsByGitRemote: Schema.Record(ProjectIconGitRemote, ProjectIconPath).pipe(
     Schema.withDecodingDefault(Effect.succeed({})),
   ),
   textGenerationModelSelection: ModelSelection.pipe(
@@ -576,6 +580,9 @@ export const ServerSettingsPatch = Schema.Struct({
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   // Whole-map replacement. Omitting a key removes that project's override.
   projectIcons: Schema.optionalKey(Schema.Record(ProjectIconWorkspaceRoot, ProjectIconPath)),
+  // Whole-map replacement. Keys are normalized repository identities such as
+  // github.com/t3tools/t3code, independent of clone URL or local path.
+  projectIconsByGitRemote: Schema.optionalKey(Schema.Record(ProjectIconGitRemote, ProjectIconPath)),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(
     Schema.Struct({

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -295,4 +295,24 @@ describe("serverSettings helpers", () => {
       config: { homePath: "~/.codex" },
     });
   });
+
+  it("replaces project icon maps so clearing an override removes it", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      projectIcons: {
+        "/workspace/one": "/icons/one.svg",
+        "/workspace/two": "/icons/two.svg",
+      },
+    };
+
+    expect(
+      applyServerSettingsPatch(current, {
+        projectIcons: {
+          "/workspace/two": "/icons/two-next.svg",
+        },
+      }).projectIcons,
+    ).toEqual({
+      "/workspace/two": "/icons/two-next.svg",
+    });
+  });
 });

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -303,16 +303,26 @@ describe("serverSettings helpers", () => {
         "/workspace/one": "/icons/one.svg",
         "/workspace/two": "/icons/two.svg",
       },
+      projectIconsByGitRemote: {
+        "github.com/example/one": "/icons/one.svg",
+        "github.com/example/two": "/icons/two.svg",
+      },
     };
 
-    expect(
-      applyServerSettingsPatch(current, {
-        projectIcons: {
-          "/workspace/two": "/icons/two-next.svg",
-        },
-      }).projectIcons,
-    ).toEqual({
+    const next = applyServerSettingsPatch(current, {
+      projectIcons: {
+        "/workspace/two": "/icons/two-next.svg",
+      },
+      projectIconsByGitRemote: {
+        "github.com/example/two": "/icons/two-next.svg",
+      },
+    });
+
+    expect(next.projectIcons).toEqual({
       "/workspace/two": "/icons/two-next.svg",
+    });
+    expect(next.projectIconsByGitRemote).toEqual({
+      "github.com/example/two": "/icons/two-next.svg",
     });
   });
 });

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -325,4 +325,90 @@ describe("serverSettings helpers", () => {
       "github.com/example/two": "/icons/two-next.svg",
     });
   });
+
+  it("applies project icon updates without replacing unrelated concurrent entries", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      projectIcons: {
+        "/workspace/one": "/icons/one.svg",
+        "/workspace/concurrent": "/icons/concurrent.svg",
+      },
+      projectIconsByGitRemote: {
+        "github.com/example/one": "/icons/one-remote.svg",
+        "github.com/example/concurrent": "/icons/concurrent-remote.svg",
+      },
+    };
+
+    const next = applyServerSettingsPatch(current, {
+      projectIconUpdate: {
+        scope: "workspace",
+        workspaceRoot: "/workspace/one",
+        repositoryKey: "github.com/example/one",
+        iconPath: "/icons/one-next.svg",
+      },
+    });
+
+    expect(next.projectIcons).toEqual({
+      "/workspace/one": "/icons/one-next.svg",
+      "/workspace/concurrent": "/icons/concurrent.svg",
+    });
+    expect(next.projectIconsByGitRemote).toEqual({
+      "github.com/example/concurrent": "/icons/concurrent-remote.svg",
+    });
+    expect("projectIconUpdate" in next).toBe(false);
+  });
+
+  it("removes the workspace override when switching to git-remote scope", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      projectIcons: {
+        "/workspace/one": "/icons/one.svg",
+      },
+      projectIconsByGitRemote: {
+        "github.com/example/other": "/icons/other.svg",
+      },
+    };
+
+    const next = applyServerSettingsPatch(current, {
+      projectIconUpdate: {
+        scope: "git-remote",
+        workspaceRoot: "/workspace/one",
+        repositoryKey: "github.com/example/one",
+        iconPath: "/icons/one-remote.svg",
+      },
+    });
+
+    expect(next.projectIcons).toEqual({});
+    expect(next.projectIconsByGitRemote).toEqual({
+      "github.com/example/one": "/icons/one-remote.svg",
+      "github.com/example/other": "/icons/other.svg",
+    });
+  });
+
+  it("clears both scopes when resetting a workspace icon", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      projectIcons: {
+        "/workspace/one": "/icons/one.svg",
+      },
+      projectIconsByGitRemote: {
+        "github.com/example/one": "/icons/one-remote.svg",
+        "github.com/example/other": "/icons/other.svg",
+      },
+    };
+
+    const next = applyServerSettingsPatch(current, {
+      projectIconUpdate: {
+        scope: "workspace",
+        workspaceRoot: "/workspace/one",
+        repositoryKey: "github.com/example/one",
+        iconPath: "",
+      },
+    });
+
+    expect(next.projectIcons).toEqual({});
+    expect(next.projectIconsByGitRemote).toEqual({
+      "github.com/example/other": "/icons/other.svg",
+    });
+  });
 });

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -125,6 +125,9 @@ export function applyServerSettingsPatch(
   const nextWithReplacements = {
     ...next,
     ...(patch.projectIcons !== undefined ? { projectIcons: patch.projectIcons } : {}),
+    ...(patch.projectIconsByGitRemote !== undefined
+      ? { projectIconsByGitRemote: patch.projectIconsByGitRemote }
+      : {}),
     ...(patch.providerInstances !== undefined
       ? { providerInstances: patch.providerInstances }
       : {}),

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -124,6 +124,7 @@ export function applyServerSettingsPatch(
   const next = deepMerge(current, patchForMerge);
   const nextWithReplacements = {
     ...next,
+    ...(patch.projectIcons !== undefined ? { projectIcons: patch.projectIcons } : {}),
     ...(patch.providerInstances !== undefined
       ? { providerInstances: patch.providerInstances }
       : {}),

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -57,6 +57,8 @@ export function resolveSourceControlWriterModelSelection(
     : settings.textGenerationModelSelection;
 }
 
+type ProjectIconMaps = Pick<ServerSettings, "projectIcons" | "projectIconsByGitRemote">;
+
 export interface PersistedServerObservabilitySettings {
   readonly otlpTracesUrl: string | undefined;
   readonly otlpMetricsUrl: string | undefined;
@@ -115,12 +117,58 @@ function mergeModelSelectionOptionsById(input: {
   return [...merged.entries()].map(([id, value]) => ({ id, value }));
 }
 
+function replaceIconInMap(
+  entries: Readonly<Record<string, string>>,
+  key: string,
+  iconPath: string,
+): Record<string, string> {
+  const next = { ...entries };
+  if (iconPath.length === 0) {
+    delete next[key];
+  } else {
+    next[key] = iconPath;
+  }
+  return next;
+}
+
+export function applyProjectIconUpdate(
+  current: ProjectIconMaps,
+  update: NonNullable<ServerSettingsPatch["projectIconUpdate"]>,
+): ProjectIconMaps {
+  if (update.scope === "git-remote") {
+    const projectIcons = { ...current.projectIcons };
+    delete projectIcons[update.workspaceRoot];
+    return {
+      projectIcons,
+      projectIconsByGitRemote: replaceIconInMap(
+        current.projectIconsByGitRemote,
+        update.repositoryKey,
+        update.iconPath,
+      ),
+    };
+  }
+
+  const projectIconsByGitRemote = { ...current.projectIconsByGitRemote };
+  if (update.repositoryKey) {
+    delete projectIconsByGitRemote[update.repositoryKey];
+  }
+  return {
+    projectIcons: replaceIconInMap(current.projectIcons, update.workspaceRoot, update.iconPath),
+    projectIconsByGitRemote,
+  };
+}
+
+/**
+ * Applies a server settings patch while treating textGenerationModelSelection as
+ * replace-on-provider/model updates. This prevents stale nested options from
+ * surviving a reset patch that intentionally omits options.
+ */
 export function applyServerSettingsPatch(
   current: ServerSettings,
   patch: ServerSettingsPatch,
 ): ServerSettings {
   const selectionPatch = patch.textGenerationModelSelection;
-  const { automaticGitFetchInterval, ...patchForMerge } = patch;
+  const { automaticGitFetchInterval, projectIconUpdate, ...patchForMerge } = patch;
   const next = deepMerge(current, patchForMerge);
   const nextWithReplacements = {
     ...next,
@@ -136,8 +184,14 @@ export function applyServerSettingsPatch(
       : {}),
     ...(automaticGitFetchInterval !== undefined ? { automaticGitFetchInterval } : {}),
   };
+  const nextWithProjectIconUpdate = projectIconUpdate
+    ? {
+        ...nextWithReplacements,
+        ...applyProjectIconUpdate(nextWithReplacements, projectIconUpdate),
+      }
+    : nextWithReplacements;
   if (!selectionPatch) {
-    return nextWithReplacements;
+    return nextWithProjectIconUpdate;
   }
 
   const instanceId = selectionPatch.instanceId ?? current.textGenerationModelSelection.instanceId;
@@ -150,7 +204,7 @@ export function applyServerSettingsPatch(
       });
 
   return {
-    ...nextWithReplacements,
+    ...nextWithProjectIconUpdate,
     textGenerationModelSelection: createModelSelection(instanceId, model, options),
   };
 }


### PR DESCRIPTION
## What Changed

- Added user-local `projectIcons` and `projectIconsByGitRemote` maps to the server `settings.json`, keyed by workspace root or normalized repository identity.
- Workspace-specific icons override git-remote icons; missing overrides fall through to repository metadata and automatic discovery.
- Custom icon paths may be absolute, home-relative (`~/…`), or project-relative. They override `t3.json` and automatic favicon discovery without changing the repository.
- Added exact signed-asset capabilities for configured icons outside the workspace, while retaining compatibility with existing favicon URLs.
- Added project-icon controls to the classic project context menu and Sidebar v2 project settings.
- Added a direct Sidebar v2 interaction: right-click the project icon on a thread and choose **Set/Change project icon…**.

## Why

Project icons are currently discovered from files committed to each repository. Personal project organization should not require adding app-specific assets or metadata to the project itself. Git-remote keys also make a dotfile-backed setting portable across devices and clone paths while retaining exact-path overrides for worktrees or exceptional clones.

## UI Changes

Before — automatic folder icon:

![Automatic project icon](https://raw.githubusercontent.com/colonelpanic8/t3code/5a6261a/automatic-project-icon.png)

After — right-clicking the Sidebar v2 thread icon exposes the action:

![Project icon context menu](https://raw.githubusercontent.com/colonelpanic8/t3code/5a6261a/project-icon-context-menu.png)

After — the dialog shows the configured external icon and the persistent settings file:

![Project icon dialog](https://raw.githubusercontent.com/colonelpanic8/t3code/5a6261a/project-icon-dialog.png)

After — a second clone at a different path inherits the normalized git-remote icon:

![Portable git-remote project icon](https://raw.githubusercontent.com/colonelpanic8/t3code/c81d2f6/project-icon-portable-remote.png)

## Checklist

- [x] `vp check`
- [x] `vp run typecheck`
- [x] `vp test run packages/contracts/src/settings.test.ts packages/shared/src/serverSettings.test.ts apps/server/src/project/ProjectFaviconResolver.test.ts apps/server/src/assets/AssetAccess.test.ts apps/server/src/serverSettings.test.ts apps/web/src/components/ProjectIconSettings.test.ts`
- [x] Verified classic-sidebar project context menu in an isolated development environment.
- [x] Verified Sidebar v2 thread-icon right-click, persistence to `settings.json`, and a signed SVG asset outside the repository.
- [x] Verified one `github.com/pingdotgg/t3code` icon setting renders for two clones at different local paths.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add user-local project icons configurable from the sidebar and project settings
> - Adds a context menu on project icons in the sidebar (both v1 and v2) to open a `ProjectIconDialog` for setting a custom icon path per workspace or per git remote.
> - Extends `ProjectFaviconResolver` to accept `customIconPaths` (absolute, `~`-relative, or workspace-relative) and return a source discriminator (`custom-setting` vs `workspace`).
> - Extends `AssetAccess.issueAssetUrl` to read `projectIcons`/`projectIconsByGitRemote` from `ServerSettings` and `RepositoryIdentityResolver` to resolve git-remote-scoped icons; issues v2 `project-icon` claims with an absolute path.
> - Adds `projectIcons` and `projectIconsByGitRemote` maps to `ServerSettings` and `ServerSettingsPatch`, with atomic update support via `projectIconUpdate`.
> - `ProjectFavicon` now computes a deterministic `configuredIconRevision` hash from current icon settings and passes it to asset URL requests for cache-busting.
> - Risk: `resolveAsset` for v2 tokens re-canonicalizes the signed absolute path at resolution time and returns `null` if the file has been replaced by a symlink or moved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f052c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed asset serving and path canonicalization for files outside the workspace; misconfiguration or symlink races are mitigated by tests but remain security-sensitive surface area.
> 
> **Overview**
> Adds **user-local project icons** stored in server `settings.json`, without changing the repository. Users can set a custom icon path per **workspace root** or per **normalized git remote** so the same icon follows clones on other machines and paths.
> 
> **Server & contracts:** New `projectIcons` and `projectIconsByGitRemote` maps plus atomic `projectIconUpdate` patches. `ProjectFaviconResolver` gains `customIconPaths` (absolute, `~/…`, or project-relative) and returns whether the icon came from a **custom setting** vs **workspace** discovery. `AssetAccess` reads those settings and repository identity, issues **v2 `project-icon`** signed tokens with a canonical **absolute path** for configured icons outside the repo, and still enforces workspace containment for auto-discovered icons (including rejecting post-sign symlink swaps).
> 
> **Web UI:** `ProjectIconDialog` / inline path field in Sidebar v2 project settings; classic sidebar context menu **Project icon…**; Sidebar v2 **right-click on the thread favicon** to set/change. `ProjectFavicon` passes a bounded **settings revision** on asset requests for cache-busting when icon maps or repository identity change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f052c818ab1e59ca5e1af48bbbd69db27af425a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- exact-stack-evidence-20260724 -->
## Current combined-stack UI evidence (2026-07-24)

Captured from PR head `804efc44c5a8321667f51400b3c513af593cde82` on upstream main `ece05087a70e94efcd57441337fa1249559362ba`, using combined integration `4dd4cef40` and package `/nix/store/pf7fjqw8ykkdgayf3ywsbgxxp6wi1m42-t3code-0.0.29-patched-main-20260724`.

The settings capture shows an external SVG stored by normalized remote identity for every clone; the second capture shows the resulting custom tree icon in Sidebar V2 and the draft header. All names, remotes, paths, and assets are disposable seed data.

![Portable custom project icon setting](https://raw.githubusercontent.com/colonelpanic8/t3code/010a6e79b705f19aab0bd00eb0efea7a22eddecf/pr-4401/project-settings-portable.png)

![Custom project icon rendered in Sidebar V2](https://raw.githubusercontent.com/colonelpanic8/t3code/010a6e79b705f19aab0bd00eb0efea7a22eddecf/pr-4401/custom-icon-sidebar.png)
<!-- /exact-stack-evidence-20260724 -->
