### PR TITLE
fix(server): refuse startup when another server owns the state dir

### DIFF
--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -35,6 +35,7 @@ const setup = Layer.effectDiscard(
     const sql = yield* SqlClient.SqlClient;
     yield* sql`PRAGMA journal_mode = WAL;`;
     yield* sql`PRAGMA foreign_keys = ON;`;
+    yield* sql`PRAGMA busy_timeout = 5000;`;
     yield* runMigrations();
   }),
 );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -87,6 +87,7 @@ import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
   clearPersistedServerRuntimeState,
+  ensureExclusiveStateDir,
   makePersistedServerRuntimeState,
   persistServerRuntimeState,
 } from "./serverRuntimeState.ts";
@@ -373,6 +374,15 @@ export const makeRoutesLayer = Layer.mergeAll(
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {
     const config = yield* ServerConfig.ServerConfig;
+
+    // Refuse startup (before binding or writing the discovery file) when another
+    // live T3 server already owns this state directory. Platform services are
+    // provided locally so this guard does not leak a FileSystem requirement past
+    // the "only ServerConfig" boundary below.
+    yield* ensureExclusiveStateDir({
+      statePath: config.serverRuntimeStatePath,
+      stateDir: config.stateDir,
+    }).pipe(Effect.provide(PlatformServicesLive));
 
     yield* fixPath();
 

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -248,13 +248,15 @@ describe("ensureExclusiveStateDir", () => {
       }).pipe(Effect.flip);
 
       assert.isTrue(isServerStateDirConflictError(error));
-      assert.equal(error.pid, state.pid);
-      assert.equal(error.port, state.port);
-      assert.equal(error.origin, state.origin);
-      assert.equal(error.stateDir, stateDir);
-      assert.include(error.message, String(state.pid));
-      assert.include(error.message, stateDir);
-      assert.include(error.message, "--base-dir");
+      if (isServerStateDirConflictError(error)) {
+        assert.equal(error.pid, state.pid);
+        assert.equal(error.port, state.port);
+        assert.equal(error.origin, state.origin);
+        assert.equal(error.stateDir, stateDir);
+        assert.include(error.message, String(state.pid));
+        assert.include(error.message, stateDir);
+        assert.include(error.message, "--base-dir");
+      }
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -310,5 +312,30 @@ describe("ensureExclusiveStateDir", () => {
         ),
       ),
     ),
+  );
+
+  it.effect("fails closed when the discovery file cannot be read", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-state-dir-guard-test-",
+      });
+      const statePath = path.join(stateDir, "server-runtime.json");
+      yield* fileSystem.makeDirectory(statePath);
+
+      const error = yield* ServerRuntimeState.ensureExclusiveStateDir({
+        statePath,
+        stateDir,
+        ownPid: 999,
+        isPidAlive: () => true,
+      }).pipe(Effect.flip);
+
+      assert.isTrue(isServerRuntimeStateError(error));
+      if (isServerRuntimeStateError(error)) {
+        assert.equal(error.operation, "read");
+        assert.equal(error.statePath, statePath);
+      }
+    }).pipe(Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -12,6 +12,7 @@ import * as Schema from "effect/Schema";
 import * as ServerRuntimeState from "./serverRuntimeState.ts";
 
 const isServerRuntimeStateError = Schema.is(ServerRuntimeState.ServerRuntimeStateError);
+const isServerStateDirConflictError = Schema.is(ServerRuntimeState.ServerStateDirConflictError);
 
 interface CapturedLog {
   readonly message: unknown;
@@ -163,5 +164,151 @@ describe("serverRuntimeState", () => {
         assert.deepInclude(error.cause, { _tag: "PlatformError" });
       }
     }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});
+
+describe("decideServerRuntimeStartup", () => {
+  const state: ServerRuntimeState.PersistedServerRuntimeState = {
+    version: 1,
+    pid: 4_242,
+    host: "127.0.0.1",
+    port: 4_971,
+    origin: "http://127.0.0.1:4971",
+    startedAt: "2026-06-20T00:00:00.000Z",
+  };
+  const alwaysAlive = () => true;
+  const alwaysDead = () => false;
+
+  it("proceeds when no discovery file exists", () => {
+    const decision = ServerRuntimeState.decideServerRuntimeStartup({
+      existing: Option.none(),
+      ownPid: 999,
+      isPidAlive: alwaysAlive,
+    });
+    assert.equal(decision._tag, "proceed");
+  });
+
+  it("reports a conflict when the recorded pid is alive", () => {
+    const decision = ServerRuntimeState.decideServerRuntimeStartup({
+      existing: Option.some(state),
+      ownPid: 999,
+      isPidAlive: alwaysAlive,
+    });
+    assert.equal(decision._tag, "conflict");
+    if (decision._tag === "conflict") {
+      assert.deepEqual(decision.state, state);
+    }
+  });
+
+  it("proceeds when the recorded pid is dead (stale file)", () => {
+    const decision = ServerRuntimeState.decideServerRuntimeStartup({
+      existing: Option.some(state),
+      ownPid: 999,
+      isPidAlive: alwaysDead,
+    });
+    assert.equal(decision._tag, "proceed");
+  });
+
+  it("proceeds when the recorded pid is our own (same-process restart)", () => {
+    const decision = ServerRuntimeState.decideServerRuntimeStartup({
+      existing: Option.some(state),
+      ownPid: state.pid,
+      // Would report a conflict if own-pid were not special-cased.
+      isPidAlive: alwaysAlive,
+    });
+    assert.equal(decision._tag, "proceed");
+  });
+});
+
+describe("ensureExclusiveStateDir", () => {
+  const state: ServerRuntimeState.PersistedServerRuntimeState = {
+    version: 1,
+    pid: 4_242,
+    host: "127.0.0.1",
+    port: 4_971,
+    origin: "http://127.0.0.1:4971",
+    startedAt: "2026-06-20T00:00:00.000Z",
+  };
+
+  it.effect("fails with a typed conflict error naming pid, port, origin, and state dir", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-state-dir-guard-test-",
+      });
+      const statePath = path.join(stateDir, "server-runtime.json");
+      yield* ServerRuntimeState.persistServerRuntimeState({ path: statePath, state });
+
+      const error = yield* ServerRuntimeState.ensureExclusiveStateDir({
+        statePath,
+        stateDir,
+        ownPid: 999,
+        isPidAlive: () => true,
+      }).pipe(Effect.flip);
+
+      assert.isTrue(isServerStateDirConflictError(error));
+      assert.equal(error.pid, state.pid);
+      assert.equal(error.port, state.port);
+      assert.equal(error.origin, state.origin);
+      assert.equal(error.stateDir, stateDir);
+      assert.include(error.message, String(state.pid));
+      assert.include(error.message, stateDir);
+      assert.include(error.message, "--base-dir");
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("proceeds when the recorded pid is dead", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-state-dir-guard-test-",
+      });
+      const statePath = path.join(stateDir, "server-runtime.json");
+      yield* ServerRuntimeState.persistServerRuntimeState({ path: statePath, state });
+
+      yield* ServerRuntimeState.ensureExclusiveStateDir({
+        statePath,
+        stateDir,
+        ownPid: 999,
+        isPidAlive: () => false,
+      });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("proceeds when the discovery file is missing or corrupt", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-state-dir-guard-test-",
+      });
+      const missingPath = path.join(stateDir, "server-runtime.json");
+
+      // Missing file: proceed.
+      yield* ServerRuntimeState.ensureExclusiveStateDir({
+        statePath: missingPath,
+        stateDir,
+        ownPid: 999,
+        isPidAlive: () => true,
+      });
+
+      // Corrupt file: read returns none, so proceed even against a "live" pid.
+      yield* fileSystem.writeFileString(missingPath, "{not json");
+      yield* ServerRuntimeState.ensureExclusiveStateDir({
+        statePath: missingPath,
+        stateDir,
+        ownPid: 999,
+        isPidAlive: () => true,
+      });
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          NodeServices.layer,
+          Logger.layer([Logger.make(() => {})], { mergeWithExisting: false }),
+        ),
+      ),
+    ),
   );
 });

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -175,7 +175,7 @@ export const ensureExclusiveStateDir = (input: {
   readonly isPidAlive?: (pid: number) => boolean;
 }) =>
   Effect.gen(function* () {
-    const existing = yield* readPersistedServerRuntimeState(input.statePath);
+    const existing = yield* readPersistedServerRuntimeStateForStartup(input.statePath);
     const decision = decideServerRuntimeStartup({
       existing,
       ownPid: input.ownPid ?? process.pid,
@@ -192,7 +192,17 @@ export const ensureExclusiveStateDir = (input: {
     }
   });
 
-export const readPersistedServerRuntimeState = (path: string) =>
+const logAndIgnoreRuntimeStateError = (error: ServerRuntimeStateError) =>
+  Effect.logWarning(error.message).pipe(
+    Effect.annotateLogs({
+      operation: error.operation,
+      statePath: error.statePath,
+      cause: error,
+    }),
+    Effect.as(Option.none<PersistedServerRuntimeState>()),
+  );
+
+const readPersistedServerRuntimeStateForStartup = (path: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const raw = yield* fs.readFileString(path).pipe(
@@ -233,13 +243,13 @@ export const readPersistedServerRuntimeState = (path: string) =>
   }).pipe(
     Effect.catchTags({
       ServerRuntimeStateError: (error) =>
-        Effect.logWarning(error.message).pipe(
-          Effect.annotateLogs({
-            operation: error.operation,
-            statePath: error.statePath,
-            cause: error,
-          }),
-          Effect.as(Option.none<PersistedServerRuntimeState>()),
-        ),
+        error.operation === "decode" ? logAndIgnoreRuntimeStateError(error) : Effect.fail(error),
+    }),
+  );
+
+export const readPersistedServerRuntimeState = (path: string) =>
+  readPersistedServerRuntimeStateForStartup(path).pipe(
+    Effect.catchTags({
+      ServerRuntimeStateError: logAndIgnoreRuntimeStateError,
     }),
   );

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -100,6 +100,98 @@ export const clearPersistedServerRuntimeState = (path: string) =>
     );
   });
 
+export class ServerStateDirConflictError extends Schema.TaggedErrorClass<ServerStateDirConflictError>()(
+  "ServerStateDirConflictError",
+  {
+    stateDir: Schema.String,
+    statePath: Schema.String,
+    pid: Schema.Int,
+    port: Schema.Int,
+    origin: Schema.String,
+  },
+) {
+  override get message(): string {
+    return (
+      `Another T3 server (pid ${this.pid}) already owns the state directory ${this.stateDir} ` +
+      `and is listening at ${this.origin} (port ${this.port}). ` +
+      `Refusing to start a second server against the same state directory, since two servers ` +
+      `sharing one state directory corrupt shared SQLite/discovery state. ` +
+      `Stop the other server, or start this one with a different --base-dir / T3CODE_HOME.`
+    );
+  }
+}
+
+/**
+ * Returns whether a pid refers to a live process. `process.kill(pid, 0)` does not
+ * send a signal; it only checks for the process' existence and our permission to
+ * signal it. EPERM means the process exists but is owned by another user, which we
+ * still treat as alive.
+ */
+export const isPidAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+export type ServerRuntimeStartupDecision =
+  | { readonly _tag: "proceed" }
+  | { readonly _tag: "conflict"; readonly state: PersistedServerRuntimeState };
+
+/**
+ * Pure decision for whether it is safe to start a server against a state directory
+ * given whatever discovery file it currently holds. Proceed when the file is absent,
+ * when it records our own pid (a same-process restart path must not self-block), or
+ * when the recorded pid is dead (stale file). Otherwise report a conflict.
+ */
+export const decideServerRuntimeStartup = (input: {
+  readonly existing: Option.Option<PersistedServerRuntimeState>;
+  readonly ownPid: number;
+  readonly isPidAlive: (pid: number) => boolean;
+}): ServerRuntimeStartupDecision => {
+  if (Option.isNone(input.existing)) {
+    return { _tag: "proceed" };
+  }
+  const state = input.existing.value;
+  if (state.pid === input.ownPid) {
+    return { _tag: "proceed" };
+  }
+  return input.isPidAlive(state.pid) ? { _tag: "conflict", state } : { _tag: "proceed" };
+};
+
+/**
+ * Best-effort single-instance guard on a state directory. Reads any existing
+ * discovery file and fails startup when a live process already owns it. This does
+ * NOT close the race between two servers that start simultaneously (both may read an
+ * empty/stale file before either writes) — it only rejects a startup when a
+ * previously-recorded, still-live server already owns the directory.
+ */
+export const ensureExclusiveStateDir = (input: {
+  readonly statePath: string;
+  readonly stateDir: string;
+  readonly ownPid?: number;
+  readonly isPidAlive?: (pid: number) => boolean;
+}) =>
+  Effect.gen(function* () {
+    const existing = yield* readPersistedServerRuntimeState(input.statePath);
+    const decision = decideServerRuntimeStartup({
+      existing,
+      ownPid: input.ownPid ?? process.pid,
+      isPidAlive: input.isPidAlive ?? isPidAlive,
+    });
+    if (decision._tag === "conflict") {
+      return yield* new ServerStateDirConflictError({
+        stateDir: input.stateDir,
+        statePath: input.statePath,
+        pid: decision.state.pid,
+        port: decision.state.port,
+        origin: decision.state.origin,
+      });
+    }
+  });
+
 export const readPersistedServerRuntimeState = (path: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;


### PR DESCRIPTION
## What Changed

- The server now reads any existing `server-runtime.json` before binding or writing its own, and refuses startup with a typed `ServerStateDirConflictError` when the recorded pid is a live process. Missing, corrupt, stale (dead-pid), or own-pid discovery files proceed exactly as before. The decision logic is a pure, unit-tested function; the guard is documented as best-effort (it does not close the simultaneous-start race).
- Added `PRAGMA busy_timeout = 5000` alongside the existing WAL/foreign_keys pragmas.

## Why

Nothing prevents two backend processes from sharing one state dir today. The discovery file is clobbered unconditionally by whichever server starts last, and with no `busy_timeout`, concurrent writers on `state.sqlite` fail with `SQLITE_BUSY` immediately instead of waiting out short write locks. Running e.g. a standalone `t3 serve` and a desktop-spawned backend against the same `~/.t3` silently corrupts shared state; failing loudly with a clear, actionable error (naming the pid, origin, and state dir, and suggesting `--base-dir` / `T3CODE_HOME`) is strictly better. The existing readers of `server-runtime.json` (`t3 connect`, `t3 project`) are pure HTTP clients and are unaffected.

Validation:

- `vp test run src/serverRuntimeState.test.ts` — 12 passed (7 new: pure decision matrix + typed-error guard behavior)
- apps/server `typecheck` (`tsgo --noEmit`) — clean
- `vp lint` on changed files — clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (N/A)
- [ ] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early server startup and shared SQLite/discovery behavior; mis-PID or race edge cases could block or briefly delay startup, but scope is limited and well tested.
> 
> **Overview**
> Prevents two T3 server processes from sharing one state directory by checking `server-runtime.json` **before** HTTP bind or discovery writes. A live recorded PID yields a typed **`ServerStateDirConflictError`** (pid, port, origin, state dir, `--base-dir` / `T3CODE_HOME` hint); missing, corrupt, stale, or own-PID files still allow startup. Decision logic is pure (`decideServerRuntimeStartup` + `isPidAlive`); the guard is best-effort for simultaneous starts.
> 
> Startup read path **fails closed** on unreadable discovery files while decode errors stay warn-and-proceed for normal readers. SQLite init adds **`PRAGMA busy_timeout = 5000`** to wait on brief lock contention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e30781c6840f12057e5748da8bb0759179f77ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse server startup when another live server owns the state directory
> - Adds `ensureExclusiveStateDir` in [serverRuntimeState.ts](https://github.com/pingdotgg/t3code/pull/4420/files#diff-b7e137a54141b0eed3e4f1279655a7ebb0e17e88a6ea34e1b4e65b942939dde8), which reads the persisted runtime state on startup and fails with a typed `ServerStateDirConflictError` (carrying pid, port, origin, stateDir) if another live process owns the state directory.
> - Invokes `ensureExclusiveStateDir` early in [server.ts](https://github.com/pingdotgg/t3code/pull/4420/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) startup, before HTTP binding, so conflicts are caught before any resources are acquired.
> - Corrupt or missing discovery files are tolerated (logged and ignored); unreadable files propagate as a `ServerRuntimeStateError`.
> - Sets SQLite `busy_timeout` to 5000ms in [Sqlite.ts](https://github.com/pingdotgg/t3code/pull/4420/files#diff-47b4fe6e24808f5d59f5b97892cce0d736c01e7a8323b77e0c6a3751ff7ba7fa) to reduce lock contention during startup.
> - Behavioral Change: servers sharing a state directory will now fail fast with a descriptive error instead of silently conflicting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e30781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->