### PR TITLE
Fix stale model picker shortcut labels

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.test.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.test.tsx
@@ -1,0 +1,132 @@
+import { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import { type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import type { ProviderInstanceEntry } from "../../providerInstances";
+
+let capturedExtraData: unknown;
+
+vi.mock("@legendapp/list/react", () => ({
+  LegendList: (props: { extraData?: unknown }) => {
+    capturedExtraData = props.extraData;
+    return null;
+  },
+}));
+
+vi.mock("~/hooks/useSettings", () => ({
+  useClientSettings: (selector: (settings: { favorites: never[] }) => unknown) =>
+    selector({ favorites: [] }),
+  useUpdateClientSettings: () => () => {},
+}));
+
+vi.mock("../ui/combobox", () => ({
+  Combobox: (props: { children?: ReactNode }) => props.children,
+  ComboboxEmpty: (props: { children?: ReactNode }) => props.children,
+  ComboboxInput: () => null,
+  ComboboxListVirtualized: (props: { children?: ReactNode }) => props.children,
+}));
+
+vi.mock("../ui/tooltip", () => ({
+  TooltipProvider: (props: { children?: ReactNode }) => props.children,
+}));
+
+vi.mock("./ModelListRow", () => ({
+  ModelListRow: () => null,
+}));
+
+vi.mock("./ModelPickerSidebar", () => ({
+  ModelPickerSidebar: () => null,
+}));
+
+vi.mock("../../providerInstances", () => ({
+  isProviderInstancePickerReady: () => true,
+  isProviderInstancePickerVisible: () => true,
+}));
+
+let ModelPickerContent: typeof import("./ModelPickerContent").ModelPickerContent;
+
+beforeAll(async () => {
+  vi.stubGlobal("navigator", { platform: "Linux", userAgent: "T3 Code test" });
+  ({ ModelPickerContent } = await import("./ModelPickerContent"));
+});
+
+describe("ModelPickerContent", () => {
+  it("invalidates virtualized rows when positional shortcut labels change", () => {
+    const instanceId = ProviderInstanceId.make("codex");
+    const driverKind = ProviderDriverKind.make("codex");
+
+    renderToStaticMarkup(
+      <ModelPickerContent
+        activeInstanceId={instanceId}
+        model="gpt-5.6-sol"
+        lockedProvider={null}
+        instanceEntries={
+          [
+            {
+              instanceId,
+              driverKind,
+              displayName: "Codex",
+              enabled: true,
+              installed: true,
+              status: "ready",
+              isDefault: true,
+              isAvailable: true,
+              snapshot: {} as never,
+              models: [],
+            },
+          ] satisfies ReadonlyArray<ProviderInstanceEntry>
+        }
+        keybindings={[
+          {
+            shortcut: {
+              key: "1",
+              metaKey: false,
+              ctrlKey: false,
+              shiftKey: false,
+              altKey: false,
+              modKey: true,
+            },
+            command: "modelPicker.jump.1",
+            whenAst: { type: "identifier", name: "modelPickerOpen" },
+          },
+          {
+            shortcut: {
+              key: "2",
+              metaKey: false,
+              ctrlKey: false,
+              shiftKey: false,
+              altKey: false,
+              modKey: true,
+            },
+            command: "modelPicker.jump.2",
+            whenAst: { type: "identifier", name: "modelPickerOpen" },
+          },
+        ]}
+        modelOptionsByInstance={
+          new Map([
+            [
+              instanceId,
+              [
+                { slug: "gpt-5.6-sol", name: "GPT-5.6-Sol" },
+                { slug: "gpt-5.6-luna", name: "GPT-5.6-Luna" },
+              ],
+            ],
+          ])
+        }
+        terminalOpen={false}
+        onInstanceModelChange={() => {}}
+      />,
+    );
+
+    expect(capturedExtraData).toEqual(
+      expect.objectContaining({
+        activeInstanceId: instanceId,
+        activeModel: "gpt-5.6-sol",
+        modelJumpLabelByKey: new Map([
+          [`${instanceId}:gpt-5.6-sol`, "Ctrl+1"],
+          [`${instanceId}:gpt-5.6-luna`, "Ctrl+2"],
+        ]),
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -471,6 +471,26 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     }
     return mapping.size > 0 ? mapping : EMPTY_MODEL_JUMP_LABELS;
   }, [keybindings, modelJumpCommandByKey, modelJumpShortcutContext]);
+  const modelListExtraData = useMemo(
+    () => ({
+      activeInstanceId: props.activeInstanceId,
+      activeModel: props.model,
+      favoritesSet,
+      getModelDisabledReason,
+      isLocked,
+      modelJumpLabelByKey,
+      toggleFavorite,
+    }),
+    [
+      favoritesSet,
+      getModelDisabledReason,
+      isLocked,
+      modelJumpLabelByKey,
+      props.activeInstanceId,
+      props.model,
+      toggleFavorite,
+    ],
+  );
 
   useEffect(() => {
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -623,7 +643,10 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                 <LegendList<string>
                   ref={modelListRef}
                   data={filteredModelKeys}
-                  extraData={favoritesSet}
+                  // LegendList caches rows by model key. Shortcut labels are
+                  // positional, so an unchanged model must rerender when
+                  // models ahead of it are inserted, removed, or reordered.
+                  extraData={modelListExtraData}
                   keyExtractor={(modelKey) => modelKey}
                   renderItem={({ item: modelKey, index }) => {
                     const model = filteredModelByKey.get(modelKey);


### PR DESCRIPTION
## What Changed

- Include the positional shortcut-label map in the virtualized model list's invalidation state.
- Include the other external row-render dependencies so cached model rows refresh when their presentation changes.
- Add a focused regression test that verifies the list receives the current per-model shortcut mapping.

## Why

LegendList caches rows by model key, but model-picker shortcuts are assigned by visible position. When models ahead of a cached row were inserted, removed, filtered, or reordered, the row could retain its previous label and display the same shortcut as another model.

Fixes #4432.

## UI Changes

Behavior-only correction: after filtering the live model list to Opus models, the surviving rows refresh to unique shortcuts from `Ctrl+1` through `Ctrl+4`. No layout or styling changes.

## Checklist

- [x] `vp test run apps/web/src/components/chat/ModelPickerContent.test.tsx`
- [x] `vp fmt --check apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ModelPickerContent.test.tsx`
- [x] `vp lint apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ModelPickerContent.test.tsx`
- [x] Verified the real picker in an isolated web environment by filtering/reordering the model list and confirming unique positional labels.
- [ ] Focused web typecheck is currently blocked by unrelated existing dependency/type errors, including `@effect/vitest` exports and existing LegendList callback inference errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI fix in the model picker virtualization layer with a regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes **stale positional shortcut labels** (e.g. duplicate `Ctrl+1`) in the virtualized model picker when the visible list is filtered, reordered, or edited.
> 
> `LegendList` caches rows by model key; jump shortcuts are assigned by **position**, so cached rows kept old labels until something else invalidated them. **`ModelPickerContent`** now passes a memoized **`modelListExtraData`** object to `extraData` instead of only `favoritesSet`, including **`modelJumpLabelByKey`** plus active selection, favorites, lock state, disabled reasons, and favorite toggles so rows re-render when presentation changes.
> 
> Adds a focused Vitest test that asserts the list receives the current per-model shortcut map in `extraData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ac18dd530bac6858bc0ba1be0b4f16e2e25b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale shortcut labels in model picker rows by expanding `LegendList` cache key
> [ModelPickerContent.tsx](https://github.com/pingdotgg/t3code/pull/4433/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c) passes only `favoritesSet` as `extraData` to `LegendList`, which caches rows by model key. When the list reorders (e.g. a model is added or removed), positional shortcut labels like Ctrl+1 become stale because rows are not invalidated.
>
> - Replaces the `favoritesSet` `extraData` prop with a `useMemo`-computed `modelListExtraData` object that includes `activeInstanceId`, `activeModel`, `favoritesSet`, `getModelDisabledReason`, `isLocked`, `modelJumpLabelByKey`, and `toggleFavorite`.
> - Any change to these values now triggers a full row re-render, keeping shortcut labels in sync with list position.
> - Adds a Vitest test suite in [ModelPickerContent.test.tsx](https://github.com/pingdotgg/t3code/pull/4433/files#diff-4389b20ef66df3735d173b314b1a27c60bb67bc535fb09f06c6d1a20fa8d53dd) asserting the correct `modelJumpLabelByKey` map is passed through `extraData`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7ac18d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->