### PR TITLE
[codex] Support multiple checkouts in workspace picker

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -1,6 +1,8 @@
-import { EnvironmentId, type VcsRef } from "@t3tools/contracts";
+import { EnvironmentId, ProjectId, type VcsRef } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildCheckoutWorkspaceChoices,
+  dedupeCheckoutOptions,
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
   resolveEnvironmentOptionLabel,
@@ -103,6 +105,90 @@ describe("resolvePreviousWorktreeLabel", () => {
     expect(resolvePreviousWorktreeLabel({ branch: null, worktreePath: "/wt" })).toBe(
       "Previous worktree",
     );
+  });
+});
+
+describe("buildCheckoutWorkspaceChoices", () => {
+  it("keeps every same-repository clone selectable as a checkout or worktree base", () => {
+    const firstProjectId = ProjectId.make("project-first-clone");
+    const secondProjectId = ProjectId.make("project-second-clone");
+
+    expect(
+      buildCheckoutWorkspaceChoices([
+        {
+          projectId: firstProjectId,
+          title: "t3code",
+          workspaceRoot: "/src/t3code",
+        },
+        {
+          projectId: secondProjectId,
+          title: "t3code-3",
+          workspaceRoot: "/src/t3code-3",
+        },
+      ]).map(({ projectId, mode }) => ({ projectId, mode })),
+    ).toEqual([
+      { projectId: firstProjectId, mode: "local" },
+      { projectId: firstProjectId, mode: "worktree" },
+      { projectId: secondProjectId, mode: "local" },
+      { projectId: secondProjectId, mode: "worktree" },
+    ]);
+  });
+});
+
+describe("dedupeCheckoutOptions", () => {
+  it("keeps the active project when duplicate normalized roots exist", () => {
+    const staleProjectId = ProjectId.make("project-stale");
+    const activeProjectId = ProjectId.make("project-active");
+
+    expect(
+      dedupeCheckoutOptions(
+        [
+          {
+            projectId: staleProjectId,
+            title: "Stale checkout",
+            workspaceRoot: "C:\\src\\t3code",
+          },
+          {
+            projectId: activeProjectId,
+            title: "Active checkout",
+            workspaceRoot: "C:/src/t3code",
+          },
+        ],
+        activeProjectId,
+      ),
+    ).toEqual([
+      {
+        projectId: activeProjectId,
+        title: "Active checkout",
+        workspaceRoot: "C:/src/t3code",
+      },
+    ]);
+  });
+
+  it("preserves checkouts that differ only by path casing", () => {
+    const lowerProjectId = ProjectId.make("project-lower");
+    const upperProjectId = ProjectId.make("project-upper");
+    const checkouts = [
+      { projectId: lowerProjectId, title: "Lowercase", workspaceRoot: "/src/t3code" },
+      { projectId: upperProjectId, title: "Uppercase", workspaceRoot: "/src/T3Code" },
+    ];
+
+    expect(dedupeCheckoutOptions(checkouts, lowerProjectId)).toEqual(checkouts);
+  });
+
+  it("deduplicates paths that differ only by trailing separators", () => {
+    const staleProjectId = ProjectId.make("project-trailing-slash");
+    const activeProjectId = ProjectId.make("project-no-trailing-slash");
+
+    expect(
+      dedupeCheckoutOptions(
+        [
+          { projectId: staleProjectId, title: "Stale", workspaceRoot: "/src/t3code/" },
+          { projectId: activeProjectId, title: "Active", workspaceRoot: "/src/t3code" },
+        ],
+        activeProjectId,
+      ).map((checkout) => checkout.projectId),
+    ).toEqual([activeProjectId]);
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentId, VcsRef, ProjectId } from "@t3tools/contracts";
+import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
 import * as Schema from "effect/Schema";
 import { toSortableTimestamp } from "../lib/threadSort";
 export {
@@ -13,8 +14,49 @@ export interface EnvironmentOption {
   isPrimary: boolean;
 }
 
+export interface CheckoutOption {
+  projectId: ProjectId;
+  title: string;
+  workspaceRoot: string;
+}
+
+export interface CheckoutWorkspaceChoice {
+  projectId: ProjectId;
+  mode: EnvMode;
+  value: string;
+}
+
+export function dedupeCheckoutOptions(
+  checkouts: readonly CheckoutOption[],
+  activeProjectId: ProjectId,
+): CheckoutOption[] {
+  const activeCheckout = checkouts.find((checkout) => checkout.projectId === activeProjectId);
+  const orderedCheckouts = activeCheckout
+    ? [activeCheckout, ...checkouts.filter((checkout) => checkout.projectId !== activeProjectId)]
+    : checkouts;
+  const seenWorkspaceRoots = new Set<string>();
+  return orderedCheckouts.filter((checkout) => {
+    const workspaceRoot = normalizeProjectPathForComparison(checkout.workspaceRoot);
+    if (seenWorkspaceRoots.has(workspaceRoot)) return false;
+    seenWorkspaceRoots.add(workspaceRoot);
+    return true;
+  });
+}
+
 export const EnvMode = Schema.Literals(["local", "worktree"]);
 export type EnvMode = typeof EnvMode.Type;
+
+export function buildCheckoutWorkspaceChoices(
+  checkouts: readonly CheckoutOption[],
+): CheckoutWorkspaceChoice[] {
+  return checkouts.flatMap((checkout) =>
+    (["local", "worktree"] as const).map((mode) => ({
+      projectId: checkout.projectId,
+      mode,
+      value: JSON.stringify([checkout.projectId, mode]),
+    })),
+  );
+}
 
 const GENERIC_LOCAL_ENVIRONMENT_LABELS = new Set(["local", "local environment"]);
 

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -15,6 +15,7 @@ import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { useProject, useThread, useThreadShellsForProjectRefs } from "../state/entities";
 import { useIsMobile } from "../hooks/useMediaQuery";
 import {
+  type CheckoutOption,
   type EnvMode,
   type EnvironmentOption,
   resolveCurrentWorkspaceLabel,
@@ -56,6 +57,8 @@ interface BranchToolbarProps {
   onComposerFocusRequest?: () => void;
   availableEnvironments?: readonly EnvironmentOption[];
   onEnvironmentChange?: (environmentId: EnvironmentId) => void;
+  availableCheckouts?: readonly CheckoutOption[];
+  onWorkspaceChange?: (projectId: CheckoutOption["projectId"], mode: EnvMode) => void;
 }
 
 interface MobileRunContextSelectorProps {
@@ -229,6 +232,8 @@ export const BranchToolbar = memo(function BranchToolbar({
   onComposerFocusRequest,
   availableEnvironments,
   onEnvironmentChange,
+  availableCheckouts,
+  onWorkspaceChange,
 }: BranchToolbarProps) {
   const threadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
@@ -340,6 +345,9 @@ export const BranchToolbar = memo(function BranchToolbar({
             onEnvModeChange={onEnvModeChange}
             previousWorktreeLabel={previousWorktreeLabel}
             onUsePreviousWorktree={onUsePreviousWorktree}
+            activeProjectId={activeProject.id}
+            availableCheckouts={availableCheckouts ?? []}
+            {...(onWorkspaceChange ? { onWorkspaceChange } : {})}
           />
         </div>
       )}

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -2,6 +2,8 @@ import { FolderGit2Icon, FolderGitIcon, FolderIcon, HistoryIcon } from "lucide-r
 import { memo, useMemo } from "react";
 
 import {
+  buildCheckoutWorkspaceChoices,
+  type CheckoutOption,
   resolveCurrentWorkspaceLabel,
   resolveEnvModeLabel,
   resolveLockedWorkspaceLabel,
@@ -24,8 +26,23 @@ interface BranchToolbarEnvModeSelectorProps {
   effectiveEnvMode: EnvMode;
   activeWorktreePath: string | null;
   onEnvModeChange: (mode: EnvMode) => void;
+  activeProjectId: CheckoutOption["projectId"];
+  availableCheckouts: readonly CheckoutOption[];
+  onWorkspaceChange?: (projectId: CheckoutOption["projectId"], mode: EnvMode) => void;
   previousWorktreeLabel?: string | null;
   onUsePreviousWorktree?: () => void;
+}
+
+function formatCheckoutPath(path: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  const homePrefix = "/Users/";
+  if (normalized.startsWith(homePrefix)) {
+    const segments = normalized.slice(homePrefix.length).split("/");
+    if (segments.length > 1) {
+      return `~/${segments.slice(1).join("/")}`;
+    }
+  }
+  return normalized;
 }
 
 export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSelector({
@@ -33,19 +50,54 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   effectiveEnvMode,
   activeWorktreePath,
   onEnvModeChange,
+  activeProjectId,
+  availableCheckouts,
+  onWorkspaceChange,
   previousWorktreeLabel,
   onUsePreviousWorktree,
 }: BranchToolbarEnvModeSelectorProps) {
   const showPreviousWorktree = Boolean(previousWorktreeLabel && onUsePreviousWorktree);
+  const hasMultipleCheckouts = availableCheckouts.length > 1 && onWorkspaceChange !== undefined;
+  const activeCheckout =
+    availableCheckouts.find((checkout) => checkout.projectId === activeProjectId) ?? null;
+  const checkoutChoices = useMemo(
+    () => buildCheckoutWorkspaceChoices(availableCheckouts),
+    [availableCheckouts],
+  );
+  const choiceValue = (projectId: CheckoutOption["projectId"], mode: EnvMode) =>
+    checkoutChoices.find((choice) => choice.projectId === projectId && choice.mode === mode)
+      ?.value ?? "";
   const envModeItems = useMemo(
-    () => [
-      { value: "local", label: resolveCurrentWorkspaceLabel(activeWorktreePath) },
-      { value: "worktree", label: resolveEnvModeLabel("worktree") },
-      ...(showPreviousWorktree && previousWorktreeLabel
-        ? [{ value: PREVIOUS_WORKTREE_SELECT_VALUE, label: previousWorktreeLabel }]
-        : []),
+    () =>
+      hasMultipleCheckouts
+        ? checkoutChoices.map((choice) => {
+            const checkout = availableCheckouts.find(
+              (candidate) => candidate.projectId === choice.projectId,
+            )!;
+            return {
+              value: choice.value,
+              label: `${checkout.title} — ${
+                choice.mode === "local"
+                  ? resolveCurrentWorkspaceLabel(activeWorktreePath)
+                  : resolveEnvModeLabel("worktree")
+              }`,
+            };
+          })
+        : [
+            { value: "local", label: resolveCurrentWorkspaceLabel(activeWorktreePath) },
+            { value: "worktree", label: resolveEnvModeLabel("worktree") },
+            ...(showPreviousWorktree && previousWorktreeLabel
+              ? [{ value: PREVIOUS_WORKTREE_SELECT_VALUE, label: previousWorktreeLabel }]
+              : []),
+          ],
+    [
+      activeWorktreePath,
+      availableCheckouts,
+      checkoutChoices,
+      hasMultipleCheckouts,
+      previousWorktreeLabel,
+      showPreviousWorktree,
     ],
-    [activeWorktreePath, previousWorktreeLabel, showPreviousWorktree],
   );
 
   if (envLocked) {
@@ -69,13 +121,22 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   return (
     <Select
       modal={false}
-      value={effectiveEnvMode}
-      onValueChange={(value: string | null) => {
+      value={
+        hasMultipleCheckouts ? choiceValue(activeProjectId, effectiveEnvMode) : effectiveEnvMode
+      }
+      onValueChange={(value) => {
         if (value === PREVIOUS_WORKTREE_SELECT_VALUE) {
           onUsePreviousWorktree?.();
           return;
         }
-        onEnvModeChange(value as EnvMode);
+        if (!hasMultipleCheckouts) {
+          onEnvModeChange(value as EnvMode);
+          return;
+        }
+        const selected = checkoutChoices.find((option) => option.value === value);
+        if (selected) {
+          onWorkspaceChange(selected.projectId, selected.mode);
+        }
       }}
       items={envModeItems}
     >
@@ -87,36 +148,82 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
         ) : (
           <FolderIcon className="size-3" />
         )}
-        <SelectValue />
+        {hasMultipleCheckouts && activeCheckout ? (
+          <span className="max-w-44 truncate">
+            {activeCheckout.title} ·{" "}
+            {effectiveEnvMode === "worktree"
+              ? resolveEnvModeLabel("worktree")
+              : resolveCurrentWorkspaceLabel(activeWorktreePath)}
+          </span>
+        ) : (
+          <SelectValue />
+        )}
       </SelectTrigger>
-      <SelectPopup>
-        <SelectGroup>
-          <SelectGroupLabel>Workspace</SelectGroupLabel>
-          <SelectItem value="local">
-            <span className="inline-flex items-center gap-1.5">
-              {activeWorktreePath ? (
-                <FolderGitIcon className="size-3" />
-              ) : (
-                <FolderIcon className="size-3" />
-              )}
-              {resolveCurrentWorkspaceLabel(activeWorktreePath)}
-            </span>
-          </SelectItem>
-          <SelectItem value="worktree">
-            <span className="inline-flex items-center gap-1.5">
-              <FolderGit2Icon className="size-3" />
-              {resolveEnvModeLabel("worktree")}
-            </span>
-          </SelectItem>
-          {showPreviousWorktree && previousWorktreeLabel ? (
-            <SelectItem value={PREVIOUS_WORKTREE_SELECT_VALUE}>
+      <SelectPopup matchTriggerWidth={!hasMultipleCheckouts}>
+        {hasMultipleCheckouts ? (
+          availableCheckouts.map((checkout) => (
+            <SelectGroup key={checkout.projectId}>
+              <SelectGroupLabel>
+                <span className="flex min-w-64 max-w-96 flex-col gap-0.5 py-0.5">
+                  <span className="truncate text-foreground">{checkout.title}</span>
+                  <span className="truncate font-normal text-muted-foreground/70">
+                    {formatCheckoutPath(checkout.workspaceRoot)}
+                  </span>
+                </span>
+              </SelectGroupLabel>
+              <SelectItem value={choiceValue(checkout.projectId, "local")}>
+                <span className="inline-flex items-center gap-1.5">
+                  <FolderIcon className="size-3" />
+                  Current checkout
+                </span>
+              </SelectItem>
+              <SelectItem value={choiceValue(checkout.projectId, "worktree")}>
+                <span className="inline-flex items-center gap-1.5">
+                  <FolderGit2Icon className="size-3" />
+                  New worktree…
+                </span>
+              </SelectItem>
+              {checkout.projectId === activeProjectId &&
+              showPreviousWorktree &&
+              previousWorktreeLabel ? (
+                <SelectItem value={PREVIOUS_WORKTREE_SELECT_VALUE}>
+                  <span className="inline-flex items-center gap-1.5">
+                    <HistoryIcon className="size-3" />
+                    {previousWorktreeLabel}
+                  </span>
+                </SelectItem>
+              ) : null}
+            </SelectGroup>
+          ))
+        ) : (
+          <SelectGroup>
+            <SelectGroupLabel>Workspace</SelectGroupLabel>
+            <SelectItem value="local">
               <span className="inline-flex items-center gap-1.5">
-                <HistoryIcon className="size-3" />
-                {previousWorktreeLabel}
+                {activeWorktreePath ? (
+                  <FolderGitIcon className="size-3" />
+                ) : (
+                  <FolderIcon className="size-3" />
+                )}
+                {resolveCurrentWorkspaceLabel(activeWorktreePath)}
               </span>
             </SelectItem>
-          ) : null}
-        </SelectGroup>
+            <SelectItem value="worktree">
+              <span className="inline-flex items-center gap-1.5">
+                <FolderGit2Icon className="size-3" />
+                {resolveEnvModeLabel("worktree")}
+              </span>
+            </SelectItem>
+            {showPreviousWorktree && previousWorktreeLabel ? (
+              <SelectItem value={PREVIOUS_WORKTREE_SELECT_VALUE}>
+                <span className="inline-flex items-center gap-1.5">
+                  <HistoryIcon className="size-3" />
+                  {previousWorktreeLabel}
+                </span>
+              </SelectItem>
+            ) : null}
+          </SelectGroup>
+        )}
       </SelectPopup>
     </Select>
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -223,7 +223,11 @@ import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
-import { resolveEffectiveEnvMode, resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
+import {
+  dedupeCheckoutOptions,
+  resolveEffectiveEnvMode,
+  resolveLocalCheckoutBranchMismatch,
+} from "./BranchToolbar.logic";
 import {
   getProviderStatusBannerKey,
   ProviderStatusBanner,
@@ -1669,6 +1673,22 @@ function ChatViewContent(props: ChatViewProps) {
     return envs;
   }, [activeProject, allProjects, projectGroupingSettings, primaryEnvironmentId, environmentById]);
   const hasMultipleEnvironments = logicalProjectEnvironments.length > 1;
+  const logicalProjectCheckouts = useMemo(() => {
+    if (!activeProject) return [];
+    const logicalKey = deriveLogicalProjectKeyFromSettings(activeProject, projectGroupingSettings);
+    const checkouts = allProjects
+      .filter(
+        (project) =>
+          project.environmentId === activeProject.environmentId &&
+          deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings) === logicalKey,
+      )
+      .map((project) => ({
+        projectId: project.id,
+        title: project.title,
+        workspaceRoot: project.workspaceRoot,
+      }));
+    return dedupeCheckoutOptions(checkouts, activeProject.id);
+  }, [activeProject, allProjects, projectGroupingSettings]);
 
   const openPullRequestDialog = useCallback(
     (reference?: string) => {
@@ -2440,6 +2460,32 @@ function ChatViewContent(props: ChatViewProps) {
       });
     },
     [draftId, envLocked, logicalProjectEnvironments, setDraftThreadContext],
+  );
+
+  const onWorkspaceChange = useCallback(
+    (projectId: ProjectId, mode: DraftThreadEnvMode) => {
+      if (envLocked || !draftId || !activeProject) return;
+      const target = logicalProjectCheckouts.find((checkout) => checkout.projectId === projectId);
+      if (!target) return;
+      setDraftThreadContext(draftId, {
+        projectRef: scopeProjectRef(activeProject.environmentId, target.projectId),
+        envMode: mode,
+        startFromOrigin: resolveNewDraftStartFromOrigin({
+          envMode: mode,
+          newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+        }),
+        ...(mode === "worktree" && draftThread?.worktreePath ? { worktreePath: null } : {}),
+      });
+    },
+    [
+      activeProject,
+      draftId,
+      draftThread?.worktreePath,
+      envLocked,
+      logicalProjectCheckouts,
+      primaryServerSettings.newWorktreesStartFromOrigin,
+      setDraftThreadContext,
+    ],
   );
 
   const activeTerminalGroup =
@@ -5892,6 +5938,10 @@ function ChatViewContent(props: ChatViewProps) {
                                   : {})}
                                 {...(hasMultipleEnvironments ? { onEnvironmentChange } : {})}
                                 availableEnvironments={logicalProjectEnvironments}
+                                availableCheckouts={logicalProjectCheckouts}
+                                {...(routeKind === "draft" && !isServerThread
+                                  ? { onWorkspaceChange }
+                                  : {})}
                               />
                             </div>
                           )}


### PR DESCRIPTION
## Problem

Repository grouping collapses projects with the same canonical repository into one logical project. When two independent clones of that repository are registered on the same environment, the new-thread workspace picker only exposed the representative clone. Users could not select the other checkout or use it as the base for a new worktree.

## Root cause

The workspace selector modeled only the workspace mode (`Current checkout` or `New worktree`). It did not retain the physical project dimension after the logical repository group was selected, even though draft sessions already support a scoped physical project reference.

## Fix

- Build checkout choices for every physical project in the selected logical repository and environment.
- Group the desktop workspace menu by checkout name and abbreviated path.
- Offer `Current checkout` and `New worktree…` beneath each checkout.
- Update the draft project reference and workspace mode together when a choice is selected.
- Preserve the existing compact selector when only one checkout is available.
- Keep the mobile selector unchanged for a separate follow-up.

<img width="558" height="568" alt="CleanShot 2026-07-24 at 00 45 41@2x" src="https://github.com/user-attachments/assets/8dfba5ae-130f-4b57-a91c-ba663822db21" />


## Verification

- `vp fmt --check` on all changed files
- `vp run --filter @t3tools/web typecheck`
- focused `BranchToolbar.logic.test.ts` suite: 39 passing tests
- targeted `vp lint`
- integrated disposable web environment with two clones of the same repository:
  - both clones appeared in one logical project
  - both checkout groups appeared in the workspace picker
  - selecting clone A's `New worktree…` made clone A the active base
  - selecting clone B's `Current checkout` switched the physical project to clone B


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple checkouts in the workspace picker of the branch toolbar
> - Adds `availableCheckouts` and `onWorkspaceChange` props to [`BranchToolbar`](https://github.com/pingdotgg/t3code/pull/4407/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) and [`BranchToolbarEnvModeSelector`](https://github.com/pingdotgg/t3code/pull/4407/files#diff-f6e603d70ca6bba6f4bb6ec0c74ab245223570c8a33c292fb1d25529770f3f67), enabling per-checkout local/worktree selection when multiple checkouts exist for the same logical project.
> - In [`ChatView`](https://github.com/pingdotgg/t3code/pull/4407/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), computes the list of logical project checkouts filtered by environment and de-duplicated by normalized path (preferring the active project), then wires `onWorkspaceChange` so selecting a checkout updates the draft thread's `projectRef`, `envMode`, and `startFromOrigin`.
> - Adds exported helpers [`buildCheckoutWorkspaceChoices`](https://github.com/pingdotgg/t3code/pull/4407/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f) and [`dedupeCheckoutOptions`](https://github.com/pingdotgg/t3code/pull/4407/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f) to generate selector entries and remove path duplicates respectively.
> - Behavioral Change: `onWorkspaceChange` is only active in draft mode and when the environment is not locked; single-checkout contexts preserve the original two-option behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e9d76d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and draft-context wiring only; no auth, server, or git execution paths. Wrong selection would affect which project a new draft targets.
> 
> **Overview**
> When a logical repository has **more than one physical clone** on the same environment, the desktop **workspace** control now lists each checkout instead of only toggling local vs new worktree for the current project.
> 
> **`BranchToolbar.logic`** adds `dedupeCheckoutOptions` (normalized roots, active project wins on duplicates) and `buildCheckoutWorkspaceChoices` (per-checkout `local` / `worktree` select values). **`ChatView`** builds `logicalProjectCheckouts` from the active logical group and wires **`onWorkspaceChange`** for draft threads so `projectRef`, `envMode`, `startFromOrigin`, and worktree path stay consistent when switching clone or mode.
> 
> **`BranchToolbarEnvModeSelector`** groups the menu by checkout title and abbreviated path, with **Current checkout** and **New worktree…** under each group; the trigger shows `title · mode` when multiple checkouts exist. Single-checkout and locked behavior is unchanged; **mobile** workspace UI is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9d76da8b367563ad0aca565814f5e7ae9bf7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->