### PR TITLE
fix(server): resolve monorepo favicons and sanitize SVGs

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -48,6 +48,14 @@ describe("AssetAccess", () => {
     ).toBe('<svg viewBox="0 0 1 1"><path /></svg>');
   });
 
+  it("preserves nested SVG elements inside the first root document", () => {
+    expect(
+      extractSvgDocument(
+        '<svg viewBox="0 0 2 2"><svg viewBox="0 0 1 1"><path /></svg><circle /></svg><script>unsafe()</script>',
+      ),
+    ).toBe('<svg viewBox="0 0 2 2"><svg viewBox="0 0 1 1"><path /></svg><circle /></svg>');
+  });
+
   it.effect("issues workspace URLs that resolve the entry file and sibling assets", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -40,6 +40,14 @@ describe("AssetAccess", () => {
     );
   });
 
+  it("extracts only the first SVG document when the source has multiple roots", () => {
+    expect(
+      extractSvgDocument(
+        '<svg viewBox="0 0 1 1"><path /></svg><script>unsafe()</script><svg></svg>',
+      ),
+    ).toBe('<svg viewBox="0 0 1 1"><path /></svg>');
+  });
+
   it.effect("issues workspace URLs that resolve the entry file and sibling assets", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -13,7 +13,12 @@ import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
-import { ASSET_ROUTE_PREFIX, issueAssetUrl, resolveAsset } from "./AssetAccess.ts";
+import {
+  ASSET_ROUTE_PREFIX,
+  extractSvgDocument,
+  issueAssetUrl,
+  resolveAsset,
+} from "./AssetAccess.ts";
 
 const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-asset-access-test-",
@@ -29,6 +34,12 @@ const testLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(NodeServices.layer));
 
 describe("AssetAccess", () => {
+  it("extracts a self-closing SVG document from surrounding content", () => {
+    expect(extractSvgDocument('<?xml version="1.0"?><svg viewBox="0 0 1 1" />trailing')).toBe(
+      '<svg viewBox="0 0 1 1" />',
+    );
+  });
+
   it.effect("issues workspace URLs that resolve the entry file and sibling assets", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -206,7 +217,7 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it.effect("issues project favicon capabilities with a signed fallback", () =>
+  it.effect("issues sanitized SVG favicon capabilities with a signed fallback", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -214,8 +225,15 @@ describe("AssetAccess", () => {
         prefix: "t3-asset-favicon-",
       });
       const faviconPath = path.join(root, "favicon.svg");
-      yield* fileSystem.writeFileString(faviconPath, "<svg />");
-      const canonicalFaviconPath = yield* fileSystem.realPath(faviconPath);
+      yield* fileSystem.writeFileString(
+        faviconPath,
+        [
+          '<?xml version="1.0"?>',
+          '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">',
+          '<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>',
+          "<!-- trailing content -->",
+        ].join("\n"),
+      );
 
       const faviconResult = yield* issueAssetUrl({
         resource: { _tag: "project-favicon", cwd: root },
@@ -227,7 +245,11 @@ describe("AssetAccess", () => {
           faviconSuffix.slice(0, faviconSeparatorIndex),
           faviconSuffix.slice(faviconSeparatorIndex + 1),
         ),
-      ).toEqual({ kind: "file", path: canonicalFaviconPath });
+      ).toEqual({
+        kind: "text",
+        body: '<svg xmlns="http://www.w3.org/2000/svg"><path /></svg>',
+        contentType: "image/svg+xml",
+      });
 
       yield* fileSystem.remove(faviconPath);
       const fallbackResult = yield* issueAssetUrl({

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -99,13 +99,82 @@ export type ResolvedAsset =
       readonly contentType: "image/svg+xml";
     };
 
-export function extractSvgDocument(source: string): string | null {
-  const documentMatch = source.match(/<svg\b[\s\S]*?<\/svg\s*>/i);
-  if (documentMatch) {
-    return documentMatch[0];
+function findMarkupEnd(source: string, start: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let index = start + 1; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index;
+    }
   }
-  const selfClosingMatch = source.match(/<svg\b[^>]*\/\s*>/i);
-  return selfClosingMatch?.[0] ?? null;
+  return -1;
+}
+
+export function extractSvgDocument(source: string): string | null {
+  let rootStart = -1;
+  let depth = 0;
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const tagStart = source.indexOf("<", cursor);
+    if (tagStart === -1) {
+      return null;
+    }
+    if (source.startsWith("<!--", tagStart)) {
+      const commentEnd = source.indexOf("-->", tagStart + 4);
+      if (commentEnd === -1) {
+        return null;
+      }
+      cursor = commentEnd + 3;
+      continue;
+    }
+    if (source.startsWith("<![CDATA[", tagStart)) {
+      const cdataEnd = source.indexOf("]]>", tagStart + 9);
+      if (cdataEnd === -1) {
+        return null;
+      }
+      cursor = cdataEnd + 3;
+      continue;
+    }
+
+    const tagEnd = findMarkupEnd(source, tagStart);
+    if (tagEnd === -1) {
+      return null;
+    }
+    const tag = source.slice(tagStart, tagEnd + 1);
+    const svgTag = tag.match(/^<\s*(\/?)\s*svg\b/i);
+    if (svgTag) {
+      const isClosing = svgTag[1] === "/";
+      const isSelfClosing = !isClosing && /\/\s*>$/.test(tag);
+      if (rootStart === -1) {
+        if (isClosing) {
+          cursor = tagEnd + 1;
+          continue;
+        }
+        rootStart = tagStart;
+        if (isSelfClosing) {
+          return source.slice(rootStart, tagEnd + 1);
+        }
+        depth = 1;
+      } else if (isClosing) {
+        depth -= 1;
+        if (depth === 0) {
+          return source.slice(rootStart, tagEnd + 1);
+        }
+      } else if (!isSelfClosing) {
+        depth += 1;
+      }
+    }
+    cursor = tagEnd + 1;
+  }
+
+  return null;
 }
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -100,7 +100,7 @@ export type ResolvedAsset =
     };
 
 export function extractSvgDocument(source: string): string | null {
-  const documentMatch = source.match(/<svg\b[\s\S]*<\/svg\s*>/i);
+  const documentMatch = source.match(/<svg\b[\s\S]*?<\/svg\s*>/i);
   if (documentMatch) {
     return documentMatch[0];
   }

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -91,7 +91,22 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
+export type ResolvedAsset =
+  | { readonly kind: "file"; readonly path: string }
+  | {
+      readonly kind: "text";
+      readonly body: string;
+      readonly contentType: "image/svg+xml";
+    };
+
+export function extractSvgDocument(source: string): string | null {
+  const documentMatch = source.match(/<svg\b[\s\S]*<\/svg\s*>/i);
+  if (documentMatch) {
+    return documentMatch[0];
+  }
+  const selfClosingMatch = source.match(/<svg\b[^>]*\/\s*>/i);
+  return selfClosingMatch?.[0] ?? null;
+}
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -394,7 +409,30 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       workspaceRoot: claims.workspaceRoot,
       relativePath: claims.relativePath,
     });
-    return faviconPath ? ({ kind: "file", path: faviconPath } satisfies ResolvedAsset) : null;
+    if (!faviconPath) return null;
+    const path = yield* Path.Path;
+    if (path.extname(faviconPath).toLowerCase() !== ".svg") {
+      return { kind: "file", path: faviconPath } satisfies ResolvedAsset;
+    }
+    const fileSystem = yield* FileSystem.FileSystem;
+    const source = yield* fileSystem.readFileString(faviconPath).pipe(
+      Effect.tapError((cause) =>
+        Effect.logError("Failed to read project SVG favicon.", {
+          path: faviconPath,
+          cause,
+        }),
+      ),
+      Effect.orElseSucceed(() => null),
+    );
+    if (source === null) return null;
+    const svg = extractSvgDocument(source);
+    return svg
+      ? ({
+          kind: "text",
+          body: svg,
+          contentType: "image/svg+xml",
+        } satisfies ResolvedAsset)
+      : ({ kind: "file", path: faviconPath } satisfies ResolvedAsset);
   }
 
   const decodedPath = decodeRelativePath(relativePath);

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -192,12 +192,20 @@ export const assetRouteLayer = HttpRouter.add(
     if (!asset) {
       return HttpServerResponse.text("Not Found", { status: 404 });
     }
+    const assetHeaders = {
+      "Cache-Control": "private, max-age=3600",
+      "X-Content-Type-Options": "nosniff",
+    };
+    if (asset.kind === "text") {
+      return HttpServerResponse.text(asset.body, {
+        status: 200,
+        contentType: asset.contentType,
+        headers: assetHeaders,
+      });
+    }
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
-      headers: {
-        "Cache-Control": "private, max-age=3600",
-        "X-Content-Type-Options": "nosniff",
-      },
+      headers: assetHeaders,
     }).pipe(
       Effect.orElseSucceed(() => HttpServerResponse.text("Internal Server Error", { status: 500 })),
     );

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -133,6 +133,53 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("resolves favicon files from monorepo apps in stable order", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "apps/zeta/favicon.svg", "<svg>zeta</svg>");
+        yield* writeTextFile(cwd, "apps/alpha/public/favicon.png", "alpha");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/alpha/public/favicon.png");
+      }),
+    );
+
+    it.effect("resolves icon hrefs from monorepo app source files", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "apps/dashboard/index.html",
+          '<link rel="icon" href="/brand/logo.svg">',
+        );
+        yield* writeTextFile(cwd, "apps/dashboard/public/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/dashboard/public/brand/logo.svg");
+      }),
+    );
+
+    it.effect("keeps root favicon metadata ahead of monorepo candidates", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "index.html", '<link rel="icon" href="/brand.svg">');
+        yield* writeTextFile(cwd, "public/brand.svg", "<svg>root</svg>");
+        yield* writeTextFile(cwd, "apps/dashboard/favicon.svg", "<svg>app</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("public/brand.svg");
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.test.ts
@@ -180,6 +180,47 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("continues across unreadable monorepo roots", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const appsRoot = path.join(cwd, "apps");
+        const packagesRoot = path.join(cwd, "packages");
+        yield* writeTextFile(cwd, "apps/dashboard/package.json", "{}");
+        yield* writeTextFile(cwd, "packages/ui/package.json", "{}");
+        yield* writeTextFile(cwd, "services/api/favicon.svg", "<svg>api</svg>");
+        const statCause = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "stat",
+          pathOrDescriptor: appsRoot,
+        });
+        const readCause = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: "readDirectory",
+          pathOrDescriptor: packagesRoot,
+        });
+        const resolver = yield* makeResolverWithFileSystem(
+          FileSystem.FileSystem.of({
+            ...fileSystem,
+            stat: (filePath) =>
+              filePath === appsRoot ? Effect.fail(statCause) : fileSystem.stat(filePath),
+            readDirectory: (directoryPath, options) =>
+              directoryPath === packagesRoot
+                ? Effect.fail(readCause)
+                : fileSystem.readDirectory(directoryPath, options),
+          }),
+        );
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("services/api/favicon.svg");
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver.ProjectFaviconResolver;

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -71,7 +71,6 @@ export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<Proje
       "resolve-path",
       "stat-candidate",
       "read-source",
-      "read-monorepo-root",
     ]),
     workspaceRoot: Schema.String,
     relativePath: Schema.optional(Schema.String),
@@ -222,39 +221,20 @@ export const make = Effect.gen(function* () {
   });
 
   const listMonorepoProjectBases = Effect.fn("ProjectFaviconResolver.listMonorepoProjectBases")(
-    function* (
-      projectCwd: string,
-    ): Effect.fn.Return<ReadonlyArray<string>, ProjectFaviconResolutionError> {
+    function* (projectCwd: string): Effect.fn.Return<ReadonlyArray<string>> {
       const bases: Array<string> = [];
       for (const monorepoRoot of MONOREPO_PROJECT_ROOTS) {
         const absoluteRoot = path.join(projectCwd, monorepoRoot);
-        const stats = yield* optionOnNotFound(fileSystem.stat(absoluteRoot)).pipe(
-          Effect.mapError(
-            (cause) =>
-              new ProjectFaviconResolutionError({
-                operation: "read-monorepo-root",
-                workspaceRoot: projectCwd,
-                relativePath: monorepoRoot,
-                absolutePath: absoluteRoot,
-                cause,
-              }),
-          ),
+        const stats = yield* fileSystem.stat(absoluteRoot).pipe(
+          Effect.map(Option.some),
+          Effect.orElseSucceed(() => Option.none()),
         );
         if (Option.isNone(stats) || stats.value.type !== "Directory") {
           continue;
         }
-        const entries = yield* fileSystem.readDirectory(absoluteRoot, { recursive: false }).pipe(
-          Effect.mapError(
-            (cause) =>
-              new ProjectFaviconResolutionError({
-                operation: "read-monorepo-root",
-                workspaceRoot: projectCwd,
-                relativePath: monorepoRoot,
-                absolutePath: absoluteRoot,
-                cause,
-              }),
-          ),
-        );
+        const entries = yield* fileSystem
+          .readDirectory(absoluteRoot, { recursive: false })
+          .pipe(Effect.orElseSucceed(() => [] as Array<string>));
         for (const entry of entries.toSorted()) {
           if (!entry.startsWith(".")) {
             bases.push(path.join(monorepoRoot, entry));

--- a/apps/server/src/project/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/ProjectFaviconResolver.ts
@@ -54,6 +54,9 @@ const ICON_SOURCE_FILES = [
   "src/index.html",
 ] as const;
 
+// Conventional one-level workspace collections checked after the repository root.
+const MONOREPO_PROJECT_ROOTS = ["apps", "packages", "services"] as const;
+
 // Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
@@ -68,6 +71,7 @@ export class ProjectFaviconResolutionError extends Schema.TaggedErrorClass<Proje
       "resolve-path",
       "stat-candidate",
       "read-source",
+      "read-monorepo-root",
     ]),
     workspaceRoot: Schema.String,
     relativePath: Schema.optional(Schema.String),
@@ -120,9 +124,9 @@ export const make = Effect.gen(function* () {
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const projectFileLoader = yield* T3ProjectFileLoader.T3ProjectFileLoader;
 
-  const resolveIconHref = (href: string): ReadonlyArray<string> => {
+  const resolveIconHref = (basePath: string, href: string): ReadonlyArray<string> => {
     const clean = href.replace(/^\//, "");
-    return [path.join("public", clean), clean];
+    return [path.join(basePath, "public", clean), path.join(basePath, clean)];
   };
 
   const findExistingFile = Effect.fn("ProjectFaviconResolver.findExistingFile")(function* (
@@ -166,6 +170,101 @@ export const make = Effect.gen(function* () {
     return null;
   });
 
+  const findFromSourceFiles = Effect.fn("ProjectFaviconResolver.findFromSourceFiles")(function* (
+    projectCwd: string,
+    basePath: string,
+  ): Effect.fn.Return<string | null, ProjectFaviconResolutionError> {
+    for (const sourceFile of ICON_SOURCE_FILES) {
+      const relativePath = path.join(basePath, sourceFile);
+      const sourcePath = yield* workspacePaths
+        .resolveRelativePathWithinRoot({
+          workspaceRoot: projectCwd,
+          relativePath,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectFaviconResolutionError({
+                operation: "resolve-path",
+                workspaceRoot: projectCwd,
+                relativePath,
+                cause,
+              }),
+          ),
+        );
+      const source = yield* optionOnNotFound(
+        fileSystem.readFileString(sourcePath.absolutePath),
+      ).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectFaviconResolutionError({
+              operation: "read-source",
+              workspaceRoot: projectCwd,
+              relativePath,
+              absolutePath: sourcePath.absolutePath,
+              cause,
+            }),
+        ),
+      );
+      if (Option.isNone(source)) {
+        continue;
+      }
+      const href = extractIconHref(source.value);
+      if (!href) {
+        continue;
+      }
+      const existing = yield* findExistingFile(projectCwd, resolveIconHref(basePath, href));
+      if (existing) {
+        return existing;
+      }
+    }
+    return null;
+  });
+
+  const listMonorepoProjectBases = Effect.fn("ProjectFaviconResolver.listMonorepoProjectBases")(
+    function* (
+      projectCwd: string,
+    ): Effect.fn.Return<ReadonlyArray<string>, ProjectFaviconResolutionError> {
+      const bases: Array<string> = [];
+      for (const monorepoRoot of MONOREPO_PROJECT_ROOTS) {
+        const absoluteRoot = path.join(projectCwd, monorepoRoot);
+        const stats = yield* optionOnNotFound(fileSystem.stat(absoluteRoot)).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectFaviconResolutionError({
+                operation: "read-monorepo-root",
+                workspaceRoot: projectCwd,
+                relativePath: monorepoRoot,
+                absolutePath: absoluteRoot,
+                cause,
+              }),
+          ),
+        );
+        if (Option.isNone(stats) || stats.value.type !== "Directory") {
+          continue;
+        }
+        const entries = yield* fileSystem.readDirectory(absoluteRoot, { recursive: false }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProjectFaviconResolutionError({
+                operation: "read-monorepo-root",
+                workspaceRoot: projectCwd,
+                relativePath: monorepoRoot,
+                absolutePath: absoluteRoot,
+                cause,
+              }),
+          ),
+        );
+        for (const entry of entries.toSorted()) {
+          if (!entry.startsWith(".")) {
+            bases.push(path.join(monorepoRoot, entry));
+          }
+        }
+      }
+      return bases;
+    },
+  );
+
   const resolvePath: ProjectFaviconResolver["Service"]["resolvePath"] = Effect.fn(
     "ProjectFaviconResolver.resolvePath",
   )(function* (cwd) {
@@ -195,47 +294,22 @@ export const make = Effect.gen(function* () {
       }
     }
 
-    for (const sourceFile of ICON_SOURCE_FILES) {
-      const sourcePath = yield* workspacePaths
-        .resolveRelativePathWithinRoot({
-          workspaceRoot: projectCwd,
-          relativePath: sourceFile,
-        })
-        .pipe(
-          Effect.mapError(
-            (cause) =>
-              new ProjectFaviconResolutionError({
-                operation: "resolve-path",
-                workspaceRoot: projectCwd,
-                relativePath: sourceFile,
-                cause,
-              }),
-          ),
-        );
-      const source = yield* optionOnNotFound(
-        fileSystem.readFileString(sourcePath.absolutePath),
-      ).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ProjectFaviconResolutionError({
-              operation: "read-source",
-              workspaceRoot: projectCwd,
-              relativePath: sourceFile,
-              absolutePath: sourcePath.absolutePath,
-              cause,
-            }),
-        ),
-      );
-      if (Option.isNone(source)) {
-        continue;
+    const rootSourceIcon = yield* findFromSourceFiles(projectCwd, "");
+    if (rootSourceIcon) {
+      return rootSourceIcon;
+    }
+
+    const monorepoProjectBases = yield* listMonorepoProjectBases(projectCwd);
+    for (const basePath of monorepoProjectBases) {
+      for (const candidate of FAVICON_CANDIDATES) {
+        const existing = yield* findExistingFile(projectCwd, [path.join(basePath, candidate)]);
+        if (existing) {
+          return existing;
+        }
       }
-      const href = extractIconHref(source.value);
-      if (!href) {
-        continue;
-      }
-      const existing = yield* findExistingFile(projectCwd, resolveIconHref(href));
-      if (existing) {
-        return existing;
+      const sourceIcon = yield* findFromSourceFiles(projectCwd, basePath);
+      if (sourceIcon) {
+        return sourceIcon;
       }
     }
 


### PR DESCRIPTION
## What Changed

- Resolve project favicons from one-level workspaces under `apps/*`, `packages/*`, and `services/*`.
- Reuse the existing favicon candidates and source metadata discovery for each workspace.
- Preserve root-level favicon precedence and deterministic monorepo search order.
- Serve project SVG favicons using only the root `<svg>` document, excluding XML declarations, doctypes, and trailing content.
- Add focused coverage for monorepo lookup, precedence, SVG extraction, and signed asset resolution.

## Why

T3 Code only searched favicon locations relative to the selected project root. Monorepos commonly keep their application favicon under paths such as `apps/web/public/favicon.svg`, so those projects fell back to the generic folder icon.

Some otherwise valid SVG favicon files also contain XML declarations or doctypes that can prevent them from rendering reliably as sidebar image assets. Extracting the SVG document before serving it keeps the original file untouched while avoiding that failure mode.

## UI Changes

No layout or component changes. Projects that previously displayed the fallback folder icon can now display their application favicon when it lives in a supported monorepo workspace.

Verified in an isolated local T3 Code environment with an XML/doctype-prefixed favicon at `apps/dashboard/public/favicon.svg`; both sidebar image instances loaded successfully at their intrinsic 150×150 size.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed asset resolution and serves transformed SVG content (mitigates trailing markup) rather than always streaming the on-disk file; favicon precedence behavior changes for monorepos.
> 
> **Overview**
> **Favicon discovery** now walks one-level workspaces under `apps/`, `packages/`, and `services/` (sorted entries), reusing the same conventional filenames and HTML/metadata icon href resolution per app. Root `t3.json`, root candidates, and root source metadata still win before any monorepo path; unreadable monorepo directories are skipped.
> 
> **SVG project favicons** are no longer served as raw files when possible: `resolveAsset` reads `.svg` favicons, runs new `extractSvgDocument` to keep only the first root `<svg>` (drops XML/doctype/comments and trailing junk like extra `<script>`/second roots), and returns `{ kind: "text", contentType: "image/svg+xml" }`. Non-SVG favicons and unparseable SVGs still use file paths. The asset route serves the `text` variant with the same private cache and `nosniff` headers as file responses.
> 
> Tests cover SVG extraction edge cases, sanitized favicon resolution, and monorepo precedence/ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917649a8aba61ea5e84729dbaae91bb110d8590d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix favicon resolution for monorepos and sanitize SVG favicons
> - Extends `ProjectFaviconResolver.resolvePath` to search monorepo subdirectories (`apps`, `packages`, `services`) for favicons, checking well-known candidate paths and `<link rel="icon">` hrefs in source files, in stable sorted order.
> - Adds `extractSvgDocument` in [AssetAccess.ts](https://github.com/pingdotgg/t3code/pull/4424/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) to extract and sanitize the first complete `<svg>` element from raw file content, handling nested SVGs, comments, and CDATA.
> - When a `.svg` favicon is resolved, the server now reads the file, extracts the SVG document, and returns it as an inline text asset with `content-type: image/svg+xml` instead of serving the raw file.
> - Updates the asset HTTP route in [http.ts](https://github.com/pingdotgg/t3code/pull/4424/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) to handle the new inline text asset variant with proper `Cache-Control` and `X-Content-Type-Options` headers.
> - Behavioral Change: callers requesting `.svg` favicons now receive sanitized inline SVG text; non-SVG favicons and failed extractions continue to return file assets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 917649a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->