### PR TITLE
fix: tone down branch-mismatch banner

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -12,16 +12,20 @@ import type { Thread } from "../types";
 import {
   MAX_HIDDEN_MOUNTED_PREVIEW_THREADS,
   MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
+  branchMismatchKey,
   buildExpiredTerminalContextToastCopy,
   buildThreadTurnInterruptInput,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  dismissBranchMismatchForSession,
   getStartedThreadModelChangeBlockReason,
   hasServerAcknowledgedLocalDispatch,
+  isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
+  shouldShowBranchMismatchBanner,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
 
@@ -289,6 +293,63 @@ describe("resolveSendEnvMode", () => {
   it("keeps worktree mode only for git repositories", () => {
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false })).toBe("local");
+  });
+});
+
+describe("branchMismatchKey", () => {
+  it("builds a key from thread id and both branches", () => {
+    expect(branchMismatchKey("thread-1", { threadBranch: "feat/a", currentBranch: "feat/b" })).toBe(
+      "thread-1:feat/a:feat/b",
+    );
+  });
+
+  it("returns null without a thread or mismatch", () => {
+    expect(branchMismatchKey(null, { threadBranch: "a", currentBranch: "b" })).toBeNull();
+    expect(branchMismatchKey("thread-1", null)).toBeNull();
+  });
+});
+
+describe("shouldShowBranchMismatchBanner", () => {
+  const base = {
+    hasMismatch: true,
+    isDismissed: false,
+    composerFocused: false,
+    composerHasContent: false,
+    wasShownForCurrentMismatch: false,
+  };
+
+  it("stays hidden during passive browsing", () => {
+    expect(shouldShowBranchMismatchBanner(base)).toBe(false);
+  });
+
+  it("shows on composer focus or content", () => {
+    expect(shouldShowBranchMismatchBanner({ ...base, composerFocused: true })).toBe(true);
+    expect(shouldShowBranchMismatchBanner({ ...base, composerHasContent: true })).toBe(true);
+  });
+
+  it("stays mounted after blur once shown for the current mismatch", () => {
+    expect(shouldShowBranchMismatchBanner({ ...base, wasShownForCurrentMismatch: true })).toBe(
+      true,
+    );
+  });
+
+  it("never shows when dismissed or without a mismatch", () => {
+    expect(
+      shouldShowBranchMismatchBanner({ ...base, composerFocused: true, isDismissed: true }),
+    ).toBe(false);
+    expect(
+      shouldShowBranchMismatchBanner({ ...base, composerFocused: true, hasMismatch: false }),
+    ).toBe(false);
+  });
+});
+
+describe("session branch mismatch dismissal", () => {
+  it("tracks dismissed keys and treats other keys as active", () => {
+    expect(isBranchMismatchDismissedForSession("t1:a:b")).toBe(false);
+    dismissBranchMismatchForSession("t1:a:b");
+    expect(isBranchMismatchDismissedForSession("t1:a:b")).toBe(true);
+    expect(isBranchMismatchDismissedForSession("t1:a:c")).toBe(false);
+    expect(isBranchMismatchDismissedForSession(null)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -313,21 +313,19 @@ describe("shouldShowBranchMismatchBanner", () => {
   const base = {
     hasMismatch: true,
     isDismissed: false,
-    composerFocused: false,
     composerHasContent: false,
     wasShownForCurrentMismatch: false,
   };
 
-  it("stays hidden during passive browsing", () => {
+  it("stays hidden during passive browsing (even though the composer autofocuses)", () => {
     expect(shouldShowBranchMismatchBanner(base)).toBe(false);
   });
 
-  it("shows on composer focus or content", () => {
-    expect(shouldShowBranchMismatchBanner({ ...base, composerFocused: true })).toBe(true);
+  it("shows once the composer has draft content", () => {
     expect(shouldShowBranchMismatchBanner({ ...base, composerHasContent: true })).toBe(true);
   });
 
-  it("stays mounted after blur once shown for the current mismatch", () => {
+  it("stays mounted after the draft clears once shown for the current mismatch", () => {
     expect(shouldShowBranchMismatchBanner({ ...base, wasShownForCurrentMismatch: true })).toBe(
       true,
     );
@@ -335,10 +333,10 @@ describe("shouldShowBranchMismatchBanner", () => {
 
   it("never shows when dismissed or without a mismatch", () => {
     expect(
-      shouldShowBranchMismatchBanner({ ...base, composerFocused: true, isDismissed: true }),
+      shouldShowBranchMismatchBanner({ ...base, composerHasContent: true, isDismissed: true }),
     ).toBe(false);
     expect(
-      shouldShowBranchMismatchBanner({ ...base, composerFocused: true, hasMismatch: false }),
+      shouldShowBranchMismatchBanner({ ...base, composerHasContent: true, hasMismatch: false }),
     ).toBe(false);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -289,6 +289,45 @@ export function buildExpiredTerminalContextToastCopy(
   };
 }
 
+export function branchMismatchKey(
+  threadId: string | null,
+  mismatch: { threadBranch: string; currentBranch: string } | null,
+): string | null {
+  if (!threadId || !mismatch) {
+    return null;
+  }
+  return `${threadId}:${mismatch.threadBranch}:${mismatch.currentBranch}`;
+}
+
+// The mismatch banner only matters when the user is about to send: passive
+// reading of an old thread carries no risk (the branch picker tint already
+// covers ambient awareness). `wasShownForCurrentMismatch` keeps the banner
+// mounted once revealed so it doesn't flicker away when the composer blurs.
+export function shouldShowBranchMismatchBanner(input: {
+  hasMismatch: boolean;
+  isDismissed: boolean;
+  composerFocused: boolean;
+  composerHasContent: boolean;
+  wasShownForCurrentMismatch: boolean;
+}): boolean {
+  if (!input.hasMismatch || input.isDismissed) {
+    return false;
+  }
+  return input.composerFocused || input.composerHasContent || input.wasShownForCurrentMismatch;
+}
+
+// Session-scoped (module-level so it survives ChatView remounts, e.g. route
+// changes). Durable cross-device dismissal is planned as a server-side ack.
+const sessionDismissedBranchMismatchKeys = new Set<string>();
+
+export function dismissBranchMismatchForSession(key: string): void {
+  sessionDismissedBranchMismatchKeys.add(key);
+}
+
+export function isBranchMismatchDismissedForSession(key: string | null): boolean {
+  return key !== null && sessionDismissedBranchMismatchKeys.has(key);
+}
+
 export function threadHasStarted(thread: Thread | null | undefined): boolean {
   return Boolean(
     thread && (thread.latestTurn !== null || thread.messages.length > 0 || thread.session !== null),

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -301,19 +301,20 @@ export function branchMismatchKey(
 
 // The mismatch banner only matters when the user is about to send: passive
 // reading of an old thread carries no risk (the branch picker tint already
-// covers ambient awareness). `wasShownForCurrentMismatch` keeps the banner
-// mounted once revealed so it doesn't flicker away when the composer blurs.
+// covers ambient awareness). Draft content is the intent signal — composer
+// focus is useless here because ChatView autofocuses the composer on every
+// thread open. `wasShownForCurrentMismatch` keeps the banner mounted once
+// revealed so it doesn't flicker away when the draft is cleared.
 export function shouldShowBranchMismatchBanner(input: {
   hasMismatch: boolean;
   isDismissed: boolean;
-  composerFocused: boolean;
   composerHasContent: boolean;
   wasShownForCurrentMismatch: boolean;
 }): boolean {
   if (!input.hasMismatch || input.isDismissed) {
     return false;
   }
-  return input.composerFocused || input.composerHasContent || input.wasShownForCurrentMismatch;
+  return input.composerHasContent || input.wasShownForCurrentMismatch;
 }
 
 // Session-scoped (module-level so it survives ChatView remounts, e.g. route

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3825,9 +3825,8 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const [isRestoringThreadBranch, setIsRestoringThreadBranch] = useState(false);
   const [branchRestoreConfirmOpen, setBranchRestoreConfirmOpen] = useState(false);
-  const [composerIntentFocused, setComposerIntentFocused] = useState(false);
-  // Once revealed for a given mismatch, the banner stays mounted through
-  // composer blur so it doesn't flicker in and out while the user works.
+  // Once revealed for a given mismatch, the banner stays mounted until the
+  // mismatch changes or resolves, so clearing the draft doesn't flicker it.
   const [revealedBranchMismatchKey, setRevealedBranchMismatchKey] = useState<string | null>(null);
   // Dismissal lives in a module-level set (survives remounts); this tick just
   // forces a re-render so the banner leaves immediately.
@@ -3851,15 +3850,19 @@ function ChatViewContent(props: ChatViewProps) {
   const showBranchMismatchBanner = shouldShowBranchMismatchBanner({
     hasMismatch: localCheckoutBranchMismatch !== null,
     isDismissed: isBranchMismatchDismissedForSession(activeBranchMismatchKey),
-    composerFocused: composerIntentFocused,
     composerHasContent: composerHasDraftContent,
     wasShownForCurrentMismatch:
       revealedBranchMismatchKey !== null && revealedBranchMismatchKey === activeBranchMismatchKey,
   });
   useEffect(() => {
-    if (showBranchMismatchBanner) {
-      setRevealedBranchMismatchKey(activeBranchMismatchKey);
-    }
+    setRevealedBranchMismatchKey((revealed) => {
+      if (showBranchMismatchBanner) {
+        return activeBranchMismatchKey;
+      }
+      // Hysteresis is scoped to an uninterrupted mismatch: reset when the
+      // mismatch resolves or changes so a recurrence re-gates on intent.
+      return revealed !== null && revealed !== activeBranchMismatchKey ? null : revealed;
+    });
   }, [activeBranchMismatchKey, showBranchMismatchBanner]);
   const handleSwitchCheckoutToThread = useCallback(async () => {
     if (
@@ -5618,20 +5621,7 @@ function ChatViewContent(props: ChatViewProps) {
                       )}
                     >
                       <div className="chat-composer-glass-host relative z-10 w-full rounded-[22px]">
-                        <div
-                          ref={attachDraftHeroComposerAnchorRef}
-                          className="relative z-10"
-                          onFocusCapture={() => setComposerIntentFocused(true)}
-                          onBlurCapture={(event) => {
-                            if (
-                              event.relatedTarget instanceof Node &&
-                              event.currentTarget.contains(event.relatedTarget)
-                            ) {
-                              return;
-                            }
-                            setComposerIntentFocused(false);
-                          }}
-                        >
+                        <div ref={attachDraftHeroComposerAnchorRef} className="relative z-10">
                           <ChatComposer
                             composerRef={composerRef}
                             composerDraftTarget={composerDraftTarget}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -138,7 +138,7 @@ import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
-import { ChevronDownIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
+import { ChevronDownIcon, GitBranchIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
@@ -231,13 +231,17 @@ import {
 } from "./chat/draftHeroTransition";
 import {
   MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
+  branchMismatchKey,
   buildExpiredTerminalContextToastCopy,
   buildLocalDraftThread,
   buildThreadTurnInterruptInput,
   collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
+  dismissBranchMismatchForSession,
   hasServerAcknowledgedLocalDispatch,
+  isBranchMismatchDismissedForSession,
+  shouldShowBranchMismatchBanner,
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
@@ -260,6 +264,16 @@ import { RightPanelSheet } from "./RightPanelSheet";
 import { previewEnvironment } from "../state/preview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { Button } from "./ui/button";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import { ServerUpdateAction } from "./ServerUpdateAction";
 import {
   buildVersionMismatchDismissalKey,
@@ -3809,52 +3823,54 @@ function ChatViewContent(props: ChatViewProps) {
         : null,
     [activeThreadBranch, activeWorktreePath, envMode, gitStatusQuery.data?.refName, isServerThread],
   );
-  const [branchRepairAction, setBranchRepairAction] = useState<
-    "update-thread" | "switch-checkout" | null
-  >(null);
-  const handleUpdateThreadToCheckout = useCallback(async () => {
-    if (!activeThread || !localCheckoutBranchMismatch || branchRepairAction !== null) {
-      return;
-    }
-    setBranchRepairAction("update-thread");
-    const updateResult = await updateThreadMetadata({
-      environmentId,
-      input: {
-        threadId: activeThread.id,
-        branch: localCheckoutBranchMismatch.currentBranch,
-        worktreePath: null,
-      },
-    });
-    setBranchRepairAction(null);
-    if (updateResult._tag === "Failure" && !isAtomCommandInterrupted(updateResult)) {
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Failed to update thread branch",
-          description: chatActionErrorMessage(squashAtomCommandFailure(updateResult)),
-        }),
-      );
-      return;
-    }
-    scheduleComposerFocus();
-  }, [
-    activeThread,
-    branchRepairAction,
-    environmentId,
+  const [isRestoringThreadBranch, setIsRestoringThreadBranch] = useState(false);
+  const [branchRestoreConfirmOpen, setBranchRestoreConfirmOpen] = useState(false);
+  const [composerIntentFocused, setComposerIntentFocused] = useState(false);
+  // Once revealed for a given mismatch, the banner stays mounted through
+  // composer blur so it doesn't flicker in and out while the user works.
+  const [revealedBranchMismatchKey, setRevealedBranchMismatchKey] = useState<string | null>(null);
+  // Dismissal lives in a module-level set (survives remounts); this tick just
+  // forces a re-render so the banner leaves immediately.
+  const [, setBranchMismatchDismissTick] = useState(0);
+  const composerHasDraftContent = useComposerDraftStore((store) => {
+    const draft = store.getComposerDraft(composerDraftTarget);
+    return Boolean(
+      draft &&
+      (draft.prompt.trim().length > 0 ||
+        draft.images.length > 0 ||
+        draft.terminalContexts.length > 0 ||
+        draft.elementContexts.length > 0 ||
+        draft.previewAnnotations.length > 0 ||
+        draft.reviewComments.length > 0),
+    );
+  });
+  const activeBranchMismatchKey = branchMismatchKey(
+    activeThread?.id ?? null,
     localCheckoutBranchMismatch,
-    scheduleComposerFocus,
-    updateThreadMetadata,
-  ]);
+  );
+  const showBranchMismatchBanner = shouldShowBranchMismatchBanner({
+    hasMismatch: localCheckoutBranchMismatch !== null,
+    isDismissed: isBranchMismatchDismissedForSession(activeBranchMismatchKey),
+    composerFocused: composerIntentFocused,
+    composerHasContent: composerHasDraftContent,
+    wasShownForCurrentMismatch:
+      revealedBranchMismatchKey !== null && revealedBranchMismatchKey === activeBranchMismatchKey,
+  });
+  useEffect(() => {
+    if (showBranchMismatchBanner) {
+      setRevealedBranchMismatchKey(activeBranchMismatchKey);
+    }
+  }, [activeBranchMismatchKey, showBranchMismatchBanner]);
   const handleSwitchCheckoutToThread = useCallback(async () => {
     if (
       !activeProjectCwd ||
       !activeThread ||
       !localCheckoutBranchMismatch ||
-      branchRepairAction !== null
+      isRestoringThreadBranch
     ) {
       return;
     }
-    setBranchRepairAction("switch-checkout");
+    setIsRestoringThreadBranch(true);
     const checkoutResult = await switchGitRef({
       environmentId,
       input: {
@@ -3863,7 +3879,7 @@ function ChatViewContent(props: ChatViewProps) {
       },
     });
     if (checkoutResult._tag === "Failure") {
-      setBranchRepairAction(null);
+      setIsRestoringThreadBranch(false);
       if (!isAtomCommandInterrupted(checkoutResult)) {
         toastManager.add(
           stackedThreadToast({
@@ -3883,7 +3899,7 @@ function ChatViewContent(props: ChatViewProps) {
         input: { threadId: activeThread.id, branch: nextBranch, worktreePath: null },
       });
       if (updateResult._tag === "Failure") {
-        setBranchRepairAction(null);
+        setIsRestoringThreadBranch(false);
         if (!isAtomCommandInterrupted(updateResult)) {
           toastManager.add(
             stackedThreadToast({
@@ -3898,76 +3914,78 @@ function ChatViewContent(props: ChatViewProps) {
       }
     }
     gitStatusQuery.refresh();
-    setBranchRepairAction(null);
+    setIsRestoringThreadBranch(false);
     scheduleComposerFocus();
   }, [
     activeProjectCwd,
     activeThread,
-    branchRepairAction,
     environmentId,
     gitStatusQuery,
+    isRestoringThreadBranch,
     localCheckoutBranchMismatch,
     scheduleComposerFocus,
     switchGitRef,
     updateThreadMetadata,
   ]);
+  const handleRestoreThreadBranch = useCallback(() => {
+    if (gitStatusQuery.data?.hasWorkingTreeChanges) {
+      setBranchRestoreConfirmOpen(true);
+      return;
+    }
+    void handleSwitchCheckoutToThread();
+  }, [gitStatusQuery.data?.hasWorkingTreeChanges, handleSwitchCheckoutToThread]);
   const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
-    if (!localCheckoutBranchMismatch) {
+    if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return systemComposerBannerItems;
     }
-    const isRepairingBranch = branchRepairAction !== null;
     return [
       ...systemComposerBannerItems,
       {
-        id: `branch-mismatch:${activeThread?.id ?? "unknown"}:${localCheckoutBranchMismatch.threadBranch}:${localCheckoutBranchMismatch.currentBranch}`,
-        variant: "warning",
-        icon: <TriangleAlertIcon />,
-        title: "You're on a different branch",
-        className:
-          "text-base sm:text-sm [&>div]:items-start max-sm:[&>div]:flex-wrap max-sm:[&>div>div:last-child]:w-full max-sm:[&>div>div:last-child]:self-start dark:shadow-none",
-        actionClassName:
-          "max-sm:w-full max-sm:border-t max-sm:border-border/60 max-sm:pt-2 max-sm:pl-6 sm:border-l sm:border-border/60 sm:pl-3",
-        description: (
-          <p className="text-pretty">
-            This thread is on{" "}
-            <code className="font-medium text-foreground">
-              {localCheckoutBranchMismatch.threadBranch}
-            </code>
-            , but you're currently checked out at{" "}
-            <code className="font-medium text-foreground">
-              {localCheckoutBranchMismatch.currentBranch}
-            </code>
-            . Sending a message will update the thread.
-          </p>
+        id: `branch-mismatch:${activeBranchMismatchKey}`,
+        variant: "info",
+        icon: <GitBranchIcon />,
+        title: (
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="shrink-0 font-normal text-muted-foreground">Branch changed — was</span>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <code className="min-w-0 truncate font-medium text-foreground">
+                    {localCheckoutBranchMismatch.threadBranch}
+                  </code>
+                }
+              />
+              <TooltipPopup side="top" className="max-w-80">
+                This thread last ran on {localCheckoutBranchMismatch.threadBranch}. Sending will
+                continue on {localCheckoutBranchMismatch.currentBranch}.
+              </TooltipPopup>
+            </Tooltip>
+          </span>
         ),
+        className: "dark:shadow-none",
         actions: (
-          <>
-            <Button
-              size="xs"
-              variant="outline"
-              disabled={isRepairingBranch}
-              onClick={() => void handleUpdateThreadToCheckout()}
-            >
-              {branchRepairAction === "update-thread" ? "Moving..." : "Move thread here"}
-            </Button>
-            <Button
-              size="xs"
-              variant="ghost"
-              disabled={isRepairingBranch}
-              onClick={() => void handleSwitchCheckoutToThread()}
-            >
-              {branchRepairAction === "switch-checkout" ? "Switching..." : "Checkout thread branch"}
-            </Button>
-          </>
+          <Button
+            size="xs"
+            variant="ghost"
+            disabled={isRestoringThreadBranch}
+            onClick={handleRestoreThreadBranch}
+          >
+            {isRestoringThreadBranch ? "Restoring..." : "Restore branch"}
+          </Button>
         ),
+        dismissLabel: "Dismiss branch change notice",
+        onDismiss: () => {
+          dismissBranchMismatchForSession(activeBranchMismatchKey);
+          setBranchMismatchDismissTick((tick) => tick + 1);
+        },
       },
     ];
   }, [
-    activeThread?.id,
-    branchRepairAction,
-    handleSwitchCheckoutToThread,
-    handleUpdateThreadToCheckout,
+    activeBranchMismatchKey,
+    handleRestoreThreadBranch,
+    isRestoringThreadBranch,
     localCheckoutBranchMismatch,
+    showBranchMismatchBanner,
     systemComposerBannerItems,
   ]);
 
@@ -5600,7 +5618,20 @@ function ChatViewContent(props: ChatViewProps) {
                       )}
                     >
                       <div className="chat-composer-glass-host relative z-10 w-full rounded-[22px]">
-                        <div ref={attachDraftHeroComposerAnchorRef} className="relative z-10">
+                        <div
+                          ref={attachDraftHeroComposerAnchorRef}
+                          className="relative z-10"
+                          onFocusCapture={() => setComposerIntentFocused(true)}
+                          onBlurCapture={(event) => {
+                            if (
+                              event.relatedTarget instanceof Node &&
+                              event.currentTarget.contains(event.relatedTarget)
+                            ) {
+                              return;
+                            }
+                            setComposerIntentFocused(false);
+                          }}
+                        >
                           <ChatComposer
                             composerRef={composerRef}
                             composerDraftTarget={composerDraftTarget}
@@ -5725,6 +5756,36 @@ function ChatViewContent(props: ChatViewProps) {
                 </div>
               </div>
             </div>
+
+            <AlertDialog open={branchRestoreConfirmOpen} onOpenChange={setBranchRestoreConfirmOpen}>
+              <AlertDialogPopup>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Switch to{" "}
+                    <code className="font-medium">
+                      {localCheckoutBranchMismatch?.threadBranch ?? ""}
+                    </code>
+                    ?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    You have uncommitted changes. They'll carry over to the other branch, or block
+                    the switch if they conflict.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                  <Button
+                    variant="default"
+                    onClick={() => {
+                      setBranchRestoreConfirmOpen(false);
+                      void handleSwitchCheckoutToThread();
+                    }}
+                  >
+                    Switch branch
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogPopup>
+            </AlertDialog>
 
             {pullRequestDialogState ? (
               <PullRequestThreadDialog


### PR DESCRIPTION
## What Changed

Reworks the "You're on a different branch" composer banner added in #2284, which fired on thread open, wasn't dismissible, and alarmed users doing routine branch switching ([user report](https://x.com/solomonneas)).

<img width="995" height="535" alt="image" src="https://github.com/user-attachments/assets/44a3e76f-1716-4a11-8021-15248df7c6e8" />


- **One-line copy**: `Branch changed — was <branch>`, info variant, git-branch icon. No description block; the consequence ("sending will continue on the current branch") lives in the branch chip's tooltip. The current branch is never named — it's already visible in the branch picker below.
- **Intent gating**: the banner only renders when the composer is focused or has draft content. Passively reading an old thread shows nothing beyond the existing branch-picker warning tint. Once revealed for a mismatch it stays mounted through blur (no flicker).
- **Single action**: "Move thread here" is removed — sending already rebinds the thread via `resolveThreadMetadataUpdateForNextTurn`, so the button duplicated the default outcome. The remaining action is **Restore branch** (checkout the thread's branch).
- **Dirty-tree confirm**: restoring with uncommitted changes prompts a confirm dialog ("They'll carry over to the other branch, or block the switch if they conflict"); a clean tree switches immediately, no dialog.
- **Dismissible**: ✕ dismisses the specific `threadId + threadBranch + currentBranch` mismatch for the session. If the checkout later moves to a *different* branch, the banner is eligible again.

Mismatch detection (`resolveLocalCheckoutBranchMismatch`) is unchanged, as is the branch-picker tint/popover from #2284.

Design doc with mockups and the reasoning (including why we deliberately did **not** auto-sync `thread.branch` on turn completion): https://3vj3y2v9zb4u.postplan.dev

## Why

The mismatch is valid but the old presentation punished the most common innocent flow: finish issue A, checkout a branch for issue B, reopen thread A just to read context → big non-dismissible amber warning at thread-open time, when the only actual risk exists at send time.

## Follow-up (separate PR)

Server-persisted dismissal ack (`{threadBranch, checkoutBranch}` on thread metadata) so dismissals hold across devices; session-scoped for now.

## Testing

- New unit tests for the intent gate, dismissal keying, and hysteresis (`ChatView.logic.test.ts`)
- `bun run typecheck`, `bun run lint`, full `apps/web` unit suite (1495 tests) all pass
- Visual treatment needs a human eyeball — automated browsers can't see authenticated views locally

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] Before/after screenshots — needs a paired session; mockups are in the design doc above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer UX and when the banner renders; restore still uses existing git checkout and thread metadata RPCs, with no change to mismatch detection itself.
> 
> **Overview**
> Reworks the **local checkout vs thread branch** composer banner so it no longer appears on every thread open.
> 
> **Intent gating:** New `shouldShowBranchMismatchBanner` logic only shows the notice when the composer has draft content (or after it was already shown for the same mismatch, so clearing the draft does not flicker it away). Passive reading stays quiet aside from existing branch-picker cues.
> 
> **Copy and actions:** The banner switches from a warning with two repair buttons to an **info** line (`Branch changed — was <thread branch>`) with tooltip context. **Move thread here** is removed; **Restore branch** checks out the thread’s branch (with an **AlertDialog** when the working tree is dirty).
> 
> **Dismissal:** Per-mismatch keys (`threadId:threadBranch:currentBranch`) can be dismissed for the **session** via a module-level set in `ChatView.logic.ts`, with unit tests for gating, keys, and dismissal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40c0f1ca666dc213f3ebe97390b7aba3bb50fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce branch-mismatch banner intrusiveness in ChatView
> - The banner now only appears when the composer has draft content or was already shown for the current mismatch, and can be dismissed per session via a new in-memory `Set` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/4416/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114).
> - The 'Move thread here' action is removed; a single 'Restore branch' action switches checkout to the thread's branch, updating thread metadata if needed.
> - If uncommitted changes exist, an `AlertDialog` confirmation prompt appears before switching branches.
> - Banner variant changed from warning to info, and the icon updated to `GitBranchIcon`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b40c0f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clearer notification when a chat’s branch differs from the current branch.
  - Added a single **Restore branch** action to return the chat to its original branch.
  - Prompts for confirmation before restoring when there are uncommitted changes.
  - Keeps the notification visible while composing to prevent unexpected flicker.
  - Added branch details and explanatory tooltip text to the notification.

- **Bug Fixes**
  - Branch mismatch notifications can now be dismissed for the current session and remain dismissed across chat view refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->