### PR TITLE
Improve composer glass fallbacks

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -453,6 +453,10 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     inset: 0;
     border: 1px solid var(--chat-composer-outline);
     border-radius: inherit;
+    content: "";
+  }
+
+  .chat-composer-glass-shell-with-context .chat-composer-glass-host::after {
     /* Keep the attachment seam open; the strip continues the outer outline below. */
     clip-path: polygon(
       0 0,
@@ -464,7 +468,6 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
       22px 100%,
       0 100%
     );
-    content: "";
   }
 
   .chat-composer-context-strip {
@@ -510,6 +513,36 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
       ),
       rgb(255 255 255 / 2%);
     box-shadow: 0 14px 32px -18px rgb(0 0 0 / 75%);
+  }
+
+  @supports not (clip-path: shape(from 0 0, line to 1px 1px)) {
+    .chat-composer-glass-shell-with-context::before {
+      inset-block-end: var(--chat-composer-context-extension);
+      border-radius: 22px;
+      clip-path: none;
+    }
+
+    .chat-composer-context-strip::before {
+      background: color-mix(
+        in srgb,
+        var(--chat-composer-glass-surface) var(--glass-opacity),
+        transparent
+      );
+      -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturation));
+      backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturation));
+    }
+
+    .dark .chat-composer-context-strip::before {
+      background:
+        linear-gradient(
+          to bottom,
+          transparent 0 1rem,
+          rgb(0 0 0 / 18%) 1rem,
+          transparent calc(1rem + 10px)
+        ),
+        linear-gradient(rgb(255 255 255 / 2%), rgb(255 255 255 / 2%)),
+        color-mix(in srgb, var(--chat-composer-glass-surface) var(--glass-opacity), transparent);
+    }
   }
 
   .alert-glass {


### PR DESCRIPTION
## Summary

- give the dark-mode context strip a subtle standalone outline and seam treatment while preserving the approved composer surface colors
- keep the composer's bottom border intact when no context strip is rendered
- add a rounded glass fallback for browsers that do not support `clip-path: shape()`

## Why

This follows up on #4404 after it merged. The dark strip needed the same clearly separated-but-connected treatment as light mode, and review identified two edge cases in the joined outline implementation: the unconditional bottom-border notch and the lack of a fallback for unsupported `shape()` clipping.

## Impact

The composer and context strip retain their existing layout and colors. Dark mode gets clearer strip separation, no-context composers keep a complete border, and unsupported browsers fall back to two independently rounded glass surfaces instead of a broken silhouette.

## Validation

- `vp fmt --check apps/web/src/index.css`
- `vp lint --report-unused-disable-directives apps/web/src/components/ChatView.tsx`
- `vp run typecheck` in `apps/web`
- `git diff --check`
- verified the joined composer, no-context border, and forced unsupported-`shape()` fallback in the paired test environment

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fallback rendering for composer glass context strip in browsers without `clip-path: shape()` support
> - Moves the seam `clip-path` from the base `.chat-composer-glass-host::after` rule to a more specific selector so clipping only applies inside `.chat-composer-glass-shell-with-context`.
> - Adds a `@supports not (clip-path: shape(...))` block in [index.css](https://github.com/pingdotgg/t3code/pull/4406/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) that provides glass backgrounds, backdrop blur/saturation, and restored 22px border-radius for the context strip and shell pseudo-elements in both light and dark themes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf724ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual fixes for the chat composer; no logic, data, or API changes.
> 
> **Overview**
> Fixes **chat composer glass** edge cases from the joined composer + context strip work.
> 
> The bottom **seam notch** on `.chat-composer-glass-host::after` now applies only when `.chat-composer-glass-shell-with-context` is present, so composers **without** a context strip keep a full rounded outline.
> 
> Adds a **`@supports not (clip-path: shape(...))`** block: the shell glass pseudo-element falls back to a **22px rounded** surface instead of the continuous `shape()` silhouette, and the context strip gets its own **glass + backdrop blur** (with dark-mode gradient layers layered on top of the glass mix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf724edbae8a356d8743ca3577681496215063c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->