### PR TITLE
Show remote environment names in thread rows

### DIFF
--- a/apps/web/src/components/RemoteEnvironmentIndicator.test.tsx
+++ b/apps/web/src/components/RemoteEnvironmentIndicator.test.tsx
@@ -2,7 +2,10 @@ import { ServerIcon } from "lucide-react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
-import { RemoteEnvironmentIndicator } from "./RemoteEnvironmentIndicator";
+import {
+  RemoteEnvironmentIndicator,
+  shouldShowRemoteEnvironmentIndicator,
+} from "./RemoteEnvironmentIndicator";
 
 describe("RemoteEnvironmentIndicator", () => {
   it("renders the environment name next to an accessible remote icon", () => {
@@ -13,5 +16,30 @@ describe("RemoteEnvironmentIndicator", () => {
     expect(markup).toContain('aria-label="Remote environment: ryzen-shine"');
     expect(markup).toContain("thread-remote-environment-label");
     expect(markup).toContain(">ryzen-shine</span>");
+    expect(markup.indexOf(">ryzen-shine</span>")).toBeLessThan(markup.indexOf("<svg"));
+  });
+
+  it("only identifies non-local secondary environments as remote", () => {
+    expect(
+      shouldShowRemoteEnvironmentIndicator({
+        currentEnvironmentId: "primary",
+        threadEnvironmentId: "remote",
+        isDesktopLocal: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowRemoteEnvironmentIndicator({
+        currentEnvironmentId: "primary",
+        threadEnvironmentId: "wsl",
+        isDesktopLocal: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowRemoteEnvironmentIndicator({
+        currentEnvironmentId: "primary",
+        threadEnvironmentId: "primary",
+        isDesktopLocal: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/RemoteEnvironmentIndicator.test.tsx
+++ b/apps/web/src/components/RemoteEnvironmentIndicator.test.tsx
@@ -1,0 +1,17 @@
+import { ServerIcon } from "lucide-react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { RemoteEnvironmentIndicator } from "./RemoteEnvironmentIndicator";
+
+describe("RemoteEnvironmentIndicator", () => {
+  it("renders the environment name next to an accessible remote icon", () => {
+    const markup = renderToStaticMarkup(
+      <RemoteEnvironmentIndicator icon={ServerIcon} label="ryzen-shine" iconClassName="size-3.5" />,
+    );
+
+    expect(markup).toContain('aria-label="Remote environment: ryzen-shine"');
+    expect(markup).toContain("thread-remote-environment-label");
+    expect(markup).toContain(">ryzen-shine</span>");
+  });
+});

--- a/apps/web/src/components/RemoteEnvironmentIndicator.tsx
+++ b/apps/web/src/components/RemoteEnvironmentIndicator.tsx
@@ -21,8 +21,20 @@ export function RemoteEnvironmentIndicator({
       className={cn("inline-flex min-w-0 items-center gap-1", className)}
       {...props}
     >
-      <Icon aria-hidden className={cn("shrink-0", iconClassName)} />
       <span className="thread-remote-environment-label min-w-0 max-w-20 truncate">{label}</span>
+      <Icon aria-hidden className={cn("shrink-0", iconClassName)} />
     </span>
+  );
+}
+
+export function shouldShowRemoteEnvironmentIndicator(input: {
+  readonly currentEnvironmentId: string | null;
+  readonly threadEnvironmentId: string;
+  readonly isDesktopLocal: boolean;
+}) {
+  return (
+    input.currentEnvironmentId !== null &&
+    input.threadEnvironmentId !== input.currentEnvironmentId &&
+    !input.isDesktopLocal
   );
 }

--- a/apps/web/src/components/RemoteEnvironmentIndicator.tsx
+++ b/apps/web/src/components/RemoteEnvironmentIndicator.tsx
@@ -1,0 +1,28 @@
+import type { LucideIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+
+import { cn } from "~/lib/utils";
+
+export function RemoteEnvironmentIndicator({
+  icon: Icon,
+  label,
+  className,
+  iconClassName,
+  ...props
+}: ComponentProps<"span"> & {
+  readonly icon: LucideIcon;
+  readonly label: string;
+  readonly iconClassName?: string;
+}) {
+  return (
+    <span
+      role="img"
+      aria-label={`Remote environment: ${label}`}
+      className={cn("inline-flex min-w-0 items-center gap-1", className)}
+      {...props}
+    >
+      <Icon aria-hidden className={cn("shrink-0", iconClassName)} />
+      <span className="thread-remote-environment-label min-w-0 max-w-20 truncate">{label}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { RemoteEnvironmentIndicator } from "./RemoteEnvironmentIndicator";
 import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
@@ -669,7 +670,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
         size="sm"
         isActive={isActive}
         data-testid={`thread-row-${thread.id}`}
-        className={`${resolveThreadRowClassName({
+        className={`@container/thread-row ${resolveThreadRowClassName({
           isActive,
           isSelected,
         })} relative isolate`}
@@ -830,14 +831,14 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                   <Tooltip>
                     <TooltipTrigger
                       render={
-                        <span
-                          aria-label={threadEnvironmentLabel ?? "Remote"}
-                          className="inline-flex items-center justify-center"
+                        <RemoteEnvironmentIndicator
+                          icon={CloudIcon}
+                          label={threadEnvironmentLabel ?? "Remote"}
+                          className="max-w-24"
+                          iconClassName="size-3 text-muted-foreground/40"
                         />
                       }
-                    >
-                      <CloudIcon className="size-3 text-muted-foreground/40" />
-                    </TooltipTrigger>
+                    />
                     <TooltipPopup side="top">{threadEnvironmentLabel}</TooltipPopup>
                   </Tooltip>
                 )}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -834,8 +834,8 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                         <RemoteEnvironmentIndicator
                           icon={CloudIcon}
                           label={threadEnvironmentLabel ?? "Remote"}
-                          className="max-w-24"
-                          iconClassName="size-3 text-muted-foreground/40"
+                          className="max-w-24 text-muted-foreground/40"
+                          iconClassName="size-3"
                         />
                       }
                     />

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -75,11 +75,12 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useThreadActions } from "../hooks/useThreadActions";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
+import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
@@ -108,7 +109,10 @@ import {
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
-import { RemoteEnvironmentIndicator } from "./RemoteEnvironmentIndicator";
+import {
+  RemoteEnvironmentIndicator,
+  shouldShowRemoteEnvironmentIndicator,
+} from "./RemoteEnvironmentIndicator";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
@@ -419,8 +423,14 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
 
-  const isRemote =
-    props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
+  const environment = useEnvironment(thread.environmentId);
+  const isDesktopLocal =
+    environment !== null && isDesktopLocalConnectionTarget(environment.entry.target);
+  const showRemoteEnvironmentIndicator = shouldShowRemoteEnvironmentIndicator({
+    currentEnvironmentId: props.currentEnvironmentId,
+    threadEnvironmentId: thread.environmentId,
+    isDesktopLocal,
+  });
 
   const detailsTooltip = (
     <SidebarV2ThreadTooltip
@@ -772,7 +782,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 </span>
               ) : null}
               <span className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1">
-                {isRemote ? (
+                {showRemoteEnvironmentIndicator ? (
                   <RemoteEnvironmentIndicator
                     icon={ServerIcon}
                     label={props.environmentLabel ?? "Remote"}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -108,6 +108,7 @@ import {
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { RemoteEnvironmentIndicator } from "./RemoteEnvironmentIndicator";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
@@ -688,7 +689,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               role="button"
               tabIndex={0}
               data-testid="sidebar-v2-row-card"
-              className={rowSurfaceClassName}
+              className={cn("@container/thread-row", rowSurfaceClassName)}
               onClick={handleClick}
               onDoubleClick={handleDoubleClick}
               onKeyDown={handleKeyDown}
@@ -770,14 +771,14 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                   <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
                 </span>
               ) : null}
-              <span
-                aria-hidden
-                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-              >
+              <span className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1">
                 {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <ServerIcon aria-hidden className="size-3.5" />
-                  </span>
+                  <RemoteEnvironmentIndicator
+                    icon={ServerIcon}
+                    label={props.environmentLabel ?? "Remote"}
+                    className="max-w-24 shrink-0 text-sidebar-muted-foreground/70"
+                    iconClassName="size-3.5"
+                  />
                 ) : null}
                 {driverKind ? (
                   <span className="inline-flex shrink-0 items-center opacity-60">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -250,6 +250,16 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     display: none;
   }
 
+  .thread-remote-environment-label {
+    display: none;
+  }
+
+  @container thread-row (min-width: 13rem) {
+    .thread-remote-environment-label {
+      display: inline;
+    }
+  }
+
   @media (min-width: 48rem) {
     @container sidebar-header (min-width: 13.5rem) {
       .sidebar-brand {


### PR DESCRIPTION
## What Changed

- Show the remote host/environment name beside the existing remote icon in inbox thread rows.
- Place the hostname before the glyph and use the same muted treatment as surrounding metadata.
- Use a named container query so narrow rows keep the compact icon-only treatment.
- Share the accessible remote indicator between the classic and v2 sidebars.
- Exclude desktop-local secondary backends such as WSL from remote labeling.

## Why

Remote threads were identifiable as remote, but the inbox did not reveal which host they belong to without hovering. Showing the environment name when the row has room makes remote threads easier to distinguish while preserving the compact layout at narrow widths.

## UI Changes

These captures use the app’s real draggable sidebar at 440px; no production sizing defaults were changed.

| Before | After |
| --- | --- |
| ![Remote thread row with icon only](https://raw.githubusercontent.com/colonelpanic8/t3code/ce89a945f97a1077e849fbb51d7a198293f192a8/.github/pr-assets/remote-host-label-v2-before.png) | ![Remote thread row with hostname before the remote icon](https://raw.githubusercontent.com/colonelpanic8/t3code/ce89a945f97a1077e849fbb51d7a198293f192a8/.github/pr-assets/remote-host-label-v2-after.png) |

Verified the real remote-thread flow in both sidebar variants. Wide rows show `ryzen-shine` before the glyph; at a 210px sidebar the label is hidden while the remote icon and accessible name remain.

## Checklist

- [x] `vp test run apps/web/src/components/RemoteEnvironmentIndicator.test.tsx --passWithNoTests`
- [x] `vp lint apps/web/src/components/RemoteEnvironmentIndicator.tsx apps/web/src/components/RemoteEnvironmentIndicator.test.tsx apps/web/src/components/Sidebar.tsx apps/web/src/components/SidebarV2.tsx`
- [x] `vp fmt --check apps/web/src/components/RemoteEnvironmentIndicator.tsx apps/web/src/components/RemoteEnvironmentIndicator.test.tsx apps/web/src/components/Sidebar.tsx apps/web/src/components/SidebarV2.tsx apps/web/src/index.css`
- [x] `vp run --filter @t3tools/web typecheck`
- [x] `vp check`
- [x] `vp run typecheck`
- [x] Tested the authenticated remote-environment inbox flow in both classic and v2 sidebars at wide and constrained row widths
- [x] Verified desktop-local secondary environments are excluded from remote labeling

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show remote environment names in sidebar thread rows
> - Adds a `RemoteEnvironmentIndicator` component that renders an icon with an accessible `aria-label` and a text label span for the environment name.
> - Updates both `SidebarThreadRow` and `SidebarV2Row` to use the new component, replacing the bare icon with a labeled indicator.
> - The environment name is hidden by default and revealed via a CSS container query (`@container thread-row (min-width: 13rem)`) so it only appears when the row is wide enough.
> - In `SidebarV2Row`, the indicator is suppressed for desktop-local connections via the new `shouldShowRemoteEnvironmentIndicator` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f40fc1a. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->