### PR TITLE
Add client-only desktop backend mode

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,6 +1,8 @@
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 
@@ -11,6 +13,7 @@ import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
@@ -54,6 +57,17 @@ export class DesktopDevelopmentBackendPortRequiredError extends Schema.TaggedErr
 ) {
   override get message(): string {
     return "T3CODE_PORT is required in desktop development.";
+  }
+}
+
+export class DesktopRendererAssetsUnavailableError extends Schema.TaggedErrorClass<DesktopRendererAssetsUnavailableError>()(
+  "DesktopRendererAssetsUnavailableError",
+  {
+    candidates: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    return `The packaged desktop renderer was not found. Checked: ${this.candidates.join(", ")}.`;
   }
 }
 
@@ -136,21 +150,68 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
 
+const resolvePackagedClientRoot = Effect.fn("desktop.bootstrap.resolvePackagedClientRoot")(
+  function* (candidates: readonly string[]) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    for (const candidate of candidates) {
+      if (
+        yield* fileSystem
+          .exists(path.join(candidate, "index.html"))
+          .pipe(Effect.orElseSucceed(() => false))
+      ) {
+        return candidate;
+      }
+    }
+    return yield* new DesktopRendererAssetsUnavailableError({ candidates: [...candidates] });
+  },
+);
+
 const bootstrap = Effect.gen(function* () {
-  const pool = yield* DesktopBackendPool.DesktopBackendPool;
-  const primaryBackend = yield* pool.primary;
+  const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
   const state = yield* DesktopState.DesktopState;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
-  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-  const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
+  const backendMode = (yield* launchMode.get).effectiveMode;
   yield* logBootstrapInfo("bootstrap start");
+
+  if (backendMode === "client-only") {
+    if (environment.isDevelopment) {
+      yield* electronProtocol.registerDesktopProtocol({
+        scheme: ElectronProtocol.getDesktopScheme(true),
+        source: "proxy",
+        targetOrigin: Option.getOrThrow(environment.devServerUrl),
+        clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
+      });
+    } else {
+      const staticRoot = yield* resolvePackagedClientRoot(environment.packagedClientRootCandidates);
+      yield* electronProtocol.registerDesktopProtocol({
+        scheme: ElectronProtocol.getDesktopScheme(false),
+        source: "static",
+        staticRoot,
+        clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
+      });
+      yield* logBootstrapInfo("bootstrap resolved packaged renderer", { staticRoot });
+    }
+
+    yield* installDesktopIpcHandlers();
+    yield* logBootstrapInfo("bootstrap ipc handlers registered");
+    if (!(yield* Ref.get(state.quitting))) {
+      yield* desktopWindow.handleRendererReady;
+    }
+    return;
+  }
 
   if (environment.isDevelopment && Option.isNone(environment.configuredBackendPort)) {
     return yield* new DesktopDevelopmentBackendPortRequiredError();
   }
 
+  const pool = yield* DesktopBackendPool.DesktopBackendPool;
+  const primaryBackend = yield* pool.primary;
+  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+  const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const backendPortSelection = yield* resolveDesktopBackendPort(environment.configuredBackendPort);
   const backendPort = backendPortSelection.port;
   yield* logBootstrapInfo(
@@ -171,14 +232,13 @@ const bootstrap = Effect.gen(function* () {
   }
   const serverExposureState = yield* serverExposure.configureFromSettings({ port: backendPort });
   const backendConfig = yield* serverExposure.backendConfig;
-  const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
   const rendererTarget = environment.isDevelopment
     ? Option.getOrThrow(environment.devServerUrl)
     : backendConfig.httpBaseUrl;
   yield* electronProtocol.registerDesktopProtocol({
     scheme: ElectronProtocol.getDesktopScheme(environment.isDevelopment),
+    source: "proxy",
     targetOrigin: rendererTarget,
-    backendOrigin: backendConfig.httpBaseUrl,
     clerkFrontendApiHostname: DesktopClerk.desktopClerkFrontendApiHostname,
   });
   yield* logBootstrapInfo("bootstrap resolved backend endpoint", {
@@ -223,6 +283,7 @@ const startup = Effect.gen(function* () {
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
+  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
@@ -230,7 +291,13 @@ const startup = Effect.gen(function* () {
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
-  yield* desktopSettings.load;
+  const settings = yield* desktopSettings.load;
+  const launchMode = yield* backendMode.latch(settings.backendMode);
+  yield* logStartupInfo("desktop backend mode selected", {
+    effectiveMode: launchMode.effectiveMode,
+    configuredMode: launchMode.configuredMode,
+    ...(launchMode.cliOverride === null ? {} : { cliOverride: launchMode.cliOverride }),
+  });
 
   if (environment.platform === "linux") {
     yield* electronApp.appendCommandLineSwitch("class", environment.linuxWmClass);
@@ -261,6 +328,10 @@ const scopedProgram = Effect.scoped(
 
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
+        const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+        if ((yield* backendMode.get).effectiveMode === "client-only") {
+          return;
+        }
         const pool = yield* DesktopBackendPool.DesktopBackendPool;
         // Stop every backend in the pool, not just the primary. The
         // electronApp.quit() path can race ahead of the layer-scope

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -199,7 +199,13 @@ const bootstrap = Effect.gen(function* () {
     yield* installDesktopIpcHandlers();
     yield* logBootstrapInfo("bootstrap ipc handlers registered");
     if (!(yield* Ref.get(state.quitting))) {
-      yield* desktopWindow.handleRendererReady;
+      yield* desktopWindow.handleRendererReady.pipe(
+        Effect.catch((error) =>
+          logBootstrapWarning("failed to open main window after renderer readiness", {
+            error: error.message,
+          }),
+        ),
+      );
     }
     return;
   }

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -6,6 +6,7 @@ import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 
+import type { DesktopBackendMode as DesktopBackendModeValue } from "@t3tools/contracts";
 import * as NetService from "@t3tools/shared/Net";
 import * as Crypto from "effect/Crypto";
 import * as ElectronApp from "../electron/ElectronApp.ts";
@@ -150,6 +151,26 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
 
+export const latchDesktopBackendModeForStartup = Effect.fn(
+  "desktop.startup.latchDesktopBackendMode",
+)(function* (configuredMode: DesktopBackendModeValue) {
+  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
+  return yield* backendMode
+    .latch(configuredMode)
+    .pipe(Effect.catchCause((cause) => fatalStartupCause("backendMode", cause)));
+});
+
+export const handleClientOnlyRendererReady = <E extends { readonly message: string }>(
+  rendererReady: Effect.Effect<void, E>,
+): Effect.Effect<void, E> =>
+  rendererReady.pipe(
+    Effect.tapError((error) =>
+      logBootstrapWarning("failed to open main window after renderer readiness", {
+        error: error.message,
+      }),
+    ),
+  );
+
 const resolvePackagedClientRoot = Effect.fn("desktop.bootstrap.resolvePackagedClientRoot")(
   function* (candidates: readonly string[]) {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -199,13 +220,7 @@ const bootstrap = Effect.gen(function* () {
     yield* installDesktopIpcHandlers();
     yield* logBootstrapInfo("bootstrap ipc handlers registered");
     if (!(yield* Ref.get(state.quitting))) {
-      yield* desktopWindow.handleRendererReady.pipe(
-        Effect.catch((error) =>
-          logBootstrapWarning("failed to open main window after renderer readiness", {
-            error: error.message,
-          }),
-        ),
-      );
+      yield* handleClientOnlyRendererReady(desktopWindow.handleRendererReady);
     }
     return;
   }
@@ -289,7 +304,6 @@ const startup = Effect.gen(function* () {
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
-  const backendMode = yield* DesktopBackendMode.DesktopBackendMode;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
@@ -298,7 +312,7 @@ const startup = Effect.gen(function* () {
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   const settings = yield* desktopSettings.load;
-  const launchMode = yield* backendMode.latch(settings.backendMode);
+  const launchMode = yield* latchDesktopBackendModeForStartup(settings.backendMode);
   yield* logStartupInfo("desktop backend mode selected", {
     effectiveMode: launchMode.effectiveMode,
     configuredMode: launchMode.configuredMode,

--- a/apps/desktop/src/app/DesktopAppErrors.test.ts
+++ b/apps/desktop/src/app/DesktopAppErrors.test.ts
@@ -1,9 +1,22 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import {
   DesktopBackendPortUnavailableError,
   DesktopDevelopmentBackendPortRequiredError,
+  handleClientOnlyRendererReady,
+  latchDesktopBackendModeForStartup,
 } from "./DesktopApp.ts";
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopState from "./DesktopState.ts";
 
 describe("DesktopApp errors", () => {
   it("preserves unavailable backend port context", () => {
@@ -27,4 +40,59 @@ describe("DesktopApp errors", () => {
 
     assert.equal(error.message, "T3CODE_PORT is required in desktop development.");
   });
+
+  it.effect("propagates client-only window creation failures", () =>
+    Effect.gen(function* () {
+      const error = new Error("window creation failed");
+
+      const exit = yield* Effect.exit(handleClientOnlyRendererReady(Effect.fail(error)));
+      assert(Exit.isFailure(exit));
+      const failure = Cause.findErrorOption(exit.cause);
+      assert(Option.isSome(failure));
+      assert.strictEqual(failure.value, error);
+    }),
+  );
+
+  it.effect("reports invalid backend-mode launch arguments as fatal startup errors", () =>
+    Effect.gen(function* () {
+      const quitCount = yield* Ref.make(0);
+      const shownErrors = yield* Ref.make<readonly { title: string; content: string }[]>([]);
+
+      const layer = Layer.mergeAll(
+        DesktopBackendMode.layerTest(["electron", "--backend-mode=invalid"]),
+        DesktopShutdown.layer,
+        DesktopState.layer,
+        Layer.mock(ElectronApp.ElectronApp)({
+          quit: Ref.update(quitCount, (count) => count + 1),
+        }),
+        Layer.mock(ElectronDialog.ElectronDialog)({
+          showErrorBox: (title, content) =>
+            Ref.update(shownErrors, (errors) => [...errors, { title, content }]),
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const exit = yield* Effect.exit(latchDesktopBackendModeForStartup("managed"));
+        assert(Exit.isFailure(exit));
+        const failure = Cause.findErrorOption(exit.cause);
+        assert(Option.isSome(failure));
+        assert(
+          DesktopBackendMode.isDesktopBackendModeArgumentError(failure.value),
+          "expected the original backend mode argument error",
+        );
+
+        const errors = yield* Ref.get(shownErrors);
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0]?.title, "T3 Code failed to start");
+        assert.include(errors[0]?.content ?? "", "Stage: backendMode");
+        assert.include(errors[0]?.content ?? "", 'Invalid --backend-mode value "invalid"');
+        assert.equal(yield* Ref.get(quitCount), 1);
+
+        const state = yield* DesktopState.DesktopState;
+        assert.isTrue(yield* Ref.get(state.quitting));
+        const shutdown = yield* DesktopShutdown.DesktopShutdown;
+        yield* shutdown.awaitRequest;
+      }).pipe(Effect.provide(layer));
+    }),
+  );
 });

--- a/apps/desktop/src/app/DesktopBackendMode.test.ts
+++ b/apps/desktop/src/app/DesktopBackendMode.test.ts
@@ -1,0 +1,70 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import * as DesktopBackendMode from "./DesktopBackendMode.ts";
+
+describe("DesktopBackendMode", () => {
+  const captureThrown = (run: () => unknown): unknown => {
+    try {
+      run();
+    } catch (error) {
+      return error;
+    }
+    throw new Error("Expected the operation to throw.");
+  };
+
+  it("uses the persisted mode when no CLI override is present", () => {
+    assert.deepEqual(DesktopBackendMode.resolveDesktopBackendModeState([], "client-only"), {
+      effectiveMode: "client-only",
+      configuredMode: "client-only",
+      cliOverride: null,
+    });
+  });
+
+  it("gives the CLI override precedence without changing the configured mode", () => {
+    assert.deepEqual(
+      DesktopBackendMode.resolveDesktopBackendModeState(
+        ["electron", "main.cjs", "--backend-mode=client-only"],
+        "managed",
+      ),
+      {
+        effectiveMode: "client-only",
+        configuredMode: "managed",
+        cliOverride: "client-only",
+      },
+    );
+  });
+
+  it("accepts a separate flag value", () => {
+    assert.equal(
+      DesktopBackendMode.parseDesktopBackendModeOverride(["electron", "--backend-mode", "managed"]),
+      "managed",
+    );
+  });
+
+  it.each([
+    ["--backend-mode=other", "invalid-value"],
+    ["--backend-mode=", "missing-value"],
+    ["--backend-mode", "missing-value"],
+  ])("rejects invalid launch argument %s", (argument, reason) => {
+    const error = captureThrown(() =>
+      DesktopBackendMode.parseDesktopBackendModeOverride(["electron", argument]),
+    );
+    assert.isTrue(DesktopBackendMode.isDesktopBackendModeArgumentError(error));
+    if (DesktopBackendMode.isDesktopBackendModeArgumentError(error)) {
+      assert.equal(error.reason, reason);
+    }
+  });
+
+  it("rejects repeated overrides", () => {
+    const error = captureThrown(() =>
+      DesktopBackendMode.parseDesktopBackendModeOverride([
+        "--backend-mode=managed",
+        "--backend-mode=client-only",
+      ]),
+    );
+    assert.isTrue(DesktopBackendMode.isDesktopBackendModeArgumentError(error));
+    if (DesktopBackendMode.isDesktopBackendModeArgumentError(error)) {
+      assert.equal(error.reason, "repeated");
+    }
+  });
+});

--- a/apps/desktop/src/app/DesktopBackendMode.ts
+++ b/apps/desktop/src/app/DesktopBackendMode.ts
@@ -1,0 +1,128 @@
+import {
+  type DesktopBackendMode as DesktopBackendModeValue,
+  type DesktopBackendModeState,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+
+const BACKEND_MODE_FLAG = "--backend-mode";
+
+export class DesktopBackendModeArgumentError extends Schema.TaggedErrorClass<DesktopBackendModeArgumentError>()(
+  "DesktopBackendModeArgumentError",
+  {
+    value: Schema.NullOr(Schema.String),
+    reason: Schema.Literals(["missing-value", "invalid-value", "repeated"]),
+  },
+) {
+  override get message(): string {
+    if (this.reason === "missing-value") {
+      return `${BACKEND_MODE_FLAG} requires either "managed" or "client-only".`;
+    }
+    if (this.reason === "repeated") {
+      return `${BACKEND_MODE_FLAG} may only be specified once.`;
+    }
+    return `Invalid ${BACKEND_MODE_FLAG} value ${JSON.stringify(this.value)}. Expected "managed" or "client-only".`;
+  }
+}
+
+export const isDesktopBackendModeArgumentError = Schema.is(DesktopBackendModeArgumentError);
+
+function parseBackendMode(value: string | undefined): DesktopBackendModeValue {
+  if (value === undefined || value.length === 0) {
+    throw new DesktopBackendModeArgumentError({
+      value: value ?? null,
+      reason: "missing-value",
+    });
+  }
+  if (value === "managed" || value === "client-only") {
+    return value;
+  }
+  throw new DesktopBackendModeArgumentError({
+    value,
+    reason: "invalid-value",
+  });
+}
+
+export function parseDesktopBackendModeOverride(
+  argv: readonly string[],
+): DesktopBackendModeValue | null {
+  let override: DesktopBackendModeValue | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === undefined) continue;
+
+    let value: string | undefined;
+    if (argument === BACKEND_MODE_FLAG) {
+      value = argv[index + 1];
+      index += 1;
+    } else if (argument.startsWith(`${BACKEND_MODE_FLAG}=`)) {
+      value = argument.slice(BACKEND_MODE_FLAG.length + 1);
+    } else {
+      continue;
+    }
+
+    if (override !== null) {
+      throw new DesktopBackendModeArgumentError({
+        value: value ?? null,
+        reason: "repeated",
+      });
+    }
+    override = parseBackendMode(value);
+  }
+
+  return override;
+}
+
+export function resolveDesktopBackendModeState(
+  argv: readonly string[],
+  configuredMode: DesktopBackendModeValue,
+): DesktopBackendModeState {
+  const cliOverride = parseDesktopBackendModeOverride(argv);
+  return {
+    effectiveMode: cliOverride ?? configuredMode,
+    configuredMode,
+    cliOverride,
+  };
+}
+
+export class DesktopBackendMode extends Context.Service<
+  DesktopBackendMode,
+  {
+    readonly latch: (
+      configuredMode: DesktopBackendModeValue,
+    ) => Effect.Effect<DesktopBackendModeState, DesktopBackendModeArgumentError>;
+    readonly get: Effect.Effect<DesktopBackendModeState>;
+  }
+>()("@t3tools/desktop/app/DesktopBackendMode") {}
+
+export const make = Effect.fn("desktop.backendMode.make")(function* (argv: readonly string[]) {
+  const stateRef = yield* Ref.make<DesktopBackendModeState>({
+    effectiveMode: "managed",
+    configuredMode: "managed",
+    cliOverride: null,
+  });
+
+  return DesktopBackendMode.of({
+    latch: (configuredMode) =>
+      Effect.try({
+        try: () => resolveDesktopBackendModeState(argv, configuredMode),
+        catch: (cause) =>
+          isDesktopBackendModeArgumentError(cause)
+            ? cause
+            : new DesktopBackendModeArgumentError({
+                value: null,
+                reason: "invalid-value",
+              }),
+      }).pipe(Effect.tap((state) => Ref.set(stateRef, state))),
+    get: Ref.get(stateRef),
+  });
+});
+
+export const layer = Layer.effect(DesktopBackendMode, make(process.argv));
+
+export const layerTest = (argv: readonly string[] = []) =>
+  Layer.effect(DesktopBackendMode, make(argv));

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -67,6 +67,10 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.appRoot, "/repo");
       assert.equal(environment.backendEntryPath, "/repo/apps/server/dist/bin.mjs");
       assert.equal(environment.backendCwd, "/repo");
+      assert.deepEqual(environment.packagedClientRootCandidates, [
+        "/Applications/T3 Code.app/Contents/Resources/app.asar/apps/server/dist/client",
+        "/Applications/T3 Code.app/Contents/Resources/app.asar.unpacked/apps/server/dist/client",
+      ]);
       assert.equal(environment.appUserModelId, "com.t3tools.t3code.dev");
       assert.equal(environment.linuxWmClass, "t3code-dev");
       assert.deepEqual(

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -53,6 +53,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly appRoot: string;
     readonly backendEntryPath: string;
     readonly backendCwd: string;
+    readonly packagedClientRootCandidates: readonly string[];
     readonly preloadPath: string;
     readonly appUpdateYmlPath: string;
     readonly devServerUrl: Option.Option<URL>;
@@ -188,6 +189,10 @@ const make = Effect.fn("desktop.environment.make")(function* (
     appRoot,
     backendEntryPath: path.join(appRoot, "apps/server/dist/bin.mjs"),
     backendCwd: input.isPackaged ? homeDirectory : appRoot,
+    packagedClientRootCandidates: [
+      path.join(input.appPath, "apps/server/dist/client"),
+      path.join(resourcesPath, "app.asar.unpacked/apps/server/dist/client"),
+    ],
     preloadPath: path.join(input.dirname, "preload.cjs"),
     appUpdateYmlPath: input.isPackaged
       ? path.join(resourcesPath, "app-update.yml")

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -1,0 +1,98 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import * as DesktopLifecycle from "./DesktopLifecycle.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopState from "./DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronTheme from "../electron/ElectronTheme.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+
+function makeRuntimeLayer(input: {
+  readonly events: string[];
+  readonly shutdownFailure?: Error;
+  readonly exitFailure?: Error;
+}) {
+  return Layer.mergeAll(
+    DesktopState.layer,
+    Layer.succeed(
+      DesktopEnvironment.DesktopEnvironment,
+      DesktopEnvironment.DesktopEnvironment.of({
+        isDevelopment: false,
+      } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]),
+    ),
+    Layer.succeed(
+      DesktopShutdown.DesktopShutdown,
+      DesktopShutdown.DesktopShutdown.of({
+        request: Effect.sync(() => {
+          input.events.push("shutdown-requested");
+        }),
+        awaitComplete: input.shutdownFailure
+          ? Effect.die(input.shutdownFailure)
+          : Effect.sync(() => {
+              input.events.push("shutdown-complete");
+            }),
+      } as unknown as DesktopShutdown.DesktopShutdown["Service"]),
+    ),
+    Layer.succeed(
+      DesktopWindow.DesktopWindow,
+      DesktopWindow.DesktopWindow.of({
+        flushMainWindowBounds: Effect.void,
+      } as unknown as DesktopWindow.DesktopWindow["Service"]),
+    ),
+    Layer.succeed(
+      ElectronApp.ElectronApp,
+      ElectronApp.ElectronApp.of({
+        relaunch: () =>
+          Effect.sync(() => {
+            input.events.push("relaunch-scheduled");
+          }),
+        exit: () =>
+          input.exitFailure
+            ? Effect.die(input.exitFailure)
+            : Effect.sync(() => {
+                input.events.push("exit");
+              }),
+      } as unknown as ElectronApp.ElectronApp["Service"]),
+    ),
+    Layer.succeed(
+      ElectronTheme.ElectronTheme,
+      ElectronTheme.ElectronTheme.of({} as ElectronTheme.ElectronTheme["Service"]),
+    ),
+  );
+}
+
+describe("DesktopLifecycle.relaunch", () => {
+  it.effect("surfaces shutdown failures after scheduling the replacement process", () => {
+    const shutdownFailure = new Error("shutdown failed");
+    const events: string[] = [];
+
+    return Effect.gen(function* () {
+      const error = yield* DesktopLifecycle.make
+        .relaunch("backendMode=client-only")
+        .pipe(Effect.flip);
+
+      assert.instanceOf(error, DesktopLifecycle.DesktopLifecycleRelaunchError);
+      assert.strictEqual(Cause.squash(error.cause as Cause.Cause<unknown>), shutdownFailure);
+      assert.deepEqual(events, ["relaunch-scheduled", "shutdown-requested"]);
+    }).pipe(Effect.provide(makeRuntimeLayer({ events, shutdownFailure })));
+  });
+
+  it.effect("surfaces exit failures instead of completing the relaunch early", () => {
+    const exitFailure = new Error("exit failed");
+    const events: string[] = [];
+
+    return Effect.gen(function* () {
+      const error = yield* DesktopLifecycle.make
+        .relaunch("backendMode=client-only")
+        .pipe(Effect.flip);
+
+      assert.instanceOf(error, DesktopLifecycle.DesktopLifecycleRelaunchError);
+      assert.strictEqual(Cause.squash(error.cause as Cause.Cause<unknown>), exitFailure);
+      assert.deepEqual(events, ["relaunch-scheduled", "shutdown-requested", "shutdown-complete"]);
+    }).pipe(Effect.provide(makeRuntimeLayer({ events, exitFailure })));
+  });
+});

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -170,10 +170,9 @@ export const make = DesktopLifecycle.of({
     }).pipe(
       Effect.catchCause((cause) => {
         const error = new DesktopLifecycleRelaunchError({ reason, cause });
-        return logLifecycleError(error.message, { error });
+        return Effect.fail(error);
       }),
-      Effect.forkDetach,
-      Effect.asVoid,
+      Effect.tapError((error) => logLifecycleError(error.message, { error })),
     );
   }),
   register: Effect.gen(function* () {

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -43,7 +43,7 @@ export class DesktopLifecycle extends Context.Service<
   {
     readonly relaunch: (
       reason: string,
-    ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
+    ) => Effect.Effect<void, DesktopLifecycleRelaunchError, DesktopLifecycleRuntimeServices>;
     readonly register: Effect.Effect<void, never, Scope.Scope | DesktopLifecycleRuntimeServices>;
   }
 >()("@t3tools/desktop/app/DesktopLifecycle") {}
@@ -146,6 +146,18 @@ export const make = DesktopLifecycle.of({
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
     const state = yield* DesktopState.DesktopState;
     yield* logLifecycleInfo("desktop relaunch requested", { reason });
+    if (!environment.isDevelopment) {
+      yield* electronApp
+        .relaunch({
+          execPath: process.execPath,
+          args: process.argv.slice(1),
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.fail(new DesktopLifecycleRelaunchError({ reason, cause })),
+          ),
+        );
+    }
     yield* Effect.gen(function* () {
       yield* Effect.yieldNow;
       yield* Ref.set(state.quitting, true);
@@ -154,10 +166,6 @@ export const make = DesktopLifecycle.of({
         yield* electronApp.exit(75);
         return;
       }
-      yield* electronApp.relaunch({
-        execPath: process.execPath,
-        args: process.argv.slice(1),
-      });
       yield* electronApp.exit(0);
     }).pipe(
       Effect.catchCause((cause) => {

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -403,6 +403,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
   const state = yield* Ref.make(initialState);
+  const startRequestedRef = yield* Ref.make(false);
   const mutex = yield* Semaphore.make(1);
 
   const { logWarning: logInstanceWarning, logError: logInstanceError } =
@@ -442,6 +443,7 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
   const start: Effect.Effect<void> = Effect.suspend(() =>
     mutex.withPermits(1)(
       Effect.gen(function* () {
+        yield* Ref.set(startRequestedRef, true);
         const current = yield* Ref.get(state);
         if (Option.isSome(current.active)) {
           return;
@@ -805,7 +807,11 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
       Effect.map(Option.getOrElse(() => false)),
     );
 
-  yield* Effect.addFinalizer(() => stop());
+  yield* Effect.addFinalizer(() =>
+    Ref.get(startRequestedRef).pipe(
+      Effect.flatMap((startRequested) => (startRequested ? stop() : Effect.void)),
+    ),
+  );
 
   return {
     id: spec.id,

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -74,6 +74,7 @@ function makePoolLayer(
           activate: Effect.die("unexpected window activate"),
           createMainIfBackendReady: Effect.die("unexpected window create"),
           showConnectingSplash: Effect.void,
+          handleRendererReady: Effect.void,
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
           flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -251,6 +251,7 @@ describe("DesktopServerExposure", () => {
       get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
       load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
       setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+      setBackendMode: () => Effect.die("unexpected backend mode update"),
       setServerExposureMode: () => Effect.fail(settingsFailure),
       setTailscaleServe: () => Effect.fail(settingsFailure),
       setUpdateChannel: () => Effect.die("unexpected update channel change"),

--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -36,8 +36,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code-dev",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3774/"),
             clerkFrontendApiHostname: "clerk.t3.codes",
           });
           assert.isDefined(handler);
@@ -100,8 +100,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
           return yield* Effect.promise(() => handler!(new Request("t3code://other/")));
@@ -128,8 +128,8 @@ describe("ElectronProtocol", () => {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
             scheme: "t3code-dev",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:5733/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
           return yield* Effect.promise(() => handler!(new Request("t3code-dev://app/")));
@@ -152,8 +152,8 @@ describe("ElectronProtocol", () => {
       const error = yield* Effect.scoped(
         protocol.registerDesktopProtocol({
           scheme: "t3code-dev",
+          source: "proxy",
           targetOrigin: new URL("http://127.0.0.1:3773/"),
-          backendOrigin: new URL("http://127.0.0.1:3774/"),
           clerkFrontendApiHostname: undefined,
         }),
       ).pipe(Effect.flip);
@@ -177,8 +177,8 @@ describe("ElectronProtocol", () => {
         Effect.scoped(
           protocol.registerDesktopProtocol({
             scheme: "t3code",
+            source: "proxy",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
-            backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           }),
         ),
@@ -198,8 +198,8 @@ describe("ElectronProtocol", () => {
   it("keeps executable sources host-restricted while allowing runtime network resources", () => {
     const policy = ElectronProtocol.makeDesktopContentSecurityPolicy({
       scheme: "t3code",
+      source: "proxy",
       targetOrigin: new URL("http://127.0.0.1:3773/"),
-      backendOrigin: new URL("http://127.0.0.1:3773/"),
       clerkFrontendApiHostname: "clerk.t3.codes",
     });
     const directives = Object.fromEntries(
@@ -226,4 +226,117 @@ describe("ElectronProtocol", () => {
     ]);
     assert.deepEqual(directives["font-src"], ["'self'", "t3code:", "data:"]);
   });
+
+  it.effect("serves packaged assets, SPA routes, HEAD requests, and CSP", () =>
+    Effect.gen(function* () {
+      let handler: ((request: Request) => Promise<Response>) | undefined;
+      handleMock.mockImplementation((_scheme, nextHandler) => {
+        handler = nextHandler;
+      });
+      netFetchMock.mockImplementation(async (url: string) => {
+        if (url.endsWith("/index.html")) {
+          return new Response("<main>T3 Code</main>", { status: 200 });
+        }
+        if (url.endsWith("/assets/app-123.js")) {
+          return new Response("export {};", { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const protocol = yield* ElectronProtocol.ElectronProtocol;
+          yield* protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            source: "static",
+            staticRoot: "/opt/t3/apps/server/dist/client",
+            clerkFrontendApiHostname: undefined,
+          });
+          assert.isDefined(handler);
+
+          const root = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(root.status, 200);
+          assert.equal(root.headers.get("content-type"), "text/html; charset=utf-8");
+          assert.include(root.headers.get("content-security-policy") ?? "", "default-src 'self'");
+          assert.equal(yield* Effect.promise(() => root.text()), "<main>T3 Code</main>");
+
+          const asset = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/assets/app-123.js")),
+          );
+          assert.equal(asset.headers.get("content-type"), "text/javascript; charset=utf-8");
+          assert.equal(yield* Effect.promise(() => asset.text()), "export {};");
+
+          const route = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/settings/connections", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(route.status, 200);
+          assert.equal(yield* Effect.promise(() => route.text()), "<main>T3 Code</main>");
+
+          const head = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/assets/app-123.js", {
+                method: "HEAD",
+              }),
+            ),
+          );
+          assert.equal(head.status, 200);
+          assert.equal(yield* Effect.promise(() => head.text()), "");
+        }),
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
+
+  it.effect("does not fall back missing assets and rejects unsafe static requests", () =>
+    Effect.gen(function* () {
+      let handler: ((request: Request) => Promise<Response>) | undefined;
+      handleMock.mockImplementation((_scheme, nextHandler) => {
+        handler = nextHandler;
+      });
+      netFetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const protocol = yield* ElectronProtocol.ElectronProtocol;
+          yield* protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            source: "static",
+            staticRoot: "/opt/t3/apps/server/dist/client",
+            clerkFrontendApiHostname: undefined,
+          });
+          assert.isDefined(handler);
+
+          const missingAsset = yield* Effect.promise(() =>
+            handler!(
+              new Request("t3code://app/assets/missing.js", {
+                headers: { accept: "text/html" },
+              }),
+            ),
+          );
+          assert.equal(missingAsset.status, 404);
+          assert.equal(netFetchMock.mock.calls.length, 1);
+
+          const traversal = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/%2e%2e%2fsecret.txt")),
+          );
+          assert.equal(traversal.status, 403);
+
+          const unsupported = yield* Effect.promise(() =>
+            handler!(new Request("t3code://app/", { method: "POST" })),
+          );
+          assert.equal(unsupported.status, 405);
+          assert.equal(unsupported.headers.get("allow"), "GET, HEAD");
+        }),
+      );
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
 });

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -1,3 +1,4 @@
+// @effect-diagnostics nodeBuiltinImport:off - Electron static protocol handlers require synchronous platform path validation.
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -5,6 +6,8 @@ import * as NodeTimersPromises from "node:timers/promises";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
 
 import * as Electron from "electron";
 
@@ -48,12 +51,22 @@ export class ElectronProtocolUnregistrationError extends Schema.TaggedErrorClass
   }
 }
 
-export interface DesktopProtocolRegistrationInput {
+interface DesktopProtocolRegistrationBase {
   readonly scheme: string;
-  readonly targetOrigin: URL;
-  readonly backendOrigin: URL;
   readonly clerkFrontendApiHostname: string | undefined;
 }
+
+export type DesktopProtocolRegistrationInput = DesktopProtocolRegistrationBase &
+  (
+    | {
+        readonly source: "proxy";
+        readonly targetOrigin: URL;
+      }
+    | {
+        readonly source: "static";
+        readonly staticRoot: string;
+      }
+  );
 
 export class ElectronProtocol extends Context.Service<
   ElectronProtocol,
@@ -102,6 +115,143 @@ function withContentSecurityPolicy(response: Response, policy: string): Response
     statusText: response.statusText,
     headers,
   });
+}
+
+const STATIC_CONTENT_TYPES: Readonly<Record<string, string>> = {
+  ".css": "text/css; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+type StaticPathResolution =
+  | { readonly _tag: "Invalid"; readonly status: 400 | 403 }
+  | { readonly _tag: "Resolved"; readonly path: string; readonly relativePath: string };
+
+export function resolveDesktopStaticPath(
+  staticRoot: string,
+  encodedPathname: string,
+): StaticPathResolution {
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(encodedPathname);
+  } catch {
+    return { _tag: "Invalid", status: 400 };
+  }
+
+  if (
+    decodedPathname.includes("\0") ||
+    decodedPathname.includes("\\") ||
+    /^[a-zA-Z]:/u.test(decodedPathname.replace(/^\/+/u, ""))
+  ) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  const segments = decodedPathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  const relativePath = segments.length === 0 ? "index.html" : segments.join("/");
+  const normalizedRoot = NodePath.resolve(staticRoot);
+  const resolvedPath = NodePath.resolve(normalizedRoot, relativePath);
+  const relativeToRoot = NodePath.relative(normalizedRoot, resolvedPath);
+  if (
+    relativeToRoot === ".." ||
+    relativeToRoot.startsWith(`..${NodePath.sep}`) ||
+    NodePath.isAbsolute(relativeToRoot)
+  ) {
+    return { _tag: "Invalid", status: 403 };
+  }
+
+  return {
+    _tag: "Resolved",
+    path: resolvedPath,
+    relativePath,
+  };
+}
+
+function shouldUseSpaFallback(request: Request, relativePath: string): boolean {
+  if (NodePath.extname(relativePath) !== "") {
+    return false;
+  }
+  const accept = request.headers.get("accept") ?? "";
+  const mode = request.headers.get("sec-fetch-mode") ?? "";
+  return mode === "navigate" || accept.includes("text/html");
+}
+
+async function fetchStaticFile(path: string): Promise<Response> {
+  try {
+    return await Electron.net.fetch(NodeURL.pathToFileURL(path).href, { method: "GET" });
+  } catch {
+    return new Response(null, { status: 404 });
+  }
+}
+
+function withStaticResponseHeaders(response: Response, path: string, headOnly: boolean): Response {
+  const headers = new Headers(response.headers);
+  const contentType = STATIC_CONTENT_TYPES[NodePath.extname(path).toLowerCase()];
+  if (contentType !== undefined) {
+    headers.set("Content-Type", contentType);
+  }
+  return new Response(headOnly ? null : response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function serveDesktopStaticRequest(
+  request: Request,
+  staticRoot: string,
+  contentSecurityPolicy: string,
+): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  if (requestUrl.host !== DESKTOP_HOST) {
+    return withContentSecurityPolicy(new Response(null, { status: 404 }), contentSecurityPolicy);
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return withContentSecurityPolicy(
+      new Response(null, {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      }),
+      contentSecurityPolicy,
+    );
+  }
+
+  const resolution = resolveDesktopStaticPath(staticRoot, requestUrl.pathname);
+  if (resolution._tag === "Invalid") {
+    return withContentSecurityPolicy(
+      new Response(null, { status: resolution.status }),
+      contentSecurityPolicy,
+    );
+  }
+
+  let response = await fetchStaticFile(resolution.path);
+  let responsePath = resolution.path;
+  if (response.status === 404 && shouldUseSpaFallback(request, resolution.relativePath)) {
+    // Resolve the shell through the same normalization as asset paths so a
+    // relative or non-normalized staticRoot still falls back correctly.
+    responsePath = NodePath.resolve(staticRoot, "index.html");
+    response = await fetchStaticFile(responsePath);
+  }
+
+  return withContentSecurityPolicy(
+    withStaticResponseHeaders(response, responsePath, request.method === "HEAD"),
+    contentSecurityPolicy,
+  );
 }
 
 async function proxyRequest(
@@ -181,9 +331,12 @@ export const make = Effect.gen(function* () {
       yield* Effect.acquireRelease(
         Effect.try({
           try: () => {
-            Electron.protocol.handle(input.scheme, (request) =>
-              proxyRequest(request, input.targetOrigin, contentSecurityPolicy),
-            );
+            Electron.protocol.handle(input.scheme, (request) => {
+              if (input.source === "static") {
+                return serveDesktopStaticRequest(request, input.staticRoot, contentSecurityPolicy);
+              }
+              return proxyRequest(request, input.targetOrigin, contentSecurityPolicy);
+            });
           },
           catch: (cause) => new ElectronProtocolRegistrationError({ scheme: input.scheme, cause }),
         }).pipe(Effect.andThen(Ref.set(registered, true))),

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 
 import * as DesktopIpc from "./DesktopIpc.ts";
 import { getClientSettings, setClientSettings } from "./methods/clientSettings.ts";
+import { getBackendModeState, setBackendMode } from "./methods/backendMode.ts";
 import {
   clearConnectionCatalog,
   getConnectionCatalog,
@@ -49,9 +50,11 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* PreviewIpc.installPreviewEventForwarding();
 
   yield* ipc.handleSync(getAppBranding);
+  yield* ipc.handleSync(getBackendModeState);
   yield* ipc.handleSync(getWindowFullscreenState);
   yield* ipc.handleSync(getLocalEnvironmentBootstraps);
   yield* ipc.handle(getLocalEnvironmentBearerToken);
+  yield* ipc.handle(setBackendMode);
 
   yield* ipc.handle(getClientSettings);
   yield* ipc.handle(setClientSettings);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -13,6 +13,8 @@ export const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 export const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 export const UPDATE_CHECK_CHANNEL = "desktop:update-check";
 export const GET_APP_BRANDING_CHANNEL = "desktop:get-app-branding";
+export const GET_BACKEND_MODE_STATE_CHANNEL = "desktop:get-backend-mode-state";
+export const SET_BACKEND_MODE_CHANNEL = "desktop:set-backend-mode";
 export const GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL = "desktop:get-local-environment-bootstraps";
 export const GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL =
   "desktop:get-local-environment-bearer-token";

--- a/apps/desktop/src/ipc/methods/backendMode.test.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.test.ts
@@ -1,0 +1,47 @@
+import { DesktopBackendModeStateSchema } from "@t3tools/contracts";
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
+import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
+import { setBackendMode } from "./backendMode.ts";
+
+const decodeBackendModeState = Schema.decodeUnknownEffect(DesktopBackendModeStateSchema);
+
+const unusedLifecycleRuntimeLayer =
+  Layer.empty as Layer.Layer<DesktopLifecycle.DesktopLifecycleRuntimeServices>;
+
+describe("backend mode IPC", () => {
+  it.effect("rejects the update when a packaged relaunch cannot be scheduled", () => {
+    const relaunchError = new DesktopLifecycle.DesktopLifecycleRelaunchError({
+      reason: "backendMode=client-only",
+      cause: Cause.die(new Error("relaunch failed")),
+    });
+    const layer = Layer.mergeAll(
+      DesktopBackendMode.layerTest(),
+      DesktopAppSettings.layerTest(),
+      Layer.succeed(
+        DesktopLifecycle.DesktopLifecycle,
+        DesktopLifecycle.DesktopLifecycle.of({
+          relaunch: () => Effect.fail(relaunchError),
+          register: Effect.void,
+        }),
+      ),
+      unusedLifecycleRuntimeLayer,
+    );
+
+    return Effect.gen(function* () {
+      const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+      yield* launchMode.latch("managed");
+      const error = yield* setBackendMode
+        .handler("client-only")
+        .pipe(Effect.flatMap(decodeBackendModeState), Effect.flip);
+
+      assert.strictEqual(error, relaunchError);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/desktop/src/ipc/methods/backendMode.test.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.test.ts
@@ -16,7 +16,7 @@ const unusedLifecycleRuntimeLayer =
   Layer.empty as Layer.Layer<DesktopLifecycle.DesktopLifecycleRuntimeServices>;
 
 describe("backend mode IPC", () => {
-  it.effect("rejects the update when a packaged relaunch cannot be scheduled", () => {
+  it.effect("restores the configured mode when a packaged relaunch cannot be scheduled", () => {
     const relaunchError = new DesktopLifecycle.DesktopLifecycleRelaunchError({
       reason: "backendMode=client-only",
       cause: Cause.die(new Error("relaunch failed")),
@@ -36,12 +36,14 @@ describe("backend mode IPC", () => {
 
     return Effect.gen(function* () {
       const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+      const settings = yield* DesktopAppSettings.DesktopAppSettings;
       yield* launchMode.latch("managed");
       const error = yield* setBackendMode
         .handler("client-only")
         .pipe(Effect.flatMap(decodeBackendModeState), Effect.flip);
 
       assert.strictEqual(error, relaunchError);
+      assert.equal((yield* settings.get).backendMode, "managed");
     }).pipe(Effect.provide(layer));
   });
 });

--- a/apps/desktop/src/ipc/methods/backendMode.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.ts
@@ -1,0 +1,60 @@
+import {
+  DesktopBackendModeSchema,
+  DesktopBackendModeStateSchema,
+  type DesktopBackendModeState,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
+import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
+import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+import * as IpcChannels from "../channels.ts";
+
+const readBackendModeState: Effect.Effect<
+  DesktopBackendModeState,
+  never,
+  DesktopBackendMode.DesktopBackendMode | DesktopAppSettings.DesktopAppSettings
+> = Effect.gen(function* () {
+  const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+  const settings = yield* DesktopAppSettings.DesktopAppSettings;
+  const launchState = yield* launchMode.get;
+  const configuredMode = (yield* settings.get).backendMode;
+  return {
+    ...launchState,
+    configuredMode,
+  };
+});
+
+export const getBackendModeState = DesktopIpc.makeSyncIpcMethod({
+  channel: IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL,
+  result: DesktopBackendModeStateSchema,
+  handler: Effect.fn("desktop.ipc.backendMode.get")(function* () {
+    return yield* readBackendModeState;
+  }),
+});
+
+export const setBackendMode = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.SET_BACKEND_MODE_CHANNEL,
+  payload: DesktopBackendModeSchema,
+  result: DesktopBackendModeStateSchema,
+  handler: Effect.fn("desktop.ipc.backendMode.set")(function* (mode) {
+    const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+    const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+    const settings = yield* DesktopAppSettings.DesktopAppSettings;
+    const change = yield* settings.setBackendMode(mode);
+    const launchState = yield* launchMode.get;
+    const state = {
+      ...launchState,
+      configuredMode: change.settings.backendMode,
+    };
+    if (
+      change.changed &&
+      launchState.cliOverride === null &&
+      launchState.effectiveMode !== change.settings.backendMode
+    ) {
+      yield* lifecycle.relaunch(`backendMode=${mode}`);
+    }
+    return state;
+  }),
+});

--- a/apps/desktop/src/ipc/methods/backendMode.ts
+++ b/apps/desktop/src/ipc/methods/backendMode.ts
@@ -42,6 +42,7 @@ export const setBackendMode = DesktopIpc.makeIpcMethod({
     const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
     const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
     const settings = yield* DesktopAppSettings.DesktopAppSettings;
+    const previousMode = (yield* settings.get).backendMode;
     const change = yield* settings.setBackendMode(mode);
     const launchState = yield* launchMode.get;
     const state = {
@@ -53,7 +54,9 @@ export const setBackendMode = DesktopIpc.makeIpcMethod({
       launchState.cliOverride === null &&
       launchState.effectiveMode !== change.settings.backendMode
     ) {
-      yield* lifecycle.relaunch(`backendMode=${mode}`);
+      yield* lifecycle
+        .relaunch(`backendMode=${mode}`)
+        .pipe(Effect.tapError(() => settings.setBackendMode(previousMode)));
     }
     return state;
   }),

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -7,6 +7,7 @@ import type * as Electron from "electron";
 
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import { getLocalEnvironmentBootstraps, getWindowFullscreenState } from "./window.ts";
 
@@ -64,7 +65,14 @@ describe("getLocalEnvironmentBootstraps", () => {
           bootstrapToken: "bootstrap-token",
         },
       ]);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([defaultWslInstance]))),
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([defaultWslInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    ),
   );
 
   it.effect("publishes a pending bootstrap only while a transient retry is scheduled", () => {
@@ -99,7 +107,14 @@ describe("getLocalEnvironmentBootstraps", () => {
           wsBaseUrl: null,
         },
       ]);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([retryingInstance])));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([retryingInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    );
   });
 
   it.effect("omits a bounded transient bootstrap after retries stop", () => {
@@ -127,8 +142,30 @@ describe("getLocalEnvironmentBootstraps", () => {
     return Effect.gen(function* () {
       const result = yield* getLocalEnvironmentBootstraps.handler();
       assert.deepEqual(result, []);
-    }).pipe(Effect.provide(DesktopBackendPool.layerTest([stoppedInstance])));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([stoppedInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    );
   });
+
+  it.effect("returns no local bootstraps in client-only mode", () =>
+    Effect.gen(function* () {
+      const mode = yield* DesktopBackendMode.DesktopBackendMode;
+      yield* mode.latch("client-only");
+      assert.deepEqual(yield* getLocalEnvironmentBootstraps.handler(), []);
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          DesktopBackendPool.layerTest([defaultWslInstance]),
+          DesktopBackendMode.layerTest(),
+        ),
+      ),
+    ),
+  );
 });
 
 describe("getWindowFullscreenState", () => {

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -12,6 +12,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as DesktopBackendMode from "../../app/DesktopBackendMode.ts";
 import * as DesktopLocalEnvironmentAuth from "../../backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "../../settings/DesktopAppSettings.ts";
@@ -69,6 +70,10 @@ export const getLocalEnvironmentBootstraps = DesktopIpc.makeSyncIpcMethod({
   channel: IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL,
   result: Schema.Array(DesktopEnvironmentBootstrapSchema),
   handler: Effect.fn("desktop.ipc.window.getLocalEnvironmentBootstraps")(function* () {
+    const launchMode = yield* DesktopBackendMode.DesktopBackendMode;
+    if ((yield* launchMode.get).effectiveMode === "client-only") {
+      return [];
+    }
     const pool = yield* DesktopBackendPool.DesktopBackendPool;
     const instances = yield* pool.list;
     const bootstraps: DesktopEnvironmentBootstrap[] = [];

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -31,6 +31,7 @@ import * as ElectronTheme from "./electron/ElectronTheme.ts";
 import * as ElectronUpdater from "./electron/ElectronUpdater.ts";
 import * as ElectronWindow from "./electron/ElectronWindow.ts";
 import * as DesktopApp from "./app/DesktopApp.ts";
+import * as DesktopBackendMode from "./app/DesktopBackendMode.ts";
 import * as DesktopAppIdentity from "./app/DesktopAppIdentity.ts";
 import * as DesktopConnectionCatalogStore from "./app/DesktopConnectionCatalogStore.ts";
 import * as DesktopClerk from "./app/DesktopClerk.ts";
@@ -125,6 +126,7 @@ const electronLayer = Layer.mergeAll(
 const desktopFoundationLayer = Layer.mergeAll(
   DesktopState.layer,
   DesktopShutdown.layer,
+  DesktopBackendMode.layer,
   DesktopAppSettings.layer,
   DesktopClientSettings.layer,
   DesktopConnectionCatalogStore.layer.pipe(Layer.provideMerge(DesktopSavedEnvironments.layer)),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -38,9 +38,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   getBackendModeState: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL);
     if (typeof result !== "object" || result === null) {
+      // An unavailable mode handler means the renderer cannot safely assume
+      // that this process owns a backend. Fail closed into the connection-only
+      // routing path instead of trying to resolve t3code:// as an HTTP backend.
       return {
-        effectiveMode: "managed",
-        configuredMode: "managed",
+        effectiveMode: "client-only",
+        configuredMode: "client-only",
         cliOverride: null,
       };
     }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -35,6 +35,18 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     }
     return result as ReturnType<DesktopBridge["getAppBranding"]>;
   },
+  getBackendModeState: () => {
+    const result = ipcRenderer.sendSync(IpcChannels.GET_BACKEND_MODE_STATE_CHANNEL);
+    if (typeof result !== "object" || result === null) {
+      return {
+        effectiveMode: "managed",
+        configuredMode: "managed",
+        cliOverride: null,
+      };
+    }
+    return result as ReturnType<DesktopBridge["getBackendModeState"]>;
+  },
+  setBackendMode: (mode) => ipcRenderer.invoke(IpcChannels.SET_BACKEND_MODE_CHANNEL, mode),
   getLocalEnvironmentBootstraps: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAPS_CHANNEL);
     if (!Array.isArray(result)) {

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -11,6 +11,7 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "./DesktopAppSettings.ts";
 
 const DesktopSettingsPatch = Schema.Struct({
+  backendMode: Schema.optionalKey(Schema.Literals(["managed", "client-only"])),
   mainWindowBounds: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({
@@ -102,6 +103,7 @@ describe("DesktopSettings", () => {
     assert.deepEqual(
       DesktopAppSettings.resolveDefaultDesktopSettings("0.0.17-nightly.20260415.1"),
       {
+        backendMode: "managed",
         mainWindowBounds: null,
         mainWindowMaximized: false,
         serverExposureMode: "local-only",
@@ -121,6 +123,7 @@ describe("DesktopSettings", () => {
       Effect.gen(function* () {
         const settings = yield* DesktopAppSettings.DesktopAppSettings;
         yield* writeSettingsPatch({
+          backendMode: "client-only",
           serverExposureMode: "network-accessible",
           tailscaleServeEnabled: true,
           tailscaleServePort: 8443,
@@ -129,6 +132,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "client-only",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
@@ -156,6 +160,10 @@ describe("DesktopSettings", () => {
         assert.isTrue(updateChannel.changed);
         assert.equal(updateChannel.settings.updateChannel, "nightly");
         assert.equal(updateChannel.settings.updateChannelConfiguredByUser, true);
+
+        const backendMode = yield* settings.setBackendMode("managed");
+        assert.isTrue(backendMode.changed);
+        assert.equal(backendMode.settings.backendMode, "managed");
       }),
     ),
   );
@@ -235,6 +243,7 @@ describe("DesktopSettings", () => {
         );
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: { x: 120, y: 80, width: 1280, height: 900 },
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
@@ -277,11 +286,13 @@ describe("DesktopSettings", () => {
 
         yield* settings.setMainWindowBounds({ x: -1200, y: 40, width: 1440, height: 960 }, true);
         yield* settings.setServerExposureMode("network-accessible");
+        yield* settings.setBackendMode("client-only");
 
         const persisted = yield* decodeDesktopSettingsPatch(
           yield* fileSystem.readFileString(environment.desktopSettingsPath),
         );
         assert.deepEqual(persisted, {
+          backendMode: "client-only",
           mainWindowBounds: { x: -1200, y: 40, width: 1440, height: 960 },
           mainWindowMaximized: true,
           serverExposureMode: "network-accessible",
@@ -300,6 +311,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
@@ -327,6 +339,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
@@ -353,6 +366,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          backendMode: "managed",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -1,6 +1,8 @@
 import {
   DesktopServerExposureModeSchema,
+  DesktopBackendModeSchema,
   DesktopUpdateChannelSchema,
+  type DesktopBackendMode,
   type DesktopServerExposureMode,
   type DesktopUpdateChannel,
 } from "@t3tools/contracts";
@@ -20,6 +22,7 @@ import { resolveDefaultDesktopUpdateChannel } from "../updates/updateChannels.ts
 import { isValidDistroName } from "../wsl/wslPathParsing.ts";
 
 export interface DesktopSettings {
+  readonly backendMode: DesktopBackendMode;
   readonly mainWindowBounds: DesktopWindowBounds | null;
   readonly mainWindowMaximized: boolean;
   readonly serverExposureMode: DesktopServerExposureMode;
@@ -67,6 +70,7 @@ export const DEFAULT_MAIN_WINDOW_SIZE = {
 } as const;
 
 export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
+  backendMode: "managed",
   mainWindowBounds: null,
   mainWindowMaximized: false,
   serverExposureMode: "local-only",
@@ -87,6 +91,7 @@ const DesktopWindowBoundsDocument = Schema.Struct({
 });
 
 const DesktopSettingsDocument = Schema.Struct({
+  backendMode: Schema.optionalKey(DesktopBackendModeSchema),
   mainWindowBounds: Schema.optionalKey(Schema.NullOr(DesktopWindowBoundsDocument)),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(DesktopServerExposureModeSchema),
@@ -147,6 +152,9 @@ export class DesktopAppSettings extends Context.Service<
     readonly setMainWindowBounds: (
       bounds: DesktopWindowBounds,
       isMaximized: boolean,
+    ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
+    readonly setBackendMode: (
+      mode: DesktopBackendMode,
     ) => Effect.Effect<DesktopSettingsChange, DesktopSettingsWriteError>;
     readonly setServerExposureMode: (
       mode: DesktopServerExposureMode,
@@ -216,6 +224,7 @@ function normalizeDesktopSettingsDocument(
     (parsed.wslBackendEnabled === undefined && parsed.wslMode === "wsl");
 
   return {
+    backendMode: parsed.backendMode === "client-only" ? "client-only" : "managed",
     mainWindowBounds,
     mainWindowMaximized: mainWindowBounds !== null && parsed.mainWindowMaximized === true,
     serverExposureMode:
@@ -238,6 +247,9 @@ function toDesktopSettingsDocument(
 ): DesktopSettingsDocument {
   const document: Mutable<DesktopSettingsDocument> = {};
 
+  if (settings.backendMode !== defaults.backendMode) {
+    document.backendMode = settings.backendMode;
+  }
   if (settings.mainWindowBounds !== null) {
     document.mainWindowBounds = settings.mainWindowBounds;
   }
@@ -281,6 +293,18 @@ function setServerExposureMode(
     : {
         ...settings,
         serverExposureMode: requestedMode,
+      };
+}
+
+function setBackendMode(
+  settings: DesktopSettings,
+  requestedMode: DesktopBackendMode,
+): DesktopSettings {
+  return settings.backendMode === requestedMode
+    ? settings
+    : {
+        ...settings,
+        backendMode: requestedMode,
       };
 }
 
@@ -506,6 +530,10 @@ export const make = Effect.gen(function* () {
           },
         }),
       ),
+    setBackendMode: (mode) =>
+      persist((settings) => setBackendMode(settings, mode)).pipe(
+        Effect.withSpan("desktop.settings.setBackendMode", { attributes: { mode } }),
+      ),
     setServerExposureMode: (mode) =>
       persist((settings) => setServerExposureMode(settings, mode)).pipe(
         Effect.withSpan("desktop.settings.setServerExposureMode", { attributes: { mode } }),
@@ -565,6 +593,7 @@ export const layerTest = (initialSettings: DesktopSettings = DEFAULT_DESKTOP_SET
         load: SynchronizedRef.get(settingsRef),
         setMainWindowBounds: (bounds, isMaximized) =>
           update((settings) => setMainWindowBounds(settings, bounds, isMaximized)),
+        setBackendMode: (mode) => update((settings) => setBackendMode(settings, mode)),
         setServerExposureMode: (mode) =>
           update((settings) => setServerExposureMode(settings, mode)),
         setTailscaleServe: (input) => update((settings) => setTailscaleServe(settings, input)),

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -159,6 +159,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
         get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
         load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
         setMainWindowBounds: () => Effect.die("unexpected main window bounds update"),
+        setBackendMode: () => Effect.die("unexpected backend mode update"),
         setServerExposureMode: () => Effect.die("unexpected server exposure update"),
         setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
         setUpdateChannel: () => Effect.fail(setUpdateChannelError),

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -74,6 +74,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     activate: Effect.void,
     createMainIfBackendReady: Effect.void,
     showConnectingSplash: Effect.void,
+    handleRendererReady: Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: Effect.void,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -211,6 +211,7 @@ function makeTestLayer(input: {
         }
         return { settings: desktopSettings, changed };
       }),
+    setBackendMode: () => Effect.die("unexpected backend mode update"),
     setServerExposureMode: () => Effect.die("unexpected server exposure update"),
     setTailscaleServe: () => Effect.die("unexpected Tailscale Serve update"),
     setUpdateChannel: () => Effect.die("unexpected update channel change"),
@@ -434,6 +435,26 @@ describe("DesktopWindow", () => {
         assert.deepEqual(fakeWindow.setAutoHideCursor.mock.calls, [[false]]);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("opens once the renderer is ready without a backend callback", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleRendererReady;
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -66,6 +66,9 @@ export class DesktopWindow extends Context.Service<
     // mode), before the WSL backend that serves the renderer is ready. It is
     // dismissed automatically once the real main window reveals.
     readonly showConnectingSplash: Effect.Effect<void>;
+    // Marks the packaged/Vite renderer as loadable independently of whether
+    // this desktop process owns a backend.
+    readonly handleRendererReady: Effect.Effect<void, DesktopWindowError>;
     // Marks the primary backend as ready so `createMainIfBackendReady` and the
     // macOS "activate without windows" path may open the real main window. The
     // renderer now always loads the local client URL (getDesktopUrl) and connects
@@ -728,6 +731,11 @@ export const make = Effect.gen(function* () {
     Effect.withSpan("desktop.window.showConnectingSplash"),
   );
 
+  const handleRendererReady = Ref.set(backendReadyRef, true).pipe(
+    Effect.andThen(createMainIfBackendReady),
+    Effect.withSpan("desktop.window.handleRendererReady"),
+  );
+
   return DesktopWindow.of({
     createMain,
     ensureMain,
@@ -755,10 +763,10 @@ export const make = Effect.gen(function* () {
     }).pipe(Effect.withSpan("desktop.window.activate")),
     createMainIfBackendReady,
     showConnectingSplash,
+    handleRendererReady,
     handleBackendReady: Effect.fn("desktop.window.handleBackendReady")(function* (httpBaseUrl) {
-      yield* Ref.set(backendReadyRef, true);
       yield* logWindowInfo("backend ready", { source: "http", url: httpBaseUrl.href });
-      yield* createMainIfBackendReady;
+      yield* handleRendererReady;
     }),
     handleBackendNotReady: Ref.set(backendReadyRef, false).pipe(
       Effect.withSpan("desktop.window.handleBackendNotReady"),

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,4 +1,3 @@
-import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   useEffect,
@@ -13,7 +12,8 @@ import { isElectron } from "../env";
 import { getLocalStorageItem } from "../hooks/useLocalStorage";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { useClientSettings } from "../hooks/useSettings";
 import ThreadSidebar from "./Sidebar";
 import ThreadSidebarV2 from "./SidebarV2";
@@ -59,7 +59,7 @@ function readInitialThreadSidebarWidth(): number {
 }
 
 function SidebarControl() {
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const { toggleSidebar } = useSidebar();
   const isSidebarVisible = useSidebarVisibility();
   const stageBackdropVariant = useSidebarStageBackdropVariant();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -42,7 +42,6 @@ import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/proje
 import { truncate } from "@t3tools/shared/String";
 import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
-import { useAtomValue } from "@effect/atom-react";
 import {
   lazy,
   memo,
@@ -201,12 +200,8 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerKeybindingsAtom,
-  primaryServerSettingsAtom,
-  serverEnvironment,
-} from "../state/server";
+import { serverEnvironment } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
@@ -1194,10 +1189,6 @@ function ChatViewContent(props: ChatViewProps) {
     (store) => store.threadLastVisitedAtById[routeThreadKey],
   );
   const settings = useEnvironmentSettings(environmentId);
-  // New-thread defaults live in the primary environment's settings.json (the
-  // settings UI never writes to remote environments), so read them from the
-  // primary server rather than the thread's environment.
-  const primaryServerSettings = useAtomValue(primaryServerSettingsAtom);
   const setStickyComposerModelSelection = useComposerDraftStore(
     (store) => store.setStickyModelSelection,
   );
@@ -1836,11 +1827,9 @@ function ChatViewContent(props: ChatViewProps) {
     selectedProvider: selectedProviderByThreadId,
     threadProvider,
   });
-  // Once a thread selects an environment, never substitute the primary
-  // environment's config while the selected environment is still loading.
-  const serverConfig = activeThread
-    ? (activeEnvironment?.serverConfig ?? null)
-    : (primaryEnvironment?.serverConfig ?? null);
+  // Once a thread or draft selects an environment, never substitute another
+  // environment's config while the selected one is still loading.
+  const serverConfig = environmentById.get(environmentId)?.serverConfig ?? null;
   const versionMismatch = resolveServerConfigVersionMismatch(serverConfig);
   const versionMismatchDismissKey =
     versionMismatch && activeThread
@@ -2362,8 +2351,8 @@ function ChatViewContent(props: ChatViewProps) {
           input: { cwd: gitStatusCwd },
         }),
   );
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
+  const keybindings = serverConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
+  const availableEditors = serverConfig?.availableEditors ?? [];
   // Prefer an instance-id match so a custom Codex instance (e.g.
   // `codex_personal`) surfaces its own status/message in the banner rather
   // than the default Codex's. Falls back to first-match-by-kind when no
@@ -3848,7 +3837,7 @@ function ChatViewContent(props: ChatViewProps) {
     ? (draftThread?.startFromOrigin ?? false)
     : canOverrideServerThreadEnvMode
       ? (pendingServerThreadStartFromOriginByThreadId[activeThread?.id ?? ""] ??
-        primaryServerSettings.newWorktreesStartFromOrigin)
+        settings.newWorktreesStartFromOrigin)
       : false;
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
@@ -5472,7 +5461,7 @@ function ChatViewContent(props: ChatViewProps) {
           envMode: mode,
           startFromOrigin: resolveNewDraftStartFromOrigin({
             envMode: mode,
-            newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+            newWorktreesStartFromOrigin: settings.newWorktreesStartFromOrigin,
           }),
           ...(mode === "worktree" && draftThread?.worktreePath ? { worktreePath: null } : {}),
         });
@@ -5484,7 +5473,7 @@ function ChatViewContent(props: ChatViewProps) {
       composerDraftTarget,
       draftThread?.worktreePath,
       isLocalDraftThread,
-      primaryServerSettings.newWorktreesStartFromOrigin,
+      settings.newWorktreesStartFromOrigin,
       setPendingServerThreadEnvMode,
       scheduleComposerFocus,
       setDraftThreadContext,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -42,7 +42,6 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
-import { useAtomValue } from "@effect/atom-react";
 
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
@@ -113,7 +112,8 @@ import { CommandPaletteResults } from "./CommandPaletteResults";
 import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
-import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { resolveDefaultProviderModelSelection } from "../providerInstances";
 import { resolveShortcutCommand, threadJumpIndexFromCommand } from "../keybindings";
 import {
@@ -390,7 +390,7 @@ export function CommandPalette({ children }: { children: ReactNode }) {
   const openAddProject = useCallback(() => dispatch({ _tag: "OpenAddProject" }), []);
   const openNewThreadIn = useCallback(() => dispatch({ _tag: "OpenNewThreadIn" }), []);
   const clearOpenIntent = useCallback(() => dispatch({ _tag: "ClearOpenIntent" }), []);
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const composerHandleRef = useRef<ChatComposerHandle | null>(null);
   const routeTarget = useParams({
     strict: false,
@@ -502,8 +502,9 @@ function OpenCommandPaletteDialog(props: {
   const projects = useProjects();
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const providers = useAtomValue(primaryServerProvidersAtom);
+  const defaultServerConfig = useDefaultServerConfig();
+  const keybindings = defaultServerConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
+  const providers = defaultServerConfig?.providers ?? [];
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
   const [browseGeneration, setBrowseGeneration] = useState(0);

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -56,7 +56,11 @@ import { useEnvironmentQuery } from "../state/query";
 import { sourceControlEnvironment } from "../state/sourceControl";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
@@ -492,6 +496,7 @@ function OpenCommandPaletteDialog(props: {
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
   const projects = useProjects();
@@ -540,12 +545,14 @@ function OpenCommandPaletteDialog(props: {
         projects: clientSettings.sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
     [
       clientSettings.sidebarProjectSortOrder,
       environmentLabelById,
       orderedProjects,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projects,

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -1,11 +1,14 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
 import { DownloadIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { type ProviderDriverKind, type ProviderInstanceId } from "@t3tools/contracts";
+import {
+  type ProviderDriverKind,
+  type ProviderInstanceId,
+  type ServerProvider,
+} from "@t3tools/contracts";
 
-import { primaryServerProvidersAtom, serverEnvironment } from "../state/server";
-import { usePrimaryEnvironment } from "../state/environments";
+import { serverEnvironment } from "../state/server";
+import { useDefaultEnvironmentId, useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { useDismissedProviderUpdateNotificationKeys } from "../providerUpdateDismissal";
 import { PROVIDER_ICON_BY_PROVIDER } from "./chat/providerIconUtils";
 import {
@@ -24,6 +27,7 @@ import { stackedThreadToast, toastManager } from "./ui/toast";
 import { useAtomCommand } from "../state/use-atom-command";
 
 const seenProviderUpdateNotificationKeys = new Set<string>();
+const EMPTY_SERVER_PROVIDERS: ReadonlyArray<ServerProvider> = [];
 type ProviderUpdateToastId = ReturnType<typeof toastManager.add>;
 
 type ActiveProviderUpdateToast =
@@ -112,8 +116,8 @@ function isTerminalProviderUpdateToastView(view: ProviderUpdateToastView) {
  */
 export function ProviderUpdatePrimaryNotification() {
   const navigate = useNavigate();
-  const providers = useAtomValue(primaryServerProvidersAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
+  const defaultEnvironmentId = useDefaultEnvironmentId();
+  const providers = useDefaultServerConfig()?.providers ?? EMPTY_SERVER_PROVIDERS;
   const updateProvider = useAtomCommand(serverEnvironment.updateProvider, {
     reportFailure: false,
   });
@@ -212,7 +216,7 @@ export function ProviderUpdatePrimaryNotification() {
     };
 
     const runUpdates = () => {
-      if (updateStarted || oneClickProviders.length === 0 || !primaryEnvironment) {
+      if (updateStarted || oneClickProviders.length === 0 || defaultEnvironmentId === null) {
         return;
       }
       updateStarted = true;
@@ -238,7 +242,7 @@ export function ProviderUpdatePrimaryNotification() {
         for (const provider of oneClickProviders) {
           results.push(
             await updateProvider({
-              environmentId: primaryEnvironment.environmentId,
+              environmentId: defaultEnvironmentId,
               input: {
                 provider: provider.driver,
                 instanceId: provider.instanceId,
@@ -327,7 +331,7 @@ export function ProviderUpdatePrimaryNotification() {
     notificationKey,
     oneClickProviders,
     openProviderSettings,
-    primaryEnvironment,
+    defaultEnvironmentId,
     updateProviders,
   ]);
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -22,7 +22,6 @@ import {
   ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
-import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -198,7 +197,8 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -3024,7 +3024,7 @@ export default function Sidebar() {
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
       : false,
   );
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
     [],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -71,6 +71,7 @@ import {
   type SidebarThreadSortOrder,
 } from "@t3tools/contracts/settings";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
+import { isRemoteEnvironmentId } from "../environmentPresence";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
@@ -114,7 +115,13 @@ import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
-import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironment,
+  useEnvironmentPresenceScope,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../state/environments";
 import {
   buildThreadRouteParams,
   resolveActiveThreadRouteRef,
@@ -382,9 +389,8 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
     reportFailure: false,
   });
   const environment = useEnvironment(thread.environmentId);
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const isRemoteThread =
-    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  const presenceScope = useEnvironmentPresenceScope();
+  const isRemoteThread = isRemoteEnvironmentId(thread.environmentId, presenceScope);
   const remoteEnvLabel = environment?.label ?? null;
   // A desktop-local secondary backend (e.g. the WSL backend) shows up as a
   // bearer environment whose connection id is prefixed "local:". It runs on the
@@ -3037,6 +3043,7 @@ export default function Sidebar() {
   const shortcutModifiers = useShortcutModifierState();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const environmentLabelById = useMemo(
     () =>
       new Map(
@@ -3091,6 +3098,7 @@ export default function Sidebar() {
       projects: orderedProjects,
       settings: projectGroupingSettings,
       primaryEnvironmentId,
+      ownsLocalEnvironment,
       resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       isDesktopLocalEnvironment: (environmentId) => desktopLocalEnvironmentIds.has(environmentId),
     });
@@ -3098,6 +3106,7 @@ export default function Sidebar() {
     environmentLabelById,
     desktopLocalEnvironmentIds,
     orderedProjects,
+    ownsLocalEnvironment,
     projectGroupingSettings,
     primaryEnvironmentId,
   ]);

--- a/apps/web/src/components/SidebarStageBackdrop.tsx
+++ b/apps/web/src/components/SidebarStageBackdrop.tsx
@@ -1,9 +1,8 @@
-import { useAtomValue } from "@effect/atom-react";
 import { useId } from "react";
 
 import { APP_STAGE_LABEL } from "../branding";
 import { resolveServerBackedAppStageLabel } from "../branding.logic";
-import { primaryServerConfigAtom } from "../state/server";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 
 export type SidebarStageBackdropVariant = "nightly" | "dev";
 
@@ -21,8 +20,7 @@ export function resolveSidebarStageBackdropVariant(
 }
 
 export function useSidebarStageBackdropVariant(): SidebarStageBackdropVariant | null {
-  const primaryServerVersion =
-    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const primaryServerVersion = useDefaultServerConfig()?.environment.serverVersion ?? null;
 
   return resolveSidebarStageBackdropVariant(
     resolveServerBackedAppStageLabel({

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -88,7 +88,8 @@ import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
-import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { useEnvironmentPresenceScope, useEnvironments } from "../state/environments";
+import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "../environmentPresence";
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
@@ -371,7 +372,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   wokeAt: string | null;
   isActive: boolean;
   jumpLabel: string | null;
-  currentEnvironmentId: string | null;
+  presenceScope: EnvironmentPresenceScope;
   environmentLabel: string | null;
   projectCwd: string | null;
   projectTitle: string | null;
@@ -523,8 +524,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
 
-  const isRemote =
-    props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
+  const isRemote = isRemoteEnvironmentId(thread.environmentId, props.presenceScope);
 
   const detailsTooltip = (
     <SidebarV2ThreadTooltip
@@ -1046,7 +1046,8 @@ export default function SidebarV2() {
     [],
   );
   const { environments } = useEnvironments();
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const presenceScope = useEnvironmentPresenceScope();
+  const { ownsLocalEnvironment, primaryEnvironmentId } = presenceScope;
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
@@ -1098,11 +1099,13 @@ export default function SidebarV2() {
         projects: sidebarProjectSortOrder === "manual" ? orderedProjects : projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
       }),
     [
       environmentLabelById,
       orderedProjects,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projects,
@@ -2427,7 +2430,7 @@ export default function SidebarV2() {
                       wokeAt={threadWokeAt(thread, { now: snoozeNow })}
                       isActive={routeThreadKey === threadKey}
                       jumpLabel={showJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null}
-                      currentEnvironmentId={primaryEnvironmentId}
+                      presenceScope={presenceScope}
                       environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
                       projectCwd={
                         projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -91,7 +91,7 @@ import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironmentPresenceScope, useEnvironments } from "../state/environments";
 import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "../environmentPresence";
 import { useProjects, useThreadShells } from "../state/entities";
-import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
+import { environmentServerConfigsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
 import { projectEnvironment } from "../state/projects";
@@ -136,7 +136,8 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import { deriveProviderInstanceEntries, type ProviderInstanceEntry } from "../providerInstances";
-import { primaryServerProvidersAtom } from "../state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { CommandDialogTrigger } from "./ui/command";
 import { Button } from "./ui/button";
@@ -1001,7 +1002,8 @@ export default function SidebarV2() {
   const threads = useThreadShells();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const defaultServerConfig = useDefaultServerConfig();
+  const keybindings = defaultServerConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
@@ -1116,7 +1118,7 @@ export default function SidebarV2() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverProviders = defaultServerConfig?.providers ?? [];
   const providerEntryByInstanceId = useMemo(
     () =>
       new Map(

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -6,7 +6,8 @@ import {
 import type { VcsStatusResult } from "@t3tools/contracts";
 import { CloudIcon, FolderGit2Icon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
-import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
+import { isRemoteEnvironmentId } from "../environmentPresence";
+import { useEnvironment, useEnvironmentPresenceScope } from "../state/environments";
 import { useProject } from "../state/entities";
 import { useEnvironmentQuery } from "../state/query";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
@@ -301,9 +302,8 @@ export function ThreadRowTrailingStatus({ thread }: { thread: SidebarThreadSumma
     threadId: thread.id,
   });
   const environment = useEnvironment(thread.environmentId);
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const isRemoteThread =
-    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  const presenceScope = useEnvironmentPresenceScope();
+  const isRemoteThread = isRemoteEnvironmentId(thread.environmentId, presenceScope);
   const remoteEnvLabel = environment?.label ?? null;
   const threadEnvironmentLabel = isRemoteThread ? (remoteEnvLabel ?? "Remote") : null;
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -12,7 +12,11 @@ import {
   buildSidebarProjectSnapshots,
 } from "~/sidebarProjectGrouping";
 import { useProjects, useThreadShells } from "~/state/entities";
-import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import {
+  useAppOwnsLocalEnvironment,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "~/state/environments";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
   Menu,
@@ -37,6 +41,7 @@ export function DraftHeroHeadline({
   const threads = useThreadShells();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projectSortOrder = useClientSettings((settings) => settings.sidebarProjectSortOrder);
   const handleNewThread = useNewThreadHandler();
@@ -56,6 +61,7 @@ export function DraftHeroHeadline({
           projects,
           settings: projectGroupingSettings,
           primaryEnvironmentId,
+          ownsLocalEnvironment,
           resolveEnvironmentLabel: (environmentId) =>
             environmentLabelById.get(environmentId) ?? null,
         }),
@@ -64,6 +70,7 @@ export function DraftHeroHeadline({
       ),
     [
       environmentLabelById,
+      ownsLocalEnvironment,
       primaryEnvironmentId,
       projectGroupingSettings,
       projectSortOrder,

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.environment.test.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.environment.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const settingsHooks = vi.hoisted(() => ({
   read: vi.fn(() => ({ providerInstances: {} })),
-  update: vi.fn(() => vi.fn()),
+  persist: vi.fn(() => vi.fn()),
 }));
 
 const hooks = vi.hoisted(() => {
@@ -62,7 +62,7 @@ vi.mock("react/compiler-runtime", () => ({
 
 vi.mock("../../hooks/useSettings", () => ({
   useEnvironmentSettings: settingsHooks.read,
-  useUpdateEnvironmentSettings: settingsHooks.update,
+  usePersistEnvironmentSettings: settingsHooks.persist,
 }));
 
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
@@ -73,7 +73,7 @@ describe("AddProviderInstanceDialog environment routing", () => {
   beforeEach(() => {
     hooks.reset();
     settingsHooks.read.mockClear();
-    settingsHooks.update.mockClear();
+    settingsHooks.persist.mockClear();
   });
 
   it("reads and writes settings through the supplied environment", () => {
@@ -86,6 +86,6 @@ describe("AddProviderInstanceDialog environment routing", () => {
     });
 
     expect(settingsHooks.read).toHaveBeenCalledWith(remoteEnvironmentId);
-    expect(settingsHooks.update).toHaveBeenCalledWith(remoteEnvironmentId);
+    expect(settingsHooks.persist).toHaveBeenCalledWith(remoteEnvironmentId);
   });
 });

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.environment.test.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.environment.test.tsx
@@ -1,0 +1,91 @@
+import type { Dispatch, SetStateAction } from "react";
+import { EnvironmentId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const settingsHooks = vi.hoisted(() => ({
+  read: vi.fn(() => ({ providerInstances: {} })),
+  update: vi.fn(() => vi.fn()),
+}));
+
+const hooks = vi.hoisted(() => {
+  let cursor = 0;
+  let slots: unknown[] = [];
+  const nextIndex = () => cursor++;
+
+  return {
+    beginRender() {
+      cursor = 0;
+    },
+    reset() {
+      cursor = 0;
+      slots = [];
+    },
+    useMemo<T>(factory: () => T): T {
+      nextIndex();
+      return factory();
+    },
+    useMemoCache(size: number): unknown[] {
+      const index = nextIndex();
+      if (!slots[index]) {
+        slots[index] = Array.from({ length: size }, () => Symbol.for("react.memo_cache_sentinel"));
+      }
+      return slots[index] as unknown[];
+    },
+    useState<T>(initialValue: T | (() => T)): [T, Dispatch<SetStateAction<T>>] {
+      const index = nextIndex();
+      if (index >= slots.length) {
+        slots[index] =
+          typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
+      }
+      const setValue: Dispatch<SetStateAction<T>> = (nextValue) => {
+        const previous = slots[index] as T;
+        slots[index] =
+          typeof nextValue === "function" ? (nextValue as (value: T) => T)(previous) : nextValue;
+      };
+      return [slots[index] as T, setValue];
+    },
+  };
+});
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useMemo: hooks.useMemo,
+    useState: hooks.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", () => ({
+  c: hooks.useMemoCache,
+}));
+
+vi.mock("../../hooks/useSettings", () => ({
+  useEnvironmentSettings: settingsHooks.read,
+  useUpdateEnvironmentSettings: settingsHooks.update,
+}));
+
+import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
+
+const remoteEnvironmentId = EnvironmentId.make("remote-device");
+
+describe("AddProviderInstanceDialog environment routing", () => {
+  beforeEach(() => {
+    hooks.reset();
+    settingsHooks.read.mockClear();
+    settingsHooks.update.mockClear();
+  });
+
+  it("reads and writes settings through the supplied environment", () => {
+    hooks.beginRender();
+    AddProviderInstanceDialog({
+      open: true,
+      environmentId: remoteEnvironmentId,
+      environmentLabel: "Remote device",
+      onOpenChange: vi.fn(),
+    });
+
+    expect(settingsHooks.read).toHaveBeenCalledWith(remoteEnvironmentId);
+    expect(settingsHooks.update).toHaveBeenCalledWith(remoteEnvironmentId);
+  });
+});

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -6,10 +6,11 @@ import { useMemo, useState } from "react";
 import {
   ProviderInstanceId,
   ProviderDriverKind,
+  type EnvironmentId,
   type ProviderInstanceConfig,
 } from "@t3tools/contracts";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
@@ -115,13 +116,20 @@ function validateInstanceId(id: string, existing: ReadonlySet<string>): string |
 }
 
 interface AddProviderInstanceDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  readonly open: boolean;
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly onOpenChange: (open: boolean) => void;
 }
 
-export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderInstanceDialogProps) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+export function AddProviderInstanceDialog({
+  open,
+  environmentId,
+  environmentLabel,
+  onOpenChange,
+}: AddProviderInstanceDialogProps) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
   const [wizardStep, setWizardStep] = useState(0);
   const [driver, setDriver] = useState<ProviderDriverKind>(DEFAULT_DRIVER_KIND);
@@ -227,8 +235,8 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
           <DialogHeader>
             <DialogTitle>Add provider instance</DialogTitle>
             <DialogDescription>
-              Configure an additional provider instance — for example, a second Codex install
-              pointed at a different workspace.
+              Configure an additional provider instance on {environmentLabel} — for example, a
+              second Codex install pointed at a different workspace.
             </DialogDescription>
             <AddProviderInstanceWizardSteps
               currentStep={wizardStep}

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import { CheckIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
@@ -10,7 +11,10 @@ import {
   type ProviderInstanceConfig,
 } from "@t3tools/contracts";
 
-import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import {
+  useEnvironmentSettings,
+  usePersistEnvironmentSettings,
+} from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
@@ -129,7 +133,7 @@ export function AddProviderInstanceDialog({
   onOpenChange,
 }: AddProviderInstanceDialogProps) {
   const settings = useEnvironmentSettings(environmentId);
-  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const persistSettings = usePersistEnvironmentSettings(environmentId);
 
   const [wizardStep, setWizardStep] = useState(0);
   const [driver, setDriver] = useState<ProviderDriverKind>(DEFAULT_DRIVER_KIND);
@@ -142,6 +146,7 @@ export function AddProviderInstanceDialog({
   // Errors are suppressed until the user has tried to submit once. After that
   // they update live so fixing the problem clears the message in place.
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   const existingIds = useMemo(
     () => new Set(Object.keys(settings.providerInstances ?? {})),
@@ -187,9 +192,11 @@ export function AddProviderInstanceDialog({
     );
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
+    if (isSaving) return;
     setHasAttemptedSubmit(true);
     if (instanceIdError !== null) return;
+    setIsSaving(true);
 
     const config = configByDriver[driver] ?? {};
     const hasConfig = Object.keys(config).length > 0;
@@ -212,7 +219,10 @@ export function AddProviderInstanceDialog({
       [brandedId]: nextInstance,
     };
     try {
-      updateSettings({ providerInstances: nextMap });
+      const result = await persistSettings({ providerInstances: nextMap });
+      if (result._tag === "Failure") {
+        throw squashAtomCommandFailure(result);
+      }
       toastManager.add({
         type: "success",
         title: "Provider instance added",
@@ -225,6 +235,8 @@ export function AddProviderInstanceDialog({
         title: "Could not add provider instance",
         description: error instanceof Error ? error.message : "Update failed.",
       });
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -433,8 +445,8 @@ export function AddProviderInstanceDialog({
                 Next
               </Button>
             ) : (
-              <Button size="sm" onClick={handleSave}>
-                Add instance
+              <Button size="sm" disabled={isSaving} onClick={handleSave}>
+                {isSaving ? "Adding…" : "Add instance"}
               </Button>
             )}
           </DialogFooter>

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -24,6 +24,8 @@ import {
   type AuthPairingLink,
   type AdvertisedEndpoint,
   type DesktopDiscoveredSshHost,
+  type DesktopBackendMode,
+  type DesktopBackendModeState,
   type DesktopSshEnvironmentTarget,
   type DesktopServerExposureState,
   type DesktopWslState,
@@ -1711,6 +1713,10 @@ function CloudRemoteEnvironmentRows({
 
 export function ConnectionsSettings() {
   const desktopBridge = window.desktopBridge;
+  const [desktopBackendModeState, setDesktopBackendModeState] =
+    useState<DesktopBackendModeState | null>(() => desktopBridge?.getBackendModeState?.() ?? null);
+  const [desktopBackendModeError, setDesktopBackendModeError] = useState<string | null>(null);
+  const [isUpdatingDesktopBackendMode, setIsUpdatingDesktopBackendMode] = useState(false);
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
   const connectPairing = useAtomCommand(connectPairingAtom, { reportFailure: false });
@@ -1734,6 +1740,10 @@ export function ConnectionsSettings() {
         .toSorted((left, right) => left.label.localeCompare(right.label)),
     [environments],
   );
+  const hasUsableClientOnlyEnvironment = savedEnvironments.some(
+    (environment) => !isDesktopLocalConnectionTarget(environment.entry.target),
+  );
+  const isClientOnlyDesktop = desktopBackendModeState?.effectiveMode === "client-only";
   const savedDesktopSshEnvironmentsByAlias = useMemo(
     () =>
       savedEnvironments.reduce<Record<string, EnvironmentPresentation>>(
@@ -1841,7 +1851,8 @@ export function ConnectionsSettings() {
   const setDefaultAdvertisedEndpointKey = useUiStateStore(
     (state) => state.setDefaultAdvertisedEndpointKey,
   );
-  const canManageLocalBackend = currentSessionScopes?.includes(AuthAccessWriteScope) ?? false;
+  const canManageLocalBackend =
+    !isClientOnlyDesktop && (currentSessionScopes?.includes(AuthAccessWriteScope) ?? false);
   const canManageRelay = currentSessionScopes?.includes(AuthRelayWriteScope) ?? false;
   const authAccessChanges = useEnvironmentQuery(
     canManageLocalBackend && primaryEnvironmentId !== null
@@ -2975,9 +2986,88 @@ export function ConnectionsSettings() {
     />
   );
 
+  const handleDesktopBackendModeChange = async (mode: DesktopBackendMode) => {
+    if (!desktopBridge || !desktopBackendModeState) return;
+    if (mode === desktopBackendModeState.configuredMode) return;
+    if (mode === "client-only" && !hasUsableClientOnlyEnvironment) {
+      setDesktopBackendModeError(
+        "Pair and save an environment before switching to client-only mode.",
+      );
+      setAddBackendDialogOpen(true);
+      return;
+    }
+
+    setIsUpdatingDesktopBackendMode(true);
+    setDesktopBackendModeError(null);
+    try {
+      const next = await desktopBridge.setBackendMode(mode);
+      setDesktopBackendModeState(next);
+      setIsUpdatingDesktopBackendMode(false);
+    } catch (error) {
+      setDesktopBackendModeError(
+        error instanceof Error ? error.message : "Could not update the desktop backend mode.",
+      );
+      setIsUpdatingDesktopBackendMode(false);
+    }
+  };
+
   return (
     <SettingsPageContainer>
-      {canManageLocalBackend ? (
+      {desktopBridge && desktopBackendModeState ? (
+        <SettingsSection title="Desktop application">
+          <SettingsRow
+            title="Backend mode"
+            description={
+              isClientOnlyDesktop
+                ? "Connect only to saved environments. This desktop process does not start or control a local backend."
+                : "Start and manage a local backend while retaining access to saved environments."
+            }
+            status={
+              desktopBackendModeError ? (
+                <span className="block text-destructive">{desktopBackendModeError}</span>
+              ) : desktopBackendModeState.cliOverride !== null ? (
+                <span className="block text-muted-foreground">
+                  This launch is overridden by --backend-mode=
+                  {desktopBackendModeState.cliOverride}. The saved preference applies when launched
+                  without that flag.
+                </span>
+              ) : null
+            }
+            control={
+              <Select
+                value={desktopBackendModeState.configuredMode}
+                onValueChange={(value) => {
+                  if (value === "managed" || value === "client-only") {
+                    void handleDesktopBackendModeChange(value);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  className="w-full sm:w-48"
+                  aria-label="Desktop backend mode"
+                  disabled={isUpdatingDesktopBackendMode}
+                >
+                  <SelectValue>
+                    {desktopBackendModeState.configuredMode === "managed"
+                      ? "Managed backend"
+                      : "Client only"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="managed">
+                    Managed backend
+                  </SelectItem>
+                  <SelectItem hideIndicator value="client-only">
+                    Client only
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            }
+          />
+        </SettingsSection>
+      ) : null}
+
+      {isClientOnlyDesktop ? null : canManageLocalBackend ? (
         <>
           <SettingsSection title="This environment">
             {primaryVersionMismatch ? (

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -1,0 +1,81 @@
+import { assert, describe, it } from "@effect/vitest";
+import { EnvironmentId } from "@t3tools/contracts";
+
+import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+
+const PRIMARY = EnvironmentId.make("primary");
+const ACTIVE = EnvironmentId.make("active");
+const SELECTED = EnvironmentId.make("selected");
+
+describe("resolveDiagnosticsEnvironmentId", () => {
+  it("preserves an explicit available selection", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [PRIMARY, ACTIVE, SELECTED],
+      }),
+      SELECTED,
+    );
+  });
+
+  it("defaults to the primary environment when one is available", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [ACTIVE, PRIMARY],
+      }),
+      PRIMARY,
+    );
+  });
+
+  it("uses the active environment when there is no primary environment", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [SELECTED, ACTIVE],
+      }),
+      ACTIVE,
+    );
+  });
+
+  it("falls back to the first available environment", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+        availableEnvironmentIds: [SELECTED, ACTIVE],
+      }),
+      SELECTED,
+    );
+  });
+
+  it("recovers when the explicit selection is no longer available", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [PRIMARY, ACTIVE],
+      }),
+      PRIMARY,
+    );
+  });
+
+  it("returns null when no environments are available", () => {
+    assert.isNull(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [],
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -3,6 +3,7 @@ import { EnvironmentId } from "@t3tools/contracts";
 
 import {
   addPendingProcessSignal,
+  connectedDiagnosticsData,
   diagnosticsConnectionNotice,
   pendingProcessSignalPids,
   removePendingProcessSignal,
@@ -131,6 +132,15 @@ describe("diagnosticsConnectionNotice", () => {
       diagnosticsConnectionNotice({ phase: "connecting", label: "Laptop", error: null }),
       "Connecting to Laptop...",
     );
+  });
+});
+
+describe("connectedDiagnosticsData", () => {
+  it("hides cached results after the selected environment disconnects", () => {
+    const cached = { processCount: 3 };
+
+    assert.strictEqual(connectedDiagnosticsData(true, cached), cached);
+    assert.isNull(connectedDiagnosticsData(false, cached));
   });
 });
 

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -1,7 +1,14 @@
 import { assert, describe, it } from "@effect/vitest";
 import { EnvironmentId } from "@t3tools/contracts";
 
-import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+import {
+  addPendingProcessSignal,
+  diagnosticsConnectionNotice,
+  pendingProcessSignalPids,
+  removePendingProcessSignal,
+  resolveDiagnosticsEnvironmentId,
+  type PendingProcessSignal,
+} from "./DiagnosticsSettings.logic";
 
 const PRIMARY = EnvironmentId.make("primary");
 const ACTIVE = EnvironmentId.make("active");
@@ -76,6 +83,107 @@ describe("resolveDiagnosticsEnvironmentId", () => {
         activeEnvironmentId: ACTIVE,
         availableEnvironmentIds: [],
       }),
+    );
+  });
+});
+
+describe("diagnosticsConnectionNotice", () => {
+  it("returns null while the environment is connected", () => {
+    assert.isNull(
+      diagnosticsConnectionNotice({ phase: "connected", label: "Laptop", error: null }),
+    );
+  });
+
+  it("explains that an offline environment cannot report diagnostics", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "offline", label: "Laptop", error: null }),
+      "Laptop is offline. Diagnostics load once it reconnects.",
+    );
+  });
+
+  it("explains that a never-connected environment cannot report diagnostics", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "available", label: "Laptop", error: null }),
+      "Laptop is not connected. Diagnostics load once it connects.",
+    );
+  });
+
+  it("includes the failure reason while reconnecting", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({
+        phase: "reconnecting",
+        label: "Laptop",
+        error: "socket hang up",
+      }),
+      "Reconnecting to Laptop... Reason: socket hang up",
+    );
+  });
+
+  it("reports a blocked connection", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "error", label: "Laptop", error: "unauthorized" }),
+      "Could not connect to Laptop. Reason: unauthorized",
+    );
+  });
+
+  it("reports an initial connection attempt", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "connecting", label: "Laptop", error: null }),
+      "Connecting to Laptop...",
+    );
+  });
+});
+
+describe("pending process signals", () => {
+  it("tracks pending signals per environment and pid", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 200 },
+    );
+
+    assert.deepEqual([...pendingProcessSignalPids(pending, PRIMARY)], [100]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, ACTIVE)], [200]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, SELECTED)], []);
+    assert.deepEqual([...pendingProcessSignalPids(pending, null)], []);
+  });
+
+  it("does not duplicate a signal that is already pending", () => {
+    const pending = addPendingProcessSignal([{ environmentId: PRIMARY, pid: 100 }], {
+      environmentId: PRIMARY,
+      pid: 100,
+    });
+
+    assert.equal(pending.length, 1);
+  });
+
+  it("keeps the same pid pending in another environment", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 100 },
+    );
+
+    assert.deepEqual([...pendingProcessSignalPids(pending, PRIMARY)], [100]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, ACTIVE)], [100]);
+  });
+
+  it("only clears the completed request, leaving other environments pending", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 200 },
+    );
+
+    const remaining = removePendingProcessSignal(pending, { environmentId: PRIMARY, pid: 100 });
+
+    assert.deepEqual([...pendingProcessSignalPids(remaining, PRIMARY)], []);
+    assert.deepEqual([...pendingProcessSignalPids(remaining, ACTIVE)], [200]);
+  });
+
+  it("ignores completions for signals that are no longer pending", () => {
+    const pending: ReadonlyArray<PendingProcessSignal> = [{ environmentId: PRIMARY, pid: 100 }];
+
+    assert.strictEqual(
+      removePendingProcessSignal(pending, { environmentId: ACTIVE, pid: 100 }),
+      pending,
     );
   });
 });

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,0 +1,30 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export function resolveDiagnosticsEnvironmentId(input: {
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+}): EnvironmentId | null {
+  const availableEnvironmentIds = new Set(input.availableEnvironmentIds);
+
+  if (
+    input.selectedEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.selectedEnvironmentId)
+  ) {
+    return input.selectedEnvironmentId;
+  }
+  if (
+    input.primaryEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.primaryEnvironmentId)
+  ) {
+    return input.primaryEnvironmentId;
+  }
+  if (
+    input.activeEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.activeEnvironmentId)
+  ) {
+    return input.activeEnvironmentId;
+  }
+  return input.availableEnvironmentIds[0] ?? null;
+}

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,6 +1,10 @@
 import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
 
+export function connectedDiagnosticsData<A>(isConnected: boolean, data: A | null): A | null {
+  return isConnected ? data : null;
+}
+
 export function resolveDiagnosticsEnvironmentId(input: {
   readonly selectedEnvironmentId: EnvironmentId | null;
   readonly primaryEnvironmentId: EnvironmentId | null;

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 export function resolveDiagnosticsEnvironmentId(input: {
@@ -27,4 +28,77 @@ export function resolveDiagnosticsEnvironmentId(input: {
     return input.activeEnvironmentId;
   }
   return input.availableEnvironmentIds[0] ?? null;
+}
+
+/**
+ * Diagnostics queries only run while the selected environment has a connected
+ * supervisor generation; otherwise they stay pending forever. Returns the
+ * message to show instead of a loading state, or `null` when diagnostics can
+ * actually be collected.
+ */
+export function diagnosticsConnectionNotice(input: {
+  readonly phase: EnvironmentConnectionPhase;
+  readonly label: string;
+  readonly error: string | null;
+}): string | null {
+  switch (input.phase) {
+    case "connected":
+      return null;
+    case "connecting":
+      return `Connecting to ${input.label}...`;
+    case "reconnecting":
+      return input.error
+        ? `Reconnecting to ${input.label}... Reason: ${input.error}`
+        : `Reconnecting to ${input.label}...`;
+    case "offline":
+      return `${input.label} is offline. Diagnostics load once it reconnects.`;
+    case "available":
+      return `${input.label} is not connected. Diagnostics load once it connects.`;
+    case "error":
+      return input.error
+        ? `Could not connect to ${input.label}. Reason: ${input.error}`
+        : `Could not connect to ${input.label}.`;
+  }
+}
+
+/**
+ * An in-flight process signal. Signals are identified by environment as well as
+ * pid so that a completion in one environment cannot clear pending state that
+ * belongs to another one.
+ */
+export interface PendingProcessSignal {
+  readonly environmentId: EnvironmentId;
+  readonly pid: number;
+}
+
+function isSamePendingProcessSignal(left: PendingProcessSignal, right: PendingProcessSignal) {
+  return left.environmentId === right.environmentId && left.pid === right.pid;
+}
+
+export function addPendingProcessSignal(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  signal: PendingProcessSignal,
+): ReadonlyArray<PendingProcessSignal> {
+  return pending.some((entry) => isSamePendingProcessSignal(entry, signal))
+    ? pending
+    : [...pending, signal];
+}
+
+export function removePendingProcessSignal(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  signal: PendingProcessSignal,
+): ReadonlyArray<PendingProcessSignal> {
+  const next = pending.filter((entry) => !isSamePendingProcessSignal(entry, signal));
+  return next.length === pending.length ? pending : next;
+}
+
+export function pendingProcessSignalPids(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  environmentId: EnvironmentId | null,
+): ReadonlySet<number> {
+  return new Set(
+    pending
+      .filter((entry) => environmentId !== null && entry.environmentId === environmentId)
+      .map((entry) => entry.pid),
+  );
 }

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -2,11 +2,9 @@ import {
   AlertTriangleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  CloudIcon,
   CopyIcon,
   FolderOpenIcon,
   InfoIcon,
-  MonitorIcon,
   RefreshCwIcon,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
@@ -31,20 +29,10 @@ import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFo
 import { useEnvironmentQuery } from "../../state/query";
 import { serverEnvironment } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
-import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
-import { useActiveEnvironmentId } from "../../state/entities";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
-import {
-  Select,
-  SelectGroup,
-  SelectGroupLabel,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
 import {
@@ -58,9 +46,9 @@ import {
   diagnosticsConnectionNotice,
   pendingProcessSignalPids,
   removePendingProcessSignal,
-  resolveDiagnosticsEnvironmentId,
   type PendingProcessSignal,
 } from "./DiagnosticsSettings.logic";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -839,28 +827,15 @@ interface LogsDirectoryState {
 }
 
 export function DiagnosticsSettingsPanel() {
-  const { environments } = useEnvironments();
-  const primaryEnvironment = usePrimaryEnvironment();
-  const activeEnvironmentId = useActiveEnvironmentId();
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
-  const environmentId = resolveDiagnosticsEnvironmentId({
-    selectedEnvironmentId,
-    primaryEnvironmentId: primaryEnvironment?.environmentId ?? null,
-    activeEnvironmentId,
-    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
-  });
-  const diagnosticsEnvironment =
-    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const {
+    environmentId,
+    environment: diagnosticsEnvironment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+  } = useSettingsEnvironment();
   const observability = diagnosticsEnvironment?.serverConfig?.observability ?? null;
   const availableEditors = diagnosticsEnvironment?.serverConfig?.availableEditors ?? [];
-  const environmentItems = useMemo(
-    () =>
-      environments.map((environment) => ({
-        value: environment.environmentId,
-        label: environment.label,
-      })),
-    [environments],
-  );
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
@@ -1082,37 +1057,12 @@ export function DiagnosticsSettingsPanel() {
           }
           control={
             diagnosticsEnvironment ? (
-              <Select
-                value={diagnosticsEnvironment.environmentId}
-                onValueChange={(value) => setSelectedEnvironmentId(value as EnvironmentId)}
-                items={environmentItems}
-              >
-                <SelectTrigger className="w-full sm:w-64" aria-label="Diagnostics environment">
-                  {diagnosticsEnvironment.entry.target._tag === "PrimaryConnectionTarget" ? (
-                    <MonitorIcon className="size-4" />
-                  ) : (
-                    <CloudIcon className="size-4" />
-                  )}
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectGroup>
-                    <SelectGroupLabel>Machine</SelectGroupLabel>
-                    {environments.map((environment) => (
-                      <SelectItem key={environment.environmentId} value={environment.environmentId}>
-                        <span className="inline-flex items-center gap-1.5">
-                          {environment.entry.target._tag === "PrimaryConnectionTarget" ? (
-                            <MonitorIcon className="size-3" />
-                          ) : (
-                            <CloudIcon className="size-3" />
-                          )}
-                          {environment.label}
-                        </span>
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectPopup>
-              </Select>
+              <SettingsEnvironmentSelector
+                environmentId={diagnosticsEnvironment.environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
             ) : (
               <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
                 Manage connections

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -43,6 +43,7 @@ import {
 } from "./settingsLayout";
 import {
   addPendingProcessSignal,
+  connectedDiagnosticsData,
   diagnosticsConnectionNotice,
   pendingProcessSignalPids,
   removePendingProcessSignal,
@@ -846,14 +847,19 @@ export function DiagnosticsSettingsPanel() {
   const selectedResourceWindow =
     RESOURCE_HISTORY_WINDOWS.find((option) => option.windowMs === resourceWindowMs) ??
     RESOURCE_HISTORY_WINDOWS[1];
-  const { data, error, isPending, refresh } = useEnvironmentQuery(
+  const {
+    data: cachedTraceData,
+    error: cachedTraceError,
+    isPending,
+    refresh,
+  } = useEnvironmentQuery(
     environmentId === null
       ? null
       : serverEnvironment.traceDiagnostics({ environmentId, input: {} }),
   );
   const {
-    data: processData,
-    error: processError,
+    data: cachedProcessData,
+    error: cachedProcessError,
     isPending: isProcessPending,
     refresh: refreshProcesses,
   } = useEnvironmentQuery(
@@ -862,8 +868,8 @@ export function DiagnosticsSettingsPanel() {
       : serverEnvironment.processDiagnostics({ environmentId, input: {} }),
   );
   const {
-    data: resourceData,
-    error: resourceError,
+    data: cachedResourceData,
+    error: cachedResourceError,
     isPending: isResourcePending,
     refresh: refreshResources,
   } = useEnvironmentQuery(
@@ -942,17 +948,15 @@ export function DiagnosticsSettingsPanel() {
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
 
-  const isInitialLoading = isPending && data === null;
-  const isProcessInitialLoading = isProcessPending && processData === null;
   const signalProcess = useCallback(
     (pid: number, signal: ServerProcessSignal) => {
+      if (environmentId === null || diagnosticsEnvironment?.connection.phase !== "connected") {
+        return;
+      }
       if (
         signal === "SIGKILL" &&
         !window.confirm(`Send SIGKILL to process ${pid}? This cannot be handled by the process.`)
       ) {
-        return;
-      }
-      if (environmentId === null) {
         return;
       }
 
@@ -998,7 +1002,12 @@ export function DiagnosticsSettingsPanel() {
         refreshProcesses();
       })();
     },
-    [environmentId, refreshProcesses, signalServerProcess],
+    [
+      diagnosticsEnvironment?.connection.phase,
+      environmentId,
+      refreshProcesses,
+      signalServerProcess,
+    ],
   );
 
   // Diagnostics RPCs only run while the environment's supervisor is connected,
@@ -1010,6 +1019,14 @@ export function DiagnosticsSettingsPanel() {
   });
   const isConnected = connectionNotice === null;
   const statPlaceholder = isConnected ? "..." : "—";
+  const data = connectedDiagnosticsData(isConnected, cachedTraceData);
+  const processData = connectedDiagnosticsData(isConnected, cachedProcessData);
+  const resourceData = connectedDiagnosticsData(isConnected, cachedResourceData);
+  const error = isConnected ? cachedTraceError : null;
+  const processError = isConnected ? cachedProcessError : null;
+  const resourceError = isConnected ? cachedResourceError : null;
+  const isInitialLoading = isPending && data === null;
+  const isProcessInitialLoading = isProcessPending && processData === null;
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
   const processResourceError = resourceData ? Option.getOrNull(resourceData.error) : null;

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -2,18 +2,22 @@ import {
   AlertTriangleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  CloudIcon,
   CopyIcon,
   FolderOpenIcon,
   InfoIcon,
+  MonitorIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { useAtomValue } from "@effect/atom-react";
+import { Link } from "@tanstack/react-router";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type {
+  EnvironmentId,
   ServerProcessDiagnosticsEntry,
   ServerProcessResourceHistorySummary,
   ServerProcessSignal,
@@ -25,19 +29,31 @@ import { cn } from "../../lib/utils";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { useEnvironmentQuery } from "../../state/query";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerObservabilityAtom,
-  serverEnvironment,
-} from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
+import { useActiveEnvironmentId } from "../../state/entities";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
-import { SettingsPageContainer, SettingsSection, useRelativeTimeTick } from "./settingsLayout";
+import {
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+  useRelativeTimeTick,
+} from "./settingsLayout";
+import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -808,10 +824,28 @@ function DiagnosticsRefreshButton({
 }
 
 export function DiagnosticsSettingsPanel() {
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
+  const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  const environmentId = resolveDiagnosticsEnvironmentId({
+    selectedEnvironmentId,
+    primaryEnvironmentId: primaryEnvironment?.environmentId ?? null,
+    activeEnvironmentId,
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+  });
+  const diagnosticsEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const observability = diagnosticsEnvironment?.serverConfig?.observability ?? null;
+  const availableEditors = diagnosticsEnvironment?.serverConfig?.availableEditors ?? [];
+  const environmentItems = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
@@ -956,8 +990,85 @@ export function DiagnosticsSettingsPanel() {
     ? Option.getOrElse(data.partialFailure, () => false)
     : false;
 
+  if (environmentId === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Environment">
+          <SettingsRow
+            title="Diagnostics source"
+            description="Process, resource, and trace diagnostics are collected by a specific backend."
+            status="Connect an environment to view diagnostics."
+            control={
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Manage connections
+              </Button>
+            }
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
+
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Diagnostics source"
+          description="Process, resource, and trace diagnostics are collected by a specific backend. Choose the machine you want to inspect."
+          status={
+            diagnosticsEnvironment ? (
+              <>
+                {connectionStatusText(diagnosticsEnvironment.connection)}
+                {diagnosticsEnvironment.displayUrl
+                  ? ` · ${diagnosticsEnvironment.displayUrl}`
+                  : null}
+              </>
+            ) : (
+              "Connect an environment to view diagnostics."
+            )
+          }
+          control={
+            diagnosticsEnvironment ? (
+              <Select
+                value={diagnosticsEnvironment.environmentId}
+                onValueChange={(value) => setSelectedEnvironmentId(value as EnvironmentId)}
+                items={environmentItems}
+              >
+                <SelectTrigger className="w-full sm:w-64" aria-label="Diagnostics environment">
+                  {diagnosticsEnvironment.entry.target._tag === "PrimaryConnectionTarget" ? (
+                    <MonitorIcon className="size-4" />
+                  ) : (
+                    <CloudIcon className="size-4" />
+                  )}
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectGroup>
+                    <SelectGroupLabel>Machine</SelectGroupLabel>
+                    {environments.map((environment) => (
+                      <SelectItem key={environment.environmentId} value={environment.environmentId}>
+                        <span className="inline-flex items-center gap-1.5">
+                          {environment.entry.target._tag === "PrimaryConnectionTarget" ? (
+                            <MonitorIcon className="size-3" />
+                          ) : (
+                            <CloudIcon className="size-3" />
+                          )}
+                          {environment.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectPopup>
+              </Select>
+            ) : (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Manage connections
+              </Button>
+            )
+          }
+        />
+      </SettingsSection>
+
       <SettingsSection
         title="Live Processes"
         headerAction={

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -53,7 +53,14 @@ import {
   SettingsSection,
   useRelativeTimeTick,
 } from "./settingsLayout";
-import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+import {
+  addPendingProcessSignal,
+  diagnosticsConnectionNotice,
+  pendingProcessSignalPids,
+  removePendingProcessSignal,
+  resolveDiagnosticsEnvironmentId,
+  type PendingProcessSignal,
+} from "./DiagnosticsSettings.logic";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -410,12 +417,12 @@ function ProcessSignalActions({
 
 function ProcessDiagnosticsTable({
   processes,
-  signalingPid,
+  signalingPids,
   onSignal,
   emptyLabel,
 }: {
   processes: ReadonlyArray<ServerProcessDiagnosticsEntry>;
-  signalingPid: number | null;
+  signalingPids: ReadonlySet<number>;
   onSignal: (pid: number, signal: ServerProcessSignal) => void;
   emptyLabel?: string;
 }) {
@@ -524,7 +531,7 @@ function ProcessDiagnosticsTable({
               <td className="p-2 align-middle sm:pr-4">
                 <ProcessSignalActions
                   process={process}
-                  isSignaling={signalingPid === process.pid}
+                  isSignaling={signalingPids.has(process.pid)}
                   onSignal={onSignal}
                 />
               </td>
@@ -823,6 +830,12 @@ function DiagnosticsRefreshButton({
   );
 }
 
+interface LogsDirectoryState {
+  readonly environmentId: EnvironmentId | null;
+  readonly isOpening: boolean;
+  readonly error: string | null;
+}
+
 export function DiagnosticsSettingsPanel() {
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
@@ -887,9 +900,20 @@ export function DiagnosticsSettingsPanel() {
           },
         }),
   );
-  const [isOpeningLogsDirectory, setIsOpeningLogsDirectory] = useState(false);
-  const [openLogsDirectoryError, setOpenLogsDirectoryError] = useState<string | null>(null);
-  const [signalingPid, setSignalingPid] = useState<number | null>(null);
+  // Panel-local state is keyed by environment so that a result produced for one
+  // environment is never shown for (or applied to) another one.
+  const [logsDirectoryState, setLogsDirectoryState] = useState<LogsDirectoryState | null>(null);
+  const [pendingSignals, setPendingSignals] = useState<ReadonlyArray<PendingProcessSignal>>([]);
+  const logsDirectory =
+    logsDirectoryState !== null && logsDirectoryState.environmentId === environmentId
+      ? logsDirectoryState
+      : null;
+  const isOpeningLogsDirectory = logsDirectory?.isOpening ?? false;
+  const openLogsDirectoryError = logsDirectory?.error ?? null;
+  const signalingPids = useMemo(
+    () => pendingProcessSignalPids(pendingSignals, environmentId),
+    [environmentId, pendingSignals],
+  );
 
   const openLogsDirectory = useCallback(() => {
     const logsDirectoryPath = observability?.logsDirectoryPath ?? null;
@@ -897,16 +921,23 @@ export function DiagnosticsSettingsPanel() {
 
     const editor = resolveAndPersistPreferredEditor(availableEditors ?? []);
     if (!editor) {
-      setOpenLogsDirectoryError("No available editors found.");
+      setLogsDirectoryState({
+        environmentId,
+        isOpening: false,
+        error: "No available editors found.",
+      });
       return;
     }
     if (environmentId === null) {
-      setOpenLogsDirectoryError("No environment is selected.");
+      setLogsDirectoryState({
+        environmentId,
+        isOpening: false,
+        error: "No environment is selected.",
+      });
       return;
     }
 
-    setIsOpeningLogsDirectory(true);
-    setOpenLogsDirectoryError(null);
+    setLogsDirectoryState({ environmentId, isOpening: true, error: null });
     void (async () => {
       const result = await openInEditor({
         environmentId,
@@ -915,13 +946,22 @@ export function DiagnosticsSettingsPanel() {
           editor,
         },
       });
-      setIsOpeningLogsDirectory(false);
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        setOpenLogsDirectoryError(
-          error instanceof Error ? error.message : "Unable to open logs folder.",
-        );
-      }
+      const failure =
+        result._tag === "Failure" && !isAtomCommandInterrupted(result)
+          ? squashAtomCommandFailure(result)
+          : null;
+      const error =
+        failure === null
+          ? null
+          : failure instanceof Error
+            ? failure.message
+            : "Unable to open logs folder.";
+      // Only the request that owns the current pending state may clear it.
+      setLogsDirectoryState((current) =>
+        current !== null && current.environmentId === environmentId
+          ? { environmentId, isOpening: false, error }
+          : current,
+      );
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
 
@@ -939,13 +979,14 @@ export function DiagnosticsSettingsPanel() {
         return;
       }
 
-      setSignalingPid(pid);
+      const pendingSignal: PendingProcessSignal = { environmentId, pid };
+      setPendingSignals((current) => addPendingProcessSignal(current, pendingSignal));
       void (async () => {
         const result = await signalServerProcess({
           environmentId,
           input: { pid, signal },
         });
-        setSignalingPid(null);
+        setPendingSignals((current) => removePendingProcessSignal(current, pendingSignal));
         if (result._tag === "Failure") {
           if (!isAtomCommandInterrupted(result)) {
             const error = squashAtomCommandFailure(result);
@@ -982,6 +1023,16 @@ export function DiagnosticsSettingsPanel() {
     },
     [environmentId, refreshProcesses, signalServerProcess],
   );
+
+  // Diagnostics RPCs only run while the environment's supervisor is connected,
+  // so anything else has to surface as a state instead of an endless spinner.
+  const connectionNotice = diagnosticsConnectionNotice({
+    phase: diagnosticsEnvironment?.connection.phase ?? "available",
+    label: diagnosticsEnvironment?.label ?? "This environment",
+    error: diagnosticsEnvironment?.connection.error ?? null,
+  });
+  const isConnected = connectionNotice === null;
+  const statPlaceholder = isConnected ? "..." : "—";
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
   const processResourceError = resourceData ? Option.getOrNull(resourceData.error) : null;
@@ -1075,7 +1126,7 @@ export function DiagnosticsSettingsPanel() {
           <div className="flex items-center gap-1.5">
             <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
             <DiagnosticsRefreshButton
-              isPending={isProcessPending}
+              isPending={isProcessPending && isConnected}
               label="Refresh process diagnostics"
               onClick={refreshProcesses}
             />
@@ -1085,21 +1136,21 @@ export function DiagnosticsSettingsPanel() {
         <StatsGrid>
           <StatBlock
             label="Child Processes"
-            value={processData ? formatCount(processData.processCount) : "..."}
+            value={processData ? formatCount(processData.processCount) : statPlaceholder}
           />
           <StatBlock
             label="CPU"
-            value={processData ? `${processData.totalCpuPercent.toFixed(1)}%` : "..."}
+            value={processData ? `${processData.totalCpuPercent.toFixed(1)}%` : statPlaceholder}
             tooltip="Total CPU across live child processes of the current server process. The desktop shell and other parent processes are not included."
           />
           <StatBlock
             label="Memory"
-            value={processData ? formatBytes(processData.totalRssBytes) : "..."}
+            value={processData ? formatBytes(processData.totalRssBytes) : statPlaceholder}
             tooltip="Total resident memory across live child processes of the current server process. The desktop shell and other parent processes are not included."
           />
           <StatBlock
             label="Server PID"
-            value={processData ? String(processData.serverPid) : "..."}
+            value={processData ? String(processData.serverPid) : statPlaceholder}
           />
         </StatsGrid>
         {processDiagnosticsError || processError ? (
@@ -1120,12 +1171,13 @@ export function DiagnosticsSettingsPanel() {
         ) : null}
         <ProcessDiagnosticsTable
           processes={processData?.processes ?? []}
-          signalingPid={signalingPid}
+          signalingPids={signalingPids}
           onSignal={signalProcess}
           emptyLabel={
-            isProcessInitialLoading
+            connectionNotice ??
+            (isProcessInitialLoading
               ? "Loading live processes..."
-              : "No live descendant processes found."
+              : "No live descendant processes found.")
           }
         />
       </SettingsSection>
@@ -1140,7 +1192,7 @@ export function DiagnosticsSettingsPanel() {
             />
             <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
             <DiagnosticsRefreshButton
-              isPending={isResourcePending}
+              isPending={isResourcePending && isConnected}
               label="Refresh resource history"
               onClick={refreshResources}
             />
@@ -1150,21 +1202,23 @@ export function DiagnosticsSettingsPanel() {
         <StatsGrid>
           <StatBlock
             label="CPU Time"
-            value={resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : "..."}
+            value={
+              resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : statPlaceholder
+            }
             tooltip="Approximate active CPU time for the T3 server root process and its descendants during the selected window. It grows only while sampled processes use CPU and older samples leave as the window moves."
           />
           <StatBlock
             label="Samples"
-            value={resourceData ? formatCount(resourceData.retainedSampleCount) : "..."}
+            value={resourceData ? formatCount(resourceData.retainedSampleCount) : statPlaceholder}
             tooltip="In-memory process samples retained by the server. This resets when the server restarts."
           />
           <StatBlock
             label="Interval"
-            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : "..."}
+            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : statPlaceholder}
           />
           <StatBlock
             label="Processes"
-            value={resourceData ? formatCount(resourceData.topProcesses.length) : "..."}
+            value={resourceData ? formatCount(resourceData.topProcesses.length) : statPlaceholder}
           />
         </StatsGrid>
         {processResourceError || resourceError ? (
@@ -1187,9 +1241,10 @@ export function DiagnosticsSettingsPanel() {
         <ProcessResourceHistoryTable
           processes={resourceData?.topProcesses ?? []}
           emptyLabel={
-            isResourcePending && resourceData === null
+            connectionNotice ??
+            (isResourcePending && resourceData === null
               ? "Collecting process resource samples..."
-              : "No process resource samples found for this window."
+              : "No process resource samples found for this window.")
           }
         />
       </SettingsSection>
@@ -1206,7 +1261,9 @@ export function DiagnosticsSettingsPanel() {
                     size="icon-xs"
                     variant="ghost"
                     className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    disabled={!observability?.logsDirectoryPath || isOpeningLogsDirectory}
+                    disabled={
+                      !isConnected || !observability?.logsDirectoryPath || isOpeningLogsDirectory
+                    }
                     onClick={openLogsDirectory}
                     aria-label="Open logs folder"
                   >
@@ -1217,7 +1274,7 @@ export function DiagnosticsSettingsPanel() {
               <TooltipPopup side="top">Open logs folder</TooltipPopup>
             </Tooltip>
             <DiagnosticsRefreshButton
-              isPending={isPending}
+              isPending={isPending && isConnected}
               label="Refresh trace diagnostics"
               onClick={refresh}
             />
@@ -1225,15 +1282,15 @@ export function DiagnosticsSettingsPanel() {
         }
       >
         <StatsGrid>
-          <StatBlock label="Spans" value={data ? formatCount(data.recordCount) : "..."} />
+          <StatBlock label="Spans" value={data ? formatCount(data.recordCount) : statPlaceholder} />
           <StatBlock
             label="Failures"
-            value={data ? formatCount(data.failureCount) : "..."}
+            value={data ? formatCount(data.failureCount) : statPlaceholder}
             tone={data && data.failureCount > 0 ? "danger" : "default"}
           />
           <StatBlock
             label="Slow Spans"
-            value={data ? formatCount(data.slowSpanCount) : "..."}
+            value={data ? formatCount(data.slowSpanCount) : statPlaceholder}
             tooltip={
               data
                 ? `Spans with a duration of ${formatDuration(data.slowSpanThresholdMs)} or longer.`
@@ -1243,7 +1300,7 @@ export function DiagnosticsSettingsPanel() {
           />
           <StatBlock
             label="Parse Errors"
-            value={data ? formatCount(data.parseErrorCount) : "..."}
+            value={data ? formatCount(data.parseErrorCount) : statPlaceholder}
             tone={data && data.parseErrorCount > 0 ? "warning" : "default"}
           />
         </StatsGrid>
@@ -1303,7 +1360,12 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading failures..." : "No failed spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading failures..." : "No failed spans found.")
+            }
+          />
         )}
       </SettingsSection>
 
@@ -1332,7 +1394,10 @@ export function DiagnosticsSettingsPanel() {
           </DiagnosticsTable>
         ) : (
           <EmptyRows
-            label={isInitialLoading ? "Loading failure groups..." : "No repeated failures found."}
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading failure groups..." : "No repeated failures found.")
+            }
           />
         )}
       </SettingsSection>
@@ -1362,7 +1427,11 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading slow spans..." : "No spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ?? (isInitialLoading ? "Loading slow spans..." : "No spans found.")
+            }
+          />
         )}
       </SettingsSection>
 
@@ -1425,7 +1494,10 @@ export function DiagnosticsSettingsPanel() {
           </ScrollArea>
         ) : (
           <EmptyRows
-            label={isInitialLoading ? "Loading recent logs..." : "No warnings or errors found."}
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading recent logs..." : "No warnings or errors found.")
+            }
           />
         )}
       </SettingsSection>
@@ -1458,7 +1530,11 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading span names..." : "No spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ?? (isInitialLoading ? "Loading span names..." : "No spans found.")
+            }
+          />
         )}
       </SettingsSection>
     </SettingsPageContainer>

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -802,10 +802,12 @@ function DiagnosticsLastChecked({ checkedAt }: { checkedAt: DateTime.Utc | null 
 
 function DiagnosticsRefreshButton({
   isPending,
+  isDisabled = false,
   label,
   onClick,
 }: {
   isPending: boolean;
+  isDisabled?: boolean;
   label: string;
   onClick: () => void;
 }) {
@@ -817,7 +819,7 @@ function DiagnosticsRefreshButton({
             size="icon-xs"
             variant="ghost"
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-            disabled={isPending}
+            disabled={isPending || isDisabled}
             onClick={onClick}
             aria-label={label}
           >
@@ -937,7 +939,8 @@ export function DiagnosticsSettingsPanel() {
       return;
     }
 
-    setLogsDirectoryState({ environmentId, isOpening: true, error: null });
+    const request: LogsDirectoryState = { environmentId, isOpening: true, error: null };
+    setLogsDirectoryState(request);
     void (async () => {
       const result = await openInEditor({
         environmentId,
@@ -950,17 +953,16 @@ export function DiagnosticsSettingsPanel() {
         result._tag === "Failure" && !isAtomCommandInterrupted(result)
           ? squashAtomCommandFailure(result)
           : null;
-      const error =
+      const failureMessage =
         failure === null
           ? null
           : failure instanceof Error
             ? failure.message
             : "Unable to open logs folder.";
-      // Only the request that owns the current pending state may clear it.
+      // Identity check: only the request that still owns the slot may clear it,
+      // so a later request (in this or another environment) is never disturbed.
       setLogsDirectoryState((current) =>
-        current !== null && current.environmentId === environmentId
-          ? { environmentId, isOpening: false, error }
-          : current,
+        current === request ? { environmentId, isOpening: false, error: failureMessage } : current,
       );
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
@@ -1127,6 +1129,7 @@ export function DiagnosticsSettingsPanel() {
             <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
             <DiagnosticsRefreshButton
               isPending={isProcessPending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh process diagnostics"
               onClick={refreshProcesses}
             />
@@ -1193,6 +1196,7 @@ export function DiagnosticsSettingsPanel() {
             <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
             <DiagnosticsRefreshButton
               isPending={isResourcePending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh resource history"
               onClick={refreshResources}
             />
@@ -1275,6 +1279,7 @@ export function DiagnosticsSettingsPanel() {
             </Tooltip>
             <DiagnosticsRefreshButton
               isPending={isPending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh trace diagnostics"
               onClick={refresh}
             />

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import { EnvironmentId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
 
 import {
   buildKeybindingRows,
@@ -8,6 +8,7 @@ import {
   commandLabel,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingsSettingsEditorKey,
   parseWhenExpressionDraft,
   shortcutToKeybindingInput,
   unknownWhenVariables,
@@ -15,6 +16,14 @@ import {
 } from "./KeybindingsSettings.logic";
 
 describe("KeybindingsSettings.logic", () => {
+  it("keys editor state by environment so drafts are discarded on target changes", () => {
+    const first = EnvironmentId.make("first");
+    const second = EnvironmentId.make("second");
+
+    expect(keybindingsSettingsEditorKey(first)).not.toBe(keybindingsSettingsEditorKey(second));
+    expect(keybindingsSettingsEditorKey(null)).toBe("no-environment");
+  });
+
   it("builds searchable rows with readable key and when values", () => {
     const rows = buildKeybindingRows(
       [

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -1,4 +1,5 @@
 import {
+  type EnvironmentId,
   type KeybindingCommand,
   type KeybindingShortcut,
   type KeybindingWhenNode,
@@ -28,6 +29,10 @@ export interface KeybindingRow {
 
 export type WhenVariableOption = string;
 export type KeybindingCommandOption = KeybindingCommand;
+
+export function keybindingsSettingsEditorKey(environmentId: EnvironmentId | null): string {
+  return environmentId ?? "no-environment";
+}
 
 const CORE_WHEN_VARIABLES = ["terminalFocus", "terminalOpen", "true", "false"] as const;
 

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -42,7 +42,10 @@ import { useOpenInPreferredEditor } from "../../editorPreferences";
 import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import { serverEnvironment } from "../../state/server";
-import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
+import {
+  useSettingsEnvironment,
+  type SettingsEnvironmentTarget,
+} from "../../hooks/useSettingsEnvironment";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -61,6 +64,7 @@ import {
   isKnownWhenVariable,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingsSettingsEditorKey,
   parseWhenExpressionDraft,
   type KeybindingCommandOption,
   type KeybindingRow,
@@ -1083,7 +1087,11 @@ function NewKeybindingTableRow({
   );
 }
 
-export function KeybindingsSettingsPanel() {
+function KeybindingsSettingsPanelContent({
+  settingsEnvironment,
+}: {
+  settingsEnvironment: SettingsEnvironmentTarget;
+}) {
   const {
     environmentId,
     environment,
@@ -1091,7 +1099,7 @@ export function KeybindingsSettingsPanel() {
     primaryEnvironmentId,
     selectEnvironment,
     isReady: environmentsReady,
-  } = useSettingsEnvironment();
+  } = settingsEnvironment;
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
   const keybindings = serverConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const keybindingsConfigPath = serverConfig?.keybindingsConfigPath ?? null;
@@ -1373,5 +1381,15 @@ export function KeybindingsSettingsPanel() {
         </SettingsSection>
       ) : null}
     </SettingsPageContainer>
+  );
+}
+
+export function KeybindingsSettingsPanel() {
+  const settingsEnvironment = useSettingsEnvironment();
+  return (
+    <KeybindingsSettingsPanelContent
+      key={keybindingsSettingsEditorKey(settingsEnvironment.environmentId)}
+      settingsEnvironment={settingsEnvironment}
+    />
   );
 }

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -24,10 +24,14 @@ import {
 import {
   type KeybindingCommand,
   type KeybindingWhenNode,
+  type ServerConfig,
   type ServerRemoveKeybindingInput,
   type ServerUpsertKeybindingInput,
 } from "@t3tools/contracts";
 import { useAtomValue } from "@effect/atom-react";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { Link } from "@tanstack/react-router";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -37,13 +41,8 @@ import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
 import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerKeybindingsAtom,
-  primaryServerKeybindingsConfigPathAtom,
-  serverEnvironment,
-} from "../../state/server";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { serverEnvironment } from "../../state/server";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -69,9 +68,12 @@ import {
   unknownWhenVariables,
   whenAstToExpression,
 } from "./KeybindingsSettings.logic";
-import { SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
+import { SettingsPageContainer, SettingsRow, SettingsSection } from "./settingsLayout";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { useAtomCommand } from "../../state/use-atom-command";
+
+const EMPTY_AVAILABLE_EDITORS: ServerConfig["availableEditors"] = [];
 
 function KeybindingPill({ value }: { value: string }) {
   const parts = value.split("+");
@@ -1082,20 +1084,26 @@ function NewKeybindingTableRow({
 }
 
 export function KeybindingsSettingsPanel() {
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
-  const keybindingsConfigPath = useAtomValue(primaryServerKeybindingsConfigPathAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
+  const {
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+    isReady: environmentsReady,
+  } = useSettingsEnvironment();
+  const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
+  const keybindings = serverConfig?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
+  const keybindingsConfigPath = serverConfig?.keybindingsConfigPath ?? null;
+  const availableEditors = serverConfig?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
+  const isConnected = environment?.connection.phase === "connected";
   const upsertKeybinding = useAtomCommand(serverEnvironment.upsertKeybinding, {
     reportFailure: false,
   });
   const removeKeybindingMutation = useAtomCommand(serverEnvironment.removeKeybinding, {
     reportFailure: false,
   });
-  const openInPreferredEditor = useOpenInPreferredEditor(
-    primaryEnvironment?.environmentId ?? null,
-    availableEditors,
-  );
+  const openInPreferredEditor = useOpenInPreferredEditor(environmentId, availableEditors);
   const [query, setQuery] = useState("");
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -1149,7 +1157,7 @@ export function KeybindingsSettingsPanel() {
 
   const saveKeybinding = useCallback(
     (input: ServerUpsertKeybindingInput) => {
-      if (!primaryEnvironment) return;
+      if (environmentId === null || !isConnected) return;
       setSavingCommand(input.command);
       const payload: ServerUpsertKeybindingInput = {
         command: input.command,
@@ -1159,7 +1167,7 @@ export function KeybindingsSettingsPanel() {
       };
       void (async () => {
         const result = await upsertKeybinding({
-          environmentId: primaryEnvironment.environmentId,
+          environmentId,
           input: payload,
         });
         setSavingCommand(null);
@@ -1177,16 +1185,16 @@ export function KeybindingsSettingsPanel() {
         }
       })();
     },
-    [primaryEnvironment, upsertKeybinding],
+    [environmentId, isConnected, upsertKeybinding],
   );
 
   const removeKeybinding = useCallback(
     (row: KeybindingRow) => {
-      if (!primaryEnvironment) return;
+      if (environmentId === null || !isConnected) return;
       setSavingCommand(row.command);
       void (async () => {
         const result = await removeKeybindingMutation({
-          environmentId: primaryEnvironment.environmentId,
+          environmentId,
           input: rowKeybindingTarget(row),
         });
         setSavingCommand(null);
@@ -1200,7 +1208,7 @@ export function KeybindingsSettingsPanel() {
         }
       })();
     },
-    [primaryEnvironment, removeKeybindingMutation],
+    [environmentId, isConnected, removeKeybindingMutation],
   );
 
   const resetKeybinding = useCallback(
@@ -1229,109 +1237,141 @@ export function KeybindingsSettingsPanel() {
 
   return (
     <SettingsPageContainer className="max-w-5xl">
-      <SettingsSection
-        title="Keybindings"
-        headerAction={
-          <div className="flex items-center gap-1.5">
-            <ExpandableHeaderSearch
-              query={query}
-              onChange={setQuery}
-              isOpen={isSearchOpen}
-              onOpenChange={setIsSearchOpen}
-              inputRef={searchInputRef}
-              collapsedAccessory={bindingsCount}
-            />
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    onClick={() => setIsAddingBinding(true)}
-                    aria-label="Add keybinding"
-                  >
-                    <PlusIcon className="size-3" />
-                  </Button>
-                }
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Keybindings environment"
+          description="Keybindings are stored by a specific server and can differ between environments."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : environmentsReady
+                ? "Connect an environment to configure its keybindings."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
               />
-              <TooltipPopup side="top">Add keybinding</TooltipPopup>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    disabled={!keybindingsConfigPath}
-                    onClick={openKeybindingsFile}
-                    aria-label="Open keybindings.json"
-                  >
-                    <FileJsonIcon className="size-3" />
-                  </Button>
-                }
-              />
-              <TooltipPopup side="top">Open keybindings.json</TooltipPopup>
-            </Tooltip>
-          </div>
-        }
-      >
-        {!isElectron ? (
-          <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
-            <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
-            <p>
-              Some shortcuts may be claimed by the browser before T3 Code sees them. Use the desktop
-              app for better keybinding support.
-            </p>
-          </div>
-        ) : null}
-
-        <ScrollArea
-          chainVerticalScroll
-          scrollFade
-          hideScrollbars
-          className="w-full max-w-full rounded-none"
-        >
-          <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-            <div>Command</div>
-            <div>Keybinding</div>
-            <div>When</div>
-            <div>Status</div>
-          </div>
-          <div className="min-w-[680px] divide-y divide-border/60">
-            {isAddingBinding ? (
-              <NewKeybindingTableRow
-                commandOptions={commandOptions}
-                allRows={rows}
-                variables={whenVariables}
-                isSaving={savingCommand !== null}
-                onSave={saveKeybinding}
-                onCancel={() => setIsAddingBinding(false)}
-              />
-            ) : null}
-            {rows.map((row) => (
-              <KeybindingTableRow
-                key={row.id}
-                row={row}
-                allRows={rows}
-                variables={whenVariables}
-                isSaving={savingCommand === row.command}
-                onSave={saveKeybinding}
-                onReset={resetKeybinding}
-                onRemove={removeKeybinding}
-              />
-            ))}
-            {rows.length === 0 && !isAddingBinding ? (
-              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
-                No keybindings match your search.
-              </div>
-            ) : null}
-          </div>
-        </ScrollArea>
+            ) : environmentsReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
       </SettingsSection>
+
+      {isConnected ? (
+        <SettingsSection
+          title="Keybindings"
+          headerAction={
+            <div className="flex items-center gap-1.5">
+              <ExpandableHeaderSearch
+                query={query}
+                onChange={setQuery}
+                isOpen={isSearchOpen}
+                onOpenChange={setIsSearchOpen}
+                inputRef={searchInputRef}
+                collapsedAccessory={bindingsCount}
+              />
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                      onClick={() => setIsAddingBinding(true)}
+                      aria-label="Add keybinding"
+                    >
+                      <PlusIcon className="size-3" />
+                    </Button>
+                  }
+                />
+                <TooltipPopup side="top">Add keybinding</TooltipPopup>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                      disabled={!keybindingsConfigPath}
+                      onClick={openKeybindingsFile}
+                      aria-label="Open keybindings.json"
+                    >
+                      <FileJsonIcon className="size-3" />
+                    </Button>
+                  }
+                />
+                <TooltipPopup side="top">Open keybindings.json</TooltipPopup>
+              </Tooltip>
+            </div>
+          }
+        >
+          {!isElectron ? (
+            <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
+              <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
+              <p>
+                Some shortcuts may be claimed by the browser before T3 Code sees them. Use the
+                desktop app for better keybinding support.
+              </p>
+            </div>
+          ) : null}
+
+          <ScrollArea
+            chainVerticalScroll
+            scrollFade
+            hideScrollbars
+            className="w-full max-w-full rounded-none"
+          >
+            <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+              <div>Command</div>
+              <div>Keybinding</div>
+              <div>When</div>
+              <div>Status</div>
+            </div>
+            <div className="min-w-[680px] divide-y divide-border/60">
+              {isAddingBinding ? (
+                <NewKeybindingTableRow
+                  commandOptions={commandOptions}
+                  allRows={rows}
+                  variables={whenVariables}
+                  isSaving={savingCommand !== null}
+                  onSave={saveKeybinding}
+                  onCancel={() => setIsAddingBinding(false)}
+                />
+              ) : null}
+              {rows.map((row) => (
+                <KeybindingTableRow
+                  key={row.id}
+                  row={row}
+                  allRows={rows}
+                  variables={whenVariables}
+                  isSaving={savingCommand === row.command}
+                  onSave={saveKeybinding}
+                  onReset={resetKeybinding}
+                  onRemove={removeKeybinding}
+                />
+              ))}
+              {rows.length === 0 && !isAddingBinding ? (
+                <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+                  No keybindings match your search.
+                </div>
+              ) : null}
+            </div>
+          </ScrollArea>
+        </SettingsSection>
+      ) : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -1,0 +1,286 @@
+import type { Dispatch, ReactElement, SetStateAction } from "react";
+import { isValidElement } from "react";
+import {
+  DEFAULT_UNIFIED_SETTINGS,
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type UnifiedSettings,
+} from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const atoms = vi.hoisted(() => ({
+  providers: null as ReadonlyArray<ServerProvider> | null,
+  providersAtom: Symbol("providers"),
+  refreshProviders: Symbol("refreshProviders"),
+  updateProvider: Symbol("updateProvider"),
+}));
+
+const commands = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  updateProvider: vi.fn(),
+}));
+
+const settingsState = vi.hoisted(() => ({
+  value: null as UnifiedSettings | null,
+  readEnvironmentIds: [] as EnvironmentId[],
+  updateEnvironmentIds: [] as EnvironmentId[],
+  updateSettings: vi.fn(),
+}));
+
+const hooks = vi.hoisted(() => {
+  let cursor = 0;
+  let slots: unknown[] = [];
+  const nextIndex = () => cursor++;
+
+  return {
+    beginRender() {
+      cursor = 0;
+    },
+    reset() {
+      cursor = 0;
+      slots = [];
+    },
+    useCallback<T>(callback: T): T {
+      nextIndex();
+      return callback;
+    },
+    useMemo<T>(factory: () => T): T {
+      nextIndex();
+      return factory();
+    },
+    useMemoCache(size: number): unknown[] {
+      const index = nextIndex();
+      if (!slots[index]) {
+        slots[index] = Array.from({ length: size }, () => Symbol.for("react.memo_cache_sentinel"));
+      }
+      return slots[index] as unknown[];
+    },
+    useRef<T>(initialValue: T): { current: T } {
+      const index = nextIndex();
+      if (!slots[index]) {
+        slots[index] = { current: initialValue };
+      }
+      return slots[index] as { current: T };
+    },
+    useState<T>(initialValue: T | (() => T)): [T, Dispatch<SetStateAction<T>>] {
+      const index = nextIndex();
+      if (index >= slots.length) {
+        slots[index] =
+          typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
+      }
+      const setValue: Dispatch<SetStateAction<T>> = (nextValue) => {
+        const previous = slots[index] as T;
+        slots[index] =
+          typeof nextValue === "function" ? (nextValue as (value: T) => T)(previous) : nextValue;
+      };
+      return [slots[index] as T, setValue];
+    },
+  };
+});
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useCallback: hooks.useCallback,
+    useMemo: hooks.useMemo,
+    useRef: hooks.useRef,
+    useState: hooks.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", () => ({
+  c: hooks.useMemoCache,
+}));
+
+vi.mock("@effect/atom-react", () => ({
+  useAtomValue: () => atoms.providers,
+}));
+
+vi.mock("../../state/server", () => ({
+  serverEnvironment: {
+    providersValueAtom: () => atoms.providersAtom,
+    refreshProviders: atoms.refreshProviders,
+    updateProvider: atoms.updateProvider,
+  },
+}));
+
+vi.mock("../../state/use-atom-command", () => ({
+  useAtomCommand: (atom: symbol) =>
+    atom === atoms.refreshProviders ? commands.refresh : commands.updateProvider,
+}));
+
+vi.mock("../../hooks/useSettings", () => ({
+  useEnvironmentSettings: (environmentId: EnvironmentId) => {
+    settingsState.readEnvironmentIds.push(environmentId);
+    return settingsState.value;
+  },
+  useUpdateEnvironmentSettings: (environmentId: EnvironmentId) => {
+    settingsState.updateEnvironmentIds.push(environmentId);
+    return settingsState.updateSettings;
+  },
+}));
+
+vi.mock("../../environments/primary", () => ({
+  usePrimarySessionState: () => ({ data: null, error: null, isPending: false, refresh: vi.fn() }),
+}));
+
+import { EnvironmentProviderSettings } from "./ProviderSettingsPanel";
+
+const environmentId = EnvironmentId.make("remote-device");
+const codexId = ProviderInstanceId.make("codex");
+const customId = ProviderInstanceId.make("codex_work");
+
+function provider(): ServerProvider {
+  return {
+    instanceId: codexId,
+    driver: ProviderDriverKind.make("codex"),
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-07-24T12:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+    versionAdvisory: {
+      status: "behind_latest",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      updateCommand: "pnpm add -g @openai/codex@latest",
+      canUpdate: true,
+      checkedAt: "2026-07-24T12:00:00.000Z",
+      message: "Update available.",
+    },
+  };
+}
+
+function visitElements(
+  node: unknown,
+  visitor: (element: ReactElement<Record<string, unknown>>) => boolean,
+): ReactElement<Record<string, unknown>> | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = visitElements(child, visitor);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!isValidElement<Record<string, unknown>>(node)) return null;
+  if (visitor(node)) return node;
+  for (const value of Object.values(node.props)) {
+    const found = visitElements(value, visitor);
+    if (found) return found;
+  }
+  return null;
+}
+
+function renderPanel(): ReactElement<Record<string, unknown>> {
+  hooks.beginRender();
+  return EnvironmentProviderSettings({
+    environmentId,
+    environmentLabel: "Remote device",
+  }) as ReactElement<Record<string, unknown>>;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("EnvironmentProviderSettings routing", () => {
+  beforeEach(() => {
+    hooks.reset();
+    atoms.providers = null;
+    settingsState.value = DEFAULT_UNIFIED_SETTINGS;
+    settingsState.readEnvironmentIds = [];
+    settingsState.updateEnvironmentIds = [];
+    settingsState.updateSettings.mockReset();
+    commands.refresh.mockReset().mockResolvedValue({ _tag: "Success" });
+    commands.updateProvider.mockReset().mockResolvedValue({ _tag: "Success" });
+  });
+
+  it("coalesces a nullable provider snapshot before rendering array-backed UI", () => {
+    expect(() => renderPanel()).not.toThrow();
+    expect(settingsState.readEnvironmentIds).toEqual([environmentId]);
+    expect(settingsState.updateEnvironmentIds).toEqual([environmentId]);
+  });
+
+  it("routes refresh and provider update commands to the selected environment", async () => {
+    atoms.providers = [provider()];
+    const panel = renderPanel();
+    const refreshButton = visitElements(
+      panel,
+      (element) => element.props["aria-label"] === "Refresh provider status",
+    );
+    expect(refreshButton).not.toBeNull();
+    (refreshButton?.props.onClick as (() => void) | undefined)?.();
+    await flushPromises();
+
+    expect(commands.refresh).toHaveBeenCalledWith({ environmentId, input: {} });
+
+    const providerCard = visitElements(
+      panel,
+      (element) =>
+        element.props.instanceId === codexId && typeof element.props.onRunUpdate === "function",
+    );
+    expect(providerCard).not.toBeNull();
+    (providerCard?.props.onRunUpdate as (() => void) | undefined)?.();
+    await flushPromises();
+
+    expect(commands.updateProvider).toHaveBeenCalledWith({
+      environmentId,
+      input: { provider: ProviderDriverKind.make("codex"), instanceId: codexId },
+    });
+  });
+
+  it("deletes and resets provider configuration without erasing shared preferences", () => {
+    settingsState.value = {
+      ...DEFAULT_UNIFIED_SETTINGS,
+      providerInstances: {
+        [codexId]: {
+          driver: ProviderDriverKind.make("codex"),
+          enabled: false,
+        },
+        [customId]: {
+          driver: ProviderDriverKind.make("codex"),
+          enabled: true,
+        },
+      },
+      providerModelPreferences: {
+        [customId]: { hiddenModels: ["hidden"], modelOrder: ["model"] },
+      },
+      favorites: [{ provider: customId, model: "favorite" }],
+    };
+    const panel = renderPanel();
+    const customCard = visitElements(panel, (element) => element.props.instanceId === customId);
+    expect(customCard).not.toBeNull();
+    (customCard?.props.onDelete as (() => void) | undefined)?.();
+
+    expect(settingsState.updateSettings).toHaveBeenLastCalledWith({
+      providerInstances: {
+        [codexId]: settingsState.value.providerInstances?.[codexId],
+      },
+    });
+
+    settingsState.updateSettings.mockClear();
+    const defaultCard = visitElements(panel, (element) => element.props.instanceId === codexId);
+    const resetAction = defaultCard?.props.headerAction;
+    const resetButton = visitElements(
+      resetAction,
+      (element) => typeof element.props.onClick === "function",
+    );
+    expect(resetButton).not.toBeNull();
+    (resetButton?.props.onClick as (() => void) | undefined)?.();
+
+    const resetPatch = settingsState.updateSettings.mock.lastCall?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(Object.keys(resetPatch ?? {}).sort()).toEqual(["providerInstances", "providers"]);
+    expect(resetPatch).not.toHaveProperty("favorites");
+    expect(resetPatch).not.toHaveProperty("providerModelPreferences");
+  });
+});

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
@@ -1,9 +1,10 @@
-import { EnvironmentId } from "@t3tools/contracts";
+import { AuthOrchestrationOperateScope, EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
+  resolvePrimaryOperateAccess,
   resolveSelectedProviderEnvironmentId,
 } from "./ProviderSettingsPanel.logic";
 
@@ -62,7 +63,7 @@ describe("provider environment access", () => {
         hasServerConfig: false,
         operateAccess: "granted",
       }),
-    ).toEqual({ kind: "loading" });
+    ).toEqual({ kind: "loading", reason: "config" });
   });
 
   it("waits for unresolved operate access instead of assuming it is editable", () => {
@@ -72,7 +73,7 @@ describe("provider environment access", () => {
         hasServerConfig: true,
         operateAccess: "pending",
       }),
-    ).toEqual({ kind: "loading" });
+    ).toEqual({ kind: "loading", reason: "permissions" });
   });
 
   it("represents known missing operate access as read only", () => {
@@ -106,5 +107,80 @@ describe("provider environment access", () => {
         operateAccess: "granted",
       }),
     ).toEqual({ kind: "error" });
+  });
+});
+
+describe("primary operate access", () => {
+  const authenticated = {
+    authenticated: true as const,
+    scopes: [AuthOrchestrationOperateScope],
+  };
+
+  it("keeps cached session data authoritative while SWR revalidates", () => {
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: true,
+        hasDesktopBridge: false,
+        session: authenticated,
+        isPending: true,
+      }),
+    ).toBe("granted");
+  });
+
+  it("reports pending only before any session has resolved", () => {
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: true,
+        hasDesktopBridge: false,
+        session: null,
+        isPending: true,
+      }),
+    ).toBe("pending");
+  });
+
+  it("denies unauthenticated sessions and sessions without the operate scope", () => {
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: true,
+        hasDesktopBridge: false,
+        session: { authenticated: false },
+        isPending: false,
+      }),
+    ).toBe("denied");
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: true,
+        hasDesktopBridge: false,
+        session: { authenticated: true, scopes: ["orchestration:read"] },
+        isPending: false,
+      }),
+    ).toBe("denied");
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: true,
+        hasDesktopBridge: false,
+        session: null,
+        isPending: false,
+      }),
+    ).toBe("denied");
+  });
+
+  it("grants desktop bridge and remote environments without blocking on the primary session", () => {
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: true,
+        hasDesktopBridge: true,
+        session: null,
+        isPending: true,
+      }),
+    ).toBe("granted");
+    expect(
+      resolvePrimaryOperateAccess({
+        isPrimary: false,
+        hasDesktopBridge: false,
+        session: null,
+        isPending: true,
+      }),
+    ).toBe("granted");
   });
 });

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
@@ -50,7 +50,7 @@ describe("provider environment access", () => {
       classifyProviderEnvironmentAccess({
         connectionPhase: "connected",
         hasServerConfig: true,
-        canOperate: true,
+        operateAccess: "granted",
       }),
     ).toEqual({ kind: "editable" });
   });
@@ -60,7 +60,17 @@ describe("provider environment access", () => {
       classifyProviderEnvironmentAccess({
         connectionPhase: "connected",
         hasServerConfig: false,
-        canOperate: true,
+        operateAccess: "granted",
+      }),
+    ).toEqual({ kind: "loading" });
+  });
+
+  it("waits for unresolved operate access instead of assuming it is editable", () => {
+    expect(
+      classifyProviderEnvironmentAccess({
+        connectionPhase: "connected",
+        hasServerConfig: true,
+        operateAccess: "pending",
       }),
     ).toEqual({ kind: "loading" });
   });
@@ -70,7 +80,7 @@ describe("provider environment access", () => {
       classifyProviderEnvironmentAccess({
         connectionPhase: "connected",
         hasServerConfig: true,
-        canOperate: false,
+        operateAccess: "denied",
       }),
     ).toEqual({ kind: "read-only" });
   });
@@ -82,7 +92,7 @@ describe("provider environment access", () => {
         classifyProviderEnvironmentAccess({
           connectionPhase,
           hasServerConfig: true,
-          canOperate: true,
+          operateAccess: "granted",
         }),
       ).toEqual({ kind: "unavailable" });
     },
@@ -93,7 +103,7 @@ describe("provider environment access", () => {
       classifyProviderEnvironmentAccess({
         connectionPhase: "error",
         hasServerConfig: true,
-        canOperate: true,
+        operateAccess: "granted",
       }),
     ).toEqual({ kind: "error" });
   });

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.test.ts
@@ -1,0 +1,100 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildProviderEnvironmentOptions,
+  classifyProviderEnvironmentAccess,
+  resolveSelectedProviderEnvironmentId,
+} from "./ProviderSettingsPanel.logic";
+
+const primaryId = EnvironmentId.make("primary");
+const relayId = EnvironmentId.make("relay");
+const sshId = EnvironmentId.make("ssh");
+
+const environments = [
+  { environmentId: sshId, label: "Zulu SSH" },
+  { environmentId: relayId, label: "Alpha Relay" },
+  { environmentId: primaryId, label: "This device" },
+] as const;
+
+describe("provider environment selection", () => {
+  it("sorts the primary environment first and the rest by label", () => {
+    expect(
+      buildProviderEnvironmentOptions(environments, primaryId).map(
+        (environment) => environment.environmentId,
+      ),
+    ).toEqual([primaryId, relayId, sshId]);
+  });
+
+  it("keeps a valid selection, then falls back to primary or the first environment", () => {
+    const options = buildProviderEnvironmentOptions(environments, primaryId);
+
+    expect(resolveSelectedProviderEnvironmentId(options, sshId, primaryId)).toBe(sshId);
+    expect(
+      resolveSelectedProviderEnvironmentId(
+        options.filter((environment) => environment.environmentId !== sshId),
+        sshId,
+        primaryId,
+      ),
+    ).toBe(primaryId);
+    expect(resolveSelectedProviderEnvironmentId(options.slice(1), primaryId, primaryId)).toBe(
+      relayId,
+    );
+    expect(resolveSelectedProviderEnvironmentId([], null, primaryId)).toBeNull();
+  });
+});
+
+describe("provider environment access", () => {
+  it("allows connected environments with config and operate access", () => {
+    expect(
+      classifyProviderEnvironmentAccess({
+        connectionPhase: "connected",
+        hasServerConfig: true,
+        canOperate: true,
+      }),
+    ).toEqual({ kind: "editable" });
+  });
+
+  it("waits for config before exposing controls", () => {
+    expect(
+      classifyProviderEnvironmentAccess({
+        connectionPhase: "connected",
+        hasServerConfig: false,
+        canOperate: true,
+      }),
+    ).toEqual({ kind: "loading" });
+  });
+
+  it("represents known missing operate access as read only", () => {
+    expect(
+      classifyProviderEnvironmentAccess({
+        connectionPhase: "connected",
+        hasServerConfig: true,
+        canOperate: false,
+      }),
+    ).toEqual({ kind: "read-only" });
+  });
+
+  it.each(["available", "offline", "connecting", "reconnecting"] as const)(
+    "keeps %s environments unavailable",
+    (connectionPhase) => {
+      expect(
+        classifyProviderEnvironmentAccess({
+          connectionPhase,
+          hasServerConfig: true,
+          canOperate: true,
+        }),
+      ).toEqual({ kind: "unavailable" });
+    },
+  );
+
+  it("separates connection errors from other unavailable states", () => {
+    expect(
+      classifyProviderEnvironmentAccess({
+        connectionPhase: "error",
+        hasServerConfig: true,
+        canOperate: true,
+      }),
+    ).toEqual({ kind: "error" });
+  });
+});

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
@@ -1,0 +1,76 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export interface ProviderEnvironmentOptionLike {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}
+
+export function buildProviderEnvironmentOptions<T extends ProviderEnvironmentOptionLike>(
+  environments: ReadonlyArray<T>,
+  primaryEnvironmentId: EnvironmentId | null,
+): ReadonlyArray<T> {
+  return environments.toSorted((left, right) => {
+    const leftIsPrimary = left.environmentId === primaryEnvironmentId;
+    const rightIsPrimary = right.environmentId === primaryEnvironmentId;
+    if (leftIsPrimary !== rightIsPrimary) {
+      return leftIsPrimary ? -1 : 1;
+    }
+    return (
+      left.label.localeCompare(right.label) ||
+      String(left.environmentId).localeCompare(String(right.environmentId))
+    );
+  });
+}
+
+export function resolveSelectedProviderEnvironmentId(
+  environments: ReadonlyArray<ProviderEnvironmentOptionLike>,
+  selectedEnvironmentId: EnvironmentId | null,
+  primaryEnvironmentId: EnvironmentId | null,
+): EnvironmentId | null {
+  if (
+    selectedEnvironmentId !== null &&
+    environments.some((environment) => environment.environmentId === selectedEnvironmentId)
+  ) {
+    return selectedEnvironmentId;
+  }
+  if (
+    primaryEnvironmentId !== null &&
+    environments.some((environment) => environment.environmentId === primaryEnvironmentId)
+  ) {
+    return primaryEnvironmentId;
+  }
+  return environments[0]?.environmentId ?? null;
+}
+
+export type ProviderEnvironmentAccess =
+  | { readonly kind: "editable" }
+  | { readonly kind: "loading" }
+  | { readonly kind: "read-only" }
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "error" };
+
+export function classifyProviderEnvironmentAccess(input: {
+  readonly connectionPhase:
+    | "available"
+    | "offline"
+    | "connecting"
+    | "reconnecting"
+    | "connected"
+    | "error";
+  readonly hasServerConfig: boolean;
+  readonly canOperate: boolean | null;
+}): ProviderEnvironmentAccess {
+  if (input.connectionPhase === "error") {
+    return { kind: "error" };
+  }
+  if (input.connectionPhase !== "connected") {
+    return { kind: "unavailable" };
+  }
+  if (!input.hasServerConfig) {
+    return { kind: "loading" };
+  }
+  if (input.canOperate === false) {
+    return { kind: "read-only" };
+  }
+  return { kind: "editable" };
+}

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
@@ -49,6 +49,14 @@ export type ProviderEnvironmentAccess =
   | { readonly kind: "unavailable" }
   | { readonly kind: "error" };
 
+/**
+ * Whether the session may change provider configuration on an environment.
+ * `pending` means the answer is still unknown, which must not be presented as
+ * editable: rendering controls we already know might be rejected only turns a
+ * permission problem into a failed write.
+ */
+export type ProviderOperateAccess = "granted" | "denied" | "pending";
+
 export function classifyProviderEnvironmentAccess(input: {
   readonly connectionPhase:
     | "available"
@@ -58,7 +66,7 @@ export function classifyProviderEnvironmentAccess(input: {
     | "connected"
     | "error";
   readonly hasServerConfig: boolean;
-  readonly canOperate: boolean | null;
+  readonly operateAccess: ProviderOperateAccess;
 }): ProviderEnvironmentAccess {
   if (input.connectionPhase === "error") {
     return { kind: "error" };
@@ -66,10 +74,10 @@ export function classifyProviderEnvironmentAccess(input: {
   if (input.connectionPhase !== "connected") {
     return { kind: "unavailable" };
   }
-  if (!input.hasServerConfig) {
+  if (!input.hasServerConfig || input.operateAccess === "pending") {
     return { kind: "loading" };
   }
-  if (input.canOperate === false) {
+  if (input.operateAccess === "denied") {
     return { kind: "read-only" };
   }
   return { kind: "editable" };

--- a/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.logic.ts
@@ -1,4 +1,8 @@
-import type { EnvironmentId } from "@t3tools/contracts";
+import {
+  AuthOrchestrationOperateScope,
+  type AuthSessionState,
+  type EnvironmentId,
+} from "@t3tools/contracts";
 
 export interface ProviderEnvironmentOptionLike {
   readonly environmentId: EnvironmentId;
@@ -44,7 +48,8 @@ export function resolveSelectedProviderEnvironmentId(
 
 export type ProviderEnvironmentAccess =
   | { readonly kind: "editable" }
-  | { readonly kind: "loading" }
+  /** `reason` distinguishes waiting on the device from waiting on permissions. */
+  | { readonly kind: "loading"; readonly reason: "config" | "permissions" }
   | { readonly kind: "read-only" }
   | { readonly kind: "unavailable" }
   | { readonly kind: "error" };
@@ -56,6 +61,39 @@ export type ProviderEnvironmentAccess =
  * permission problem into a failed write.
  */
 export type ProviderOperateAccess = "granted" | "denied" | "pending";
+
+/**
+ * Resolve whether the session may reconfigure providers on an environment.
+ *
+ * Only the primary environment exposes its own granted scopes to the client
+ * today, so remote sessions are optimistic: the connection brokers request
+ * `orchestration:operate`, and the environment RPC layer stays authoritative if
+ * a narrower credential was minted.
+ *
+ * Cached session data wins over an in-flight revalidation. The session atom is
+ * SWR-backed, so it reports `isPending` on every background refresh; treating
+ * that as unknown would flip a working panel back to loading and discard
+ * in-progress edits.
+ */
+export function resolvePrimaryOperateAccess(input: {
+  readonly isPrimary: boolean;
+  readonly hasDesktopBridge: boolean;
+  readonly session: Pick<AuthSessionState, "authenticated" | "scopes"> | null;
+  readonly isPending: boolean;
+}): ProviderOperateAccess {
+  if (!input.isPrimary || input.hasDesktopBridge) {
+    return "granted";
+  }
+  if (input.session === null) {
+    return input.isPending ? "pending" : "denied";
+  }
+  if (!input.session.authenticated) {
+    return "denied";
+  }
+  return (input.session.scopes ?? []).includes(AuthOrchestrationOperateScope)
+    ? "granted"
+    : "denied";
+}
 
 export function classifyProviderEnvironmentAccess(input: {
   readonly connectionPhase:
@@ -74,8 +112,11 @@ export function classifyProviderEnvironmentAccess(input: {
   if (input.connectionPhase !== "connected") {
     return { kind: "unavailable" };
   }
-  if (!input.hasServerConfig || input.operateAccess === "pending") {
-    return { kind: "loading" };
+  if (!input.hasServerConfig) {
+    return { kind: "loading", reason: "config" };
+  }
+  if (input.operateAccess === "pending") {
+    return { kind: "loading", reason: "permissions" };
   }
   if (input.operateAccess === "denied") {
     return { kind: "read-only" };

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -307,6 +307,7 @@ export function EnvironmentProviderSettings({
   const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
     ReadonlySet<ProviderDriverKind>
   >(() => new Set());
+  const updatingProviderDriversRef = useRef(new Set<ProviderDriverKind>());
   const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
   const refreshingRef = useRef(false);
 
@@ -359,48 +360,47 @@ export function EnvironmentProviderSettings({
 
   const runProviderUpdate = useCallback(
     async (candidate: ProviderUpdateCandidate) => {
-      let started = false;
+      if (updatingProviderDriversRef.current.has(candidate.driver)) {
+        return;
+      }
+      updatingProviderDriversRef.current.add(candidate.driver);
       setUpdatingProviderDrivers((previous) => {
-        if (previous.has(candidate.driver)) {
-          return previous;
-        }
-        started = true;
         const next = new Set(previous);
         next.add(candidate.driver);
         return next;
       });
-      if (!started) {
-        return;
-      }
-
-      const result = await updateProvider({
-        environmentId,
-        input: {
-          provider: candidate.driver,
-          instanceId: candidate.instanceId,
-        },
-      });
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: `Could not update ${PROVIDER_DISPLAY_NAMES[candidate.driver] ?? candidate.driver}`,
-            description:
-              error instanceof Error
-                ? error.message
-                : "The provider update command could not be started.",
-          }),
-        );
-      }
-      setUpdatingProviderDrivers((previous) => {
-        if (!previous.has(candidate.driver)) {
-          return previous;
+      try {
+        const result = await updateProvider({
+          environmentId,
+          input: {
+            provider: candidate.driver,
+            instanceId: candidate.instanceId,
+          },
+        });
+        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: `Could not update ${PROVIDER_DISPLAY_NAMES[candidate.driver] ?? candidate.driver}`,
+              description:
+                error instanceof Error
+                  ? error.message
+                  : "The provider update command could not be started.",
+            }),
+          );
         }
-        const next = new Set(previous);
-        next.delete(candidate.driver);
-        return next;
-      });
+      } finally {
+        updatingProviderDriversRef.current.delete(candidate.driver);
+        setUpdatingProviderDrivers((previous) => {
+          if (!previous.has(candidate.driver)) {
+            return previous;
+          }
+          const next = new Set(previous);
+          next.delete(candidate.driver);
+          return next;
+        });
+      }
     },
     [environmentId, updateProvider],
   );

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -18,32 +18,20 @@ import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import * as Arr from "effect/Array";
 import * as Equal from "effect/Equal";
 import * as Result from "effect/Result";
-import {
-  CloudIcon,
-  LaptopIcon,
-  LoaderIcon,
-  MonitorIcon,
-  PlusIcon,
-  RefreshCwIcon,
-  TerminalIcon,
-} from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { useCallback, useMemo, useRef, useState } from "react";
 
-import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
 import { usePrimarySessionState } from "../../environments/primary";
 import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { cn } from "../../lib/utils";
 import { resolveAppModelSelectionState } from "../../modelSelection";
 import { deriveProviderInstanceEntries } from "../../providerInstances";
-import {
-  useEnvironments,
-  usePrimaryEnvironmentId,
-  type EnvironmentPresentation,
-} from "../../state/environments";
+import type { EnvironmentPresentation } from "../../state/environments";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { getRelativeTimeState } from "../../timestampFormat";
-import { ConnectionStatusDot } from "../ConnectionStatusDot";
 import {
   canOneClickUpdateProviderCandidate,
   collectProviderUpdateCandidates,
@@ -72,12 +60,11 @@ import {
   useRelativeTimeTick,
 } from "./settingsLayout";
 import {
-  buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
   type ProviderEnvironmentAccess,
   resolvePrimaryOperateAccess,
-  resolveSelectedProviderEnvironmentId,
 } from "./ProviderSettingsPanel.logic";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 
 const EMPTY_SERVER_PROVIDERS: ReadonlyArray<ServerProvider> = [];
 
@@ -127,36 +114,6 @@ function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }
   );
 }
 
-function providerEnvironmentIcon(environment: EnvironmentPresentation) {
-  if (environment.entry.target._tag === "PrimaryConnectionTarget") return MonitorIcon;
-  if (environment.entry.target._tag === "RelayConnectionTarget") return CloudIcon;
-  if (environment.entry.target._tag === "SshConnectionTarget") return TerminalIcon;
-  if (isDesktopLocalConnectionTarget(environment.entry.target)) return LaptopIcon;
-  return CloudIcon;
-}
-
-function providerEnvironmentDetail(environment: EnvironmentPresentation): string {
-  if (environment.entry.target._tag === "PrimaryConnectionTarget") return "Primary device";
-  if (environment.relayManaged) return "T3 Connect";
-  if (environment.entry.target._tag === "SshConnectionTarget") return "SSH";
-  if (isDesktopLocalConnectionTarget(environment.entry.target)) return "Local device";
-  return environment.displayUrl ?? "Remote device";
-}
-
-function connectionDotClassName(environment: EnvironmentPresentation): string {
-  switch (environment.connection.phase) {
-    case "connected":
-      return "bg-success";
-    case "connecting":
-    case "reconnecting":
-      return "bg-warning";
-    case "error":
-      return "bg-destructive";
-    default:
-      return "bg-muted-foreground/40";
-  }
-}
-
 function EnvironmentUnavailableRow({
   environment,
   access,
@@ -193,99 +150,51 @@ function EnvironmentUnavailableRow({
 }
 
 export function ProviderSettingsPanel() {
-  const { environments, isReady } = useEnvironments();
-  const primaryEnvironmentId = usePrimaryEnvironmentId();
-  const options = useMemo(
-    () => buildProviderEnvironmentOptions(environments, primaryEnvironmentId),
-    [environments, primaryEnvironmentId],
-  );
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(
+  const {
+    environmentId,
+    environment,
+    environments,
     primaryEnvironmentId,
-  );
-  const effectiveEnvironmentId = resolveSelectedProviderEnvironmentId(
-    options,
-    selectedEnvironmentId,
-    primaryEnvironmentId,
-  );
-  useEffect(() => {
-    if (effectiveEnvironmentId !== selectedEnvironmentId) {
-      setSelectedEnvironmentId(effectiveEnvironmentId);
-    }
-  }, [effectiveEnvironmentId, selectedEnvironmentId]);
-  const selectedEnvironment =
-    options.find((environment) => environment.environmentId === effectiveEnvironmentId) ?? null;
-  const showDeviceList =
-    options.length === 0 ||
-    options.length > 1 ||
-    options[0]?.entry.target._tag !== "PrimaryConnectionTarget";
+    selectEnvironment,
+    isReady,
+  } = useSettingsEnvironment();
 
   return (
     <SettingsPageContainer>
-      {showDeviceList ? (
-        <SettingsSection title="Devices">
-          {options.length === 0 ? (
-            // The catalog hydrates asynchronously, so an empty list before it is
-            // ready means "not loaded yet", not "nothing is connected".
-            <SettingsRow
-              title={isReady ? "No connected devices" : "Loading devices"}
-              description={
-                isReady
-                  ? "Connect an execution environment before configuring providers."
-                  : "Reading connected execution environments."
-              }
-            />
-          ) : (
-            <div className="grid gap-1 sm:grid-cols-2">
-              {options.map((environment) => {
-                const Icon = providerEnvironmentIcon(environment);
-                const selected = environment.environmentId === effectiveEnvironmentId;
-                const statusText = connectionStatusText(environment.connection);
-                const isPending =
-                  environment.connection.phase === "connecting" ||
-                  environment.connection.phase === "reconnecting";
-                return (
-                  <button
-                    key={environment.environmentId}
-                    type="button"
-                    aria-pressed={selected}
-                    className={cn(
-                      "flex min-w-0 items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors sm:px-4",
-                      selected
-                        ? "bg-primary/8 ring-1 ring-primary/25 dark:bg-primary/12"
-                        : "hover:bg-muted/40",
-                    )}
-                    onClick={() => setSelectedEnvironmentId(environment.environmentId)}
-                  >
-                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
-                      <Icon className="size-4" aria-hidden />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="flex items-center gap-1.5">
-                        <ConnectionStatusDot
-                          tooltipText={statusText}
-                          dotClassName={connectionDotClassName(environment)}
-                          pingClassName={isPending ? "bg-warning/60 duration-2000" : null}
-                        />
-                        <span className="truncate text-sm font-medium text-foreground">
-                          {environment.label}
-                        </span>
-                      </span>
-                      <span className="block truncate pl-[18px] text-xs text-muted-foreground">
-                        {providerEnvironmentDetail(environment)} · {statusText}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </SettingsSection>
-      ) : null}
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Provider settings"
+          description="Provider availability, authentication, models, and update controls are scoped to this environment."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : isReady
+                ? "Connect an environment to configure providers."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
+            ) : isReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
+      </SettingsSection>
 
-      {selectedEnvironment ? (
+      {environment ? (
         <SelectedEnvironmentProviderSettings
-          key={selectedEnvironment.environmentId}
-          environment={selectedEnvironment}
+          key={environment.environmentId}
+          environment={environment}
         />
       ) : null}
     </SettingsPageContainer>

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -1,0 +1,758 @@
+import { useAtomValue } from "@effect/atom-react";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
+import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import {
+  AuthOrchestrationOperateScope,
+  defaultInstanceIdForDriver,
+  type EnvironmentId,
+  PROVIDER_DISPLAY_NAMES,
+  ProviderDriverKind,
+  type ProviderInstanceConfig,
+  type ProviderInstanceId,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import * as Arr from "effect/Array";
+import * as Equal from "effect/Equal";
+import * as Result from "effect/Result";
+import {
+  CloudIcon,
+  LaptopIcon,
+  LoaderIcon,
+  MonitorIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  TerminalIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { isDesktopLocalConnectionTarget } from "../../connection/desktopLocal";
+import { usePrimarySessionState } from "../../environments/primary";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { cn } from "../../lib/utils";
+import { resolveAppModelSelectionState } from "../../modelSelection";
+import {
+  useEnvironments,
+  usePrimaryEnvironmentId,
+  type EnvironmentPresentation,
+} from "../../state/environments";
+import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { getRelativeTimeState } from "../../timestampFormat";
+import { ConnectionStatusDot } from "../ConnectionStatusDot";
+import {
+  canOneClickUpdateProviderCandidate,
+  collectProviderUpdateCandidates,
+  hasOneClickUpdateProviderCandidate,
+  isProviderUpdateActive,
+  type ProviderUpdateCandidate,
+} from "../ProviderUpdateLaunchNotification.logic";
+import { Button } from "../ui/button";
+import { stackedThreadToast, toastManager } from "../ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
+import { ProviderInstanceCard } from "./ProviderInstanceCard";
+import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
+import { buildProviderInstanceUpdatePatch } from "./SettingsPanels.logic";
+import {
+  SettingResetButton,
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+  useRelativeTimeTick,
+} from "./settingsLayout";
+import {
+  buildProviderEnvironmentOptions,
+  classifyProviderEnvironmentAccess,
+  resolveSelectedProviderEnvironmentId,
+} from "./ProviderSettingsPanel.logic";
+
+const EMPTY_SERVER_PROVIDERS: ReadonlyArray<ServerProvider> = [];
+
+function withoutProviderInstanceKey<V>(
+  record: Readonly<Record<ProviderInstanceId, V>> | undefined,
+  key: ProviderInstanceId,
+): Record<ProviderInstanceId, V> {
+  const next = { ...record } as Record<ProviderInstanceId, V>;
+  delete next[key];
+  return next;
+}
+
+function withoutProviderInstanceFavorites(
+  favorites: ReadonlyArray<{ readonly provider: ProviderInstanceId; readonly model: string }>,
+  instanceId: ProviderInstanceId,
+) {
+  return favorites.filter((favorite) => favorite.provider !== instanceId);
+}
+
+const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({
+  provider: definition.value,
+}));
+
+function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }) {
+  useRelativeTimeTick();
+  const lastCheckedRelative = getRelativeTimeState(lastCheckedAt);
+
+  if (lastCheckedRelative.status === "missing") {
+    return null;
+  }
+
+  if (lastCheckedRelative.status === "invalid") {
+    return <span className="text-[11px] text-muted-foreground/50">Checked unavailable</span>;
+  }
+
+  return (
+    <span className="text-[11px] text-muted-foreground/60">
+      {lastCheckedRelative.suffix ? (
+        <>
+          Checked <span className="font-mono tabular-nums">{lastCheckedRelative.value}</span>{" "}
+          {lastCheckedRelative.suffix}
+        </>
+      ) : (
+        <>Checked {lastCheckedRelative.value}</>
+      )}
+    </span>
+  );
+}
+
+function providerEnvironmentIcon(environment: EnvironmentPresentation) {
+  if (environment.entry.target._tag === "PrimaryConnectionTarget") return MonitorIcon;
+  if (environment.entry.target._tag === "RelayConnectionTarget") return CloudIcon;
+  if (environment.entry.target._tag === "SshConnectionTarget") return TerminalIcon;
+  if (isDesktopLocalConnectionTarget(environment.entry.target)) return LaptopIcon;
+  return CloudIcon;
+}
+
+function providerEnvironmentDetail(environment: EnvironmentPresentation): string {
+  if (environment.entry.target._tag === "PrimaryConnectionTarget") return "Primary device";
+  if (environment.relayManaged) return "T3 Connect";
+  if (environment.entry.target._tag === "SshConnectionTarget") return "SSH";
+  if (isDesktopLocalConnectionTarget(environment.entry.target)) return "Local device";
+  return environment.displayUrl ?? "Remote device";
+}
+
+function connectionDotClassName(environment: EnvironmentPresentation): string {
+  switch (environment.connection.phase) {
+    case "connected":
+      return "bg-success";
+    case "connecting":
+    case "reconnecting":
+      return "bg-warning";
+    case "error":
+      return "bg-destructive";
+    default:
+      return "bg-muted-foreground/40";
+  }
+}
+
+function EnvironmentUnavailableRow({
+  environment,
+  accessKind,
+}: {
+  readonly environment: EnvironmentPresentation;
+  readonly accessKind: "loading" | "read-only" | "unavailable" | "error";
+}) {
+  const title =
+    accessKind === "loading"
+      ? "Loading provider settings"
+      : accessKind === "read-only"
+        ? "Provider settings are read only"
+        : accessKind === "error"
+          ? "Could not connect to this device"
+          : "Provider settings are unavailable";
+  const description =
+    accessKind === "loading"
+      ? `Waiting for ${environment.label}'s configuration.`
+      : accessKind === "read-only"
+        ? `This session can view ${environment.label}, but it cannot change provider configuration.`
+        : connectionStatusText(environment.connection);
+  return (
+    <SettingsSection title="Providers">
+      <SettingsRow
+        title={
+          <span className="inline-flex items-center gap-2">
+            {accessKind === "loading" ? (
+              <LoaderIcon className="size-3.5 animate-spin text-muted-foreground" />
+            ) : null}
+            {title}
+          </span>
+        }
+        description={description}
+      />
+    </SettingsSection>
+  );
+}
+
+export function ProviderSettingsPanel() {
+  const { environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const options = useMemo(
+    () => buildProviderEnvironmentOptions(environments, primaryEnvironmentId),
+    [environments, primaryEnvironmentId],
+  );
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(
+    primaryEnvironmentId,
+  );
+  const effectiveEnvironmentId = resolveSelectedProviderEnvironmentId(
+    options,
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+  );
+  useEffect(() => {
+    if (effectiveEnvironmentId !== selectedEnvironmentId) {
+      setSelectedEnvironmentId(effectiveEnvironmentId);
+    }
+  }, [effectiveEnvironmentId, selectedEnvironmentId]);
+  const selectedEnvironment =
+    options.find((environment) => environment.environmentId === effectiveEnvironmentId) ?? null;
+  const showDeviceList =
+    options.length === 0 ||
+    options.length > 1 ||
+    options[0]?.entry.target._tag !== "PrimaryConnectionTarget";
+
+  return (
+    <SettingsPageContainer>
+      {showDeviceList ? (
+        <SettingsSection title="Devices">
+          {options.length === 0 ? (
+            <SettingsRow
+              title="No connected devices"
+              description="Connect an execution environment before configuring providers."
+            />
+          ) : (
+            <div className="grid gap-1 sm:grid-cols-2">
+              {options.map((environment) => {
+                const Icon = providerEnvironmentIcon(environment);
+                const selected = environment.environmentId === effectiveEnvironmentId;
+                const statusText = connectionStatusText(environment.connection);
+                const isPending =
+                  environment.connection.phase === "connecting" ||
+                  environment.connection.phase === "reconnecting";
+                return (
+                  <button
+                    key={environment.environmentId}
+                    type="button"
+                    aria-pressed={selected}
+                    className={cn(
+                      "flex min-w-0 items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors sm:px-4",
+                      selected
+                        ? "bg-primary/8 ring-1 ring-primary/25 dark:bg-primary/12"
+                        : "hover:bg-muted/40",
+                    )}
+                    onClick={() => setSelectedEnvironmentId(environment.environmentId)}
+                  >
+                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background text-muted-foreground">
+                      <Icon className="size-4" aria-hidden />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center gap-1.5">
+                        <ConnectionStatusDot
+                          tooltipText={statusText}
+                          dotClassName={connectionDotClassName(environment)}
+                          pingClassName={isPending ? "bg-warning/60 duration-2000" : null}
+                        />
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {environment.label}
+                        </span>
+                      </span>
+                      <span className="block truncate pl-[18px] text-xs text-muted-foreground">
+                        {providerEnvironmentDetail(environment)} · {statusText}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </SettingsSection>
+      ) : null}
+
+      {selectedEnvironment ? (
+        <SelectedEnvironmentProviderSettings
+          key={selectedEnvironment.environmentId}
+          environment={selectedEnvironment}
+        />
+      ) : null}
+    </SettingsPageContainer>
+  );
+}
+
+function SelectedEnvironmentProviderSettings({
+  environment,
+}: {
+  readonly environment: EnvironmentPresentation;
+}) {
+  const primarySessionState = usePrimarySessionState();
+  const isPrimary = environment.entry.target._tag === "PrimaryConnectionTarget";
+  // Remote connection brokers request the standard client scopes, which include
+  // orchestration:operate. The environment RPC layer remains authoritative if a
+  // custom remote credential grants less access.
+  const canOperate = isPrimary
+    ? window.desktopBridge
+      ? true
+      : primarySessionState.data?.authenticated
+        ? (primarySessionState.data.scopes ?? []).includes(AuthOrchestrationOperateScope)
+        : null
+    : true;
+  const access = classifyProviderEnvironmentAccess({
+    connectionPhase: environment.connection.phase,
+    hasServerConfig: environment.serverConfig !== null,
+    canOperate,
+  });
+  if (access.kind !== "editable") {
+    return <EnvironmentUnavailableRow environment={environment} accessKind={access.kind} />;
+  }
+  return (
+    <EnvironmentProviderSettings
+      environmentId={environment.environmentId}
+      environmentLabel={environment.label}
+    />
+  );
+}
+
+export function EnvironmentProviderSettings({
+  environmentId,
+  environmentLabel,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const serverProviders =
+    useAtomValue(serverEnvironment.providersValueAtom(environmentId)) ?? EMPTY_SERVER_PROVIDERS;
+  const refreshServerProviders = useAtomCommand(serverEnvironment.refreshProviders, {
+    reportFailure: false,
+  });
+  const updateProvider = useAtomCommand(serverEnvironment.updateProvider, {
+    reportFailure: false,
+  });
+  const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
+  const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
+  const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
+    ReadonlySet<ProviderDriverKind>
+  >(() => new Set());
+  const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
+  const refreshingRef = useRef(false);
+
+  const providerUpdateCandidates = useMemo(
+    () => collectProviderUpdateCandidates(serverProviders),
+    [serverProviders],
+  );
+  const providerUpdateCandidateByInstanceId = useMemo(
+    () => new Map(providerUpdateCandidates.map((candidate) => [candidate.instanceId, candidate])),
+    [providerUpdateCandidates],
+  );
+  const visibleProviderSettings = PROVIDER_SETTINGS.filter(
+    (providerSettings) =>
+      providerSettings.provider !== "cursor" ||
+      serverProviders.some(
+        (provider) =>
+          provider.instanceId === defaultInstanceIdForDriver(ProviderDriverKind.make("cursor")),
+      ),
+  );
+  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
+  const textGenInstanceId = textGenerationModelSelection.instanceId;
+  const lastCheckedAt =
+    serverProviders.length > 0
+      ? serverProviders.reduce(
+          (latest, provider) => (provider.checkedAt > latest ? provider.checkedAt : latest),
+          serverProviders[0]!.checkedAt,
+        )
+      : null;
+
+  const refreshProviders = useCallback(() => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setIsRefreshingProviders(true);
+    void (async () => {
+      const result = await refreshServerProviders({
+        environmentId,
+        input: {},
+      });
+      refreshingRef.current = false;
+      setIsRefreshingProviders(false);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        console.warn("Failed to refresh providers", {
+          operation: "refresh-providers",
+          environmentId,
+          ...safeErrorLogAttributes(squashAtomCommandFailure(result)),
+        });
+      }
+    })();
+  }, [environmentId, refreshServerProviders]);
+
+  const runProviderUpdate = useCallback(
+    async (candidate: ProviderUpdateCandidate) => {
+      let started = false;
+      setUpdatingProviderDrivers((previous) => {
+        if (previous.has(candidate.driver)) {
+          return previous;
+        }
+        started = true;
+        const next = new Set(previous);
+        next.add(candidate.driver);
+        return next;
+      });
+      if (!started) {
+        return;
+      }
+
+      const result = await updateProvider({
+        environmentId,
+        input: {
+          provider: candidate.driver,
+          instanceId: candidate.instanceId,
+        },
+      });
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: `Could not update ${PROVIDER_DISPLAY_NAMES[candidate.driver] ?? candidate.driver}`,
+            description:
+              error instanceof Error
+                ? error.message
+                : "The provider update command could not be started.",
+          }),
+        );
+      }
+      setUpdatingProviderDrivers((previous) => {
+        if (!previous.has(candidate.driver)) {
+          return previous;
+        }
+        const next = new Set(previous);
+        next.delete(candidate.driver);
+        return next;
+      });
+    },
+    [environmentId, updateProvider],
+  );
+
+  interface InstanceRow {
+    readonly instanceId: ProviderInstanceId;
+    readonly instance: ProviderInstanceConfig;
+    readonly driver: ProviderDriverKind;
+    readonly isDefault: boolean;
+    readonly isDirty?: boolean;
+  }
+
+  const instancesByDriver = new Map<
+    ProviderDriverKind,
+    Array<[ProviderInstanceId, ProviderInstanceConfig]>
+  >();
+  for (const [rawId, instance] of Object.entries(settings.providerInstances ?? {})) {
+    const driver = instance.driver;
+    const list = instancesByDriver.get(driver) ?? [];
+    list.push([rawId as ProviderInstanceId, instance]);
+    instancesByDriver.set(driver, list);
+  }
+
+  const defaultSlotIdsBySource = new Set<string>(
+    visibleProviderSettings.map((providerSettings) =>
+      String(defaultInstanceIdForDriver(providerSettings.provider)),
+    ),
+  );
+
+  const rows: InstanceRow[] = [];
+  const visibleDriverKinds = new Set<ProviderDriverKind>(
+    visibleProviderSettings.map((providerSettings) => providerSettings.provider),
+  );
+
+  for (const providerSettings of visibleProviderSettings) {
+    type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
+    const legacyProviders = settings.providers as Record<string, LegacyProviderSettings>;
+    const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
+      string,
+      LegacyProviderSettings
+    >;
+    const driver = providerSettings.provider;
+    const defaultInstanceId = defaultInstanceIdForDriver(driver);
+    const explicitInstance = settings.providerInstances?.[defaultInstanceId];
+    const legacyConfig = legacyProviders[providerSettings.provider]!;
+    const defaultLegacyConfig = defaultLegacyProviders[providerSettings.provider]!;
+    const effectiveInstance: ProviderInstanceConfig =
+      explicitInstance ??
+      ({
+        driver,
+        enabled: legacyConfig.enabled,
+        config: legacyConfig,
+      } satisfies ProviderInstanceConfig);
+    const isDirty =
+      explicitInstance !== undefined || !Equal.equals(legacyConfig, defaultLegacyConfig);
+    rows.push({
+      instanceId: defaultInstanceId,
+      instance: effectiveInstance,
+      driver,
+      isDefault: true,
+      isDirty,
+    });
+    for (const [id, instance] of instancesByDriver.get(providerSettings.provider) ?? []) {
+      if (id === defaultInstanceId) continue;
+      rows.push({ instanceId: id, instance, driver: instance.driver, isDefault: false });
+    }
+  }
+  for (const [driver, list] of instancesByDriver) {
+    if (visibleDriverKinds.has(driver)) continue;
+    for (const [id, instance] of list) {
+      rows.push({
+        instanceId: id,
+        instance,
+        driver: instance.driver,
+        isDefault: defaultSlotIdsBySource.has(String(id)),
+      });
+    }
+  }
+
+  const updateProviderInstance = (
+    row: InstanceRow,
+    next: ProviderInstanceConfig,
+    options?: {
+      readonly textGenerationModelSelection?: Parameters<
+        typeof buildProviderInstanceUpdatePatch
+      >[0]["textGenerationModelSelection"];
+    },
+  ) => {
+    updateSettings(
+      buildProviderInstanceUpdatePatch({
+        settings,
+        instanceId: row.instanceId,
+        instance: next,
+        driver: row.driver,
+        isDefault: row.isDefault,
+        textGenerationModelSelection: options?.textGenerationModelSelection,
+      }),
+    );
+  };
+
+  const deleteProviderInstance = (id: ProviderInstanceId) => {
+    updateSettings({
+      providerInstances: withoutProviderInstanceKey(settings.providerInstances, id),
+    });
+  };
+
+  const updateProviderModelPreferences = (
+    instanceId: ProviderInstanceId,
+    next: {
+      readonly hiddenModels: ReadonlyArray<string>;
+      readonly modelOrder: ReadonlyArray<string>;
+    },
+  ) => {
+    const hiddenModels = [...new Set(next.hiddenModels.filter((slug) => slug.trim().length > 0))];
+    const modelOrder = [...new Set(next.modelOrder.filter((slug) => slug.trim().length > 0))];
+    const rest = withoutProviderInstanceKey(settings.providerModelPreferences, instanceId);
+    updateSettings({
+      providerModelPreferences:
+        hiddenModels.length === 0 && modelOrder.length === 0
+          ? rest
+          : {
+              ...rest,
+              [instanceId]: {
+                hiddenModels,
+                modelOrder,
+              },
+            },
+    });
+  };
+
+  const updateProviderFavoriteModels = (
+    instanceId: ProviderInstanceId,
+    nextFavoriteModels: ReadonlyArray<string>,
+  ) => {
+    const favoriteModels = [
+      ...new Set(
+        Arr.filterMap(nextFavoriteModels, (slug) => {
+          const trimmedSlug = slug.trim();
+          return trimmedSlug.length > 0 ? Result.succeed(trimmedSlug) : Result.failVoid;
+        }),
+      ),
+    ];
+    updateSettings({
+      favorites: [
+        ...withoutProviderInstanceFavorites(settings.favorites ?? [], instanceId),
+        ...favoriteModels.map((model) => ({ provider: instanceId, model })),
+      ],
+    });
+  };
+
+  const resetDefaultInstance = (driverKind: ProviderDriverKind) => {
+    type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
+    const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
+      string,
+      LegacyProviderSettings | undefined
+    >;
+    const defaultInstanceId = defaultInstanceIdForDriver(driverKind);
+    const defaultLegacyProvider = defaultLegacyProviders[driverKind];
+    if (defaultLegacyProvider === undefined) return;
+    updateSettings({
+      providers: {
+        ...settings.providers,
+        [driverKind]: defaultLegacyProvider,
+      } as typeof settings.providers,
+      providerInstances: withoutProviderInstanceKey(settings.providerInstances, defaultInstanceId),
+    });
+  };
+
+  return (
+    <>
+      <SettingsSection
+        title="Providers"
+        headerAction={
+          <div className="flex items-center gap-1.5">
+            <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => setIsAddInstanceDialogOpen(true)}
+                    aria-label="Add provider instance"
+                  >
+                    <PlusIcon className="size-3" />
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Add provider instance</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    disabled={isRefreshingProviders}
+                    onClick={() => void refreshProviders()}
+                    aria-label="Refresh provider status"
+                  >
+                    {isRefreshingProviders ? (
+                      <LoaderIcon className="size-3 animate-spin" />
+                    ) : (
+                      <RefreshCwIcon className="size-3" />
+                    )}
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Refresh provider status</TooltipPopup>
+            </Tooltip>
+          </div>
+        }
+      >
+        {rows.map((row) => {
+          const driverOption = getDriverOption(row.driver);
+          const liveProvider = serverProviders.find(
+            (candidate) => candidate.instanceId === row.instanceId,
+          );
+          const updateCandidate = liveProvider
+            ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
+            : undefined;
+          const isDriverUpdateRunning =
+            updateCandidate !== undefined &&
+            (updatingProviderDrivers.has(updateCandidate.driver) ||
+              serverProviders.some(
+                (provider) =>
+                  provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
+              ));
+          const showInlineUpdateButton =
+            updateCandidate !== undefined &&
+            hasOneClickUpdateProviderCandidate(updateCandidate, serverProviders);
+          const canRunInlineUpdate =
+            updateCandidate !== undefined &&
+            canOneClickUpdateProviderCandidate(updateCandidate, serverProviders) &&
+            !updatingProviderDrivers.has(updateCandidate.driver);
+          const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
+            hiddenModels: [],
+            modelOrder: [],
+          };
+          const favoriteModels = Arr.filterMap(settings.favorites ?? [], (favorite) =>
+            favorite.provider === row.instanceId ? Result.succeed(favorite.model) : Result.failVoid,
+          );
+          const resetLabel = driverOption?.label ?? String(row.driver);
+          const headerAction =
+            row.isDefault && row.isDirty ? (
+              <SettingResetButton
+                label={`${resetLabel} provider settings`}
+                onClick={() => resetDefaultInstance(row.driver)}
+              />
+            ) : null;
+          return (
+            <ProviderInstanceCard
+              key={row.instanceId}
+              instanceId={row.instanceId}
+              instance={row.instance}
+              driverOption={driverOption}
+              liveProvider={liveProvider}
+              isExpanded={openInstanceDetails[row.instanceId] ?? false}
+              onExpandedChange={(open) =>
+                setOpenInstanceDetails((existing) => ({
+                  ...existing,
+                  [row.instanceId]: open,
+                }))
+              }
+              onUpdate={(next) => {
+                const wasEnabled = row.instance.enabled ?? true;
+                const isDisabling = next.enabled === false && wasEnabled;
+                const shouldClearTextGen = isDisabling && textGenInstanceId === row.instanceId;
+                if (shouldClearTextGen) {
+                  updateProviderInstance(row, next, {
+                    textGenerationModelSelection:
+                      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+                  });
+                } else {
+                  updateProviderInstance(row, next);
+                }
+              }}
+              onDelete={row.isDefault ? undefined : () => deleteProviderInstance(row.instanceId)}
+              headerAction={headerAction}
+              hiddenModels={modelPreferences.hiddenModels}
+              favoriteModels={favoriteModels}
+              modelOrder={modelPreferences.modelOrder}
+              onHiddenModelsChange={(hiddenModels) =>
+                updateProviderModelPreferences(row.instanceId, {
+                  ...modelPreferences,
+                  hiddenModels,
+                })
+              }
+              onFavoriteModelsChange={(favoriteModels) =>
+                updateProviderFavoriteModels(row.instanceId, favoriteModels)
+              }
+              onModelOrderChange={(modelOrder) =>
+                updateProviderModelPreferences(row.instanceId, {
+                  ...modelPreferences,
+                  modelOrder,
+                })
+              }
+              onRunUpdate={
+                showInlineUpdateButton && updateCandidate
+                  ? () => {
+                      if (!canRunInlineUpdate) {
+                        return;
+                      }
+                      void runProviderUpdate(updateCandidate);
+                    }
+                  : undefined
+              }
+              isUpdating={showInlineUpdateButton ? isDriverUpdateRunning : undefined}
+            />
+          );
+        })}
+      </SettingsSection>
+
+      {isAddInstanceDialogOpen ? (
+        <AddProviderInstanceDialog
+          open
+          environmentId={environmentId}
+          environmentLabel={environmentLabel}
+          onOpenChange={setIsAddInstanceDialogOpen}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -57,6 +57,12 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
+import {
+  getProviderSummary,
+  getProviderVersionLabel,
+  PROVIDER_STATUS_STYLES,
+  type ProviderStatusKey,
+} from "./providerStatus";
 import { buildProviderInstanceUpdatePatch } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -68,6 +74,7 @@ import {
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
+  type ProviderOperateAccess,
   resolveSelectedProviderEnvironmentId,
 } from "./ProviderSettingsPanel.logic";
 
@@ -154,22 +161,18 @@ function EnvironmentUnavailableRow({
   accessKind,
 }: {
   readonly environment: EnvironmentPresentation;
-  readonly accessKind: "loading" | "read-only" | "unavailable" | "error";
+  readonly accessKind: "loading" | "unavailable" | "error";
 }) {
   const title =
     accessKind === "loading"
       ? "Loading provider settings"
-      : accessKind === "read-only"
-        ? "Provider settings are read only"
-        : accessKind === "error"
-          ? "Could not connect to this device"
-          : "Provider settings are unavailable";
+      : accessKind === "error"
+        ? "Could not connect to this device"
+        : "Provider settings are unavailable";
   const description =
     accessKind === "loading"
       ? `Waiting for ${environment.label}'s configuration.`
-      : accessKind === "read-only"
-        ? `This session can view ${environment.label}, but it cannot change provider configuration.`
-        : connectionStatusText(environment.connection);
+      : connectionStatusText(environment.connection);
   return (
     <SettingsSection title="Providers">
       <SettingsRow
@@ -188,7 +191,7 @@ function EnvironmentUnavailableRow({
 }
 
 export function ProviderSettingsPanel() {
-  const { environments } = useEnvironments();
+  const { environments, isReady } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const options = useMemo(
     () => buildProviderEnvironmentOptions(environments, primaryEnvironmentId),
@@ -219,9 +222,15 @@ export function ProviderSettingsPanel() {
       {showDeviceList ? (
         <SettingsSection title="Devices">
           {options.length === 0 ? (
+            // The catalog hydrates asynchronously, so an empty list before it is
+            // ready means "not loaded yet", not "nothing is connected".
             <SettingsRow
-              title="No connected devices"
-              description="Connect an execution environment before configuring providers."
+              title={isReady ? "No connected devices" : "Loading devices"}
+              description={
+                isReady
+                  ? "Connect an execution environment before configuring providers."
+                  : "Reading connected execution environments."
+              }
             />
           ) : (
             <div className="grid gap-1 sm:grid-cols-2">
@@ -291,18 +300,25 @@ function SelectedEnvironmentProviderSettings({
   // Remote connection brokers request the standard client scopes, which include
   // orchestration:operate. The environment RPC layer remains authoritative if a
   // custom remote credential grants less access.
-  const canOperate = isPrimary
-    ? window.desktopBridge
-      ? true
-      : primarySessionState.data?.authenticated
-        ? (primarySessionState.data.scopes ?? []).includes(AuthOrchestrationOperateScope)
-        : null
-    : true;
+  const operateAccess: ProviderOperateAccess = !isPrimary
+    ? "granted"
+    : window.desktopBridge
+      ? "granted"
+      : primarySessionState.isPending
+        ? "pending"
+        : primarySessionState.data?.authenticated
+          ? (primarySessionState.data.scopes ?? []).includes(AuthOrchestrationOperateScope)
+            ? "granted"
+            : "denied"
+          : "denied";
   const access = classifyProviderEnvironmentAccess({
     connectionPhase: environment.connection.phase,
     hasServerConfig: environment.serverConfig !== null,
-    canOperate,
+    operateAccess,
   });
+  if (access.kind === "read-only") {
+    return <ReadOnlyProviderSettings environment={environment} />;
+  }
   if (access.kind !== "editable") {
     return <EnvironmentUnavailableRow environment={environment} accessKind={access.kind} />;
   }
@@ -311,6 +327,55 @@ function SelectedEnvironmentProviderSettings({
       environmentId={environment.environmentId}
       environmentLabel={environment.label}
     />
+  );
+}
+
+/**
+ * Connected devices this session may read but not reconfigure. The provider
+ * catalogue is still worth showing — knowing which providers a box has and
+ * whether they are authenticated is most of the value — so render each one as
+ * a status row and omit every mutation control.
+ */
+function ReadOnlyProviderSettings({
+  environment,
+}: {
+  readonly environment: EnvironmentPresentation;
+}) {
+  const providers = environment.serverConfig?.providers ?? EMPTY_SERVER_PROVIDERS;
+  return (
+    <SettingsSection title="Providers">
+      <SettingsRow
+        title="Read only"
+        description={`This session can view ${environment.label}, but it cannot change provider configuration.`}
+      />
+      {providers.map((provider) => {
+        const driverOption = getDriverOption(provider.driver);
+        const summary = getProviderSummary(provider);
+        const versionLabel = getProviderVersionLabel(provider.version);
+        return (
+          <SettingsRow
+            key={provider.instanceId}
+            title={
+              <span className="inline-flex items-center gap-2">
+                <span
+                  className={cn(
+                    "size-2 rounded-full",
+                    PROVIDER_STATUS_STYLES[provider.status as ProviderStatusKey].dot,
+                  )}
+                  aria-hidden
+                />
+                {driverOption?.label ?? String(provider.driver)}
+                {versionLabel ? (
+                  <code className="text-[11px] text-muted-foreground">{versionLabel}</code>
+                ) : null}
+              </span>
+            }
+            description={summary.detail ?? summary.headline}
+            status={summary.detail ? summary.headline : null}
+          />
+        );
+      })}
+    </SettingsSection>
   );
 }
 

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -6,7 +6,6 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import {
-  AuthOrchestrationOperateScope,
   defaultInstanceIdForDriver,
   type EnvironmentId,
   PROVIDER_DISPLAY_NAMES,
@@ -35,6 +34,7 @@ import { usePrimarySessionState } from "../../environments/primary";
 import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { resolveAppModelSelectionState } from "../../modelSelection";
+import { deriveProviderInstanceEntries } from "../../providerInstances";
 import {
   useEnvironments,
   usePrimaryEnvironmentId,
@@ -74,7 +74,8 @@ import {
 import {
   buildProviderEnvironmentOptions,
   classifyProviderEnvironmentAccess,
-  type ProviderOperateAccess,
+  type ProviderEnvironmentAccess,
+  resolvePrimaryOperateAccess,
   resolveSelectedProviderEnvironmentId,
 } from "./ProviderSettingsPanel.logic";
 
@@ -158,27 +159,28 @@ function connectionDotClassName(environment: EnvironmentPresentation): string {
 
 function EnvironmentUnavailableRow({
   environment,
-  accessKind,
+  access,
 }: {
   readonly environment: EnvironmentPresentation;
-  readonly accessKind: "loading" | "unavailable" | "error";
+  readonly access: Exclude<ProviderEnvironmentAccess, { kind: "editable" | "read-only" }>;
 }) {
-  const title =
-    accessKind === "loading"
-      ? "Loading provider settings"
-      : accessKind === "error"
-        ? "Could not connect to this device"
-        : "Provider settings are unavailable";
-  const description =
-    accessKind === "loading"
-      ? `Waiting for ${environment.label}'s configuration.`
-      : connectionStatusText(environment.connection);
+  const isLoading = access.kind === "loading";
+  const title = isLoading
+    ? "Loading provider settings"
+    : access.kind === "error"
+      ? "Could not connect to this device"
+      : "Provider settings are unavailable";
+  const description = isLoading
+    ? access.reason === "permissions"
+      ? "Checking what this session is allowed to change."
+      : `Waiting for ${environment.label}'s configuration.`
+    : connectionStatusText(environment.connection);
   return (
     <SettingsSection title="Providers">
       <SettingsRow
         title={
           <span className="inline-flex items-center gap-2">
-            {accessKind === "loading" ? (
+            {isLoading ? (
               <LoaderIcon className="size-3.5 animate-spin text-muted-foreground" />
             ) : null}
             {title}
@@ -297,20 +299,12 @@ function SelectedEnvironmentProviderSettings({
 }) {
   const primarySessionState = usePrimarySessionState();
   const isPrimary = environment.entry.target._tag === "PrimaryConnectionTarget";
-  // Remote connection brokers request the standard client scopes, which include
-  // orchestration:operate. The environment RPC layer remains authoritative if a
-  // custom remote credential grants less access.
-  const operateAccess: ProviderOperateAccess = !isPrimary
-    ? "granted"
-    : window.desktopBridge
-      ? "granted"
-      : primarySessionState.isPending
-        ? "pending"
-        : primarySessionState.data?.authenticated
-          ? (primarySessionState.data.scopes ?? []).includes(AuthOrchestrationOperateScope)
-            ? "granted"
-            : "denied"
-          : "denied";
+  const operateAccess = resolvePrimaryOperateAccess({
+    isPrimary,
+    hasDesktopBridge: Boolean(window.desktopBridge),
+    session: primarySessionState.data,
+    isPending: primarySessionState.isPending,
+  });
   const access = classifyProviderEnvironmentAccess({
     connectionPhase: environment.connection.phase,
     hasServerConfig: environment.serverConfig !== null,
@@ -320,7 +314,7 @@ function SelectedEnvironmentProviderSettings({
     return <ReadOnlyProviderSettings environment={environment} />;
   }
   if (access.kind !== "editable") {
-    return <EnvironmentUnavailableRow environment={environment} accessKind={access.kind} />;
+    return <EnvironmentUnavailableRow environment={environment} access={access} />;
   }
   return (
     <EnvironmentProviderSettings
@@ -341,30 +335,33 @@ function ReadOnlyProviderSettings({
 }: {
   readonly environment: EnvironmentPresentation;
 }) {
-  const providers = environment.serverConfig?.providers ?? EMPTY_SERVER_PROVIDERS;
+  // `deriveProviderInstanceEntries` resolves the same per-instance display name
+  // the pickers use, so two instances of one driver stay distinguishable here.
+  const entries = deriveProviderInstanceEntries(
+    environment.serverConfig?.providers ?? EMPTY_SERVER_PROVIDERS,
+  );
   return (
     <SettingsSection title="Providers">
       <SettingsRow
         title="Read only"
         description={`This session can view ${environment.label}, but it cannot change provider configuration.`}
       />
-      {providers.map((provider) => {
-        const driverOption = getDriverOption(provider.driver);
-        const summary = getProviderSummary(provider);
-        const versionLabel = getProviderVersionLabel(provider.version);
+      {entries.map((entry) => {
+        const summary = getProviderSummary(entry.snapshot);
+        const versionLabel = getProviderVersionLabel(entry.snapshot.version);
         return (
           <SettingsRow
-            key={provider.instanceId}
+            key={entry.instanceId}
             title={
               <span className="inline-flex items-center gap-2">
                 <span
                   className={cn(
                     "size-2 rounded-full",
-                    PROVIDER_STATUS_STYLES[provider.status as ProviderStatusKey].dot,
+                    PROVIDER_STATUS_STYLES[entry.status as ProviderStatusKey].dot,
                   )}
                   aria-hidden
                 />
-                {driverOption?.label ?? String(provider.driver)}
+                {entry.displayName}
                 {versionLabel ? (
                   <code className="text-[11px] text-muted-foreground">{versionLabel}</code>
                 ) : null}

--- a/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/SettingsEnvironmentSelector.tsx
@@ -1,0 +1,73 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { CloudIcon, MonitorIcon } from "lucide-react";
+import { useMemo } from "react";
+
+import type { EnvironmentPresentation } from "../../state/environments";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+interface SettingsEnvironmentSelectorProps {
+  readonly environmentId: EnvironmentId;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
+}
+
+export function SettingsEnvironmentSelector({
+  environmentId,
+  environments,
+  primaryEnvironmentId,
+  onEnvironmentChange,
+}: SettingsEnvironmentSelectorProps) {
+  const selectedEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const items = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
+
+  return (
+    <Select
+      value={environmentId}
+      items={items}
+      onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
+    >
+      <SelectTrigger size="sm" className="w-36 sm:w-52" aria-label="Settings environment">
+        {environmentId === primaryEnvironmentId ? (
+          <MonitorIcon className="size-3.5" />
+        ) : (
+          <CloudIcon className="size-3.5" />
+        )}
+        <SelectValue>{selectedEnvironment?.label ?? "Select environment"}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectGroup>
+          <SelectGroupLabel>Configure environment</SelectGroupLabel>
+          {environments.map((environment) => (
+            <SelectItem key={environment.environmentId} value={environment.environmentId}>
+              <span className="inline-flex items-center gap-1.5">
+                {environment.environmentId === primaryEnvironmentId ? (
+                  <MonitorIcon className="size-3.5" />
+                ) : (
+                  <CloudIcon className="size-3.5" />
+                )}
+                {environment.label}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectPopup>
+    </Select>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceId,
   type ProviderInstanceConfig,
@@ -10,7 +11,79 @@ import {
   formatDiagnosticsDescription,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
+  resolveSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
+
+const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000001");
+const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000002");
+
+describe("settings environment selection", () => {
+  it("preserves an explicit selected environment", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
+        selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: LOCAL_ENVIRONMENT_ID,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("defaults to the primary environment in managed mode", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [REMOTE_ENVIRONMENT_ID, LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(LOCAL_ENVIRONMENT_ID);
+  });
+
+  it("defaults to the active remote environment in client-only mode", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("falls back when the selected environment is no longer available", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(LOCAL_ENVIRONMENT_ID);
+  });
+
+  it("uses the first saved environment when client-only mode has no active environment yet", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [REMOTE_ENVIRONMENT_ID, LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("returns null when no environments are available", () => {
+    expect(
+      resolveSettingsEnvironmentId({
+        availableEnvironmentIds: [],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("project grouping toggle", () => {
   it("enables repository grouping and disables into separate projects", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -7,12 +7,15 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildGeneralSettingsRestorePatch,
   buildProviderInstanceUpdatePatch,
   formatDiagnosticsDescription,
+  hasChangedGeneralServerSettings,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   resolveSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
+import * as Duration from "effect/Duration";
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000001");
 const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000002");
@@ -82,6 +85,33 @@ describe("settings environment selection", () => {
         activeEnvironmentId: null,
       }),
     ).toBeNull();
+  });
+});
+
+describe("general settings restore", () => {
+  it("detects whether server-backed general settings differ from their defaults", () => {
+    expect(hasChangedGeneralServerSettings(DEFAULT_SERVER_SETTINGS)).toBe(false);
+    expect(
+      hasChangedGeneralServerSettings({
+        ...DEFAULT_SERVER_SETTINGS,
+        automaticGitFetchInterval: Duration.seconds(5),
+      }),
+    ).toBe(true);
+  });
+
+  it("omits server-backed defaults when only client settings need restoring", () => {
+    const clientOnlyPatch = buildGeneralSettingsRestorePatch({
+      includeServerSettings: false,
+    });
+    const serverAndClientPatch = buildGeneralSettingsRestorePatch({
+      includeServerSettings: true,
+    });
+
+    expect(clientOnlyPatch).toHaveProperty("wordWrap");
+    expect(clientOnlyPatch).not.toHaveProperty("enableAssistantStreaming");
+    expect(clientOnlyPatch).not.toHaveProperty("textGenerationModelSelection");
+    expect(serverAndClientPatch).toHaveProperty("enableAssistantStreaming");
+    expect(serverAndClientPatch).toHaveProperty("textGenerationModelSelection");
   });
 });
 

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,4 +1,5 @@
 import type {
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
@@ -7,6 +8,29 @@ import type {
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+
+export function resolveSettingsEnvironmentId(input: {
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+}): EnvironmentId | null {
+  const availableIds = new Set(input.availableEnvironmentIds);
+  const candidates = [
+    input.selectedEnvironmentId,
+    input.primaryEnvironmentId,
+    input.activeEnvironmentId,
+    input.availableEnvironmentIds[0] ?? null,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate !== null && availableIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -8,6 +8,51 @@ import type {
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import * as Duration from "effect/Duration";
+import * as Equal from "effect/Equal";
+
+export function hasChangedGeneralServerSettings(settings: ServerSettings): boolean {
+  return (
+    settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ||
+    settings.enableProviderUpdateChecks !== DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks ||
+    Duration.toMillis(settings.automaticGitFetchInterval) !==
+      Duration.toMillis(DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval) ||
+    settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
+    settings.newWorktreesStartFromOrigin !== DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ||
+    settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ||
+    !Equal.equals(
+      settings.textGenerationModelSelection,
+      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+    )
+  );
+}
+
+export function buildGeneralSettingsRestorePatch(input: {
+  readonly includeServerSettings: boolean;
+}): Partial<UnifiedSettings> {
+  return {
+    timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+    wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
+    diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+    glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+    sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+    sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+    autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+    ...(input.includeServerSettings
+      ? {
+          enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+          enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+          automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+          defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+          newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+          addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+          textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+        }
+      : {}),
+  };
+}
 
 export function resolveSettingsEnvironmentId(input: {
   readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -221,7 +221,10 @@ function AboutVersionSection() {
       ? !canCheckForUpdate(updateState)
       : isDesktopUpdateButtonDisabled(updateState);
 
-  const actionLabel: Record<string, string> = { download: "Download", install: "Install" };
+  const actionLabel: Record<string, string> = {
+    download: "Download",
+    install: "Install",
+  };
   const statusLabel: Record<string, string> = {
     checking: "Checking…",
     downloading: "Downloading…",
@@ -298,7 +301,9 @@ function AboutVersionSection() {
               onValueChange={(value) => {
                 if (value === selectedHostedAppChannel) return;
                 window.location.assign(
-                  buildHostedChannelSelectionUrl({ channel: value as HostedAppChannel }),
+                  buildHostedChannelSelectionUrl({
+                    channel: value as HostedAppChannel,
+                  }),
                 );
               }}
             >
@@ -321,7 +326,9 @@ function AboutVersionSection() {
   );
 }
 
-export function useSettingsRestore(onRestored?: () => void) {
+export type SettingsOwnership = "client" | "environment";
+
+export function useSettingsRestore(ownership: SettingsOwnership, onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
   const { environmentId, environment } = useSettingsEnvironment();
   const settings = useEnvironmentSettings(environmentId);
@@ -333,10 +340,12 @@ export function useSettingsRestore(onRestored?: () => void) {
   );
   const hasChangedServerSettings = hasChangedGeneralServerSettings(settings);
   const canRestoreDefaults =
-    !hasChangedServerSettings || environment?.connection.phase === "connected";
+    ownership === "client" ||
+    !hasChangedServerSettings ||
+    environment?.connection.phase === "connected";
 
-  const changedSettingLabels = useMemo(
-    () => [
+  const changedSettingLabels = useMemo(() => {
+    const clientSettingLabels = [
       ...(theme !== "system" ? ["Theme"] : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
@@ -356,6 +365,14 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
+      ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
+        ? ["Archive confirmation"]
+        : []),
+      ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
+        ? ["Delete confirmation"]
+        : []),
+    ];
+    const environmentSettingLabels = [
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -377,34 +394,29 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
-      ...(settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive
-        ? ["Archive confirmation"]
-        : []),
-      ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
-        ? ["Delete confirmation"]
-        : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
-    ],
-    [
-      isTextGenerationModelDirty,
-      settings.autoOpenPlanSidebar,
-      settings.confirmThreadArchive,
-      settings.confirmThreadDelete,
-      settings.addProjectBaseDirectory,
-      settings.defaultThreadEnvMode,
-      settings.newWorktreesStartFromOrigin,
-      settings.diffIgnoreWhitespace,
-      settings.glassOpacity,
-      settings.automaticGitFetchInterval,
-      settings.enableAssistantStreaming,
-      settings.enableProviderUpdateChecks,
-      settings.sidebarProjectGroupingMode,
-      settings.sidebarThreadPreviewCount,
-      settings.timestampFormat,
-      settings.wordWrap,
-      theme,
-    ],
-  );
+    ];
+    return ownership === "client" ? clientSettingLabels : environmentSettingLabels;
+  }, [
+    isTextGenerationModelDirty,
+    ownership,
+    settings.addProjectBaseDirectory,
+    settings.autoOpenPlanSidebar,
+    settings.automaticGitFetchInterval,
+    settings.confirmThreadArchive,
+    settings.confirmThreadDelete,
+    settings.defaultThreadEnvMode,
+    settings.diffIgnoreWhitespace,
+    settings.enableAssistantStreaming,
+    settings.enableProviderUpdateChecks,
+    settings.glassOpacity,
+    settings.newWorktreesStartFromOrigin,
+    settings.sidebarProjectGroupingMode,
+    settings.sidebarThreadPreviewCount,
+    settings.timestampFormat,
+    settings.wordWrap,
+    theme,
+  ]);
 
   const restoreDefaults = useCallback(async () => {
     if (changedSettingLabels.length === 0 || !canRestoreDefaults) return;
@@ -416,21 +428,22 @@ export function useSettingsRestore(onRestored?: () => void) {
     );
     if (!confirmed) return;
 
-    setTheme("system");
-    updateSettings(
-      buildGeneralSettingsRestorePatch({
-        includeServerSettings: hasChangedServerSettings,
-      }),
-    );
+    if (ownership === "client") {
+      setTheme("system");
+      updateSettings(buildGeneralSettingsRestorePatch({ includeServerSettings: false }));
+    } else {
+      updateSettings({
+        enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+        enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+        automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+        defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+        newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+        addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+        textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+      });
+    }
     onRestored?.();
-  }, [
-    canRestoreDefaults,
-    changedSettingLabels,
-    hasChangedServerSettings,
-    onRestored,
-    setTheme,
-    updateSettings,
-  ]);
+  }, [canRestoreDefaults, changedSettingLabels, onRestored, ownership, setTheme, updateSettings]);
 
   return {
     canRestoreDefaults,
@@ -439,7 +452,7 @@ export function useSettingsRestore(onRestored?: () => void) {
   };
 }
 
-export function GeneralSettingsPanel() {
+function OwnershipSettingsPanel({ ownership }: { ownership: SettingsOwnership }) {
   const { theme, setTheme } = useTheme();
   const {
     environmentId,
@@ -497,393 +510,331 @@ export function GeneralSettingsPanel() {
 
   return (
     <SettingsPageContainer>
-      <SettingsSection title="Environment">
-        <SettingsRow
-          title="Server settings"
-          description="Assistant behavior, workspace defaults, provider maintenance, and text generation are configured per environment."
-          status={
-            environment
-              ? [connectionStatusText(environment.connection), environment.displayUrl]
-                  .filter(Boolean)
-                  .join(" · ")
-              : environmentsReady
-                ? "Connect an environment to configure its server settings."
-                : "Loading environments."
-          }
-          control={
-            environmentId !== null && environment !== null ? (
-              <SettingsEnvironmentSelector
-                environmentId={environmentId}
-                environments={environments}
-                primaryEnvironmentId={primaryEnvironmentId}
-                onEnvironmentChange={selectEnvironment}
-              />
-            ) : environmentsReady ? (
-              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
-                Open connections
-              </Button>
-            ) : null
-          }
-        />
-      </SettingsSection>
-
-      <SettingsSection title="General">
-        <SettingsRow
-          title="Theme"
-          description="Choose how T3 Code looks across the app."
-          resetAction={
-            theme !== "system" ? (
-              <SettingResetButton label="theme" onClick={() => setTheme("system")} />
-            ) : null
-          }
-          control={
-            <Select
-              value={theme}
-              onValueChange={(value) => {
-                if (value === "system" || value === "light" || value === "dark") {
-                  setTheme(value);
-                }
-              }}
-            >
-              <SelectTrigger className="w-full sm:w-40" aria-label="Theme preference">
-                <SelectValue>
-                  {THEME_OPTIONS.find((option) => option.value === theme)?.label ?? "System"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectPopup align="end" alignItemWithTrigger={false}>
-                {THEME_OPTIONS.map((option) => (
-                  <SelectItem hideIndicator key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectPopup>
-            </Select>
-          }
-        />
-
-        <SettingsRow
-          title="Glass opacity"
-          description="Control how transparent glass surfaces are. Higher values make menus, dialogs, and the composer more solid."
-          resetAction={
-            settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? (
-              <SettingResetButton
-                label="glass opacity"
-                onClick={() =>
-                  updateSettings({ glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity })
-                }
-              />
-            ) : null
-          }
-          control={
-            <div className="flex w-full items-center gap-3 sm:w-52">
-              <output
-                className="min-w-12 rounded-md bg-muted px-2 py-1 text-center font-mono text-xs font-medium tabular-nums text-foreground"
-                htmlFor="glass-opacity"
-              >
-                {settings.glassOpacity}%
-              </output>
-              <input
-                aria-label="Glass opacity"
-                className="glass-opacity-slider min-w-0 flex-1"
-                id="glass-opacity"
-                max={MAX_GLASS_OPACITY}
-                min={MIN_GLASS_OPACITY}
-                onChange={(event) => {
-                  const glassOpacity = Number(event.currentTarget.value);
-                  if (
-                    Number.isInteger(glassOpacity) &&
-                    glassOpacity >= MIN_GLASS_OPACITY &&
-                    glassOpacity <= MAX_GLASS_OPACITY
-                  ) {
-                    updateSettings({ glassOpacity });
-                  }
-                }}
-                step={5}
-                style={glassOpacitySliderStyle}
-                type="range"
-                value={settings.glassOpacity}
-              />
-            </div>
-          }
-        />
-
-        <SettingsRow
-          title="Project Grouping"
-          description="Combine matching repositories across environments."
-          resetAction={
-            settings.sidebarProjectGroupingMode !==
-            DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode ? (
-              <SettingResetButton
-                label="project grouping"
-                onClick={() =>
-                  updateSettings({
-                    sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={isProjectGroupingEnabled(settings.sidebarProjectGroupingMode)}
-              onCheckedChange={(checked) => {
-                if (!checked && settings.sidebarProjectGroupingMode !== "separate") {
-                  lastEnabledProjectGroupingMode.current = settings.sidebarProjectGroupingMode;
-                  rememberEnabledProjectGroupingMode(settings.sidebarProjectGroupingMode);
-                }
-                updateSettings({
-                  sidebarProjectGroupingMode: projectGroupingModeFromToggle(
-                    checked,
-                    lastEnabledProjectGroupingMode.current,
-                  ),
-                });
-              }}
-              aria-label="Project Grouping"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Time format"
-          description="System default follows your browser or OS clock preference."
-          resetAction={
-            settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat ? (
-              <SettingResetButton
-                label="time format"
-                onClick={() =>
-                  updateSettings({
-                    timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Select
-              value={settings.timestampFormat}
-              onValueChange={(value) => {
-                if (value === "locale" || value === "12-hour" || value === "24-hour") {
-                  updateSettings({ timestampFormat: value });
-                }
-              }}
-            >
-              <SelectTrigger className="w-full sm:w-40" aria-label="Timestamp format">
-                <SelectValue>{TIMESTAMP_FORMAT_LABELS[settings.timestampFormat]}</SelectValue>
-              </SelectTrigger>
-              <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="locale">
-                  {TIMESTAMP_FORMAT_LABELS.locale}
-                </SelectItem>
-                <SelectItem hideIndicator value="12-hour">
-                  {TIMESTAMP_FORMAT_LABELS["12-hour"]}
-                </SelectItem>
-                <SelectItem hideIndicator value="24-hour">
-                  {TIMESTAMP_FORMAT_LABELS["24-hour"]}
-                </SelectItem>
-              </SelectPopup>
-            </Select>
-          }
-        />
-
-        <SettingsRow
-          title="Word wrap"
-          description="Wrap long lines in code blocks, tables, diffs, and file previews by default."
-          resetAction={
-            settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? (
-              <SettingResetButton
-                label="word wrapping"
-                onClick={() =>
-                  updateSettings({
-                    wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.wordWrap}
-              onCheckedChange={(checked) => updateSettings({ wordWrap: Boolean(checked) })}
-              aria-label="Wrap code, tables, diffs, and file previews by default"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Hide whitespace changes"
-          description="Set whether the diff panel ignores whitespace-only edits by default."
-          resetAction={
-            settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace ? (
-              <SettingResetButton
-                label="diff whitespace changes"
-                onClick={() =>
-                  updateSettings({
-                    diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.diffIgnoreWhitespace}
-              onCheckedChange={(checked) =>
-                updateSettings({ diffIgnoreWhitespace: Boolean(checked) })
-              }
-              aria-label="Hide whitespace changes by default"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Assistant output"
-          description="Show token-by-token output while a response is in progress."
-          resetAction={
-            settings.enableAssistantStreaming !==
-            DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ? (
-              <SettingResetButton
-                label="assistant output"
-                disabled={!canConfigureServer}
-                onClick={() =>
-                  updateSettings({
-                    enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.enableAssistantStreaming}
-              disabled={!canConfigureServer}
-              onCheckedChange={(checked) =>
-                updateSettings({ enableAssistantStreaming: Boolean(checked) })
-              }
-              aria-label="Stream assistant messages"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Provider update checks"
-          description="Check installed provider CLIs for newer available versions."
-          resetAction={
-            settings.enableProviderUpdateChecks !==
-            DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks ? (
-              <SettingResetButton
-                label="provider update checks"
-                disabled={!canConfigureServer}
-                onClick={() =>
-                  updateSettings({
-                    enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.enableProviderUpdateChecks}
-              disabled={!canConfigureServer}
-              onCheckedChange={(checked) =>
-                updateSettings({ enableProviderUpdateChecks: Boolean(checked) })
-              }
-              aria-label="Check provider versions"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Auto-open task panel"
-          description="Open the right-side plan and task panel automatically when steps appear."
-          resetAction={
-            settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar ? (
-              <SettingResetButton
-                label="auto-open task panel"
-                onClick={() =>
-                  updateSettings({
-                    autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.autoOpenPlanSidebar}
-              onCheckedChange={(checked) =>
-                updateSettings({ autoOpenPlanSidebar: Boolean(checked) })
-              }
-              aria-label="Open the task panel automatically"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="New threads"
-          description="Pick the default workspace mode for newly created draft threads."
-          resetAction={
-            settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
-            settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
-              <SettingResetButton
-                label="new threads"
-                disabled={!canConfigureServer}
-                onClick={() =>
-                  updateSettings({
-                    defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
-                    newWorktreesStartFromOrigin:
-                      DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Select
-              value={settings.defaultThreadEnvMode}
-              onValueChange={(value) => {
-                if (value === "local" || value === "worktree") {
-                  updateSettings({ defaultThreadEnvMode: value });
-                }
-              }}
-            >
-              <SelectTrigger
-                className="w-full sm:w-44"
-                aria-label="Default thread mode"
-                disabled={!canConfigureServer}
-              >
-                <SelectValue>
-                  {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="local">
-                  Local
-                </SelectItem>
-                <SelectItem hideIndicator value="worktree">
-                  New worktree
-                </SelectItem>
-              </SelectPopup>
-            </Select>
-          }
-        />
-
-        {settings.defaultThreadEnvMode === "worktree" ? (
+      {ownership === "environment" ? (
+        <SettingsSection title="Environment">
           <SettingsRow
-            className="bg-muted/20 sm:pl-9"
-            title="Start from origin"
-            description="Creates the worktree from the latest matching branch on origin instead of your local branch."
-            resetAction={
-              settings.newWorktreesStartFromOrigin !==
-              DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
-                <SettingResetButton
-                  label="new worktrees start from origin"
+            title="Server settings"
+            description="Assistant behavior, workspace defaults, provider maintenance, and text generation are configured per environment."
+            status={
+              environment
+                ? [connectionStatusText(environment.connection), environment.displayUrl]
+                    .filter(Boolean)
+                    .join(" · ")
+                : environmentsReady
+                  ? "Connect an environment to configure its server settings."
+                  : "Loading environments."
+            }
+            control={
+              environmentId !== null && environment !== null ? (
+                <SettingsEnvironmentSelector
+                  environmentId={environmentId}
+                  environments={environments}
+                  primaryEnvironmentId={primaryEnvironmentId}
+                  onEnvironmentChange={selectEnvironment}
+                />
+              ) : environmentsReady ? (
+                <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                  Open connections
+                </Button>
+              ) : null
+            }
+          />
+        </SettingsSection>
+      ) : null}
+
+      <SettingsSection title={ownership === "client" ? "Client" : "General"}>
+        {ownership === "client" ? (
+          <>
+            <SettingsRow
+              title="Theme"
+              description="Choose how T3 Code looks across the app."
+              resetAction={
+                theme !== "system" ? (
+                  <SettingResetButton label="theme" onClick={() => setTheme("system")} />
+                ) : null
+              }
+              control={
+                <Select
+                  value={theme}
+                  onValueChange={(value) => {
+                    if (value === "system" || value === "light" || value === "dark") {
+                      setTheme(value);
+                    }
+                  }}
+                >
+                  <SelectTrigger className="w-full sm:w-40" aria-label="Theme preference">
+                    <SelectValue>
+                      {THEME_OPTIONS.find((option) => option.value === theme)?.label ?? "System"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup align="end" alignItemWithTrigger={false}>
+                    {THEME_OPTIONS.map((option) => (
+                      <SelectItem hideIndicator key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+              }
+            />
+
+            <SettingsRow
+              title="Glass opacity"
+              description="Control how transparent glass surfaces are. Higher values make menus, dialogs, and the composer more solid."
+              resetAction={
+                settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? (
+                  <SettingResetButton
+                    label="glass opacity"
+                    onClick={() =>
+                      updateSettings({
+                        glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <div className="flex w-full items-center gap-3 sm:w-52">
+                  <output
+                    className="min-w-12 rounded-md bg-muted px-2 py-1 text-center font-mono text-xs font-medium tabular-nums text-foreground"
+                    htmlFor="glass-opacity"
+                  >
+                    {settings.glassOpacity}%
+                  </output>
+                  <input
+                    aria-label="Glass opacity"
+                    className="glass-opacity-slider min-w-0 flex-1"
+                    id="glass-opacity"
+                    max={MAX_GLASS_OPACITY}
+                    min={MIN_GLASS_OPACITY}
+                    onChange={(event) => {
+                      const glassOpacity = Number(event.currentTarget.value);
+                      if (
+                        Number.isInteger(glassOpacity) &&
+                        glassOpacity >= MIN_GLASS_OPACITY &&
+                        glassOpacity <= MAX_GLASS_OPACITY
+                      ) {
+                        updateSettings({ glassOpacity });
+                      }
+                    }}
+                    step={5}
+                    style={glassOpacitySliderStyle}
+                    type="range"
+                    value={settings.glassOpacity}
+                  />
+                </div>
+              }
+            />
+
+            <SettingsRow
+              title="Project Grouping"
+              description="Combine matching repositories across environments."
+              resetAction={
+                settings.sidebarProjectGroupingMode !==
+                DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode ? (
+                  <SettingResetButton
+                    label="project grouping"
+                    onClick={() =>
+                      updateSettings({
+                        sidebarProjectGroupingMode:
+                          DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={isProjectGroupingEnabled(settings.sidebarProjectGroupingMode)}
+                  onCheckedChange={(checked) => {
+                    if (!checked && settings.sidebarProjectGroupingMode !== "separate") {
+                      lastEnabledProjectGroupingMode.current = settings.sidebarProjectGroupingMode;
+                      rememberEnabledProjectGroupingMode(settings.sidebarProjectGroupingMode);
+                    }
+                    updateSettings({
+                      sidebarProjectGroupingMode: projectGroupingModeFromToggle(
+                        checked,
+                        lastEnabledProjectGroupingMode.current,
+                      ),
+                    });
+                  }}
+                  aria-label="Project Grouping"
+                />
+              }
+            />
+
+            <SettingsRow
+              title="Time format"
+              description="System default follows your browser or OS clock preference."
+              resetAction={
+                settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat ? (
+                  <SettingResetButton
+                    label="time format"
+                    onClick={() =>
+                      updateSettings({
+                        timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Select
+                  value={settings.timestampFormat}
+                  onValueChange={(value) => {
+                    if (value === "locale" || value === "12-hour" || value === "24-hour") {
+                      updateSettings({ timestampFormat: value });
+                    }
+                  }}
+                >
+                  <SelectTrigger className="w-full sm:w-40" aria-label="Timestamp format">
+                    <SelectValue>{TIMESTAMP_FORMAT_LABELS[settings.timestampFormat]}</SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup align="end" alignItemWithTrigger={false}>
+                    <SelectItem hideIndicator value="locale">
+                      {TIMESTAMP_FORMAT_LABELS.locale}
+                    </SelectItem>
+                    <SelectItem hideIndicator value="12-hour">
+                      {TIMESTAMP_FORMAT_LABELS["12-hour"]}
+                    </SelectItem>
+                    <SelectItem hideIndicator value="24-hour">
+                      {TIMESTAMP_FORMAT_LABELS["24-hour"]}
+                    </SelectItem>
+                  </SelectPopup>
+                </Select>
+              }
+            />
+
+            <SettingsRow
+              title="Word wrap"
+              description="Wrap long lines in code blocks, tables, diffs, and file previews by default."
+              resetAction={
+                settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? (
+                  <SettingResetButton
+                    label="word wrapping"
+                    onClick={() =>
+                      updateSettings({
+                        wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.wordWrap}
+                  onCheckedChange={(checked) => updateSettings({ wordWrap: Boolean(checked) })}
+                  aria-label="Wrap code, tables, diffs, and file previews by default"
+                />
+              }
+            />
+
+            <SettingsRow
+              title="Hide whitespace changes"
+              description="Set whether the diff panel ignores whitespace-only edits by default."
+              resetAction={
+                settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace ? (
+                  <SettingResetButton
+                    label="diff whitespace changes"
+                    onClick={() =>
+                      updateSettings({
+                        diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.diffIgnoreWhitespace}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ diffIgnoreWhitespace: Boolean(checked) })
+                  }
+                  aria-label="Hide whitespace changes by default"
+                />
+              }
+            />
+          </>
+        ) : null}
+
+        {ownership === "environment" ? (
+          <>
+            <SettingsRow
+              title="Assistant output"
+              description="Show token-by-token output while a response is in progress."
+              resetAction={
+                settings.enableAssistantStreaming !==
+                DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ? (
+                  <SettingResetButton
+                    label="assistant output"
+                    disabled={!canConfigureServer}
+                    onClick={() =>
+                      updateSettings({
+                        enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.enableAssistantStreaming}
                   disabled={!canConfigureServer}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      enableAssistantStreaming: Boolean(checked),
+                    })
+                  }
+                  aria-label="Stream assistant messages"
+                />
+              }
+            />
+
+            <SettingsRow
+              title="Provider update checks"
+              description="Check installed provider CLIs for newer available versions."
+              resetAction={
+                settings.enableProviderUpdateChecks !==
+                DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks ? (
+                  <SettingResetButton
+                    label="provider update checks"
+                    disabled={!canConfigureServer}
+                    onClick={() =>
+                      updateSettings({
+                        enableProviderUpdateChecks:
+                          DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.enableProviderUpdateChecks}
+                  disabled={!canConfigureServer}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      enableProviderUpdateChecks: Boolean(checked),
+                    })
+                  }
+                  aria-label="Check provider versions"
+                />
+              }
+            />
+          </>
+        ) : null}
+
+        {ownership === "client" ? (
+          <SettingsRow
+            title="Auto-open task panel"
+            description="Open the right-side plan and task panel automatically when steps appear."
+            resetAction={
+              settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar ? (
+                <SettingResetButton
+                  label="auto-open task panel"
                   onClick={() =>
                     updateSettings({
-                      newWorktreesStartFromOrigin:
-                        DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                      autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
                     })
                   }
                 />
@@ -891,200 +842,307 @@ export function GeneralSettingsPanel() {
             }
             control={
               <Switch
-                checked={settings.newWorktreesStartFromOrigin}
-                disabled={!canConfigureServer}
+                checked={settings.autoOpenPlanSidebar}
                 onCheckedChange={(checked) =>
-                  updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
+                  updateSettings({ autoOpenPlanSidebar: Boolean(checked) })
                 }
-                aria-label="Start new worktrees from origin by default"
+                aria-label="Open the task panel automatically"
               />
             }
           />
         ) : null}
 
-        <SettingsRow
-          title="Add project starts in"
-          description='Leave empty to use "~/" when the Add Project browser opens.'
-          resetAction={
-            settings.addProjectBaseDirectory !==
-            DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ? (
-              <SettingResetButton
-                label="add project base directory"
-                disabled={!canConfigureServer}
-                onClick={() =>
-                  updateSettings({
-                    addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <DraftInput
-              className="w-full sm:w-72"
-              disabled={!canConfigureServer}
-              value={settings.addProjectBaseDirectory}
-              onCommit={(next) => updateSettings({ addProjectBaseDirectory: next })}
-              placeholder="~/"
-              spellCheck={false}
-              aria-label="Add project base directory"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Archive confirmation"
-          description="Require a second click on the inline archive action before a thread is archived."
-          resetAction={
-            settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
-              <SettingResetButton
-                label="archive confirmation"
-                onClick={() =>
-                  updateSettings({
-                    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.confirmThreadArchive}
-              onCheckedChange={(checked) =>
-                updateSettings({ confirmThreadArchive: Boolean(checked) })
+        {ownership === "environment" ? (
+          <>
+            <SettingsRow
+              title="New threads"
+              description="Pick the default workspace mode for newly created draft threads."
+              resetAction={
+                settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||
+                settings.newWorktreesStartFromOrigin !==
+                  DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+                  <SettingResetButton
+                    label="new threads"
+                    disabled={!canConfigureServer}
+                    onClick={() =>
+                      updateSettings({
+                        defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+                        newWorktreesStartFromOrigin:
+                          DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                      })
+                    }
+                  />
+                ) : null
               }
-              aria-label="Confirm thread archiving"
-            />
-          }
-        />
-
-        <SettingsRow
-          title="Delete confirmation"
-          description="Ask before deleting a thread and its chat history."
-          resetAction={
-            settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
-              <SettingResetButton
-                label="delete confirmation"
-                onClick={() =>
-                  updateSettings({
-                    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Switch
-              checked={settings.confirmThreadDelete}
-              onCheckedChange={(checked) =>
-                updateSettings({ confirmThreadDelete: Boolean(checked) })
+              control={
+                <Select
+                  value={settings.defaultThreadEnvMode}
+                  onValueChange={(value) => {
+                    if (value === "local" || value === "worktree") {
+                      updateSettings({ defaultThreadEnvMode: value });
+                    }
+                  }}
+                >
+                  <SelectTrigger
+                    className="w-full sm:w-44"
+                    aria-label="Default thread mode"
+                    disabled={!canConfigureServer}
+                  >
+                    <SelectValue>
+                      {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup align="end" alignItemWithTrigger={false}>
+                    <SelectItem hideIndicator value="local">
+                      Local
+                    </SelectItem>
+                    <SelectItem hideIndicator value="worktree">
+                      New worktree
+                    </SelectItem>
+                  </SelectPopup>
+                </Select>
               }
-              aria-label="Confirm thread deletion"
             />
-          }
-        />
 
-        <SettingsRow
-          title="Text generation model"
-          description="Default model for generated text like thread titles and source control content. Source control settings can override it with a dedicated source control writer model."
-          resetAction={
-            isTextGenerationModelDirty ? (
-              <SettingResetButton
-                label="text generation model"
-                disabled={!canConfigureServer}
-                onClick={() =>
-                  updateSettings({
-                    textGenerationModelSelection:
-                      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
-                  })
+            {settings.defaultThreadEnvMode === "worktree" ? (
+              <SettingsRow
+                className="bg-muted/20 sm:pl-9"
+                title="Start from origin"
+                description="Creates the worktree from the latest matching branch on origin instead of your local branch."
+                resetAction={
+                  settings.newWorktreesStartFromOrigin !==
+                  DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
+                    <SettingResetButton
+                      label="new worktrees start from origin"
+                      disabled={!canConfigureServer}
+                      onClick={() =>
+                        updateSettings({
+                          newWorktreesStartFromOrigin:
+                            DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+                        })
+                      }
+                    />
+                  ) : null
+                }
+                control={
+                  <Switch
+                    checked={settings.newWorktreesStartFromOrigin}
+                    disabled={!canConfigureServer}
+                    onCheckedChange={(checked) =>
+                      updateSettings({
+                        newWorktreesStartFromOrigin: Boolean(checked),
+                      })
+                    }
+                    aria-label="Start new worktrees from origin by default"
+                  />
                 }
               />
-            ) : null
-          }
-          control={
-            <fieldset
-              className="flex flex-wrap items-center justify-end gap-1.5"
-              disabled={!canConfigureServer}
-            >
-              <ProviderModelPicker
-                activeInstanceId={textGenInstanceId}
-                disabled={!canConfigureServer}
-                model={textGenModel}
-                lockedProvider={null}
-                instanceEntries={textGenerationModelInstanceEntries}
-                modelOptionsByInstance={textGenerationModelOptionsByInstance}
-                triggerVariant="outline"
-                triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
-                onInstanceModelChange={(instanceId, model) => {
-                  updateSettings({
-                    textGenerationModelSelection: resolveAppModelSelectionState(
-                      {
-                        ...settings,
-                        textGenerationModelSelection: createModelSelection(instanceId, model),
-                      },
-                      serverProviders,
-                    ),
-                  });
-                }}
-              />
-              <TraitsPicker
-                provider={textGenProvider}
-                models={
-                  // Use the exact instance's models (rather than the
-                  // first-kind-match) so a custom text-gen instance like
-                  // `codex_personal` gets its own model list, not the
-                  // default Codex one.
-                  textGenInstanceEntry?.models ?? []
-                }
-                model={textGenModel}
-                prompt=""
-                onPromptChange={() => {}}
-                modelOptions={textGenModelOptions}
-                allowPromptInjectedEffort={false}
-                triggerVariant="outline"
-                triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
-                onModelOptionsChange={(nextOptions) => {
-                  updateSettings({
-                    textGenerationModelSelection: resolveAppModelSelectionState(
-                      {
-                        ...settings,
-                        textGenerationModelSelection: createModelSelection(
-                          textGenInstanceId,
-                          textGenModel,
-                          nextOptions,
-                        ),
-                      },
-                      serverProviders,
-                    ),
-                  });
-                }}
-              />
-            </fieldset>
-          }
-        />
-      </SettingsSection>
+            ) : null}
 
-      <SettingsSection title="About">
-        {isElectron || HOSTED_APP_CHANNEL ? (
-          <AboutVersionSection />
-        ) : (
+            <SettingsRow
+              title="Add project starts in"
+              description='Leave empty to use "~/" when the Add Project browser opens.'
+              resetAction={
+                settings.addProjectBaseDirectory !==
+                DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ? (
+                  <SettingResetButton
+                    label="add project base directory"
+                    disabled={!canConfigureServer}
+                    onClick={() =>
+                      updateSettings({
+                        addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <DraftInput
+                  className="w-full sm:w-72"
+                  disabled={!canConfigureServer}
+                  value={settings.addProjectBaseDirectory}
+                  onCommit={(next) => updateSettings({ addProjectBaseDirectory: next })}
+                  placeholder="~/"
+                  spellCheck={false}
+                  aria-label="Add project base directory"
+                />
+              }
+            />
+          </>
+        ) : null}
+
+        {ownership === "client" ? (
+          <>
+            <SettingsRow
+              title="Archive confirmation"
+              description="Require a second click on the inline archive action before a thread is archived."
+              resetAction={
+                settings.confirmThreadArchive !== DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive ? (
+                  <SettingResetButton
+                    label="archive confirmation"
+                    onClick={() =>
+                      updateSettings({
+                        confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.confirmThreadArchive}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ confirmThreadArchive: Boolean(checked) })
+                  }
+                  aria-label="Confirm thread archiving"
+                />
+              }
+            />
+
+            <SettingsRow
+              title="Delete confirmation"
+              description="Ask before deleting a thread and its chat history."
+              resetAction={
+                settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete ? (
+                  <SettingResetButton
+                    label="delete confirmation"
+                    onClick={() =>
+                      updateSettings({
+                        confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+                      })
+                    }
+                  />
+                ) : null
+              }
+              control={
+                <Switch
+                  checked={settings.confirmThreadDelete}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ confirmThreadDelete: Boolean(checked) })
+                  }
+                  aria-label="Confirm thread deletion"
+                />
+              }
+            />
+          </>
+        ) : null}
+
+        {ownership === "environment" ? (
           <SettingsRow
-            title={<AboutVersionTitle />}
-            description="Current version of the application."
+            title="Text generation model"
+            description="Default model for generated text like thread titles and source control content. Source control settings can override it with a dedicated source control writer model."
+            resetAction={
+              isTextGenerationModelDirty ? (
+                <SettingResetButton
+                  label="text generation model"
+                  disabled={!canConfigureServer}
+                  onClick={() =>
+                    updateSettings({
+                      textGenerationModelSelection:
+                        DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <fieldset
+                className="flex flex-wrap items-center justify-end gap-1.5"
+                disabled={!canConfigureServer}
+              >
+                <ProviderModelPicker
+                  activeInstanceId={textGenInstanceId}
+                  disabled={!canConfigureServer}
+                  model={textGenModel}
+                  lockedProvider={null}
+                  instanceEntries={textGenerationModelInstanceEntries}
+                  modelOptionsByInstance={textGenerationModelOptionsByInstance}
+                  triggerVariant="outline"
+                  triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
+                  onInstanceModelChange={(instanceId, model) => {
+                    updateSettings({
+                      textGenerationModelSelection: resolveAppModelSelectionState(
+                        {
+                          ...settings,
+                          textGenerationModelSelection: createModelSelection(instanceId, model),
+                        },
+                        serverProviders,
+                      ),
+                    });
+                  }}
+                />
+                <TraitsPicker
+                  provider={textGenProvider}
+                  models={
+                    // Use the exact instance's models (rather than the
+                    // first-kind-match) so a custom text-gen instance like
+                    // `codex_personal` gets its own model list, not the
+                    // default Codex one.
+                    textGenInstanceEntry?.models ?? []
+                  }
+                  model={textGenModel}
+                  prompt=""
+                  onPromptChange={() => {}}
+                  modelOptions={textGenModelOptions}
+                  allowPromptInjectedEffort={false}
+                  triggerVariant="outline"
+                  triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
+                  onModelOptionsChange={(nextOptions) => {
+                    updateSettings({
+                      textGenerationModelSelection: resolveAppModelSelectionState(
+                        {
+                          ...settings,
+                          textGenerationModelSelection: createModelSelection(
+                            textGenInstanceId,
+                            textGenModel,
+                            nextOptions,
+                          ),
+                        },
+                        serverProviders,
+                      ),
+                    });
+                  }}
+                />
+              </fieldset>
+            }
           />
-        )}
-        <SettingsRow
-          title="Diagnostics"
-          description={diagnosticsDescription}
-          control={
-            <Button render={<Link to="/settings/diagnostics" />} size="xs" variant="outline">
-              View diagnostics
-            </Button>
-          }
-        />
+        ) : null}
       </SettingsSection>
+
+      {ownership === "client" ? (
+        <SettingsSection title="About">
+          {isElectron || HOSTED_APP_CHANNEL ? (
+            <AboutVersionSection />
+          ) : (
+            <SettingsRow
+              title={<AboutVersionTitle />}
+              description="Current version of the application."
+            />
+          )}
+        </SettingsSection>
+      ) : (
+        <SettingsSection title="Diagnostics">
+          <SettingsRow
+            title="Diagnostics"
+            description={diagnosticsDescription}
+            control={
+              <Button render={<Link to="/settings/diagnostics" />} size="xs" variant="outline">
+                View diagnostics
+              </Button>
+            }
+          />
+        </SettingsSection>
+      )}
     </SettingsPageContainer>
   );
+}
+
+export function GeneralSettingsPanel() {
+  return <OwnershipSettingsPanel ownership="client" />;
+}
+
+export function EnvironmentSettingsPanel() {
+  return <OwnershipSettingsPanel ownership="environment" />;
 }
 
 export function ArchivedThreadsPanel() {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -63,7 +63,9 @@ import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import {
+  buildGeneralSettingsRestorePatch,
   formatDiagnosticsDescription,
+  hasChangedGeneralServerSettings,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   readLastEnabledProjectGroupingMode,
@@ -321,7 +323,7 @@ function AboutVersionSection() {
 
 export function useSettingsRestore(onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
-  const { environmentId } = useSettingsEnvironment();
+  const { environmentId, environment } = useSettingsEnvironment();
   const settings = useEnvironmentSettings(environmentId);
   const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
@@ -329,6 +331,9 @@ export function useSettingsRestore(onRestored?: () => void) {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const hasChangedServerSettings = hasChangedGeneralServerSettings(settings);
+  const canRestoreDefaults =
+    !hasChangedServerSettings || environment?.connection.phase === "connected";
 
   const changedSettingLabels = useMemo(
     () => [
@@ -402,7 +407,7 @@ export function useSettingsRestore(onRestored?: () => void) {
   );
 
   const restoreDefaults = useCallback(async () => {
-    if (changedSettingLabels.length === 0) return;
+    if (changedSettingLabels.length === 0 || !canRestoreDefaults) return;
     const api = readLocalApi();
     const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
       ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
@@ -412,28 +417,23 @@ export function useSettingsRestore(onRestored?: () => void) {
     if (!confirmed) return;
 
     setTheme("system");
-    updateSettings({
-      timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
-      wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
-      diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
-      glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
-      sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
-      sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
-      autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
-      enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
-      enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
-      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
-      defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
-      newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-      addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
-      confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
-      confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
-      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
-    });
+    updateSettings(
+      buildGeneralSettingsRestorePatch({
+        includeServerSettings: hasChangedServerSettings,
+      }),
+    );
     onRestored?.();
-  }, [changedSettingLabels, onRestored, setTheme, updateSettings]);
+  }, [
+    canRestoreDefaults,
+    changedSettingLabels,
+    hasChangedServerSettings,
+    onRestored,
+    setTheme,
+    updateSettings,
+  ]);
 
   return {
+    canRestoreDefaults,
     changedSettingLabels,
     restoreDefaults,
   };
@@ -743,6 +743,7 @@ export function GeneralSettingsPanel() {
             DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming ? (
               <SettingResetButton
                 label="assistant output"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
@@ -771,6 +772,7 @@ export function GeneralSettingsPanel() {
             DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks ? (
               <SettingResetButton
                 label="provider update checks"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
@@ -826,6 +828,7 @@ export function GeneralSettingsPanel() {
               DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
               <SettingResetButton
                 label="new threads"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
@@ -876,6 +879,7 @@ export function GeneralSettingsPanel() {
               DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin ? (
                 <SettingResetButton
                   label="new worktrees start from origin"
+                  disabled={!canConfigureServer}
                   onClick={() =>
                     updateSettings({
                       newWorktreesStartFromOrigin:
@@ -906,6 +910,7 @@ export function GeneralSettingsPanel() {
             DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory ? (
               <SettingResetButton
                 label="add project base directory"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
@@ -986,6 +991,7 @@ export function GeneralSettingsPanel() {
             isTextGenerationModelDirty ? (
               <SettingResetButton
                 label="text generation model"
+                disabled={!canConfigureServer}
                 onClick={() =>
                   updateSettings({
                     textGenerationModelSelection:

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -9,6 +9,7 @@ import {
   type ScopedThreadRef,
   type SidebarProjectGroupingMode,
 } from "@t3tools/contracts";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
   isAtomCommandInterrupted,
@@ -36,7 +37,8 @@ import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useTheme } from "../../hooks/useTheme";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -49,7 +51,7 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
-import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
@@ -59,6 +61,7 @@ import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../
 import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import {
   formatDiagnosticsDescription,
   isProjectGroupingEnabled,
@@ -318,8 +321,9 @@ function AboutVersionSection() {
 
 export function useSettingsRestore(onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const { environmentId } = useSettingsEnvironment();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
   const isTextGenerationModelDirty = !Equal.equals(
     settings.textGenerationModelSelection ?? null,
@@ -437,13 +441,23 @@ export function useSettingsRestore(onRestored?: () => void) {
 
 export function GeneralSettingsPanel() {
   const { theme, setTheme } = useTheme();
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const {
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+    isReady: environmentsReady,
+  } = useSettingsEnvironment();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
   );
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
+  const observability = serverConfig?.observability ?? null;
+  const serverProviders = serverConfig?.providers ?? [];
+  const canConfigureServer = environment?.connection.phase === "connected";
   const glassOpacityRatio =
     (settings.glassOpacity - MIN_GLASS_OPACITY) / (MAX_GLASS_OPACITY - MIN_GLASS_OPACITY);
   const glassOpacitySliderStyle = {
@@ -483,6 +497,36 @@ export function GeneralSettingsPanel() {
 
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Server settings"
+          description="Assistant behavior, workspace defaults, provider maintenance, and text generation are configured per environment."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : environmentsReady
+                ? "Connect an environment to configure its server settings."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
+            ) : environmentsReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
+      </SettingsSection>
+
       <SettingsSection title="General">
         <SettingsRow
           title="Theme"
@@ -710,6 +754,7 @@ export function GeneralSettingsPanel() {
           control={
             <Switch
               checked={settings.enableAssistantStreaming}
+              disabled={!canConfigureServer}
               onCheckedChange={(checked) =>
                 updateSettings({ enableAssistantStreaming: Boolean(checked) })
               }
@@ -737,6 +782,7 @@ export function GeneralSettingsPanel() {
           control={
             <Switch
               checked={settings.enableProviderUpdateChecks}
+              disabled={!canConfigureServer}
               onCheckedChange={(checked) =>
                 updateSettings({ enableProviderUpdateChecks: Boolean(checked) })
               }
@@ -799,7 +845,11 @@ export function GeneralSettingsPanel() {
                 }
               }}
             >
-              <SelectTrigger className="w-full sm:w-44" aria-label="Default thread mode">
+              <SelectTrigger
+                className="w-full sm:w-44"
+                aria-label="Default thread mode"
+                disabled={!canConfigureServer}
+              >
                 <SelectValue>
                   {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
                 </SelectValue>
@@ -838,6 +888,7 @@ export function GeneralSettingsPanel() {
             control={
               <Switch
                 checked={settings.newWorktreesStartFromOrigin}
+                disabled={!canConfigureServer}
                 onCheckedChange={(checked) =>
                   updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
                 }
@@ -866,6 +917,7 @@ export function GeneralSettingsPanel() {
           control={
             <DraftInput
               className="w-full sm:w-72"
+              disabled={!canConfigureServer}
               value={settings.addProjectBaseDirectory}
               onCommit={(next) => updateSettings({ addProjectBaseDirectory: next })}
               placeholder="~/"
@@ -944,9 +996,13 @@ export function GeneralSettingsPanel() {
             ) : null
           }
           control={
-            <div className="flex flex-wrap items-center justify-end gap-1.5">
+            <fieldset
+              className="flex flex-wrap items-center justify-end gap-1.5"
+              disabled={!canConfigureServer}
+            >
               <ProviderModelPicker
                 activeInstanceId={textGenInstanceId}
+                disabled={!canConfigureServer}
                 model={textGenModel}
                 lockedProvider={null}
                 instanceEntries={textGenerationModelInstanceEntries}
@@ -997,7 +1053,7 @@ export function GeneralSettingsPanel() {
                   });
                 }}
               />
-            </div>
+            </fieldset>
           }
         />
       </SettingsSection>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,20 +1,15 @@
-import { ArchiveIcon, ArchiveX, LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import { ArchiveIcon, ArchiveX, LoaderIcon } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { CSSProperties } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import {
-  defaultInstanceIdForDriver,
   type DesktopUpdateChannel,
-  PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
-  type ProviderInstanceConfig,
-  type ProviderInstanceId,
   type ScopedThreadRef,
   type SidebarProjectGroupingMode,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
-import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
   isAtomCommandInterrupted,
   settlePromise,
@@ -26,10 +21,8 @@ import {
   MIN_GLASS_OPACITY,
 } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
-import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
-import * as Result from "effect/Result";
 import { APP_VERSION, HOSTED_APP_CHANNEL, HOSTED_APP_CHANNEL_LABEL } from "../../branding";
 import {
   canCheckForUpdate,
@@ -56,33 +49,17 @@ import {
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
-import {
-  primaryServerObservabilityAtom,
-  primaryServerProvidersAtom,
-  serverEnvironment,
-} from "../../state/server";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
-import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
+import { formatRelativeTimeLabel } from "../../timestampFormat";
 import { Button } from "../ui/button";
 import { DraftInput } from "../ui/draft-input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
-import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import {
-  canOneClickUpdateProviderCandidate,
-  collectProviderUpdateCandidates,
-  hasOneClickUpdateProviderCandidate,
-  isProviderUpdateActive,
-  type ProviderUpdateCandidate,
-} from "../ProviderUpdateLaunchNotification.logic";
-import { ProviderInstanceCard } from "./ProviderInstanceCard";
-import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
-import {
-  buildProviderInstanceUpdatePatch,
   formatDiagnosticsDescription,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
@@ -94,10 +71,8 @@ import {
   SettingsPageContainer,
   SettingsRow,
   SettingsSection,
-  useRelativeTimeTick,
 } from "./settingsLayout";
 import { ProjectFavicon } from "../ProjectFavicon";
-import { useAtomCommand } from "../../state/use-atom-command";
 
 const THEME_OPTIONS = [
   {
@@ -121,52 +96,6 @@ const TIMESTAMP_FORMAT_LABELS = {
 } as const;
 
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
-
-function withoutProviderInstanceKey<V>(
-  record: Readonly<Record<ProviderInstanceId, V>> | undefined,
-  key: ProviderInstanceId,
-): Record<ProviderInstanceId, V> {
-  const next = { ...record } as Record<ProviderInstanceId, V>;
-  delete next[key];
-  return next;
-}
-
-function withoutProviderInstanceFavorites(
-  favorites: ReadonlyArray<{ readonly provider: ProviderInstanceId; readonly model: string }>,
-  instanceId: ProviderInstanceId,
-) {
-  return favorites.filter((favorite) => favorite.provider !== instanceId);
-}
-
-const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({
-  provider: definition.value,
-}));
-
-function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }) {
-  useRelativeTimeTick();
-  const lastCheckedRelative = getRelativeTimeState(lastCheckedAt);
-
-  if (lastCheckedRelative.status === "missing") {
-    return null;
-  }
-
-  if (lastCheckedRelative.status === "invalid") {
-    return <span className="text-[11px] text-muted-foreground/50">Checked unavailable</span>;
-  }
-
-  return (
-    <span className="text-[11px] text-muted-foreground/60">
-      {lastCheckedRelative.suffix ? (
-        <>
-          Checked <span className="font-mono tabular-nums">{lastCheckedRelative.value}</span>{" "}
-          {lastCheckedRelative.suffix}
-        </>
-      ) : (
-        <>Checked {lastCheckedRelative.value}</>
-      )}
-    </span>
-  );
-}
 
 function AboutVersionTitle() {
   return (
@@ -1092,451 +1021,6 @@ export function GeneralSettingsPanel() {
           }
         />
       </SettingsSection>
-    </SettingsPageContainer>
-  );
-}
-
-export function ProviderSettingsPanel() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
-  const refreshServerProviders = useAtomCommand(serverEnvironment.refreshProviders, {
-    reportFailure: false,
-  });
-  const updateProvider = useAtomCommand(serverEnvironment.updateProvider, {
-    reportFailure: false,
-  });
-  const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
-  const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
-  const [updatingProviderDrivers, setUpdatingProviderDrivers] = useState<
-    ReadonlySet<ProviderDriverKind>
-  >(() => new Set());
-  const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
-  const refreshingRef = useRef(false);
-
-  const providerUpdateCandidates = useMemo(
-    () => collectProviderUpdateCandidates(serverProviders),
-    [serverProviders],
-  );
-  const providerUpdateCandidateByInstanceId = useMemo(
-    () => new Map(providerUpdateCandidates.map((candidate) => [candidate.instanceId, candidate])),
-    [providerUpdateCandidates],
-  );
-  const visibleProviderSettings = PROVIDER_SETTINGS.filter(
-    (providerSettings) =>
-      providerSettings.provider !== "cursor" ||
-      serverProviders.some(
-        (provider) =>
-          provider.instanceId === defaultInstanceIdForDriver(ProviderDriverKind.make("cursor")),
-      ),
-  );
-  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
-  const textGenInstanceId = textGenerationModelSelection.instanceId;
-  const lastCheckedAt =
-    serverProviders.length > 0
-      ? serverProviders.reduce(
-          (latest, provider) => (provider.checkedAt > latest ? provider.checkedAt : latest),
-          serverProviders[0]!.checkedAt,
-        )
-      : null;
-
-  const refreshProviders = useCallback(() => {
-    if (refreshingRef.current) return;
-    refreshingRef.current = true;
-    setIsRefreshingProviders(true);
-    if (!primaryEnvironment) {
-      refreshingRef.current = false;
-      setIsRefreshingProviders(false);
-      return;
-    }
-    void (async () => {
-      const result = await refreshServerProviders({
-        environmentId: primaryEnvironment.environmentId,
-        input: {},
-      });
-      refreshingRef.current = false;
-      setIsRefreshingProviders(false);
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        console.warn("Failed to refresh providers", {
-          operation: "refresh-providers",
-          environmentId: primaryEnvironment.environmentId,
-          ...safeErrorLogAttributes(squashAtomCommandFailure(result)),
-        });
-      }
-    })();
-  }, [primaryEnvironment, refreshServerProviders]);
-
-  const runProviderUpdate = useCallback(
-    async (candidate: ProviderUpdateCandidate) => {
-      if (!primaryEnvironment) return;
-      let started = false;
-      setUpdatingProviderDrivers((previous) => {
-        if (previous.has(candidate.driver)) {
-          return previous;
-        }
-        started = true;
-        const next = new Set(previous);
-        next.add(candidate.driver);
-        return next;
-      });
-      if (!started) {
-        return;
-      }
-
-      const result = await updateProvider({
-        environmentId: primaryEnvironment.environmentId,
-        input: {
-          provider: candidate.driver,
-          instanceId: candidate.instanceId,
-        },
-      });
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: `Could not update ${PROVIDER_DISPLAY_NAMES[candidate.driver] ?? candidate.driver}`,
-            description:
-              error instanceof Error
-                ? error.message
-                : "The provider update command could not be started.",
-          }),
-        );
-      }
-      setUpdatingProviderDrivers((previous) => {
-        if (!previous.has(candidate.driver)) {
-          return previous;
-        }
-        const next = new Set(previous);
-        next.delete(candidate.driver);
-        return next;
-      });
-    },
-    [primaryEnvironment, updateProvider],
-  );
-
-  interface InstanceRow {
-    readonly instanceId: ProviderInstanceId;
-    readonly instance: ProviderInstanceConfig;
-    readonly driver: ProviderDriverKind;
-    readonly isDefault: boolean;
-    readonly isDirty?: boolean;
-  }
-
-  const instancesByDriver = new Map<
-    ProviderDriverKind,
-    Array<[ProviderInstanceId, ProviderInstanceConfig]>
-  >();
-  for (const [rawId, instance] of Object.entries(settings.providerInstances ?? {})) {
-    const driver = instance.driver;
-    const list = instancesByDriver.get(driver) ?? [];
-    list.push([rawId as ProviderInstanceId, instance]);
-    instancesByDriver.set(driver, list);
-  }
-
-  const defaultSlotIdsBySource = new Set<string>(
-    visibleProviderSettings.map((providerSettings) =>
-      String(defaultInstanceIdForDriver(providerSettings.provider)),
-    ),
-  );
-
-  const rows: InstanceRow[] = [];
-  const visibleDriverKinds = new Set<ProviderDriverKind>(
-    visibleProviderSettings.map((providerSettings) => providerSettings.provider),
-  );
-
-  for (const providerSettings of visibleProviderSettings) {
-    type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
-    const legacyProviders = settings.providers as Record<string, LegacyProviderSettings>;
-    const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
-      string,
-      LegacyProviderSettings
-    >;
-    const driver = providerSettings.provider;
-    const defaultInstanceId = defaultInstanceIdForDriver(driver);
-    const explicitInstance = settings.providerInstances?.[defaultInstanceId];
-    const legacyConfig = legacyProviders[providerSettings.provider]!;
-    const defaultLegacyConfig = defaultLegacyProviders[providerSettings.provider]!;
-    const effectiveInstance: ProviderInstanceConfig =
-      explicitInstance ??
-      ({
-        driver,
-        enabled: legacyConfig.enabled,
-        config: legacyConfig,
-      } satisfies ProviderInstanceConfig);
-    const isDirty =
-      explicitInstance !== undefined || !Equal.equals(legacyConfig, defaultLegacyConfig);
-    rows.push({
-      instanceId: defaultInstanceId,
-      instance: effectiveInstance,
-      driver,
-      isDefault: true,
-      isDirty,
-    });
-    for (const [id, instance] of instancesByDriver.get(providerSettings.provider) ?? []) {
-      if (id === defaultInstanceId) continue;
-      rows.push({ instanceId: id, instance, driver: instance.driver, isDefault: false });
-    }
-  }
-  for (const [driver, list] of instancesByDriver) {
-    if (visibleDriverKinds.has(driver)) continue;
-    for (const [id, instance] of list) {
-      rows.push({
-        instanceId: id,
-        instance,
-        driver: instance.driver,
-        isDefault: defaultSlotIdsBySource.has(String(id)),
-      });
-    }
-  }
-
-  const updateProviderInstance = (
-    row: InstanceRow,
-    next: ProviderInstanceConfig,
-    options?: {
-      readonly textGenerationModelSelection?: Parameters<
-        typeof buildProviderInstanceUpdatePatch
-      >[0]["textGenerationModelSelection"];
-    },
-  ) => {
-    updateSettings(
-      buildProviderInstanceUpdatePatch({
-        settings,
-        instanceId: row.instanceId,
-        instance: next,
-        driver: row.driver,
-        isDefault: row.isDefault,
-        textGenerationModelSelection: options?.textGenerationModelSelection,
-      }),
-    );
-  };
-
-  const deleteProviderInstance = (id: ProviderInstanceId) => {
-    updateSettings({
-      providerInstances: withoutProviderInstanceKey(settings.providerInstances, id),
-      providerModelPreferences: withoutProviderInstanceKey(settings.providerModelPreferences, id),
-      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], id),
-    });
-  };
-
-  const updateProviderModelPreferences = (
-    instanceId: ProviderInstanceId,
-    next: {
-      readonly hiddenModels: ReadonlyArray<string>;
-      readonly modelOrder: ReadonlyArray<string>;
-    },
-  ) => {
-    const hiddenModels = [...new Set(next.hiddenModels.filter((slug) => slug.trim().length > 0))];
-    const modelOrder = [...new Set(next.modelOrder.filter((slug) => slug.trim().length > 0))];
-    const rest = withoutProviderInstanceKey(settings.providerModelPreferences, instanceId);
-    updateSettings({
-      providerModelPreferences:
-        hiddenModels.length === 0 && modelOrder.length === 0
-          ? rest
-          : {
-              ...rest,
-              [instanceId]: {
-                hiddenModels,
-                modelOrder,
-              },
-            },
-    });
-  };
-
-  const updateProviderFavoriteModels = (
-    instanceId: ProviderInstanceId,
-    nextFavoriteModels: ReadonlyArray<string>,
-  ) => {
-    const favoriteModels = [
-      ...new Set(
-        Arr.filterMap(nextFavoriteModels, (slug) => {
-          const trimmedSlug = slug.trim();
-          return trimmedSlug.length > 0 ? Result.succeed(trimmedSlug) : Result.failVoid;
-        }),
-      ),
-    ];
-    updateSettings({
-      favorites: [
-        ...withoutProviderInstanceFavorites(settings.favorites ?? [], instanceId),
-        ...favoriteModels.map((model) => ({ provider: instanceId, model })),
-      ],
-    });
-  };
-
-  const resetDefaultInstance = (driverKind: ProviderDriverKind) => {
-    type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
-    const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
-      string,
-      LegacyProviderSettings | undefined
-    >;
-    const defaultInstanceId = defaultInstanceIdForDriver(driverKind);
-    const defaultLegacyProvider = defaultLegacyProviders[driverKind];
-    if (defaultLegacyProvider === undefined) return;
-    updateSettings({
-      providers: {
-        ...settings.providers,
-        [driverKind]: defaultLegacyProvider,
-      } as typeof settings.providers,
-      providerInstances: withoutProviderInstanceKey(settings.providerInstances, defaultInstanceId),
-      providerModelPreferences: withoutProviderInstanceKey(
-        settings.providerModelPreferences,
-        defaultInstanceId,
-      ),
-      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], defaultInstanceId),
-    });
-  };
-
-  return (
-    <SettingsPageContainer>
-      <SettingsSection
-        title="Providers"
-        headerAction={
-          <div className="flex items-center gap-1.5">
-            <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    onClick={() => setIsAddInstanceDialogOpen(true)}
-                    aria-label="Add provider instance"
-                  >
-                    <PlusIcon className="size-3" />
-                  </Button>
-                }
-              />
-              <TooltipPopup side="top">Add provider instance</TooltipPopup>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    size="icon-xs"
-                    variant="ghost"
-                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    disabled={isRefreshingProviders}
-                    onClick={() => void refreshProviders()}
-                    aria-label="Refresh provider status"
-                  >
-                    {isRefreshingProviders ? (
-                      <LoaderIcon className="size-3 animate-spin" />
-                    ) : (
-                      <RefreshCwIcon className="size-3" />
-                    )}
-                  </Button>
-                }
-              />
-              <TooltipPopup side="top">Refresh provider status</TooltipPopup>
-            </Tooltip>
-          </div>
-        }
-      >
-        {rows.map((row) => {
-          const driverOption = getDriverOption(row.driver);
-          const liveProvider = serverProviders.find(
-            (candidate) => candidate.instanceId === row.instanceId,
-          );
-          const updateCandidate = liveProvider
-            ? providerUpdateCandidateByInstanceId.get(liveProvider.instanceId)
-            : undefined;
-          const isDriverUpdateRunning =
-            updateCandidate !== undefined &&
-            (updatingProviderDrivers.has(updateCandidate.driver) ||
-              serverProviders.some(
-                (provider) =>
-                  provider.driver === updateCandidate.driver && isProviderUpdateActive(provider),
-              ));
-          const showInlineUpdateButton =
-            updateCandidate !== undefined &&
-            hasOneClickUpdateProviderCandidate(updateCandidate, serverProviders);
-          const canRunInlineUpdate =
-            updateCandidate !== undefined &&
-            canOneClickUpdateProviderCandidate(updateCandidate, serverProviders) &&
-            !updatingProviderDrivers.has(updateCandidate.driver);
-          const modelPreferences = settings.providerModelPreferences?.[row.instanceId] ?? {
-            hiddenModels: [],
-            modelOrder: [],
-          };
-          const favoriteModels = Arr.filterMap(settings.favorites ?? [], (favorite) =>
-            favorite.provider === row.instanceId ? Result.succeed(favorite.model) : Result.failVoid,
-          );
-          const resetLabel = driverOption?.label ?? String(row.driver);
-          const headerAction =
-            row.isDefault && row.isDirty ? (
-              <SettingResetButton
-                label={`${resetLabel} provider settings`}
-                onClick={() => resetDefaultInstance(row.driver)}
-              />
-            ) : null;
-          return (
-            <ProviderInstanceCard
-              key={row.instanceId}
-              instanceId={row.instanceId}
-              instance={row.instance}
-              driverOption={driverOption}
-              liveProvider={liveProvider}
-              isExpanded={openInstanceDetails[row.instanceId] ?? false}
-              onExpandedChange={(open) =>
-                setOpenInstanceDetails((existing) => ({
-                  ...existing,
-                  [row.instanceId]: open,
-                }))
-              }
-              onUpdate={(next) => {
-                const wasEnabled = row.instance.enabled ?? true;
-                const isDisabling = next.enabled === false && wasEnabled;
-                const shouldClearTextGen = isDisabling && textGenInstanceId === row.instanceId;
-                if (shouldClearTextGen) {
-                  updateProviderInstance(row, next, {
-                    textGenerationModelSelection:
-                      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
-                  });
-                } else {
-                  updateProviderInstance(row, next);
-                }
-              }}
-              onDelete={row.isDefault ? undefined : () => deleteProviderInstance(row.instanceId)}
-              headerAction={headerAction}
-              hiddenModels={modelPreferences.hiddenModels}
-              favoriteModels={favoriteModels}
-              modelOrder={modelPreferences.modelOrder}
-              onHiddenModelsChange={(hiddenModels) =>
-                updateProviderModelPreferences(row.instanceId, {
-                  ...modelPreferences,
-                  hiddenModels,
-                })
-              }
-              onFavoriteModelsChange={(favoriteModels) =>
-                updateProviderFavoriteModels(row.instanceId, favoriteModels)
-              }
-              onModelOrderChange={(modelOrder) =>
-                updateProviderModelPreferences(row.instanceId, {
-                  ...modelPreferences,
-                  modelOrder,
-                })
-              }
-              onRunUpdate={
-                showInlineUpdateButton && updateCandidate
-                  ? () => {
-                      if (!canRunInlineUpdate) {
-                        return;
-                      }
-                      void runProviderUpdate(updateCandidate);
-                    }
-                  : undefined
-              }
-              isUpdating={showInlineUpdateButton ? isDriverUpdateRunning : undefined}
-            />
-          );
-        })}
-      </SettingsSection>
-
-      {isAddInstanceDialogOpen ? (
-        <AddProviderInstanceDialog open onOpenChange={setIsAddInstanceDialogOpen} />
-      ) : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SettingsSidebarNav.test.ts
+++ b/apps/web/src/components/settings/SettingsSidebarNav.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { SETTINGS_NAV_GROUPS } from "./SettingsSidebarNav";
+
+describe("settings navigation ownership", () => {
+  it("separates client-owned pages from environment-owned pages", () => {
+    expect(
+      SETTINGS_NAV_GROUPS.map((group) => ({
+        label: group.label,
+        routes: group.items.map((item) => item.to),
+      })),
+    ).toEqual([
+      {
+        label: "Client",
+        routes: [
+          "/settings/general",
+          "/settings/connections",
+          "/settings/beta",
+          "/settings/archived",
+        ],
+      },
+      {
+        label: "Environment",
+        routes: [
+          "/settings/environment",
+          "/settings/keybindings",
+          "/settings/providers",
+          "/settings/source-control",
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -15,6 +15,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -24,6 +25,7 @@ import { T3ConnectSidebarAvatar, T3ConnectSidebarSignIn } from "../clerk/T3Conne
 
 export type SettingsSectionPath =
   | "/settings/general"
+  | "/settings/environment"
   | "/settings/keybindings"
   | "/settings/providers"
   | "/settings/source-control"
@@ -31,18 +33,38 @@ export type SettingsSectionPath =
   | "/settings/beta"
   | "/settings/archived";
 
-export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
+export type SettingsNavItem = {
   label: string;
   to: SettingsSectionPath;
   icon: ComponentType<{ className?: string }>;
+};
+
+export const SETTINGS_NAV_GROUPS: ReadonlyArray<{
+  label: "Client" | "Environment";
+  items: ReadonlyArray<SettingsNavItem>;
 }> = [
-  { label: "General", to: "/settings/general", icon: Settings2Icon },
-  { label: "Keybindings", to: "/settings/keybindings", icon: KeyboardIcon },
-  { label: "Providers", to: "/settings/providers", icon: BotIcon },
-  { label: "Source Control", to: "/settings/source-control", icon: GitBranchIcon },
-  { label: "Connections", to: "/settings/connections", icon: Link2Icon },
-  { label: "Beta", to: "/settings/beta", icon: FlaskConicalIcon },
-  { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },
+  {
+    label: "Client",
+    items: [
+      { label: "General", to: "/settings/general", icon: Settings2Icon },
+      { label: "Connections", to: "/settings/connections", icon: Link2Icon },
+      { label: "Beta", to: "/settings/beta", icon: FlaskConicalIcon },
+      { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },
+    ],
+  },
+  {
+    label: "Environment",
+    items: [
+      { label: "General", to: "/settings/environment", icon: Settings2Icon },
+      { label: "Keybindings", to: "/settings/keybindings", icon: KeyboardIcon },
+      { label: "Providers", to: "/settings/providers", icon: BotIcon },
+      {
+        label: "Source Control",
+        to: "/settings/source-control",
+        icon: GitBranchIcon,
+      },
+    ],
+  },
 ];
 
 export function SettingsSidebarNav({ pathname }: { pathname: string }) {
@@ -72,37 +94,42 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   return (
     <>
       <SidebarContent className="overflow-x-hidden">
-        <SidebarGroup className="px-2 py-3">
-          <SidebarMenu>
-            {SETTINGS_NAV_ITEMS.map((item) => {
-              const Icon = item.icon;
-              const isActive = pathname === item.to;
-              return (
-                <SidebarMenuItem key={item.to}>
-                  <SidebarMenuButton
-                    size="sm"
-                    isActive={isActive}
-                    className={
-                      isActive
-                        ? "h-8 items-center gap-2 rounded-md bg-sidebar-row-active px-2 py-1.5 text-left text-sm font-medium text-sidebar-foreground"
-                        : "h-8 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium text-sidebar-muted-foreground/80 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
-                    }
-                    onClick={() => handleSectionClick(item.to)}
-                  >
-                    <Icon
+        {SETTINGS_NAV_GROUPS.map((group) => (
+          <SidebarGroup className="px-2 py-2 first:pt-3" key={group.label}>
+            <SidebarGroupLabel className="h-6 px-2 text-[10px] font-semibold tracking-[0.08em] text-sidebar-muted-foreground/55 uppercase">
+              {group.label}
+            </SidebarGroupLabel>
+            <SidebarMenu>
+              {group.items.map((item) => {
+                const Icon = item.icon;
+                const isActive = pathname === item.to;
+                return (
+                  <SidebarMenuItem key={item.to}>
+                    <SidebarMenuButton
+                      size="sm"
+                      isActive={isActive}
                       className={
                         isActive
-                          ? "size-4 shrink-0 text-sidebar-foreground"
-                          : "size-4 shrink-0 text-sidebar-muted-foreground/60"
+                          ? "h-8 items-center gap-2 rounded-md bg-sidebar-row-active px-2 py-1.5 text-left text-sm font-medium text-sidebar-foreground"
+                          : "h-8 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium text-sidebar-muted-foreground/80 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
                       }
-                    />
-                    <span className="truncate">{item.label}</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              );
-            })}
-          </SidebarMenu>
-        </SidebarGroup>
+                      onClick={() => handleSectionClick(item.to)}
+                    >
+                      <Icon
+                        className={
+                          isActive
+                            ? "size-4 shrink-0 text-sidebar-foreground"
+                            : "size-4 shrink-0 text-sidebar-muted-foreground/60"
+                        }
+                      />
+                      <span className="truncate">{item.label}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroup>
+        ))}
       </SidebarContent>
       <SidebarFooter className="p-2">
         <T3ConnectSidebarSignIn />

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -2,7 +2,10 @@ import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useState, type ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import type {
+  EnvironmentId,
   SourceControlProviderKind,
   SourceControlDiscoveryResult,
   SourceControlProviderAuth,
@@ -12,9 +15,9 @@ import type {
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
+import { useSettingsEnvironment } from "../../hooks/useSettingsEnvironment";
 import { cn } from "../../lib/utils";
-import { usePrimaryEnvironment } from "../../state/environments";
 import { useEnvironmentQuery } from "../../state/query";
 import { sourceControlEnvironment } from "../../state/sourceControl";
 import { Badge } from "../ui/badge";
@@ -48,8 +51,14 @@ import {
   type Icon,
 } from "../Icons";
 import { RedactedSensitiveText } from "./RedactedSensitiveText";
+import { SettingsEnvironmentSelector } from "./SettingsEnvironmentSelector";
 import { SourceControlWritingSettingsSection } from "./SourceControlWritingSettings";
-import { SettingResetButton, SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import {
+  SettingResetButton,
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+} from "./settingsLayout";
 
 const EMPTY_DISCOVERY_RESULT: SourceControlDiscoveryResult = {
   versionControlSystems: [],
@@ -291,11 +300,18 @@ function DiscoveryItemRow({
   );
 }
 
-function GitFetchIntervalSettings() {
-  const automaticGitFetchInterval = usePrimarySettings(
+function GitFetchIntervalSettings({
+  environmentId,
+  isConnected,
+}: {
+  environmentId: EnvironmentId;
+  isConnected: boolean;
+}) {
+  const automaticGitFetchInterval = useEnvironmentSettings(
+    environmentId,
     (settings) => settings.automaticGitFetchInterval,
   );
-  const updateSettings = useUpdatePrimarySettings();
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const automaticGitFetchIntervalSeconds = durationToSeconds(automaticGitFetchInterval);
   const defaultAutomaticGitFetchIntervalSeconds = durationToSeconds(
     DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
@@ -319,6 +335,7 @@ function GitFetchIntervalSettings() {
               {canResetFetchInterval ? (
                 <SettingResetButton
                   label="fetch interval"
+                  disabled={!isConnected}
                   onClick={() =>
                     updateSettings({
                       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
@@ -335,6 +352,7 @@ function GitFetchIntervalSettings() {
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <NumberField
+            disabled={!isConnected}
             value={automaticGitFetchIntervalSeconds}
             min={0}
             step={GIT_FETCH_INTERVAL_STEP_SECONDS}
@@ -441,9 +459,17 @@ function EmptySourceControlDiscovery({
 }
 
 export function SourceControlSettingsPanel() {
-  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  const {
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment,
+    isReady: environmentsReady,
+  } = useSettingsEnvironment();
+  const isConnected = environment?.connection.phase === "connected";
   const discovery = useEnvironmentQuery(
-    environmentId === null
+    environmentId === null || !isConnected
       ? null
       : sourceControlEnvironment.discovery({
           environmentId,
@@ -466,7 +492,7 @@ export function SourceControlSettingsPanel() {
             variant="ghost"
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
             onClick={handleScan}
-            disabled={discovery.isPending}
+            disabled={!isConnected || discovery.isPending}
             aria-label="Rescan server environment"
           >
             <RefreshCwIcon className={cn("size-3", discovery.isPending && "animate-spin")} />
@@ -479,7 +505,37 @@ export function SourceControlSettingsPanel() {
 
   return (
     <SettingsPageContainer>
-      {isInitialScanPending ? (
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Source control environment"
+          description="Git tooling, credentials, hosting integrations, and fetch behavior belong to a specific server."
+          status={
+            environment
+              ? [connectionStatusText(environment.connection), environment.displayUrl]
+                  .filter(Boolean)
+                  .join(" · ")
+              : environmentsReady
+                ? "Connect an environment to inspect its source-control configuration."
+                : "Loading environments."
+          }
+          control={
+            environmentId !== null && environment !== null ? (
+              <SettingsEnvironmentSelector
+                environmentId={environmentId}
+                environments={environments}
+                primaryEnvironmentId={primaryEnvironmentId}
+                onEnvironmentChange={selectEnvironment}
+              />
+            ) : environmentsReady ? (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Open connections
+              </Button>
+            ) : null
+          }
+        />
+      </SettingsSection>
+
+      {!isConnected || environmentId === null ? null : isInitialScanPending ? (
         <>
           <SourceControlSectionSkeleton title="Version Control" headerAction={scanButton} />
           <SourceControlSectionSkeleton title="Source Control Providers" />
@@ -490,7 +546,12 @@ export function SourceControlSettingsPanel() {
             <SettingsSection title="Version Control" headerAction={scanButton}>
               {result.versionControlSystems.map((item) => (
                 <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
-                  {item.kind === "git" ? <GitFetchIntervalSettings /> : undefined}
+                  {item.kind === "git" ? (
+                    <GitFetchIntervalSettings
+                      environmentId={environmentId}
+                      isConnected={isConnected}
+                    />
+                  ) : undefined}
                 </DiscoveryItemRow>
               ))}
             </SettingsSection>
@@ -515,7 +576,12 @@ export function SourceControlSettingsPanel() {
         />
       )}
 
-      {environmentId !== null ? <SourceControlWritingSettingsSection /> : null}
+      {environmentId !== null ? (
+        <SourceControlWritingSettingsSection
+          environmentId={environmentId}
+          isConnected={isConnected}
+        />
+      ) : null}
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -1,11 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useRef } from "react";
-import type { SourceControlWritingStyleMode } from "@t3tools/contracts";
+import type { EnvironmentId, SourceControlWritingStyleMode } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import { resolveSourceControlWriterModelSelection } from "@t3tools/shared/serverSettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -15,7 +15,7 @@ import {
   getCustomModelOptionsByInstance,
   resolveAppModelSelectionState,
 } from "../../modelSelection";
-import { primaryServerProvidersAtom } from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
@@ -40,10 +40,17 @@ const MODE_OPTIONS: Record<SourceControlWritingStyleMode, { label: string; descr
     },
   };
 
-export function SourceControlWritingSettingsSection() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+export function SourceControlWritingSettingsSection({
+  environmentId,
+  isConnected,
+}: {
+  environmentId: EnvironmentId;
+  isConnected: boolean;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const serverProviders =
+    useAtomValue(serverEnvironment.configValueAtom(environmentId))?.providers ?? [];
   const customInstructionsRef = useRef<HTMLTextAreaElement>(null);
   const style = settings.sourceControlWritingStyle;
   const defaults = DEFAULT_UNIFIED_SETTINGS.sourceControlWritingStyle;
@@ -79,6 +86,7 @@ export function SourceControlWritingSettingsSection() {
           isSourceControlWritingStyleDirty ? (
             <SettingResetButton
               label="source control writing style"
+              disabled={!isConnected}
               onClick={() =>
                 updateSettings({
                   sourceControlWritingStyle: {
@@ -92,6 +100,7 @@ export function SourceControlWritingSettingsSection() {
         }
         control={
           <Select
+            disabled={!isConnected}
             value={style.mode}
             onValueChange={(value) => {
               const customInstructions = customInstructionsRef.current?.value.trim();
@@ -119,6 +128,7 @@ export function SourceControlWritingSettingsSection() {
         {style.mode === "custom" ? (
           <div className="mt-3 max-w-2xl pb-3.5">
             <Textarea
+              disabled={!isConnected}
               key={style.customInstructions}
               ref={customInstructionsRef}
               defaultValue={style.customInstructions}
@@ -143,6 +153,7 @@ export function SourceControlWritingSettingsSection() {
           style.followChangeRequestTemplates !== defaults.followChangeRequestTemplates ? (
             <SettingResetButton
               label="change request templates"
+              disabled={!isConnected}
               onClick={() =>
                 updateSettings({
                   sourceControlWritingStyle: {
@@ -156,6 +167,7 @@ export function SourceControlWritingSettingsSection() {
         control={
           <Switch
             checked={style.followChangeRequestTemplates}
+            disabled={!isConnected}
             onCheckedChange={(checked) =>
               updateSettings({
                 sourceControlWritingStyle: {
@@ -176,6 +188,7 @@ export function SourceControlWritingSettingsSection() {
             {usesDedicatedModel ? (
               <ProviderModelPicker
                 activeInstanceId={activeSelection.instanceId}
+                disabled={!isConnected}
                 model={activeSelection.model}
                 lockedProvider={null}
                 instanceEntries={instanceEntries}
@@ -192,6 +205,7 @@ export function SourceControlWritingSettingsSection() {
             ) : null}
             <Switch
               checked={usesDedicatedModel}
+              disabled={!isConnected}
               onCheckedChange={(checked) =>
                 updateSettings({
                   sourceControlWriterModelSelection: checked

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -88,7 +88,15 @@ export function SettingsRow({
   );
 }
 
-export function SettingResetButton({ label, onClick }: { label: string; onClick: () => void }) {
+export function SettingResetButton({
+  label,
+  disabled = false,
+  onClick,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
   return (
     <Tooltip>
       <TooltipTrigger
@@ -98,6 +106,7 @@ export function SettingResetButton({ label, onClick }: { label: string; onClick:
             variant="ghost"
             aria-label={`Reset ${label} to default`}
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+            disabled={disabled}
             onClick={(event) => {
               event.stopPropagation();
               onClick();

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -1,11 +1,10 @@
-import { useAtomValue } from "@effect/atom-react";
 import { SettingsIcon } from "lucide-react";
 import { memo, useCallback } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 import { APP_STAGE_LABEL } from "../../branding";
 import { cn } from "../../lib/utils";
-import { primaryServerConfigAtom } from "../../state/server";
+import { useDefaultServerConfig } from "../../hooks/useDefaultServerConfig";
 import { resolveSidebarStageBadgeLabel } from "../Sidebar.logic";
 import { SidebarStageBackdrop, resolveSidebarStageBackdropVariant } from "../SidebarStageBackdrop";
 import {
@@ -72,8 +71,7 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
 }
 
 function useSidebarStageLabel() {
-  const primaryServerVersion =
-    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const primaryServerVersion = useDefaultServerConfig()?.environment.serverVersion ?? null;
 
   return resolveSidebarStageBadgeLabel({
     primaryServerVersion,

--- a/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
@@ -1,10 +1,9 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
 import type { ServerProvider } from "@t3tools/contracts";
 import { CircleCheckIcon, DownloadIcon, LoaderIcon, TriangleAlertIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useState, type CSSProperties } from "react";
 
-import { primaryServerProvidersAtom } from "../../state/server";
+import { useDefaultServerConfig } from "../../hooks/useDefaultServerConfig";
 import {
   getProviderUpdateSidebarPillView,
   type ProviderUpdateSidebarPillView,
@@ -40,7 +39,7 @@ function latestProviderCheckedAt(
 
 export function SidebarProviderUpdatePill() {
   const navigate = useNavigate();
-  const providers = useAtomValue(primaryServerProvidersAtom);
+  const providers = useDefaultServerConfig()?.providers ?? [];
   const [dismissedKeys, setDismissedKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [renderedView, setRenderedView] = useState<ProviderUpdateSidebarPillView | null>(null);
   const [pendingView, setPendingView] = useState<ProviderUpdateSidebarPillView | null>(null);

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -45,7 +45,8 @@ import { FetchHttpClient } from "effect/unstable/http";
 import { readDesktopPrimaryBearerToken } from "../environments/primary/desktopAuth";
 import { primaryEnvironmentHttpLayer } from "../environments/primary/httpLayer";
 import {
-  readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
+  isDesktopClientOnlyMode,
   type PrimaryEnvironmentTarget,
 } from "../environments/primary/target";
 import { clearComposerDraftsEnvironment } from "../composerDraftStore";
@@ -399,7 +400,7 @@ export type PrimaryEnvironmentTargetRead =
     };
 
 export function readPrimaryEnvironmentTargetResult(
-  readTarget: () => PrimaryEnvironmentTarget | null = readPrimaryEnvironmentTarget,
+  readTarget: () => PrimaryEnvironmentTarget | null = readOptionalPrimaryEnvironmentTarget,
 ): PrimaryEnvironmentTargetRead {
   try {
     return { _tag: "Success", target: readTarget() };
@@ -456,7 +457,7 @@ export function secondaryRegistrationsToRetainAfterTopologyRead(
 const platformConnectionSourceLayer = Layer.effect(
   PlatformConnectionSource,
   Effect.gen(function* () {
-    if (isHostedStaticApp()) {
+    if (isHostedStaticApp() || isDesktopClientOnlyMode()) {
       return PlatformConnectionSource.of({
         registrations: Stream.empty,
       });

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -81,6 +81,33 @@ describe("environment grouping", () => {
     expect(projectGroupCount).toBe(1);
   });
 
+  it("marks every project remote for an app with no local backend of its own", () => {
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+    });
+
+    const [clientOnly] = buildSidebarProjectSnapshots({
+      projects: [remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId: null,
+      ownsLocalEnvironment: false,
+      resolveEnvironmentLabel: () => "remote",
+    });
+
+    expect(clientOnly?.environmentPresence).toBe("remote-only");
+    expect(clientOnly?.remoteEnvironmentLabels).toEqual(["remote"]);
+
+    const [managed] = buildSidebarProjectSnapshots({
+      projects: [remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId: null,
+      resolveEnvironmentLabel: () => "remote",
+    });
+
+    expect(managed?.environmentPresence).toBe("local-only");
+  });
+
   it("keeps projects without repository identity physically scoped", () => {
     const primary = makeProject();
     const remote = makeProject({

--- a/apps/web/src/environmentPresence.test.ts
+++ b/apps/web/src/environmentPresence.test.ts
@@ -1,0 +1,29 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { isRemoteEnvironmentId } from "./environmentPresence";
+
+const primaryEnvironmentId = EnvironmentId.make("env-primary");
+const remoteEnvironmentId = EnvironmentId.make("env-remote");
+
+describe("isRemoteEnvironmentId", () => {
+  it("treats the primary environment as local and everything else as remote", () => {
+    const scope = { primaryEnvironmentId, ownsLocalEnvironment: true };
+
+    expect(isRemoteEnvironmentId(primaryEnvironmentId, scope)).toBe(false);
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(true);
+  });
+
+  it("treats every environment as remote when the app owns no local backend", () => {
+    const scope = { primaryEnvironmentId: null, ownsLocalEnvironment: false };
+
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(true);
+    expect(isRemoteEnvironmentId(primaryEnvironmentId, scope)).toBe(true);
+  });
+
+  it("treats nothing as remote while a managed app's primary is still registering", () => {
+    const scope = { primaryEnvironmentId: null, ownsLocalEnvironment: true };
+
+    expect(isRemoteEnvironmentId(remoteEnvironmentId, scope)).toBe(false);
+  });
+});

--- a/apps/web/src/environmentPresence.ts
+++ b/apps/web/src/environmentPresence.ts
@@ -1,0 +1,28 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+/**
+ * The comparison the UI uses to decide whether an environment is "remote" —
+ * i.e. somewhere other than the machine this app runs its own backend on.
+ */
+export interface EnvironmentPresenceScope {
+  /** The environment served by the app's own backend, when it has one. */
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  /**
+   * False when this app can never own a local backend: a client-only desktop
+   * and the hosted static web app only ever talk to backends they paired with,
+   * so every environment they reach is remote. This is deliberately separate
+   * from a null `primaryEnvironmentId`, which a managed app also reports while
+   * its local backend is still registering — there, nothing is remote yet.
+   */
+  readonly ownsLocalEnvironment: boolean;
+}
+
+export function isRemoteEnvironmentId(
+  environmentId: EnvironmentId,
+  scope: EnvironmentPresenceScope,
+): boolean {
+  if (!scope.ownsLocalEnvironment) {
+    return true;
+  }
+  return scope.primaryEnvironmentId !== null && environmentId !== scope.primaryEnvironmentId;
+}

--- a/apps/web/src/environments/primary/bootstrap.test.ts
+++ b/apps/web/src/environments/primary/bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   isPrimaryEnvironmentProtocolUnsupportedError,
   isPrimaryEnvironmentUrlInvalidError,
   readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
   resolvePrimaryEnvironmentHttpUrl,
   resolveInitialPrimaryEnvironmentDescriptor,
   resetPrimaryEnvironmentDescriptorForTests,
@@ -256,5 +257,22 @@ describe("environmentBootstrap", () => {
       protocol: "file:",
       message: "The window-origin primary environment target uses unsupported protocol file:.",
     });
+  });
+
+  it("returns no primary target for a client-only desktop without using the custom origin", () => {
+    vi.stubGlobal("window", {
+      location: new URL("t3code://app/"),
+      history: { replaceState: vi.fn() },
+      desktopBridge: {
+        getBackendModeState: () => ({
+          effectiveMode: "client-only",
+          configuredMode: "client-only",
+          cliOverride: null,
+        }),
+        getLocalEnvironmentBootstraps: () => [],
+      },
+    });
+
+    expect(readOptionalPrimaryEnvironmentTarget()).toBeNull();
   });
 });

--- a/apps/web/src/environments/primary/index.ts
+++ b/apps/web/src/environments/primary/index.ts
@@ -48,6 +48,8 @@ export {
   PrimaryEnvironmentProtocolUnsupportedError,
   PrimaryEnvironmentUrlInvalidError,
   readPrimaryEnvironmentTarget,
+  readOptionalPrimaryEnvironmentTarget,
+  isDesktopClientOnlyMode,
   resolvePrimaryEnvironmentHttpUrl,
   isLoopbackHostname,
   type PrimaryEnvironmentTarget,

--- a/apps/web/src/environments/primary/target.ts
+++ b/apps/web/src/environments/primary/target.ts
@@ -73,6 +73,11 @@ export interface PrimaryEnvironmentTarget {
   };
 }
 
+export function isDesktopClientOnlyMode(): boolean {
+  const bridge = window.desktopBridge;
+  return bridge?.getBackendModeState?.().effectiveMode === "client-only";
+}
+
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 
 function getDesktopLocalEnvironmentBootstrap(): DesktopEnvironmentBootstrap | null {
@@ -291,4 +296,8 @@ export function readPrimaryEnvironmentTarget(): PrimaryEnvironmentTarget {
     resolveConfiguredPrimaryTarget() ??
     resolveWindowOriginPrimaryTarget()
   );
+}
+
+export function readOptionalPrimaryEnvironmentTarget(): PrimaryEnvironmentTarget | null {
+  return isDesktopClientOnlyMode() ? null : readPrimaryEnvironmentTarget();
 }

--- a/apps/web/src/hooks/useDefaultServerConfig.ts
+++ b/apps/web/src/hooks/useDefaultServerConfig.ts
@@ -20,5 +20,14 @@ export function useDefaultEnvironmentId() {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const activeEnvironmentId = useActiveEnvironmentId();
   const { environments } = useEnvironments();
-  return primaryEnvironmentId ?? activeEnvironmentId ?? environments[0]?.environmentId ?? null;
+  const activeEnvironment =
+    activeEnvironmentId === null
+      ? null
+      : environments.find((environment) => environment.environmentId === activeEnvironmentId);
+  return (
+    primaryEnvironmentId ??
+    activeEnvironment?.environmentId ??
+    environments[0]?.environmentId ??
+    null
+  );
 }

--- a/apps/web/src/hooks/useDefaultServerConfig.ts
+++ b/apps/web/src/hooks/useDefaultServerConfig.ts
@@ -1,0 +1,24 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { ServerConfig } from "@t3tools/contracts";
+
+import { useActiveEnvironmentId } from "../state/entities";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { serverEnvironment } from "../state/server";
+
+/**
+ * Server configuration for global client surfaces.
+ *
+ * A managed client keeps using its primary backend. A client without a
+ * managed backend follows the active saved environment instead.
+ */
+export function useDefaultServerConfig(): ServerConfig | null {
+  const environmentId = useDefaultEnvironmentId();
+  return useAtomValue(serverEnvironment.configValueAtom(environmentId));
+}
+
+export function useDefaultEnvironmentId() {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const { environments } = useEnvironments();
+  return primaryEnvironmentId ?? activeEnvironmentId ?? environments[0]?.environmentId ?? null;
+}

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -1,10 +1,13 @@
-import { useAtomValue } from "@effect/atom-react";
 import {
   scopedProjectKey,
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
-import { DEFAULT_RUNTIME_MODE, type ScopedProjectRef } from "@t3tools/contracts";
+import {
+  DEFAULT_RUNTIME_MODE,
+  DEFAULT_SERVER_SETTINGS,
+  type ScopedProjectRef,
+} from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import {
@@ -20,21 +23,15 @@ import {
   getProjectOrderKey,
   selectProjectGroupingSettings,
 } from "../logicalProject";
-import { readThreadShell, useProjects, useThread } from "../state/entities";
+import { readThreadShell, useProjects, useServerConfigs, useThread } from "../state/entities";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
-import { primaryServerSettingsAtom } from "../state/server";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useClientSettings } from "./useSettings";
 
 export function useNewThreadHandler() {
   const projects = useProjects();
-  // New-thread defaults are a user preference, and the settings UI only ever
-  // edits the primary environment's settings.json. Reading the target
-  // environment's own settings here would silently reset remote projects to
-  // the decoded defaults ("local" mode, current branch), since nothing can
-  // set those values on a remote server.
-  const primaryServerSettings = useAtomValue(primaryServerSettingsAtom);
+  const serverConfigs = useServerConfigs();
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const router = useRouter();
   const getCurrentRouteTarget = useCallback(() => {
@@ -105,6 +102,8 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
+      const targetServerSettings =
+        serverConfigs.get(projectRef.environmentId)?.settings ?? DEFAULT_SERVER_SETTINGS;
       const logicalProjectKey = project
         ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
         : scopedProjectKey(projectRef);
@@ -146,7 +145,7 @@ export function useNewThreadHandler() {
           // preserved. When the draft is already open and no options were
           // passed, leave it alone entirely — the user may have just picked a
           // branch in the composer.
-          const defaultEnvMode = primaryServerSettings.defaultThreadEnvMode;
+          const defaultEnvMode = targetServerSettings.defaultThreadEnvMode;
           const workspaceContext = hasExplicitWorkspaceOption
             ? {
                 ...(hasBranchOption ? { branch: options?.branch ?? null } : {}),
@@ -162,7 +161,7 @@ export function useNewThreadHandler() {
                   envMode: defaultEnvMode,
                   startFromOrigin: resolveNewDraftStartFromOrigin({
                     envMode: defaultEnvMode,
-                    newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+                    newWorktreesStartFromOrigin: targetServerSettings.newWorktreesStartFromOrigin,
                   }),
                 };
           if (workspaceContext) {
@@ -245,7 +244,7 @@ export function useNewThreadHandler() {
       const draftId = newDraftId();
       const threadId = newThreadId();
       const createdAt = new Date().toISOString();
-      const initialEnvMode = options?.envMode ?? primaryServerSettings.defaultThreadEnvMode;
+      const initialEnvMode = options?.envMode ?? targetServerSettings.defaultThreadEnvMode;
       return (async () => {
         setLogicalProjectDraftThreadId(logicalProjectKey, projectRef, draftId, {
           threadId,
@@ -257,7 +256,7 @@ export function useNewThreadHandler() {
             options?.startFromOrigin ??
             resolveNewDraftStartFromOrigin({
               envMode: initialEnvMode,
-              newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
+              newWorktreesStartFromOrigin: targetServerSettings.newWorktreesStartFromOrigin,
             }),
           runtimeMode: carryRuntimeMode ?? DEFAULT_RUNTIME_MODE,
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
@@ -279,7 +278,7 @@ export function useNewThreadHandler() {
         });
       })();
     },
-    [getCurrentRouteTarget, primaryServerSettings, projectGroupingSettings, projects, router],
+    [getCurrentRouteTarget, projectGroupingSettings, projects, router, serverConfigs],
   );
 }
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -5,9 +5,9 @@
  * `settings.json` on the server, fetched via `server.getConfig`) and
  * client-only settings (persisted in localStorage).
  *
- * Live server settings always require an environment id. Primary-environment
- * access is intentionally named as such so environment-sensitive consumers
- * cannot silently read the wrong server's settings.
+ * Live server settings require an environment id. Callers without a selected
+ * environment receive schema defaults for server fields while client fields
+ * remain fully functional.
  */
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useAtomValue } from "@effect/atom-react";
@@ -222,10 +222,10 @@ export function useClientSettings<T = ClientSettings>(
 
 /** Read current settings for one environment, merged with client-local preferences. */
 export function useEnvironmentSettings<T = UnifiedSettings>(
-  environmentId: EnvironmentId,
+  environmentId: EnvironmentId | null,
   selector?: (settings: UnifiedSettings) => T,
 ): T {
-  const serverSettings = useAtomValue(serverEnvironment.settingsValueAtom(environmentId));
+  const serverSettings = useAtomValue(serverEnvironment.configValueAtom(environmentId))?.settings;
   return useMergedSettings(serverSettings ?? DEFAULT_SERVER_SETTINGS, selector);
 }
 
@@ -273,7 +273,7 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
   return updateSettings;
 }
 
-export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {
+export function useUpdateEnvironmentSettings(environmentId: EnvironmentId | null) {
   return useUpdateSettingsTarget(environmentId);
 }
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -277,6 +277,20 @@ export function useUpdateEnvironmentSettings(environmentId: EnvironmentId | null
   return useUpdateSettingsTarget(environmentId);
 }
 
+export function usePersistEnvironmentSettings(environmentId: EnvironmentId) {
+  const persistServerSettings = useAtomCommand(serverEnvironment.updateSettings, {
+    reportFailure: false,
+  });
+  return useCallback(
+    (patch: ServerSettingsPatch) =>
+      persistServerSettings({
+        environmentId,
+        input: { patch },
+      }),
+    [environmentId, persistServerSettings],
+  );
+}
+
 export function useUpdatePrimarySettings() {
   return useUpdateSettingsTarget(usePrimaryEnvironment()?.environmentId ?? null);
 }

--- a/apps/web/src/hooks/useSettingsEnvironment.ts
+++ b/apps/web/src/hooks/useSettingsEnvironment.ts
@@ -1,0 +1,56 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useAtomValue } from "@effect/atom-react";
+
+import { resolveSettingsEnvironmentId } from "../components/settings/SettingsPanels.logic";
+import { useActiveEnvironmentId } from "../state/entities";
+import {
+  useEnvironments,
+  usePrimaryEnvironmentId,
+  type EnvironmentPresentation,
+} from "../state/environments";
+import {
+  selectedSettingsEnvironmentIdAtom,
+  setSelectedSettingsEnvironmentId,
+} from "../state/settingsEnvironment";
+
+export interface SettingsEnvironmentTarget {
+  readonly isReady: boolean;
+  readonly environmentId: EnvironmentId | null;
+  readonly environment: EnvironmentPresentation | null;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly selectEnvironment: (environmentId: EnvironmentId) => void;
+}
+
+/**
+ * Resolve the server environment configured by a settings surface.
+ *
+ * Managed clients retain their historical primary-server behavior. Clients
+ * without a managed backend start with the currently active saved
+ * environment, then fall back to the first available environment.
+ */
+export function useSettingsEnvironment(): SettingsEnvironmentTarget {
+  const { isReady, environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const selectedEnvironmentId = useAtomValue(selectedSettingsEnvironmentIdAtom);
+  const environmentId = resolveSettingsEnvironmentId({
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+    activeEnvironmentId,
+  });
+  const environment =
+    environmentId === null
+      ? null
+      : (environments.find((candidate) => candidate.environmentId === environmentId) ?? null);
+
+  return {
+    isReady,
+    environmentId,
+    environment,
+    environments,
+    primaryEnvironmentId,
+    selectEnvironment: setSelectedSettingsEnvironmentId,
+  };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SettingsSourceControlRouteImport } from './routes/settings.sou
 import { Route as SettingsProvidersRouteImport } from './routes/settings.providers'
 import { Route as SettingsKeybindingsRouteImport } from './routes/settings.keybindings'
 import { Route as SettingsGeneralRouteImport } from './routes/settings.general'
+import { Route as SettingsEnvironmentRouteImport } from './routes/settings.environment'
 import { Route as SettingsDiagnosticsRouteImport } from './routes/settings.diagnostics'
 import { Route as SettingsConnectionsRouteImport } from './routes/settings.connections'
 import { Route as SettingsBetaRouteImport } from './routes/settings.beta'
@@ -70,6 +71,11 @@ const SettingsGeneralRoute = SettingsGeneralRouteImport.update({
   path: '/general',
   getParentRoute: () => SettingsRoute,
 } as any)
+const SettingsEnvironmentRoute = SettingsEnvironmentRouteImport.update({
+  id: '/environment',
+  path: '/environment',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const SettingsDiagnosticsRoute = SettingsDiagnosticsRouteImport.update({
   id: '/diagnostics',
   path: '/diagnostics',
@@ -117,6 +123,7 @@ export interface FileRoutesByFullPath {
   '/settings/beta': typeof SettingsBetaRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -133,6 +140,7 @@ export interface FileRoutesByTo {
   '/settings/beta': typeof SettingsBetaRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -152,6 +160,7 @@ export interface FileRoutesById {
   '/settings/beta': typeof SettingsBetaRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/diagnostics': typeof SettingsDiagnosticsRoute
+  '/settings/environment': typeof SettingsEnvironmentRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
@@ -172,6 +181,7 @@ export interface FileRouteTypes {
     | '/settings/beta'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/keybindings'
     | '/settings/providers'
@@ -188,6 +198,7 @@ export interface FileRouteTypes {
     | '/settings/beta'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/keybindings'
     | '/settings/providers'
@@ -206,6 +217,7 @@ export interface FileRouteTypes {
     | '/settings/beta'
     | '/settings/connections'
     | '/settings/diagnostics'
+    | '/settings/environment'
     | '/settings/general'
     | '/settings/keybindings'
     | '/settings/providers'
@@ -288,6 +300,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsGeneralRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/environment': {
+      id: '/settings/environment'
+      path: '/environment'
+      fullPath: '/settings/environment'
+      preLoaderRoute: typeof SettingsEnvironmentRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/diagnostics': {
       id: '/settings/diagnostics'
       path: '/diagnostics'
@@ -359,6 +378,7 @@ interface SettingsRouteChildren {
   SettingsBetaRoute: typeof SettingsBetaRoute
   SettingsConnectionsRoute: typeof SettingsConnectionsRoute
   SettingsDiagnosticsRoute: typeof SettingsDiagnosticsRoute
+  SettingsEnvironmentRoute: typeof SettingsEnvironmentRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
   SettingsKeybindingsRoute: typeof SettingsKeybindingsRoute
   SettingsProvidersRoute: typeof SettingsProvidersRoute
@@ -370,6 +390,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsBetaRoute: SettingsBetaRoute,
   SettingsConnectionsRoute: SettingsConnectionsRoute,
   SettingsDiagnosticsRoute: SettingsDiagnosticsRoute,
+  SettingsEnvironmentRoute: SettingsEnvironmentRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsKeybindingsRoute: SettingsKeybindingsRoute,
   SettingsProvidersRoute: SettingsProvidersRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -36,7 +36,10 @@ import {
 import { useUiStateStore } from "../uiStateStore";
 import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import { configureClientTracing } from "../observability/clientTracing";
-import { resolveInitialServerAuthGateState } from "../environments/primary";
+import {
+  isDesktopClientOnlyMode,
+  resolveInitialServerAuthGateState,
+} from "../environments/primary";
 import { hasHostedPairingRequest, isHostedStaticApp } from "../hostedPairing";
 import { shellEnvironment } from "../state/shell";
 import { useAtomValue } from "@effect/atom-react";
@@ -63,7 +66,7 @@ export const Route = createRootRoute({
       };
     }
 
-    if (isHostedStaticApp(new URL(window.location.href))) {
+    if (isHostedStaticApp(new URL(window.location.href)) || isDesktopClientOnlyMode()) {
       return {
         authGateState: {
           status: "hosted-static",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import {
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { useClientSettings } from "../hooks/useSettings";
+import { useDefaultServerConfig } from "../hooks/useDefaultServerConfig";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -138,7 +139,7 @@ function RootRouteView() {
         <SlowRpcRequestToastCoordinator />
         <HostedStaticEnvironmentBootstrap />
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
-        {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
+        <ProviderUpdateLaunchNotification />
         {appShell}
       </AnchoredToastProvider>
     </ToastProvider>
@@ -156,8 +157,7 @@ function GlassAppearanceSync() {
 }
 
 function DocumentTitleSync() {
-  const primaryServerVersion =
-    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const primaryServerVersion = useDefaultServerConfig()?.environment.serverVersion ?? null;
   const title = resolveServerBackedAppDisplayName({
     baseName: APP_BASE_NAME,
     fallbackDisplayName: APP_DISPLAY_NAME,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,5 +1,4 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
 import { useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
@@ -20,14 +19,15 @@ import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
-import { primaryServerKeybindingsAtom } from "~/state/server";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
+import { useDefaultServerConfig } from "~/hooks/useDefaultServerConfig";
 
 function ChatRouteGlobalShortcuts() {
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
-  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const keybindings = useDefaultServerConfig()?.keybindings ?? DEFAULT_RESOLVED_KEYBINDINGS;
   const sidebarV2Enabled = useClientSettings((settings) => settings.sidebarV2Enabled);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -6,7 +6,7 @@ import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
-import { usePrimaryEnvironmentId } from "../state/environments";
+import { useAppOwnsLocalEnvironment, usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
@@ -32,15 +32,17 @@ function ChatRouteGlobalShortcuts() {
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const projects = useProjects();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
   const projectGroupCount = useMemo(
     () =>
       buildSidebarProjectSnapshots({
         projects,
         settings: projectGroupingSettings,
         primaryEnvironmentId,
+        ownsLocalEnvironment,
         resolveEnvironmentLabel: () => null,
       }).length,
-    [primaryEnvironmentId, projectGroupingSettings, projects],
+    [ownsLocalEnvironment, primaryEnvironmentId, projectGroupingSettings, projects],
   );
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef

--- a/apps/web/src/routes/settings.environment.tsx
+++ b/apps/web/src/routes/settings.environment.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { EnvironmentSettingsPanel } from "../components/settings/SettingsPanels";
+
+function SettingsEnvironmentRoute() {
+  return <EnvironmentSettingsPanel />;
+}
+
+export const Route = createFileRoute("/settings/environment")({
+  component: SettingsEnvironmentRoute,
+});

--- a/apps/web/src/routes/settings.providers.tsx
+++ b/apps/web/src/routes/settings.providers.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { ProviderSettingsPanel } from "../components/settings/SettingsPanels";
+import { ProviderSettingsPanel } from "../components/settings/ProviderSettingsPanel";
 
 function SettingsProvidersRoute() {
   return <ProviderSettingsPanel />;

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -17,13 +17,14 @@ import { cn } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
-  const { changedSettingLabels, restoreDefaults } = useSettingsRestore(onRestored);
+  const { canRestoreDefaults, changedSettingLabels, restoreDefaults } =
+    useSettingsRestore(onRestored);
 
   return (
     <Button
       size="xs"
       variant="ghost"
-      disabled={changedSettingLabels.length === 0}
+      disabled={changedSettingLabels.length === 0 || !canRestoreDefaults}
       onClick={() => void restoreDefaults()}
     >
       <RotateCcwIcon className="mx-1 size-3.5" />

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -9,16 +9,24 @@ import {
 } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 
-import { useSettingsRestore } from "../components/settings/SettingsPanels";
+import { type SettingsOwnership, useSettingsRestore } from "../components/settings/SettingsPanels";
 import { Button } from "../components/ui/button";
 import { SidebarInset } from "../components/ui/sidebar";
 import { isElectron } from "../env";
 import { cn } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
-function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
-  const { canRestoreDefaults, changedSettingLabels, restoreDefaults } =
-    useSettingsRestore(onRestored);
+function RestoreDefaultsButton({
+  ownership,
+  onRestored,
+}: {
+  ownership: SettingsOwnership;
+  onRestored: () => void;
+}) {
+  const { canRestoreDefaults, changedSettingLabels, restoreDefaults } = useSettingsRestore(
+    ownership,
+    onRestored,
+  );
 
   return (
     <Button
@@ -38,7 +46,12 @@ function SettingsContentLayout() {
   const navigate = useNavigate();
   const canGoBack = useCanGoBack();
   const [restoreSignal, setRestoreSignal] = useState(0);
-  const showRestoreDefaults = location.pathname === "/settings/general";
+  const restoreOwnership: SettingsOwnership | null =
+    location.pathname === "/settings/general"
+      ? "client"
+      : location.pathname === "/settings/environment"
+        ? "environment"
+        : null;
   const handleRestored = () => setRestoreSignal((value) => value + 1);
   const navigateBackWithinApp = useCallback(() => {
     if (canGoBack) {
@@ -81,9 +94,9 @@ function SettingsContentLayout() {
           >
             <div className="flex min-h-7 items-center gap-2 sm:min-h-6">
               <span className="text-sm font-medium text-foreground">Settings</span>
-              {showRestoreDefaults ? (
+              {restoreOwnership ? (
                 <div className="ms-auto flex items-center gap-2">
-                  <RestoreDefaultsButton onRestored={handleRestored} />
+                  <RestoreDefaultsButton ownership={restoreOwnership} onRestored={handleRestored} />
                 </div>
               ) : null}
             </div>
@@ -100,9 +113,9 @@ function SettingsContentLayout() {
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>
-            {showRestoreDefaults ? (
+            {restoreOwnership ? (
               <div className="ms-auto flex items-center gap-2">
-                <RestoreDefaultsButton onRestored={handleRestored} />
+                <RestoreDefaultsButton ownership={restoreOwnership} onRestored={handleRestored} />
               </div>
             ) : null}
           </div>

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,5 +1,6 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
+import { isRemoteEnvironmentId, type EnvironmentPresenceScope } from "./environmentPresence";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKey,
@@ -116,6 +117,10 @@ export function buildSidebarProjectSnapshots(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;
   primaryEnvironmentId: EnvironmentId | null;
+  // False when the app has no backend of its own (a client-only desktop or the
+  // hosted static web app), which makes every member of a group remote.
+  // Defaults to true so callers that always own a local backend are unchanged.
+  ownsLocalEnvironment?: boolean;
   resolveEnvironmentLabel: (environmentId: EnvironmentId) => string | null;
   // Returns true when an env id maps to a desktopLocal saved-env
   // record (today: the WSL backend). Defaults to "false for every
@@ -159,6 +164,10 @@ export function buildSidebarProjectSnapshots(input: {
     }
   }
 
+  const presenceScope: EnvironmentPresenceScope = {
+    primaryEnvironmentId: input.primaryEnvironmentId,
+    ownsLocalEnvironment: input.ownsLocalEnvironment ?? true,
+  };
   const result: SidebarProjectSnapshot[] = [];
   const seen = new Set<string>();
   for (const project of input.projects) {
@@ -177,17 +186,11 @@ export function buildSidebarProjectSnapshots(input: {
       continue;
     }
 
-    const hasLocal =
-      input.primaryEnvironmentId !== null &&
-      members.some((member) => member.environmentId === input.primaryEnvironmentId);
-    const hasRemote =
-      input.primaryEnvironmentId !== null
-        ? members.some((member) => member.environmentId !== input.primaryEnvironmentId)
-        : false;
-    const remoteMembers = members.filter(
-      (member) =>
-        input.primaryEnvironmentId !== null && member.environmentId !== input.primaryEnvironmentId,
+    const remoteMembers = members.filter((member) =>
+      isRemoteEnvironmentId(member.environmentId, presenceScope),
     );
+    const hasRemote = remoteMembers.length > 0;
+    const hasLocal = remoteMembers.length < members.length;
     const remoteEnvironmentLabels = remoteMembers
       .flatMap((member) => (member.environmentLabel ? [member.environmentLabel] : []))
       .filter((label, index, labels) => labels.indexOf(label) === index);

--- a/apps/web/src/state/environments.ts
+++ b/apps/web/src/state/environments.ts
@@ -9,6 +9,9 @@ import * as Option from "effect/Option";
 import { useMemo } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
+import type { EnvironmentPresenceScope } from "../environmentPresence";
+import { isDesktopClientOnlyMode } from "../environments/primary";
+import { isHostedStaticApp } from "../hostedPairing";
 import { environmentPresentations, useEnvironmentPresentation } from "./presentation";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { useEnvironmentQuery } from "./query";
@@ -58,6 +61,30 @@ export function useEnvironments() {
 
 export function usePrimaryEnvironmentId(): EnvironmentId | null {
   return useAtomValue(primaryEnvironmentIdAtom);
+}
+
+/**
+ * Whether this app can ever serve an environment from its own backend. A
+ * client-only desktop and the hosted static web app cannot, so they have no
+ * local environment for threads and projects to belong to.
+ */
+export function appOwnsLocalEnvironment(): boolean {
+  return !isHostedStaticApp() && !isDesktopClientOnlyMode();
+}
+
+export function useAppOwnsLocalEnvironment(): boolean {
+  // The answer is fixed for the app's lifetime: the hosted-static check is
+  // origin/build derived, and changing the desktop backend mode relaunches.
+  return useMemo(appOwnsLocalEnvironment, []);
+}
+
+export function useEnvironmentPresenceScope(): EnvironmentPresenceScope {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const ownsLocalEnvironment = useAppOwnsLocalEnvironment();
+  return useMemo(
+    () => ({ primaryEnvironmentId, ownsLocalEnvironment }),
+    [primaryEnvironmentId, ownsLocalEnvironment],
+  );
 }
 
 export function useEnvironment(

--- a/apps/web/src/state/settingsEnvironment.ts
+++ b/apps/web/src/state/settingsEnvironment.ts
@@ -1,0 +1,13 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../rpc/atomRegistry";
+
+export const selectedSettingsEnvironmentIdAtom = Atom.make<EnvironmentId | null>(null).pipe(
+  Atom.keepAlive,
+  Atom.withLabel("web-selected-settings-environment-id"),
+);
+
+export function setSelectedSettingsEnvironmentId(environmentId: EnvironmentId): void {
+  appAtomRegistry.set(selectedSettingsEnvironmentIdAtom, environmentId);
+}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -163,6 +163,7 @@ export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 export type DesktopUpdateChannel = "latest" | "nightly";
 export type DesktopAppStageLabel = "Alpha" | "Dev" | "Nightly";
+export type DesktopBackendMode = "managed" | "client-only";
 
 export const DesktopUpdateStatusSchema = Schema.Literals([
   "disabled",
@@ -178,6 +179,19 @@ export const DesktopRuntimeArchSchema = Schema.Literals(["arm64", "x64", "other"
 export const DesktopThemeSchema = Schema.Literals(["light", "dark", "system"]);
 export const DesktopUpdateChannelSchema = Schema.Literals(["latest", "nightly"]);
 export const DesktopAppStageLabelSchema = Schema.Literals(["Alpha", "Dev", "Nightly"]);
+export const DesktopBackendModeSchema = Schema.Literals(["managed", "client-only"]);
+
+export interface DesktopBackendModeState {
+  effectiveMode: DesktopBackendMode;
+  configuredMode: DesktopBackendMode;
+  cliOverride: DesktopBackendMode | null;
+}
+
+export const DesktopBackendModeStateSchema = Schema.Struct({
+  effectiveMode: DesktopBackendModeSchema,
+  configuredMode: DesktopBackendModeSchema,
+  cliOverride: Schema.NullOr(DesktopBackendModeSchema),
+});
 
 export interface DesktopAppBranding {
   baseName: string;
@@ -977,6 +991,8 @@ export const DesktopPreviewAutomationWaitForInputSchema = Schema.Struct({
 
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
+  getBackendModeState: () => DesktopBackendModeState;
+  setBackendMode: (mode: DesktopBackendMode) => Promise<DesktopBackendModeState>;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.


### PR DESCRIPTION
## Consolidation update

This branch is rebased onto the latest `main` and now serves as the combined client/server-model stack:

- Merges #4479's complete per-device **Providers settings UI and behavior**: environment selection, environment-scoped reads/writes/refreshes/updates/instance creation, editable and read-only provider views, loading/offline/error states, and shared model-preference preservation.
- Folds the non-provider environment-scoped settings work from #4559.
- Folds #4567's client-versus-environment settings ownership and navigation.
- Folds #4486's diagnostics environment selection and connection-aware state.
- Does not replay #4548 separately because #4479 supersedes its provider-specific implementation. During integration, #4479's standalone **Devices** picker was replaced by #4559's shared settings-environment selector; its provider cards, dialogs, scoped commands, and permission-aware UI states remain.

## What Changed

Let the desktop app run as a pure client for remote or independently managed backends, instead of always owning a local backend process.

- Add a persisted desktop backend mode with `managed` and `client-only` options, plus a launch-only `--backend-mode` override, exposed over IPC.
- In `client-only`, bootstrap skips the backend pool entirely and serves the renderer from packaged static assets (or the dev-server proxy), opens the window on renderer readiness rather than backend readiness, and skips backend shutdown on quit.
- `ElectronProtocol` now takes an explicit `source: "proxy" | "static"` (dropping the separate `backendOrigin`). Static serving adds path-safe file resolution with SPA fallback, MIME types, CSP, and HEAD support.
- Web routing treats client-only like hosted static, and local environment bootstraps are empty, so a client-only desktop is never stranded on a dead primary-backend state — it is routed to Connections instead.

## Why

The desktop app should be usable as a pure client without stranding users who have no saved connections.

## Scope note

This PR previously also contained Linux local `t3 serve` discovery. That half has been split into a separate PR so the two can be reviewed independently — the discovery work carries a distinct security surface (a live pairing credential on disk) and is Linux-only, whereas this change is cross-platform.

## UI Changes

- Connections gains a **Desktop application** → **Backend mode** control.
- Client-only users with no connections are routed to Connections rather than a dead primary-backend state.
- Providers gains per-environment selection, scoped provider cards and controls, and explicit loading, offline, error, empty, editable, and read-only states from #4479.
- General, Source Control, Keybindings, and Diagnostics use the same selected-environment model; Diagnostics includes connection-aware refresh and failure states.
- Settings navigation distinguishes client-owned settings from environment-owned settings.

## Packaged desktop evidence

Final privacy-reviewed evidence for this PR is pinned to immutable asset commit
[`d23321ea7d7200ef4d5e14f20dd2367997731706`](https://github.com/colonelpanic8/t3code/tree/d23321ea7d7200ef4d5e14f20dd2367997731706).

Capture context:

- PR head: `bb2c567e6879cf762910a02a8d20943edc2689ce`
- PR base: `ece05087a70e94efcd57441337fa1249559362ba`
- Synthetic combined-stack integration: `5ba3b7bd0995f401993706689105f41f51c16b02`
- Exact GUI-tested package: `/nix/store/86n9kxipsprgw6nbzyw7qhrw0wl4lfwx-t3code-0.0.29-patched-main-20260724`

The packaged Electron app started with `--backend-mode=client-only` without
starting or owning a local backend, resolved its installed renderer assets,
and paired successfully to an independently started packaged `t3 serve`
backend. The saved environment then appeared online.

<details>
<summary>Client-only startup with no saved environment</summary>

![Client-only startup with no saved environment](https://raw.githubusercontent.com/colonelpanic8/t3code/d23321ea7d7200ef4d5e14f20dd2367997731706/startup-clean.png)

</details>

<details>
<summary>Connections settings and active CLI override</summary>

![Connections settings showing client-only semantics and the active CLI override](https://raw.githubusercontent.com/colonelpanic8/t3code/d23321ea7d7200ef4d5e14f20dd2367997731706/connections-settings.png)

</details>

<details>
<summary>Independent backend paired and online</summary>

![Independently managed backend paired and online](https://raw.githubusercontent.com/colonelpanic8/t3code/d23321ea7d7200ef4d5e14f20dd2367997731706/after-pair.png)

</details>

[Connected home state](https://github.com/colonelpanic8/t3code/blob/d23321ea7d7200ef4d5e14f20dd2367997731706/connected-home.png) ·
[capture manifest](https://github.com/colonelpanic8/t3code/blob/d23321ea7d7200ef4d5e14f20dd2367997731706/README.md)

After this GUI capture, the maintained stack advanced its upstream base to
`41a430a88e8dde9c428f59d54dd328aa6a66a8fd`. The intervening upstream delta
was isolated to #4472 model registration and did not overlap this desktop
change. The resulting final installed package
`/nix/store/brp90sqhjxnnpczsnw9nmp1rlzi0qjgk-t3code-0.0.29-patched-main-20260724`
built and activated successfully. The screenshots above remain specifically
attributable to the exact earlier package and synthetic integration listed
above; they are not represented as a GUI recapture of the later package.


## Checklist

- [x] `corepack pnpm exec vp check` (0 errors; 11 pre-existing unrelated warnings)
- [x] `corepack pnpm exec vp run --filter @t3tools/contracts --filter @t3tools/shared --filter t3 --filter @t3tools/desktop --filter @t3tools/web typecheck` — clean
- [x] `CI=true vitest run apps/desktop/src apps/web/src/components/settings apps/web/src/environments apps/server/src/startupAccess.test.ts` — 63 files, 437 tests
- [x] Manually verified in an isolated Electron desktop: mode switch relaunches, client-only opens without a backend, packaged static renderer serves deep links, saved connections reconnect after restart


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add client-only desktop backend mode that serves static assets without a local backend
> - Introduces a `client-only` backend mode for the desktop app, selectable via the Connections settings page or `--backend-mode` CLI flag; in this mode the desktop app skips local backend startup entirely.
> - Adds [`DesktopBackendMode`](https://github.com/pingdotgg/t3code/pull/4444/files#diff-fe897f319c63323a036f58e2c313a8fb10e13eb3892020586e85a4b4fa70fd24) service to parse, validate, and latch backend mode from settings and CLI; persists mode via [`DesktopAppSettings`](https://github.com/pingdotgg/t3code/pull/4444/files#diff-da1b6b3c5df9caab17960eb845ada8087f7236bd4f4dbf5d2f4d8b51095696dd) and triggers an app relaunch on change.
> - Extends [`ElectronProtocol`](https://github.com/pingdotgg/t3code/pull/4444/files#diff-25fd7328df6d1131991bc9498d73c423aef7bf0aee3e8b2c863c05b908090f78) to serve packaged static assets (with SPA fallback, CSP, path traversal protection) when in client-only mode instead of proxying to a local backend.
> - Exposes `getBackendModeState` (sync) and `setBackendMode` IPC methods via [`preload.ts`](https://github.com/pingdotgg/t3code/pull/4444/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac) so the renderer can read and change mode; the UI prevents switching to client-only without a saved remote environment.
> - Refactors settings panels (General, Diagnostics, Keybindings, Source Control, Providers) to be environment-scoped, disabling server-backed controls when the selected environment is disconnected.
> - Adds `isDesktopClientOnlyMode` detection in the web layer so routing, connection source selection, and sidebar/thread logic treat client-only the same as the hosted static app.
> - Risk: switching backend mode triggers an app relaunch; if relaunch fails the settings change is reverted, but the UI will surface the error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acb11a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Electron startup/shutdown, custom protocol static file serving (path traversal mitigations), and preload fail-closed behavior that can suppress local backend until IPC is ready; large cross-cutting desktop + web surface.
> 
> **Overview**
> Introduces **managed** vs **client-only** desktop backend mode (persisted settings, `--backend-mode` CLI override, IPC get/set). In **client-only**, startup skips the backend pool, registers Electron protocol as **static** packaged assets or dev **proxy**, opens the main window on renderer readiness, and does not stop backends on quit.
> 
> **ElectronProtocol** now uses `source: "proxy" | "static"` (drops `backendOrigin`); static mode adds safe path resolution, SPA fallback, MIME/CSP, and GET/HEAD handling. **Connections** exposes backend mode switching (relaunch); preload fails closed to client-only if mode IPC is missing.
> 
> Web UI shifts from always using the primary server atom to **environment-scoped** config: Providers/Add Provider, Diagnostics (selector + connection-aware loading), keybindings editor keys, and sidebar/command palette grouping use `useDefaultServerConfig`, `EnvironmentPresenceScope`, and `ownsLocalEnvironment` so client-only desktops do not assume a local primary backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb11a66ee272bcafbc859be023dbac623ea8608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->