### PR TITLE
fix(web): hide conversation content behind composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5739,6 +5739,13 @@ function ChatViewContent(props: ChatViewProps) {
                   : "pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2"
               }
             >
+              {!isDraftHeroState && (
+                <div
+                  aria-hidden
+                  data-chat-composer-scrim="true"
+                  className="absolute inset-0 bg-background"
+                />
+              )}
               <div
                 ref={attachDraftHeroTransitionGroupRef}
                 className="chat-composer-horizontal-inset w-full"


### PR DESCRIPTION
## What Changed

Added an opaque background behind the docked composer so conversation content cannot appear through or below it.

Draft hero mode remains unchanged.

## Why

The composer overlay was transparent outside its visible controls, allowing underlying conversation text to remain visible. The scrim covers the complete docked overlay while keeping the composer above it.

## UI Changes

Before: Conversation text visible beneath the composer.

After: Conversation text is fully obscured by the composer area.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="904" height="510" alt="composer-overlay-before" src="https://github.com/user-attachments/assets/88d44065-1ab2-4329-a875-977c33f7e17b" />
 <td><img width="904" height="510" alt="composer-overlay-after" src="https://github.com/user-attachments/assets/39d83772-0dfc-481f-93ee-1bbc353cee7d" />
</table>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional UI layer in ChatView with no logic or data-path changes; low regression risk aside from minor visual stacking at the bottom of the thread.
> 
> **Overview**
> When the chat composer is **docked** at the bottom (not in empty-draft hero mode), the overlay now includes a full-area **`bg-background` scrim** (`data-chat-composer-scrim`) behind the interactive composer stack.
> 
> That blocks timeline messages from showing through the otherwise transparent parts of the composer overlay. **Draft hero** layout is unchanged—the scrim is not rendered when `isDraftHeroState` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 036b78cdfbdb6b775d74ab287cae2f8f54ae12c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide conversation content behind the chat composer overlay
> Adds a full-coverage background scrim div inside the composer overlay in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4443/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). The scrim renders only in the docked (non-draft-hero) state and sits behind the interactive composer content, preventing chat messages from showing through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 036b78c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->