### PR TITLE
fix: Claude Code skills discoverable for the composer $ picker

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,8 @@
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "catalog:",
     "effect": "catalog:",
-    "node-pty": "^1.1.0"
+    "node-pty": "^1.1.0",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -118,6 +118,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const { cwd } = yield* ServerConfig;
       const httpClient = yield* HttpClient.HttpClient;
@@ -165,9 +166,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         effectiveConfig,
         () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
         processEnv,
+        cwd,
       ).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
         Effect.provideService(Path.Path, path),
       );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -1,0 +1,137 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
+
+const writeSkill = Effect.fn(function* (
+  skillsDir: string,
+  directoryName: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const skillDir = path.join(skillsDir, directoryName);
+  yield* fs.makeDirectory(skillDir, { recursive: true });
+  yield* fs.writeFileString(path.join(skillDir, "SKILL.md"), contents);
+});
+
+it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
+  it.effect("discovers user and project skills with frontmatter metadata", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "codex-review",
+        [
+          "---",
+          "name: codex-review",
+          "description: Ask Codex for a review.",
+          "---",
+          "",
+          "# Body",
+        ].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".claude", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Deploy the app.", "---", "", "# Deploy"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+
+      assert.deepEqual(skills, [
+        {
+          name: "codex-review",
+          path: path.join(configDir, "skills", "codex-review", "SKILL.md"),
+          enabled: true,
+          scope: "user",
+          description: "Ask Codex for a review.",
+        },
+        {
+          name: "deploy",
+          path: path.join(workspace, ".claude", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Deploy the app.",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("prefers project skills over user skills on name collisions", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: User deploy.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(workspace, ".claude", "skills"),
+        "deploy",
+        ["---", "name: deploy", "description: Project deploy.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
+
+      assert.equal(skills.length, 1);
+      assert.equal(skills[0]?.scope, "project");
+      assert.equal(skills[0]?.description, "Project deploy.");
+    }),
+  );
+
+  it.effect("falls back to the directory name and tolerates malformed frontmatter", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const skillsDir = path.join(configDir, "skills");
+
+      yield* writeSkill(skillsDir, "no-frontmatter", "# Just a heading\n");
+      yield* writeSkill(skillsDir, "broken-yaml", "---\nname: [unclosed\n---\n");
+      // A stray file (not a directory with SKILL.md) must be skipped.
+      yield* fs.makeDirectory(skillsDir, { recursive: true });
+      yield* fs.writeFileString(path.join(skillsDir, "README.md"), "not a skill");
+
+      const skills = yield* discoverClaudeSkills({ homePath: configDir }, undefined);
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["broken-yaml", "no-frontmatter"],
+      );
+      assert.equal(
+        skills.every((skill) => skill.description === undefined),
+        true,
+      );
+    }),
+  );
+
+  it.effect("returns an empty list when no skill roots exist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+
+      const skills = yield* discoverClaudeSkills(
+        { homePath: path.join(tempDir, "missing-home") },
+        path.join(tempDir, "missing-workspace"),
+      );
+
+      assert.deepEqual(skills, []);
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -93,7 +93,7 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
-  it.effect("falls back to the directory name and tolerates malformed frontmatter", () =>
+  it.effect("falls back to the directory name and skips malformed frontmatter", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -109,14 +109,14 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
 
       const skills = yield* discoverClaudeSkills({ homePath: configDir }, undefined);
 
+      // A skill with no frontmatter falls back to its directory name; a skill
+      // whose frontmatter fails to parse is skipped entirely (Claude Code
+      // won't load it either).
       assert.deepEqual(
         skills.map((skill) => skill.name),
-        ["broken-yaml", "no-frontmatter"],
+        ["no-frontmatter"],
       );
-      assert.equal(
-        skills.every((skill) => skill.description === undefined),
-        true,
-      );
+      assert.equal(skills[0]?.description, undefined);
     }),
   );
 

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -120,6 +120,46 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
+  it.effect("honors CLAUDE_CONFIG_DIR from the environment when homePath is unset", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const environmentConfigDir = path.join(tempDir, "env-config");
+
+      yield* writeSkill(
+        path.join(environmentConfigDir, "skills"),
+        "env-skill",
+        ["---", "name: env-skill", "description: From env config dir.", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: "" }, undefined, {
+        CLAUDE_CONFIG_DIR: environmentConfigDir,
+      });
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["env-skill"],
+      );
+
+      // An explicit homePath wins over the environment variable, matching
+      // makeClaudeEnvironment which overwrites CLAUDE_CONFIG_DIR for the CLI.
+      const explicitHome = path.join(tempDir, "explicit-home");
+      yield* writeSkill(
+        path.join(explicitHome, "skills"),
+        "explicit-skill",
+        ["---", "name: explicit-skill", "---"].join("\n"),
+      );
+      const explicitSkills = yield* discoverClaudeSkills({ homePath: explicitHome }, undefined, {
+        CLAUDE_CONFIG_DIR: environmentConfigDir,
+      });
+      assert.deepEqual(
+        explicitSkills.map((skill) => skill.name),
+        ["explicit-skill"],
+      );
+    }),
+  );
+
   it.effect("returns an empty list when no skill roots exist", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -160,6 +160,34 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
+  it.effect("resolves a relative CLAUDE_CONFIG_DIR against the workspace cwd", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const workspace = path.join(tempDir, "workspace");
+      yield* fs.makeDirectory(workspace, { recursive: true });
+
+      // The spawned CLI resolves a relative CLAUDE_CONFIG_DIR against its own
+      // cwd (the workspace), so discovery must do the same.
+      yield* writeSkill(
+        path.join(workspace, "relative-config", "skills"),
+        "relative-skill",
+        ["---", "name: relative-skill", "---"].join("\n"),
+      );
+
+      const skills = yield* discoverClaudeSkills({ homePath: "" }, workspace, {
+        CLAUDE_CONFIG_DIR: "relative-config",
+      });
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["relative-skill"],
+      );
+      assert.equal(skills[0]?.scope, "user");
+    }),
+  );
+
   it.effect("returns an empty list when no skill roots exist", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -1,0 +1,121 @@
+/**
+ * ClaudeSkills — filesystem discovery of Claude Code skills for the `$` picker.
+ *
+ * Claude Code loads skills from `<config dir>/skills` (user scope) and
+ * `<cwd>/.claude/skills` (project scope), one directory per skill with a
+ * `SKILL.md` carrying YAML frontmatter. The Agent SDK init handshake surfaces
+ * skills only as slash commands without their filesystem paths, so the
+ * provider snapshot scans the same locations directly, mirroring how the
+ * Codex app-server reports its skills.
+ *
+ * @module provider/Drivers/ClaudeSkills
+ */
+import * as NodeOS from "node:os";
+
+import type { ClaudeSettings, ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import { parse as parseYamlDocument } from "yaml";
+
+import { expandHomePath } from "../../pathExpansion.ts";
+
+type ClaudeSkillScope = "user" | "project";
+
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+function parseSkillFrontmatter(contents: string): {
+  readonly name?: string;
+  readonly description?: string;
+} {
+  const match = FRONTMATTER_PATTERN.exec(contents);
+  if (!match) {
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYamlDocument(match[1] ?? "");
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return {};
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  const description = typeof record.description === "string" ? record.description.trim() : "";
+  return {
+    ...(name ? { name } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
+/**
+ * Resolve the Claude config directory the CLI would use: the instance's
+ * `homePath` (`CLAUDE_CONFIG_DIR`) when set, otherwise `~/.claude`.
+ */
+const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
+  config: Pick<ClaudeSettings, "homePath">,
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  const homePath = config.homePath.trim();
+  return homePath.length > 0
+    ? path.resolve(expandHomePath(homePath))
+    : path.join(NodeOS.homedir(), ".claude");
+});
+
+/**
+ * Enumerate Claude Code skills from the user config dir and the workspace.
+ * Discovery is best-effort: unreadable roots and malformed skill entries are
+ * skipped so a broken skill never degrades the provider snapshot. On name
+ * collisions the project-scoped skill wins, matching Claude Code's
+ * most-specific-wins resolution.
+ */
+export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* (
+  config: Pick<ClaudeSettings, "homePath">,
+  cwd?: string,
+): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const configDirPath = yield* resolveClaudeConfigDirPath(config);
+
+  const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
+    { directory: path.join(configDirPath, "skills"), scope: "user" },
+    ...(cwd ? [{ directory: path.join(cwd, ".claude", "skills"), scope: "project" as const }] : []),
+  ];
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+  for (const root of roots) {
+    const entries = yield* fileSystem
+      .readDirectory(root.directory)
+      .pipe(Effect.orElseSucceed((): ReadonlyArray<string> => []));
+
+    for (const entry of [...entries].sort()) {
+      const skillPath = path.join(root.directory, entry, "SKILL.md");
+      const contents = yield* fileSystem
+        .readFileString(skillPath)
+        .pipe(Effect.orElseSucceed(() => undefined));
+      if (contents === undefined) {
+        continue;
+      }
+
+      const frontmatter = parseSkillFrontmatter(contents);
+      const name = frontmatter.name ?? entry.trim();
+      if (!name) {
+        continue;
+      }
+
+      skillsByName.set(name, {
+        name,
+        path: skillPath,
+        enabled: true,
+        scope: root.scope,
+        ...(frontmatter.description ? { description: frontmatter.description } : {}),
+      });
+    }
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+});

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -64,6 +64,7 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
 const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
   config: Pick<ClaudeSettings, "homePath">,
   environment: NodeJS.ProcessEnv,
+  cwd?: string,
 ): Effect.fn.Return<string, never, Path.Path> {
   const path = yield* Path.Path;
   const homePath = config.homePath.trim();
@@ -72,10 +73,12 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
   }
   // No tilde expansion here: the spawned CLI receives this env var verbatim
   // (env vars are never shell-expanded), so a literal `~` must stay literal
-  // for discovery to scan the same directory the runtime would.
+  // for discovery to scan the same directory the runtime would. A relative
+  // value is resolved against the workspace cwd — the subprocess's own cwd —
+  // for the same reason.
   const environmentConfigDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
   if (environmentConfigDir.length > 0) {
-    return path.resolve(environmentConfigDir);
+    return cwd ? path.resolve(cwd, environmentConfigDir) : path.resolve(environmentConfigDir);
   }
   return path.join(NodeOS.homedir(), ".claude");
 });
@@ -94,7 +97,7 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
 ): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env);
+  const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env, cwd);
 
   const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
     { directory: path.join(configDirPath, "skills"), scope: "user" },

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -70,9 +70,12 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
   if (homePath.length > 0) {
     return path.resolve(expandHomePath(homePath));
   }
+  // No tilde expansion here: the spawned CLI receives this env var verbatim
+  // (env vars are never shell-expanded), so a literal `~` must stay literal
+  // for discovery to scan the same directory the runtime would.
   const environmentConfigDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
   if (environmentConfigDir.length > 0) {
-    return path.resolve(expandHomePath(environmentConfigDir));
+    return path.resolve(environmentConfigDir);
   }
   return path.join(NodeOS.homedir(), ".claude");
 });

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -53,17 +53,25 @@ function parseSkillFrontmatter(contents: string): {
 }
 
 /**
- * Resolve the Claude config directory the CLI would use: the instance's
- * `homePath` (`CLAUDE_CONFIG_DIR`) when set, otherwise `~/.claude`.
+ * Resolve the Claude config directory the CLI would use, matching the
+ * precedence the spawned CLI sees: the instance's `homePath` (exported as
+ * `CLAUDE_CONFIG_DIR` by `makeClaudeEnvironment`), then a `CLAUDE_CONFIG_DIR`
+ * already present in the process environment, then `~/.claude`.
  */
 const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
   config: Pick<ClaudeSettings, "homePath">,
+  environment: NodeJS.ProcessEnv,
 ): Effect.fn.Return<string, never, Path.Path> {
   const path = yield* Path.Path;
   const homePath = config.homePath.trim();
-  return homePath.length > 0
-    ? path.resolve(expandHomePath(homePath))
-    : path.join(NodeOS.homedir(), ".claude");
+  if (homePath.length > 0) {
+    return path.resolve(expandHomePath(homePath));
+  }
+  const environmentConfigDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
+  if (environmentConfigDir.length > 0) {
+    return path.resolve(expandHomePath(environmentConfigDir));
+  }
+  return path.join(NodeOS.homedir(), ".claude");
 });
 
 /**
@@ -76,10 +84,11 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
 export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* (
   config: Pick<ClaudeSettings, "homePath">,
   cwd?: string,
+  environment?: NodeJS.ProcessEnv,
 ): Effect.fn.Return<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const configDirPath = yield* resolveClaudeConfigDirPath(config);
+  const configDirPath = yield* resolveClaudeConfigDirPath(config, environment ?? process.env);
 
   const roots: ReadonlyArray<{ directory: string; scope: ClaudeSkillScope }> = [
     { directory: path.join(configDirPath, "skills"), scope: "user" },

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -24,29 +24,32 @@ type ClaudeSkillScope = "user" | "project";
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
-function parseSkillFrontmatter(contents: string): {
-  readonly name?: string;
-  readonly description?: string;
-} {
+type SkillFrontmatter =
+  | { readonly kind: "missing" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "parsed"; readonly name?: string; readonly description?: string };
+
+function parseSkillFrontmatter(contents: string): SkillFrontmatter {
   const match = FRONTMATTER_PATTERN.exec(contents);
   if (!match) {
-    return {};
+    return { kind: "missing" };
   }
 
   let parsed: unknown;
   try {
     parsed = parseYamlDocument(match[1] ?? "");
   } catch {
-    return {};
+    return { kind: "malformed" };
   }
   if (typeof parsed !== "object" || parsed === null) {
-    return {};
+    return { kind: "malformed" };
   }
 
   const record = parsed as Record<string, unknown>;
   const name = typeof record.name === "string" ? record.name.trim() : "";
   const description = typeof record.description === "string" ? record.description.trim() : "";
   return {
+    kind: "parsed",
     ...(name ? { name } : {}),
     ...(description ? { description } : {}),
   };
@@ -111,7 +114,14 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       }
 
       const frontmatter = parseSkillFrontmatter(contents);
-      const name = frontmatter.name ?? entry.trim();
+      // Malformed frontmatter means the skill won't load in Claude Code
+      // either — skip it rather than surfacing a broken entry under its
+      // directory name.
+      if (frontmatter.kind === "malformed") {
+        continue;
+      }
+
+      const name = (frontmatter.kind === "parsed" ? frontmatter.name : undefined) ?? entry.trim();
       if (!name) {
         continue;
       }
@@ -121,7 +131,9 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
         path: skillPath,
         enabled: true,
         scope: root.scope,
-        ...(frontmatter.description ? { description: frontmatter.description } : {}),
+        ...(frontmatter.kind === "parsed" && frontmatter.description
+          ? { description: frontmatter.description }
+          : {}),
       });
     }
   }

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -7,6 +7,7 @@ import {
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
@@ -40,6 +41,7 @@ import {
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
@@ -732,10 +734,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     claudeSettings: ClaudeSettings,
   ) => Effect.Effect<ClaudeCapabilitiesProbe | undefined>,
   environment?: NodeJS.ProcessEnv,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
-  ChildProcessSpawner.ChildProcessSpawner | Path.Path
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > {
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
@@ -845,6 +848,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
+  const skills = yield* discoverClaudeSkills(claudeSettings, cwd);
   const slashCommands = capabilities?.slashCommands ?? [];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
@@ -855,6 +859,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
       checkedAt,
       models,
       slashCommands: dedupedSlashCommands,
+      skills,
       probe: {
         installed: true,
         version: parsedVersion,
@@ -876,6 +881,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     checkedAt,
     models,
     slashCommands: dedupedSlashCommands,
+    skills,
     probe: {
       installed: true,
       version: parsedVersion,

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -848,7 +848,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
-  const skills = yield* discoverClaudeSkills(claudeSettings, cwd);
+  const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
   const slashCommands = capabilities?.slashCommands ?? [];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.78


### PR DESCRIPTION
## Problem

The composer's `$` skill selector only worked for Codex. The Codex driver populates the provider snapshot's `skills` array via the app-server's `skills/list` RPC, but the Claude provider never set `skills` at all, so `buildServerProvider` defaulted it to `[]` and the composer always showed "No skills found. Try / to browse provider commands."

## Fix

Add filesystem skill discovery to the Claude provider, mirroring what the Codex app-server does for Codex:

- **`ClaudeSkills.ts`** (new): scans `<config dir>/skills` (user scope — `CLAUDE_CONFIG_DIR` when the instance sets `homePath`, else `~/.claude`) and `<cwd>/.claude/skills` (project scope) for `<skill-dir>/SKILL.md`, parses YAML frontmatter for `name`/`description`, and maps entries into `ServerProviderSkill[]`. Project skills win name collisions (Claude Code's most-specific-wins resolution). Discovery is best-effort: unreadable roots, stray files, and malformed frontmatter are skipped rather than failing the snapshot; a frontmatter-less skill falls back to its directory name.
- **`ClaudeProvider.ts`**: `checkClaudeProviderStatus` now accepts the workspace `cwd`, runs discovery, and attaches `skills` to the ready/unverified-auth snapshots.
- **`ClaudeDriver.ts`**: passes `ServerConfig.cwd` and provides `FileSystem` to the status check.

The Agent SDK init handshake surfaces skills only as slash commands without filesystem paths, so scanning the same directories Claude Code loads from is the practical way to get paths + scopes for the picker.

No client changes needed — the web/mobile composers already render whatever `selectedProviderStatus.skills` contains.

## Testing

- New `ClaudeSkills.test.ts` covering user+project discovery, collision precedence, malformed-frontmatter/stray-file tolerance, and missing roots (4 tests).
- Existing `ProviderRegistry` / Claude probe suites pass (48 tests).
- `typecheck`, `lint`, `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only local filesystem discovery during provider status checks; failures are swallowed so snapshots stay available.
> 
> **Overview**
> **Claude provider snapshots now include filesystem-discovered skills** so the composer `$` picker can list them (previously only Codex populated `skills`).
> 
> Adds **`discoverClaudeSkills`**, which scans user `<configDir>/skills` and project `<cwd>/.claude/skills` for `SKILL.md` files, parses YAML frontmatter via the new **`yaml`** dependency, and returns `ServerProviderSkill` entries with scope and paths. Config dir resolution matches the spawned CLI (`homePath` → `CLAUDE_CONFIG_DIR` → `~/.claude`, with relative env paths resolved against workspace `cwd`). Project skills override user skills on name collisions; bad roots, missing files, and invalid frontmatter are skipped without failing the status check.
> 
> **`checkClaudeProviderStatus`** takes workspace `cwd`, runs discovery, and passes **`skills`** into **`buildServerProvider`** for both ready and auth-unknown paths. **`ClaudeDriver`** supplies `FileSystem` and passes `cwd` into the status check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be852bd89a80f3b67602301b9bc1cf4d67a850f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Claude Code skills discoverable via the composer `$` picker
> - Adds `discoverClaudeSkills` in [`ClaudeSkills.ts`](https://github.com/pingdotgg/t3code/pull/4414/files#diff-df655ed95ed759ff78376524f2ceda1b436b639952ddab7e7e19f618a43e77c3) to enumerate skills from two roots: `<configDir>/skills` (user scope) and `<cwd>/.claude/skills` (project scope), parsing YAML frontmatter from each `SKILL.md` file.
> - Config directory resolves with this precedence: `config.homePath`, then `CLAUDE_CONFIG_DIR` env var (resolved relative to workspace cwd), then `~/.claude`.
> - Project-scope skills take precedence over user-scope skills on name collisions; entries with missing frontmatter fall back to the directory name.
> - `checkClaudeProviderStatus` in [`ClaudeProvider.ts`](https://github.com/pingdotgg/t3code/pull/4414/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) now accepts an optional `cwd` and requires `FileSystem`, returning discovered skills in the `ServerProviderDraft`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7be852b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code skills are now automatically discovered and shown in the `$` picker.
  * Skills can be loaded from both user-level and project-level locations.
  * Skill names and descriptions are read from `SKILL.md` metadata.
  * Project-level skills take precedence when names overlap.

* **Bug Fixes**
  * Missing, unreadable, or malformed skill files no longer interrupt Claude provider status checks.
  * Skills are safely ignored when configured skill directories do not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->