### PR TITLE
Fix connection setup blocked by editor discovery

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -4,7 +4,6 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -153,33 +152,6 @@ it.effect("discovers editors through the service API", () =>
 
     assert.equal(editors.includes("vscode"), true);
     assert.equal(editors.includes("file-manager"), true);
-  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-);
-
-it.effect("publishes editor discovery to cached availability state", () =>
-  Effect.gen(function* () {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-editors-" });
-    yield* fileSystem.writeFileString(path.join(binDir, "code.CMD"), "@echo off\r\n");
-
-    yield* Effect.gen(function* () {
-      const launcher = yield* ExternalLauncher.ExternalLauncher;
-      const discovered = yield* launcher.streamAvailableEditors.pipe(
-        Stream.filter((editors) => editors.includes("vscode")),
-        Stream.runHead,
-      );
-
-      assert.include(Option.getOrThrow(discovered), "vscode");
-      assert.include(yield* launcher.availableEditors, "vscode");
-    }).pipe(
-      Effect.provide(
-        testLayer({
-          platform: "win32",
-          env: { PATH: binDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
-        }),
-      ),
-    );
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 

--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -4,6 +4,7 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -152,6 +153,33 @@ it.effect("discovers editors through the service API", () =>
 
     assert.equal(editors.includes("vscode"), true);
     assert.equal(editors.includes("file-manager"), true);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("publishes editor discovery to cached availability state", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-editors-" });
+    yield* fileSystem.writeFileString(path.join(binDir, "code.CMD"), "@echo off\r\n");
+
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      const discovered = yield* launcher.streamAvailableEditors.pipe(
+        Stream.filter((editors) => editors.includes("vscode")),
+        Stream.runHead,
+      );
+
+      assert.include(Option.getOrThrow(discovered), "vscode");
+      assert.include(yield* launcher.availableEditors, "vscode");
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "win32",
+          env: { PATH: binDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        }),
+      ),
+    );
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );
 

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -27,6 +27,8 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
@@ -304,7 +306,9 @@ const resolveAvailableEditors = Effect.fn("externalLauncher.resolveAvailableEdit
 export class ExternalLauncher extends Context.Service<
   ExternalLauncher,
   {
+    readonly availableEditors: Effect.Effect<ReadonlyArray<EditorId>>;
     readonly resolveAvailableEditors: () => Effect.Effect<ReadonlyArray<EditorId>>;
+    readonly streamAvailableEditors: Stream.Stream<ReadonlyArray<EditorId>>;
     /** Launch a URL target in the default browser. */
     readonly launchBrowser: (target: string) => Effect.Effect<void, ExternalLauncherError>;
     /**
@@ -434,6 +438,7 @@ export const make = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const availableEditors = yield* SubscriptionRef.make<ReadonlyArray<EditorId>>([]);
 
   const provideCommandResolutionServices = <A, E, R>(
     effect: Effect.Effect<A, E, R | FileSystem.FileSystem | Path.Path>,
@@ -443,8 +448,16 @@ export const make = Effect.gen(function* () {
       Effect.provideService(Path.Path, path),
     );
 
+  yield* provideCommandResolutionServices(resolveAvailableEditors()).pipe(
+    Effect.flatMap((editors) => SubscriptionRef.set(availableEditors, editors)),
+    Effect.ignoreCause({ log: true }),
+    Effect.forkScoped,
+  );
+
   return ExternalLauncher.of({
+    availableEditors: SubscriptionRef.get(availableEditors),
     resolveAvailableEditors: () => provideCommandResolutionServices(resolveAvailableEditors()),
+    streamAvailableEditors: SubscriptionRef.changes(availableEditors),
     launchBrowser: (target) =>
       launchBrowser(target).pipe(
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -569,7 +569,9 @@ const buildAppUnderTest = (options?: {
       ),
       Layer.provide(
         Layer.mock(ExternalLauncher.ExternalLauncher)({
+          availableEditors: Effect.succeed([]),
           resolveAvailableEditors: () => Effect.succeed([]),
+          streamAvailableEditors: Stream.empty,
           ...options?.layers?.externalLauncher,
         }),
       ),
@@ -4283,6 +4285,42 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         version: 1,
         type: "keybindingsUpdated",
         payload: { keybindings: [], issues: [] },
+      });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("streams editor availability without blocking the config snapshot", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest({
+        layers: {
+          externalLauncher: {
+            availableEditors: Effect.succeed([]),
+            resolveAvailableEditors: () => Effect.never,
+            streamAvailableEditors: Stream.succeed(["vscode"]),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const events = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.timeout("1 second"),
+          ),
+        ),
+      );
+
+      const [first, second] = Array.from(events);
+      assert.equal(first?.type, "snapshot");
+      if (first?.type === "snapshot") {
+        assert.deepEqual(first.config.availableEditors, []);
+      }
+      assert.deepEqual(second, {
+        version: 1,
+        type: "availableEditorsUpdated",
+        payload: { availableEditors: ["vscode"] },
       });
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1083,7 +1083,7 @@ const makeWsRpcLayer = (
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
           providers,
-          availableEditors: yield* externalLauncher.resolveAvailableEditors(),
+          availableEditors: yield* externalLauncher.availableEditors,
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,
@@ -2011,6 +2011,13 @@ const makeWsRpcLayer = (
                   payload: { settings },
                 })),
               );
+              const availableEditorsUpdates = externalLauncher.streamAvailableEditors.pipe(
+                Stream.map((availableEditors) => ({
+                  version: 1 as const,
+                  type: "availableEditorsUpdated" as const,
+                  payload: { availableEditors },
+                })),
+              );
 
               yield* providerRegistry
                 .refresh()
@@ -2018,7 +2025,10 @@ const makeWsRpcLayer = (
 
               const liveUpdates = Stream.merge(
                 keybindingsUpdates,
-                Stream.merge(providerStatuses, settingsUpdates),
+                Stream.merge(
+                  providerStatuses,
+                  Stream.merge(settingsUpdates, availableEditorsUpdates),
+                ),
               );
 
               return Stream.concat(

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -80,6 +80,24 @@ describe("server state projection", () => {
     expect(result.latestEvent.type).toBe("settingsUpdated");
   });
 
+  it("applies editor availability updates without replacing the config snapshot", () => {
+    const snapshot = applyServerConfigProjection(Option.none(), {
+      version: 1,
+      type: "snapshot",
+      config: CONFIG,
+    });
+    const availableEditors: ServerConfig["availableEditors"] = ["vscode"];
+    const projected = applyServerConfigProjection(snapshot, {
+      version: 1,
+      type: "availableEditorsUpdated",
+      payload: { availableEditors },
+    });
+
+    const result = Option.getOrThrow(projected);
+    expect(result.config.availableEditors).toBe(availableEditors);
+    expect(result.latestEvent.type).toBe("availableEditorsUpdated");
+  });
+
   it("retains welcome when a ready event follows in the same stream chunk", () => {
     const welcome = {
       environment: {} as ServerLifecycleWelcomePayload["environment"],

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -72,6 +72,15 @@ export function applyServerConfigProjection(
         latestEvent: event,
         source: "live",
       }));
+    case "availableEditorsUpdated":
+      return Option.map(current, (projection) => ({
+        config: {
+          ...projection.config,
+          availableEditors: event.payload.availableEditors,
+        },
+        latestEvent: event,
+        source: "live",
+      }));
   }
 }
 

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -475,6 +475,12 @@ export const ServerConfigSettingsUpdatedPayload = Schema.Struct({
 });
 export type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
 
+export const ServerConfigAvailableEditorsUpdatedPayload = Schema.Struct({
+  availableEditors: Schema.Array(EditorId),
+});
+export type ServerConfigAvailableEditorsUpdatedPayload =
+  typeof ServerConfigAvailableEditorsUpdatedPayload.Type;
+
 export const ServerConfigStreamSnapshotEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("snapshot"),
@@ -506,11 +512,20 @@ export const ServerConfigStreamSettingsUpdatedEvent = Schema.Struct({
 export type ServerConfigStreamSettingsUpdatedEvent =
   typeof ServerConfigStreamSettingsUpdatedEvent.Type;
 
+export const ServerConfigStreamAvailableEditorsUpdatedEvent = Schema.Struct({
+  version: Schema.Literal(1),
+  type: Schema.Literal("availableEditorsUpdated"),
+  payload: ServerConfigAvailableEditorsUpdatedPayload,
+});
+export type ServerConfigStreamAvailableEditorsUpdatedEvent =
+  typeof ServerConfigStreamAvailableEditorsUpdatedEvent.Type;
+
 export const ServerConfigStreamEvent = Schema.Union([
   ServerConfigStreamSnapshotEvent,
   ServerConfigStreamKeybindingsUpdatedEvent,
   ServerConfigStreamProviderStatusesEvent,
   ServerConfigStreamSettingsUpdatedEvent,
+  ServerConfigStreamAvailableEditorsUpdatedEvent,
 ]);
 export type ServerConfigStreamEvent = typeof ServerConfigStreamEvent.Type;
 


### PR DESCRIPTION
On loaded Windows systems, editor availability can spend longer than the 15-second connection deadline walking PATH and PATHEXT entries, so `server.getConfig` is interrupted and a healthy local backend is reported as disconnected. This moves editor discovery out of the connection-critical config snapshot: `ExternalLauncher` now starts the scan as a scoped background task, exposes an immediate cached snapshot, and publishes `availableEditorsUpdated` when discovery completes; the client applies that update without replacing the rest of its config. The regression coverage deliberately makes the old discovery method never complete and verifies that the WebSocket config snapshot still arrives within one second, with focused server/editor/client tests plus contracts, client-runtime, and server typechecks, targeted lint, formatting, and `git diff --check` passing. Fixes #3610.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix connection setup blocked by editor discovery using a non-blocking cached snapshot
> - The `subscribeServerConfig` WebSocket endpoint previously called `resolveAvailableEditors` synchronously during the initial snapshot, blocking connection setup until editor discovery completed.
> - `ExternalLauncher` now seeds a `SubscriptionRef` with an empty editor list and populates it via a background fiber, exposing `availableEditors` (non-blocking snapshot) and `streamAvailableEditors` (change stream).
> - The WebSocket layer reads the cached snapshot for the initial config and pushes `availableEditorsUpdated` events as the background fiber updates the ref.
> - `applyServerConfigProjection` in the client runtime now handles `availableEditorsUpdated` events to update `availableEditors` without replacing the rest of the config.
> - Behavioral Change: the initial snapshot always returns an empty `availableEditors` list; updates arrive shortly after via the stream rather than being present at connection time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dd176c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to editor listing and config streaming; launch paths still use on-demand resolution. Main product change is briefly empty `availableEditors` before the update event.
> 
> **Overview**
> **Editor discovery no longer blocks the WebSocket config snapshot.** `ExternalLauncher` keeps editor IDs in a `SubscriptionRef`, kicks off PATH/PATHEXT scanning in a scoped background fiber at startup, and exposes an immediate `availableEditors` read plus `streamAvailableEditors` for later changes.
> 
> `subscribeServerConfig` builds the initial snapshot from the cached list (often `[]` until discovery finishes) instead of awaiting `resolveAvailableEditors()`, and merges **`availableEditorsUpdated`** into the live update stream alongside settings and provider events. Contracts and client `applyServerConfigProjection` apply that event by patching only `config.availableEditors`.
> 
> **Behavioral note:** clients may see an empty editor list on first snapshot, then a follow-up event when discovery completes—addressing Windows setups that previously exceeded the ~15s connection deadline during sync discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd176c1568689051e87c17b1984659eb2c7fc0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->