### PR TITLE
ci: use Blacksmith git checkout caching on Blacksmith Linux runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -37,7 +37,7 @@ jobs:
       ALCHEMY_TELEMETRY_DISABLED: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/mobile-eas-preview.yml
+++ b/.github/workflows/mobile-eas-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/mobile-showcase-screenshots.yml
+++ b/.github/workflows/mobile-showcase-screenshots.yml
@@ -76,7 +76,7 @@ jobs:
       T3_SHOWCASE_ANDROID_ABI: x86_64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
       ref: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           fetch-depth: 0
 
@@ -189,7 +189,7 @@ jobs:
       CLERK_CLI_OAUTH_CLIENT_ID: ${{ vars.CLERK_CLI_OAUTH_CLIENT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 
@@ -266,7 +266,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           fetch-depth: 0
@@ -678,7 +678,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 
@@ -799,7 +799,7 @@ jobs:
       VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 
@@ -909,7 +909,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           ref: main
           fetch-depth: 0
@@ -982,7 +982,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: useblacksmith/checkout@v1
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 


### PR DESCRIPTION
## What

Swaps `actions/checkout@v6` → `useblacksmith/checkout@v1` on every job that runs on a `blacksmith-*-ubuntu` runner (15 checkout steps across ci, release, deploy-relay, mobile-eas-preview/production, and the Android showcase-screenshots job).

## Why

[Blacksmith's git checkout caching](https://docs.blacksmith.sh/blacksmith-caching/git-checkout-caching) keeps a persistent bare mirror of the repo on a sticky disk. The first run hydrates the mirror (normal clone speed); every run after that does an incremental `git fetch` instead of pulling the full ~280 MB pack from GitHub, and the workspace references the mirror via git alternates. That applies to the `fetch-depth: 0` checkouts too (preflight, check_changes, EAS fingerprinting), which are the slowest ones today.

It's a drop-in fork of `actions/checkout` — all inputs (`ref`, `fetch-depth`, `token`, etc.) work unchanged, and if the sticky disk/mirror is unavailable it silently falls back to a standard clone, so there's no new failure mode.

## What's intentionally left on `actions/checkout`

- **macOS jobs** (`mobile_native_static_analysis`, iOS showcase screenshots, the macOS release-build matrix legs) and the **Windows** release leg — checkout caching is backed by sticky disks, which are a Linux-runner primitive.
- **GitHub-hosted jobs** (`pr-size`, `publish_cli` on `ubuntu-24.04`) — no Blacksmith infra there.
- The `build` matrix job uses one shared checkout step across Linux/macOS/Windows runners, so it stays on `actions/checkout` rather than forking the step per-OS.

## Notes

- Feature is in beta; on any cache problem it falls back to a plain clone rather than failing the job.
- Sticky disk storage is billed at $0.50/GB/mo; one repo mirror is a few hundred MB, evicted after 7 days of inactivity.
- First run per repo does a full mirror clone, so don't expect the speedup until the second run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only checkout action swap with documented fallback to standard clone; no application or auth logic changes.
> 
> **Overview**
> On every job that runs on **`blacksmith-*-ubuntu`** runners, checkout steps now use **`useblacksmith/checkout@v1`** instead of **`actions/checkout@v6`**. That covers CI (check, test, release smoke), relay deploy, mobile EAS preview/production, Android showcase screenshots, and multiple release pipeline jobs (preflight, relay deploy, WSL node-pty build, release, web deploy, finalize, etc.).
> 
> The Blacksmith action is a drop-in replacement: existing inputs like **`ref`**, **`fetch-depth`**, and **`token`** are unchanged. It uses a persistent bare mirror on sticky disk so later runs can incremental **`git fetch`** instead of full clones, including full-history checkouts.
> 
> **macOS/Windows** release and mobile jobs, **GitHub-hosted** runners, and the shared **build** matrix checkout stay on **`actions/checkout`** because caching is Linux sticky-disk only or the step is shared across OSes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5df2472417d3f9a7ff705d50f5c36bbffed5ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use Blacksmith git checkout caching across all CI/CD workflows
> Replaces `actions/checkout@v6` with `useblacksmith/checkout@v1` in all GitHub Actions workflows to leverage Blacksmith's git checkout caching on Blacksmith Linux runners. Affected workflows include `ci.yml`, `release.yml`, `deploy-relay.yml`, `mobile-eas-preview.yml`, `mobile-eas-production.yml`, and `mobile-showcase-screenshots.yml`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5df247.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->