### PR TITLE
Add environment-aware new thread picker

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -201,6 +201,8 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
       assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
       assert.equal(defaultsByCommand.get("terminal.splitVertical"), "mod+shift+d");
+      assert.equal(defaultsByCommand.get("chat.newEnvironment"), "mod+shift+n");
+      assert.isFalse(defaultsByCommand.has("chat.newLocal"));
       assert.equal(defaultsByCommand.get("modelPicker.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("modelPicker.jump.9"), "mod+9");
     }),
@@ -299,6 +301,55 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         }
         assert.isTrue(byCommand.has("script.run-tests.run"));
       }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("migrates the previous new-local default to the environment picker", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        {
+          key: "mod+shift+n",
+          command: "chat.newLocal",
+          when: "!terminalFocus",
+        },
+        {
+          key: "mod+shift+l",
+          command: "chat.newLocal",
+          when: "!terminalFocus",
+        },
+      ]);
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings.Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.isTrue(
+        persisted.some(
+          (entry) =>
+            entry.command === "chat.newEnvironment" &&
+            entry.key === "mod+shift+n" &&
+            entry.when === "!terminalFocus",
+        ),
+      );
+      assert.isFalse(
+        persisted.some(
+          (entry) =>
+            entry.command === "chat.newLocal" &&
+            entry.key === "mod+shift+n" &&
+            entry.when === "!terminalFocus",
+        ),
+      );
+      assert.isTrue(
+        persisted.some(
+          (entry) =>
+            entry.command === "chat.newLocal" &&
+            entry.key === "mod+shift+l" &&
+            entry.when === "!terminalFocus",
+        ),
+      );
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
   it.effect("skips conflicting default keybindings on startup and logs a detailed warning", () => {

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -109,6 +109,17 @@ function isSameKeybindingRule(left: KeybindingRule, right: KeybindingRule): bool
   );
 }
 
+const LEGACY_NEW_LOCAL_DEFAULT: KeybindingRule = {
+  key: "mod+shift+n",
+  command: "chat.newLocal",
+  when: "!terminalFocus",
+};
+const NEW_ENVIRONMENT_DEFAULT: KeybindingRule = {
+  key: "mod+shift+n",
+  command: "chat.newEnvironment",
+  when: "!terminalFocus",
+};
+
 function keybindingShortcutContext(rule: KeybindingRule): string | null {
   const parsed = parseKeybindingShortcut(rule.key);
   if (!parsed) return null;
@@ -493,7 +504,16 @@ const make = Effect.gen(function* () {
         yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
         return;
       }
-      const customConfig = runtimeConfig.keybindings;
+      const shouldMigrateNewEnvironmentDefault =
+        !runtimeConfig.keybindings.some((entry) => entry.command === "chat.newEnvironment") &&
+        runtimeConfig.keybindings.some((entry) =>
+          isSameKeybindingRule(entry, LEGACY_NEW_LOCAL_DEFAULT),
+        );
+      const customConfig = shouldMigrateNewEnvironmentDefault
+        ? runtimeConfig.keybindings.map((entry) =>
+            isSameKeybindingRule(entry, LEGACY_NEW_LOCAL_DEFAULT) ? NEW_ENVIRONMENT_DEFAULT : entry,
+          )
+        : runtimeConfig.keybindings;
       const existingCommands = new Set(customConfig.map((entry) => entry.command));
       const missingDefaults: KeybindingRule[] = [];
       const shortcutConflictWarnings: Array<{
@@ -530,7 +550,7 @@ const make = Effect.gen(function* () {
           reason: "shortcut context already used by existing rule",
         });
       }
-      if (missingDefaults.length === 0) {
+      if (missingDefaults.length === 0 && !shouldMigrateNewEnvironmentDefault) {
         yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
         return;
       }

--- a/apps/web/src/commandPaletteBus.ts
+++ b/apps/web/src/commandPaletteBus.ts
@@ -3,7 +3,7 @@
 const COMMAND_PALETTE_OPEN_EVENT = "t3code:open-command-palette";
 
 export interface CommandPaletteOpenDetail {
-  readonly open?: "add-project" | "new-thread-in";
+  readonly open?: "add-project" | "new-thread-in" | "new-thread-on";
 }
 
 export function openCommandPalette(detail?: CommandPaletteOpenDetail): void {

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -5,8 +5,17 @@ import {
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
+  resolveNewThreadOnIntent,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
+
+describe("resolveNewThreadOnIntent", () => {
+  it("keeps the intent pending until environment-backed projects load", () => {
+    expect(resolveNewThreadOnIntent({ isActive: false, environmentItemCount: 0 })).toBe("ignore");
+    expect(resolveNewThreadOnIntent({ isActive: true, environmentItemCount: 0 })).toBe("defer");
+    expect(resolveNewThreadOnIntent({ isActive: true, environmentItemCount: 1 })).toBe("open");
+  });
+});
 
 describe("enumerateCommandPaletteItems", () => {
   it("assigns positional jump shortcuts to the first nine displayed items", () => {

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -10,10 +10,19 @@ import {
 } from "./CommandPalette.logic";
 
 describe("resolveNewThreadOnIntent", () => {
-  it("keeps the intent pending until environment-backed projects load", () => {
-    expect(resolveNewThreadOnIntent({ isActive: false, environmentItemCount: 0 })).toBe("ignore");
-    expect(resolveNewThreadOnIntent({ isActive: true, environmentItemCount: 0 })).toBe("defer");
-    expect(resolveNewThreadOnIntent({ isActive: true, environmentItemCount: 1 })).toBe("open");
+  it("distinguishes loading from a loaded-empty environment list", () => {
+    expect(
+      resolveNewThreadOnIntent({ isActive: false, isLoaded: false, environmentItemCount: 0 }),
+    ).toBe("ignore");
+    expect(
+      resolveNewThreadOnIntent({ isActive: true, isLoaded: false, environmentItemCount: 0 }),
+    ).toBe("defer");
+    expect(
+      resolveNewThreadOnIntent({ isActive: true, isLoaded: true, environmentItemCount: 0 }),
+    ).toBe("clear");
+    expect(
+      resolveNewThreadOnIntent({ isActive: true, isLoaded: true, environmentItemCount: 1 }),
+    ).toBe("open");
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -8,6 +8,7 @@ import {
   resolveNewThreadOnIntent,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
+import { reduceCommandPaletteUiState } from "./CommandPalette";
 
 describe("resolveNewThreadOnIntent", () => {
   it("distinguishes loading from a loaded-empty environment list", () => {
@@ -23,6 +24,17 @@ describe("resolveNewThreadOnIntent", () => {
     expect(
       resolveNewThreadOnIntent({ isActive: true, isLoaded: true, environmentItemCount: 1 }),
     ).toBe("open");
+  });
+});
+
+describe("reduceCommandPaletteUiState", () => {
+  it("closes and clears a deferred open intent when no targets are available", () => {
+    expect(
+      reduceCommandPaletteUiState(
+        { open: true, openIntent: { kind: "new-thread-on" } },
+        { _tag: "SetOpen", open: false },
+      ),
+    ).toEqual({ open: false, openIntent: null });
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -17,10 +17,12 @@ export const ADDON_ICON_CLASS = "size-4";
 
 export function resolveNewThreadOnIntent(input: {
   isActive: boolean;
+  isLoaded: boolean;
   environmentItemCount: number;
-}): "ignore" | "defer" | "open" {
+}): "ignore" | "defer" | "clear" | "open" {
   if (!input.isActive) return "ignore";
-  return input.environmentItemCount > 0 ? "open" : "defer";
+  if (!input.isLoaded) return "defer";
+  return input.environmentItemCount > 0 ? "open" : "clear";
 }
 
 export interface CommandPaletteItem {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -15,6 +15,14 @@ export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-muted-foreground/80";
 export const ADDON_ICON_CLASS = "size-4";
 
+export function resolveNewThreadOnIntent(input: {
+  isActive: boolean;
+  environmentItemCount: number;
+}): "ignore" | "defer" | "open" {
+  if (!input.isActive) return "ignore";
+  return input.environmentItemCount > 0 ? "open" : "defer";
+}
+
 export interface CommandPaletteItem {
   readonly kind: "action" | "submenu";
   readonly value: string;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -60,7 +60,11 @@ import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import {
+  useAllEnvironmentShellsBootstrapped,
+  useProjects,
+  useThreadShells,
+} from "../state/entities";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
@@ -518,6 +522,7 @@ function OpenCommandPaletteDialog(props: {
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
+  const environmentShellsLoaded = useAllEnvironmentShellsBootstrapped();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -1264,13 +1269,18 @@ function OpenCommandPaletteDialog(props: {
   useLayoutEffect(() => {
     const resolution = resolveNewThreadOnIntent({
       isActive: openIntent?.kind === "new-thread-on",
+      isLoaded: environmentShellsLoaded,
       environmentItemCount: newThreadEnvironmentItems.length,
     });
+    if (resolution === "clear") {
+      clearOpenIntent();
+      return;
+    }
     if (resolution !== "open") {
       return;
     }
     openNewThreadOnFlow();
-  }, [newThreadEnvironmentItems.length, openIntent]);
+  }, [clearOpenIntent, environmentShellsLoaded, newThreadEnvironmentItems.length, openIntent]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -36,6 +36,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useEffectEvent,
   useLayoutEffect,
   useMemo,
   useReducer,
@@ -104,6 +105,7 @@ import {
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
+  resolveNewThreadOnIntent,
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -1242,17 +1244,11 @@ function OpenCommandPaletteDialog(props: {
     projectThreadItems,
   ]);
 
-  useLayoutEffect(() => {
-    if (openIntent?.kind !== "new-thread-on") {
-      return;
-    }
+  const openNewThreadOnFlow = useEffectEvent(() => {
     clearOpenIntent();
     setAddProjectCloneFlow(null);
     setViewStack([]);
     setQuery("");
-    if (newThreadEnvironmentItems.length === 0) {
-      return;
-    }
     pushPaletteView({
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
       groups: [
@@ -1263,7 +1259,18 @@ function OpenCommandPaletteDialog(props: {
         },
       ],
     });
-  }, [clearOpenIntent, newThreadEnvironmentItems, openIntent]);
+  });
+
+  useLayoutEffect(() => {
+    const resolution = resolveNewThreadOnIntent({
+      isActive: openIntent?.kind === "new-thread-on",
+      environmentItemCount: newThreadEnvironmentItems.length,
+    });
+    if (resolution !== "open") {
+      return;
+    }
+    openNewThreadOnFlow();
+  }, [newThreadEnvironmentItems.length, openIntent]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -22,11 +22,13 @@ import {
   ArrowDownIcon,
   ArrowLeftIcon,
   ArrowUpIcon,
+  CloudIcon,
   CornerLeftUpIcon,
   FolderIcon,
   FolderPlusIcon,
   LinkIcon,
   MessageSquareIcon,
+  MonitorIcon,
   SettingsIcon,
   SquarePenIcon,
 } from "lucide-react";
@@ -156,6 +158,19 @@ function getEnvironmentBrowsePlatform(os: string | null | undefined): string {
     return "Linux";
   }
   return typeof navigator === "undefined" ? "" : navigator.platform;
+}
+
+function renderProjectActionIcon(project: {
+  environmentId: EnvironmentId;
+  workspaceRoot: string;
+}): ReactNode {
+  return (
+    <ProjectFavicon
+      environmentId={project.environmentId}
+      cwd={project.workspaceRoot}
+      className={ITEM_ICON_CLASS}
+    />
+  );
 }
 
 interface AddProjectEnvironmentOption {
@@ -340,7 +355,7 @@ function errorMessage(error: unknown): string {
 }
 
 interface CommandPaletteOpenIntent {
-  readonly kind: "add-project" | "new-thread-in";
+  readonly kind: "add-project" | "new-thread-in" | "new-thread-on";
 }
 
 interface CommandPaletteUiState {
@@ -353,6 +368,7 @@ type CommandPaletteUiAction =
   | { readonly _tag: "Toggle" }
   | { readonly _tag: "OpenAddProject" }
   | { readonly _tag: "OpenNewThreadIn" }
+  | { readonly _tag: "OpenNewThreadOn" }
   | { readonly _tag: "ClearOpenIntent" };
 
 function reduceCommandPaletteUiState(
@@ -371,6 +387,8 @@ function reduceCommandPaletteUiState(
       return { open: true, openIntent: { kind: "add-project" } };
     case "OpenNewThreadIn":
       return { open: true, openIntent: { kind: "new-thread-in" } };
+    case "OpenNewThreadOn":
+      return { open: true, openIntent: { kind: "new-thread-on" } };
     case "ClearOpenIntent":
       return state.openIntent ? { ...state, openIntent: null } : state;
   }
@@ -385,6 +403,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   const toggleOpen = useCallback(() => dispatch({ _tag: "Toggle" }), []);
   const openAddProject = useCallback(() => dispatch({ _tag: "OpenAddProject" }), []);
   const openNewThreadIn = useCallback(() => dispatch({ _tag: "OpenNewThreadIn" }), []);
+  const openNewThreadOn = useCallback(() => dispatch({ _tag: "OpenNewThreadOn" }), []);
   const clearOpenIntent = useCallback(() => dispatch({ _tag: "ClearOpenIntent" }), []);
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const composerHandleRef = useRef<ChatComposerHandle | null>(null);
@@ -424,13 +443,15 @@ export function CommandPalette({ children }: { children: ReactNode }) {
       onOpenCommandPalette((detail) => {
         if (detail.open === "new-thread-in") {
           openNewThreadIn();
+        } else if (detail.open === "new-thread-on") {
+          openNewThreadOn();
         } else if (detail.open === "add-project") {
           openAddProject();
         } else {
           setOpen(true);
         }
       }),
-    [openAddProject, openNewThreadIn, setOpen],
+    [openAddProject, openNewThreadIn, openNewThreadOn, setOpen],
   );
 
   return (
@@ -620,6 +641,13 @@ function OpenCommandPaletteDialog(props: {
 
     return options;
   }, [environments]);
+  const newThreadEnvironmentOptions = useMemo(
+    () =>
+      [...addProjectEnvironmentOptions].sort((left, right) =>
+        left.label.localeCompare(right.label),
+      ),
+    [addProjectEnvironmentOptions],
+  );
   const defaultAddProjectEnvironmentId = addProjectEnvironmentOptions[0]?.environmentId ?? null;
   const wslAddProjectEnvironmentOption = useMemo(
     () =>
@@ -793,17 +821,92 @@ function OpenCommandPaletteDialog(props: {
             group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
           );
         },
-        icon: (project) => (
-          <ProjectFavicon
-            environmentId={project.environmentId}
-            cwd={project.workspaceRoot}
-            className={ITEM_ICON_CLASS}
-          />
-        ),
+        icon: renderProjectActionIcon,
         runProject: openProjectFromSearch,
       }),
     [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
   );
+
+  const newThreadEnvironmentItems = useMemo((): CommandPaletteSubmenuItem[] => {
+    const orderedEnvironmentOptions = currentProjectEnvironmentId
+      ? [
+          ...newThreadEnvironmentOptions.filter(
+            (option) => option.environmentId === currentProjectEnvironmentId,
+          ),
+          ...newThreadEnvironmentOptions.filter(
+            (option) => option.environmentId !== currentProjectEnvironmentId,
+          ),
+        ]
+      : newThreadEnvironmentOptions;
+
+    return orderedEnvironmentOptions.flatMap((option): CommandPaletteSubmenuItem[] => {
+      const environmentEntries = buildSidebarProjectPickerEntries({
+        groups: projectGroups,
+        preferredProjectRef: contextualProjectRef,
+        targetEnvironmentId: option.environmentId,
+      });
+      if (environmentEntries.length === 0) return [];
+
+      const groupByTargetKey = new Map(
+        environmentEntries.map(({ group, targetProject }) => [
+          `${targetProject.environmentId}:${targetProject.id}`,
+          group,
+        ]),
+      );
+      const environmentProjects = environmentEntries.map(({ group, targetProject }) => ({
+        ...targetProject,
+        title: group.displayName,
+      }));
+      const projectItems = enumerateCommandPaletteItems(
+        buildProjectActionItems({
+          projects: environmentProjects,
+          valuePrefix: `new-thread-on:${option.environmentId}`,
+          searchTerms: (project) => {
+            const group = groupByTargetKey.get(`${project.environmentId}:${project.id}`);
+            return (
+              group?.memberProjects
+                .filter((member) => member.environmentId === option.environmentId)
+                .flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+            );
+          },
+          icon: renderProjectActionIcon,
+          runProject: async (project) => {
+            await handleNewThread(scopeProjectRef(project.environmentId, project.id));
+          },
+        }),
+      );
+      const projectCount = projectItems.length;
+      const EnvironmentIcon = option.isPrimary ? MonitorIcon : CloudIcon;
+
+      return [
+        {
+          kind: "submenu",
+          value: `new-thread-on:${option.environmentId}`,
+          searchTerms: [
+            option.label,
+            option.isPrimary ? "local this device" : "remote environment machine",
+          ],
+          title: option.label,
+          description: `${String(projectCount)} ${projectCount === 1 ? "project" : "projects"}`,
+          icon: <EnvironmentIcon className={ITEM_ICON_CLASS} />,
+          addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
+          groups: [
+            {
+              value: `new-thread-on-projects:${option.environmentId}`,
+              label: "Projects",
+              items: projectItems,
+            },
+          ],
+        },
+      ];
+    });
+  }, [
+    contextualProjectRef,
+    currentProjectEnvironmentId,
+    handleNewThread,
+    newThreadEnvironmentOptions,
+    projectGroups,
+  ]);
 
   const projectThreadItems = useMemo(
     () =>
@@ -817,13 +920,7 @@ function OpenCommandPaletteDialog(props: {
               group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
             );
           },
-          icon: (project) => (
-            <ProjectFavicon
-              environmentId={project.environmentId}
-              cwd={project.workspaceRoot}
-              className={ITEM_ICON_CLASS}
-            />
-          ),
+          icon: renderProjectActionIcon,
           runProject: async (project) => {
             const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
             const contextualRefBelongsToGroup =
@@ -1145,6 +1242,29 @@ function OpenCommandPaletteDialog(props: {
     projectThreadItems,
   ]);
 
+  useLayoutEffect(() => {
+    if (openIntent?.kind !== "new-thread-on") {
+      return;
+    }
+    clearOpenIntent();
+    setAddProjectCloneFlow(null);
+    setViewStack([]);
+    setQuery("");
+    if (newThreadEnvironmentItems.length === 0) {
+      return;
+    }
+    pushPaletteView({
+      addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
+      groups: [
+        {
+          value: "environments",
+          label: "Run on",
+          items: newThreadEnvironmentItems,
+        },
+      ],
+    });
+  }, [clearOpenIntent, newThreadEnvironmentItems, openIntent]);
+
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 
   if (projects.length > 0) {
@@ -1172,6 +1292,33 @@ function OpenCommandPaletteDialog(props: {
             handleNewThread,
           });
         },
+      });
+    }
+
+    if (newThreadEnvironmentItems.length > 0) {
+      actionItems.push({
+        kind: "submenu",
+        value: "action:new-thread-on",
+        searchTerms: [
+          "new thread",
+          "environment",
+          "remote",
+          "machine",
+          "project",
+          "pick",
+          "choose",
+        ],
+        title: "New thread on...",
+        icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
+        addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
+        shortcutCommand: "chat.newEnvironment",
+        groups: [
+          {
+            value: "environments",
+            label: "Run on",
+            items: newThreadEnvironmentItems,
+          },
+        ],
       });
     }
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -377,7 +377,7 @@ type CommandPaletteUiAction =
   | { readonly _tag: "OpenNewThreadOn" }
   | { readonly _tag: "ClearOpenIntent" };
 
-function reduceCommandPaletteUiState(
+export function reduceCommandPaletteUiState(
   state: CommandPaletteUiState,
   action: CommandPaletteUiAction,
 ): CommandPaletteUiState {
@@ -1273,14 +1273,14 @@ function OpenCommandPaletteDialog(props: {
       environmentItemCount: newThreadEnvironmentItems.length,
     });
     if (resolution === "clear") {
-      clearOpenIntent();
+      setOpen(false);
       return;
     }
     if (resolution !== "open") {
       return;
     }
     openNewThreadOnFlow();
-  }, [clearOpenIntent, environmentShellsLoaded, newThreadEnvironmentItems.length, openIntent]);
+  }, [environmentShellsLoaded, newThreadEnvironmentItems.length, openIntent, setOpen]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -142,6 +142,7 @@ import {
 } from "../sidebarProjectGrouping";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
+const NEW_THREAD_ON_ENVIRONMENTS_VIEW_VALUE = "new-thread-on-environments";
 
 function getLocalFileManagerName(platform: string): string {
   if (isMacPlatform(platform)) {
@@ -914,6 +915,16 @@ function OpenCommandPaletteDialog(props: {
     newThreadEnvironmentOptions,
     projectGroups,
   ]);
+  const newThreadEnvironmentGroups = useMemo<CommandPaletteView["groups"]>(
+    () => [
+      {
+        value: NEW_THREAD_ON_ENVIRONMENTS_VIEW_VALUE,
+        label: "Run on",
+        items: newThreadEnvironmentItems,
+      },
+    ],
+    [newThreadEnvironmentItems],
+  );
 
   const projectThreadItems = useMemo(
     () =>
@@ -1256,19 +1267,20 @@ function OpenCommandPaletteDialog(props: {
     setQuery("");
     pushPaletteView({
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [
-        {
-          value: "environments",
-          label: "Run on",
-          items: newThreadEnvironmentItems,
-        },
-      ],
+      groups: newThreadEnvironmentGroups,
     });
   });
 
   useLayoutEffect(() => {
+    if (openIntent?.kind !== "new-thread-on") {
+      return;
+    }
+    if (viewStack.length > 0 || query !== "") {
+      clearOpenIntent();
+      return;
+    }
     const resolution = resolveNewThreadOnIntent({
-      isActive: openIntent?.kind === "new-thread-on",
+      isActive: true,
       isLoaded: environmentShellsLoaded,
       environmentItemCount: newThreadEnvironmentItems.length,
     });
@@ -1280,7 +1292,15 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
     openNewThreadOnFlow();
-  }, [environmentShellsLoaded, newThreadEnvironmentItems.length, openIntent, setOpen]);
+  }, [
+    clearOpenIntent,
+    environmentShellsLoaded,
+    newThreadEnvironmentItems.length,
+    openIntent,
+    query,
+    setOpen,
+    viewStack.length,
+  ]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 
@@ -1329,13 +1349,7 @@ function OpenCommandPaletteDialog(props: {
         icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
         addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
         shortcutCommand: "chat.newEnvironment",
-        groups: [
-          {
-            value: "environments",
-            label: "Run on",
-            items: newThreadEnvironmentItems,
-          },
-        ],
+        groups: newThreadEnvironmentGroups,
       });
     }
 
@@ -1408,6 +1422,14 @@ function OpenCommandPaletteDialog(props: {
   const rootGroups = buildRootGroups({ actionItems, recentThreadItems });
   const sourceSelectionViewValue =
     addProjectEnvironmentId === null ? null : `sources:${addProjectEnvironmentId}`;
+  const currentViewValue = currentView?.groups[0]?.value;
+  const refreshedNewThreadOnGroups =
+    currentViewValue === NEW_THREAD_ON_ENVIRONMENTS_VIEW_VALUE
+      ? newThreadEnvironmentGroups
+      : currentViewValue?.startsWith("new-thread-on-projects:")
+        ? (newThreadEnvironmentItems.find((item) => item.groups[0]?.value === currentViewValue)
+            ?.groups ?? [])
+        : null;
   const activeGroups =
     addProjectEnvironmentId !== null &&
     currentView !== null &&
@@ -1416,7 +1438,9 @@ function OpenCommandPaletteDialog(props: {
           addProjectEnvironmentId,
           buildAddProjectRemoteSourceReadiness(sourceControlDiscovery.data),
         )
-      : (currentView?.groups ?? rootGroups);
+      : refreshedNewThreadOnGroups !== null
+        ? refreshedNewThreadOnGroups
+        : (currentView?.groups ?? rootGroups);
 
   const filteredGroups = filterCommandPaletteGroups({
     activeGroups,

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -149,7 +149,9 @@ describe("KeybindingsSettings.logic", () => {
       },
     ] satisfies ResolvedKeybindingsConfig);
 
-    expect(options).toEqual(expect.arrayContaining(["chat.new", "script.setup-db.run"]));
+    expect(options).toEqual(
+      expect.arrayContaining(["chat.new", "chat.newLocal", "script.setup-db.run"]),
+    );
   });
 
   it("reports unknown when variables without rejecting parseable expressions", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -4,6 +4,7 @@ import {
   type KeybindingWhenNode,
   type ResolvedKeybindingRule,
   type ResolvedKeybindingsConfig,
+  STATIC_KEYBINDING_COMMANDS,
 } from "@t3tools/contracts";
 import {
   DEFAULT_RESOLVED_KEYBINDINGS,
@@ -255,10 +256,7 @@ export function buildWhenVariableOptions(): ReadonlyArray<WhenVariableOption> {
 export function buildKeybindingCommandOptions(
   keybindings: ResolvedKeybindingsConfig,
 ): ReadonlyArray<KeybindingCommandOption> {
-  const commands = new Set<KeybindingCommand>();
-  for (const binding of DEFAULT_RESOLVED_KEYBINDINGS) {
-    commands.add(binding.command);
-  }
+  const commands = new Set<KeybindingCommand>(STATIC_KEYBINDING_COMMANDS);
   for (const binding of keybindings) {
     commands.add(binding.command);
   }

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -318,6 +318,43 @@ describe("environment grouping", () => {
     expect(entries[1]?.group.displayName).toBe("separate");
   });
 
+  it("builds environment-scoped picker entries without falling back to another machine", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const primaryOnly = makeProject({
+      id: ProjectId.make("project-primary-only"),
+      title: "primary-only",
+      workspaceRoot: "/tmp/primary-only",
+    });
+    const groups = buildSidebarProjectSnapshots({
+      projects: [primaryOnly, primary, remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    const entries = buildSidebarProjectPickerEntries({
+      groups,
+      preferredProjectRef: {
+        environmentId: primaryEnvironmentId,
+        projectId: primary.id,
+      },
+      targetEnvironmentId: remoteEnvironmentId,
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.group.projectKey).toBe(repositoryIdentity.canonicalKey);
+    expect(entries[0]?.targetProject).toMatchObject({
+      environmentId: remoteEnvironmentId,
+      id: remote.id,
+    });
+    expect(entries[0]?.isPreferred).toBe(false);
+  });
+
   it("keeps manual project order when building grouped sidebar entries", () => {
     const primary = makeProject({ repositoryIdentity });
     const remote = makeProject({

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -124,7 +124,7 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
-  { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
+  { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newEnvironment" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
@@ -318,6 +318,10 @@ describe("shortcutLabelForCommand", () => {
       "⌘B",
     );
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "chat.new", "MacIntel"), "⇧⌘O");
+    assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "chat.newEnvironment", "Linux"),
+      "Ctrl+Shift+N",
+    );
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "diff.toggle", "Linux"), "Ctrl+D");
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "rightPanel.toggle", "MacIntel"),
@@ -472,15 +476,33 @@ describe("chat/editor shortcuts", () => {
   });
 
   it("matches chat.newLocal shortcut", () => {
+    const localBindings = compile([
+      { shortcut: modShortcut("l", { shiftKey: true }), command: "chat.newLocal" },
+    ]);
     assert.isTrue(
-      isChatNewLocalShortcut(event({ key: "n", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+      isChatNewLocalShortcut(event({ key: "l", metaKey: true, shiftKey: true }), localBindings, {
         platform: "MacIntel",
       }),
     );
     assert.isTrue(
-      isChatNewLocalShortcut(event({ key: "n", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+      isChatNewLocalShortcut(event({ key: "l", ctrlKey: true, shiftKey: true }), localBindings, {
         platform: "Linux",
       }),
+    );
+  });
+
+  it("resolves the environment-aware new-thread shortcut", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "n", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "chat.newEnvironment",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "n", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+      }),
+      "chat.newEnvironment",
     );
   });
 

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -77,6 +77,13 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
+      if (command === "chat.newEnvironment") {
+        event.preventDefault();
+        event.stopPropagation();
+        openCommandPalette({ open: "new-thread-on" });
+        return;
+      }
+
       if (command === "chat.newLocal") {
         event.preventDefault();
         event.stopPropagation();

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -222,31 +222,42 @@ export function buildSidebarProjectSnapshots(input: {
 export function buildSidebarProjectPickerEntries(input: {
   groups: ReadonlyArray<SidebarProjectSnapshot>;
   preferredProjectRef: ScopedProjectRef | null;
+  targetEnvironmentId?: EnvironmentId;
 }) {
   const entries = input.groups.flatMap((group): SidebarProjectPickerEntry[] => {
+    const environmentMembers =
+      input.targetEnvironmentId === undefined
+        ? group.memberProjects
+        : group.memberProjects.filter(
+            (project) => project.environmentId === input.targetEnvironmentId,
+          );
+    if (environmentMembers.length === 0) return [];
+
     const isPreferred = input.preferredProjectRef
       ? group.memberProjectRefs.some(
           (projectRef) =>
             projectRef.environmentId === input.preferredProjectRef?.environmentId &&
-            projectRef.projectId === input.preferredProjectRef.projectId,
+            projectRef.projectId === input.preferredProjectRef.projectId &&
+            (input.targetEnvironmentId === undefined ||
+              projectRef.environmentId === input.targetEnvironmentId),
         )
       : false;
     const preferredProject = isPreferred
-      ? (group.memberProjects.find(
+      ? (environmentMembers.find(
           (project) =>
             project.environmentId === input.preferredProjectRef?.environmentId &&
             project.id === input.preferredProjectRef?.projectId,
         ) ??
-        group.memberProjects.find(
+        environmentMembers.find(
           (project) => project.environmentId === input.preferredProjectRef?.environmentId,
         ))
       : null;
     const targetProject =
       preferredProject ??
-      group.memberProjects.find(
+      environmentMembers.find(
         (project) => project.environmentId === group.environmentId && project.id === group.id,
       ) ??
-      group.memberProjects[0];
+      environmentMembers[0];
     if (!targetProject) return [];
 
     return [{ group, targetProject, isPreferred }];

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -65,6 +65,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
 
+    const parsedEnvironment = yield* decode(KeybindingRule, {
+      key: "mod+shift+n",
+      command: "chat.newEnvironment",
+    });
+    assert.strictEqual(parsedEnvironment.command, "chat.newEnvironment");
+
     const parsedModelPickerToggle = yield* decode(KeybindingRule, {
       key: "mod+shift+m",
       command: "modelPicker.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -65,6 +65,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "composer.stash",
   "chat.new",
+  "chat.newEnvironment",
   "chat.newLocal",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -47,7 +47,7 @@ export const MODEL_PICKER_KEYBINDING_COMMANDS = [
 ] as const;
 export type ModelPickerKeybindingCommand = (typeof MODEL_PICKER_KEYBINDING_COMMANDS)[number];
 
-const STATIC_KEYBINDING_COMMANDS = [
+export const STATIC_KEYBINDING_COMMANDS = [
   "sidebar.toggle",
   "terminal.toggle",
   "terminal.split",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -38,7 +38,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+s", command: "composer.stash", when: "!terminalFocus" },
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
-  { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  { key: "mod+shift+n", command: "chat.newEnvironment", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },


### PR DESCRIPTION
## What Changed

- Added a `chat.newEnvironment` command on Mod+Shift+N.
- Added a two-stage new-thread flow: choose an environment, then choose a project available on that environment.
- Presents every environment in one flat `Run on` list; the primary environment is labeled with its runtime hostname instead of `Local`.
- Keeps existing Mod+N project/context behavior unchanged.
- Migrates only the previous exact Mod+Shift+N `chat.newLocal` default while preserving custom `chat.newLocal` bindings.

## Why

Thread creation previously collapsed projects across environments and silently selected one machine. This makes execution location explicit without treating local as a separate mode.

## UI Changes

Environment selection:

![Choose an environment](https://raw.githubusercontent.com/colonelpanic8/t3code/pr-assets/remote-environment-thread-picker/remote-environment-thread-picker/environment.png)

Environment-scoped project selection:

![Choose a project](https://raw.githubusercontent.com/colonelpanic8/t3code/pr-assets/remote-environment-thread-picker/remote-environment-thread-picker/project.png)

## Checklist

- [x] Focused keybinding and environment-grouping tests pass (92 tests).
- [x] Targeted formatting and lint checks pass.
- [x] Integrated web verification covers environment -> project -> draft.
- [x] Repository-wide `vp check` completes with only existing warnings outside this change.
- [ ] Repository-wide `vp run typecheck` is blocked by the existing interactive Astro dependency prompt and existing unrelated web type errors; changed packages/files introduce no reported type errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default shortcut behavior changes for all users who relied on Mod+Shift+N for instant local threads; migration is narrow but still touches persisted keybinding config on startup.
> 
> **Overview**
> **Mod+Shift+N** now runs **`chat.newEnvironment`**, opening the command palette on a **“New thread on…”** flow instead of immediately starting a local thread. **`chat.newLocal`** remains available for custom bindings but is no longer the default on that chord.
> 
> The palette adds a flat **Run on** list of environments (with per-environment project submenus), waits until environment shells are bootstrapped before opening, and closes if nothing is available. Project rows are built with **`targetEnvironmentId`** so choices stay on the chosen machine rather than falling back to another environment’s project.
> 
> On the server, startup keybinding sync **migrates** only the exact legacy default (`mod+shift+n` + `chat.newLocal` + `!terminalFocus`) to **`chat.newEnvironment`**, leaving other `chat.newLocal` entries (e.g. `mod+shift+l`) untouched. Contracts and settings expose **`chat.newEnvironment`** via exported **`STATIC_KEYBINDING_COMMANDS`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e2155e6978473f51115f17609948b7caa9cc5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add environment-aware new thread picker with `chat.newEnvironment` command
> - Adds a 'New thread on...' flow to the command palette that lets users pick an environment and project before starting a thread, triggered by `mod+shift+n` via the new `chat.newEnvironment` command.
> - Updates `DEFAULT_KEYBINDINGS` in [shared/src/keybindings.ts](https://github.com/pingdotgg/t3code/pull/4426/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06) to bind `mod+shift+n` to `chat.newEnvironment` instead of `chat.newLocal`.
> - Extends `buildSidebarProjectPickerEntries` to accept an optional `targetEnvironmentId`, scoping project entries to that environment without falling back to other machines.
> - Migrates existing user keybinding configs at startup: if the legacy `chat.newLocal` default is found without a `chat.newEnvironment` binding, it is automatically replaced.
> - Behavioral Change: `mod+shift+n` now opens the environment picker palette instead of directly creating a local thread; users with customized `chat.newLocal` bindings on other keys are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e2155e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->