### PR TITLE
fix(client): self-heal empty thread details and back off failed thread subscriptions

### DIFF
--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -355,6 +355,135 @@ describe("environment RPC", () => {
     }),
   );
 
+  it.effect("grows the retry delay for consecutive expected failures", () =>
+    Effect.gen(function* () {
+      const domainError = new Error("thread not found yet");
+      const subscriptionCount = yield* Ref.make(0);
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.unwrap(
+            Ref.update(subscriptionCount, (count) => count + 1).pipe(
+              Effect.as(Stream.fail(domainError)),
+            ),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, supervisor } = yield* makeHarness();
+      const awaitSubscriptions = Effect.fn("TestEnvironmentRpc.awaitSubscriptions")(function* (
+        count: number,
+      ) {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if ((yield* Ref.get(subscriptionCount)) >= count) {
+            return;
+          }
+          yield* Effect.yieldNow;
+        }
+        return yield* Effect.die(new Error(`Expected ${count} subscriptions.`));
+      });
+      const settle = Effect.gen(function* () {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          yield* Effect.yieldNow;
+        }
+      });
+
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      const subscriptionFiber = yield* subscribe(
+        WS_METHODS.subscribeTerminalEvents,
+        {},
+        {
+          onExpectedFailure: () => Effect.void,
+          retryExpectedFailureAfter: (attempt) => 100 * 2 ** attempt,
+        },
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      yield* awaitSubscriptions(1);
+      yield* settle;
+
+      // First failure retries after the base delay.
+      yield* TestClock.adjust("100 millis");
+      yield* awaitSubscriptions(2);
+      yield* settle;
+
+      // Second failure doubles the delay: the base delay alone must not
+      // resubscribe, the remaining half must.
+      yield* TestClock.adjust("100 millis");
+      yield* settle;
+      expect(yield* Ref.get(subscriptionCount)).toBe(2);
+
+      yield* TestClock.adjust("100 millis");
+      yield* awaitSubscriptions(3);
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(subscriptionCount)).toBe(3);
+    }),
+  );
+
+  it.effect("resets the retry delay after a delivered element", () =>
+    Effect.gen(function* () {
+      const domainError = new Error("thread not found yet");
+      const subscriptionCount = yield* Ref.make(0);
+      const client = {
+        [WS_METHODS.subscribeTerminalEvents]: () =>
+          Stream.unwrap(
+            Ref.updateAndGet(subscriptionCount, (count) => count + 1).pipe(
+              Effect.map((count) =>
+                count === 2
+                  ? Stream.make("event" as never).pipe(Stream.concat(Stream.fail(domainError)))
+                  : Stream.fail(domainError),
+              ),
+            ),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { activeSession, supervisor } = yield* makeHarness();
+      const awaitSubscriptions = Effect.fn("TestEnvironmentRpc.awaitSubscriptions")(function* (
+        count: number,
+      ) {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if ((yield* Ref.get(subscriptionCount)) >= count) {
+            return;
+          }
+          yield* Effect.yieldNow;
+        }
+        return yield* Effect.die(new Error(`Expected ${count} subscriptions.`));
+      });
+      const settle = Effect.gen(function* () {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          yield* Effect.yieldNow;
+        }
+      });
+
+      yield* SubscriptionRef.set(activeSession, Option.some(session(client)));
+      const subscriptionFiber = yield* subscribe(
+        WS_METHODS.subscribeTerminalEvents,
+        {},
+        {
+          onExpectedFailure: () => Effect.void,
+          retryExpectedFailureAfter: (attempt) => 100 * 2 ** attempt,
+        },
+      ).pipe(
+        Stream.runDrain,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.forkChild,
+      );
+      yield* awaitSubscriptions(1);
+      yield* settle;
+
+      // The second subscription delivers an element before failing, which
+      // resets the backoff, so the third retry waits the base delay again.
+      yield* TestClock.adjust("100 millis");
+      yield* awaitSubscriptions(2);
+      yield* settle;
+
+      yield* TestClock.adjust("100 millis");
+      yield* awaitSubscriptions(3);
+      yield* Fiber.interrupt(subscriptionFiber);
+
+      expect(yield* Ref.get(subscriptionCount)).toBe(3);
+    }),
+  );
+
   it.effect("does not classify subscription defects as expected failures", () =>
     Effect.gen(function* () {
       const defect = new Error("subscription invariant failed");

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -152,7 +152,7 @@ interface SubscriptionOptions<TTag extends EnvironmentSubscriptionRpcTag> {
   readonly onExpectedFailure?: (
     cause: Cause.Cause<EnvironmentRpcStreamFailure<TTag>>,
   ) => Effect.Effect<void, never, never>;
-  readonly retryExpectedFailureAfter?: Duration.Input;
+  readonly retryExpectedFailureAfter?: Duration.Input | ((attempt: number) => Duration.Input);
   readonly resubscribe?: Stream.Stream<unknown, never, never>;
 }
 
@@ -189,6 +189,10 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                   EnvironmentRpcStreamValue<TTag>,
                   EnvironmentRpcStreamFailure<TTag>
                 >;
+                // Counts consecutive expected failures so retry backoff can
+                // grow; any delivered element proves the subscription works
+                // again and resets it.
+                let consecutiveExpectedFailures = 0;
                 const subscribeToSession = (): Stream.Stream<
                   EnvironmentRpcStreamValue<TTag>,
                   EnvironmentRpcStreamFailure<TTag>
@@ -198,6 +202,11 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                       makeInput(session).pipe(
                         Effect.map((input) =>
                           method(input).pipe(
+                            Stream.tap(() =>
+                              Effect.sync(() => {
+                                consecutiveExpectedFailures = 0;
+                              }),
+                            ),
                             Stream.catchCause((cause) => {
                               const hasOnlyExpectedFailures =
                                 cause.reasons.length > 0 &&
@@ -227,14 +236,18 @@ export function subscribeDynamic<TTag extends EnvironmentSubscriptionRpcTag>(
                                 const handled = Stream.fromEffect(
                                   options.onExpectedFailure(cause),
                                 ).pipe(Stream.drain);
-                                if (options.retryExpectedFailureAfter === undefined) {
+                                const retryAfter = options.retryExpectedFailureAfter;
+                                if (retryAfter === undefined) {
                                   return handled;
                                 }
+                                const delay =
+                                  typeof retryAfter === "function"
+                                    ? retryAfter(consecutiveExpectedFailures)
+                                    : retryAfter;
+                                consecutiveExpectedFailures += 1;
                                 return handled.pipe(
                                   Stream.concat(
-                                    Stream.fromEffect(
-                                      Effect.sleep(options.retryExpectedFailureAfter),
-                                    ).pipe(Stream.drain),
+                                    Stream.fromEffect(Effect.sleep(delay)).pipe(Stream.drain),
                                   ),
                                   Stream.concat(subscribeToSession()),
                                 );

--- a/packages/client-runtime/src/state/threads-sync.test.ts
+++ b/packages/client-runtime/src/state/threads-sync.test.ts
@@ -1,11 +1,13 @@
 import {
   EnvironmentId,
   EventId,
+  MessageId,
   ORCHESTRATION_WS_METHODS,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
   TurnId,
+  type OrchestrationMessage,
   type OrchestrationThread,
   type OrchestrationThreadDetailSnapshot,
   type OrchestrationThreadStreamItem,
@@ -53,6 +55,15 @@ const PREPARED: PreparedConnection = {
   httpAuthorization: null,
   target: TARGET,
 };
+const MESSAGE: OrchestrationMessage = {
+  id: MessageId.make("message-1"),
+  role: "user",
+  text: "Hello",
+  turnId: null,
+  streaming: false,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+};
 const BASE_THREAD: OrchestrationThread = {
   id: THREAD_ID,
   projectId: ProjectId.make("project-1"),
@@ -72,7 +83,7 @@ const BASE_THREAD: OrchestrationThread = {
   settledOverride: null,
   settledAt: null,
   deletedAt: null,
-  messages: [],
+  messages: [MESSAGE],
   proposedPlans: [],
   activities: [],
   checkpoints: [],
@@ -345,6 +356,55 @@ describe("EnvironmentThreads", () => {
     }),
   );
 
+  it.effect("reloads the HTTP snapshot when the cached thread has no messages", () =>
+    Effect.gen(function* () {
+      // A cached body without messages must not resume from its snapshot
+      // sequence: the events that carried the messages sit below it and would
+      // never be replayed.
+      const httpSequence = CACHED_SNAPSHOT_SEQUENCE + 2;
+      const harness = yield* makeHarness({
+        cached: { ...BASE_THREAD, messages: [] },
+        httpSnapshot: Option.some({
+          snapshotSequence: httpSequence,
+          thread: { ...BASE_THREAD, title: "HTTP title" },
+        }),
+      });
+      yield* Queue.offer(harness.inputs, titleUpdated("Live title", httpSequence + 1));
+
+      const state = yield* awaitThreadState(
+        harness.observed,
+        (value) =>
+          value.status === "live" &&
+          Option.isSome(value.data) &&
+          value.data.value.title === "Live title",
+      );
+
+      expect(Option.getOrThrow(state.data).messages).toEqual([MESSAGE]);
+      expect(yield* Ref.get(harness.loaderCalls)).toBe(1);
+      expect(yield* Ref.get(harness.lastSubscribeAfterSequence)).toBe(httpSequence);
+    }),
+  );
+
+  it.effect("resumes from the cached sequence when the snapshot reload yields nothing", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ cached: { ...BASE_THREAD, messages: [] } });
+      yield* Queue.offer(harness.inputs, titleUpdated("Live title", CACHED_SNAPSHOT_SEQUENCE + 1));
+
+      yield* awaitThreadState(
+        harness.observed,
+        (value) =>
+          value.status === "live" &&
+          Option.isSome(value.data) &&
+          value.data.value.title === "Live title",
+      );
+
+      // Offline/404: the reload attempt happened, but the subscription still
+      // degrades to resuming from the cached sequence.
+      expect(yield* Ref.get(harness.loaderCalls)).toBe(1);
+      expect(yield* Ref.get(harness.lastSubscribeAfterSequence)).toBe(CACHED_SNAPSHOT_SEQUENCE);
+    }),
+  );
+
   it.effect("reduces live events and persists the latest thread", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({ cached: BASE_THREAD });
@@ -560,6 +620,102 @@ describe("EnvironmentThreads", () => {
       expect(Option.isNone(recovered.error)).toBe(true);
       expect(yield* Ref.get(harness.subscriptionCount)).toBe(2);
       expect(yield* Ref.get(harness.retryCount)).toBe(0);
+    }),
+  );
+
+  it.effect("caps the retry backoff at 2 seconds while the thread has no data", () =>
+    Effect.gen(function* () {
+      // An unsent draft subscribes to a thread that does not exist yet; the
+      // moment the draft is submitted the thread must be picked up promptly,
+      // so the backoff must never exceed 2 seconds while there is no data.
+      const harness = yield* makeHarness();
+      const awaitSubscriptions = Effect.fn("TestEnvironmentThreads.awaitSubscriptions")(function* (
+        count: number,
+      ) {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if ((yield* Ref.get(harness.subscriptionCount)) >= count) {
+            return;
+          }
+          yield* Effect.yieldNow;
+        }
+        return yield* Effect.die(new Error(`Expected ${count} subscriptions.`));
+      });
+      const settle = Effect.gen(function* () {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          yield* Effect.yieldNow;
+        }
+      });
+      yield* awaitSubscriptions(1);
+
+      // Uncapped the fifth delay would be 4 seconds; with no data every delay
+      // from the fourth failure onward is capped at 2 seconds.
+      const delays = ["250 millis", "500 millis", "1 seconds", "2 seconds", "2 seconds"] as const;
+      for (const [index, delay] of delays.entries()) {
+        yield* Queue.offer(harness.inputs, new Error("thread not found yet"));
+        yield* awaitThreadState(harness.observed, (value) => Option.isSome(value.error));
+        yield* settle;
+        yield* TestClock.adjust(delay);
+        yield* awaitSubscriptions(index + 2);
+      }
+
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(delays.length + 1);
+    }),
+  );
+
+  it.effect("keeps the 10 second retry cap when cached data exists", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ cached: BASE_THREAD });
+      const awaitSubscriptions = Effect.fn("TestEnvironmentThreads.awaitSubscriptions")(function* (
+        count: number,
+      ) {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if ((yield* Ref.get(harness.subscriptionCount)) >= count) {
+            return;
+          }
+          yield* Effect.yieldNow;
+        }
+        return yield* Effect.die(new Error(`Expected ${count} subscriptions.`));
+      });
+      const settle = Effect.gen(function* () {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          yield* Effect.yieldNow;
+        }
+      });
+      const failOnce = Effect.gen(function* () {
+        yield* Queue.offer(harness.inputs, new Error("thread subscription rejected"));
+        yield* awaitThreadState(harness.observed, (value) => Option.isSome(value.error));
+        yield* settle;
+      });
+      yield* awaitSubscriptions(1);
+
+      const delays = ["250 millis", "500 millis", "1 seconds", "2 seconds"] as const;
+      for (const [index, delay] of delays.entries()) {
+        yield* failOnce;
+        yield* TestClock.adjust(delay);
+        yield* awaitSubscriptions(index + 2);
+      }
+
+      // Fifth failure: with data the delay keeps doubling past the no-data
+      // cap, so 2 seconds is not enough and the full 4 seconds is required.
+      yield* failOnce;
+      yield* TestClock.adjust("2 seconds");
+      yield* settle;
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(5);
+      yield* TestClock.adjust("2 seconds");
+      yield* awaitSubscriptions(6);
+
+      yield* failOnce;
+      yield* TestClock.adjust("8 seconds");
+      yield* awaitSubscriptions(7);
+
+      // Seventh failure: uncapped this would wait 16 seconds; the cap holds
+      // it at 10 seconds.
+      yield* failOnce;
+      yield* TestClock.adjust("8 seconds");
+      yield* settle;
+      expect(yield* Ref.get(harness.subscriptionCount)).toBe(7);
+      yield* TestClock.adjust("2 seconds");
+      yield* awaitSubscriptions(8);
     }),
   );
 

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -7,6 +7,7 @@ import {
   type ThreadId as ThreadIdType,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
@@ -48,6 +49,21 @@ function shouldPersistThread(thread: OrchestrationThread): boolean {
   return status !== "starting" && status !== "running";
 }
 
+// Unsent drafts legitimately subscribe to threads that do not exist server-side
+// yet, so expected failures can persist for minutes and must not hot-loop; the
+// first retry stays fast so transient errors still recover quickly. The cap has
+// two regimes: without data the thread likely does not exist yet and may be
+// created at any moment (draft submission), so retries must stay frequent
+// enough to pick it up promptly; once data exists a persistently failing
+// subscription can back way off.
+const RETRY_BASE_MILLIS = 250;
+const RETRY_CAP_NO_DATA_MILLIS = 2_000;
+const RETRY_CAP_WITH_DATA_MILLIS = 10_000;
+
+function retrySubscribeBackoff(attempt: number, capMillis: number): Duration.Duration {
+  return Duration.millis(Math.min(RETRY_BASE_MILLIS * 2 ** attempt, capMillis));
+}
+
 export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make")(function* (
   threadId: ThreadIdType,
 ) {
@@ -69,6 +85,10 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
     ),
   );
   const cachedThread = Option.map(cached, (snapshot) => snapshot.thread);
+  // The retry-delay callback runs synchronously, so track data presence in a
+  // plain flag (kept current by setThread/setDeleted) instead of reading the
+  // SubscriptionRef effectfully.
+  let hasData = Option.isSome(cachedThread);
   const state = yield* SubscriptionRef.make<EnvironmentThreadState>({
     data: cachedThread,
     status: statusWithoutLiveData(cachedThread),
@@ -144,6 +164,7 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   const setThread = Effect.fn("EnvironmentThreadState.setThread")(function* (
     thread: OrchestrationThread,
   ) {
+    hasData = true;
     const waiting = yield* Ref.get(awaitingCompletion);
     yield* SubscriptionRef.set(state, {
       data: Option.some(thread),
@@ -160,6 +181,7 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   });
 
   const setDeleted = Effect.fn("EnvironmentThreadState.setDeleted")(function* () {
+    hasData = false;
     yield* Ref.set(awaitingCompletion, false);
     yield* SubscriptionRef.set(state, {
       data: Option.none(),
@@ -252,7 +274,14 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
         yield* setSynchronizing;
 
         let current = yield* SubscriptionRef.get(state);
-        if (Option.isNone(current.data) && current.status !== "deleted") {
+        // A cached body with no messages but a current snapshot sequence would
+        // resume past the events that carried the messages and could never
+        // self-heal, so treat it like a cold cache and reload the snapshot.
+        // If the loader yields nothing (offline/404) we still resume from the
+        // cached sequence below, exactly as before.
+        const needsSnapshot =
+          Option.isNone(current.data) || current.data.value.messages.length === 0;
+        if (needsSnapshot && current.status !== "deleted") {
           const prepared = yield* SubscriptionRef.get(supervisor.prepared).pipe(
             Effect.flatMap(
               Option.match({
@@ -292,7 +321,11 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
       }),
       {
         onExpectedFailure: setStreamError,
-        retryExpectedFailureAfter: "250 millis",
+        retryExpectedFailureAfter: (attempt) =>
+          retrySubscribeBackoff(
+            attempt,
+            hasData ? RETRY_CAP_WITH_DATA_MILLIS : RETRY_CAP_NO_DATA_MILLIS,
+          ),
         resubscribe: foregroundResubscriptions,
       },
     ).pipe(Stream.runForEach(applyItem)),

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -88,7 +88,7 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   // The retry-delay callback runs synchronously, so track data presence in a
   // plain flag (kept current by setThread/setDeleted) instead of reading the
   // SubscriptionRef effectfully.
-  let hasData = Option.isSome(cachedThread);
+  let hasData = Option.isSome(cachedThread) && cachedThread.value.messages.length > 0;
   const state = yield* SubscriptionRef.make<EnvironmentThreadState>({
     data: cachedThread,
     status: statusWithoutLiveData(cachedThread),
@@ -164,7 +164,7 @@ export const makeEnvironmentThreadState = Effect.fn("EnvironmentThreadState.make
   const setThread = Effect.fn("EnvironmentThreadState.setThread")(function* (
     thread: OrchestrationThread,
   ) {
-    hasData = true;
+    hasData = thread.messages.length > 0;
     const waiting = yield* Ref.get(awaitingCompletion);
     yield* SubscriptionRef.set(state, {
       data: Option.some(thread),


### PR DESCRIPTION
## What Changed

Two client-runtime fixes for thread views that can render empty forever:

- **Self-heal empty cached thread bodies.** `makeEnvironmentThreadState` skipped the HTTP snapshot whenever any cached body existed and resumed the socket subscription from the cached snapshot sequence. If the cached body had no messages but a current sequence, the events that carried the messages were below the resume cursor and were never replayed — the thread rendered empty permanently, surviving app restarts. The subscription now reloads the HTTP snapshot whenever the cached body has no messages, and still degrades to today's sequence-resume when the loader yields nothing (offline/404).
- **Exponential backoff for expected subscription failures.** `subscribeDynamic`'s `retryExpectedFailureAfter` now also accepts `(attempt: number) => Duration.Input`, with the consecutive-failure counter reset by any delivered element. The thread subscription uses it: 250ms base, doubling, capped at **2s while the thread has no data** and **10s once data exists**. Existing plain-duration call sites are unchanged.

## Why

An unsent composer draft subscribes to its pre-allocated thread id before the thread exists server-side (intentionally, so the subscription picks the thread up the moment the draft is submitted). With the flat 250ms retry, every open draft hot-looped an HTTP snapshot fetch + socket subscribe into a 404 four times per second, indefinitely. Measured before: steady ~4 req/s for as long as a draft stays open. Measured after: 250ms → 500ms → 1s → 2s steady (≤2s worst-case pickup after the draft is submitted; verified live that draft submission still promotes promptly and the created thread's messages appear).

The 2s/10s split matters because the draft-promotion flow renders the message timeline from the thread-detail subscription: a thread with no data yet may be created at any moment and must be picked up quickly, while a thread that already has data and keeps failing can back way off.

The empty-cache self-heal closes the loop for users who already have a poisoned cache: previously nothing ever re-fetched the full body, so the thread stayed empty forever.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Validation:

```
vp check                # 0 errors
vp run typecheck        # exit 0
vp test run packages/client-runtime/src/state/threads-sync.test.ts packages/client-runtime/src/rpc/client.test.ts   # 28 passed
```

Plus a live pass in an isolated `vp run dev` environment: draft-open retry cadence measured at 250ms/500ms/1s/2s-steady (previously flat 250ms), draft submission still promotes and shows its messages, and existing threads render normally across reloads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread sync and retry behavior for all thread detail subscriptions; wrong backoff or snapshot logic could delay live updates or add extra HTTP load, but scope is client-runtime only with broad test coverage.
> 
> **Overview**
> Fixes thread views that could stay empty forever and stops draft subscriptions from hot-looping on 404s.
> 
> **Empty cached thread bodies** now trigger an HTTP snapshot reload before the live subscription resumes when the cached body has **no messages**, so replay does not skip message events below the cached sequence. If the loader returns nothing (offline/404), behavior falls back to resuming from the cached sequence as before.
> 
> **Expected subscription failures** use **exponential backoff** instead of a flat delay: `retryExpectedFailureAfter` accepts a duration or `(attempt) => duration`, consecutive failures increase the wait, and any delivered stream element resets the counter. Thread subscriptions use 250ms base doubling, capped at **2s without message data** (draft / not-yet-created threads) and **10s once data exists**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17b96ec7ef389cdcc351113e83514612b49dc72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread subscriptions to self-heal empty thread details and back off on repeated failures
> - When a cached thread has no messages, the client now reloads the HTTP snapshot before resuming the live subscription, falling back to the cached sequence if the reload yields nothing (e.g. offline/404).
> - Replaces the fixed `retryExpectedFailureAfter` delay with an exponential backoff via `retrySubscribeBackoff` in [`threads.ts`](https://github.com/pingdotgg/t3code/pull/4405/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815): capped at 2s when no data exists, 10s when cached data is present.
> - Extends `SubscriptionOptions.retryExpectedFailureAfter` in [`client.ts`](https://github.com/pingdotgg/t3code/pull/4405/files#diff-f60493a8e60511194714ca2543e1d58cfb8198eb71d2bf0c9655acdc93220c38) to accept a function `(attempt: number) => Duration.Input`, enabling per-attempt delay computation.
> - Backoff counter resets to zero whenever an element is delivered from the stream.
> - Behavioral Change: threads with empty cached message arrays now trigger an extra HTTP snapshot fetch before subscribing to live events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e17b96e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->