### PR TITLE
Increase light-mode contrast for user message bubbles

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -434,6 +434,7 @@ describe("MessagesTimeline", () => {
 
     expect(markup).not.toContain("Show full message");
     expect(markup).toContain('data-user-message-collapsible="false"');
+    expect(markup).toContain("rounded-2xl bg-accent p-3");
   });
 
   it("renders inline terminal labels with the composer chip UI", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -890,7 +890,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
 
   return (
     <div className="group flex flex-col items-end gap-1">
-      <div className="relative max-w-[80%] rounded-2xl bg-secondary p-3">
+      <div className="relative max-w-[80%] rounded-2xl bg-accent p-3">
         {regularImages.length > 0 && (
           <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
             {regularImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (


### PR DESCRIPTION
## Summary
- Change user message bubbles from `bg-secondary` to higher-contrast `bg-accent`.
- Add a regression assertion covering the updated bubble styling.

## Testing
- `MessagesTimeline.test.tsx` updated with a class-name assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on user message bubbles plus a test assertion; no logic, auth, or data paths touched.
> 
> **Overview**
> **User message bubbles** in the chat timeline use **`bg-accent`** instead of **`bg-secondary`**, so they read more clearly against the page background in light mode (especially where contrast with `secondary` was weak).
> 
> A **`MessagesTimeline`** test now asserts the short-message bubble markup includes **`rounded-2xl bg-accent p-3`**, so this styling does not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e44d0b2005dffda7586e2910c267c0da3a75761b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase light-mode contrast for user message bubbles by switching to `bg-accent`
> Changes the background color class on the `UserTimelineRow` message container in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/4441/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) from `bg-secondary` to `bg-accent` to improve contrast in light mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e44d0b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->