### PR TITLE
fix(web): keep settled threads reachable when opened directly

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -155,6 +155,7 @@ import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
 import { NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
 import { useClientSettings, useEnvironmentSettings } from "../hooks/useSettings";
+import { useNowMinute } from "../hooks/useNowMinute";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
@@ -3823,17 +3824,7 @@ function ChatViewContent(props: ChatViewProps) {
     hasDedicatedWorktree: (activeThread?.worktreePath ?? null) !== null,
   });
   const supportsSettlement = serverConfig?.environment.capabilities.threadSettlement === true;
-  // Minute-quantized clock, same as the sidebar partition's: keeps this memo
-  // recomputing as time passes (inactivity auto-settle) without a per-render
-  // time source, and keeps banner and sidebar on the same tick.
-  const [nowMinute, setNowMinute] = useState(() => new Date().toISOString().slice(0, 16));
-  useEffect(() => {
-    const id = window.setInterval(
-      () => setNowMinute(new Date().toISOString().slice(0, 16)),
-      60_000,
-    );
-    return () => window.clearInterval(id);
-  }, []);
+  const nowMinute = useNowMinute();
   const activeThreadSettled = useMemo(() => {
     if (activeThreadShell === null || !supportsSettlement) return false;
     return effectiveSettled(activeThreadShell, {
@@ -3852,6 +3843,11 @@ function ChatViewContent(props: ChatViewProps) {
     reportFailure: false,
   });
   const [isUnsettling, setIsUnsettling] = useState(false);
+  // The pending flag belongs to the thread that was un-settled: navigating
+  // to another settled thread mid-flight must not show it as "Un-settling...".
+  useEffect(() => {
+    setIsUnsettling(false);
+  }, [activeThread?.id]);
   const handleUnsettleActiveThread = useCallback(async () => {
     if (!activeThreadRef) return;
     setIsUnsettling(true);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3842,15 +3842,15 @@ function ChatViewContent(props: ChatViewProps) {
   const unsettleThreadMutation = useAtomCommand(threadEnvironment.unsettle, {
     reportFailure: false,
   });
-  const [isUnsettling, setIsUnsettling] = useState(false);
-  // The pending flag belongs to the thread that was un-settled: navigating
-  // to another settled thread mid-flight must not show it as "Un-settling...".
-  useEffect(() => {
-    setIsUnsettling(false);
-  }, [activeThread?.id]);
+  // Keyed by thread, not a boolean: the pending state must follow the thread
+  // it belongs to across navigation, and a request resolving for thread A
+  // must never clear (or re-enable) thread B's button.
+  const [unsettlingThreadKey, setUnsettlingThreadKey] = useState<string | null>(null);
+  const isUnsettling = unsettlingThreadKey !== null && unsettlingThreadKey === activeThreadKey;
   const handleUnsettleActiveThread = useCallback(async () => {
     if (!activeThreadRef) return;
-    setIsUnsettling(true);
+    const threadKey = scopedThreadKey(activeThreadRef);
+    setUnsettlingThreadKey(threadKey);
     try {
       const result = await unsettleThreadMutation({
         environmentId: activeThreadRef.environmentId,
@@ -3867,7 +3867,7 @@ function ChatViewContent(props: ChatViewProps) {
         );
       }
     } finally {
-      setIsUnsettling(false);
+      setUnsettlingThreadKey((current) => (current === threadKey ? null : current));
     }
   }, [activeThreadRef, unsettleThreadMutation]);
   const [branchRepairAction, setBranchRepairAction] = useState<

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3823,14 +3823,31 @@ function ChatViewContent(props: ChatViewProps) {
     hasDedicatedWorktree: (activeThread?.worktreePath ?? null) !== null,
   });
   const supportsSettlement = serverConfig?.environment.capabilities.threadSettlement === true;
+  // Minute-quantized clock, same as the sidebar partition's: keeps this memo
+  // recomputing as time passes (inactivity auto-settle) without a per-render
+  // time source, and keeps banner and sidebar on the same tick.
+  const [nowMinute, setNowMinute] = useState(() => new Date().toISOString().slice(0, 16));
+  useEffect(() => {
+    const id = window.setInterval(
+      () => setNowMinute(new Date().toISOString().slice(0, 16)),
+      60_000,
+    );
+    return () => window.clearInterval(id);
+  }, []);
   const activeThreadSettled = useMemo(() => {
     if (activeThreadShell === null || !supportsSettlement) return false;
     return effectiveSettled(activeThreadShell, {
-      now: new Date().toISOString(),
+      now: `${nowMinute}:00.000Z`,
       autoSettleAfterDays,
       changeRequestState: activeThreadPr?.state ?? null,
     });
-  }, [activeThreadPr?.state, activeThreadShell, autoSettleAfterDays, supportsSettlement]);
+  }, [
+    activeThreadPr?.state,
+    activeThreadShell,
+    autoSettleAfterDays,
+    nowMinute,
+    supportsSettlement,
+  ]);
   const unsettleThreadMutation = useAtomCommand(threadEnvironment.unsettle, {
     reportFailure: false,
   });
@@ -3959,33 +3976,39 @@ function ChatViewContent(props: ChatViewProps) {
     switchGitRef,
     updateThreadMetadata,
   ]);
-  const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
-    const items = [...systemComposerBannerItems];
-    if (activeThreadSettled) {
-      items.push({
-        id: `thread-settled:${activeThread?.id ?? "unknown"}`,
-        variant: "info",
-        icon: <CheckCircle2Icon />,
-        title: "This thread is settled",
-        description: "Sending a message moves it back to Active in the sidebar.",
-        actions: (
-          <Button
-            size="xs"
-            variant="outline"
-            disabled={isUnsettling}
-            onClick={() => void handleUnsettleActiveThread()}
-          >
-            {isUnsettling ? "Un-settling..." : "Un-settle"}
-          </Button>
-        ),
-      });
+  // The stack renders items[0] front-most and tucks the rest behind hover, so
+  // ordering is priority: system banners, then the branch-mismatch warning,
+  // and the informational settled banner last — it must never cover a warning.
+  const settledComposerBannerItem = useMemo<ComposerBannerStackItem | null>(() => {
+    if (!activeThreadSettled) {
+      return null;
     }
+    return {
+      id: `thread-settled:${activeThread?.id ?? "unknown"}`,
+      variant: "info",
+      icon: <CheckCircle2Icon />,
+      title: "This thread is settled",
+      description: "Sending a message moves it back to Active in the sidebar.",
+      actions: (
+        <Button
+          size="xs"
+          variant="outline"
+          disabled={isUnsettling}
+          onClick={() => void handleUnsettleActiveThread()}
+        >
+          {isUnsettling ? "Un-settling..." : "Un-settle"}
+        </Button>
+      ),
+    };
+  }, [activeThread?.id, activeThreadSettled, handleUnsettleActiveThread, isUnsettling]);
+  const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
+    const settledItems = settledComposerBannerItem === null ? [] : [settledComposerBannerItem];
     if (!localCheckoutBranchMismatch) {
-      return items;
+      return [...systemComposerBannerItems, ...settledItems];
     }
     const isRepairingBranch = branchRepairAction !== null;
     return [
-      ...items,
+      ...systemComposerBannerItems,
       {
         id: `branch-mismatch:${activeThread?.id ?? "unknown"}:${localCheckoutBranchMismatch.threadBranch}:${localCheckoutBranchMismatch.currentBranch}`,
         variant: "warning",
@@ -4029,16 +4052,15 @@ function ChatViewContent(props: ChatViewProps) {
           </>
         ),
       },
+      ...settledItems,
     ];
   }, [
     activeThread?.id,
-    activeThreadSettled,
     branchRepairAction,
     handleSwitchCheckoutToThread,
-    handleUnsettleActiveThread,
     handleUpdateThreadToCheckout,
-    isUnsettling,
     localCheckoutBranchMismatch,
+    settledComposerBannerItem,
     systemComposerBannerItems,
   ]);
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -25,6 +25,7 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
+import { effectiveSettled } from "@t3tools/client-runtime/state/thread-settled";
 import {
   parseScopedThreadKey,
   scopedThreadKey,
@@ -138,7 +139,7 @@ import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
-import { ChevronDownIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
+import { CheckCircle2Icon, ChevronDownIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
@@ -153,7 +154,7 @@ import {
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
 import { NO_PROVIDER_MODEL_SELECTION } from "../providerInstances";
-import { useEnvironmentSettings } from "../hooks/useSettings";
+import { useClientSettings, useEnvironmentSettings } from "../hooks/useSettings";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
@@ -202,6 +203,7 @@ import {
   useThread,
   useThreadProposedPlans,
   useThreadRefs,
+  useThreadShell,
 } from "../state/entities";
 import { environmentShell } from "../state/shell";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
@@ -220,6 +222,7 @@ import {
   shouldShowProviderStatusBanner,
 } from "./chat/ProviderStatusBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
+import { resolveThreadPr } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -3809,6 +3812,51 @@ function ChatViewContent(props: ChatViewProps) {
         : null,
     [activeThreadBranch, activeWorktreePath, envMode, gitStatusQuery.data?.refName, isServerThread],
   );
+  // Settled state of the open thread, resolved exactly like the sidebar
+  // partition (same shell, same capability gate, same PR auto-settle input)
+  // so the banner and the sidebar row never disagree.
+  const activeThreadShell = useThreadShell(isServerThread ? activeThreadRef : null);
+  const autoSettleAfterDays = useClientSettings((settings) => settings.sidebarAutoSettleAfterDays);
+  const activeThreadPr = resolveThreadPr({
+    threadBranch: activeThread?.branch ?? null,
+    gitStatus: gitStatusQuery.data ?? null,
+    hasDedicatedWorktree: (activeThread?.worktreePath ?? null) !== null,
+  });
+  const supportsSettlement = serverConfig?.environment.capabilities.threadSettlement === true;
+  const activeThreadSettled = useMemo(() => {
+    if (activeThreadShell === null || !supportsSettlement) return false;
+    return effectiveSettled(activeThreadShell, {
+      now: new Date().toISOString(),
+      autoSettleAfterDays,
+      changeRequestState: activeThreadPr?.state ?? null,
+    });
+  }, [activeThreadPr?.state, activeThreadShell, autoSettleAfterDays, supportsSettlement]);
+  const unsettleThreadMutation = useAtomCommand(threadEnvironment.unsettle, {
+    reportFailure: false,
+  });
+  const [isUnsettling, setIsUnsettling] = useState(false);
+  const handleUnsettleActiveThread = useCallback(async () => {
+    if (!activeThreadRef) return;
+    setIsUnsettling(true);
+    try {
+      const result = await unsettleThreadMutation({
+        environmentId: activeThreadRef.environmentId,
+        input: { threadId: activeThreadRef.threadId, reason: "user" },
+      });
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to un-settle thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    } finally {
+      setIsUnsettling(false);
+    }
+  }, [activeThreadRef, unsettleThreadMutation]);
   const [branchRepairAction, setBranchRepairAction] = useState<
     "update-thread" | "switch-checkout" | null
   >(null);
@@ -3912,12 +3960,32 @@ function ChatViewContent(props: ChatViewProps) {
     updateThreadMetadata,
   ]);
   const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
+    const items = [...systemComposerBannerItems];
+    if (activeThreadSettled) {
+      items.push({
+        id: `thread-settled:${activeThread?.id ?? "unknown"}`,
+        variant: "info",
+        icon: <CheckCircle2Icon />,
+        title: "This thread is settled",
+        description: "Sending a message moves it back to Active in the sidebar.",
+        actions: (
+          <Button
+            size="xs"
+            variant="outline"
+            disabled={isUnsettling}
+            onClick={() => void handleUnsettleActiveThread()}
+          >
+            {isUnsettling ? "Un-settling..." : "Un-settle"}
+          </Button>
+        ),
+      });
+    }
     if (!localCheckoutBranchMismatch) {
-      return systemComposerBannerItems;
+      return items;
     }
     const isRepairingBranch = branchRepairAction !== null;
     return [
-      ...systemComposerBannerItems,
+      ...items,
       {
         id: `branch-mismatch:${activeThread?.id ?? "unknown"}:${localCheckoutBranchMismatch.threadBranch}:${localCheckoutBranchMismatch.currentBranch}`,
         variant: "warning",
@@ -3964,9 +4032,12 @@ function ChatViewContent(props: ChatViewProps) {
     ];
   }, [
     activeThread?.id,
+    activeThreadSettled,
     branchRepairAction,
     handleSwitchCheckoutToThread,
+    handleUnsettleActiveThread,
     handleUpdateThreadToCheckout,
+    isUnsettling,
     localCheckoutBranchMismatch,
     systemComposerBannerItems,
   ]);

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1223,11 +1223,24 @@ export default function SidebarV2() {
     lastSettledResetKeyRef.current = settledResetKey;
     setSettledVisibleCount(SETTLED_TAIL_INITIAL_COUNT);
   }
-  const hiddenSettledCount = Math.max(0, settledThreads.length - settledVisibleCount);
-  const visibleSettledThreads = useMemo(
-    () => (hiddenSettledCount > 0 ? settledThreads.slice(0, settledVisibleCount) : settledThreads),
-    [hiddenSettledCount, settledThreads, settledVisibleCount],
-  );
+  const visibleSettledThreads = useMemo(() => {
+    if (settledThreads.length <= settledVisibleCount) return settledThreads;
+    const visible = settledThreads.slice(0, settledVisibleCount);
+    // The open thread must never hide under "Show more": navigating into a
+    // deep settled thread (search, deep link) pulls its row into the visible
+    // tail so the highlight and the un-settle affordance stay reachable.
+    if (routeThreadKey !== null) {
+      const routeThread = settledThreads
+        .slice(settledVisibleCount)
+        .find(
+          (thread) =>
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
+        );
+      if (routeThread !== undefined) visible.push(routeThread);
+    }
+    return visible;
+  }, [routeThreadKey, settledThreads, settledVisibleCount]);
+  const hiddenSettledCount = settledThreads.length - visibleSettledThreads.length;
   const showMoreSettled = useCallback(
     () => setSettledVisibleCount((count) => count + SETTLED_TAIL_PAGE_COUNT),
     [],

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -78,6 +78,7 @@ import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
+import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
@@ -952,14 +953,7 @@ export default function SidebarV2() {
 
   // now is quantized to the minute so effectiveSettled memoization doesn't
   // churn on every render; auto-settle thresholds are day-granular anyway.
-  const [nowMinute, setNowMinute] = useState(() => new Date().toISOString().slice(0, 16));
-  useEffect(() => {
-    const id = window.setInterval(
-      () => setNowMinute(new Date().toISOString().slice(0, 16)),
-      60_000,
-    );
-    return () => window.clearInterval(id);
-  }, []);
+  const nowMinute = useNowMinute();
 
   // PR states stream in per-row (rows own the VCS subscriptions); a merged or
   // closed PR auto-settles its thread on the next partition.

--- a/apps/web/src/hooks/useNowMinute.ts
+++ b/apps/web/src/hooks/useNowMinute.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/** Minute-quantized clock ("YYYY-MM-DDTHH:MM") for settled-state resolution.
+    Quantizing keeps consumers on the same tick, so surfaces resolving
+    effectiveSettled against it (sidebar partition, composer banner) can
+    never disagree within a minute. */
+export function useNowMinute(): string {
+  const [nowMinute, setNowMinute] = useState(() => new Date().toISOString().slice(0, 16));
+  useEffect(() => {
+    const id = window.setInterval(
+      () => setNowMinute(new Date().toISOString().slice(0, 16)),
+      60_000,
+    );
+    return () => window.clearInterval(id);
+  }, []);
+  return nowMinute;
+}

--- a/apps/web/src/hooks/useNowMinute.ts
+++ b/apps/web/src/hooks/useNowMinute.ts
@@ -1,27 +1,63 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 /** Minute-quantized clock ("YYYY-MM-DDTHH:MM") for settled-state resolution.
-    Ticks are aligned to UTC minute boundaries — not offset from mount time —
-    so every consumer (sidebar partition, composer banner) crosses each minute
-    together and effectiveSettled can never disagree between surfaces. */
-export function useNowMinute(): string {
-  const [nowMinute, setNowMinute] = useState(() => new Date().toISOString().slice(0, 16));
-  useEffect(() => {
-    let intervalId: number | null = null;
-    const timeoutId = window.setTimeout(
-      () => {
-        setNowMinute(new Date().toISOString().slice(0, 16));
-        intervalId = window.setInterval(
-          () => setNowMinute(new Date().toISOString().slice(0, 16)),
-          60_000,
-        );
-      },
-      60_000 - (Date.now() % 60_000),
-    );
-    return () => {
-      window.clearTimeout(timeoutId);
-      if (intervalId !== null) window.clearInterval(intervalId);
-    };
-  }, []);
+    One module-level timer feeds every consumer through useSyncExternalStore,
+    so all surfaces resolving effectiveSettled against it (sidebar partition,
+    composer banner) share a single value by construction and tick on UTC
+    minute boundaries together. */
+
+function currentMinute(): string {
+  return new Date().toISOString().slice(0, 16);
+}
+
+let nowMinute = currentMinute();
+let timerId: number | null = null;
+let timerIsInterval = false;
+const listeners = new Set<() => void>();
+
+function tick(): void {
+  const next = currentMinute();
+  if (next !== nowMinute) {
+    nowMinute = next;
+    for (const listener of listeners) listener();
+  }
+}
+
+function startTimer(): void {
+  // Align to the next UTC minute boundary, then tick every 60s. Ticks re-read
+  // the clock, so a throttled or late timer self-corrects when it fires.
+  timerIsInterval = false;
+  timerId = window.setTimeout(
+    () => {
+      tick();
+      timerIsInterval = true;
+      timerId = window.setInterval(tick, 60_000);
+    },
+    60_000 - (Date.now() % 60_000),
+  );
+}
+
+function subscribe(listener: () => void): () => void {
+  if (listeners.size === 0) {
+    // The stored minute may have gone stale while no one was subscribed.
+    nowMinute = currentMinute();
+    startTimer();
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timerId !== null) {
+      if (timerIsInterval) window.clearInterval(timerId);
+      else window.clearTimeout(timerId);
+      timerId = null;
+    }
+  };
+}
+
+function getSnapshot(): string {
   return nowMinute;
+}
+
+export function useNowMinute(): string {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/apps/web/src/hooks/useNowMinute.ts
+++ b/apps/web/src/hooks/useNowMinute.ts
@@ -39,8 +39,6 @@ function startTimer(): void {
 
 function subscribe(listener: () => void): () => void {
   if (listeners.size === 0) {
-    // The stored minute may have gone stale while no one was subscribed.
-    nowMinute = currentMinute();
     startTimer();
   }
   listeners.add(listener);
@@ -55,6 +53,14 @@ function subscribe(listener: () => void): () => void {
 }
 
 function getSnapshot(): string {
+  // With no timer running (no subscribers yet — e.g. the first render after
+  // a full unmount), the stored minute may be stale; re-read it so a fresh
+  // mount renders the current minute instead of waiting for the first tick.
+  // While the timer runs the cached value is returned untouched, as
+  // useSyncExternalStore requires between change notifications.
+  if (timerId === null) {
+    nowMinute = currentMinute();
+  }
   return nowMinute;
 }
 

--- a/apps/web/src/hooks/useNowMinute.ts
+++ b/apps/web/src/hooks/useNowMinute.ts
@@ -1,17 +1,27 @@
 import { useEffect, useState } from "react";
 
 /** Minute-quantized clock ("YYYY-MM-DDTHH:MM") for settled-state resolution.
-    Quantizing keeps consumers on the same tick, so surfaces resolving
-    effectiveSettled against it (sidebar partition, composer banner) can
-    never disagree within a minute. */
+    Ticks are aligned to UTC minute boundaries — not offset from mount time —
+    so every consumer (sidebar partition, composer banner) crosses each minute
+    together and effectiveSettled can never disagree between surfaces. */
 export function useNowMinute(): string {
   const [nowMinute, setNowMinute] = useState(() => new Date().toISOString().slice(0, 16));
   useEffect(() => {
-    const id = window.setInterval(
-      () => setNowMinute(new Date().toISOString().slice(0, 16)),
-      60_000,
+    let intervalId: number | null = null;
+    const timeoutId = window.setTimeout(
+      () => {
+        setNowMinute(new Date().toISOString().slice(0, 16));
+        intervalId = window.setInterval(
+          () => setNowMinute(new Date().toISOString().slice(0, 16)),
+          60_000,
+        );
+      },
+      60_000 - (Date.now() % 60_000),
     );
-    return () => window.clearInterval(id);
+    return () => {
+      window.clearTimeout(timeoutId);
+      if (intervalId !== null) window.clearInterval(intervalId);
+    };
   }, []);
   return nowMinute;
 }


### PR DESCRIPTION
## Problem

Opening an old (settled) thread via search left you stuck:

- The thread's row sits below the "Show more" cutoff in the sidebar's settled tail, so there's no visible highlight and no reachable un-settle affordance.
- There was no indication in the thread view that the thread is settled, and no way to un-settle it without sending a message.

<img width="996" height="588" alt="image" src="https://github.com/user-attachments/assets/c590cfc0-67c3-45ca-b16b-1736ffc191b9" />


## Changes

**SidebarV2 — force-reveal the open thread.** When the route thread is settled and falls below the settled-tail paging cutoff, its row is appended to the bottom of the visible settled section (just above "Show more"). The active highlight and the hover un-settle action are therefore always reachable; the hidden count adjusts to match. No change when the thread is already visible or active.

**ChatView — settled banner above the composer.** When the open thread is settled, a banner in the existing `ComposerBannerStack` shows "This thread is settled — sending a message moves it back to Active in the sidebar" with an **Un-settle** button. The button issues the same `thread.unsettle` command (`reason: "user"`) the sidebar uses, so it pins the thread active against auto-settle; failures surface as an error toast.

Settled state is resolved with the exact same inputs as the sidebar partition (`effectiveSettled`, `sidebarAutoSettleAfterDays`, the `threadSettlement` capability gate, and PR state), so the banner and sidebar row can't disagree. Server threads only — never drafts.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean for touched files
- `apps/web` unit tests — 1465 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only behavior around settled-thread visibility and un-settle; reuses existing settlement APIs and mirrors sidebar logic to avoid state mismatch.
> 
> **Overview**
> Fixes the case where opening a **settled** thread via search or deep link left no sidebar highlight and no way to un-settle without sending a message.
> 
> **Sidebar:** If the routed thread is settled but past the settled-tail “Show more” cutoff, its row is **appended** to the visible settled list so selection and hover un-settle stay reachable; the hidden count is derived from what is actually shown.
> 
> **Chat:** When the open server thread is settled (same `effectiveSettled` inputs as the sidebar—shell, `sidebarAutoSettleAfterDays`, settlement capability, PR state), an **info** banner in `ComposerBannerStack` explains settled state and offers **Un-settle** via `threadEnvironment.unsettle` (`reason: "user"`), with per-thread pending state and error toasts. Banner ordering keeps system/branch notices above the settled banner.
> 
> **Shared clock:** New `useNowMinute` hook replaces Sidebar’s local minute interval so sidebar and chat share one UTC-aligned minute timer for auto-settle timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b16180afd6347a032b613c951d7f78ca82b404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep settled threads visible in sidebar and show Un-settle banner in composer
> - When a settled thread is opened directly, [SidebarV2](https://github.com/pingdotgg/t3code/pull/4413/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) now always includes it in the visible settled section, even if it would otherwise be hidden behind "Show more".
> - [ChatViewContent](https://github.com/pingdotgg/t3code/pull/4413/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) shows an informational banner in the composer when the active thread is settled, with an Un-settle button that calls `threadEnvironment.unsettle` and shows an error toast on failure.
> - A new shared [`useNowMinute`](https://github.com/pingdotgg/t3code/pull/4413/files#diff-96616a3e017330453b36c1791c6ec67080d03033df5fb41fa73e3fe6a885b1be) hook provides a minute-quantized UTC timestamp via a single module-level timer, replacing a local interval in `SidebarV2`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54b1618.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settled-thread indicators and an **Un-settle** action for active threads.
  * Added an informational banner when a thread is settled, while preserving higher-priority warnings.

* **Bug Fixes**
  * Active settled threads now remain visible in the sidebar, even when outside the current display limit.
  * Updated the sidebar’s hidden-thread count to accurately reflect visible routed threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->