### PR TITLE
Open generated images from tool activity

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -1,5 +1,5 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { ThreadId } from "@t3tools/contracts";
+import { EventId, ThreadId } from "@t3tools/contracts";
 import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -203,6 +203,59 @@ describe("AssetAccess", () => {
         kind: "file",
         path: attachmentPath,
       });
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("issues exact capabilities for provider-generated images", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-generated-image-",
+      });
+      const imagePath = path.join(root, "generated.png");
+      const siblingPath = path.join(root, "other.png");
+      yield* fileSystem.writeFile(imagePath, new Uint8Array([137, 80, 78, 71]));
+      yield* fileSystem.writeFile(siblingPath, new Uint8Array([137, 80, 78, 71]));
+      const canonicalImagePath = yield* fileSystem.realPath(imagePath);
+      const resource = {
+        _tag: "generated-image" as const,
+        threadId: ThreadId.make("thread-1"),
+        activityId: EventId.make("activity-1"),
+      };
+
+      const result = yield* issueAssetUrl({
+        resource,
+        generatedImagePath: imagePath,
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "generated.png")).toEqual({
+        kind: "file",
+        path: canonicalImagePath,
+      });
+      expect(yield* resolveAsset(token, "other.png")).toBeNull();
+      expect(yield* resolveAsset(token, "../generated.png")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects generated-image resources without matching image paths", () =>
+    Effect.gen(function* () {
+      const resource = {
+        _tag: "generated-image" as const,
+        threadId: ThreadId.make("thread-1"),
+        activityId: EventId.make("activity-1"),
+      };
+      const missingPathError = yield* issueAssetUrl({ resource }).pipe(Effect.flip);
+      expect(missingPathError._tag).toBe("AssetGeneratedImageNotFoundError");
+
+      const invalidTypeError = yield* issueAssetUrl({
+        resource,
+        generatedImagePath: "/tmp/generated.txt",
+      }).pipe(Effect.flip);
+      expect(invalidTypeError._tag).toBe("AssetPreviewTypeValidationError");
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -1,6 +1,8 @@
 import type { AssetResource } from "@t3tools/contracts";
 import {
   AssetAttachmentNotFoundError,
+  AssetGeneratedImageInspectionError,
+  AssetGeneratedImageNotFoundError,
   AssetPreviewTypeValidationError,
   AssetProjectFaviconInspectionError,
   AssetProjectFaviconNotFoundError,
@@ -75,6 +77,12 @@ const AssetClaimsSchema = Schema.Union([
     version: Schema.Literal(1),
     kind: Schema.Literal("attachment"),
     attachmentId: Schema.String,
+    expiresAt: Schema.Number,
+  }),
+  Schema.Struct({
+    version: Schema.Literal(1),
+    kind: Schema.Literal("generated-image"),
+    absolutePath: Schema.String,
     expiresAt: Schema.Number,
   }),
   Schema.Struct({
@@ -162,9 +170,37 @@ const resolveCanonicalWorkspaceFileForRequest = (input: {
     Effect.orElseSucceed(() => null),
   );
 
+const resolveCanonicalGeneratedImage = Effect.fn("AssetAccess.resolveCanonicalGeneratedImage")(
+  function* (absolutePath: string) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    if (!path.isAbsolute(absolutePath) || !isWorkspaceImagePreviewPath(absolutePath)) {
+      return null;
+    }
+    const canonicalPath = yield* optionOnNotFound(fileSystem.realPath(absolutePath));
+    if (Option.isNone(canonicalPath) || !isWorkspaceImagePreviewPath(canonicalPath.value)) {
+      return null;
+    }
+    const info = yield* optionOnNotFound(fileSystem.stat(canonicalPath.value));
+    return Option.isSome(info) && info.value.type === "File" ? canonicalPath.value : null;
+  },
+);
+
+const resolveCanonicalGeneratedImageForRequest = (absolutePath: string) =>
+  resolveCanonicalGeneratedImage(absolutePath).pipe(
+    Effect.tapError((cause) =>
+      Effect.logError("Failed to resolve generated image asset.", {
+        absolutePath,
+        cause,
+      }),
+    ),
+    Effect.orElseSucceed(() => null),
+  );
+
 export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (input: {
   readonly resource: AssetResource;
   readonly workspaceRoot?: string;
+  readonly generatedImagePath?: string;
 }) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -270,6 +306,43 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         expiresAt,
       };
       fileName = path.basename(attachmentPath);
+      break;
+    }
+    case "generated-image": {
+      if (!input.generatedImagePath) {
+        return yield* new AssetGeneratedImageNotFoundError({
+          resource: input.resource,
+        });
+      }
+      if (
+        !path.isAbsolute(input.generatedImagePath) ||
+        !isWorkspaceImagePreviewPath(input.generatedImagePath)
+      ) {
+        return yield* new AssetPreviewTypeValidationError({
+          resource: input.resource,
+        });
+      }
+      const canonicalPath = yield* resolveCanonicalGeneratedImage(input.generatedImagePath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AssetGeneratedImageInspectionError({
+              resource: input.resource,
+              cause,
+            }),
+        ),
+      );
+      if (!canonicalPath) {
+        return yield* new AssetGeneratedImageNotFoundError({
+          resource: input.resource,
+        });
+      }
+      claims = {
+        version: 1,
+        kind: "generated-image",
+        absolutePath: canonicalPath,
+        expiresAt,
+      };
+      fileName = path.basename(canonicalPath);
       break;
     }
     case "project-favicon": {
@@ -400,6 +473,13 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   const decodedPath = decodeRelativePath(relativePath);
   if (decodedPath === null) return null;
   const path = yield* Path.Path;
+  if (claims.kind === "generated-image") {
+    if (decodedPath !== path.basename(claims.absolutePath)) return null;
+    const generatedImagePath = yield* resolveCanonicalGeneratedImageForRequest(claims.absolutePath);
+    return generatedImagePath
+      ? ({ kind: "file", path: generatedImagePath } satisfies ResolvedAsset)
+      : null;
+  }
   if (claims.kind === "workspace-file-exact") {
     if (decodedPath !== path.basename(claims.relativePath)) return null;
     const exactWorkspaceFile = yield* resolveCanonicalWorkspaceFileForRequest({

--- a/apps/server/src/assets/GeneratedImageResolver.test.ts
+++ b/apps/server/src/assets/GeneratedImageResolver.test.ts
@@ -1,0 +1,117 @@
+import { EventId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { it as effectIt } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  findGeneratedImagePath,
+  isGeneratedImageFileLookupRetryable,
+  retryGeneratedImageFileLookup,
+} from "./GeneratedImageResolver.ts";
+
+const ACTIVITY_ID = EventId.make("activity-generated-image");
+
+function activity(
+  item: Record<string, unknown>,
+  overrides: Partial<OrchestrationThreadActivity> = {},
+): OrchestrationThreadActivity {
+  return {
+    id: ACTIVITY_ID,
+    tone: "tool",
+    kind: "tool.completed",
+    summary: "Image view",
+    payload: { data: { item } },
+    turnId: null,
+    createdAt: "2026-07-24T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("generated image resolution", () => {
+  it("reads the saved path from a completed image generation activity", () => {
+    const path = "/provider/session/generated.png";
+    expect(
+      findGeneratedImagePath(
+        [
+          activity({
+            type: "imageGeneration",
+            status: "completed",
+            savedPath: path,
+          }),
+        ],
+        ACTIVITY_ID,
+      ),
+    ).toBe(path);
+  });
+
+  it("rejects non-generation, incomplete, and mismatched activities", () => {
+    expect(
+      findGeneratedImagePath(
+        [activity({ type: "imageView", status: "completed", path: "/tmp/viewed.png" })],
+        ACTIVITY_ID,
+      ),
+    ).toBeNull();
+    expect(
+      findGeneratedImagePath(
+        [
+          activity({
+            type: "imageGeneration",
+            status: "inProgress",
+            savedPath: "/tmp/generated.png",
+          }),
+        ],
+        ACTIVITY_ID,
+      ),
+    ).toBeNull();
+    expect(
+      findGeneratedImagePath(
+        [
+          activity(
+            {
+              type: "imageGeneration",
+              status: "completed",
+              savedPath: "/tmp/generated.png",
+            },
+            { kind: "tool.updated" },
+          ),
+        ],
+        ACTIVITY_ID,
+      ),
+    ).toBeNull();
+    expect(
+      findGeneratedImagePath(
+        [
+          activity({
+            type: "imageGeneration",
+            status: "completed",
+            savedPath: "/tmp/generated.png",
+          }),
+        ],
+        EventId.make("activity-other"),
+      ),
+    ).toBeNull();
+  });
+
+  effectIt.live("retries transient not-found failures and preserves other failures", () =>
+    Effect.gen(function* () {
+      let attempts = 0;
+      const result = yield* retryGeneratedImageFileLookup(
+        Effect.suspend(() => {
+          attempts += 1;
+          return attempts < 3
+            ? Effect.fail({ _tag: "AssetGeneratedImageNotFoundError" as const })
+            : Effect.succeed("ready");
+        }),
+      );
+
+      expect(result).toBe("ready");
+      expect(attempts).toBe(3);
+      expect(
+        isGeneratedImageFileLookupRetryable({ _tag: "AssetGeneratedImageNotFoundError" }),
+      ).toBe(true);
+      expect(
+        isGeneratedImageFileLookupRetryable({ _tag: "AssetGeneratedImageInspectionError" }),
+      ).toBe(false);
+    }),
+  );
+});

--- a/apps/server/src/assets/GeneratedImageResolver.test.ts
+++ b/apps/server/src/assets/GeneratedImageResolver.test.ts
@@ -92,19 +92,31 @@ describe("generated image resolution", () => {
     ).toBeNull();
   });
 
-  effectIt.live("retries transient not-found failures and preserves other failures", () =>
+  effectIt.live("retries the projection lookup until the generated image appears", () =>
     Effect.gen(function* () {
       let attempts = 0;
       const result = yield* retryGeneratedImageFileLookup(
         Effect.suspend(() => {
           attempts += 1;
-          return attempts < 3
-            ? Effect.fail({ _tag: "AssetGeneratedImageNotFoundError" as const })
-            : Effect.succeed("ready");
+          const generatedImagePath = findGeneratedImagePath(
+            attempts < 3
+              ? []
+              : [
+                  activity({
+                    type: "imageGeneration",
+                    status: "completed",
+                    savedPath: "/tmp/generated.png",
+                  }),
+                ],
+            ACTIVITY_ID,
+          );
+          return generatedImagePath
+            ? Effect.succeed(generatedImagePath)
+            : Effect.fail({ _tag: "AssetGeneratedImageNotFoundError" as const });
         }),
       );
 
-      expect(result).toBe("ready");
+      expect(result).toBe("/tmp/generated.png");
       expect(attempts).toBe(3);
       expect(
         isGeneratedImageFileLookupRetryable({ _tag: "AssetGeneratedImageNotFoundError" }),

--- a/apps/server/src/assets/GeneratedImageResolver.ts
+++ b/apps/server/src/assets/GeneratedImageResolver.ts
@@ -1,0 +1,52 @@
+import type { EventId, OrchestrationThreadActivity } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+
+const GENERATED_IMAGE_LOOKUP_RETRY_COUNT = 20;
+const GENERATED_IMAGE_LOOKUP_RETRY_INTERVAL = "250 millis";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function findGeneratedImagePath(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  activityId: EventId,
+): string | null {
+  const activity = activities.find((candidate) => candidate.id === activityId);
+  if (!activity || activity.kind !== "tool.completed") {
+    return null;
+  }
+
+  const payload = asRecord(activity.payload);
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  if (
+    item?.type !== "imageGeneration" ||
+    item.status !== "completed" ||
+    typeof item.savedPath !== "string"
+  ) {
+    return null;
+  }
+
+  const savedPath = item.savedPath.trim();
+  return savedPath.length > 0 ? savedPath : null;
+}
+
+export function isGeneratedImageFileLookupRetryable(error: unknown): boolean {
+  return asRecord(error)?._tag === "AssetGeneratedImageNotFoundError";
+}
+
+export function retryGeneratedImageFileLookup<A, E, R>(
+  lookup: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return lookup.pipe(
+    Effect.retry({
+      times: GENERATED_IMAGE_LOOKUP_RETRY_COUNT,
+      schedule: Schedule.spaced(GENERATED_IMAGE_LOOKUP_RETRY_INTERVAL),
+      while: isGeneratedImageFileLookupRetryable,
+    }),
+  );
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -49,6 +49,8 @@ import {
   OrchestrationReplayEventsError,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
+  AssetGeneratedImageInspectionError,
+  AssetGeneratedImageNotFoundError,
   AssetWorkspaceContextNotFoundError,
   AssetWorkspaceContextResolutionError,
   EnvironmentAuthorizationError,
@@ -90,6 +92,10 @@ import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import { issueAssetUrl } from "./assets/AssetAccess.ts";
+import {
+  findGeneratedImagePath,
+  retryGeneratedImageFileLookup,
+} from "./assets/GeneratedImageResolver.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
@@ -1720,6 +1726,34 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             WS_METHODS.assetsCreateUrl,
             Effect.gen(function* () {
+              if (input.resource._tag === "generated-image") {
+                const resource = input.resource;
+                const thread = yield* projectionSnapshotQuery
+                  .getThreadDetailById(resource.threadId)
+                  .pipe(
+                    Effect.mapError(
+                      (cause) =>
+                        new AssetGeneratedImageInspectionError({
+                          resource,
+                          cause,
+                        }),
+                    ),
+                  );
+                const generatedImagePath = Option.isSome(thread)
+                  ? findGeneratedImagePath(thread.value.activities, resource.activityId)
+                  : null;
+                if (!generatedImagePath) {
+                  return yield* new AssetGeneratedImageNotFoundError({
+                    resource,
+                  });
+                }
+                return yield* retryGeneratedImageFileLookup(
+                  issueAssetUrl({
+                    resource,
+                    generatedImagePath,
+                  }),
+                );
+              }
               if (input.resource._tag !== "workspace-file") {
                 return yield* issueAssetUrl({ resource: input.resource });
               }

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1728,29 +1728,31 @@ const makeWsRpcLayer = (
             Effect.gen(function* () {
               if (input.resource._tag === "generated-image") {
                 const resource = input.resource;
-                const thread = yield* projectionSnapshotQuery
-                  .getThreadDetailById(resource.threadId)
-                  .pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new AssetGeneratedImageInspectionError({
-                          resource,
-                          cause,
-                        }),
-                    ),
-                  );
-                const generatedImagePath = Option.isSome(thread)
-                  ? findGeneratedImagePath(thread.value.activities, resource.activityId)
-                  : null;
-                if (!generatedImagePath) {
-                  return yield* new AssetGeneratedImageNotFoundError({
-                    resource,
-                  });
-                }
                 return yield* retryGeneratedImageFileLookup(
-                  issueAssetUrl({
-                    resource,
-                    generatedImagePath,
+                  Effect.gen(function* () {
+                    const thread = yield* projectionSnapshotQuery
+                      .getThreadDetailById(resource.threadId)
+                      .pipe(
+                        Effect.mapError(
+                          (cause) =>
+                            new AssetGeneratedImageInspectionError({
+                              resource,
+                              cause,
+                            }),
+                        ),
+                      );
+                    const generatedImagePath = Option.isSome(thread)
+                      ? findGeneratedImagePath(thread.value.activities, resource.activityId)
+                      : null;
+                    if (!generatedImagePath) {
+                      return yield* new AssetGeneratedImageNotFoundError({
+                        resource,
+                      });
+                    }
+                    return yield* issueAssetUrl({
+                      resource,
+                      generatedImagePath,
+                    });
                   }),
                 );
               }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5614,7 +5614,7 @@ function ChatViewContent(props: ChatViewProps) {
       />
     ) : activeRightPanelSurface?.kind === "generated-image" ? (
       <GeneratedImagePanel
-        key={activeRightPanelSurface.id}
+        key={`${activeRightPanelSurface.id}:${activeRightPanelSurface.loadRequestId}`}
         environmentId={activeThreadRef.environmentId}
         threadRef={activeThreadRef}
         activityId={activeRightPanelSurface.activityId}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -139,6 +139,7 @@ import {
   usePreviewMiniPlayerStore,
 } from "../previewMiniPlayerStore";
 import { RightPanelTabs } from "./RightPanelTabs";
+import { GeneratedImagePanel } from "./chat/GeneratedImagePanel";
 import { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
@@ -5610,6 +5611,14 @@ function ChatViewContent(props: ChatViewProps) {
         workspaceRoot={activeWorkspaceRoot}
         timestampFormat={timestampFormat}
         mode="embedded"
+      />
+    ) : activeRightPanelSurface?.kind === "generated-image" ? (
+      <GeneratedImagePanel
+        key={activeRightPanelSurface.id}
+        environmentId={activeThreadRef.environmentId}
+        threadRef={activeThreadRef}
+        activityId={activeRightPanelSurface.activityId}
+        name={activeRightPanelSurface.name}
       />
     ) : (activeRightPanelSurface?.kind === "files" || activeRightPanelSurface?.kind === "file") &&
       activeProject &&

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -1,6 +1,15 @@
 import type { ContextMenuItem, PreviewSessionSnapshot } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
-import { ClipboardList, FileDiff, Files, Globe2, Plus, TerminalSquare, X } from "lucide-react";
+import {
+  ClipboardList,
+  FileDiff,
+  Files,
+  Globe2,
+  ImageIcon,
+  Plus,
+  TerminalSquare,
+  X,
+} from "lucide-react";
 import {
   type MouseEvent as ReactMouseEvent,
   type ReactElement,
@@ -198,6 +207,8 @@ function surfaceTitle(
       return "Files";
     case "file":
       return surface.relativePath.slice(surface.relativePath.lastIndexOf("/") + 1);
+    case "generated-image":
+      return surface.name;
     case "terminal":
       return (
         terminalLabelsById.get(surface.activeTerminalId) ??
@@ -262,6 +273,8 @@ function SurfaceIcon({
           className="size-3.5"
         />
       );
+    case "generated-image":
+      return <ImageIcon className="size-3.5 shrink-0" />;
     case "terminal":
       return <TerminalSquare className="size-3.5 shrink-0" />;
     case "plan":

--- a/apps/web/src/components/chat/GeneratedImagePanel.test.tsx
+++ b/apps/web/src/components/chat/GeneratedImagePanel.test.tsx
@@ -1,0 +1,45 @@
+import { EnvironmentId, EventId, ThreadId } from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { GeneratedImagePanel } from "./GeneratedImagePanel";
+
+const assetUrlState = vi.hoisted(() => ({
+  current: {
+    _tag: "Success" as const,
+    url: "https://environment.example/api/assets/generated-image/generated.png",
+  },
+}));
+
+vi.mock("~/assets/assetUrls", () => ({
+  useAssetUrlState: () => assetUrlState.current,
+}));
+
+const environmentId = EnvironmentId.make("environment-local");
+const threadRef = scopeThreadRef(environmentId, ThreadId.make("thread-1"));
+
+beforeEach(() => {
+  assetUrlState.current = {
+    _tag: "Success",
+    url: "https://environment.example/api/assets/generated-image/generated.png",
+  };
+});
+
+describe("GeneratedImagePanel", () => {
+  it("renders the selected generated image", () => {
+    const markup = renderToStaticMarkup(
+      <GeneratedImagePanel
+        environmentId={environmentId}
+        threadRef={threadRef}
+        activityId={EventId.make("activity-generated-image")}
+        name="generated.png"
+      />,
+    );
+
+    expect(markup).toContain('alt="generated.png"');
+    expect(markup).toContain(
+      'src="https://environment.example/api/assets/generated-image/generated.png"',
+    );
+  });
+});

--- a/apps/web/src/components/chat/GeneratedImagePanel.tsx
+++ b/apps/web/src/components/chat/GeneratedImagePanel.tsx
@@ -1,0 +1,42 @@
+import type { EnvironmentId, EventId, ScopedThreadRef } from "@t3tools/contracts";
+import { LoaderCircle } from "lucide-react";
+import { useState } from "react";
+
+import { useAssetUrlState } from "~/assets/assetUrls";
+
+export function GeneratedImagePanel(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadRef: ScopedThreadRef;
+  readonly activityId: EventId;
+  readonly name: string;
+}) {
+  const assetUrl = useAssetUrlState(props.environmentId, {
+    _tag: "generated-image",
+    threadId: props.threadRef.threadId,
+    activityId: props.activityId,
+  });
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-xs leading-relaxed text-destructive">
+        Unable to load generated image.
+      </div>
+    );
+  }
+
+  return assetUrl._tag === "Success" ? (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+      <img
+        className="max-h-full max-w-full object-contain"
+        src={assetUrl.url}
+        alt={props.name}
+        onError={() => setFailedUrl(assetUrl.url)}
+      />
+    </div>
+  ) : (
+    <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
+      <LoaderCircle className="size-5 animate-spin" />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -541,6 +541,84 @@ describe("deriveMessagesTimelineRows", () => {
     ).toBeDefined();
   });
 
+  it("keeps generated images visible when their completed turn is folded", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user",
+            text: "Draw it",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "assistant-thought-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:01Z",
+          message: {
+            id: "assistant-thought" as never,
+            role: "assistant",
+            text: "Generating an image.",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:01Z",
+            updatedAt: "2026-01-01T00:00:01Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-generated-image",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:02Z",
+          entry: {
+            id: "work-generated-image",
+            createdAt: "2026-01-01T00:00:02Z",
+            turnId: "turn-1" as never,
+            label: "Generated image",
+            tone: "tool",
+            itemType: "image_view",
+            toolLifecycleStatus: "completed",
+            generatedImage: {
+              activityId: "activity-generated-image" as never,
+              name: "generated.png",
+            },
+          },
+        },
+        {
+          id: "assistant-final-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:03Z",
+          message: {
+            id: "assistant-final" as never,
+            role: "assistant",
+            text: "Done",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:03Z",
+            updatedAt: "2026-01-01T00:00:03Z",
+            streaming: false,
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "user-entry",
+      "turn-fold:turn-1",
+      "work-generated-image",
+      "assistant-final-entry",
+    ]);
+  });
+
   it("derives a sane duration for a steer-superseded turn with one instant commentary message", () => {
     // A steer ends the previous turn early: its only message completes the
     // instant it is created, and trailing work entries land after it. The
@@ -1010,6 +1088,73 @@ describe("deriveMessagesTimelineRows", () => {
     expect(expandedRows.find((row) => row.kind === "work-toggle")).toMatchObject({
       expanded: true,
     });
+  });
+
+  it("keeps generated images outside collapsed work-log groups", () => {
+    const generatedImage = {
+      id: "work-generated-image",
+      kind: "work" as const,
+      createdAt: "2026-01-01T00:00:02Z",
+      entry: {
+        id: "work-generated-image",
+        createdAt: "2026-01-01T00:00:02Z",
+        label: "Generated image",
+        tone: "tool" as const,
+        generatedImage: {
+          activityId: "activity-generated-image" as never,
+          name: "generated.png",
+        },
+      },
+    };
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-before",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:01Z",
+          entry: {
+            id: "work-before",
+            createdAt: "2026-01-01T00:00:01Z",
+            label: "Before",
+            tone: "tool",
+          },
+        },
+        generatedImage,
+        {
+          id: "work-after-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:03Z",
+          entry: {
+            id: "work-after-1",
+            createdAt: "2026-01-01T00:00:03Z",
+            label: "After one",
+            tone: "tool",
+          },
+        },
+        {
+          id: "work-after-2",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:04Z",
+          entry: {
+            id: "work-after-2",
+            createdAt: "2026-01-01T00:00:04Z",
+            label: "After two",
+            tone: "tool",
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "work-before",
+      "work-generated-image",
+      "work-after-2",
+      "work-toggle:work-after-1",
+    ]);
   });
 });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -352,7 +352,8 @@ function deriveTurnFolds(input: {
     }
     const hiddenEntryIds = new Set<string>();
     for (const entry of group.entries) {
-      if (entry.id !== group.terminalEntry?.id) {
+      const isGeneratedImage = entry.kind === "work" && entry.entry.generatedImage !== undefined;
+      if (entry.id !== group.terminalEntry?.id && !isGeneratedImage) {
         hiddenEntryIds.add(entry.id);
       }
     }
@@ -465,8 +466,10 @@ export function deriveMessagesTimelineRows(input: {
       while (cursor < input.timelineEntries.length) {
         const nextEntry = input.timelineEntries[cursor];
         if (
+          timelineEntry.entry.generatedImage !== undefined ||
           !nextEntry ||
           nextEntry.kind !== "work" ||
+          nextEntry.entry.generatedImage !== undefined ||
           collapsedEntryIds.has(nextEntry.id) ||
           foldsByAnchorEntryId.has(nextEntry.id)
         ) {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,4 +1,4 @@
-import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
+import { CheckpointRef, EnvironmentId, EventId, MessageId, TurnId } from "@t3tools/contracts";
 import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
@@ -223,6 +223,37 @@ function buildUserTimelineEntry(text: string) {
 }
 
 describe("MessagesTimeline", () => {
+  it("renders completed image generation work as a compact image link", () => {
+    const timelineEntries = [
+      {
+        id: "work-generated-image",
+        kind: "work" as const,
+        createdAt: MESSAGE_CREATED_AT,
+        entry: {
+          id: "activity-generated-image",
+          createdAt: MESSAGE_CREATED_AT,
+          label: "Image view",
+          tone: "tool" as const,
+          itemType: "image_view" as const,
+          toolLifecycleStatus: "completed" as const,
+          sourceActivityKind: "tool.completed",
+          generatedImage: {
+            activityId: EventId.make("activity-generated-image"),
+            name: "generated.png",
+          },
+        },
+      },
+    ];
+
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline {...buildProps()} timelineEntries={timelineEntries} />,
+    );
+
+    expect(markup).toContain('aria-label="Open generated image generated.png"');
+    expect(markup).toContain(">generated.png</span>");
+    expect(markup).not.toContain("<img");
+  });
+
   it("uses the larger leading inset only when the top fade is enabled", () => {
     const timelineEntries = [buildUserTimelineEntry("Hello")];
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -47,6 +47,7 @@ import {
   EyeIcon,
   GlobeIcon,
   HammerIcon,
+  ImageIcon,
   MessageCircleIcon,
   MousePointerClickIcon,
   PaintbrushIcon,
@@ -99,6 +100,7 @@ import { cn } from "~/lib/utils";
 import { useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { formatChatTimestampTooltip, formatShortTimestamp } from "../../timestampFormat";
+import { useRightPanelStore } from "~/rightPanelStore";
 
 import {
   buildInlineTerminalContextText,
@@ -1921,11 +1923,37 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
 
+const GeneratedImageWorkEntryLink = memo(function GeneratedImageWorkEntryLink({
+  threadRef,
+  image,
+}: {
+  threadRef: ScopedThreadRef;
+  image: NonNullable<TimelineWorkEntry["generatedImage"]>;
+}) {
+  return (
+    <button
+      type="button"
+      className="mt-1 ms-7 flex max-w-[calc(100%-1.75rem)] items-center gap-1.5 text-left text-xs text-info-foreground underline-offset-2 hover:underline"
+      aria-label={`Open generated image ${image.name}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        useRightPanelStore.getState().openGeneratedImage(threadRef, image.activityId, image.name);
+      }}
+      onKeyDown={stopRowToggle}
+      onPointerDown={stopRowToggle}
+    >
+      <ImageIcon className="size-3.5 shrink-0" aria-hidden />
+      <span className="truncate">{image.name}</span>
+    </button>
+  );
+});
+
 const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   workEntry: TimelineWorkEntry;
   workspaceRoot: string | undefined;
 }) {
   const { workEntry, workspaceRoot } = props;
+  const ctx = use(TimelineRowCtx);
   const activity = use(TimelineRowActivityCtx);
   const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
@@ -2075,6 +2103,9 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
             {expandedBody}
           </pre>
         </div>
+      ) : null}
+      {workEntry.generatedImage && ctx.threadRef ? (
+        <GeneratedImageWorkEntryLink threadRef={ctx.threadRef} image={workEntry.generatedImage} />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1999,6 +1999,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
         role: "button" as const,
         tabIndex: 0 as const,
         "aria-label": displayText,
+        "aria-expanded": expanded,
         onClick: () => setExpanded((v) => !v),
         onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
           if (e.key === "Enter" || e.key === " ") {
@@ -2010,15 +2011,15 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
     : {};
 
   return (
-    <div
-      className={cn(
-        "flex flex-col rounded-md px-0.5 py-0.5 transition-colors",
-        canExpand &&
-          "cursor-pointer hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
-      )}
-      {...rowToggleProps}
-    >
-      <div className="flex select-none items-center gap-1.5 transition-[opacity,translate] duration-200">
+    <div className="flex flex-col rounded-md px-0.5 py-0.5">
+      <div
+        className={cn(
+          "flex select-none items-center gap-1.5 rounded-md transition-[background-color,opacity,translate] duration-200",
+          canExpand &&
+            "cursor-pointer hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70",
+        )}
+        {...rowToggleProps}
+      >
         <span className={iconWrapperClass}>
           <WorkEntryIconSvg
             name={entryIconName}

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -1,5 +1,5 @@
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
-import { type EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { type EnvironmentId, EventId, ThreadId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
@@ -202,6 +202,57 @@ describe("rightPanelStore", () => {
           revealRequestId: 3,
         },
       ],
+    });
+  });
+
+  it("opens generated images as reusable named surfaces", () => {
+    const activityId = EventId.make("activity-generated-image");
+
+    useRightPanelStore.getState().openGeneratedImage(refA, activityId, "first-name.png");
+    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().openGeneratedImage(refA, activityId, "generated.png");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: "generated-image:activity-generated-image",
+      surfaces: [
+        {
+          id: "generated-image:activity-generated-image",
+          kind: "generated-image",
+          activityId,
+          name: "generated.png",
+        },
+        { id: "plan", kind: "plan" },
+      ],
+    });
+  });
+
+  it("drops malformed generated-image surfaces during migration", () => {
+    expect(
+      migratePersistedRightPanelState({
+        byThreadKey: {
+          "env-1:thread-A": {
+            isOpen: true,
+            activeSurfaceId: "generated-image:wrong-id",
+            surfaces: [
+              {
+                id: "generated-image:wrong-id",
+                kind: "generated-image",
+                activityId: "activity-generated-image",
+                name: "generated.png",
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: true,
+          activeSurfaceId: null,
+          surfaces: [],
+        },
+      },
     });
   });
 

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -205,7 +205,7 @@ describe("rightPanelStore", () => {
     });
   });
 
-  it("opens generated images as reusable named surfaces", () => {
+  it("reuses generated-image surfaces while refreshing them when reopened", () => {
     const activityId = EventId.make("activity-generated-image");
 
     useRightPanelStore.getState().openGeneratedImage(refA, activityId, "first-name.png");
@@ -221,8 +221,30 @@ describe("rightPanelStore", () => {
           kind: "generated-image",
           activityId,
           name: "generated.png",
+          loadRequestId: 2,
         },
         { id: "plan", kind: "plan" },
+      ],
+    });
+  });
+
+  it("refreshes an already-active generated-image surface when reopened", () => {
+    const activityId = EventId.make("activity-generated-image");
+
+    useRightPanelStore.getState().openGeneratedImage(refA, activityId, "generated.png");
+    useRightPanelStore.getState().openGeneratedImage(refA, activityId, "generated.png");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: "generated-image:activity-generated-image",
+      surfaces: [
+        {
+          id: "generated-image:activity-generated-image",
+          kind: "generated-image",
+          activityId,
+          name: "generated.png",
+          loadRequestId: 2,
+        },
       ],
     });
   });

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -249,6 +249,44 @@ describe("rightPanelStore", () => {
     });
   });
 
+  it("upgrades v8 generated-image surfaces with neutral load request state", () => {
+    expect(useRightPanelStore.persist.getOptions().version).toBe(9);
+    expect(
+      migratePersistedRightPanelState({
+        byThreadKey: {
+          "env-1:thread-A": {
+            isOpen: true,
+            activeSurfaceId: "generated-image:activity-generated-image",
+            surfaces: [
+              {
+                id: "generated-image:activity-generated-image",
+                kind: "generated-image",
+                activityId: "activity-generated-image",
+                name: "generated.png",
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      byThreadKey: {
+        "env-1:thread-A": {
+          isOpen: true,
+          activeSurfaceId: "generated-image:activity-generated-image",
+          surfaces: [
+            {
+              id: "generated-image:activity-generated-image",
+              kind: "generated-image",
+              activityId: "activity-generated-image",
+              name: "generated.png",
+              loadRequestId: 0,
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it("drops malformed generated-image surfaces during migration", () => {
     expect(
       migratePersistedRightPanelState({

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -5,16 +5,25 @@
  * surface descriptors and the active surface, while each feature continues to
  * own its durable resource state. Browser surfaces point at preview tab ids,
  * terminal surfaces point at terminal session ids, file surfaces point at
- * workspace paths, and diff/plan/files remain singleton surfaces.
+ * workspace paths, generated-image surfaces point at provider activities, and
+ * diff/plan/files remain singleton surfaces.
  */
 import { scopedThreadKey } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef } from "@t3tools/contracts";
+import type { EventId, ScopedThreadRef } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { resolveStorage } from "./lib/storage";
 
-export const RIGHT_PANEL_KINDS = ["plan", "diff", "files", "file", "preview", "terminal"] as const;
+export const RIGHT_PANEL_KINDS = [
+  "plan",
+  "diff",
+  "files",
+  "file",
+  "preview",
+  "terminal",
+  "generated-image",
+] as const;
 export type RightPanelKind = (typeof RIGHT_PANEL_KINDS)[number];
 
 export type RightPanelSurface =
@@ -37,10 +46,16 @@ export type RightPanelSurface =
       revealLine: number | null;
       revealRequestId: number;
     }
+  | {
+      id: `generated-image:${string}`;
+      kind: "generated-image";
+      activityId: EventId;
+      name: string;
+    }
   | { id: "plan"; kind: "plan" };
 
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
-const RIGHT_PANEL_STORAGE_VERSION = 7;
+const RIGHT_PANEL_STORAGE_VERSION = 8;
 
 export interface ThreadRightPanelState {
   isOpen: boolean;
@@ -50,9 +65,13 @@ export interface ThreadRightPanelState {
 
 interface RightPanelStoreState {
   byThreadKey: Record<string, ThreadRightPanelState>;
-  open: (ref: ScopedThreadRef, kind: Exclude<RightPanelKind, "file" | "terminal">) => void;
+  open: (
+    ref: ScopedThreadRef,
+    kind: Exclude<RightPanelKind, "file" | "terminal" | "generated-image">,
+  ) => void;
   openBrowser: (ref: ScopedThreadRef, tabId: string | null) => void;
   openFile: (ref: ScopedThreadRef, relativePath: string, line?: number) => void;
+  openGeneratedImage: (ref: ScopedThreadRef, activityId: EventId, name: string) => void;
   openTerminal: (ref: ScopedThreadRef, terminalId: string) => void;
   splitTerminal: (
     ref: ScopedThreadRef,
@@ -72,7 +91,10 @@ interface RightPanelStoreState {
   show: (ref: ScopedThreadRef) => void;
   close: (ref: ScopedThreadRef) => void;
   toggleVisibility: (ref: ScopedThreadRef) => void;
-  toggle: (ref: ScopedThreadRef, kind: Exclude<RightPanelKind, "file" | "terminal">) => void;
+  toggle: (
+    ref: ScopedThreadRef,
+    kind: Exclude<RightPanelKind, "file" | "terminal" | "generated-image">,
+  ) => void;
   removeThread: (ref: ScopedThreadRef) => void;
 }
 
@@ -83,7 +105,7 @@ const EMPTY_THREAD_STATE: ThreadRightPanelState = {
 };
 
 const singletonSurface = (
-  kind: Exclude<RightPanelKind, "file" | "preview" | "terminal">,
+  kind: Exclude<RightPanelKind, "file" | "preview" | "terminal" | "generated-image">,
 ): RightPanelSurface => {
   switch (kind) {
     case "diff":
@@ -110,6 +132,13 @@ const fileSurface = (
   relativePath,
   revealLine,
   revealRequestId,
+});
+
+const generatedImageSurface = (activityId: EventId, name: string): RightPanelSurface => ({
+  id: `generated-image:${activityId}`,
+  kind: "generated-image",
+  activityId,
+  name,
 });
 
 const terminalSurface = (terminalId: string): RightPanelSurface => ({
@@ -183,6 +212,17 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                           ? surface.revealRequestId
                           : 0;
                       return [{ ...surface, revealLine, revealRequestId }];
+                    }
+                    if (surface.kind === "generated-image") {
+                      if (
+                        typeof surface.activityId !== "string" ||
+                        surface.id !== `generated-image:${surface.activityId}` ||
+                        typeof surface.name !== "string" ||
+                        surface.name.trim().length === 0
+                      ) {
+                        return [];
+                      }
+                      return [surface];
                     }
                     if (surface.kind !== "terminal") return [surface];
                     if (
@@ -283,6 +323,20 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
                     entry.id === surface.id ? surface : entry,
                   )
                 : [...withoutStandaloneExplorer, surface],
+            };
+          }),
+        })),
+      openGeneratedImage: (ref, activityId, name) =>
+        set((state) => ({
+          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+            const surface = generatedImageSurface(activityId, name);
+            const existing = current.surfaces.some((entry) => entry.id === surface.id);
+            return {
+              isOpen: true,
+              activeSurfaceId: surface.id,
+              surfaces: existing
+                ? current.surfaces.map((entry) => (entry.id === surface.id ? surface : entry))
+                : [...current.surfaces, surface],
             };
           }),
         })),

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -51,6 +51,7 @@ export type RightPanelSurface =
       kind: "generated-image";
       activityId: EventId;
       name: string;
+      loadRequestId: number;
     }
   | { id: "plan"; kind: "plan" };
 
@@ -134,11 +135,16 @@ const fileSurface = (
   revealRequestId,
 });
 
-const generatedImageSurface = (activityId: EventId, name: string): RightPanelSurface => ({
+const generatedImageSurface = (
+  activityId: EventId,
+  name: string,
+  loadRequestId: number,
+): RightPanelSurface => ({
   id: `generated-image:${activityId}`,
   kind: "generated-image",
   activityId,
   name,
+  loadRequestId,
 });
 
 const terminalSurface = (terminalId: string): RightPanelSurface => ({
@@ -222,7 +228,14 @@ export function migratePersistedRightPanelState(persistedState: unknown): {
                       ) {
                         return [];
                       }
-                      return [surface];
+                      const loadRequestId =
+                        "loadRequestId" in surface &&
+                        typeof surface.loadRequestId === "number" &&
+                        Number.isSafeInteger(surface.loadRequestId) &&
+                        surface.loadRequestId >= 0
+                          ? surface.loadRequestId
+                          : 0;
+                      return [{ ...surface, loadRequestId }];
                     }
                     if (surface.kind !== "terminal") return [surface];
                     if (
@@ -329,8 +342,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
       openGeneratedImage: (ref, activityId, name) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
-            const surface = generatedImageSurface(activityId, name);
-            const existing = current.surfaces.some((entry) => entry.id === surface.id);
+            const surfaceId = `generated-image:${activityId}` as const;
+            const existing = current.surfaces.find(
+              (entry): entry is Extract<RightPanelSurface, { kind: "generated-image" }> =>
+                entry.id === surfaceId && entry.kind === "generated-image",
+            );
+            const surface = generatedImageSurface(
+              activityId,
+              name,
+              (existing?.loadRequestId ?? 0) + 1,
+            );
             return {
               isOpen: true,
               activeSurfaceId: surface.id,

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -56,7 +56,7 @@ export type RightPanelSurface =
   | { id: "plan"; kind: "plan" };
 
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
-const RIGHT_PANEL_STORAGE_VERSION = 8;
+const RIGHT_PANEL_STORAGE_VERSION = 9;
 
 export interface ThreadRightPanelState {
   isOpen: boolean;

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -691,6 +691,54 @@ describe("workEntryIndicatesToolFailure", () => {
 });
 
 describe("deriveWorkLogEntries", () => {
+  it("exposes completed image generation metadata without leaking its saved path", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({
+        id: "generated-image",
+        kind: "tool.completed",
+        summary: "Image view",
+        payload: {
+          itemType: "image_view",
+          data: {
+            item: {
+              type: "imageGeneration",
+              status: "completed",
+              savedPath: "/provider/session/images/generated.png",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entry?.generatedImage).toEqual({
+      activityId: "generated-image",
+      name: "generated.png",
+    });
+    expect(JSON.stringify(entry)).not.toContain("/provider/session");
+  });
+
+  it("does not expose incomplete image generation metadata", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeActivity({
+        id: "generated-image",
+        kind: "tool.updated",
+        summary: "Image view",
+        payload: {
+          itemType: "image_view",
+          data: {
+            item: {
+              type: "imageGeneration",
+              status: "inProgress",
+              savedPath: "/provider/session/images/generated.png",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(entry?.generatedImage).toBeUndefined();
+  });
+
   it("omits tool started entries and keeps completed entries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -73,6 +73,10 @@ export interface WorkLogEntry {
   toolTitle?: string;
   toolData?: unknown;
   itemType?: ToolLifecycleItemType;
+  generatedImage?: {
+    activityId: OrchestrationThreadActivity["id"];
+    name: string;
+  };
   requestKind?: PendingApproval["requestKind"];
   /** From runtime item / task payload `status` when present (e.g. tool.updated). */
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
@@ -718,6 +722,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     activityKind: activity.kind,
   };
   const itemType = extractWorkLogItemType(payload);
+  const generatedImage = extractGeneratedImage(payload, activity.kind, activity.id);
   const requestKind = extractWorkLogRequestKind(payload);
   if (detail) {
     entry.detail = detail;
@@ -742,6 +747,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (itemType) {
     entry.itemType = itemType;
+  }
+  if (generatedImage) {
+    entry.generatedImage = generatedImage;
   }
   if (requestKind) {
     entry.requestKind = requestKind;
@@ -818,6 +826,7 @@ function mergeDerivedWorkLogEntries(
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
+  const generatedImage = next.generatedImage ?? previous.generatedImage;
   return {
     ...previous,
     ...next,
@@ -832,6 +841,7 @@ function mergeDerivedWorkLogEntries(
     ...(toolCallId ? { toolCallId } : {}),
     ...(toolLifecycleStatus !== undefined ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),
+    ...(generatedImage !== undefined ? { generatedImage } : {}),
   };
 }
 
@@ -1084,6 +1094,28 @@ function extractToolTitle(payload: Record<string, unknown> | null): string | nul
 function extractToolCallId(payload: Record<string, unknown> | null): string | null {
   const data = asRecord(payload?.data);
   return asTrimmedString(data?.toolCallId);
+}
+
+function extractGeneratedImage(
+  payload: Record<string, unknown> | null,
+  activityKind: OrchestrationThreadActivity["kind"],
+  activityId: OrchestrationThreadActivity["id"],
+): WorkLogEntry["generatedImage"] | null {
+  if (activityKind !== "tool.completed") {
+    return null;
+  }
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  if (
+    item?.type !== "imageGeneration" ||
+    item.status !== "completed" ||
+    typeof item.savedPath !== "string"
+  ) {
+    return null;
+  }
+  const normalizedPath = item.savedPath.trim().replaceAll("\\", "/");
+  const name = normalizedPath.split("/").at(-1)?.trim();
+  return name ? { activityId, name } : null;
 }
 
 function normalizeInlinePreview(value: string): string {

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -1,6 +1,6 @@
 import * as Schema from "effect/Schema";
 
-import { ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { EventId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 const ASSET_PATH_MAX_LENGTH = 1024;
 
@@ -8,6 +8,10 @@ export const AssetResource = Schema.Union([
   Schema.TaggedStruct("workspace-file", {
     threadId: ThreadId,
     path: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
+  }),
+  Schema.TaggedStruct("generated-image", {
+    threadId: ThreadId,
+    activityId: EventId,
   }),
   Schema.TaggedStruct("attachment", {
     attachmentId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
@@ -133,6 +137,29 @@ export class AssetAttachmentNotFoundError extends Schema.TaggedErrorClass<AssetA
   }
 }
 
+export class AssetGeneratedImageNotFoundError extends Schema.TaggedErrorClass<AssetGeneratedImageNotFoundError>()(
+  "AssetGeneratedImageNotFoundError",
+  {
+    resource: AssetResource,
+  },
+) {
+  override get message(): string {
+    return "Generated image was not found.";
+  }
+}
+
+export class AssetGeneratedImageInspectionError extends Schema.TaggedErrorClass<AssetGeneratedImageInspectionError>()(
+  "AssetGeneratedImageInspectionError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to inspect the generated image.";
+  }
+}
+
 export class AssetProjectFaviconResolutionError extends Schema.TaggedErrorClass<AssetProjectFaviconResolutionError>()(
   "AssetProjectFaviconResolutionError",
   {
@@ -190,6 +217,8 @@ export const AssetAccessError = Schema.Union([
   AssetWorkspaceAssetNotFoundError,
   AssetWorkspaceResolutionError,
   AssetAttachmentNotFoundError,
+  AssetGeneratedImageNotFoundError,
+  AssetGeneratedImageInspectionError,
   AssetProjectFaviconResolutionError,
   AssetProjectFaviconInspectionError,
   AssetProjectFaviconNotFoundError,


### PR DESCRIPTION
## What Changed

- Recognize completed `imageGeneration` activities and expose only their activity ID and filename to the client timeline.
- Resolve the provider-saved image path server-side and serve it through a signed, exact-file asset capability.
- Render generated images as compact evidence links in the work log instead of automatically expanding thumbnails.
- Open selected generated images in a dedicated right-panel tab alongside files, diffs, terminals, and browser previews.
- Keep generated-image links visible across turn/work-log folding and preserve open image tabs across reloads.
- Retry the short projection race when an image link is opened immediately after completion, while failing non-transient asset errors immediately.

## Why

Generated images already arrive with a provider-saved path in completed tool activity, but that activity was rendered only as a text work-log row. The image should remain viewable after streaming finishes and after a thread is reloaded, without depending on the assistant to repeat a filename.

The interaction follows the Codex desktop pattern: images remain compact, link-like evidence in the transcript and open on demand in the existing right-side workspace. This avoids large automatic thumbnails and avoids requesting image assets until the user selects one.

This builds on the direction explored by #3984, which promotes image filenames explicitly mentioned in assistant Markdown, and #4321, which covers broader workspace/browser media references. Neither PR is included as a dependency here.

## UI Changes

- Completed image-generation activity shows an image icon and filename link under the work-log row.
- Selecting the link opens or activates a named generated-image tab in the right panel.
- The panel shows the full image with contained sizing, loading state, and load-error state.
- Multiple generated images remain separate compact transcript links and separate reusable panel tabs.

### Current browser evidence

Captured from the exact current PR head `9939cc9a46e6a33dbbca4961b1c755f9ed6fae21` in the combined package `0.0.29-patched-main-20260724` (integration `4dd4cef4039303179929a1dbdbf0c9b358c076f9`). The fixture uses a real provider `imageGeneration` event in a disposable repository.

| Compact work-log link | Generated-image right panel |
| --- | --- |
| ![Generated-image work-log link](https://raw.githubusercontent.com/colonelpanic8/t3code/c9cc827689e0061b8862630b3924911f49c8f980/pr-4427/generated-image-link.png) | ![Generated image opened in the right panel](https://raw.githubusercontent.com/colonelpanic8/t3code/c9cc827689e0061b8862630b3924911f49c8f980/pr-4427/generated-image-panel.png) |

![Opening a generated image in the right panel](https://raw.githubusercontent.com/colonelpanic8/t3code/c9cc827689e0061b8862630b3924911f49c8f980/pr-4427/open-generated-image-panel.gif)

[MP4 version of the interaction](https://raw.githubusercontent.com/colonelpanic8/t3code/c9cc827689e0061b8862630b3924911f49c8f980/pr-4427/open-generated-image-panel-trimmed.mp4)

## Checklist

- [x] `pnpm exec vp test run apps/web/src/rightPanelStore.test.ts apps/web/src/components/chat/MessagesTimeline.test.tsx apps/web/src/components/chat/GeneratedImagePanel.test.tsx apps/server/src/assets/GeneratedImageResolver.test.ts` (48 tests)
- [x] Targeted `pnpm exec vp check` for all changed server/web files
- [x] `pnpm --filter t3 run typecheck`
- [x] React best-practices review: no asset request before selection, no render-time store subscription, keyboard events isolated from the collapsible parent row
- [x] Integrated browser verification in an isolated authenticated environment against the exact combined package: real generated-image activity rendered a compact work-log link and opened the signed image in a reusable right-panel tab
- [ ] `pnpm --filter @t3tools/web run typecheck` currently reports only existing unrelated errors in `BranchToolbarBranchSelector.tsx`, `ModelPickerContent.tsx`, `PreviewAutomationHosts.tsx`, and the atom query hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed asset issuance for absolute provider paths and WS asset URL creation with retries; path validation and exact basename checks limit exposure, but persisted right-panel state migrates to v9.
> 
> **Overview**
> Adds end-to-end support for **viewing provider-generated images** from completed `imageGeneration` tool activity without exposing filesystem paths in the transcript.
> 
> **Server & contracts:** Introduces a `generated-image` `AssetResource` (thread + activity id). `assetsCreateUrl` loads the thread projection, reads `savedPath` from the completed activity via `GeneratedImageResolver`, and issues **signed, exact-file** asset tokens after validating image preview paths. Transient “activity not projected yet” failures retry (~20× / 250ms); other errors fail immediately.
> 
> **Web UI:** Work log entries for completed generations get **activity id + filename only** (not `savedPath`). The timeline shows a compact **filename link** that opens a **`generated-image` right-panel tab** (`GeneratedImagePanel` fetches the signed URL on demand). Timeline folding and work-log grouping **keep generated-image rows visible** when surrounding tool output is collapsed.
> 
> **Persistence:** Right-panel store v9 adds `generated-image` surfaces with `loadRequestId` refresh on reopen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2944f46c085204fb42d7f049d45b6636103298a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add generated image viewer to the chat right panel from tool activity
> - Adds a `GeneratedImagePanel` component that fetches a signed asset URL for a `generated-image` resource and renders the image, with spinner and error states.
> - Extends `AssetAccess` to issue and resolve time-limited tokens for generated images, restricting paths to workspace image-preview locations and canonicalizing before serving.
> - Adds `GeneratedImageResolver` utilities to extract `savedPath` from completed `imageGeneration` tool activities and retry the lookup up to 20 times with 250ms spacing.
> - Adds `openGeneratedImage` to `rightPanelStore` (bumps persisted state to version 9) and wires a click link in `MessagesTimeline` work rows to open the panel.
> - Generated-image work entries are excluded from folded turns and contiguous work-log grouping so they stay visible in the timeline.
> - Risk: persisted right-panel state is migrated to version 9; malformed `generated-image` entries are dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2944f46.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
