### PR TITLE
Use xdg directories: Separate configuration, data, state, cache, and runtime storage

### DIFF
--- a/apps/desktop/src/app/DesktopApp.test.ts
+++ b/apps/desktop/src/app/DesktopApp.test.ts
@@ -1,0 +1,48 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import { configureElectronStoragePaths } from "./DesktopApp.ts";
+
+describe("configureElectronStoragePaths", () => {
+  it.effect("creates a fresh split-layout cache directory before configuring Electron", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-electron-storage-",
+      });
+      const electronCachePath = `${root}/cache/electron`;
+      const configuredPaths: Array<readonly [string, string]> = [];
+      const electronAppLayer = Layer.succeed(
+        ElectronApp.ElectronApp,
+        ElectronApp.ElectronApp.of({
+          setPath: (name, path) =>
+            name === "cache"
+              ? fileSystem.exists(path).pipe(
+                  Effect.map((exists) => {
+                    assert.isTrue(exists);
+                    configuredPaths.push([name, path]);
+                  }),
+                )
+              : Effect.sync(() => {
+                  configuredPaths.push([name, path]);
+                }),
+        } as ElectronApp.ElectronApp["Service"]),
+      );
+
+      yield* configureElectronStoragePaths({
+        userDataPath: `${root}/state/electron`,
+        storageLayout: "split",
+        electronCachePath,
+      }).pipe(Effect.provide(electronAppLayer));
+
+      assert.deepEqual(configuredPaths, [
+        ["userData", `${root}/state/electron`],
+        ["cache", electronCachePath],
+      ]);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -229,6 +229,9 @@ const startup = Effect.gen(function* () {
   yield* shellEnvironment.installIntoProcess;
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
+  if (environment.storageLayout === "split") {
+    yield* electronApp.setPath("cache", environment.electronCachePath);
+  }
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   yield* desktopSettings.load;
 

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,5 +1,6 @@
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -62,6 +63,23 @@ const { logInfo: logBootstrapInfo, logWarning: logBootstrapWarning } =
 
 const { logInfo: logStartupInfo, logError: logStartupError } =
   DesktopObservability.makeComponentLogger("desktop-startup");
+
+export const configureElectronStoragePaths = Effect.fn(
+  "desktop.startup.configureElectronStoragePaths",
+)(function* (input: {
+  readonly userDataPath: string;
+  readonly storageLayout: DesktopEnvironment.DesktopEnvironment["Service"]["storageLayout"];
+  readonly electronCachePath: string;
+}) {
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const fileSystem = yield* FileSystem.FileSystem;
+
+  yield* electronApp.setPath("userData", input.userDataPath);
+  if (input.storageLayout === "split") {
+    yield* fileSystem.makeDirectory(input.electronCachePath, { recursive: true });
+    yield* electronApp.setPath("cache", input.electronCachePath);
+  }
+});
 
 const resolveDesktopBackendPort = Effect.fn("resolveDesktopBackendPort")(function* (
   configuredPort: Option.Option<number>,
@@ -228,10 +246,11 @@ const startup = Effect.gen(function* () {
 
   yield* shellEnvironment.installIntoProcess;
   const userDataPath = yield* appIdentity.resolveUserDataPath;
-  yield* electronApp.setPath("userData", userDataPath);
-  if (environment.storageLayout === "split") {
-    yield* electronApp.setPath("cache", environment.electronCachePath);
-  }
+  yield* configureElectronStoragePaths({
+    userDataPath,
+    storageLayout: environment.storageLayout,
+    electronCachePath: environment.electronCachePath,
+  });
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   yield* desktopSettings.load;
 

--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -149,7 +149,10 @@ describe("DesktopAppIdentity", () => {
 
         assert.equal(userDataPath, "/Users/alice/Library/Application Support/T3 Code (Alpha)");
       }),
-      { legacyPathExists: true },
+      {
+        legacyPathExists: true,
+        environment: { env: { T3CODE_HOME: "/Users/alice/.t3" } },
+      },
     ),
   );
 
@@ -176,7 +179,10 @@ describe("DesktopAppIdentity", () => {
           `Failed to inspect legacy desktop user-data path at "${legacyPath}".`,
         );
       }),
-      { legacyPathProbeError: cause },
+      {
+        legacyPathProbeError: cause,
+        environment: { env: { T3CODE_HOME: "/Users/alice/.t3" } },
+      },
     );
   });
 

--- a/apps/desktop/src/app/DesktopAppIdentity.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.ts
@@ -91,6 +91,9 @@ export const make = Effect.gen(function* () {
   });
 
   const resolveUserDataPath = Effect.gen(function* () {
+    if (environment.storageLayout === "split") {
+      return environment.electronUserDataPath;
+    }
     const legacyPath = environment.path.join(
       environment.appDataDirectory,
       environment.legacyUserDataDirName,

--- a/apps/desktop/src/app/DesktopConfig.ts
+++ b/apps/desktop/src/app/DesktopConfig.ts
@@ -34,8 +34,18 @@ const compactEnv = (env: Readonly<Record<string, string | undefined>>): Record<s
 
 export const DesktopConfig = Config.all({
   appDataDirectory: trimmedString("APPDATA"),
+  localAppDataDirectory: trimmedString("LOCALAPPDATA"),
   xdgConfigHome: trimmedString("XDG_CONFIG_HOME"),
+  xdgDataHome: trimmedString("XDG_DATA_HOME"),
+  xdgStateHome: trimmedString("XDG_STATE_HOME"),
+  xdgCacheHome: trimmedString("XDG_CACHE_HOME"),
+  xdgRuntimeDir: trimmedString("XDG_RUNTIME_DIR"),
   t3Home: trimmedString("T3CODE_HOME"),
+  t3ConfigDir: trimmedString("T3CODE_CONFIG_DIR"),
+  t3DataDir: trimmedString("T3CODE_DATA_DIR"),
+  t3StateDir: trimmedString("T3CODE_STATE_DIR"),
+  t3CacheDir: trimmedString("T3CODE_CACHE_DIR"),
+  t3RuntimeDir: trimmedString("T3CODE_RUNTIME_DIR"),
   devServerUrl: Config.url("VITE_DEV_SERVER_URL").pipe(Config.option),
   appUserModelIdOverride: trimmedString("T3CODE_DESKTOP_APP_USER_MODEL_ID"),
   devRemoteT3ServerEntryPath: trimmedString("T3CODE_DEV_REMOTE_T3_SERVER_ENTRY_PATH"),

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -1,8 +1,10 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopConfig from "./DesktopConfig.ts";
@@ -106,9 +108,96 @@ describe("DesktopEnvironment", () => {
       );
       const production = yield* makeEnvironment();
 
-      assert.equal(development.stateDir, "/Users/alice/.t3/dev");
-      assert.equal(production.stateDir, "/Users/alice/.t3/userdata");
+      assert.equal(
+        development.stateDir,
+        "/Users/alice/Library/Application Support/t3code-dev/state",
+      );
+      assert.equal(production.stateDir, "/Users/alice/Library/Application Support/t3code/state");
+      assert.equal(production.configDir, "/Users/alice/Library/Application Support/t3code/config");
+      assert.equal(production.dataDir, "/Users/alice/Library/Application Support/t3code/data");
+      assert.equal(production.cacheDir, "/Users/alice/Library/Caches/t3code");
+      assert.equal(production.runtimeDir, "/tmp/t3code");
     }),
+  );
+
+  it.effect("honors all five XDG roots on Linux", () =>
+    Effect.gen(function* () {
+      const environment = yield* makeEnvironment(
+        {
+          platform: "linux",
+          homeDirectory: "/home/alice",
+          temporaryDirectory: "/tmp",
+          userId: 1000,
+        },
+        {
+          XDG_CONFIG_HOME: "/xdg/config",
+          XDG_DATA_HOME: "/xdg/data",
+          XDG_STATE_HOME: "/xdg/state",
+          XDG_CACHE_HOME: "/xdg/cache",
+          XDG_RUNTIME_DIR: "/run/user/1000",
+        },
+      );
+
+      assert.equal(environment.storageLayout, "split");
+      assert.equal(environment.configDir, "/xdg/config/t3code");
+      assert.equal(environment.dataDir, "/xdg/data/t3code");
+      assert.equal(environment.stateDir, "/xdg/state/t3code");
+      assert.equal(environment.cacheDir, "/xdg/cache/t3code");
+      assert.equal(environment.runtimeDir, "/run/user/1000/t3code");
+      assert.equal(environment.serverSettingsPath, "/xdg/config/t3code/settings.json");
+      assert.equal(environment.browserArtifactsDir, "/xdg/cache/t3code/browser-artifacts");
+      assert.equal(environment.electronUserDataPath, "/xdg/state/t3code/electron");
+    }),
+  );
+
+  it.effect("rejects mixing T3CODE_HOME with granular directory overrides", () =>
+    Effect.gen(function* () {
+      const error = yield* makeEnvironment(
+        { platform: "linux", homeDirectory: "/home/alice" },
+        {
+          T3CODE_HOME: "/tmp/legacy-t3",
+          T3CODE_STATE_DIR: "/tmp/t3-state",
+        },
+      ).pipe(Effect.flip);
+
+      assert.instanceOf(
+        error,
+        DesktopEnvironment.DesktopStorageDirectoryConfigurationConflictError,
+      );
+    }),
+  );
+
+  it.effect("keeps an initialized legacy installation without copying it", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-environment-legacy-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+      const splitStateHome = path.join(root, "state");
+      yield* fileSystem.makeDirectory(legacyStateDir, { recursive: true });
+      yield* fileSystem.makeDirectory(path.join(splitStateHome, "t3code"), {
+        recursive: true,
+      });
+      yield* fileSystem.writeFileString(path.join(legacyStateDir, "state.sqlite"), "legacy");
+      yield* fileSystem.writeFileString(path.join(splitStateHome, "t3code", "state.sqlite"), "");
+
+      const environment = yield* makeEnvironment(
+        {
+          platform: "linux",
+          homeDirectory,
+          temporaryDirectory: root,
+          userId: 1000,
+        },
+        { XDG_STATE_HOME: splitStateHome },
+      );
+
+      assert.equal(environment.storageLayout, "legacy");
+      assert.equal(environment.stateDir, legacyStateDir);
+      assert.equal(environment.serverSettingsPath, path.join(legacyStateDir, "settings.json"));
+    }).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("uses a configured app user model id override", () =>

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -226,6 +226,35 @@ describe("DesktopEnvironment", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect.each([
+    { artifactName: "desktop settings", fileName: "desktop-settings.json" },
+    { artifactName: "client settings", fileName: "client-settings.json" },
+    { artifactName: "saved environments", fileName: "saved-environments.json" },
+  ])("keeps legacy storage when only legacy $artifactName are initialized", ({ fileName }) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-environment-legacy-settings-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+      yield* fileSystem.makeDirectory(legacyStateDir, { recursive: true });
+      yield* fileSystem.writeFileString(path.join(legacyStateDir, fileName), "{}");
+
+      const environment = yield* makeEnvironment({
+        platform: "linux",
+        homeDirectory,
+        temporaryDirectory: root,
+        userId: 1000,
+      });
+
+      assert.equal(environment.storageLayout, "legacy");
+      assert.equal(environment.configDir, legacyStateDir);
+      assert.equal(environment.stateDir, legacyStateDir);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("does not treat Electron preferences as initialized server storage", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -55,16 +55,13 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.isDevelopment, true);
       assert.equal(environment.appDataDirectory, "/Users/alice/Library/Application Support");
       assert.equal(environment.baseDir, "/tmp/t3");
-      assert.equal(environment.stateDir, "/tmp/t3/userdata");
-      assert.equal(environment.desktopSettingsPath, "/tmp/t3/userdata/desktop-settings.json");
-      assert.equal(environment.clientSettingsPath, "/tmp/t3/userdata/client-settings.json");
-      assert.equal(
-        environment.savedEnvironmentRegistryPath,
-        "/tmp/t3/userdata/saved-environments.json",
-      );
-      assert.equal(environment.serverSettingsPath, "/tmp/t3/userdata/settings.json");
-      assert.equal(environment.logDir, "/tmp/t3/userdata/logs");
-      assert.equal(environment.browserArtifactsDir, "/tmp/t3/userdata/browser-artifacts");
+      assert.equal(environment.stateDir, "/tmp/t3/dev");
+      assert.equal(environment.desktopSettingsPath, "/tmp/t3/dev/desktop-settings.json");
+      assert.equal(environment.clientSettingsPath, "/tmp/t3/dev/client-settings.json");
+      assert.equal(environment.savedEnvironmentRegistryPath, "/tmp/t3/dev/saved-environments.json");
+      assert.equal(environment.serverSettingsPath, "/tmp/t3/dev/settings.json");
+      assert.equal(environment.logDir, "/tmp/t3/dev/logs");
+      assert.equal(environment.browserArtifactsDir, "/tmp/t3/dev/browser-artifacts");
       assert.equal(environment.rootDir, "/repo");
       assert.equal(environment.appRoot, "/repo");
       assert.equal(environment.backendEntryPath, "/repo/apps/server/dist/bin.mjs");
@@ -197,6 +194,36 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.storageLayout, "legacy");
       assert.equal(environment.stateDir, legacyStateDir);
       assert.equal(environment.serverSettingsPath, path.join(legacyStateDir, "settings.json"));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("does not treat Electron preferences as initialized server storage", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-environment-electron-only-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const electronDirectory = path.join(
+        homeDirectory,
+        "Library",
+        "Application Support",
+        "T3 Code (Alpha)",
+      );
+      yield* fileSystem.makeDirectory(electronDirectory, { recursive: true });
+      yield* fileSystem.writeFileString(path.join(electronDirectory, "Local State"), "{}");
+
+      const environment = yield* makeEnvironment({
+        homeDirectory,
+        temporaryDirectory: root,
+      });
+
+      assert.equal(environment.storageLayout, "split");
+      assert.equal(
+        environment.stateDir,
+        path.join(homeDirectory, "Library", "Application Support", "t3code", "state"),
+      );
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -55,13 +55,16 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.isDevelopment, true);
       assert.equal(environment.appDataDirectory, "/Users/alice/Library/Application Support");
       assert.equal(environment.baseDir, "/tmp/t3");
-      assert.equal(environment.stateDir, "/tmp/t3/dev");
-      assert.equal(environment.desktopSettingsPath, "/tmp/t3/dev/desktop-settings.json");
-      assert.equal(environment.clientSettingsPath, "/tmp/t3/dev/client-settings.json");
-      assert.equal(environment.savedEnvironmentRegistryPath, "/tmp/t3/dev/saved-environments.json");
-      assert.equal(environment.serverSettingsPath, "/tmp/t3/dev/settings.json");
-      assert.equal(environment.logDir, "/tmp/t3/dev/logs");
-      assert.equal(environment.browserArtifactsDir, "/tmp/t3/dev/browser-artifacts");
+      assert.equal(environment.stateDir, "/tmp/t3/userdata");
+      assert.equal(environment.desktopSettingsPath, "/tmp/t3/userdata/desktop-settings.json");
+      assert.equal(environment.clientSettingsPath, "/tmp/t3/userdata/client-settings.json");
+      assert.equal(
+        environment.savedEnvironmentRegistryPath,
+        "/tmp/t3/userdata/saved-environments.json",
+      );
+      assert.equal(environment.serverSettingsPath, "/tmp/t3/userdata/settings.json");
+      assert.equal(environment.logDir, "/tmp/t3/userdata/logs");
+      assert.equal(environment.browserArtifactsDir, "/tmp/t3/userdata/browser-artifacts");
       assert.equal(environment.rootDir, "/repo");
       assert.equal(environment.appRoot, "/repo");
       assert.equal(environment.backendEntryPath, "/repo/apps/server/dist/bin.mjs");
@@ -190,6 +193,32 @@ describe("DesktopEnvironment", () => {
         },
         { XDG_STATE_HOME: splitStateHome },
       );
+
+      assert.equal(environment.storageLayout, "legacy");
+      assert.equal(environment.stateDir, legacyStateDir);
+      assert.equal(environment.serverSettingsPath, path.join(legacyStateDir, "settings.json"));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("keeps legacy storage when only legacy secrets are initialized", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-environment-legacy-secrets-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+      yield* fileSystem.makeDirectory(path.join(legacyStateDir, "secrets"), {
+        recursive: true,
+      });
+
+      const environment = yield* makeEnvironment({
+        platform: "linux",
+        homeDirectory,
+        temporaryDirectory: root,
+        userId: 1000,
+      });
 
       assert.equal(environment.storageLayout, "legacy");
       assert.equal(environment.stateDir, legacyStateDir);

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -4,12 +4,23 @@ import type {
   DesktopRuntimeArch,
   DesktopRuntimeInfo,
 } from "@t3tools/contracts";
+import {
+  applyT3StorageDirectoryOverrides,
+  hasT3StorageDirectoryOverrides,
+  resolveDefaultT3StorageRoots,
+  resolveLegacyT3StorageRoots,
+  resolveT3StorageDirectoryOverrides,
+  selectT3StorageRoots,
+  type T3StorageLayout,
+} from "@t3tools/shared/storagePaths";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as NodeOS from "node:os";
 
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopConfig from "./DesktopConfig.ts";
@@ -25,6 +36,18 @@ export interface MakeDesktopEnvironmentInput {
   readonly isPackaged: boolean;
   readonly resourcesPath: string;
   readonly runningUnderArm64Translation: boolean;
+  readonly temporaryDirectory?: string;
+  readonly userId?: number;
+}
+
+export class DesktopStorageDirectoryConfigurationConflictError extends Error {
+  override readonly name = "DesktopStorageDirectoryConfigurationConflictError";
+
+  constructor() {
+    super(
+      "T3CODE_HOME cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.",
+    );
+  }
 }
 
 export class DesktopEnvironment extends Context.Service<
@@ -41,14 +64,21 @@ export class DesktopEnvironment extends Context.Service<
     readonly resourcesPath: string;
     readonly homeDirectory: string;
     readonly appDataDirectory: string;
+    readonly storageLayout: T3StorageLayout;
+    readonly configDir: string;
+    readonly dataDir: string;
     readonly baseDir: string;
     readonly stateDir: string;
+    readonly cacheDir: string;
+    readonly runtimeDir: string;
     readonly desktopSettingsPath: string;
     readonly clientSettingsPath: string;
     readonly savedEnvironmentRegistryPath: string;
     readonly serverSettingsPath: string;
     readonly logDir: string;
     readonly browserArtifactsDir: string;
+    readonly electronUserDataPath: string;
+    readonly electronCachePath: string;
     readonly rootDir: string;
     readonly appRoot: string;
     readonly backendEntryPath: string;
@@ -133,8 +163,13 @@ function resolveDesktopRuntimeInfo(input: {
 
 const make = Effect.fn("desktop.environment.make")(function* (
   input: MakeDesktopEnvironmentInput,
-): Effect.fn.Return<DesktopEnvironment["Service"], Config.ConfigError, Path.Path> {
+): Effect.fn.Return<
+  DesktopEnvironment["Service"],
+  Config.ConfigError | DesktopStorageDirectoryConfigurationConflictError,
+  FileSystem.FileSystem | Path.Path
+> {
   const path = yield* Path.Path;
+  const fileSystem = yield* FileSystem.FileSystem;
   const config = yield* DesktopConfig.DesktopConfig;
   const homeDirectory = input.homeDirectory;
   const devServerUrl = config.devServerUrl;
@@ -147,8 +182,97 @@ const make = Effect.fn("desktop.environment.make")(function* (
       : input.platform === "darwin"
         ? path.join(homeDirectory, "Library", "Application Support")
         : Option.getOrElse(config.xdgConfigHome, () => path.join(homeDirectory, ".config"));
-  const configuredBaseDir = config.t3Home;
-  const baseDir = Option.getOrElse(configuredBaseDir, () => path.join(homeDirectory, ".t3"));
+  const userDataDirName = isDevelopment ? "t3code-dev" : "t3code";
+  const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
+  const pathOperations = {
+    join: (...paths: ReadonlyArray<string>) => path.join(...paths),
+    resolve: (...paths: ReadonlyArray<string>) => path.resolve(...paths),
+    isAbsolute: (candidate: string) => path.isAbsolute(candidate),
+  };
+  const storageEnvironment = {
+    T3CODE_CONFIG_DIR: Option.getOrUndefined(config.t3ConfigDir),
+    T3CODE_DATA_DIR: Option.getOrUndefined(config.t3DataDir),
+    T3CODE_STATE_DIR: Option.getOrUndefined(config.t3StateDir),
+    T3CODE_CACHE_DIR: Option.getOrUndefined(config.t3CacheDir),
+    T3CODE_RUNTIME_DIR: Option.getOrUndefined(config.t3RuntimeDir),
+    XDG_CONFIG_HOME: Option.getOrUndefined(config.xdgConfigHome),
+    XDG_DATA_HOME: Option.getOrUndefined(config.xdgDataHome),
+    XDG_STATE_HOME: Option.getOrUndefined(config.xdgStateHome),
+    XDG_CACHE_HOME: Option.getOrUndefined(config.xdgCacheHome),
+    XDG_RUNTIME_DIR: Option.getOrUndefined(config.xdgRuntimeDir),
+    APPDATA: Option.getOrUndefined(config.appDataDirectory),
+    LOCALAPPDATA: Option.getOrUndefined(config.localAppDataDirectory),
+  };
+  const defaultSplitRoots = resolveDefaultT3StorageRoots({
+    platform: input.platform,
+    homeDirectory,
+    temporaryDirectory: input.temporaryDirectory ?? NodeOS.tmpdir(),
+    ...(input.userId === undefined ? {} : { userId: input.userId }),
+    isDevelopment,
+    environment: storageEnvironment,
+    path: pathOperations,
+  });
+  const directoryOverrides = resolveT3StorageDirectoryOverrides({
+    environment: storageEnvironment,
+    homeDirectory,
+    path: pathOperations,
+  });
+  const explicitSplitRoots = hasT3StorageDirectoryOverrides(directoryOverrides)
+    ? applyT3StorageDirectoryOverrides(defaultSplitRoots, directoryOverrides)
+    : undefined;
+  const configuredBaseDir = Option.map(config.t3Home, (value) => {
+    const expanded =
+      value === "~"
+        ? homeDirectory
+        : value.startsWith("~/") || value.startsWith("~\\")
+          ? path.join(homeDirectory, value.slice(2))
+          : value;
+    return path.resolve(expanded);
+  });
+  if (Option.isSome(configuredBaseDir) && hasT3StorageDirectoryOverrides(directoryOverrides)) {
+    return yield* Effect.fail(new DesktopStorageDirectoryConfigurationConflictError());
+  }
+  const legacyBaseDir = path.join(homeDirectory, ".t3");
+  const legacyRoots = resolveLegacyT3StorageRoots({
+    baseDir: legacyBaseDir,
+    stateDirectoryName: isDevelopment ? "dev" : "userdata",
+    path,
+  });
+  const explicitLegacyRoots = Option.map(configuredBaseDir, (baseDir) =>
+    resolveLegacyT3StorageRoots({
+      baseDir,
+      stateDirectoryName: "userdata",
+      path,
+    }),
+  );
+  const legacyArtifacts = [
+    path.join(legacyRoots.stateDir, "state.sqlite"),
+    path.join(legacyRoots.configDir, "settings.json"),
+    path.join(legacyRoots.configDir, "keybindings.json"),
+    path.join(legacyRoots.stateDir, "environment-id"),
+    path.join(legacyRoots.stateDir, "connection-catalog.json"),
+    path.join(appDataDirectory, legacyUserDataDirName, "Local State"),
+    path.join(appDataDirectory, legacyUserDataDirName, "Preferences"),
+    path.join(appDataDirectory, userDataDirName, "Local State"),
+    path.join(appDataDirectory, userDataDirName, "Preferences"),
+  ];
+  const legacyStorageInitialized = (yield* Effect.all(
+    legacyArtifacts.map((artifact) =>
+      fileSystem.exists(artifact).pipe(Effect.orElseSucceed(() => false)),
+    ),
+    { concurrency: "unbounded" },
+  )).some(Boolean);
+  const storageRoots = selectT3StorageRoots({
+    ...(Option.isNone(explicitLegacyRoots)
+      ? {}
+      : { explicitLegacyRoots: explicitLegacyRoots.value }),
+    ...(explicitSplitRoots === undefined ? {} : { explicitSplitRoots }),
+    defaultSplitRoots,
+    legacyRoots,
+    legacyStorageInitialized,
+  });
+  const { cacheDir, configDir, dataDir, runtimeDir, stateDir } = storageRoots;
+  const baseDir = dataDir;
   const rootDir = path.resolve(input.dirname, "../../..");
   const appRoot = input.isPackaged ? input.appPath : rootDir;
   const branding = resolveDesktopAppBranding({
@@ -156,12 +280,6 @@ const make = Effect.fn("desktop.environment.make")(function* (
     appVersion: input.appVersion,
   });
   const displayName = branding.displayName;
-  const stateDir = path.join(
-    baseDir,
-    isDevelopment && Option.isNone(configuredBaseDir) ? "dev" : "userdata",
-  );
-  const userDataDirName = isDevelopment ? "t3code-dev" : "t3code";
-  const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
   const resourcesPath = input.resourcesPath;
 
   return DesktopEnvironment.of({
@@ -176,14 +294,24 @@ const make = Effect.fn("desktop.environment.make")(function* (
     resourcesPath,
     homeDirectory,
     appDataDirectory,
+    storageLayout: storageRoots.layout,
+    configDir,
+    dataDir,
     baseDir,
     stateDir,
-    desktopSettingsPath: path.join(stateDir, "desktop-settings.json"),
-    clientSettingsPath: path.join(stateDir, "client-settings.json"),
+    cacheDir,
+    runtimeDir,
+    desktopSettingsPath: path.join(configDir, "desktop-settings.json"),
+    clientSettingsPath: path.join(configDir, "client-settings.json"),
     savedEnvironmentRegistryPath: path.join(stateDir, "saved-environments.json"),
-    serverSettingsPath: path.join(stateDir, "settings.json"),
+    serverSettingsPath: path.join(configDir, "settings.json"),
     logDir: path.join(stateDir, "logs"),
-    browserArtifactsDir: path.join(stateDir, "browser-artifacts"),
+    browserArtifactsDir: path.join(
+      storageRoots.layout === "legacy" ? stateDir : cacheDir,
+      "browser-artifacts",
+    ),
+    electronUserDataPath: path.join(stateDir, "electron"),
+    electronCachePath: path.join(cacheDir, "electron"),
     rootDir,
     appRoot,
     backendEntryPath: path.join(appRoot, "apps/server/dist/bin.mjs"),

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -252,9 +252,12 @@ const make = Effect.fn("desktop.environment.make")(function* (
     path.join(legacyRoots.stateDir, "state.sqlite"),
     path.join(legacyRoots.configDir, "settings.json"),
     path.join(legacyRoots.configDir, "keybindings.json"),
+    path.join(legacyRoots.configDir, "desktop-settings.json"),
+    path.join(legacyRoots.configDir, "client-settings.json"),
     path.join(legacyRoots.stateDir, "environment-id"),
     path.join(legacyRoots.stateDir, "connection-catalog.json"),
     path.join(legacyRoots.stateDir, "secrets"),
+    path.join(legacyRoots.stateDir, "saved-environments.json"),
   ];
   const legacyStorageInitialized = (yield* Effect.all(
     legacyArtifacts.map((artifact) => fileSystem.exists(artifact)),

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -20,6 +20,8 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 import * as NodeOS from "node:os";
 
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
@@ -40,13 +42,12 @@ export interface MakeDesktopEnvironmentInput {
   readonly userId?: number;
 }
 
-export class DesktopStorageDirectoryConfigurationConflictError extends Error {
-  override readonly name = "DesktopStorageDirectoryConfigurationConflictError";
-
-  constructor() {
-    super(
-      "T3CODE_HOME cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.",
-    );
+export class DesktopStorageDirectoryConfigurationConflictError extends Schema.TaggedErrorClass<DesktopStorageDirectoryConfigurationConflictError>()(
+  "DesktopStorageDirectoryConfigurationConflictError",
+  {},
+) {
+  override get message(): string {
+    return "T3CODE_HOME cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.";
   }
 }
 
@@ -165,7 +166,9 @@ const make = Effect.fn("desktop.environment.make")(function* (
   input: MakeDesktopEnvironmentInput,
 ): Effect.fn.Return<
   DesktopEnvironment["Service"],
-  Config.ConfigError | DesktopStorageDirectoryConfigurationConflictError,
+  | Config.ConfigError
+  | DesktopStorageDirectoryConfigurationConflictError
+  | PlatformError.PlatformError,
   FileSystem.FileSystem | Path.Path
 > {
   const path = yield* Path.Path;
@@ -230,7 +233,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     return path.resolve(expanded);
   });
   if (Option.isSome(configuredBaseDir) && hasT3StorageDirectoryOverrides(directoryOverrides)) {
-    return yield* Effect.fail(new DesktopStorageDirectoryConfigurationConflictError());
+    return yield* new DesktopStorageDirectoryConfigurationConflictError();
   }
   const legacyBaseDir = path.join(homeDirectory, ".t3");
   const legacyRoots = resolveLegacyT3StorageRoots({
@@ -241,7 +244,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
   const explicitLegacyRoots = Option.map(configuredBaseDir, (baseDir) =>
     resolveLegacyT3StorageRoots({
       baseDir,
-      stateDirectoryName: "userdata",
+      stateDirectoryName: isDevelopment ? "dev" : "userdata",
       path,
     }),
   );
@@ -251,15 +254,9 @@ const make = Effect.fn("desktop.environment.make")(function* (
     path.join(legacyRoots.configDir, "keybindings.json"),
     path.join(legacyRoots.stateDir, "environment-id"),
     path.join(legacyRoots.stateDir, "connection-catalog.json"),
-    path.join(appDataDirectory, legacyUserDataDirName, "Local State"),
-    path.join(appDataDirectory, legacyUserDataDirName, "Preferences"),
-    path.join(appDataDirectory, userDataDirName, "Local State"),
-    path.join(appDataDirectory, userDataDirName, "Preferences"),
   ];
   const legacyStorageInitialized = (yield* Effect.all(
-    legacyArtifacts.map((artifact) =>
-      fileSystem.exists(artifact).pipe(Effect.orElseSucceed(() => false)),
-    ),
+    legacyArtifacts.map((artifact) => fileSystem.exists(artifact)),
     { concurrency: "unbounded" },
   )).some(Boolean);
   const storageRoots = selectT3StorageRoots({

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -244,7 +244,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
   const explicitLegacyRoots = Option.map(configuredBaseDir, (baseDir) =>
     resolveLegacyT3StorageRoots({
       baseDir,
-      stateDirectoryName: isDevelopment ? "dev" : "userdata",
+      stateDirectoryName: "userdata",
       path,
     }),
   );
@@ -254,6 +254,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     path.join(legacyRoots.configDir, "keybindings.json"),
     path.join(legacyRoots.stateDir, "environment-id"),
     path.join(legacyRoots.stateDir, "connection-catalog.json"),
+    path.join(legacyRoots.stateDir, "secrets"),
   ];
   const legacyStorageInitialized = (yield* Effect.all(
     legacyArtifacts.map((artifact) => fileSystem.exists(artifact)),

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -143,7 +143,15 @@ describe("DesktopBackendConfiguration", () => {
         assert.equal(first.bootstrap.noBrowser, true);
         assert.equal(first.bootstrap.port, 4888);
         assert.equal(first.bootstrap.host, "0.0.0.0");
-        assert.equal(first.bootstrap.t3Home, environment.baseDir);
+        assert.deepEqual(first.bootstrap.storageRoots, {
+          layout: "legacy",
+          configDir: environment.configDir,
+          dataDir: environment.dataDir,
+          stateDir: environment.stateDir,
+          cacheDir: environment.cacheDir,
+          runtimeDir: environment.runtimeDir,
+          legacyBaseDir: environment.baseDir,
+        });
         assert.equal(first.bootstrap.tailscaleServeEnabled, true);
         assert.equal(first.bootstrap.tailscaleServePort, 8443);
         assert.match(first.bootstrap.desktopBootstrapToken, /^[0-9a-f]{48}$/i);
@@ -520,7 +528,7 @@ describe("DesktopBackendConfiguration", () => {
           // not spawn wsl.exe (which would loop on preflight failures while the
           // Connections backend control is hidden). Resolve the Windows primary.
           assert.equal(config.executablePath, process.execPath);
-          assert.equal(config.bootstrap.t3Home, environment.baseDir);
+          assert.equal(config.bootstrap.storageRoots?.dataDir, environment.dataDir);
           assert.isTrue(Option.isNone(config.preflightFailure));
         }).pipe(
           Effect.provide(

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -457,10 +457,20 @@ describe("DesktopBackendConfiguration", () => {
       const previousWslEnv = process.env.WSLENV;
       const previousOpenAiKey = process.env.OPENAI_API_KEY;
       const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
+      const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+      const previousXdgDataHome = process.env.XDG_DATA_HOME;
+      const previousXdgStateHome = process.env.XDG_STATE_HOME;
+      const previousXdgCacheHome = process.env.XDG_CACHE_HOME;
+      const previousXdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
       try {
         process.env.WSLENV = "GOPATH/p:OPENAI_API_KEY/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u";
         process.env.OPENAI_API_KEY = "openai-key";
         process.env.ANTHROPIC_API_KEY = "anthropic-key";
+        process.env.XDG_CONFIG_HOME = "C:\\xdg\\config";
+        process.env.XDG_DATA_HOME = "C:\\xdg\\data";
+        process.env.XDG_STATE_HOME = "C:\\xdg\\state";
+        process.env.XDG_CACHE_HOME = "C:\\xdg\\cache";
+        process.env.XDG_RUNTIME_DIR = "C:\\xdg\\runtime";
 
         yield* Effect.gen(function* () {
           const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
@@ -478,6 +488,11 @@ describe("DesktopBackendConfiguration", () => {
           assert.equal(config.httpBaseUrl.href, "http://172.27.0.99:5050/");
           assert.equal(config.env.OPENAI_API_KEY, "openai-key");
           assert.equal(config.env.ANTHROPIC_API_KEY, "anthropic-key");
+          assert.isUndefined(config.env.XDG_CONFIG_HOME);
+          assert.isUndefined(config.env.XDG_DATA_HOME);
+          assert.isUndefined(config.env.XDG_STATE_HOME);
+          assert.isUndefined(config.env.XDG_CACHE_HOME);
+          assert.isUndefined(config.env.XDG_RUNTIME_DIR);
           // The existing WSLENV is preserved byte-for-byte (note the empty
           // "::" segment survives — WSL ignores it, so we don't normalize
           // it away) and ANTHROPIC_API_KEY is appended. OPENAI_API_KEY is
@@ -506,6 +521,11 @@ describe("DesktopBackendConfiguration", () => {
         restoreEnv("WSLENV", previousWslEnv);
         restoreEnv("OPENAI_API_KEY", previousOpenAiKey);
         restoreEnv("ANTHROPIC_API_KEY", previousAnthropicKey);
+        restoreEnv("XDG_CONFIG_HOME", previousXdgConfigHome);
+        restoreEnv("XDG_DATA_HOME", previousXdgDataHome);
+        restoreEnv("XDG_STATE_HOME", previousXdgStateHome);
+        restoreEnv("XDG_CACHE_HOME", previousXdgCacheHome);
+        restoreEnv("XDG_RUNTIME_DIR", previousXdgRuntimeDir);
       }
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -462,10 +462,12 @@ describe("DesktopBackendConfiguration", () => {
       const previousXdgStateHome = process.env.XDG_STATE_HOME;
       const previousXdgCacheHome = process.env.XDG_CACHE_HOME;
       const previousXdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
+      const previousLowercaseT3CodeHome = process.env.t3code_home;
       try {
-        process.env.WSLENV = "GOPATH/p:OPENAI_API_KEY/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u";
+        process.env.WSLENV = "GOPATH/p:openai_api_key/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u";
         process.env.OPENAI_API_KEY = "openai-key";
         process.env.ANTHROPIC_API_KEY = "anthropic-key";
+        process.env.t3code_home = "C:\\t3code";
         process.env.XDG_CONFIG_HOME = "C:\\xdg\\config";
         process.env.XDG_DATA_HOME = "C:\\xdg\\data";
         process.env.XDG_STATE_HOME = "C:\\xdg\\state";
@@ -488,6 +490,7 @@ describe("DesktopBackendConfiguration", () => {
           assert.equal(config.httpBaseUrl.href, "http://172.27.0.99:5050/");
           assert.equal(config.env.OPENAI_API_KEY, "openai-key");
           assert.equal(config.env.ANTHROPIC_API_KEY, "anthropic-key");
+          assert.isUndefined(config.env.t3code_home);
           assert.isUndefined(config.env.XDG_CONFIG_HOME);
           assert.isUndefined(config.env.XDG_DATA_HOME);
           assert.isUndefined(config.env.XDG_STATE_HOME);
@@ -499,7 +502,7 @@ describe("DesktopBackendConfiguration", () => {
           // already declared, so it isn't forwarded twice.
           assert.equal(
             config.env.WSLENV,
-            "GOPATH/p:OPENAI_API_KEY/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u:ANTHROPIC_API_KEY",
+            "GOPATH/p:openai_api_key/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u:ANTHROPIC_API_KEY",
           );
         }).pipe(
           Effect.provide(
@@ -526,6 +529,7 @@ describe("DesktopBackendConfiguration", () => {
         restoreEnv("XDG_STATE_HOME", previousXdgStateHome);
         restoreEnv("XDG_CACHE_HOME", previousXdgCacheHome);
         restoreEnv("XDG_RUNTIME_DIR", previousXdgRuntimeDir);
+        restoreEnv("t3code_home", previousLowercaseT3CodeHome);
       }
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -73,6 +73,15 @@ const emptyBackendObservabilitySettings: BackendObservabilitySettings = {
   otlpMetricsUrl: Option.none(),
 };
 
+const STORAGE_ENV_NAMES = [
+  "T3CODE_HOME",
+  "T3CODE_CONFIG_DIR",
+  "T3CODE_DATA_DIR",
+  "T3CODE_STATE_DIR",
+  "T3CODE_CACHE_DIR",
+  "T3CODE_RUNTIME_DIR",
+] as const;
+
 const DESKTOP_BACKEND_ENV_NAMES = [
   "T3CODE_PORT",
   "T3CODE_MODE",
@@ -84,6 +93,7 @@ const DESKTOP_BACKEND_ENV_NAMES = [
   "T3CODE_DESKTOP_HTTPS_ENDPOINTS",
   "T3CODE_TAILSCALE_SERVE",
   "T3CODE_TAILSCALE_SERVE_PORT",
+  ...STORAGE_ENV_NAMES,
 ] as const;
 
 // Sensitive env vars that the WSL backend needs but Windows process.env won't
@@ -91,6 +101,7 @@ const DESKTOP_BACKEND_ENV_NAMES = [
 // handled separately via a `--dev-url` CLI flag because WSLENV translation of
 // URL-shaped values (colons / slashes) is unreliable.
 const WSL_FORWARDED_ENV_NAMES = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"] as const;
+const WINDOWS_STORAGE_ENV_NAMES = new Set<string>(STORAGE_ENV_NAMES);
 
 const WSL_SERVER_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
@@ -340,7 +351,25 @@ const resolvePrimaryStartConfig = Effect.fn("desktop.backendConfiguration.resolv
       mode: "desktop" as const,
       noBrowser: true,
       port: backendExposure.port,
-      t3Home: environment.baseDir,
+      storageRoots:
+        environment.storageLayout === "legacy"
+          ? {
+              layout: "legacy" as const,
+              configDir: environment.configDir,
+              dataDir: environment.dataDir,
+              stateDir: environment.stateDir,
+              cacheDir: environment.cacheDir,
+              runtimeDir: environment.runtimeDir,
+              legacyBaseDir: environment.baseDir,
+            }
+          : {
+              layout: "split" as const,
+              configDir: environment.configDir,
+              dataDir: environment.dataDir,
+              stateDir: environment.stateDir,
+              cacheDir: environment.cacheDir,
+              runtimeDir: environment.runtimeDir,
+            },
       host: backendExposure.bindHost,
       desktopBootstrapToken: input.bootstrapToken,
       tailscaleServeEnabled: backendExposure.tailscaleServeEnabled,
@@ -470,24 +499,22 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
     }
   }
 
-  // Build an explicit copy of process.env minus T3CODE_HOME (dev-runner
-  // exports the Windows-side base dir for the primary; if it leaks into
-  // the WSL backend the Linux side ends up sharing C:\Users\...\.t3 via
-  // /mnt/c, which means both backends read/write the same database and
-  // their env-ids collide).
-  const parentEnvWithoutT3Home: Record<string, string | undefined> = {};
+  // Do not leak Windows-side storage overrides into the Linux backend. Paths
+  // that are valid for the primary can resolve through /mnt/c in WSL, causing
+  // both backends to share a database and environment identity.
+  const parentEnvWithoutStorageOverrides: Record<string, string | undefined> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (key === "T3CODE_HOME") continue;
-    parentEnvWithoutT3Home[key] = value;
+    if (WINDOWS_STORAGE_ENV_NAMES.has(key)) continue;
+    parentEnvWithoutStorageOverrides[key] = value;
   }
-  const wslEnv = mergeWslEnv(parentEnvWithoutT3Home.WSLENV, forwardedEnvNames);
+  const wslEnv = mergeWslEnv(parentEnvWithoutStorageOverrides.WSLENV, forwardedEnvNames);
 
   const baseConfig = {
     executablePath: "wsl.exe",
     entryPath: wslEntryPath,
     cwd: environment.backendCwd,
     env: {
-      ...parentEnvWithoutT3Home,
+      ...parentEnvWithoutStorageOverrides,
       ...backendChildEnvPatch(),
       ...forwardedEnv,
       ...(wslEnv !== undefined ? { WSLENV: wslEnv } : {}),

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -132,11 +132,11 @@ const mergeWslEnv = (
   const seenNames = new Set(
     existing
       .split(":")
-      .map((entry) => getWslEnvEntryName(entry.trim()))
+      .map((entry) => getWslEnvEntryName(entry.trim()).toUpperCase())
       .filter((name) => name.length > 0),
   );
 
-  const additions = forwardedEnvNames.filter((name) => !seenNames.has(name));
+  const additions = forwardedEnvNames.filter((name) => !seenNames.has(name.toUpperCase()));
 
   // Preserve the user's WSLENV exactly as Windows handed it to us — empty
   // "::" segments and duplicate entries are harmless no-ops to WSL and not
@@ -511,7 +511,7 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
   // both backends to share a database and environment identity.
   const parentEnvWithoutStorageOverrides: Record<string, string | undefined> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (WINDOWS_STORAGE_ENV_NAMES.has(key)) continue;
+    if (WINDOWS_STORAGE_ENV_NAMES.has(key.toUpperCase())) continue;
     parentEnvWithoutStorageOverrides[key] = value;
   }
   const wslEnv = mergeWslEnv(parentEnvWithoutStorageOverrides.WSLENV, forwardedEnvNames);

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -101,7 +101,14 @@ const DESKTOP_BACKEND_ENV_NAMES = [
 // handled separately via a `--dev-url` CLI flag because WSLENV translation of
 // URL-shaped values (colons / slashes) is unreliable.
 const WSL_FORWARDED_ENV_NAMES = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"] as const;
-const WINDOWS_STORAGE_ENV_NAMES = new Set<string>(STORAGE_ENV_NAMES);
+const WINDOWS_STORAGE_ENV_NAMES = new Set<string>([
+  ...STORAGE_ENV_NAMES,
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_RUNTIME_DIR",
+]);
 
 const WSL_SERVER_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -69,6 +69,8 @@ const desktopEnvironmentLayer = Layer.unwrap(
     return DesktopEnvironment.layer({
       dirname: __dirname,
       homeDirectory: NodeOS.homedir(),
+      temporaryDirectory: NodeOS.tmpdir(),
+      ...(process.getuid === undefined ? {} : { userId: process.getuid() }),
       platform,
       processArch,
       ...metadata,

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -17,11 +17,12 @@ import * as NetService from "@t3tools/shared/Net";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { deriveServerPaths } from "../config.ts";
 import {
+  ForcedLegacyLayoutConflictError,
+  ForcedXdgLayoutConflictError,
   resolveServerConfig,
   RuntimeDirectoryOpenError,
   RuntimeDirectoryOwnerMismatchError,
   StorageDirectoryConfigurationConflictError,
-  StorageLayoutConfigurationConflictError,
 } from "./config.ts";
 
 const isRuntimeDirectoryOwnerMismatchError = Schema.is(RuntimeDirectoryOwnerMismatchError);
@@ -887,6 +888,77 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
     }),
   );
 
+  it.effect.each([
+    {
+      artifactName: "desktop settings",
+      directory: "configDir" as const,
+      fileName: "desktop-settings.json",
+    },
+    {
+      artifactName: "client settings",
+      directory: "configDir" as const,
+      fileName: "client-settings.json",
+    },
+    {
+      artifactName: "saved environments",
+      directory: "stateDir" as const,
+      fileName: "saved-environments.json",
+    },
+  ])(
+    "keeps legacy storage when only legacy $artifactName are initialized",
+    ({ directory, fileName }) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped({
+          prefix: "t3-cli-config-legacy-desktop-artifact-",
+        });
+        const homeDirectory = path.join(root, "home");
+        const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+        const legacyRoots = {
+          configDir: legacyStateDir,
+          stateDir: legacyStateDir,
+        };
+        yield* fs.makeDirectory(legacyRoots[directory], { recursive: true });
+        yield* fs.writeFileString(path.join(legacyRoots[directory], fileName), "{}");
+
+        const resolved = yield* resolveServerConfig(
+          {
+            mode: Option.some("web"),
+            port: Option.some(3773),
+            host: Option.none(),
+            baseDir: Option.none(),
+            cwd: Option.none(),
+            devUrl: Option.none(),
+            noBrowser: Option.none(),
+            bootstrapFd: Option.none(),
+            autoBootstrapProjectFromCwd: Option.none(),
+            logWebSocketEvents: Option.none(),
+            tailscaleServeEnabled: Option.none(),
+            tailscaleServePort: Option.none(),
+          },
+          Option.none(),
+          {
+            homeDirectory,
+            temporaryDirectory: root,
+            userId: NodeOS.userInfo().uid,
+            platform: "linux",
+          },
+        ).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+              NetService.layer,
+            ),
+          ),
+        );
+
+        expect(resolved.layout).toBe("legacy");
+        expect(resolved.configDir).toBe(legacyStateDir);
+        expect(resolved.stateDir).toBe(legacyStateDir);
+      }),
+  );
+
   it.effect("keeps initialized legacy storage even when split directories contain debris", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -1086,7 +1158,50 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         Effect.flip,
       );
 
-      expect(error).toBeInstanceOf(StorageLayoutConfigurationConflictError);
+      expect(error).toBeInstanceOf(ForcedXdgLayoutConflictError);
+      expect(error.message).toBe(
+        "--storage-layout xdg cannot be combined with T3CODE_HOME or --base-dir.",
+      );
+    }),
+  );
+
+  it.effect("rejects forced legacy storage with granular directory overrides", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          storageLayout: Option.some("legacy"),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { T3CODE_CONFIG_DIR: "/tmp/t3-config" },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(ForcedLegacyLayoutConflictError);
+      expect(error.message).toBe(
+        "--storage-layout legacy cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.",
+      );
     }),
   );
 });

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -16,7 +16,11 @@ import {
 import * as NetService from "@t3tools/shared/Net";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { deriveServerPaths } from "../config.ts";
-import { resolveServerConfig, StorageDirectoryConfigurationConflictError } from "./config.ts";
+import {
+  resolveServerConfig,
+  StorageDirectoryConfigurationConflictError,
+  StorageLayoutConfigurationConflictError,
+} from "./config.ts";
 
 const deriveExplicitServerPaths = (baseDir: string, devUrl: URL | undefined) =>
   deriveServerPaths(baseDir, devUrl, { baseDirIsExplicit: true });
@@ -721,6 +725,91 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
     }),
   );
 
+  it.effect("forces XDG storage even when legacy storage is initialized", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-config-forced-xdg-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+      yield* fs.makeDirectory(legacyStateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(legacyStateDir, "state.sqlite"), "legacy");
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          storageLayout: Option.some("xdg"),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        { homeDirectory, temporaryDirectory: root, userId: 1000, platform: "linux" },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.layout).toBe("split");
+      expect(resolved.stateDir).toBe(path.join(homeDirectory, ".local", "state", "t3code"));
+    }),
+  );
+
+  it.effect("forces legacy storage when no legacy artifacts exist", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-config-forced-legacy-",
+      });
+      const homeDirectory = path.join(root, "home");
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          storageLayout: Option.some("legacy"),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        { homeDirectory, temporaryDirectory: root, userId: 1000, platform: "linux" },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.layout).toBe("legacy");
+      expect(resolved.stateDir).toBe(path.join(homeDirectory, ".t3", "userdata"));
+    }),
+  );
+
   it.effect("rejects mixing the legacy home override with granular directory overrides", () =>
     Effect.gen(function* () {
       const error = yield* resolveServerConfig(
@@ -754,6 +843,39 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
       );
 
       expect(error).toBeInstanceOf(StorageDirectoryConfigurationConflictError);
+    }),
+  );
+
+  it.effect("rejects forced XDG storage with a legacy home override", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.some("/tmp/legacy-t3"),
+          storageLayout: Option.some("xdg"),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+            NetService.layer,
+          ),
+        ),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(StorageLayoutConfigurationConflictError);
     }),
   );
 });

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -18,12 +18,13 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { deriveServerPaths } from "../config.ts";
 import {
   resolveServerConfig,
+  RuntimeDirectoryOpenError,
+  RuntimeDirectoryOwnerMismatchError,
   StorageDirectoryConfigurationConflictError,
   StorageLayoutConfigurationConflictError,
-  UnsafeRuntimeDirectoryError,
 } from "./config.ts";
 
-const isUnsafeRuntimeDirectoryError = Schema.is(UnsafeRuntimeDirectoryError);
+const isRuntimeDirectoryOwnerMismatchError = Schema.is(RuntimeDirectoryOwnerMismatchError);
 
 const deriveExplicitServerPaths = (baseDir: string, devUrl: URL | undefined) =>
   deriveServerPaths(baseDir, devUrl);
@@ -776,10 +777,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         Effect.flip,
       );
 
-      expect(error).toBeInstanceOf(UnsafeRuntimeDirectoryError);
-      if (isUnsafeRuntimeDirectoryError(error)) {
-        expect(error.reason).toBe("open");
-      }
+      expect(error).toBeInstanceOf(RuntimeDirectoryOpenError);
       expect((yield* fs.stat(targetDir)).mode & 0o777).toBe(0o750);
     }),
   );
@@ -833,9 +831,8 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         Effect.flip,
       );
 
-      expect(error).toBeInstanceOf(UnsafeRuntimeDirectoryError);
-      if (isUnsafeRuntimeDirectoryError(error)) {
-        expect(error.reason).toBe("wrong-owner");
+      expect(error).toBeInstanceOf(RuntimeDirectoryOwnerMismatchError);
+      if (isRuntimeDirectoryOwnerMismatchError(error)) {
         expect(error.actualUserId).toBe(actualUserId);
         expect(error.expectedUserId).toBe(actualUserId + 1);
       }

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -20,7 +20,10 @@ import {
   resolveServerConfig,
   StorageDirectoryConfigurationConflictError,
   StorageLayoutConfigurationConflictError,
+  UnsafeRuntimeDirectoryError,
 } from "./config.ts";
+
+const isUnsafeRuntimeDirectoryError = Schema.is(UnsafeRuntimeDirectoryError);
 
 const deriveExplicitServerPaths = (baseDir: string, devUrl: URL | undefined) =>
   deriveServerPaths(baseDir, devUrl);
@@ -718,6 +721,172 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
       expect(resolved.serverRuntimeStatePath).toBe(
         path.join(runtimeHome, "t3code", "server-runtime.json"),
       );
+    }),
+  );
+
+  it.effect("rejects a split runtime directory symlink without chmodding its target", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-config-runtime-symlink-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const runtimeHome = path.join(root, "runtime");
+      const runtimeDir = path.join(runtimeHome, "t3code");
+      const targetDir = path.join(root, "target");
+      yield* fs.makeDirectory(runtimeHome, { recursive: true });
+      yield* fs.makeDirectory(targetDir, { recursive: true });
+      yield* fs.chmod(targetDir, 0o750);
+      yield* fs.symlink(targetDir, runtimeDir);
+
+      const error = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        {
+          homeDirectory,
+          temporaryDirectory: root,
+          userId: NodeOS.userInfo().uid,
+          platform: "linux",
+        },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { XDG_RUNTIME_DIR: runtimeHome },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(UnsafeRuntimeDirectoryError);
+      if (isUnsafeRuntimeDirectoryError(error)) {
+        expect(error.reason).toBe("open");
+      }
+      expect((yield* fs.stat(targetDir)).mode & 0o777).toBe(0o750);
+    }),
+  );
+
+  it.effect("rejects a split runtime directory owned by another user", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-config-runtime-owner-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const runtimeHome = path.join(root, "runtime");
+      const runtimeDir = path.join(runtimeHome, "t3code");
+      yield* fs.makeDirectory(runtimeDir, { recursive: true });
+      const actualUserId = NodeOS.userInfo().uid;
+
+      const error = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        {
+          homeDirectory,
+          temporaryDirectory: root,
+          userId: actualUserId + 1,
+          platform: "linux",
+        },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { XDG_RUNTIME_DIR: runtimeHome },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(UnsafeRuntimeDirectoryError);
+      if (isUnsafeRuntimeDirectoryError(error)) {
+        expect(error.reason).toBe("wrong-owner");
+        expect(error.actualUserId).toBe(actualUserId);
+        expect(error.expectedUserId).toBe(actualUserId + 1);
+      }
+    }),
+  );
+
+  it.effect("keeps legacy storage when only legacy secrets are initialized", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-config-legacy-secrets-",
+      });
+      const homeDirectory = path.join(root, "home");
+      const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+      yield* fs.makeDirectory(path.join(legacyStateDir, "secrets"), { recursive: true });
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        {
+          homeDirectory,
+          temporaryDirectory: root,
+          userId: NodeOS.userInfo().uid,
+          platform: "linux",
+        },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.layout).toBe("legacy");
+      expect(resolved.stateDir).toBe(legacyStateDir);
+      expect(resolved.secretsDir).toBe(path.join(legacyStateDir, "secrets"));
     }),
   );
 

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -23,7 +23,7 @@ import {
 } from "./config.ts";
 
 const deriveExplicitServerPaths = (baseDir: string, devUrl: URL | undefined) =>
-  deriveServerPaths(baseDir, devUrl, { baseDirIsExplicit: true });
+  deriveServerPaths(baseDir, devUrl);
 
 const encodeDesktopBootstrap = Schema.encodeEffect(Schema.fromJsonString(DesktopBackendBootstrap));
 
@@ -133,7 +133,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
       });
-      assert.equal(resolved.stateDir, join(baseDir, "userdata"));
+      assert.equal(resolved.stateDir, join(baseDir, "dev"));
     }),
   );
 
@@ -203,7 +203,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServeEnabled: true,
         tailscaleServePort: 8443,
       });
-      assert.equal(resolved.dbPath, join(baseDir, "userdata", "state.sqlite"));
+      assert.equal(resolved.dbPath, join(baseDir, "dev", "state.sqlite"));
     }),
   );
 
@@ -218,8 +218,9 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           tailscaleServePort: 443,
         }),
       );
+      const bootstrapBaseDir = "/tmp/t3-bootstrap-home";
       const derivedPaths = yield* deriveExplicitServerPaths(
-        baseDir,
+        bootstrapBaseDir,
         new URL("http://127.0.0.1:4173"),
       );
 
@@ -263,7 +264,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         mode: "web",
         port: 8788,
         cwd: process.cwd(),
-        baseDir,
+        baseDir: bootstrapBaseDir,
         ...derivedPaths,
         host: "127.0.0.1",
         staticDir: undefined,
@@ -403,15 +404,16 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
     }),
   );
 
-  it.effect("applies flag then env precedence over bootstrap envelope values", () =>
+  it.effect("keeps bootstrap storage pinned while applying other flag and env precedence", () =>
     Effect.gen(function* () {
       const { join } = yield* Path.Path;
-      const baseDir = join(NodeOS.tmpdir(), "t3-cli-config-env-wins");
+      const envBaseDir = join(NodeOS.tmpdir(), "t3-cli-config-env-wins");
+      const bootstrapBaseDir = "/tmp/t3-bootstrap-home";
       const fd = yield* openBootstrapFd(
         makeDesktopBootstrap({
           port: 4888,
           host: "127.0.0.2",
-          t3Home: "/tmp/t3-bootstrap-home",
+          t3Home: bootstrapBaseDir,
           noBrowser: false,
           desktopBootstrapToken: "desktop-token",
           tailscaleServeEnabled: false,
@@ -419,7 +421,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         }),
       );
       const derivedPaths = yield* deriveExplicitServerPaths(
-        baseDir,
+        bootstrapBaseDir,
         new URL("http://127.0.0.1:4173"),
       );
 
@@ -447,7 +449,8 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
                 env: {
                   T3CODE_MODE: "web",
                   T3CODE_BOOTSTRAP_FD: String(fd),
-                  T3CODE_HOME: baseDir,
+                  T3CODE_HOME: envBaseDir,
+                  T3CODE_STATE_DIR: join(NodeOS.tmpdir(), "ignored-state"),
                   T3CODE_NO_BROWSER: "true",
                   T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "true",
                   T3CODE_LOG_WS_EVENTS: "true",
@@ -465,7 +468,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         mode: "web",
         port: 8788,
         cwd: process.cwd(),
-        baseDir,
+        baseDir: bootstrapBaseDir,
         ...derivedPaths,
         host: "127.0.0.1",
         staticDir: undefined,
@@ -478,6 +481,48 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
       });
+    }),
+  );
+
+  it.effect("does not chmod the unified legacy state directory as a runtime directory", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-cli-config-legacy-mode-",
+      });
+      const stateDir = path.join(baseDir, "userdata");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.chmod(stateDir, 0o750);
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.some(baseDir),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        { platform: "linux" },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.layout).toBe("legacy");
+      expect((yield* fs.stat(stateDir)).mode & 0o777).toBe(0o750);
     }),
   );
 

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -16,7 +16,7 @@ import {
 import * as NetService from "@t3tools/shared/Net";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { deriveServerPaths } from "../config.ts";
-import { resolveServerConfig } from "./config.ts";
+import { resolveServerConfig, StorageDirectoryConfigurationConflictError } from "./config.ts";
 
 const deriveExplicitServerPaths = (baseDir: string, devUrl: URL | undefined) =>
   deriveServerPaths(baseDir, devUrl, { baseDirIsExplicit: true });
@@ -606,6 +606,154 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
       });
+    }),
+  );
+
+  it.effect("uses all five XDG roots for a new installation", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cli-config-xdg-" });
+      const homeDirectory = path.join(root, "home");
+      const configHome = path.join(root, "config");
+      const dataHome = path.join(root, "data");
+      const stateHome = path.join(root, "state");
+      const cacheHome = path.join(root, "cache");
+      const runtimeHome = path.join(root, "runtime");
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        { homeDirectory, temporaryDirectory: root, userId: 1000, platform: "linux" },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: {
+                  XDG_CONFIG_HOME: configHome,
+                  XDG_DATA_HOME: dataHome,
+                  XDG_STATE_HOME: stateHome,
+                  XDG_CACHE_HOME: cacheHome,
+                  XDG_RUNTIME_DIR: runtimeHome,
+                },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.layout).toBe("split");
+      expect(resolved.configDir).toBe(path.join(configHome, "t3code"));
+      expect(resolved.dataDir).toBe(path.join(dataHome, "t3code"));
+      expect(resolved.stateDir).toBe(path.join(stateHome, "t3code"));
+      expect(resolved.cacheDir).toBe(path.join(cacheHome, "t3code"));
+      expect(resolved.runtimeDir).toBe(path.join(runtimeHome, "t3code"));
+      expect(resolved.settingsPath).toBe(path.join(configHome, "t3code", "settings.json"));
+      expect(resolved.dbPath).toBe(path.join(stateHome, "t3code", "state.sqlite"));
+      expect(resolved.attachmentsDir).toBe(path.join(dataHome, "t3code", "attachments"));
+      expect(resolved.serverRuntimeStatePath).toBe(
+        path.join(runtimeHome, "t3code", "server-runtime.json"),
+      );
+    }),
+  );
+
+  it.effect("keeps initialized legacy storage even when split directories contain debris", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cli-config-legacy-" });
+      const homeDirectory = path.join(root, "home");
+      const legacyStateDir = path.join(homeDirectory, ".t3", "userdata");
+      const splitStateDir = path.join(root, "state", "t3code");
+      yield* fs.makeDirectory(legacyStateDir, { recursive: true });
+      yield* fs.makeDirectory(splitStateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(legacyStateDir, "state.sqlite"), "legacy");
+      yield* fs.writeFileString(path.join(splitStateDir, "state.sqlite"), "");
+
+      const resolved = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.none(),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+        { homeDirectory, temporaryDirectory: root, userId: 1000, platform: "linux" },
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { XDG_STATE_HOME: path.join(root, "state") },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+      );
+
+      expect(resolved.layout).toBe("legacy");
+      expect(resolved.stateDir).toBe(legacyStateDir);
+      expect(resolved.dbPath).toBe(path.join(legacyStateDir, "state.sqlite"));
+    }),
+  );
+
+  it.effect("rejects mixing the legacy home override with granular directory overrides", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveServerConfig(
+        {
+          mode: Option.some("web"),
+          port: Option.some(3773),
+          host: Option.none(),
+          baseDir: Option.some("/tmp/legacy-t3"),
+          cwd: Option.none(),
+          devUrl: Option.none(),
+          noBrowser: Option.none(),
+          bootstrapFd: Option.none(),
+          autoBootstrapProjectFromCwd: Option.none(),
+          logWebSocketEvents: Option.none(),
+          tailscaleServeEnabled: Option.none(),
+          tailscaleServePort: Option.none(),
+        },
+        Option.none(),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            ConfigProvider.layer(
+              ConfigProvider.fromEnv({
+                env: { T3CODE_STATE_DIR: "/tmp/t3-state" },
+              }),
+            ),
+            NetService.layer,
+          ),
+        ),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(StorageDirectoryConfigurationConflictError);
     }),
   );
 });

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -288,14 +288,21 @@ export class StorageDirectoryConfigurationConflictError extends Schema.TaggedErr
   }
 }
 
-export class StorageLayoutConfigurationConflictError extends Schema.TaggedErrorClass<StorageLayoutConfigurationConflictError>()(
-  "StorageLayoutConfigurationConflictError",
-  { storageLayout: CliStorageLayout },
+export class ForcedXdgLayoutConflictError extends Schema.TaggedErrorClass<ForcedXdgLayoutConflictError>()(
+  "ForcedXdgLayoutConflictError",
+  {},
 ) {
   override get message(): string {
-    return this.storageLayout === "xdg"
-      ? "--storage-layout xdg cannot be combined with T3CODE_HOME or --base-dir."
-      : "--storage-layout legacy cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.";
+    return "--storage-layout xdg cannot be combined with T3CODE_HOME or --base-dir.";
+  }
+}
+
+export class ForcedLegacyLayoutConflictError extends Schema.TaggedErrorClass<ForcedLegacyLayoutConflictError>()(
+  "ForcedLegacyLayoutConflictError",
+  {},
+) {
+  override get message(): string {
+    return "--storage-layout legacy cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.";
   }
 }
 
@@ -354,9 +361,12 @@ const legacyStorageIsInitialized = Effect.fn(function* (roots: T3StorageRoots) {
     path.join(roots.stateDir, "state.sqlite"),
     path.join(roots.configDir, "settings.json"),
     path.join(roots.configDir, "keybindings.json"),
+    path.join(roots.configDir, "desktop-settings.json"),
+    path.join(roots.configDir, "client-settings.json"),
     path.join(roots.stateDir, "environment-id"),
     path.join(roots.stateDir, "connection-catalog.json"),
     path.join(roots.stateDir, "secrets"),
+    path.join(roots.stateDir, "saved-environments.json"),
   ];
   const results = yield* Effect.all(
     artifacts.map((artifact) => fs.exists(artifact)),
@@ -541,18 +551,14 @@ export const resolveServerConfig = (
       forcedStorageLayout === "xdg" &&
       Option.isSome(explicitBaseDir)
     ) {
-      return yield* new StorageLayoutConfigurationConflictError({
-        storageLayout: forcedStorageLayout,
-      });
+      return yield* new ForcedXdgLayoutConflictError();
     }
     if (
       !bootstrapStorageIsPinned &&
       forcedStorageLayout === "legacy" &&
       hasT3StorageDirectoryOverrides(directoryOverrides)
     ) {
-      return yield* new StorageLayoutConfigurationConflictError({
-        storageLayout: forcedStorageLayout,
-      });
+      return yield* new ForcedLegacyLayoutConflictError();
     }
     const defaultSplitRoots = resolveDefaultT3StorageRoots({
       platform,

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -12,6 +12,17 @@ import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 import { Argument, Flag } from "effect/unstable/cli";
+import * as NodeOS from "node:os";
+import {
+  applyT3StorageDirectoryOverrides,
+  hasT3StorageDirectoryOverrides,
+  resolveDefaultT3StorageRoots,
+  resolveLegacyT3StorageRoots,
+  resolveT3StorageDirectoryOverrides,
+  selectT3StorageRoots,
+  type T3StorageRoots,
+} from "@t3tools/shared/storagePaths";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import { readBootstrapEnvelope } from "../bootstrap.ts";
 import * as ServerConfig from "../config.ts";
@@ -32,7 +43,7 @@ export const hostFlag = Flag.string("host").pipe(
 );
 export const baseDirFlag = Flag.string("base-dir").pipe(
   Flag.withDescription(
-    "Explicit T3 Code data directory; runtime state is stored under userdata (equivalent to T3CODE_HOME).",
+    "Use the legacy unified T3 Code directory layout (equivalent to T3CODE_HOME).",
   ),
   Flag.optional,
 );
@@ -105,6 +116,51 @@ const EnvServerConfig = Config.all({
   port: Config.port("T3CODE_PORT").pipe(Config.option, Config.map(Option.getOrUndefined)),
   host: Config.string("T3CODE_HOST").pipe(Config.option, Config.map(Option.getOrUndefined)),
   t3Home: Config.string("T3CODE_HOME").pipe(Config.option, Config.map(Option.getOrUndefined)),
+  t3ConfigDir: Config.string("T3CODE_CONFIG_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  t3DataDir: Config.string("T3CODE_DATA_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  t3StateDir: Config.string("T3CODE_STATE_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  t3CacheDir: Config.string("T3CODE_CACHE_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  t3RuntimeDir: Config.string("T3CODE_RUNTIME_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  xdgConfigHome: Config.string("XDG_CONFIG_HOME").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  xdgDataHome: Config.string("XDG_DATA_HOME").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  xdgStateHome: Config.string("XDG_STATE_HOME").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  xdgCacheHome: Config.string("XDG_CACHE_HOME").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  xdgRuntimeDir: Config.string("XDG_RUNTIME_DIR").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
+  appData: Config.string("APPDATA").pipe(Config.option, Config.map(Option.getOrUndefined)),
+  localAppData: Config.string("LOCALAPPDATA").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
   devUrl: Config.url("VITE_DEV_SERVER_URL").pipe(Config.option, Config.map(Option.getOrUndefined)),
   devAllowedOrigins: Config.string("T3CODE_DEV_ALLOWED_ORIGINS").pipe(
     Config.withDefault(""),
@@ -207,12 +263,42 @@ const loadPersistedObservabilitySettings = Effect.fn(function* (settingsPath: st
   return parsePersistedServerObservabilitySettings(raw);
 });
 
+export class StorageDirectoryConfigurationConflictError extends Schema.TaggedErrorClass<StorageDirectoryConfigurationConflictError>()(
+  "StorageDirectoryConfigurationConflictError",
+  {},
+) {
+  override get message(): string {
+    return "T3CODE_HOME/--base-dir cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.";
+  }
+}
+
+const legacyStorageIsInitialized = Effect.fn(function* (roots: T3StorageRoots) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const artifacts = [
+    path.join(roots.stateDir, "state.sqlite"),
+    path.join(roots.configDir, "settings.json"),
+    path.join(roots.configDir, "keybindings.json"),
+    path.join(roots.stateDir, "environment-id"),
+    path.join(roots.stateDir, "connection-catalog.json"),
+  ];
+  const results = yield* Effect.all(
+    artifacts.map((artifact) => fs.exists(artifact).pipe(Effect.orElseSucceed(() => false))),
+    { concurrency: "unbounded" },
+  );
+  return results.some(Boolean);
+});
+
 export const resolveServerConfig = (
   flags: CliServerFlags,
   cliLogLevel: Option.Option<LogLevel.LogLevel>,
   options?: {
     readonly startupPresentation?: ServerConfig.StartupPresentation;
     readonly forceAutoBootstrapProjectFromCwd?: boolean;
+    readonly homeDirectory?: string;
+    readonly temporaryDirectory?: string;
+    readonly userId?: number;
+    readonly platform?: NodeJS.Platform;
   },
 ) =>
   Effect.gen(function* () {
@@ -274,18 +360,87 @@ export const resolveServerConfig = (
       normalizedFlags.baseDir,
       Option.fromUndefinedOr(env.t3Home),
     ).pipe(Option.filter((value) => value.trim().length > 0));
-    const baseDir = yield* resolveBaseDir(
-      Option.getOrUndefined(
-        resolveOptionPrecedence(explicitBaseDir, Option.fromUndefinedOr(bootstrap?.t3Home)),
-      ),
-    );
+    const homeDirectory = options?.homeDirectory ?? NodeOS.homedir();
+    const temporaryDirectory = options?.temporaryDirectory ?? NodeOS.tmpdir();
+    const platform = options?.platform ?? (yield* HostProcessPlatform);
+    const userId = options?.userId ?? (platform === "win32" ? undefined : NodeOS.userInfo().uid);
+    const pathOperations = {
+      join: (...paths: ReadonlyArray<string>) => path.join(...paths),
+      resolve: (...paths: ReadonlyArray<string>) => path.resolve(...paths),
+      isAbsolute: (candidate: string) => path.isAbsolute(candidate),
+    };
+    const storageEnvironment = {
+      T3CODE_CONFIG_DIR: env.t3ConfigDir,
+      T3CODE_DATA_DIR: env.t3DataDir,
+      T3CODE_STATE_DIR: env.t3StateDir,
+      T3CODE_CACHE_DIR: env.t3CacheDir,
+      T3CODE_RUNTIME_DIR: env.t3RuntimeDir,
+      XDG_CONFIG_HOME: env.xdgConfigHome,
+      XDG_DATA_HOME: env.xdgDataHome,
+      XDG_STATE_HOME: env.xdgStateHome,
+      XDG_CACHE_HOME: env.xdgCacheHome,
+      XDG_RUNTIME_DIR: env.xdgRuntimeDir,
+      APPDATA: env.appData,
+      LOCALAPPDATA: env.localAppData,
+    };
+    const directoryOverrides = resolveT3StorageDirectoryOverrides({
+      environment: storageEnvironment,
+      homeDirectory,
+      path: pathOperations,
+    });
+    if (Option.isSome(explicitBaseDir) && hasT3StorageDirectoryOverrides(directoryOverrides)) {
+      return yield* new StorageDirectoryConfigurationConflictError();
+    }
+    const defaultSplitRoots = resolveDefaultT3StorageRoots({
+      platform,
+      homeDirectory,
+      temporaryDirectory,
+      ...(userId === undefined ? {} : { userId }),
+      isDevelopment: devUrl !== undefined,
+      environment: storageEnvironment,
+      path: pathOperations,
+    });
+    const explicitSplitRoots = hasT3StorageDirectoryOverrides(directoryOverrides)
+      ? applyT3StorageDirectoryOverrides(defaultSplitRoots, directoryOverrides)
+      : undefined;
+    const explicitLegacyRoots = Option.isSome(explicitBaseDir)
+      ? resolveLegacyT3StorageRoots({
+          baseDir: yield* resolveBaseDir(explicitBaseDir.value),
+          stateDirectoryName: "userdata",
+          path,
+        })
+      : undefined;
+    const legacyRoots = resolveLegacyT3StorageRoots({
+      baseDir: path.join(homeDirectory, ".t3"),
+      stateDirectoryName: devUrl === undefined ? "userdata" : "dev",
+      path,
+    });
+    const bootstrapRoots =
+      bootstrap?.storageRoots ??
+      (bootstrap?.t3Home === undefined
+        ? undefined
+        : resolveLegacyT3StorageRoots({
+            baseDir: yield* resolveBaseDir(bootstrap.t3Home),
+            stateDirectoryName: devUrl === undefined ? "userdata" : "dev",
+            path,
+          }));
+    const storageRoots = selectT3StorageRoots({
+      ...(explicitLegacyRoots === undefined ? {} : { explicitLegacyRoots }),
+      ...(explicitSplitRoots === undefined ? {} : { explicitSplitRoots }),
+      ...(bootstrapRoots === undefined ? {} : { bootstrapRoots }),
+      defaultSplitRoots,
+      legacyRoots,
+      legacyStorageInitialized: yield* legacyStorageIsInitialized(legacyRoots),
+    });
     const rawCwd = Option.getOrElse(normalizedFlags.cwd, () => process.cwd());
     const cwd = path.resolve(yield* expandHomePath(rawCwd.trim()));
     yield* fs.makeDirectory(cwd, { recursive: true });
-    const derivedPaths = yield* ServerConfig.deriveServerPaths(baseDir, devUrl, {
-      baseDirIsExplicit: Option.isSome(explicitBaseDir),
-    });
+    const derivedPaths = yield* ServerConfig.deriveServerPathsFromRoots(storageRoots);
+    const baseDir = derivedPaths.dataDir;
     yield* ServerConfig.ensureServerDirectories(derivedPaths);
+    if (platform !== "win32") {
+      yield* fs.chmod(derivedPaths.runtimeDir, 0o700);
+    }
     const persistedObservabilitySettings = yield* loadPersistedObservabilitySettings(
       derivedPaths.settingsPath,
     );

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -307,7 +307,7 @@ const legacyStorageIsInitialized = Effect.fn(function* (roots: T3StorageRoots) {
     path.join(roots.stateDir, "connection-catalog.json"),
   ];
   const results = yield* Effect.all(
-    artifacts.map((artifact) => fs.exists(artifact).pipe(Effect.orElseSucceed(() => false))),
+    artifacts.map((artifact) => fs.exists(artifact)),
     { concurrency: "unbounded" },
   );
   return results.some(Boolean);
@@ -351,6 +351,8 @@ export const resolveServerConfig = (
         ? yield* readBootstrapEnvelope(DesktopBackendBootstrap, bootstrapFd)
         : Option.none();
     const bootstrap = Option.getOrUndefined(bootstrapEnvelope);
+    const bootstrapStorageIsPinned =
+      bootstrap?.storageRoots !== undefined || bootstrap?.t3Home !== undefined;
 
     const mode: ServerConfig.RuntimeMode = Option.getOrElse(
       resolveOptionPrecedence(
@@ -414,15 +416,27 @@ export const resolveServerConfig = (
       homeDirectory,
       path: pathOperations,
     });
-    if (Option.isSome(explicitBaseDir) && hasT3StorageDirectoryOverrides(directoryOverrides)) {
+    if (
+      !bootstrapStorageIsPinned &&
+      Option.isSome(explicitBaseDir) &&
+      hasT3StorageDirectoryOverrides(directoryOverrides)
+    ) {
       return yield* new StorageDirectoryConfigurationConflictError();
     }
-    if (forcedStorageLayout === "xdg" && Option.isSome(explicitBaseDir)) {
+    if (
+      !bootstrapStorageIsPinned &&
+      forcedStorageLayout === "xdg" &&
+      Option.isSome(explicitBaseDir)
+    ) {
       return yield* new StorageLayoutConfigurationConflictError({
         storageLayout: forcedStorageLayout,
       });
     }
-    if (forcedStorageLayout === "legacy" && hasT3StorageDirectoryOverrides(directoryOverrides)) {
+    if (
+      !bootstrapStorageIsPinned &&
+      forcedStorageLayout === "legacy" &&
+      hasT3StorageDirectoryOverrides(directoryOverrides)
+    ) {
       return yield* new StorageLayoutConfigurationConflictError({
         storageLayout: forcedStorageLayout,
       });
@@ -442,7 +456,7 @@ export const resolveServerConfig = (
     const explicitLegacyRoots = Option.isSome(explicitBaseDir)
       ? resolveLegacyT3StorageRoots({
           baseDir: yield* resolveBaseDir(explicitBaseDir.value),
-          stateDirectoryName: "userdata",
+          stateDirectoryName: devUrl === undefined ? "userdata" : "dev",
           path,
         })
       : undefined;
@@ -460,29 +474,30 @@ export const resolveServerConfig = (
             stateDirectoryName: devUrl === undefined ? "userdata" : "dev",
             path,
           }));
-    const storageRoots = selectT3StorageRoots({
-      ...(forcedStorageLayout === "legacy"
-        ? { explicitLegacyRoots: explicitLegacyRoots ?? legacyRoots }
-        : explicitLegacyRoots === undefined
-          ? {}
-          : { explicitLegacyRoots }),
-      ...(forcedStorageLayout === "xdg"
-        ? { explicitSplitRoots: explicitSplitRoots ?? defaultSplitRoots }
-        : explicitSplitRoots === undefined
-          ? {}
-          : { explicitSplitRoots }),
-      ...(bootstrapRoots === undefined ? {} : { bootstrapRoots }),
-      defaultSplitRoots,
-      legacyRoots,
-      legacyStorageInitialized: yield* legacyStorageIsInitialized(legacyRoots),
-    });
+    const storageRoots =
+      bootstrapRoots ??
+      selectT3StorageRoots({
+        ...(forcedStorageLayout === "legacy"
+          ? { explicitLegacyRoots: explicitLegacyRoots ?? legacyRoots }
+          : explicitLegacyRoots === undefined
+            ? {}
+            : { explicitLegacyRoots }),
+        ...(forcedStorageLayout === "xdg"
+          ? { explicitSplitRoots: explicitSplitRoots ?? defaultSplitRoots }
+          : explicitSplitRoots === undefined
+            ? {}
+            : { explicitSplitRoots }),
+        defaultSplitRoots,
+        legacyRoots,
+        legacyStorageInitialized: yield* legacyStorageIsInitialized(legacyRoots),
+      });
     const rawCwd = Option.getOrElse(normalizedFlags.cwd, () => process.cwd());
     const cwd = path.resolve(yield* expandHomePath(rawCwd.trim()));
     yield* fs.makeDirectory(cwd, { recursive: true });
     const derivedPaths = yield* ServerConfig.deriveServerPathsFromRoots(storageRoots);
     const baseDir = derivedPaths.dataDir;
     yield* ServerConfig.ensureServerDirectories(derivedPaths);
-    if (platform !== "win32") {
+    if (platform !== "win32" && storageRoots.layout === "split") {
       yield* fs.chmod(derivedPaths.runtimeDir, 0o700);
     }
     const persistedObservabilitySettings = yield* loadPersistedObservabilitySettings(

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -299,27 +299,51 @@ export class StorageLayoutConfigurationConflictError extends Schema.TaggedErrorC
   }
 }
 
-export class UnsafeRuntimeDirectoryError extends Schema.TaggedErrorClass<UnsafeRuntimeDirectoryError>()(
-  "UnsafeRuntimeDirectoryError",
+export class RuntimeDirectoryOpenError extends Schema.TaggedErrorClass<RuntimeDirectoryOpenError>()(
+  "RuntimeDirectoryOpenError",
   {
     runtimeDir: Schema.String,
-    reason: Schema.Literals(["open", "not-directory", "wrong-owner", "chmod"]),
-    expectedUserId: Schema.optional(Schema.Number),
-    actualUserId: Schema.optional(Schema.Number),
-    cause: Schema.optional(Schema.Defect()),
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    switch (this.reason) {
-      case "open":
-        return `Refusing to use runtime directory '${this.runtimeDir}' because it could not be opened without following symbolic links.`;
-      case "not-directory":
-        return `Refusing to use runtime directory '${this.runtimeDir}' because it is not a directory.`;
-      case "wrong-owner":
-        return `Refusing to use runtime directory '${this.runtimeDir}' because it is owned by user ${this.actualUserId ?? "unknown"} instead of ${this.expectedUserId ?? "unknown"}.`;
-      case "chmod":
-        return `Failed to restrict runtime directory '${this.runtimeDir}' permissions.`;
-    }
+    return `Refusing to use runtime directory '${this.runtimeDir}' because it could not be opened without following symbolic links.`;
+  }
+}
+
+export class RuntimeDirectoryNotADirectoryError extends Schema.TaggedErrorClass<RuntimeDirectoryNotADirectoryError>()(
+  "RuntimeDirectoryNotADirectoryError",
+  {
+    runtimeDir: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Refusing to use runtime directory '${this.runtimeDir}' because it is not a directory.`;
+  }
+}
+
+export class RuntimeDirectoryOwnerMismatchError extends Schema.TaggedErrorClass<RuntimeDirectoryOwnerMismatchError>()(
+  "RuntimeDirectoryOwnerMismatchError",
+  {
+    runtimeDir: Schema.String,
+    expectedUserId: Schema.Number,
+    actualUserId: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Refusing to use runtime directory '${this.runtimeDir}' because it is owned by user ${this.actualUserId} instead of ${this.expectedUserId}.`;
+  }
+}
+
+export class RuntimeDirectoryChmodError extends Schema.TaggedErrorClass<RuntimeDirectoryChmodError>()(
+  "RuntimeDirectoryChmodError",
+  {
+    runtimeDir: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to restrict runtime directory '${this.runtimeDir}' permissions.`;
   }
 }
 
@@ -348,9 +372,8 @@ const prepareSplitRuntimeDirectory = Effect.fn("prepareSplitRuntimeDirectory")(f
   yield* Effect.tryPromise({
     try: () => NodeFSP.mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
     catch: (cause) =>
-      new UnsafeRuntimeDirectoryError({
+      new RuntimeDirectoryOpenError({
         runtimeDir,
-        reason: "open",
         cause,
       }),
   });
@@ -363,9 +386,8 @@ const prepareSplitRuntimeDirectory = Effect.fn("prepareSplitRuntimeDirectory")(f
           NodeFS.constants.O_RDONLY | NodeFS.constants.O_DIRECTORY | NodeFS.constants.O_NOFOLLOW,
         ),
       catch: (cause) =>
-        new UnsafeRuntimeDirectoryError({
+        new RuntimeDirectoryOpenError({
           runtimeDir,
-          reason: "open",
           cause,
         }),
     }),
@@ -374,22 +396,19 @@ const prepareSplitRuntimeDirectory = Effect.fn("prepareSplitRuntimeDirectory")(f
         const stat = yield* Effect.tryPromise({
           try: () => handle.stat(),
           catch: (cause) =>
-            new UnsafeRuntimeDirectoryError({
+            new RuntimeDirectoryOpenError({
               runtimeDir,
-              reason: "open",
               cause,
             }),
         });
         if (!stat.isDirectory()) {
-          return yield* new UnsafeRuntimeDirectoryError({
+          return yield* new RuntimeDirectoryNotADirectoryError({
             runtimeDir,
-            reason: "not-directory",
           });
         }
         if (stat.uid !== userId) {
-          return yield* new UnsafeRuntimeDirectoryError({
+          return yield* new RuntimeDirectoryOwnerMismatchError({
             runtimeDir,
-            reason: "wrong-owner",
             expectedUserId: userId,
             actualUserId: stat.uid,
           });
@@ -397,9 +416,8 @@ const prepareSplitRuntimeDirectory = Effect.fn("prepareSplitRuntimeDirectory")(f
         yield* Effect.tryPromise({
           try: () => handle.chmod(0o700),
           catch: (cause) =>
-            new UnsafeRuntimeDirectoryError({
+            new RuntimeDirectoryChmodError({
               runtimeDir,
-              reason: "chmod",
               cause,
             }),
         });

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -1,6 +1,9 @@
+// @effect-diagnostics nodeBuiltinImport:off
 import * as NetService from "@t3tools/shared/Net";
 import { parsePersistedServerObservabilitySettings } from "@t3tools/shared/serverSettings";
 import { DesktopBackendBootstrap, PortSchema } from "@t3tools/contracts";
+import * as NodeFS from "node:fs";
+import * as NodeFSP from "node:fs/promises";
 import * as Config from "effect/Config";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -296,6 +299,30 @@ export class StorageLayoutConfigurationConflictError extends Schema.TaggedErrorC
   }
 }
 
+export class UnsafeRuntimeDirectoryError extends Schema.TaggedErrorClass<UnsafeRuntimeDirectoryError>()(
+  "UnsafeRuntimeDirectoryError",
+  {
+    runtimeDir: Schema.String,
+    reason: Schema.Literals(["open", "not-directory", "wrong-owner", "chmod"]),
+    expectedUserId: Schema.optional(Schema.Number),
+    actualUserId: Schema.optional(Schema.Number),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    switch (this.reason) {
+      case "open":
+        return `Refusing to use runtime directory '${this.runtimeDir}' because it could not be opened without following symbolic links.`;
+      case "not-directory":
+        return `Refusing to use runtime directory '${this.runtimeDir}' because it is not a directory.`;
+      case "wrong-owner":
+        return `Refusing to use runtime directory '${this.runtimeDir}' because it is owned by user ${this.actualUserId ?? "unknown"} instead of ${this.expectedUserId ?? "unknown"}.`;
+      case "chmod":
+        return `Failed to restrict runtime directory '${this.runtimeDir}' permissions.`;
+    }
+  }
+}
+
 const legacyStorageIsInitialized = Effect.fn(function* (roots: T3StorageRoots) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -305,12 +332,80 @@ const legacyStorageIsInitialized = Effect.fn(function* (roots: T3StorageRoots) {
     path.join(roots.configDir, "keybindings.json"),
     path.join(roots.stateDir, "environment-id"),
     path.join(roots.stateDir, "connection-catalog.json"),
+    path.join(roots.stateDir, "secrets"),
   ];
   const results = yield* Effect.all(
     artifacts.map((artifact) => fs.exists(artifact)),
     { concurrency: "unbounded" },
   );
   return results.some(Boolean);
+});
+
+const prepareSplitRuntimeDirectory = Effect.fn("prepareSplitRuntimeDirectory")(function* (
+  runtimeDir: string,
+  userId: number,
+) {
+  yield* Effect.tryPromise({
+    try: () => NodeFSP.mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
+    catch: (cause) =>
+      new UnsafeRuntimeDirectoryError({
+        runtimeDir,
+        reason: "open",
+        cause,
+      }),
+  });
+
+  return yield* Effect.acquireUseRelease(
+    Effect.tryPromise({
+      try: () =>
+        NodeFSP.open(
+          runtimeDir,
+          NodeFS.constants.O_RDONLY | NodeFS.constants.O_DIRECTORY | NodeFS.constants.O_NOFOLLOW,
+        ),
+      catch: (cause) =>
+        new UnsafeRuntimeDirectoryError({
+          runtimeDir,
+          reason: "open",
+          cause,
+        }),
+    }),
+    (handle) =>
+      Effect.gen(function* () {
+        const stat = yield* Effect.tryPromise({
+          try: () => handle.stat(),
+          catch: (cause) =>
+            new UnsafeRuntimeDirectoryError({
+              runtimeDir,
+              reason: "open",
+              cause,
+            }),
+        });
+        if (!stat.isDirectory()) {
+          return yield* new UnsafeRuntimeDirectoryError({
+            runtimeDir,
+            reason: "not-directory",
+          });
+        }
+        if (stat.uid !== userId) {
+          return yield* new UnsafeRuntimeDirectoryError({
+            runtimeDir,
+            reason: "wrong-owner",
+            expectedUserId: userId,
+            actualUserId: stat.uid,
+          });
+        }
+        yield* Effect.tryPromise({
+          try: () => handle.chmod(0o700),
+          catch: (cause) =>
+            new UnsafeRuntimeDirectoryError({
+              runtimeDir,
+              reason: "chmod",
+              cause,
+            }),
+        });
+      }),
+    (handle) => Effect.promise(() => handle.close()).pipe(Effect.ignore),
+  );
 });
 
 export const resolveServerConfig = (
@@ -496,10 +591,10 @@ export const resolveServerConfig = (
     yield* fs.makeDirectory(cwd, { recursive: true });
     const derivedPaths = yield* ServerConfig.deriveServerPathsFromRoots(storageRoots);
     const baseDir = derivedPaths.dataDir;
-    yield* ServerConfig.ensureServerDirectories(derivedPaths);
-    if (platform !== "win32" && storageRoots.layout === "split") {
-      yield* fs.chmod(derivedPaths.runtimeDir, 0o700);
+    if (platform !== "win32" && storageRoots.layout === "split" && userId !== undefined) {
+      yield* prepareSplitRuntimeDirectory(derivedPaths.runtimeDir, userId);
     }
+    yield* ServerConfig.ensureServerDirectories(derivedPaths);
     const persistedObservabilitySettings = yield* loadPersistedObservabilitySettings(
       derivedPaths.settingsPath,
     );

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -47,6 +47,14 @@ export const baseDirFlag = Flag.string("base-dir").pipe(
   ),
   Flag.optional,
 );
+export const CliStorageLayout = Schema.Literals(["xdg", "legacy"]);
+export type CliStorageLayout = typeof CliStorageLayout.Type;
+export const storageLayoutFlag = Flag.choice("storage-layout", CliStorageLayout.literals).pipe(
+  Flag.withDescription(
+    "Force the XDG/platform-native split layout or the legacy unified layout instead of selecting automatically.",
+  ),
+  Flag.optional,
+);
 export const devUrlFlag = Flag.string("dev-url").pipe(
   Flag.withSchema(Schema.URLFromString),
   Flag.withDescription("Dev web URL to proxy/redirect to (equivalent to VITE_DEV_SERVER_URL)."),
@@ -202,6 +210,7 @@ export interface CliServerFlags {
   readonly port: Option.Option<number>;
   readonly host: Option.Option<string>;
   readonly baseDir: Option.Option<string>;
+  readonly storageLayout?: Option.Option<CliStorageLayout>;
   readonly cwd: Option.Option<string>;
   readonly devUrl: Option.Option<URL>;
   readonly noBrowser: Option.Option<boolean>;
@@ -214,16 +223,19 @@ export interface CliServerFlags {
 
 export interface CliAuthLocationFlags {
   readonly baseDir: Option.Option<string>;
+  readonly storageLayout?: Option.Option<CliStorageLayout>;
   readonly devUrl?: Option.Option<URL>;
 }
 
 export const sharedServerLocationFlags = {
   baseDir: baseDirFlag,
+  storageLayout: storageLayoutFlag,
   devUrl: devUrlFlag,
 } as const;
 
 export const projectLocationFlags = {
   baseDir: baseDirFlag,
+  storageLayout: storageLayoutFlag,
 } as const;
 
 export const sharedServerCommandFlags = {
@@ -231,6 +243,7 @@ export const sharedServerCommandFlags = {
   port: portFlag,
   host: hostFlag,
   baseDir: baseDirFlag,
+  storageLayout: storageLayoutFlag,
   cwd: Argument.string("cwd").pipe(
     Argument.withDescription(
       "Working directory for provider sessions (defaults to the current directory).",
@@ -269,6 +282,17 @@ export class StorageDirectoryConfigurationConflictError extends Schema.TaggedErr
 ) {
   override get message(): string {
     return "T3CODE_HOME/--base-dir cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.";
+  }
+}
+
+export class StorageLayoutConfigurationConflictError extends Schema.TaggedErrorClass<StorageLayoutConfigurationConflictError>()(
+  "StorageLayoutConfigurationConflictError",
+  { storageLayout: CliStorageLayout },
+) {
+  override get message(): string {
+    return this.storageLayout === "xdg"
+      ? "--storage-layout xdg cannot be combined with T3CODE_HOME or --base-dir."
+      : "--storage-layout legacy cannot be combined with T3CODE_CONFIG_DIR, T3CODE_DATA_DIR, T3CODE_STATE_DIR, T3CODE_CACHE_DIR, or T3CODE_RUNTIME_DIR.";
   }
 }
 
@@ -311,6 +335,7 @@ export const resolveServerConfig = (
       port: flags.port ?? Option.none(),
       host: flags.host ?? Option.none(),
       baseDir: flags.baseDir ?? Option.none(),
+      storageLayout: flags.storageLayout ?? Option.none(),
       cwd: flags.cwd ?? Option.none(),
       devUrl: flags.devUrl ?? Option.none(),
       noBrowser: flags.noBrowser ?? Option.none(),
@@ -360,6 +385,7 @@ export const resolveServerConfig = (
       normalizedFlags.baseDir,
       Option.fromUndefinedOr(env.t3Home),
     ).pipe(Option.filter((value) => value.trim().length > 0));
+    const forcedStorageLayout = Option.getOrUndefined(normalizedFlags.storageLayout);
     const homeDirectory = options?.homeDirectory ?? NodeOS.homedir();
     const temporaryDirectory = options?.temporaryDirectory ?? NodeOS.tmpdir();
     const platform = options?.platform ?? (yield* HostProcessPlatform);
@@ -390,6 +416,16 @@ export const resolveServerConfig = (
     });
     if (Option.isSome(explicitBaseDir) && hasT3StorageDirectoryOverrides(directoryOverrides)) {
       return yield* new StorageDirectoryConfigurationConflictError();
+    }
+    if (forcedStorageLayout === "xdg" && Option.isSome(explicitBaseDir)) {
+      return yield* new StorageLayoutConfigurationConflictError({
+        storageLayout: forcedStorageLayout,
+      });
+    }
+    if (forcedStorageLayout === "legacy" && hasT3StorageDirectoryOverrides(directoryOverrides)) {
+      return yield* new StorageLayoutConfigurationConflictError({
+        storageLayout: forcedStorageLayout,
+      });
     }
     const defaultSplitRoots = resolveDefaultT3StorageRoots({
       platform,
@@ -425,8 +461,16 @@ export const resolveServerConfig = (
             path,
           }));
     const storageRoots = selectT3StorageRoots({
-      ...(explicitLegacyRoots === undefined ? {} : { explicitLegacyRoots }),
-      ...(explicitSplitRoots === undefined ? {} : { explicitSplitRoots }),
+      ...(forcedStorageLayout === "legacy"
+        ? { explicitLegacyRoots: explicitLegacyRoots ?? legacyRoots }
+        : explicitLegacyRoots === undefined
+          ? {}
+          : { explicitLegacyRoots }),
+      ...(forcedStorageLayout === "xdg"
+        ? { explicitSplitRoots: explicitSplitRoots ?? defaultSplitRoots }
+        : explicitSplitRoots === undefined
+          ? {}
+          : { explicitSplitRoots }),
       ...(bootstrapRoots === undefined ? {} : { bootstrapRoots }),
       defaultSplitRoots,
       legacyRoots,
@@ -550,6 +594,7 @@ export const resolveCliAuthConfig = (
       port: Option.none(),
       host: Option.none(),
       baseDir: flags.baseDir,
+      storageLayout: flags.storageLayout ?? Option.none(),
       cwd: Option.none(),
       devUrl: flags.devUrl ?? Option.none(),
       noBrowser: Option.none(),

--- a/apps/server/src/cli/service.ts
+++ b/apps/server/src/cli/service.ts
@@ -13,6 +13,15 @@ import { projectLocationFlags, resolveCliAuthConfig } from "./config.ts";
 export const bootServiceLayer = (config: ServerConfig.ServerConfig["Service"]) =>
   BootService.layer({
     baseDir: config.baseDir,
+    storageRoots: {
+      layout: config.layout,
+      configDir: config.configDir,
+      dataDir: config.dataDir,
+      stateDir: config.stateDir,
+      cacheDir: config.cacheDir,
+      runtimeDir: config.runtimeDir,
+      ...(config.legacyBaseDir === undefined ? {} : { legacyBaseDir: config.legacyBaseDir }),
+    },
     logsDir: config.logsDir,
     cliVersion: packageJson.version,
   }).pipe(Layer.provide(ProcessRunner.layer));

--- a/apps/server/src/cli/service.ts
+++ b/apps/server/src/cli/service.ts
@@ -8,7 +8,7 @@ import packageJson from "../../package.json" with { type: "json" };
 import * as BootService from "../cloud/bootService.ts";
 import type * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
-import { projectLocationFlags, resolveCliAuthConfig } from "./config.ts";
+import { projectLocationFlags, resolveCliAuthConfig, type CliAuthLocationFlags } from "./config.ts";
 
 export const bootServiceLayer = (config: ServerConfig.ServerConfig["Service"]) =>
   BootService.layer({
@@ -72,7 +72,7 @@ export function formatServiceStatus(
 }
 
 const runServiceCommand = Effect.fn("cli.service.run")(function* <A, E>(
-  flags: { readonly baseDir: Parameters<typeof resolveCliAuthConfig>[0]["baseDir"] },
+  flags: CliAuthLocationFlags,
   run: Effect.Effect<A, E, BootService.BootService>,
 ) {
   const logLevel = yield* GlobalFlag.LogLevel;

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -123,6 +123,31 @@ it("renders a systemd unit with absolute paths and append-mode logging", () => {
   );
 });
 
+it("pins every split storage root in the background service environment", () => {
+  const unit = BootService.renderBootServiceUnit({
+    nodePath: "/usr/bin/node",
+    t3EntryPath: "/home/alice/.local/share/t3code/runtime/t3.mjs",
+    baseDir: "/home/alice/.local/share/t3code",
+    storageRoots: {
+      layout: "split",
+      configDir: "/home/alice/.config/t3code",
+      dataDir: "/home/alice/.local/share/t3code",
+      stateDir: "/home/alice/.local/state/t3code",
+      cacheDir: "/home/alice/.cache/t3code",
+      runtimeDir: "/run/user/1000/t3code",
+    },
+    logPath: "/home/alice/.local/state/t3code/logs/boot-service.log",
+    unitPath: "/home/alice/.config/systemd/user/t3code.service",
+  });
+
+  assert.include(unit, "Environment=T3CODE_CONFIG_DIR=/home/alice/.config/t3code");
+  assert.include(unit, "Environment=T3CODE_DATA_DIR=/home/alice/.local/share/t3code");
+  assert.include(unit, "Environment=T3CODE_STATE_DIR=/home/alice/.local/state/t3code");
+  assert.include(unit, "Environment=T3CODE_CACHE_DIR=/home/alice/.cache/t3code");
+  assert.include(unit, "Environment=T3CODE_RUNTIME_DIR=/run/user/1000/t3code");
+  assert.notInclude(unit, "Environment=T3CODE_HOME=");
+});
+
 it("quotes systemd values containing spaces and escapes percent specifiers", () => {
   assert.equal(BootService.quoteSystemdValue("/plain/path"), "/plain/path");
   assert.equal(BootService.quoteSystemdValue("/home/me/T3 Data"), '"/home/me/T3 Data"');

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -109,6 +109,7 @@ it("renders a systemd unit with absolute paths and append-mode logging", () => {
       "Type=simple",
       "WorkingDirectory=%h",
       "Environment=T3CODE_HOME=/home/theo/.t3",
+      "UnsetEnvironment=T3CODE_CONFIG_DIR T3CODE_DATA_DIR T3CODE_STATE_DIR T3CODE_CACHE_DIR T3CODE_RUNTIME_DIR",
       "Environment=T3_BOOT_SERVICE_UNIT=t3code.service",
       "ExecStart=/usr/local/bin/node /home/theo/.t3/runtime/versions/0.0.27/node_modules/t3/dist/bin.mjs serve",
       "Restart=always",
@@ -146,6 +147,7 @@ it("pins every split storage root in the background service environment", () => 
   assert.include(unit, "Environment=T3CODE_CACHE_DIR=/home/alice/.cache/t3code");
   assert.include(unit, "Environment=T3CODE_RUNTIME_DIR=/run/user/1000/t3code");
   assert.notInclude(unit, "Environment=T3CODE_HOME=");
+  assert.include(unit, "UnsetEnvironment=T3CODE_HOME");
 });
 
 it("quotes systemd values containing spaces and escapes percent specifiers", () => {

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -14,6 +14,7 @@ import {
   HostProcessExecutablePath,
   HostProcessPlatform,
 } from "@t3tools/shared/hostProcess";
+import { t3StorageEnvironment, type T3StorageRoots } from "@t3tools/shared/storagePaths";
 
 import * as ProcessRunner from "../processRunner.ts";
 import { ensurePinnedRuntimeInstalled, pinnedRuntimePaths } from "./pinnedRuntime.ts";
@@ -74,6 +75,7 @@ export interface BootServicePlan {
   /** Absolute path of the pinned t3 entry point the unit will run. */
   readonly t3EntryPath: string;
   readonly baseDir: string;
+  readonly storageRoots?: T3StorageRoots;
   readonly logPath: string;
   readonly unitPath: string;
 }
@@ -85,6 +87,13 @@ export interface BootServicePlan {
  * `logPath` because `systemctl --user` failures are otherwise invisible.
  */
 export function renderBootServiceUnit(plan: BootServicePlan): string {
+  const storageEnvironment =
+    plan.storageRoots === undefined
+      ? { T3CODE_HOME: plan.baseDir }
+      : t3StorageEnvironment(plan.storageRoots);
+  const storageEnvironmentLines = Object.entries(storageEnvironment).map(
+    ([name, value]) => `Environment=${name}=${quoteSystemdValue(value)}`,
+  );
   // No After=network-online.target: it does not exist in the systemd *user*
   // manager, so ordering on it is silently ignored. The server retries its
   // relay connection, and Restart=always covers early-boot failures.
@@ -100,7 +109,7 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
     "[Service]",
     "Type=simple",
     "WorkingDirectory=%h",
-    `Environment=T3CODE_HOME=${quoteSystemdValue(plan.baseDir)}`,
+    ...storageEnvironmentLines,
     `Environment=${BOOT_SERVICE_UNIT_ENV}=${BOOT_SERVICE_UNIT_FILE}`,
     `ExecStart=${quoteSystemdValue(plan.nodePath)} ${quoteSystemdValue(plan.t3EntryPath)} serve`,
     "Restart=always",
@@ -184,6 +193,7 @@ export interface BootServiceHost {
 
 export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   readonly baseDir: string;
+  readonly storageRoots?: T3StorageRoots;
   readonly logsDir: string;
   readonly cliVersion: string;
   readonly host?: BootServiceHost;
@@ -295,6 +305,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     nodePath: host.execPath,
     t3EntryPath: plannedEntryPath,
     baseDir: input.baseDir,
+    ...(input.storageRoots === undefined ? {} : { storageRoots: input.storageRoots }),
     logPath,
     unitPath,
   };
@@ -427,6 +438,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
 
 export const layer = (input: {
   readonly baseDir: string;
+  readonly storageRoots?: T3StorageRoots;
   readonly logsDir: string;
   readonly cliVersion: string;
   readonly host?: BootServiceHost;

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -14,7 +14,15 @@ import {
   HostProcessExecutablePath,
   HostProcessPlatform,
 } from "@t3tools/shared/hostProcess";
-import { t3StorageEnvironment, type T3StorageRoots } from "@t3tools/shared/storagePaths";
+import {
+  T3CODE_CACHE_DIR_ENV,
+  T3CODE_CONFIG_DIR_ENV,
+  T3CODE_DATA_DIR_ENV,
+  T3CODE_RUNTIME_DIR_ENV,
+  T3CODE_STATE_DIR_ENV,
+  t3StorageEnvironment,
+  type T3StorageRoots,
+} from "@t3tools/shared/storagePaths";
 
 import * as ProcessRunner from "../processRunner.ts";
 import { ensurePinnedRuntimeInstalled, pinnedRuntimePaths } from "./pinnedRuntime.ts";
@@ -27,6 +35,13 @@ import { ensurePinnedRuntimeInstalled, pinnedRuntimePaths } from "./pinnedRuntim
  */
 
 const BOOT_SERVICE_NAME = "t3code";
+const GRANULAR_STORAGE_ENVIRONMENT_NAMES = [
+  T3CODE_CONFIG_DIR_ENV,
+  T3CODE_DATA_DIR_ENV,
+  T3CODE_STATE_DIR_ENV,
+  T3CODE_CACHE_DIR_ENV,
+  T3CODE_RUNTIME_DIR_ENV,
+];
 
 export const BOOT_SERVICE_UNIT_FILE = `${BOOT_SERVICE_NAME}.service`;
 export const BOOT_SERVICE_UNIT_ENV = "T3_BOOT_SERVICE_UNIT";
@@ -94,6 +109,9 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
   const storageEnvironmentLines = Object.entries(storageEnvironment).map(
     ([name, value]) => `Environment=${name}=${quoteSystemdValue(value)}`,
   );
+  const unsetStorageEnvironmentLine = Object.hasOwn(storageEnvironment, "T3CODE_HOME")
+    ? `UnsetEnvironment=${GRANULAR_STORAGE_ENVIRONMENT_NAMES.join(" ")}`
+    : "UnsetEnvironment=T3CODE_HOME";
   // No After=network-online.target: it does not exist in the systemd *user*
   // manager, so ordering on it is silently ignored. The server retries its
   // relay connection, and Restart=always covers early-boot failures.
@@ -110,6 +128,7 @@ export function renderBootServiceUnit(plan: BootServicePlan): string {
     "Type=simple",
     "WorkingDirectory=%h",
     ...storageEnvironmentLines,
+    unsetStorageEnvironmentLine,
     `Environment=${BOOT_SERVICE_UNIT_ENV}=${BOOT_SERVICE_UNIT_FILE}`,
     `ExecStart=${quoteSystemdValue(plan.nodePath)} ${quoteSystemdValue(plan.t3EntryPath)} serve`,
     "Restart=always",

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -311,6 +311,17 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
           nodePath: host.execPath,
           t3EntryPath: runtimePaths.entryPath,
           baseDir: serverConfig.baseDir,
+          storageRoots: {
+            layout: serverConfig.layout,
+            configDir: serverConfig.configDir,
+            dataDir: serverConfig.dataDir,
+            stateDir: serverConfig.stateDir,
+            cacheDir: serverConfig.cacheDir,
+            runtimeDir: serverConfig.runtimeDir,
+            ...(serverConfig.legacyBaseDir === undefined
+              ? {}
+              : { legacyBaseDir: serverConfig.legacyBaseDir }),
+          },
           logPath: path.join(serverConfig.logsDir, "boot-service.log"),
           unitPath,
         });

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -45,10 +45,6 @@ export interface ServerDerivedPaths extends T3StorageRoots {
   readonly secretsDir: string;
 }
 
-export interface DeriveServerPathsOptions {
-  readonly baseDirIsExplicit?: boolean;
-}
-
 /**
  * ServerConfig - Service tag for server runtime configuration.
  */
@@ -97,13 +93,12 @@ export const layer = (config: ServerConfig["Service"]) => Layer.succeed(ServerCo
 export const deriveServerPaths = Effect.fn(function* (
   baseDir: ServerConfig["Service"]["baseDir"],
   devUrl: ServerConfig["Service"]["devUrl"],
-  options: DeriveServerPathsOptions = {},
 ): Effect.fn.Return<ServerDerivedPaths, never, Path.Path> {
   const path = yield* Path.Path;
   return yield* deriveServerPathsFromRoots(
     resolveLegacyT3StorageRoots({
       baseDir,
-      stateDirectoryName: devUrl !== undefined && !options.baseDirIsExplicit ? "dev" : "userdata",
+      stateDirectoryName: devUrl !== undefined ? "dev" : "userdata",
       path,
     }),
   );

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -13,6 +13,7 @@ import * as Layer from "effect/Layer";
 import * as LogLevel from "effect/LogLevel";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import { resolveLegacyT3StorageRoots, type T3StorageRoots } from "@t3tools/shared/storagePaths";
 
 export const DEFAULT_PORT = 3773;
 
@@ -25,8 +26,7 @@ export type StartupPresentation = typeof StartupPresentation.Type;
 /**
  * ServerDerivedPaths - Derived paths from the base directory.
  */
-export interface ServerDerivedPaths {
-  readonly stateDir: string;
+export interface ServerDerivedPaths extends T3StorageRoots {
   readonly dbPath: string;
   readonly keybindingsConfigPath: string;
   readonly settingsPath: string;
@@ -69,6 +69,7 @@ export class ServerConfig extends Context.Service<
     readonly port: number;
     readonly host: string | undefined;
     readonly cwd: string;
+    /** @deprecated Compatibility alias for dataDir. */
     readonly baseDir: string;
     readonly staticDir: string | undefined;
     readonly devUrl: URL | undefined;
@@ -98,23 +99,34 @@ export const deriveServerPaths = Effect.fn(function* (
   devUrl: ServerConfig["Service"]["devUrl"],
   options: DeriveServerPathsOptions = {},
 ): Effect.fn.Return<ServerDerivedPaths, never, Path.Path> {
-  const { join } = yield* Path.Path;
-  const stateDir = join(
-    baseDir,
-    devUrl !== undefined && !options.baseDirIsExplicit ? "dev" : "userdata",
+  const path = yield* Path.Path;
+  return yield* deriveServerPathsFromRoots(
+    resolveLegacyT3StorageRoots({
+      baseDir,
+      stateDirectoryName: devUrl !== undefined && !options.baseDirIsExplicit ? "dev" : "userdata",
+      path,
+    }),
   );
+});
+
+export const deriveServerPathsFromRoots = Effect.fn(function* (
+  roots: T3StorageRoots,
+): Effect.fn.Return<ServerDerivedPaths, never, Path.Path> {
+  const { join } = yield* Path.Path;
+  const { cacheDir, configDir, dataDir, runtimeDir, stateDir } = roots;
   const dbPath = join(stateDir, "state.sqlite");
-  const attachmentsDir = join(stateDir, "attachments");
+  const attachmentsDir = join(roots.layout === "legacy" ? stateDir : dataDir, "attachments");
   const logsDir = join(stateDir, "logs");
   const providerLogsDir = join(logsDir, "provider");
-  const providerStatusCacheDir = join(baseDir, "caches");
+  const providerStatusCacheDir =
+    roots.layout === "legacy" ? cacheDir : join(cacheDir, "provider-status");
   return {
-    stateDir,
+    ...roots,
     dbPath,
-    keybindingsConfigPath: join(stateDir, "keybindings.json"),
-    settingsPath: join(stateDir, "settings.json"),
+    keybindingsConfigPath: join(configDir, "keybindings.json"),
+    settingsPath: join(configDir, "settings.json"),
     providerStatusCacheDir,
-    worktreesDir: join(baseDir, "worktrees"),
+    worktreesDir: join(dataDir, "worktrees"),
     attachmentsDir,
     logsDir,
     serverLogPath: join(logsDir, "server.log"),
@@ -124,7 +136,7 @@ export const deriveServerPaths = Effect.fn(function* (
     terminalLogsDir: join(logsDir, "terminals"),
     anonymousIdPath: join(stateDir, "anonymous-id"),
     environmentIdPath: join(stateDir, "environment-id"),
-    serverRuntimeStatePath: join(stateDir, "server-runtime.json"),
+    serverRuntimeStatePath: join(runtimeDir, "server-runtime.json"),
     secretsDir: join(stateDir, "secrets"),
   };
 });
@@ -135,7 +147,11 @@ export const ensureServerDirectories = Effect.fn(function* (derivedPaths: Server
 
   yield* Effect.all(
     [
+      fs.makeDirectory(derivedPaths.configDir, { recursive: true }),
+      fs.makeDirectory(derivedPaths.dataDir, { recursive: true }),
       fs.makeDirectory(derivedPaths.stateDir, { recursive: true }),
+      fs.makeDirectory(derivedPaths.cacheDir, { recursive: true }),
+      fs.makeDirectory(derivedPaths.runtimeDir, { recursive: true }),
       fs.makeDirectory(derivedPaths.logsDir, { recursive: true }),
       fs.makeDirectory(derivedPaths.providerLogsDir, { recursive: true }),
       fs.makeDirectory(derivedPaths.terminalLogsDir, { recursive: true }),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1109,6 +1109,22 @@ const makeWsRpcLayer = (
               : {}),
             otlpMetricsEnabled: config.otlpMetricsUrl !== undefined,
           },
+          storage: {
+            layout: config.layout,
+            configDirectoryPath: config.configDir,
+            dataDirectoryPath: config.dataDir,
+            stateDirectoryPath: config.stateDir,
+            cacheDirectoryPath: config.cacheDir,
+            runtimeDirectoryPath: config.runtimeDir,
+            databaseFilePath: config.dbPath,
+            settingsFilePath: config.settingsPath,
+            keybindingsFilePath: config.keybindingsConfigPath,
+            worktreesDirectoryPath: config.worktreesDir,
+            attachmentsDirectoryPath: config.attachmentsDir,
+            ...(config.legacyBaseDir === undefined
+              ? {}
+              : { legacyBaseDirectoryPath: config.legacyBaseDir }),
+          },
           settings,
           shellResumeCompletionMarker: true,
           threadResumeCompletionMarker: true,

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -28,6 +28,7 @@ import { useEnvironmentQuery } from "../../state/query";
 import {
   primaryServerAvailableEditorsAtom,
   primaryServerObservabilityAtom,
+  primaryServerStorageAtom,
   serverEnvironment,
 } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
@@ -157,6 +158,39 @@ function StatsGrid({ children }: { children: ReactNode }) {
 
 function EmptyRows({ label }: { label: string }) {
   return <div className="px-4 py-4 text-xs text-muted-foreground sm:px-5">{label}</div>;
+}
+
+function StoragePathRow({ label, path }: { label: string; path: string }) {
+  const { copyToClipboard, isCopied } = useCopyToClipboard({
+    target: `${label.toLowerCase()} path`,
+    timeout: 1_200,
+  });
+
+  return (
+    <div className="relative grid min-w-0 gap-1 py-3 pl-4 pr-12 sm:grid-cols-[8rem_minmax(0,1fr)_auto] sm:items-center sm:gap-3 sm:px-5">
+      <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/70">
+        {label}
+      </div>
+      <code className="min-w-0 break-all text-xs text-foreground/90">{path}</code>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              className="absolute right-4 mt-0.5 inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground sm:static sm:mt-0"
+              aria-label={
+                isCopied ? `Copied ${label.toLowerCase()} path` : `Copy ${label.toLowerCase()} path`
+              }
+              onClick={() => copyToClipboard(path)}
+            >
+              <CopyIcon className="size-3.5" />
+            </button>
+          }
+        />
+        <TooltipPopup side="top">{isCopied ? "Copied" : "Copy path"}</TooltipPopup>
+      </Tooltip>
+    </div>
+  );
 }
 
 function ExpandableText({
@@ -809,6 +843,7 @@ function DiagnosticsRefreshButton({
 
 export function DiagnosticsSettingsPanel() {
   const observability = useAtomValue(primaryServerObservabilityAtom);
+  const storage = useAtomValue(primaryServerStorageAtom);
   const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
   const primaryEnvironment = usePrimaryEnvironment();
   const environmentId = primaryEnvironment?.environmentId ?? null;
@@ -958,6 +993,35 @@ export function DiagnosticsSettingsPanel() {
 
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Storage Locations">
+        {storage ? (
+          <>
+            <div className="border-b border-border/60 px-4 py-3 text-xs leading-relaxed text-muted-foreground sm:px-5">
+              {storage.layout === "split"
+                ? "T3 Code is using separate configuration, data, state, cache, and runtime directories."
+                : "T3 Code is using the legacy unified directory. No data has been moved or copied."}
+            </div>
+            <div className="relative divide-y divide-border/60">
+              <StoragePathRow label="Configuration" path={storage.configDirectoryPath} />
+              <StoragePathRow label="Data" path={storage.dataDirectoryPath} />
+              <StoragePathRow label="State" path={storage.stateDirectoryPath} />
+              <StoragePathRow label="Cache" path={storage.cacheDirectoryPath} />
+              <StoragePathRow label="Runtime" path={storage.runtimeDirectoryPath} />
+              {storage.legacyBaseDirectoryPath ? (
+                <StoragePathRow label="Legacy root" path={storage.legacyBaseDirectoryPath} />
+              ) : null}
+              <StoragePathRow label="Database" path={storage.databaseFilePath} />
+              <StoragePathRow label="Settings" path={storage.settingsFilePath} />
+              <StoragePathRow label="Keybindings" path={storage.keybindingsFilePath} />
+              <StoragePathRow label="Worktrees" path={storage.worktreesDirectoryPath} />
+              <StoragePathRow label="Attachments" path={storage.attachmentsDirectoryPath} />
+            </div>
+          </>
+        ) : (
+          <EmptyRows label="Storage locations are unavailable from this server version." />
+        )}
+      </SettingsSection>
+
       <SettingsSection
         title="Live Processes"
         headerAction={

--- a/apps/web/src/state/server.ts
+++ b/apps/web/src/state/server.ts
@@ -98,3 +98,7 @@ export const primaryServerObservabilityAtom = Atom.make(
   (get): ServerConfig["observability"] | null =>
     get(primaryServerConfigAtom)?.observability ?? null,
 ).pipe(Atom.withLabel("web-primary-server-observability"));
+
+export const primaryServerStorageAtom = Atom.make(
+  (get): ServerConfig["storage"] | null => get(primaryServerConfigAtom)?.storage ?? null,
+).pipe(Atom.withLabel("web-primary-server-storage"));

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
   - [Remote access](./user/remote-access.md)
   - [Keeping T3 Code in sync](./user/server-updates.md)
   - [Keybindings](./user/keybindings.md)
+  - [Storage directories](./user/storage-directories.md)
 - [T3 Connect](./cloud/t3-connect-clerk.md)
 - [Integrations](./integrations/source-control-providers.md)
 - [Mobile](./mobile/app.md)

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -165,12 +165,15 @@ The backend reads observability config at process start. If you change OTLP env 
 
 The trace file is the fastest way to inspect raw span data.
 
-Resolve the production or explicitly configured trace file once. Runtime state lives under the
-base directory's `userdata` folder:
+Resolve the production trace file from **Settings → Diagnostics → Storage
+Locations**. For a new Linux installation using the default roots:
 
 ```bash
-TRACE_FILE="${T3CODE_HOME:-$HOME/.t3}/userdata/logs/server.trace.ndjson"
+TRACE_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/t3code/logs/server.trace.ndjson"
 ```
+
+Legacy installations continue using
+`${T3CODE_HOME:-$HOME/.t3}/userdata/logs/server.trace.ndjson`.
 
 Tail it:
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -5,7 +5,7 @@
 - `vp run dev:server` — Starts just the WebSocket server. The server process runs on Bun (`@effect/platform-bun` + `BunPtyAdapter`), but task running uses `vp run`.
 - `vp run dev:web` — Starts just the Vite dev server for the web app.
 - Dev commands run from a linked **git worktree** default to that worktree's gitignored `.t3`, even when `T3CODE_HOME` is set, storing state in `<worktree>/.t3/userdata`. Pass `--home-dir <path>` to choose another isolated directory explicitly. Submodules are not worktrees and keep the normal precedence.
-- From the **main checkout**, dev commands implicitly use `~/.t3/dev`, keeping development state separate from `~/.t3/userdata`. An explicit `--home-dir <path>` stores state under `<path>/userdata`; the base directory remains available for caches, worktrees, and other shared data.
+- The dev runner uses an isolated legacy-layout directory for compatibility. An explicit `--home-dir <path>` stores state under `<path>/userdata`; production and direct server launches use the effective storage roots described in [Storage directories](../user/storage-directories.md).
 - Web dev commands do not auto-open a browser. Open the one-time pairing URL printed by the server so the first browser navigation is authenticated. Set `T3CODE_NO_BROWSER=0` only when interactive auto-open is intentional.
 - Pass dev-runner flags directly after the root task name, for example:
   `vp run dev --home-dir /tmp/t3code-dev`

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -2,7 +2,12 @@
 
 T3 Code reads keybindings from:
 
-- `~/.t3/keybindings.json`
+- `$XDG_CONFIG_HOME/t3code/keybindings.json` (normally
+  `~/.config/t3code/keybindings.json`) for a new installation
+- `~/.t3/userdata/keybindings.json` while using the legacy layout
+
+The exact active path is shown under **Settings → Diagnostics → Storage
+Locations**.
 
 The file must be a JSON array of rules:
 

--- a/docs/user/storage-directories.md
+++ b/docs/user/storage-directories.md
@@ -40,6 +40,13 @@ in host-local directories.
 the old unified layout beneath the supplied directory and cannot be combined
 with the granular overrides.
 
+Use `--storage-layout xdg` to force the platform-native split layout, even when
+an initialized legacy installation exists. Use `--storage-layout legacy` to
+force the default legacy tree under `~/.t3`, even when it has not been
+initialized. These values override automatic layout selection; `xdg` cannot be
+combined with `T3CODE_HOME` or `--base-dir`, and `legacy` cannot be combined
+with granular directory overrides.
+
 ## Existing installations
 
 If T3 Code finds initialized storage under `~/.t3`, it continues using that

--- a/docs/user/storage-directories.md
+++ b/docs/user/storage-directories.md
@@ -1,0 +1,47 @@
+# Storage directories
+
+New T3 Code installations keep configuration, durable data, machine state,
+disposable caches, and process-lifetime files in separate directories.
+
+On Linux, the default roots are:
+
+| Purpose       | Default                                                       |
+| ------------- | ------------------------------------------------------------- |
+| Configuration | `${XDG_CONFIG_HOME:-$HOME/.config}/t3code`                    |
+| Data          | `${XDG_DATA_HOME:-$HOME/.local/share}/t3code`                 |
+| State         | `${XDG_STATE_HOME:-$HOME/.local/state}/t3code`                |
+| Cache         | `${XDG_CACHE_HOME:-$HOME/.cache}/t3code`                      |
+| Runtime       | `$XDG_RUNTIME_DIR/t3code`, with a per-user temporary fallback |
+
+Settings and keybindings live in the configuration directory. Attachments and
+worktrees live in the data directory. The SQLite database, identity, secrets,
+and logs live in the state directory. Provider caches and desktop browser
+artifacts live in the cache directory. Live-server discovery state lives in the
+runtime directory.
+
+The effective paths for the connected server are shown under **Settings →
+Diagnostics → Storage Locations**.
+
+## Overrides
+
+Each root can be overridden independently:
+
+- `T3CODE_CONFIG_DIR`
+- `T3CODE_DATA_DIR`
+- `T3CODE_STATE_DIR`
+- `T3CODE_CACHE_DIR`
+- `T3CODE_RUNTIME_DIR`
+
+This lets a machine-local environment point the configuration root at a
+dotfiles checkout while keeping durable data, state, caches, and runtime files
+in host-local directories.
+
+`T3CODE_HOME` and `--base-dir` are legacy compatibility controls. They select
+the old unified layout beneath the supplied directory and cannot be combined
+with the granular overrides.
+
+## Existing installations
+
+If T3 Code finds initialized storage under `~/.t3`, it continues using that
+layout. Startup does not copy, move, delete, or automatically switch any data.
+An explicit migration workflow will be handled separately.

--- a/packages/contracts/src/desktopBootstrap.ts
+++ b/packages/contracts/src/desktopBootstrap.ts
@@ -2,6 +2,27 @@ import * as Schema from "effect/Schema";
 
 import { PortSchema } from "./baseSchemas.ts";
 
+export const DesktopBackendStorageRoots = Schema.Union([
+  Schema.Struct({
+    layout: Schema.Literal("split"),
+    configDir: Schema.String,
+    dataDir: Schema.String,
+    stateDir: Schema.String,
+    cacheDir: Schema.String,
+    runtimeDir: Schema.String,
+  }),
+  Schema.Struct({
+    layout: Schema.Literal("legacy"),
+    configDir: Schema.String,
+    dataDir: Schema.String,
+    stateDir: Schema.String,
+    cacheDir: Schema.String,
+    runtimeDir: Schema.String,
+    legacyBaseDir: Schema.String,
+  }),
+]);
+export type DesktopBackendStorageRoots = typeof DesktopBackendStorageRoots.Type;
+
 export const DesktopBackendBootstrap = Schema.Struct({
   mode: Schema.Literal("desktop"),
   noBrowser: Schema.Boolean,
@@ -10,6 +31,7 @@ export const DesktopBackendBootstrap = Schema.Struct({
   // Windows-side baseDir maps to /mnt/c/... and the Linux side should use its
   // own home directory instead.
   t3Home: Schema.optional(Schema.String),
+  storageRoots: Schema.optional(DesktopBackendStorageRoots),
   host: Schema.String,
   desktopBootstrapToken: Schema.String,
   tailscaleServeEnabled: Schema.Boolean,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -407,6 +407,22 @@ export const ServerSignalProcessResult = Schema.Struct({
 });
 export type ServerSignalProcessResult = typeof ServerSignalProcessResult.Type;
 
+export const ServerStorageLayout = Schema.Struct({
+  layout: Schema.Literals(["split", "legacy"]),
+  configDirectoryPath: TrimmedNonEmptyString,
+  dataDirectoryPath: TrimmedNonEmptyString,
+  stateDirectoryPath: TrimmedNonEmptyString,
+  cacheDirectoryPath: TrimmedNonEmptyString,
+  runtimeDirectoryPath: TrimmedNonEmptyString,
+  databaseFilePath: TrimmedNonEmptyString,
+  settingsFilePath: TrimmedNonEmptyString,
+  keybindingsFilePath: TrimmedNonEmptyString,
+  worktreesDirectoryPath: TrimmedNonEmptyString,
+  attachmentsDirectoryPath: TrimmedNonEmptyString,
+  legacyBaseDirectoryPath: Schema.optionalKey(TrimmedNonEmptyString),
+});
+export type ServerStorageLayout = typeof ServerStorageLayout.Type;
+
 export const ServerConfig = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
   auth: ServerAuthDescriptor,
@@ -417,6 +433,8 @@ export const ServerConfig = Schema.Struct({
   providers: ServerProviders,
   availableEditors: Schema.Array(EditorId),
   observability: ServerObservability,
+  /** Effective server-side storage paths. Optional for older server compatibility. */
+  storage: Schema.optionalKey(ServerStorageLayout),
   settings: ServerSettings,
   /** Whether shell subscriptions can emit an opt-in catch-up completion marker. */
   shellResumeCompletionMarker: Schema.optionalKey(Schema.Boolean),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -147,6 +147,10 @@
       "types": "./src/path.ts",
       "import": "./src/path.ts"
     },
+    "./storagePaths": {
+      "types": "./src/storagePaths.ts",
+      "import": "./src/storagePaths.ts"
+    },
     "./keybindings": {
       "types": "./src/keybindings.ts",
       "import": "./src/keybindings.ts"

--- a/packages/shared/src/storagePaths.test.ts
+++ b/packages/shared/src/storagePaths.test.ts
@@ -1,0 +1,135 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import { describe, expect, it } from "@effect/vitest";
+import * as NodePath from "node:path";
+
+import {
+  applyT3StorageDirectoryOverrides,
+  resolveDefaultT3StorageRoots,
+  resolveLegacyT3StorageRoots,
+  resolveT3StorageDirectoryOverrides,
+  selectT3StorageRoots,
+  t3StorageEnvironment,
+} from "./storagePaths.ts";
+
+const path = {
+  join: NodePath.posix.join,
+  resolve: NodePath.posix.resolve,
+  isAbsolute: NodePath.posix.isAbsolute,
+};
+
+const linuxDefaults = (environment: Readonly<Record<string, string | undefined>> = {}) =>
+  resolveDefaultT3StorageRoots({
+    platform: "linux",
+    homeDirectory: "/home/alice",
+    temporaryDirectory: "/tmp",
+    userId: 1000,
+    isDevelopment: false,
+    environment,
+    path,
+  });
+
+describe("T3 storage paths", () => {
+  it("resolves all five Linux XDG roots independently", () => {
+    expect(
+      linuxDefaults({
+        XDG_CONFIG_HOME: "/xdg/config",
+        XDG_DATA_HOME: "/xdg/data",
+        XDG_STATE_HOME: "/xdg/state",
+        XDG_CACHE_HOME: "/xdg/cache",
+        XDG_RUNTIME_DIR: "/run/user/1000",
+      }),
+    ).toEqual({
+      layout: "split",
+      configDir: "/xdg/config/t3code",
+      dataDir: "/xdg/data/t3code",
+      stateDir: "/xdg/state/t3code",
+      cacheDir: "/xdg/cache/t3code",
+      runtimeDir: "/run/user/1000/t3code",
+    });
+  });
+
+  it("uses the XDG defaults and a per-user temporary runtime fallback", () => {
+    expect(linuxDefaults()).toEqual({
+      layout: "split",
+      configDir: "/home/alice/.config/t3code",
+      dataDir: "/home/alice/.local/share/t3code",
+      stateDir: "/home/alice/.local/state/t3code",
+      cacheDir: "/home/alice/.cache/t3code",
+      runtimeDir: "/tmp/t3code-1000",
+    });
+  });
+
+  it("ignores relative XDG base directories", () => {
+    expect(
+      linuxDefaults({
+        XDG_CONFIG_HOME: "relative/config",
+        XDG_RUNTIME_DIR: "relative/runtime",
+      }),
+    ).toMatchObject({
+      configDir: "/home/alice/.config/t3code",
+      runtimeDir: "/tmp/t3code-1000",
+    });
+  });
+
+  it("applies granular T3 overrides without collapsing the other roots", () => {
+    const overrides = resolveT3StorageDirectoryOverrides({
+      environment: {
+        T3CODE_CONFIG_DIR: "~/dotfiles/t3code",
+        T3CODE_STATE_DIR: "/machine/t3code",
+      },
+      homeDirectory: "/home/alice",
+      path,
+    });
+
+    expect(applyT3StorageDirectoryOverrides(linuxDefaults(), overrides)).toEqual({
+      layout: "split",
+      configDir: "/home/alice/dotfiles/t3code",
+      dataDir: "/home/alice/.local/share/t3code",
+      stateDir: "/machine/t3code",
+      cacheDir: "/home/alice/.cache/t3code",
+      runtimeDir: "/tmp/t3code-1000",
+    });
+  });
+
+  it("models the legacy tree without pretending it has five independent roots", () => {
+    const roots = resolveLegacyT3StorageRoots({
+      baseDir: "/home/alice/.t3",
+      stateDirectoryName: "userdata",
+      path,
+    });
+    expect(roots).toEqual({
+      layout: "legacy",
+      configDir: "/home/alice/.t3/userdata",
+      dataDir: "/home/alice/.t3",
+      stateDir: "/home/alice/.t3/userdata",
+      cacheDir: "/home/alice/.t3/caches",
+      runtimeDir: "/home/alice/.t3/userdata",
+      legacyBaseDir: "/home/alice/.t3",
+    });
+    expect(t3StorageEnvironment(roots)).toEqual({ T3CODE_HOME: "/home/alice/.t3" });
+  });
+
+  it("keeps initialized legacy storage unless a layout is explicitly selected", () => {
+    const split = linuxDefaults();
+    const legacy = resolveLegacyT3StorageRoots({
+      baseDir: "/home/alice/.t3",
+      stateDirectoryName: "userdata",
+      path,
+    });
+    expect(
+      selectT3StorageRoots({
+        defaultSplitRoots: split,
+        legacyRoots: legacy,
+        legacyStorageInitialized: true,
+      }),
+    ).toBe(legacy);
+    expect(
+      selectT3StorageRoots({
+        explicitSplitRoots: split,
+        defaultSplitRoots: split,
+        legacyRoots: legacy,
+        legacyStorageInitialized: true,
+      }),
+    ).toBe(split);
+  });
+});

--- a/packages/shared/src/storagePaths.test.ts
+++ b/packages/shared/src/storagePaths.test.ts
@@ -59,6 +59,27 @@ describe("T3 storage paths", () => {
     });
   });
 
+  it("honors an independently configured XDG root on macOS", () => {
+    expect(
+      resolveDefaultT3StorageRoots({
+        platform: "darwin",
+        homeDirectory: "/Users/alice",
+        temporaryDirectory: "/tmp",
+        userId: 501,
+        isDevelopment: false,
+        environment: { XDG_CACHE_HOME: "/custom/cache" },
+        path,
+      }),
+    ).toEqual({
+      layout: "split",
+      configDir: "/Users/alice/.config/t3code",
+      dataDir: "/Users/alice/.local/share/t3code",
+      stateDir: "/Users/alice/.local/state/t3code",
+      cacheDir: "/custom/cache/t3code",
+      runtimeDir: "/tmp/t3code-501",
+    });
+  });
+
   it("ignores relative XDG base directories", () => {
     expect(
       linuxDefaults({

--- a/packages/shared/src/storagePaths.ts
+++ b/packages/shared/src/storagePaths.ts
@@ -1,0 +1,229 @@
+export const T3CODE_CONFIG_DIR_ENV = "T3CODE_CONFIG_DIR";
+export const T3CODE_DATA_DIR_ENV = "T3CODE_DATA_DIR";
+export const T3CODE_STATE_DIR_ENV = "T3CODE_STATE_DIR";
+export const T3CODE_CACHE_DIR_ENV = "T3CODE_CACHE_DIR";
+export const T3CODE_RUNTIME_DIR_ENV = "T3CODE_RUNTIME_DIR";
+
+export type T3StorageLayout = "split" | "legacy";
+
+export interface T3StorageRoots {
+  readonly layout: T3StorageLayout;
+  readonly configDir: string;
+  readonly dataDir: string;
+  readonly stateDir: string;
+  readonly cacheDir: string;
+  readonly runtimeDir: string;
+  readonly legacyBaseDir?: string;
+}
+
+export interface T3StorageDirectoryOverrides {
+  readonly configDir?: string;
+  readonly dataDir?: string;
+  readonly stateDir?: string;
+  readonly cacheDir?: string;
+  readonly runtimeDir?: string;
+}
+
+export interface StoragePathOperations {
+  readonly join: (...paths: ReadonlyArray<string>) => string;
+  readonly resolve: (...paths: ReadonlyArray<string>) => string;
+  readonly isAbsolute: (path: string) => boolean;
+}
+
+export interface ResolveDefaultT3StorageRootsInput {
+  readonly platform: NodeJS.Platform;
+  readonly homeDirectory: string;
+  readonly temporaryDirectory: string;
+  readonly userId?: number;
+  readonly isDevelopment: boolean;
+  readonly environment: Readonly<Record<string, string | undefined>>;
+  readonly path: StoragePathOperations;
+}
+
+const trimmed = (value: string | undefined): string | undefined => {
+  const result = value?.trim();
+  return result && result.length > 0 ? result : undefined;
+};
+
+const absoluteEnvironmentDirectory = (
+  value: string | undefined,
+  path: StoragePathOperations,
+): string | undefined => {
+  const candidate = trimmed(value);
+  return candidate !== undefined && path.isAbsolute(candidate) ? candidate : undefined;
+};
+
+const expandHome = (value: string, homeDirectory: string, path: StoragePathOperations): string => {
+  if (value === "~") return homeDirectory;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(homeDirectory, value.slice(2));
+  }
+  return value;
+};
+
+const resolveOverride = (
+  value: string | undefined,
+  homeDirectory: string,
+  path: StoragePathOperations,
+): string | undefined => {
+  const candidate = trimmed(value);
+  return candidate === undefined
+    ? undefined
+    : path.resolve(expandHome(candidate, homeDirectory, path));
+};
+
+export function hasT3StorageDirectoryOverrides(overrides: T3StorageDirectoryOverrides): boolean {
+  return Object.values(overrides).some((value) => value !== undefined);
+}
+
+export function resolveT3StorageDirectoryOverrides(input: {
+  readonly environment: Readonly<Record<string, string | undefined>>;
+  readonly homeDirectory: string;
+  readonly path: StoragePathOperations;
+}): T3StorageDirectoryOverrides {
+  const { environment, homeDirectory, path } = input;
+  const configDir = resolveOverride(environment[T3CODE_CONFIG_DIR_ENV], homeDirectory, path);
+  const dataDir = resolveOverride(environment[T3CODE_DATA_DIR_ENV], homeDirectory, path);
+  const stateDir = resolveOverride(environment[T3CODE_STATE_DIR_ENV], homeDirectory, path);
+  const cacheDir = resolveOverride(environment[T3CODE_CACHE_DIR_ENV], homeDirectory, path);
+  const runtimeDir = resolveOverride(environment[T3CODE_RUNTIME_DIR_ENV], homeDirectory, path);
+  return {
+    ...(configDir === undefined ? {} : { configDir }),
+    ...(dataDir === undefined ? {} : { dataDir }),
+    ...(stateDir === undefined ? {} : { stateDir }),
+    ...(cacheDir === undefined ? {} : { cacheDir }),
+    ...(runtimeDir === undefined ? {} : { runtimeDir }),
+  };
+}
+
+export function resolveDefaultT3StorageRoots(
+  input: ResolveDefaultT3StorageRootsInput,
+): T3StorageRoots {
+  const { environment, homeDirectory, isDevelopment, path, platform, temporaryDirectory } = input;
+  const applicationDirectoryName = isDevelopment ? "t3code-dev" : "t3code";
+  const runtimeFallbackName =
+    input.userId === undefined
+      ? applicationDirectoryName
+      : `${applicationDirectoryName}-${String(input.userId)}`;
+
+  if (platform === "win32") {
+    const roamingApplicationData =
+      trimmed(environment.APPDATA) ?? path.join(homeDirectory, "AppData", "Roaming");
+    const localApplicationData =
+      trimmed(environment.LOCALAPPDATA) ?? path.join(homeDirectory, "AppData", "Local");
+    const localRoot = path.join(localApplicationData, applicationDirectoryName);
+    return {
+      layout: "split",
+      configDir: path.join(roamingApplicationData, applicationDirectoryName),
+      dataDir: path.join(localRoot, "data"),
+      stateDir: path.join(localRoot, "state"),
+      cacheDir: path.join(localRoot, "cache"),
+      runtimeDir: path.join(localRoot, "runtime"),
+    };
+  }
+
+  const xdgConfigHome = absoluteEnvironmentDirectory(environment.XDG_CONFIG_HOME, path);
+  const xdgDataHome = absoluteEnvironmentDirectory(environment.XDG_DATA_HOME, path);
+  const xdgStateHome = absoluteEnvironmentDirectory(environment.XDG_STATE_HOME, path);
+  const xdgCacheHome = absoluteEnvironmentDirectory(environment.XDG_CACHE_HOME, path);
+  const xdgRuntimeHome = absoluteEnvironmentDirectory(environment.XDG_RUNTIME_DIR, path);
+
+  if (platform === "darwin" && xdgConfigHome === undefined && xdgDataHome === undefined) {
+    const applicationSupportRoot = path.join(
+      homeDirectory,
+      "Library",
+      "Application Support",
+      applicationDirectoryName,
+    );
+    return {
+      layout: "split",
+      configDir: path.join(applicationSupportRoot, "config"),
+      dataDir: path.join(applicationSupportRoot, "data"),
+      stateDir: path.join(applicationSupportRoot, "state"),
+      cacheDir: path.join(homeDirectory, "Library", "Caches", applicationDirectoryName),
+      runtimeDir: path.join(temporaryDirectory, runtimeFallbackName),
+    };
+  }
+
+  return {
+    layout: "split",
+    configDir: path.join(
+      xdgConfigHome ?? path.join(homeDirectory, ".config"),
+      applicationDirectoryName,
+    ),
+    dataDir: path.join(
+      xdgDataHome ?? path.join(homeDirectory, ".local", "share"),
+      applicationDirectoryName,
+    ),
+    stateDir: path.join(
+      xdgStateHome ?? path.join(homeDirectory, ".local", "state"),
+      applicationDirectoryName,
+    ),
+    cacheDir: path.join(
+      xdgCacheHome ?? path.join(homeDirectory, ".cache"),
+      applicationDirectoryName,
+    ),
+    runtimeDir:
+      xdgRuntimeHome === undefined
+        ? path.join(temporaryDirectory, runtimeFallbackName)
+        : path.join(xdgRuntimeHome, applicationDirectoryName),
+  };
+}
+
+export function applyT3StorageDirectoryOverrides(
+  defaults: T3StorageRoots,
+  overrides: T3StorageDirectoryOverrides,
+): T3StorageRoots {
+  return {
+    layout: "split",
+    configDir: overrides.configDir ?? defaults.configDir,
+    dataDir: overrides.dataDir ?? defaults.dataDir,
+    stateDir: overrides.stateDir ?? defaults.stateDir,
+    cacheDir: overrides.cacheDir ?? defaults.cacheDir,
+    runtimeDir: overrides.runtimeDir ?? defaults.runtimeDir,
+  };
+}
+
+export function resolveLegacyT3StorageRoots(input: {
+  readonly baseDir: string;
+  readonly stateDirectoryName: "userdata" | "dev";
+  readonly path: Pick<StoragePathOperations, "join">;
+}): T3StorageRoots {
+  const stateDir = input.path.join(input.baseDir, input.stateDirectoryName);
+  return {
+    layout: "legacy",
+    configDir: stateDir,
+    dataDir: input.baseDir,
+    stateDir,
+    cacheDir: input.path.join(input.baseDir, "caches"),
+    runtimeDir: stateDir,
+    legacyBaseDir: input.baseDir,
+  };
+}
+
+export function selectT3StorageRoots(input: {
+  readonly explicitLegacyRoots?: T3StorageRoots;
+  readonly explicitSplitRoots?: T3StorageRoots;
+  readonly bootstrapRoots?: T3StorageRoots;
+  readonly defaultSplitRoots: T3StorageRoots;
+  readonly legacyRoots: T3StorageRoots;
+  readonly legacyStorageInitialized: boolean;
+}): T3StorageRoots {
+  if (input.explicitLegacyRoots !== undefined) return input.explicitLegacyRoots;
+  if (input.explicitSplitRoots !== undefined) return input.explicitSplitRoots;
+  if (input.bootstrapRoots !== undefined) return input.bootstrapRoots;
+  return input.legacyStorageInitialized ? input.legacyRoots : input.defaultSplitRoots;
+}
+
+export function t3StorageEnvironment(roots: T3StorageRoots): Readonly<Record<string, string>> {
+  if (roots.layout === "legacy" && roots.legacyBaseDir !== undefined) {
+    return { T3CODE_HOME: roots.legacyBaseDir };
+  }
+  return {
+    [T3CODE_CONFIG_DIR_ENV]: roots.configDir,
+    [T3CODE_DATA_DIR_ENV]: roots.dataDir,
+    [T3CODE_STATE_DIR_ENV]: roots.stateDir,
+    [T3CODE_CACHE_DIR_ENV]: roots.cacheDir,
+    [T3CODE_RUNTIME_DIR_ENV]: roots.runtimeDir,
+  };
+}

--- a/packages/shared/src/storagePaths.ts
+++ b/packages/shared/src/storagePaths.ts
@@ -128,7 +128,14 @@ export function resolveDefaultT3StorageRoots(
   const xdgCacheHome = absoluteEnvironmentDirectory(environment.XDG_CACHE_HOME, path);
   const xdgRuntimeHome = absoluteEnvironmentDirectory(environment.XDG_RUNTIME_DIR, path);
 
-  if (platform === "darwin" && xdgConfigHome === undefined && xdgDataHome === undefined) {
+  if (
+    platform === "darwin" &&
+    xdgConfigHome === undefined &&
+    xdgDataHome === undefined &&
+    xdgStateHome === undefined &&
+    xdgCacheHome === undefined &&
+    xdgRuntimeHome === undefined
+  ) {
     const applicationSupportRoot = path.join(
       homeDirectory,
       "Library",


### PR DESCRIPTION
## What Changed

- Introduce a shared five-root storage model for configuration, durable data, machine state, disposable caches, and runtime files.
- Use platform-native defaults: XDG roots on Linux, Application Support and Library/Caches on macOS, and roaming/local application data on Windows.
- Keep initialized `~/.t3` installations on the exact legacy layout. Selection checks real artifacts, so an empty or partially-created XDG directory cannot hide existing data.
- Add independent `T3CODE_CONFIG_DIR`, `T3CODE_DATA_DIR`, `T3CODE_STATE_DIR`, `T3CODE_CACHE_DIR`, and `T3CODE_RUNTIME_DIR` overrides. `T3CODE_HOME` and `--base-dir` remain explicit legacy compatibility controls and conflict with granular overrides.
- Add `--storage-layout xdg|legacy` to server and storage-aware subcommands so users can override automatic selection while incompatible explicit path controls still fail clearly.
- Place settings and keybindings in config; worktrees and attachments in data; SQLite, identities, secrets, and logs in state; provider and desktop browser caches in cache; and live server discovery state in runtime.
- Propagate the exact resolved roots through desktop bootstrap, WSL isolation, background services, and self-update.
- Add **Settings → Diagnostics → Storage Locations** with the effective layout, all resolved paths, and copy controls.
- Document the storage model and override behavior.

## Why

The legacy tree mixes portable plaintext configuration, durable binary data, machine-local state, caches, and runtime files. That makes dotfile management difficult and made the earlier partial XDG implementation unsafe: an empty XDG startup could appear to replace a real legacy installation.

This change establishes the core storage contract first. It deliberately performs no migration: startup never copies, moves, deletes, or automatically switches existing data. A manual copy-based migration workflow can be designed separately once this contract is stable.

This supersedes #4419.

## UI Changes

Settings diagnostics now shows whether the connected server is using the split or legacy layout and lists configuration, data, state, cache, runtime, database, settings, keybindings, worktree, and attachment paths.

The flow was verified against a disposable `/tmp/t3code-test.*` environment. The page correctly identified the explicit legacy layout, stated that no data was moved or copied, and copied a selected path.

## Checklist

- [x] `vp fmt --check` for all 29 changed files
- [x] `vp lint --deny-warnings` for all changed TypeScript and TSX files
- [x] Typechecks for `@t3tools/shared`, `@t3tools/contracts`, `t3`, and `@t3tools/desktop`
- [x] 197 focused tests across shared path resolution, server configuration/services, desktop resolution/bootstrap, and server integration
- [x] Follow-up server typecheck, targeted lint/format checks, bundle build, and built CLI help verification for `--storage-layout`
- [x] Isolated web verification with `test-t3-app`
- [x] `git diff --check`

The full web typecheck still reports unrelated errors already present on the base revision in BranchToolbarBranchSelector, ModelPickerContent, PreviewAutomationHosts, and atom query helpers. The changed diagnostics UI passes lint and the integrated browser verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wrong layout selection or path mapping can point servers at empty split dirs or split primary/WSL storage; bootstrap-pinned roots and legacy artifact detection are critical to avoid data loss or duplicate env identity.
> 
> **Overview**
> Introduces a **split vs legacy** storage contract in `@t3tools/shared/storagePaths`, used by the server CLI, desktop app, bootstrap, and boot service. New installs default to platform-native five-root layouts (XDG on Linux, Application Support/Caches on macOS, roaming/local on Windows); existing `~/.t3` installs stay on the unified tree when real legacy artifacts are detected—no automatic migration.
> 
> **Server:** `resolveServerConfig` picks roots from env, `--base-dir`, `--storage-layout xdg|legacy`, and desktop bootstrap `storageRoots`; maps settings/keybindings to config, DB/secrets/logs to state, attachments/worktrees to data, caches separately, runtime files with symlink/owner checks on Linux split layouts. **Desktop:** `DesktopEnvironment` mirrors the same selection; split layout sets Electron `userData`/`cache` under state/cache; WSL backend strips Windows storage env vars so Linux does not share a DB via `/mnt/c`. **UI/docs:** Diagnostics shows effective storage paths; contracts expose `storage` on server config and bootstrap payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7270e82ccb610903290cafbfd0ccd177af5a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate configuration, data, state, cache, and runtime storage into XDG-compliant directories
> - Introduces split (XDG/platform-native) vs legacy (unified `T3CODE_HOME`) storage layouts across server, desktop, and shared packages, with automatic selection based on whether legacy artifacts exist on disk.
> - Adds `--storage-layout xdg|legacy` CLI flag and `T3CODE_CONFIG_DIR`, `T3CODE_DATA_DIR`, `T3CODE_STATE_DIR`, `T3CODE_CACHE_DIR`, `T3CODE_RUNTIME_DIR` environment variables to override individual directories.
> - Adds [`storagePaths.ts`](https://github.com/pingdotgg/t3code/pull/4437/files#diff-5379e781e9801fbd3bfee3995f22b22fc0f12c84443ac6a942ff376904474272) in `@t3tools/shared` with platform-aware helpers for resolving, overriding, and selecting storage roots across Windows/macOS/Linux.
> - On non-Windows with split layout, the runtime directory is created with mode `0700`, validated for ownership and symlink safety, and rejected if checks fail.
> - The generated systemd unit now sets `Environment=` lines for the active layout and uses `UnsetEnvironment=` to clear variables from the opposite layout.
> - A new Storage Locations section in Settings → Diagnostics displays the active layout and all resolved paths with copy-to-clipboard support.
> - Risk: Existing installations that lack legacy artifacts on disk will automatically migrate to split layout on next startup, changing the locations of `settings.json`, `keybindings.json`, attachments, and the provider status cache.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d7270e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->