### PR TITLE
fix: respect time format for sidebar snooze

### DIFF
--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -10,7 +10,7 @@ function localDate(year: number, month: number, day: number, hour: number, minut
 describe("resolveSnoozePresets", () => {
   it("offers hour, evening, tomorrow, next week in the morning", () => {
     // Wednesday 2026-04-08 10:00 local.
-    const presets = resolveSnoozePresets(localDate(2026, 4, 8, 10));
+    const presets = resolveSnoozePresets(localDate(2026, 4, 8, 10), "locale");
     expect(presets.map((preset) => preset.id)).toEqual([
       "hour",
       "evening",
@@ -30,7 +30,7 @@ describe("resolveSnoozePresets", () => {
   });
 
   it("whenLabel complements the label instead of repeating it", () => {
-    const presets = resolveSnoozePresets(localDate(2026, 4, 8, 10));
+    const presets = resolveSnoozePresets(localDate(2026, 4, 8, 10), "locale");
     for (const preset of presets) {
       // Day words live in the label column; the time column is time-only
       // (plus a weekday for next week, which names a different day).
@@ -43,24 +43,27 @@ describe("resolveSnoozePresets", () => {
   });
 
   it("drops the evening preset once evening is near or past", () => {
-    expect(resolveSnoozePresets(localDate(2026, 4, 8, 17, 30)).map((preset) => preset.id)).toEqual([
-      "hour",
-      "tomorrow",
-      "next-week",
-    ]);
-    expect(resolveSnoozePresets(localDate(2026, 4, 8, 21)).map((preset) => preset.id)).toEqual([
-      "hour",
-      "tomorrow",
-      "next-week",
-    ]);
+    expect(
+      resolveSnoozePresets(localDate(2026, 4, 8, 17, 30), "locale").map((preset) => preset.id),
+    ).toEqual(["hour", "tomorrow", "next-week"]);
+    expect(
+      resolveSnoozePresets(localDate(2026, 4, 8, 21), "locale").map((preset) => preset.id),
+    ).toEqual(["hour", "tomorrow", "next-week"]);
   });
 
   it("puts next week a full week out when today is Monday", () => {
     // Monday 2026-04-06.
-    const presets = resolveSnoozePresets(localDate(2026, 4, 6, 10));
+    const presets = resolveSnoozePresets(localDate(2026, 4, 6, 10), "locale");
     const nextWeek = new Date(presets.find((preset) => preset.id === "next-week")!.snoozedUntil);
     expect(nextWeek.getDay()).toBe(1);
     expect(nextWeek.getDate()).toBe(13);
+  });
+  it("formats preset times with the selected clock preference", () => {
+    const twelveHour = resolveSnoozePresets(localDate(2026, 4, 8, 10), "12-hour");
+    const twentyFourHour = resolveSnoozePresets(localDate(2026, 4, 8, 10), "24-hour");
+
+    expect(twelveHour.find((preset) => preset.id === "evening")!.whenLabel).toMatch(/PM/i);
+    expect(twentyFourHour.find((preset) => preset.id === "evening")!.whenLabel).toBe("18:00");
   });
 });
 
@@ -68,12 +71,23 @@ describe("snoozeWakeDescription", () => {
   const now = localDate(2026, 4, 8, 10);
 
   it("uses bare time today, 'tomorrow' next day, weekday within the week", () => {
-    expect(snoozeWakeDescription(localDate(2026, 4, 8, 18).toISOString(), now)).not.toContain(
+    expect(
+      snoozeWakeDescription(localDate(2026, 4, 8, 18).toISOString(), now, "locale"),
+    ).not.toContain("tomorrow");
+    expect(snoozeWakeDescription(localDate(2026, 4, 9, 9).toISOString(), now, "locale")).toContain(
       "tomorrow",
     );
-    expect(snoozeWakeDescription(localDate(2026, 4, 9, 9).toISOString(), now)).toContain(
-      "tomorrow",
+    expect(snoozeWakeDescription(localDate(2026, 4, 13, 9).toISOString(), now, "locale")).toMatch(
+      /Mon/,
     );
-    expect(snoozeWakeDescription(localDate(2026, 4, 13, 9).toISOString(), now)).toMatch(/Mon/);
+  });
+
+  it("formats wake descriptions with the selected clock preference", () => {
+    expect(snoozeWakeDescription(localDate(2026, 4, 8, 18).toISOString(), now, "12-hour")).toMatch(
+      /PM/i,
+    );
+    expect(snoozeWakeDescription(localDate(2026, 4, 8, 18).toISOString(), now, "24-hour")).toBe(
+      "18:00",
+    );
   });
 });

--- a/apps/web/src/components/Sidebar.snooze.ts
+++ b/apps/web/src/components/Sidebar.snooze.ts
@@ -1,22 +1,50 @@
-import { snoozeWakeLabel } from "@t3tools/client-runtime/state/thread-settled";
-import { parseTimestampDate } from "../timestampFormat";
-
-export {
-  resolveSnoozePresets,
+import type { TimestampFormat } from "@t3tools/contracts/settings";
+import {
+  resolveSnoozePresets as resolveSharedSnoozePresets,
+  snoozeWakeLabel,
   type SnoozePreset,
 } from "@t3tools/client-runtime/state/thread-settled";
-export { snoozeWakeLabel };
+
+import { formatShortTimestamp, parseTimestampDate } from "../timestampFormat";
+
+export { snoozeWakeLabel, type SnoozePreset };
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
+
+function timeOfDayLabel(date: Date, timestampFormat: TimestampFormat): string {
+  return formatShortTimestamp(date.toISOString(), timestampFormat);
+}
+
+export function resolveSnoozePresets(
+  now: Date,
+  timestampFormat: TimestampFormat,
+): ReadonlyArray<SnoozePreset> {
+  return resolveSharedSnoozePresets(now).map((preset) => {
+    const wake = parseTimestampDate(preset.snoozedUntil);
+    if (wake === null) return preset;
+    const time = timeOfDayLabel(wake, timestampFormat);
+    return {
+      ...preset,
+      whenLabel:
+        preset.id === "next-week"
+          ? `${wake.toLocaleDateString(undefined, { weekday: "short" })} ${time}`
+          : time,
+    };
+  });
+}
 
 /**
  * Human wake time for menus and toasts: "tomorrow 9:00", "Mon 9:00",
  * "17:30" (today).
  */
-export function snoozeWakeDescription(snoozedUntil: string, now: Date): string {
+export function snoozeWakeDescription(
+  snoozedUntil: string,
+  now: Date,
+  timestampFormat: TimestampFormat,
+): string {
   const wake = parseTimestampDate(snoozedUntil);
   if (wake === null) return "";
-  const time = wake.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  const time = timeOfDayLabel(wake, timestampFormat);
   const startOfToday = new Date(now);
   startOfToday.setHours(0, 0, 0, 0);
   const dayDelta = Math.floor((wake.getTime() - startOfToday.getTime()) / DAY_MS);

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -13,6 +13,7 @@ import {
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
 import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
+import type { TimestampFormat } from "@t3tools/contracts/settings";
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
@@ -341,11 +342,15 @@ function SnoozePopoverButton(props: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSnooze: (preset: SnoozePreset) => void;
+  timestampFormat: TimestampFormat;
 }) {
-  const { open, onOpenChange, onSnooze } = props;
+  const { open, onOpenChange, onSnooze, timestampFormat } = props;
   // Presets resolve at open time so "In 1 hour" is relative to the click,
   // not to when the row mounted.
-  const presets = useMemo(() => (open ? resolveSnoozePresets(new Date()) : []), [open]);
+  const presets = useMemo(
+    () => (open ? resolveSnoozePresets(new Date(), timestampFormat) : []),
+    [open, timestampFormat],
+  );
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger
@@ -412,6 +417,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   projectCwd: string | null;
   projectTitle: string | null;
   providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
+  timestampFormat: TimestampFormat;
   onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
   onThreadActivate: (threadRef: ScopedThreadRef) => void;
   onStartRename: (threadRef: ScopedThreadRef, title: string) => void;
@@ -1020,6 +1026,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                         open={snoozeMenuOpen}
                         onOpenChange={setSnoozeMenuOpen}
                         onSnooze={handleSnoozePreset}
+                        timestampFormat={props.timestampFormat}
                       />
                     ) : null}
                     {props.settlementSupported ? (
@@ -1207,6 +1214,7 @@ export default function SidebarV2() {
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const {
     settleThread,
@@ -2156,7 +2164,7 @@ export default function SidebarV2() {
           toastManager.add(
             stackedThreadToast({
               type: "success",
-              title: `Snoozed until ${snoozeWakeDescription(preset.snoozedUntil, new Date())}`,
+              title: `Snoozed until ${snoozeWakeDescription(preset.snoozedUntil, new Date(), timestampFormat)}`,
               timeout: 5_000,
               actionProps: {
                 children: "Undo",
@@ -2174,7 +2182,7 @@ export default function SidebarV2() {
         }
       })();
     },
-    [attemptUnsnooze, planForwardNavigation, snoozeThread],
+    [attemptUnsnooze, planForwardNavigation, snoozeThread, timestampFormat],
   );
 
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
@@ -2215,7 +2223,7 @@ export default function SidebarV2() {
         supportedCount: titleRegenerationThreads.length,
         actionableCount: regeneratableTitleThreads.length,
       });
-      const snoozePresets = resolveSnoozePresets(new Date());
+      const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
       const clicked = await settlePromise(() =>
         api.contextMenu.show(
           [
@@ -2352,6 +2360,7 @@ export default function SidebarV2() {
       removeFromSelection,
       serverConfigs,
       updateThreadMetadata,
+      timestampFormat,
     ],
   );
 
@@ -2391,7 +2400,7 @@ export default function SidebarV2() {
         const isSnoozed = snoozedThreadKeysRef.current.has(threadKey);
         const isPinned = thread.pinnedAt != null;
         // Presets resolve at menu-open time (same as the popover).
-        const snoozePresets = resolveSnoozePresets(new Date());
+        const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
             [
@@ -2590,6 +2599,7 @@ export default function SidebarV2() {
       serverConfigs,
       startThreadRename,
       updateThreadMetadata,
+      timestampFormat,
     ],
   );
 
@@ -2998,6 +3008,7 @@ export default function SidebarV2() {
                           ) ?? null
                         }
                         providerEntryByInstanceId={providerEntryByInstanceId}
+                        timestampFormat={timestampFormat}
                         onThreadClick={handleThreadClick}
                         onThreadActivate={navigateToThread}
                         onStartRename={startThreadRename}


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

Fixed the sidebar snooze time labels to respect the app’s Time format setting.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

Previously, the snooze menu and “Snoozed until …” toast formatted wake times directly with the browser locale, so users with `24-hour` selected could still see AM/PM labels. The change routes those labels through the shared timestamp formatter and passes the current `timestampFormat` setting into the snooze popover, context menus, and toast. Added tests covering both 12-hour and 24-hour snooze labels.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

Before:
<img width="476" height="298" alt="image" src="https://github.com/user-attachments/assets/73067f57-5a6d-4636-bdf5-7b8b99bc42a1" />

After:
<img width="502" height="302" alt="image" src="https://github.com/user-attachments/assets/369217cc-0df3-4cb5-9a4d-a490a9decd91" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to snooze label formatting with tests; no snooze scheduling or server behavior changes.
> 
> **Overview**
> **Snooze wake times in the sidebar now follow the user's Time format setting** (`12-hour`, `24-hour`, or `locale`) instead of always using the browser's `toLocaleTimeString`.
> 
> `Sidebar.snooze` still gets preset math from shared `resolveSnoozePresets`, but rewrites each preset's `whenLabel` through `formatShortTimestamp`. `snoozeWakeDescription` uses the same formatter for the time portion of success toasts and context-menu labels.
> 
> `SidebarV2` reads `timestampFormat` from client settings and passes it into the snooze popover, single- and bulk-snooze context menus, and the "Snoozed until …" toast. Tests cover 12-hour vs 24-hour output for presets and wake descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5862b9da0cb5135a49e193c819990bf26f3813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar snooze to respect 12-hour/24-hour time format preference
> - Adds a `TimestampFormat` parameter to `resolveSnoozePresets` and `snoozeWakeDescription` in [Sidebar.snooze.ts](https://github.com/pingdotgg/t3code/pull/4438/files#diff-aa08b135e6021ee4769614f1b47560550d1c612002868fa231671cc6dd92189c), replacing `toLocaleTimeString` with `formatShortTimestamp` for time rendering.
> - The `next-week` preset now prefixes a short weekday to the time (e.g., `Mon 09:00` or `Mon 9:00 AM`).
> - [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4438/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) reads `timestampFormat` from client settings and passes it through to snooze popovers, context menus, and toast notifications.
> - Behavioral Change: callers of `resolveSnoozePresets` and `snoozeWakeDescription` must now supply a `TimestampFormat` argument; the previously re-exported shared `resolveSnoozePresets` is replaced by a local wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d5862b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->