### PR TITLE
fix(server): settle stale running provider sessions on startup

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -109,6 +109,7 @@ function createProviderServiceHarness(
     respondToRequest: () => unsupported(),
     respondToUserInput: () => unsupported(),
     stopSession: () => unsupported(),
+    reconcileStaleSessionsOnBoot: () => Effect.void,
     listSessions,
     getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
     getInstanceInfo: (instanceId) =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -311,6 +311,7 @@ describe("ProviderCommandReactor", () => {
       respondToRequest: respondToRequest as ProviderServiceShape["respondToRequest"],
       respondToUserInput: respondToUserInput as ProviderServiceShape["respondToUserInput"],
       stopSession: stopSession as ProviderServiceShape["stopSession"],
+      reconcileStaleSessionsOnBoot: () => Effect.void,
       listSessions: () => Effect.succeed(runtimeSessions),
       getCapabilities: (_provider) =>
         Effect.succeed({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -105,6 +105,7 @@ function createProviderServiceHarness() {
     respondToRequest: () => unsupported(),
     respondToUserInput: () => unsupported(),
     stopSession: () => unsupported(),
+    reconcileStaleSessionsOnBoot: () => Effect.void,
     listSessions: () => Effect.succeed([...runtimeSessions]),
     getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
     getInstanceInfo: (instanceId) => {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -711,6 +711,80 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
 );
 
 it.effect(
+  "ProviderServiceLive reconciles stale running sessions on boot and preserves the resume cursor",
+  () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-service-"));
+      const dbPath = NodePath.join(tempDir, "orchestration.sqlite");
+
+      const threadId = asThreadId("thread-boot-reconcile");
+      const resumeCursor = { opaque: "resume-boot-reconcile" } as const;
+
+      const codex = makeFakeCodexAdapter();
+      const registry = makeAdapterRegistryMock({
+        [ProviderDriverKind.make("codex")]: codex.adapter,
+      });
+
+      const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(persistenceLayer),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+
+      // Seed the row an unclean shutdown leaves behind: still "running", with a
+      // resume cursor the next user turn must be able to resume from.
+      yield* Effect.gen(function* () {
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        yield* repository.upsert({
+          threadId,
+          providerName: "codex",
+          providerInstanceId: codexInstanceId,
+          adapterKey: "codex",
+          runtimeMode: "full-access",
+          status: "running",
+          lastSeenAt: "2026-04-14T00:00:00.000Z",
+          resumeCursor,
+          runtimePayload: null,
+        });
+      }).pipe(Effect.provide(runtimeRepositoryLayer));
+
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(defaultServerSettingsLayer),
+        Layer.provide(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      );
+
+      yield* Effect.gen(function* () {
+        const providerService = yield* ProviderService.ProviderService;
+        yield* providerService.reconcileStaleSessionsOnBoot();
+      }).pipe(Effect.provide(providerLayer));
+
+      const reconciled = yield* Effect.gen(function* () {
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        return yield* repository.getByThreadId({ threadId });
+      }).pipe(Effect.provide(runtimeRepositoryLayer));
+
+      assert.equal(Option.isSome(reconciled), true);
+      const row = Option.getOrThrow(reconciled);
+      // Status is settled, but the resume cursor survives so the next turn can
+      // resume the provider conversation.
+      assert.equal(row.status, "stopped");
+      assert.deepStrictEqual(row.resumeCursor, resumeCursor);
+
+      NodeFS.rmSync(tempDir, { recursive: true, force: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect(
   "ProviderServiceLive restores rollback routing after restart using persisted thread mapping",
   () =>
     Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -38,6 +38,7 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import {
   ProviderAdapterRequestError,
   ProviderAdapterSessionNotFoundError,
+  ProviderSessionDirectoryPersistenceError,
   ProviderUnsupportedError,
   ProviderValidationError,
   type ProviderAdapterError,
@@ -763,25 +764,84 @@ it.effect(
         ),
       );
 
-      yield* Effect.gen(function* () {
-        const providerService = yield* ProviderService.ProviderService;
-        yield* providerService.reconcileStaleSessionsOnBoot();
-      }).pipe(Effect.provide(providerLayer));
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const providerServices = yield* Layer.build(providerLayer);
+          const providerService = yield* ProviderService.ProviderService.pipe(
+            Effect.provide(providerServices),
+          );
+          yield* providerService.reconcileStaleSessionsOnBoot();
 
-      const reconciled = yield* Effect.gen(function* () {
-        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
-        return yield* repository.getByThreadId({ threadId });
-      }).pipe(Effect.provide(runtimeRepositoryLayer));
+          // Observe the row while ProviderService is still in scope. Its
+          // shutdown finalizer also settles live rows, so asserting after the
+          // layer closes would not prove that boot reconciliation ran.
+          const reconciled = yield* Effect.gen(function* () {
+            const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+            return yield* repository.getByThreadId({ threadId });
+          }).pipe(Effect.provide(runtimeRepositoryLayer));
 
-      assert.equal(Option.isSome(reconciled), true);
-      const row = Option.getOrThrow(reconciled);
-      // Status is settled, but the resume cursor survives so the next turn can
-      // resume the provider conversation.
-      assert.equal(row.status, "stopped");
-      assert.deepStrictEqual(row.resumeCursor, resumeCursor);
+          assert.equal(Option.isSome(reconciled), true);
+          const row = Option.getOrThrow(reconciled);
+          // Status is settled, but the resume cursor survives so the next turn
+          // can resume the provider conversation.
+          assert.equal(row.status, "stopped");
+          assert.deepStrictEqual(row.resumeCursor, resumeCursor);
+        }),
+      );
 
       NodeFS.rmSync(tempDir, { recursive: true, force: true });
     }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect("ProviderServiceLive surfaces boot reconciliation directory read failures", () =>
+  Effect.gen(function* () {
+    const expected = new ProviderSessionDirectoryPersistenceError({
+      operation: "ProviderSessionDirectory.listBindings",
+      detail: "simulated list failure",
+      cause: "test",
+    });
+    const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+      Layer.provide(SqlitePersistenceMemory),
+    );
+    const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+    const failingDirectoryLayer = Layer.effect(
+      ProviderSessionDirectory.ProviderSessionDirectory,
+      Effect.map(ProviderSessionDirectory.ProviderSessionDirectory, (directory) =>
+        ProviderSessionDirectory.ProviderSessionDirectory.of({
+          ...directory,
+          listBindings: () => Effect.fail(expected),
+        }),
+      ),
+    ).pipe(Layer.provide(directoryLayer));
+    const codex = makeFakeCodexAdapter();
+    const registry = makeAdapterRegistryMock({
+      [ProviderDriverKind.make("codex")]: codex.adapter,
+    });
+    const providerLayer = makeProviderServiceLive().pipe(
+      Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+      Layer.provide(failingDirectoryLayer),
+      Layer.provide(defaultServerSettingsLayer),
+      Layer.provide(AnalyticsService.layerTest),
+      Layer.provide(
+        Layer.succeed(
+          ProviderEventLoggers.ProviderEventLoggers,
+          ProviderEventLoggers.NoOpProviderEventLoggers,
+        ),
+      ),
+    );
+
+    const error = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const providerServices = yield* Layer.build(providerLayer);
+        const providerService = yield* ProviderService.ProviderService.pipe(
+          Effect.provide(providerServices),
+        );
+        return yield* providerService.reconcileStaleSessionsOnBoot().pipe(Effect.flip);
+      }),
+    );
+
+    assert.strictEqual(error, expected);
+  }).pipe(Effect.provide(NodeServices.layer)),
 );
 
 it.effect(

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1077,44 +1077,44 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     // `resumeCursor`, so the idle reaper and session routing stop treating them
     // as live while the next user turn can still resume the provider
     // conversation from where it left off.
-    const bindings = yield* directory.listBindings().pipe(Effect.orElseSucceed(() => []));
+    const bindings = yield* directory.listBindings();
     const staleBindings = bindings.filter((binding) => binding.status !== "stopped");
     if (staleBindings.length === 0) {
       return;
     }
-    yield* Effect.forEach(
-      staleBindings,
-      (binding) =>
-        Effect.flatMap(nowIso, (lastRuntimeEventAt) =>
-          directory.upsert({
+    const reconciled = yield* Effect.forEach(staleBindings, (binding) =>
+      Effect.flatMap(nowIso, (lastRuntimeEventAt) =>
+        directory.upsert({
+          threadId: binding.threadId,
+          provider: binding.provider,
+          ...(binding.providerInstanceId !== undefined
+            ? { providerInstanceId: binding.providerInstanceId }
+            : {}),
+          status: "stopped",
+          runtimePayload: {
+            activeTurnId: null,
+            lastRuntimeEvent: "provider.startupReconcile",
+            lastRuntimeEventAt,
+          },
+        }),
+      ).pipe(
+        Effect.as(true),
+        Effect.catchCause((cause) =>
+          Effect.logWarning("failed to reconcile stale provider session on boot", {
             threadId: binding.threadId,
             provider: binding.provider,
-            ...(binding.providerInstanceId !== undefined
-              ? { providerInstanceId: binding.providerInstanceId }
-              : {}),
-            status: "stopped",
-            runtimePayload: {
-              activeTurnId: null,
-              lastRuntimeEvent: "provider.startupReconcile",
-              lastRuntimeEventAt,
-            },
-          }),
-        ).pipe(
-          Effect.catchCause((cause) =>
-            Effect.logWarning("failed to reconcile stale provider session on boot", {
-              threadId: binding.threadId,
-              provider: binding.provider,
-              errorTag: causeErrorTag(cause),
-            }),
-          ),
+            errorTag: causeErrorTag(cause),
+          }).pipe(Effect.as(false)),
         ),
-      { discard: true },
+      ),
     );
+    const reconciledCount = reconciled.filter(Boolean).length;
     yield* Effect.logInfo("provider.sessions.reconciled_on_boot", {
-      sessionCount: staleBindings.length,
+      sessionCount: reconciledCount,
+      failedSessionCount: staleBindings.length - reconciledCount,
     });
     yield* analytics.record("provider.sessions.reconciled_on_boot", {
-      sessionCount: staleBindings.length,
+      sessionCount: reconciledCount,
     });
   });
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1068,6 +1068,56 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     ),
   );
 
+  const reconcileStaleSessionsOnBoot = Effect.fn("reconcileStaleSessionsOnBoot")(function* () {
+    // This process just started with empty adapter maps, so every persisted
+    // session and provider child is definitionally gone. Any runtime row that
+    // is not already "stopped" outlived an unclean shutdown (SIGKILL, crash,
+    // power loss) that never ran `runStopAll`. Settle those rows exactly as the
+    // finalizer does — rewrite status to "stopped" without touching
+    // `resumeCursor`, so the idle reaper and session routing stop treating them
+    // as live while the next user turn can still resume the provider
+    // conversation from where it left off.
+    const bindings = yield* directory.listBindings().pipe(Effect.orElseSucceed(() => []));
+    const staleBindings = bindings.filter((binding) => binding.status !== "stopped");
+    if (staleBindings.length === 0) {
+      return;
+    }
+    yield* Effect.forEach(
+      staleBindings,
+      (binding) =>
+        Effect.flatMap(nowIso, (lastRuntimeEventAt) =>
+          directory.upsert({
+            threadId: binding.threadId,
+            provider: binding.provider,
+            ...(binding.providerInstanceId !== undefined
+              ? { providerInstanceId: binding.providerInstanceId }
+              : {}),
+            status: "stopped",
+            runtimePayload: {
+              activeTurnId: null,
+              lastRuntimeEvent: "provider.startupReconcile",
+              lastRuntimeEventAt,
+            },
+          }),
+        ).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to reconcile stale provider session on boot", {
+              threadId: binding.threadId,
+              provider: binding.provider,
+              errorTag: causeErrorTag(cause),
+            }),
+          ),
+        ),
+      { discard: true },
+    );
+    yield* Effect.logInfo("provider.sessions.reconciled_on_boot", {
+      sessionCount: staleBindings.length,
+    });
+    yield* analytics.record("provider.sessions.reconciled_on_boot", {
+      sessionCount: staleBindings.length,
+    });
+  });
+
   return {
     startSession,
     sendTurn,
@@ -1075,6 +1125,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     respondToRequest,
     respondToUserInput,
     stopSession,
+    reconcileStaleSessionsOnBoot,
     listSessions,
     getCapabilities,
     getInstanceInfo,

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -158,6 +158,7 @@ describe("ProviderSessionReaper", () => {
       respondToRequest: () => unsupported(),
       respondToUserInput: () => unsupported(),
       stopSession,
+      reconcileStaleSessionsOnBoot: () => Effect.void,
       listSessions: () => Effect.succeed([]),
       getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
       getInstanceInfo: (instanceId) => {

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -28,7 +28,7 @@ import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
 
-import type { ProviderServiceError } from "../Errors.ts";
+import type { ProviderServiceError, ProviderSessionDirectoryPersistenceError } from "../Errors.ts";
 import type { ProviderAdapterCapabilities } from "./ProviderAdapter.ts";
 import type { ProviderInstanceRoutingInfo } from "./ProviderAdapterRegistry.ts";
 
@@ -91,7 +91,10 @@ export interface ProviderServiceShape {
    * user turn can still resume the provider conversation. Intended to run once
    * at boot, before reactors and the idle reaper start handling new work.
    */
-  readonly reconcileStaleSessionsOnBoot: () => Effect.Effect<void>;
+  readonly reconcileStaleSessionsOnBoot: () => Effect.Effect<
+    void,
+    ProviderSessionDirectoryPersistenceError
+  >;
 
   /**
    * List active provider sessions.

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -80,6 +80,20 @@ export interface ProviderServiceShape {
   ) => Effect.Effect<void, ProviderServiceError>;
 
   /**
+   * Settle provider session runtime rows that an unclean shutdown left in a
+   * live status.
+   *
+   * A freshly started process owns no provider children and no in-memory
+   * sessions, so every runtime row not already marked `"stopped"` is stale: it
+   * survived a crash, SIGKILL, or power loss that skipped the graceful-shutdown
+   * finalizer. This rewrites those rows to `"stopped"` while preserving each
+   * `resumeCursor`, mirroring the finalizer's persistence mutation so the next
+   * user turn can still resume the provider conversation. Intended to run once
+   * at boot, before reactors and the idle reaper start handling new work.
+   */
+  readonly reconcileStaleSessionsOnBoot: () => Effect.Effect<void>;
+
+  /**
    * List active provider sessions.
    *
    * Aggregates runtime session lists from all registered adapters.

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -33,6 +33,7 @@ import * as ServerSettings from "./serverSettings.ts";
 import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
+import * as ProviderService from "./provider/Services/ProviderService.ts";
 import * as ProviderSessionReaper from "./provider/Services/ProviderSessionReaper.ts";
 import {
   formatHeadlessServeOutput,
@@ -292,6 +293,7 @@ export const make = Effect.gen(function* () {
   const serverConfig = yield* ServerConfig.ServerConfig;
   const keybindings = yield* Keybindings.Keybindings;
   const orchestrationReactor = yield* OrchestrationReactor.OrchestrationReactor;
+  const providerService = yield* ProviderService.ProviderService;
   const providerSessionReaper = yield* ProviderSessionReaper.ProviderSessionReaper;
   const lifecycleEvents = yield* ServerLifecycleEvents.ServerLifecycleEvents;
   const serverSettings = yield* ServerSettings.ServerSettingsService;
@@ -336,6 +338,13 @@ export const make = Effect.gen(function* () {
         Effect.forkScoped,
       ),
     );
+
+    // Settle provider session rows an unclean shutdown left "running" before
+    // any reactor, the idle reaper, or a new user turn can act on them. This
+    // runs once, on a process whose adapter maps are empty, and only touches
+    // rows already present at boot — sessions started later get fresh rows.
+    yield* Effect.logDebug("startup phase: reconciling stale provider sessions");
+    yield* runStartupPhase("provider.reconcile", providerService.reconcileStaleSessionsOnBoot());
 
     yield* Effect.logDebug("startup phase: starting orchestration reactors");
     yield* runStartupPhase(


### PR DESCRIPTION
## What Changed

Added a boot reconciliation pass, `ProviderService.reconcileStaleSessionsOnBoot`, run once from a new `provider.reconcile` startup phase before the orchestration reactors and idle reaper start (and before the command gate accepts new sessions). It rewrites every `provider_session_runtime` row not already `"stopped"` to `"stopped"` using the same directory mutation the graceful-shutdown finalizer (`runStopAll`) uses, deliberately omitting `resumeCursor` so it is preserved and the next user turn can still resume the provider conversation.

## Why

When the backend dies uncleanly (SIGKILL, crash, power loss), the shutdown finalizer never runs, so session rows stay at a live status even though every in-memory session and provider child process died with the server. Nothing reconciles them at boot — they linger as phantom "running" sessions until the idle reaper's 30-minute inactivity sweep catches them, and session routing/recovery treats them as live in the meantime. A freshly started process has empty adapter maps, so any non-stopped row at boot is definitionally dead; settling it immediately (with graceful-shutdown parity) is strictly better than waiting for the reaper. The pass only touches rows present at boot, so it cannot race with or double-settle sessions started afterward.

Validation:

- `pnpm test src/provider/Layers/ProviderService.test.ts` — 29 passed, including a new test seeding a `running` row with a `resumeCursor` and asserting it settles to `stopped` with the cursor intact
- 106 focused tests passed across the touched test files (extended `ProviderServiceShape` mocks)
- apps/server `typecheck` (`tsgo --noEmit`) — clean; `vp fmt --check` — clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (N/A)
- [ ] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted session status at startup and affects routing/reaper behavior after crashes; scope is limited to rows present at boot and mirrors existing shutdown settlement.
> 
> **Overview**
> Adds **`reconcileStaleSessionsOnBoot`** to `ProviderService` and runs it once during a new **`provider.reconcile`** startup phase in `serverRuntimeStartup`, **before** orchestration reactors and the idle session reaper start.
> 
> After an unclean shutdown, persisted provider session rows can still look **live** even though in-memory sessions and child processes are gone. The new pass lists directory bindings whose status is not `"stopped"`, upserts them to **`stopped`** with `activeTurnId: null` and a `provider.startupReconcile` runtime event—matching the graceful-shutdown finalizer pattern and **not** clearing **`resumeCursor`**, so the next turn can still resume. Per-row failures are logged; successes are counted in logs and analytics. Directory read failures propagate as `ProviderSessionDirectoryPersistenceError`.
> 
> Test mocks across orchestration/provider tests stub the new API; `ProviderService.test.ts` adds coverage for successful reconciliation and list-bindings failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba7aabccc924469d7e1891931cc5e57e212861c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle stale running provider sessions on server startup
> - Adds `reconcileStaleSessionsOnBoot` to `ProviderServiceShape` and its live implementation, which finds any non-stopped provider session bindings in the directory and upserts them to `stopped`, preserving resume cursors and emitting analytics/log events.
> - Injects this as a new `provider.reconcile` startup phase in [`serverRuntimeStartup.ts`](https://github.com/pingdotgg/t3code/pull/4421/files#diff-1930335d6e319fc5766e0578303e19f9d788e9990f87604b77f9f768e61d7118), running before orchestration reactors and the session reaper start.
> - Behavioral Change: Sessions left in a `running` state from a previous process will now be marked `stopped` on every server boot before normal operation begins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ba7aab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->