### PR TITLE
#6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,17 @@ agents.
   examples of idiomatic usage, tests, module structure, and API design.
 - When writing relay infrastructure code with Alchemy, inspect `.repos/alchemy-effect/` for examples of
   idiomatic usage, tests, module structure, and API design.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues; external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Uses the default canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout using root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# T3 Code
+
+T3 Code connects a single user experience to independently configured coding-agent providers.
+
+## Language
+
+**Pi**:
+Mario Zechner's Pi coding agent, specifically the `@earendil-works/pi-coding-agent` CLI and its native agent/session behavior.
+_Avoid_: piAgent, generic Pi
+
+**Supported Pi Version**:
+Pi CLI version 0.81.1 or later. The T3 Code Pi integration's contract is defined against the RPC and extension behavior available in version 0.81.1.
+
+**Pi Provider**:
+The T3 Code provider driver that starts the user-installed Pi CLI in RPC mode and translates its protocol into T3 Code provider events and operations.
+_Avoid_: Pi integration, Pi wrapper
+
+**Focused Pi Parity**:
+The initial Pi capability set: normal session, streaming, attachment, interruption, model, and approval flows shared with existing providers. Pi-specific features remain deferred until the integration is stable.
+
+**Pi Session Directory**:
+The Pi-managed storage directory assigned to one T3 Code Pi provider instance. Threads started through that instance persist there as native Pi sessions.
+
+**Pi Provider Configuration**:
+Pi's own configuration for credentials, built-in providers, custom providers, and model definitions. Pi remains the source of truth for this configuration; T3 Code may separately configure a Pi runtime instance and presentation preferences.
+
+**Pi Runtime Instance**:
+One independently configured connection from T3 Code to Pi, with its own executable/configuration environment and isolated Pi session directory. A runtime instance uses Pi's provider and model configuration without owning it.
+
+**Pi Config Directory**:
+The Pi configuration directory selected for a Pi runtime instance. When unset, the instance uses Pi's normal user configuration; when set, T3 Code passes it to Pi as `PI_AGENT_DIR`.
+
+**Pi Tool Policy**:
+Pi's enabled and disabled tool set. In base Pi RPC mode, enabled tools run without T3 Code per-tool confirmation; supervised execution would require a Pi extension that blocks and requests confirmation through Pi's extension UI protocol.
+
+**Pi Continuation Compatibility**:
+The rule that a Pi thread may resume only through the Pi runtime instance that created it, preserving its Pi configuration directory, extensions, credentials, model catalog, and native session storage.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ _Avoid_: Pi integration, Pi wrapper
 The initial Pi capability set: normal session, streaming, attachment, interruption, model, and approval flows shared with existing providers. Pi-specific features remain deferred until the integration is stable.
 
 **Pi Session Directory**:
-The Pi-managed storage directory assigned to one T3 Code Pi provider instance. Threads started through that instance persist there as native Pi sessions.
+The Pi-managed storage directory assigned to one T3 Code Pi provider instance. T3 Code starts threads in persistent-session mode there with their stable native session IDs; Pi materializes the session file lazily while persisting the thread's first accepted prompt turn.
 
 **Pi Provider Configuration**:
 Pi's own configuration for credentials, built-in providers, custom providers, and model definitions. Pi remains the source of truth for this configuration; T3 Code may separately configure a Pi runtime instance and presentation preferences.

--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -1,4 +1,4 @@
-import type { ApprovalRequestId } from "@t3tools/contracts";
+import type { ApprovalRequestId, ProviderUserInputAnswers } from "@t3tools/contracts";
 import { Pressable, View } from "react-native";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
@@ -8,7 +8,7 @@ import type { PendingUserInput, PendingUserInputDraftAnswer } from "../../lib/th
 export interface PendingUserInputCardProps {
   readonly pendingUserInput: PendingUserInput;
   readonly drafts: Record<string, PendingUserInputDraftAnswer>;
-  readonly answers: Record<string, string> | null;
+  readonly answers: ProviderUserInputAnswers | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
   readonly onSelectOption: (
     requestId: ApprovalRequestId,

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -10,6 +10,7 @@ import type {
   OrchestrationThreadShell,
   ProviderApprovalDecision,
   ProviderInteractionMode,
+  ProviderUserInputAnswers,
   RuntimeMode,
   ServerConfig as T3ServerConfig,
   ThreadId,
@@ -57,7 +58,7 @@ export interface ThreadDetailScreenProps {
   readonly respondingApprovalId: ApprovalRequestId | null;
   readonly activePendingUserInput: PendingUserInput | null;
   readonly activePendingUserInputDrafts: Record<string, PendingUserInputDraftAnswer>;
-  readonly activePendingUserInputAnswers: Record<string, string> | null;
+  readonly activePendingUserInputAnswers: ProviderUserInputAnswers | null;
   readonly respondingUserInputId: ApprovalRequestId | null;
   readonly draftMessage: string;
   readonly draftAttachments: ReadonlyArray<DraftComposerImageAttachment>;

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -12,7 +12,9 @@ import {
 } from "@t3tools/contracts";
 
 import {
+  buildPendingUserInputAnswers,
   buildThreadFeed,
+  derivePendingUserInputs,
   deriveThreadFeedPresentation,
   type ThreadFeedActivity,
   type ThreadFeedEntry,
@@ -52,6 +54,47 @@ function makeThread(
     ...input,
   };
 }
+
+describe("pending user input", () => {
+  it("preserves tagged cancellation answers for Pi input dialogs", () => {
+    const pendingInputs = derivePendingUserInputs([
+      makeActivity({
+        id: EventId.make("input-requested"),
+        kind: "user-input.requested",
+        summary: "User input requested",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        payload: {
+          requestId: "release-summary",
+          questions: [
+            {
+              id: "release-summary",
+              header: "Release summary",
+              question: "Describe the release.",
+              options: [{ label: "Cancel", description: "Cancel this input request" }],
+              cancelOptionLabel: "Cancel",
+            },
+          ],
+        },
+      }),
+    ]);
+    const question = pendingInputs[0]?.questions[0];
+    if (!question) {
+      throw new Error("expected pending user input question");
+    }
+
+    expect(question.cancelOptionLabel).toBe("Cancel");
+    expect(
+      buildPendingUserInputAnswers([question], {
+        "release-summary": { customAnswer: "Cancel" },
+      }),
+    ).toEqual({ "release-summary": { value: "Cancel" } });
+    expect(
+      buildPendingUserInputAnswers([question], {
+        "release-summary": { selectedOptionLabel: "Cancel" },
+      }),
+    ).toEqual({ "release-summary": { cancelled: true } });
+  });
+});
 
 describe("buildThreadFeed", () => {
   it("keeps historic work entries attributed to their turns", () => {

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -3,6 +3,7 @@ import type {
   OrchestrationLatestTurn,
   OrchestrationThread,
   OrchestrationThreadActivity,
+  ProviderUserInputAnswers,
   ToolLifecycleItemType,
   TurnId,
   UserInputQuestion,
@@ -195,7 +196,13 @@ function parseUserInputQuestions(
           };
         })
         .filter((option): option is UserInputQuestion["options"][number] => option !== null);
-      if (options.length === 0) {
+      const cancelOptionLabel = question.cancelOptionLabel;
+      if (
+        options.length === 0 ||
+        (cancelOptionLabel !== undefined &&
+          (typeof cancelOptionLabel !== "string" ||
+            !options.some((option) => option.label === cancelOptionLabel)))
+      ) {
         return null;
       }
       return {
@@ -203,6 +210,7 @@ function parseUserInputQuestions(
         header: question.header,
         question: question.question,
         options,
+        ...(cancelOptionLabel !== undefined ? { cancelOptionLabel } : {}),
         multiSelect: question.multiSelect === true,
       };
     })
@@ -1295,15 +1303,22 @@ export function setPendingUserInputCustomAnswer(
 export function buildPendingUserInputAnswers(
   questions: ReadonlyArray<UserInputQuestion>,
   draftAnswers: Record<string, PendingUserInputDraftAnswer>,
-): Record<string, string> | null {
-  const answers: Record<string, string> = {};
+): ProviderUserInputAnswers | null {
+  const answers: Record<string, unknown> = {};
 
   for (const question of questions) {
-    const answer = resolvePendingUserInputAnswer(draftAnswers[question.id]);
+    const draft = draftAnswers[question.id];
+    const answer = resolvePendingUserInputAnswer(draft);
     if (!answer) {
       return null;
     }
-    answers[question.id] = answer;
+    const customAnswer = normalizeDraftAnswer(draft?.customAnswer);
+    answers[question.id] =
+      question.cancelOptionLabel && customAnswer
+        ? { value: customAnswer }
+        : question.cancelOptionLabel && answer === question.cancelOptionLabel
+          ? { cancelled: true }
+          : answer;
   }
 
   return answers;

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -614,6 +614,25 @@ export function runtimeEventToActivities(
     }
 
     case "item.updated": {
+      if (event.payload.itemType === "context_compaction") {
+        return [
+          {
+            id: event.eventId,
+            createdAt: event.createdAt,
+            tone: "info",
+            kind: "context-compaction",
+            summary: event.payload.title ?? "Compacting conversation",
+            payload: {
+              itemType: event.payload.itemType,
+              ...(event.payload.status ? { status: event.payload.status } : {}),
+              ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+              ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            },
+            turnId: toTurnId(event.turnId) ?? null,
+            ...maybeSequence,
+          },
+        ];
+      }
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
@@ -637,6 +656,29 @@ export function runtimeEventToActivities(
     }
 
     case "item.completed": {
+      if (event.payload.itemType === "context_compaction") {
+        return [
+          {
+            id: event.eventId,
+            createdAt: event.createdAt,
+            tone: event.payload.status === "failed" ? "error" : "info",
+            kind: "context-compaction",
+            summary:
+              event.payload.title ??
+              (event.payload.status === "failed"
+                ? "Context compaction failed"
+                : "Context compacted"),
+            payload: {
+              itemType: event.payload.itemType,
+              ...(event.payload.status ? { status: event.payload.status } : {}),
+              ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+              ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            },
+            turnId: toTurnId(event.turnId) ?? null,
+            ...maybeSequence,
+          },
+        ];
+      }
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
@@ -644,11 +686,12 @@ export function runtimeEventToActivities(
         {
           id: event.eventId,
           createdAt: event.createdAt,
-          tone: "tool",
+          tone: event.payload.status === "failed" ? "error" : "tool",
           kind: "tool.completed",
           summary: event.payload.title ?? "Tool",
           payload: {
             itemType: event.payload.itemType,
+            ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
           },
@@ -659,6 +702,24 @@ export function runtimeEventToActivities(
     }
 
     case "item.started": {
+      if (event.payload.itemType === "context_compaction") {
+        return [
+          {
+            id: event.eventId,
+            createdAt: event.createdAt,
+            tone: "info",
+            kind: "context-compaction",
+            summary: event.payload.title ?? "Compacting conversation",
+            payload: {
+              itemType: event.payload.itemType,
+              ...(event.payload.status ? { status: event.payload.status } : {}),
+              ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            },
+            turnId: toTurnId(event.turnId) ?? null,
+            ...maybeSequence,
+          },
+        ];
+      }
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
@@ -671,6 +732,7 @@ export function runtimeEventToActivities(
           summary: `${event.payload.title ?? "Tool"} started`,
           payload: {
             itemType: event.payload.itemType,
+            ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,

--- a/apps/server/src/provider/Drivers/PiDriver.test.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.test.ts
@@ -1,0 +1,24 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import { ProviderInstanceId } from "@t3tools/contracts";
+import { expect, it } from "vite-plus/test";
+
+import { resolvePiSessionDirectory } from "./PiDriver.ts";
+
+it("isolates native Pi session storage by runtime instance", () => {
+  expect(
+    resolvePiSessionDirectory({
+      stateDir: "/tmp/t3/userdata",
+      instanceId: ProviderInstanceId.make("pi_personal"),
+      join: NodePath.join,
+    }),
+  ).toBe("/tmp/t3/userdata/pi-sessions/pi_personal");
+  expect(
+    resolvePiSessionDirectory({
+      stateDir: "/tmp/t3/userdata",
+      instanceId: ProviderInstanceId.make("pi_work"),
+      join: NodePath.join,
+    }),
+  ).toBe("/tmp/t3/userdata/pi-sessions/pi_work");
+});

--- a/apps/server/src/provider/Drivers/PiDriver.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.ts
@@ -17,6 +17,7 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import * as TextGeneration from "../../textGeneration/TextGeneration.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makePiAdapter, makePiImageAttachmentLoader } from "../Layers/PiAdapter.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makePiSessionRuntime } from "./PiSessionRuntime.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import {
@@ -79,6 +80,7 @@ export type PiDriverEnv =
   | FileSystem.FileSystem
   | Path.Path
   | ProcessRunner
+  | ProviderEventLoggers
   | ServerConfig
   | ServerSettingsService;
 
@@ -115,6 +117,7 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
     Effect.gen(function* () {
       const serverConfig = yield* ServerConfig;
       const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
       const processRunner = yield* ProcessRunner;
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -140,6 +143,7 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
         instanceId,
         sessionDirectory,
         environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
         loadImageAttachment: makePiImageAttachmentLoader({
           attachmentsDir: serverConfig.attachmentsDir,
           fileSystem,

--- a/apps/server/src/provider/Drivers/PiDriver.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.ts
@@ -27,36 +27,101 @@ import { checkPiProviderStatus, makePendingPiProvider } from "./PiProvider.ts";
 
 const decodePiSettings = Schema.decodeSync(PiSettings);
 const DRIVER_KIND = ProviderDriverKind.make("pi");
-const SETUP_MESSAGE = "Pi session runtime is not available until Pi native session support is enabled.";
+const SETUP_MESSAGE =
+  "Pi session runtime is not available until Pi native session support is enabled.";
 
 const unavailableAdapter: ProviderAdapterShape<ProviderAdapterRequestError> = {
   provider: DRIVER_KIND,
   capabilities: { sessionModelSwitch: "unsupported" },
-  startSession: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "startSession", detail: SETUP_MESSAGE })),
-  sendTurn: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "sendTurn", detail: SETUP_MESSAGE })),
-  interruptTurn: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "interruptTurn", detail: SETUP_MESSAGE })),
-  respondToRequest: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "respondToRequest", detail: SETUP_MESSAGE })),
-  respondToUserInput: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "respondToUserInput", detail: SETUP_MESSAGE })),
+  startSession: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "startSession",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
+  sendTurn: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "sendTurn",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
+  interruptTurn: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "interruptTurn",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
+  respondToRequest: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "respondToRequest",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
+  respondToUserInput: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "respondToUserInput",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
   stopSession: () => Effect.void,
   listSessions: () => Effect.succeed([]),
   hasSession: () => Effect.succeed(false),
-  readThread: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "readThread", detail: SETUP_MESSAGE })),
-  rollbackThread: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "rollbackThread", detail: SETUP_MESSAGE })),
+  readThread: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "readThread",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
+  rollbackThread: () =>
+    Effect.fail(
+      new ProviderAdapterRequestError({
+        provider: DRIVER_KIND,
+        method: "rollbackThread",
+        detail: SETUP_MESSAGE,
+      }),
+    ),
   stopAll: () => Effect.void,
   streamEvents: Stream.empty,
 };
 
 const unavailableTextGeneration = TextGeneration.TextGeneration.of({
-  generateCommitMessage: () => Effect.fail(new TextGenerationError({ operation: "generateCommitMessage", detail: SETUP_MESSAGE })),
-  generatePrContent: () => Effect.fail(new TextGenerationError({ operation: "generatePrContent", detail: SETUP_MESSAGE })),
-  generateBranchName: () => Effect.fail(new TextGenerationError({ operation: "generateBranchName", detail: SETUP_MESSAGE })),
-  generateThreadTitle: () => Effect.fail(new TextGenerationError({ operation: "generateThreadTitle", detail: SETUP_MESSAGE })),
+  generateCommitMessage: () =>
+    Effect.fail(
+      new TextGenerationError({ operation: "generateCommitMessage", detail: SETUP_MESSAGE }),
+    ),
+  generatePrContent: () =>
+    Effect.fail(new TextGenerationError({ operation: "generatePrContent", detail: SETUP_MESSAGE })),
+  generateBranchName: () =>
+    Effect.fail(
+      new TextGenerationError({ operation: "generateBranchName", detail: SETUP_MESSAGE }),
+    ),
+  generateThreadTitle: () =>
+    Effect.fail(
+      new TextGenerationError({ operation: "generateThreadTitle", detail: SETUP_MESSAGE }),
+    ),
 });
 
 export type PiDriverEnv = ProcessRunner | ServerSettingsService;
 
 const withInstanceIdentity =
-  (input: { readonly instanceId: ProviderInstance["instanceId"]; readonly displayName: string | undefined; readonly accentColor: string | undefined; readonly continuationGroupKey: string }) =>
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
   (snapshot: ServerProviderDraft) => ({
     ...snapshot,
     instanceId: input.instanceId,
@@ -74,20 +139,46 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsService;
+      const processRunner = yield* ProcessRunner;
       const processEnv = mergeProviderInstanceEnvironment(environment);
-      const continuationIdentity = defaultProviderContinuationIdentity({ driverKind: DRIVER_KIND, instanceId });
-      const stampIdentity = withInstanceIdentity({ instanceId, displayName, accentColor, continuationGroupKey: continuationIdentity.continuationKey });
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
       const effectiveConfig = { ...config, enabled } satisfies PiSettings;
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<PiSettings>>({
-        maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({ provider: DRIVER_KIND, packageName: "@earendil-works/pi-coding-agent" }),
+        maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+          provider: DRIVER_KIND,
+          packageName: "@earendil-works/pi-coding-agent",
+        }),
         getSettings: snapshotSettings.getSettings,
         streamSettings: snapshotSettings.streamSettings,
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
-        initialSnapshot: (settings) => makePendingPiProvider(settings.provider).pipe(Effect.map(stampIdentity)),
-        checkProvider: checkPiProviderStatus(effectiveConfig, processEnv).pipe(Effect.map(stampIdentity)),
+        initialSnapshot: (settings) =>
+          makePendingPiProvider(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider: checkPiProviderStatus(effectiveConfig, processEnv).pipe(
+          Effect.provideService(ProcessRunner, processRunner),
+          Effect.map(stampIdentity),
+        ),
         refreshInterval: Duration.minutes(5),
-      }).pipe(Effect.mapError((cause) => new ProviderDriverError({ driver: DRIVER_KIND, instanceId, detail: `Failed to build Pi snapshot: ${cause.message ?? String(cause)}`, cause })));
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Pi snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
 
       return {
         instanceId,

--- a/apps/server/src/provider/Drivers/PiDriver.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.ts
@@ -1,0 +1,104 @@
+import { PiSettings, ProviderDriverKind, TextGenerationError } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import { ProcessRunner } from "../../processRunner.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import * as TextGeneration from "../../textGeneration/TextGeneration.ts";
+import { ProviderAdapterRequestError, ProviderDriverError } from "../Errors.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+import { checkPiProviderStatus, makePendingPiProvider } from "./PiProvider.ts";
+
+const decodePiSettings = Schema.decodeSync(PiSettings);
+const DRIVER_KIND = ProviderDriverKind.make("pi");
+const SETUP_MESSAGE = "Pi session runtime is not available until Pi native session support is enabled.";
+
+const unavailableAdapter: ProviderAdapterShape<ProviderAdapterRequestError> = {
+  provider: DRIVER_KIND,
+  capabilities: { sessionModelSwitch: "unsupported" },
+  startSession: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "startSession", detail: SETUP_MESSAGE })),
+  sendTurn: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "sendTurn", detail: SETUP_MESSAGE })),
+  interruptTurn: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "interruptTurn", detail: SETUP_MESSAGE })),
+  respondToRequest: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "respondToRequest", detail: SETUP_MESSAGE })),
+  respondToUserInput: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "respondToUserInput", detail: SETUP_MESSAGE })),
+  stopSession: () => Effect.void,
+  listSessions: () => Effect.succeed([]),
+  hasSession: () => Effect.succeed(false),
+  readThread: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "readThread", detail: SETUP_MESSAGE })),
+  rollbackThread: () => Effect.fail(new ProviderAdapterRequestError({ provider: DRIVER_KIND, method: "rollbackThread", detail: SETUP_MESSAGE })),
+  stopAll: () => Effect.void,
+  streamEvents: Stream.empty,
+};
+
+const unavailableTextGeneration = TextGeneration.TextGeneration.of({
+  generateCommitMessage: () => Effect.fail(new TextGenerationError({ operation: "generateCommitMessage", detail: SETUP_MESSAGE })),
+  generatePrContent: () => Effect.fail(new TextGenerationError({ operation: "generatePrContent", detail: SETUP_MESSAGE })),
+  generateBranchName: () => Effect.fail(new TextGenerationError({ operation: "generateBranchName", detail: SETUP_MESSAGE })),
+  generateThreadTitle: () => Effect.fail(new TextGenerationError({ operation: "generateThreadTitle", detail: SETUP_MESSAGE })),
+});
+
+export type PiDriverEnv = ProcessRunner | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: { readonly instanceId: ProviderInstance["instanceId"]; readonly displayName: string | undefined; readonly accentColor: string | undefined; readonly continuationGroupKey: string }) =>
+  (snapshot: ServerProviderDraft) => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "Pi", supportsMultipleInstances: true },
+  configSchema: PiSettings,
+  defaultConfig: () => decodePiSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsService;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({ driverKind: DRIVER_KIND, instanceId });
+      const stampIdentity = withInstanceIdentity({ instanceId, displayName, accentColor, continuationGroupKey: continuationIdentity.continuationKey });
+      const effectiveConfig = { ...config, enabled } satisfies PiSettings;
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<PiSettings>>({
+        maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({ provider: DRIVER_KIND, packageName: "@earendil-works/pi-coding-agent" }),
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) => makePendingPiProvider(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider: checkPiProviderStatus(effectiveConfig, processEnv).pipe(Effect.map(stampIdentity)),
+        refreshInterval: Duration.minutes(5),
+      }).pipe(Effect.mapError((cause) => new ProviderDriverError({ driver: DRIVER_KIND, instanceId, detail: `Failed to build Pi snapshot: ${cause.message ?? String(cause)}`, cause })));
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter: unavailableAdapter,
+        textGeneration: unavailableTextGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Drivers/PiDriver.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.ts
@@ -6,6 +6,7 @@ import {
 } from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
@@ -15,7 +16,7 @@ import { ProcessRunner } from "../../processRunner.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import * as TextGeneration from "../../textGeneration/TextGeneration.ts";
 import { ProviderDriverError } from "../Errors.ts";
-import { makePiAdapter } from "../Layers/PiAdapter.ts";
+import { makePiAdapter, makePiImageAttachmentLoader } from "../Layers/PiAdapter.ts";
 import { makePiSessionRuntime } from "./PiSessionRuntime.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import {
@@ -75,6 +76,7 @@ const unavailableTextGeneration = TextGeneration.TextGeneration.of({
 
 export type PiDriverEnv =
   | ChildProcessSpawner.ChildProcessSpawner
+  | FileSystem.FileSystem
   | Path.Path
   | ProcessRunner
   | ServerConfig
@@ -114,6 +116,7 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
       const serverConfig = yield* ServerConfig;
       const serverSettings = yield* ServerSettingsService;
       const processRunner = yield* ProcessRunner;
+      const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const processEnv = mergeProviderInstanceEnvironment(environment);
@@ -137,6 +140,10 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
         instanceId,
         sessionDirectory,
         environment: processEnv,
+        loadImageAttachment: makePiImageAttachmentLoader({
+          attachmentsDir: serverConfig.attachmentsDir,
+          fileSystem,
+        }),
         makeRuntime: makePiSessionRuntime,
       }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner));
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Drivers/PiDriver.ts
+++ b/apps/server/src/provider/Drivers/PiDriver.ts
@@ -1,13 +1,22 @@
-import { PiSettings, ProviderDriverKind, TextGenerationError } from "@t3tools/contracts";
+import {
+  PiSettings,
+  ProviderDriverKind,
+  type ProviderInstanceId,
+  TextGenerationError,
+} from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import * as Stream from "effect/Stream";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
+import { ServerConfig } from "../../config.ts";
 import { ProcessRunner } from "../../processRunner.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import * as TextGeneration from "../../textGeneration/TextGeneration.ts";
-import { ProviderAdapterRequestError, ProviderDriverError } from "../Errors.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makePiAdapter } from "../Layers/PiAdapter.ts";
+import { makePiSessionRuntime } from "./PiSessionRuntime.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import {
   defaultProviderContinuationIdentity,
@@ -17,103 +26,67 @@ import {
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 import type { ServerProviderDraft } from "../providerSnapshot.ts";
-import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import {
   haveProviderSnapshotSettingsChanged,
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
-import { checkPiProviderStatus, makePendingPiProvider } from "./PiProvider.ts";
+import {
+  checkPiProviderStatus,
+  discoverPiModelCatalog,
+  makePendingPiProvider,
+} from "./PiProvider.ts";
 
 const decodePiSettings = Schema.decodeSync(PiSettings);
 const DRIVER_KIND = ProviderDriverKind.make("pi");
-const SETUP_MESSAGE =
-  "Pi session runtime is not available until Pi native session support is enabled.";
-
-const unavailableAdapter: ProviderAdapterShape<ProviderAdapterRequestError> = {
-  provider: DRIVER_KIND,
-  capabilities: { sessionModelSwitch: "unsupported" },
-  startSession: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "startSession",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  sendTurn: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "sendTurn",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  interruptTurn: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "interruptTurn",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  respondToRequest: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "respondToRequest",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  respondToUserInput: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "respondToUserInput",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  stopSession: () => Effect.void,
-  listSessions: () => Effect.succeed([]),
-  hasSession: () => Effect.succeed(false),
-  readThread: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "readThread",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  rollbackThread: () =>
-    Effect.fail(
-      new ProviderAdapterRequestError({
-        provider: DRIVER_KIND,
-        method: "rollbackThread",
-        detail: SETUP_MESSAGE,
-      }),
-    ),
-  stopAll: () => Effect.void,
-  streamEvents: Stream.empty,
-};
+const TEXT_GENERATION_UNAVAILABLE_MESSAGE =
+  "Pi text generation is not available until the Pi conversation runtime is enabled.";
 
 const unavailableTextGeneration = TextGeneration.TextGeneration.of({
   generateCommitMessage: () =>
     Effect.fail(
-      new TextGenerationError({ operation: "generateCommitMessage", detail: SETUP_MESSAGE }),
+      new TextGenerationError({
+        operation: "generateCommitMessage",
+        detail: TEXT_GENERATION_UNAVAILABLE_MESSAGE,
+      }),
     ),
   generatePrContent: () =>
-    Effect.fail(new TextGenerationError({ operation: "generatePrContent", detail: SETUP_MESSAGE })),
+    Effect.fail(
+      new TextGenerationError({
+        operation: "generatePrContent",
+        detail: TEXT_GENERATION_UNAVAILABLE_MESSAGE,
+      }),
+    ),
   generateBranchName: () =>
     Effect.fail(
-      new TextGenerationError({ operation: "generateBranchName", detail: SETUP_MESSAGE }),
+      new TextGenerationError({
+        operation: "generateBranchName",
+        detail: TEXT_GENERATION_UNAVAILABLE_MESSAGE,
+      }),
     ),
   generateThreadTitle: () =>
     Effect.fail(
-      new TextGenerationError({ operation: "generateThreadTitle", detail: SETUP_MESSAGE }),
+      new TextGenerationError({
+        operation: "generateThreadTitle",
+        detail: TEXT_GENERATION_UNAVAILABLE_MESSAGE,
+      }),
     ),
 });
 
-export type PiDriverEnv = ProcessRunner | ServerSettingsService;
+export type PiDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Path.Path
+  | ProcessRunner
+  | ServerConfig
+  | ServerSettingsService;
+
+export function resolvePiSessionDirectory(input: {
+  readonly stateDir: string;
+  readonly instanceId: ProviderInstanceId;
+  readonly join: (...paths: ReadonlyArray<string>) => string;
+}): string {
+  return input.join(input.stateDir, "pi-sessions", input.instanceId);
+}
 
 const withInstanceIdentity =
   (input: {
@@ -138,8 +111,11 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
   defaultConfig: () => decodePiSettings({}),
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig;
       const serverSettings = yield* ServerSettingsService;
       const processRunner = yield* ProcessRunner;
+      const path = yield* Path.Path;
+      const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const continuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
@@ -152,7 +128,28 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies PiSettings;
+      const sessionDirectory = resolvePiSessionDirectory({
+        stateDir: serverConfig.stateDir,
+        instanceId,
+        join: path.join,
+      });
+      const adapter = yield* makePiAdapter(effectiveConfig, {
+        instanceId,
+        sessionDirectory,
+        environment: processEnv,
+        makeRuntime: makePiSessionRuntime,
+      }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner));
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const checkProvider = checkPiProviderStatus(
+        effectiveConfig,
+        processEnv,
+        discoverPiModelCatalog,
+        serverConfig.cwd,
+      ).pipe(
+        Effect.provideService(ProcessRunner, processRunner),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+        Effect.map(stampIdentity),
+      );
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<PiSettings>>({
         maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
           provider: DRIVER_KIND,
@@ -163,10 +160,7 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
         haveSettingsChanged: haveProviderSnapshotSettingsChanged,
         initialSnapshot: (settings) =>
           makePendingPiProvider(settings.provider).pipe(Effect.map(stampIdentity)),
-        checkProvider: checkPiProviderStatus(effectiveConfig, processEnv).pipe(
-          Effect.provideService(ProcessRunner, processRunner),
-          Effect.map(stampIdentity),
-        ),
+        checkProvider,
         refreshInterval: Duration.minutes(5),
       }).pipe(
         Effect.mapError(
@@ -188,7 +182,7 @@ export const PiDriver: ProviderDriver<PiSettings, PiDriverEnv> = {
         accentColor,
         enabled,
         snapshot,
-        adapter: unavailableAdapter,
+        adapter,
         textGeneration: unavailableTextGeneration,
       } satisfies ProviderInstance;
     }),

--- a/apps/server/src/provider/Drivers/PiModels.test.ts
+++ b/apps/server/src/provider/Drivers/PiModels.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { mapPiModelCatalog, parsePiModelSlug } from "./PiModels.ts";
+
+describe("Pi model catalog mapping", () => {
+  it("keeps Pi provider/model identities distinct and groups them by provider", () => {
+    const models = mapPiModelCatalog([
+      {
+        model: {
+          provider: "custom-gateway",
+          id: "team/coder",
+          name: "Team Coder",
+        },
+        thinkingLevels: ["off", "high", "max"],
+        currentThinkingLevel: "high",
+      },
+      {
+        model: {
+          provider: "openai",
+          id: "gpt-plain",
+          name: "GPT Plain",
+        },
+        thinkingLevels: ["off"],
+        currentThinkingLevel: "off",
+      },
+    ]);
+
+    expect(models).toEqual([
+      {
+        slug: "custom-gateway/team%2Fcoder",
+        name: "Team Coder",
+        shortName: "team/coder",
+        subProvider: "custom-gateway",
+        isCustom: false,
+        capabilities: {
+          optionDescriptors: [
+            {
+              id: "reasoningEffort",
+              label: "Thinking",
+              type: "select",
+              currentValue: "high",
+              options: [
+                { id: "off", label: "Off" },
+                { id: "high", label: "High", isDefault: true },
+                { id: "max", label: "Max" },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        slug: "openai/gpt-plain",
+        name: "GPT Plain",
+        shortName: "gpt-plain",
+        subProvider: "openai",
+        isCustom: false,
+        capabilities: {
+          optionDescriptors: [],
+        },
+      },
+    ]);
+  });
+
+  it("round-trips a picker model slug back to Pi's provider/model selection", () => {
+    expect(parsePiModelSlug("custom-gateway/team%2Fcoder")).toEqual({
+      provider: "custom-gateway",
+      modelId: "team/coder",
+    });
+    expect(parsePiModelSlug("not-a-pi-model")).toBeUndefined();
+    expect(parsePiModelSlug("custom-gateway/%E0%A4%A")).toBeUndefined();
+  });
+});

--- a/apps/server/src/provider/Drivers/PiModels.ts
+++ b/apps/server/src/provider/Drivers/PiModels.ts
@@ -1,0 +1,129 @@
+import type { ServerProviderModel } from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+
+export interface PiRpcModel {
+  readonly provider: string;
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface PiModelCatalogEntry {
+  readonly model: PiRpcModel;
+  readonly thinkingLevels: ReadonlyArray<string>;
+  readonly currentThinkingLevel?: string | undefined;
+}
+
+export interface PiModelSelection {
+  readonly provider: string;
+  readonly modelId: string;
+}
+
+const THINKING_LEVEL_LABELS: Readonly<Record<string, string>> = {
+  off: "Off",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+};
+
+export function makePiModelSlug(input: PiModelSelection): string {
+  return `${encodeURIComponent(input.provider)}/${encodeURIComponent(input.modelId)}`;
+}
+
+export function parsePiModelSlug(value: string): PiModelSelection | undefined {
+  const separator = value.indexOf("/");
+  if (separator <= 0 || separator === value.length - 1) {
+    return undefined;
+  }
+
+  try {
+    const provider = decodeURIComponent(value.slice(0, separator)).trim();
+    const modelId = decodeURIComponent(value.slice(separator + 1)).trim();
+    return provider && modelId ? { provider, modelId } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function thinkingLabel(level: string): string {
+  return THINKING_LEVEL_LABELS[level] ?? level;
+}
+
+function distinctThinkingLevels(levels: ReadonlyArray<string>): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const valid: string[] = [];
+  for (const rawLevel of levels) {
+    const level = rawLevel.trim();
+    if (!level || seen.has(level)) {
+      continue;
+    }
+    seen.add(level);
+    valid.push(level);
+  }
+  return valid;
+}
+
+function modelCapabilities(input: PiModelCatalogEntry) {
+  const levels = distinctThinkingLevels(input.thinkingLevels);
+  // Pi reports `["off"]` for models without reasoning support. There is no
+  // selectable alternative in that case, so omit the picker control rather
+  // than fabricating a reasoning capability.
+  if (levels.length <= 1) {
+    return createModelCapabilities({ optionDescriptors: [] });
+  }
+
+  const current =
+    input.currentThinkingLevel !== undefined && levels.includes(input.currentThinkingLevel)
+      ? input.currentThinkingLevel
+      : undefined;
+  return createModelCapabilities({
+    optionDescriptors: [
+      {
+        id: "reasoningEffort",
+        label: "Thinking",
+        type: "select",
+        options: levels.map((level) => ({
+          id: level,
+          label: thinkingLabel(level),
+          ...(level === current ? { isDefault: true } : {}),
+        })),
+        ...(current ? { currentValue: current } : {}),
+      },
+    ],
+  });
+}
+
+/** Convert Pi's provider-scoped catalog into the normal T3 model picker shape. */
+export function mapPiModelCatalog(
+  catalog: ReadonlyArray<PiModelCatalogEntry>,
+): ReadonlyArray<ServerProviderModel> {
+  const seen = new Set<string>();
+  const models: ServerProviderModel[] = [];
+
+  for (const entry of catalog) {
+    const provider = entry.model.provider.trim();
+    const modelId = entry.model.id.trim();
+    const name = entry.model.name.trim() || modelId;
+    if (!provider || !modelId || !name) {
+      continue;
+    }
+
+    const slug = makePiModelSlug({ provider, modelId });
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+    models.push({
+      slug,
+      name,
+      shortName: modelId,
+      subProvider: provider,
+      isCustom: false,
+      capabilities: modelCapabilities(entry),
+    });
+  }
+
+  return models;
+}

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -98,4 +98,44 @@ describe("checkPiProviderStatus", () => {
       ),
     ),
   );
+
+  it.effect("does not treat a failed version command as usable", () =>
+    withProcessResult(
+      Effect.succeed({
+        stdout: "pi 0.81.1\n",
+        stderr: "fatal error",
+        code: 1,
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      }),
+    ).pipe(
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.status).toBe("error");
+          expect(snapshot.message).toContain("version check failed");
+        }),
+      ),
+    ),
+  );
+
+  it.effect("does not treat a timed-out version command as usable", () =>
+    withProcessResult(
+      Effect.succeed({
+        stdout: "",
+        stderr: "",
+        code: null,
+        timedOut: true,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      }),
+    ).pipe(
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.status).toBe("error");
+          expect(snapshot.message).toContain("timed out");
+        }),
+      ),
+    ),
+  );
 });

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { PiSettings } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -14,9 +15,7 @@ const settings = (overrides: Partial<PiSettings> = {}): PiSettings => ({
   ...overrides,
 });
 
-const withProcessResult = (
-  result: ReturnType<ProcessRunner["Service"]["run"]>,
-) =>
+const withProcessResult = (result: ReturnType<ProcessRunner["Service"]["run"]>) =>
   checkPiProviderStatus(settings(), process.env).pipe(
     Effect.provideService(ProcessRunner, ProcessRunner.of({ run: () => result })),
   );
@@ -27,7 +26,7 @@ describe("checkPiProviderStatus", () => {
       Effect.succeed({
         stdout: "pi 0.81.1\n",
         stderr: "",
-        code: 0,
+        code: ChildProcessSpawner.ExitCode(0),
         timedOut: false,
         stdoutTruncated: false,
         stderrTruncated: false,
@@ -45,10 +44,9 @@ describe("checkPiProviderStatus", () => {
 
   it.effect("passes the selected Pi config directory to the status probe", () => {
     let receivedEnvironment: NodeJS.ProcessEnv | undefined;
-    return checkPiProviderStatus(
-      settings({ configDirectory: "/Users/example/.pi-work" }),
-      { EXAMPLE: "value" },
-    ).pipe(
+    return checkPiProviderStatus(settings({ configDirectory: "/Users/example/.pi-work" }), {
+      EXAMPLE: "value",
+    }).pipe(
       Effect.provideService(
         ProcessRunner,
         ProcessRunner.of({
@@ -57,7 +55,7 @@ describe("checkPiProviderStatus", () => {
             return Effect.succeed({
               stdout: "pi 0.81.1\n",
               stderr: "",
-              code: 0,
+              code: ChildProcessSpawner.ExitCode(0),
               timedOut: false,
               stdoutTruncated: false,
               stderrTruncated: false,
@@ -96,7 +94,7 @@ describe("checkPiProviderStatus", () => {
       Effect.succeed({
         stdout: "pi 0.81.0\n",
         stderr: "",
-        code: 0,
+        code: ChildProcessSpawner.ExitCode(0),
         timedOut: false,
         stdoutTruncated: false,
         stderrTruncated: false,
@@ -113,9 +111,7 @@ describe("checkPiProviderStatus", () => {
   );
 
   it.effect("reports a missing or invalid Pi binary", () =>
-    withProcessResult(
-      Effect.fail({ _tag: "ProcessSpawnError" } as never),
-    ).pipe(
+    withProcessResult(Effect.fail({ _tag: "ProcessSpawnError" } as never)).pipe(
       Effect.tap((snapshot) =>
         Effect.sync(() => {
           expect(snapshot.installed).toBe(false);
@@ -131,7 +127,7 @@ describe("checkPiProviderStatus", () => {
       Effect.succeed({
         stdout: "not a Pi version\n",
         stderr: "",
-        code: 0,
+        code: ChildProcessSpawner.ExitCode(0),
         timedOut: false,
         stdoutTruncated: false,
         stderrTruncated: false,
@@ -152,7 +148,7 @@ describe("checkPiProviderStatus", () => {
       Effect.succeed({
         stdout: "pi 0.81.1\n",
         stderr: "fatal error",
-        code: 1,
+        code: ChildProcessSpawner.ExitCode(1),
         timedOut: false,
         stdoutTruncated: false,
         stderrTruncated: false,

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "@effect/vitest";
+import { PiSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { ProcessRunner } from "../../processRunner.ts";
+import { checkPiProviderStatus } from "./PiProvider.ts";
+
+const settings = (overrides: Partial<PiSettings> = {}): PiSettings => ({
+  enabled: true,
+  binaryPath: "pi",
+  configDirectory: "",
+  launchArgs: "",
+  ...overrides,
+});
+
+const withProcessResult = (
+  result: ReturnType<ProcessRunner["Service"]["run"]>,
+) =>
+  checkPiProviderStatus(settings(), process.env).pipe(
+    Effect.provideService(ProcessRunner, ProcessRunner.of({ run: () => result })),
+  );
+
+describe("checkPiProviderStatus", () => {
+  it.effect("reports a usable supported Pi binary", () =>
+    withProcessResult(
+      Effect.succeed({
+        stdout: "pi 0.81.1\n",
+        stderr: "",
+        code: 0,
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      }),
+    ).pipe(
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.installed).toBe(true);
+          expect(snapshot.status).toBe("ready");
+          expect(snapshot.version).toBe("0.81.1");
+        }),
+      ),
+    ),
+  );
+
+  it.effect("reports an upgrade requirement for an old Pi binary", () =>
+    withProcessResult(
+      Effect.succeed({
+        stdout: "pi 0.81.0\n",
+        stderr: "",
+        code: 0,
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      }),
+    ).pipe(
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.installed).toBe(true);
+          expect(snapshot.status).toBe("error");
+          expect(snapshot.message).toContain("Upgrade to v0.81.1");
+        }),
+      ),
+    ),
+  );
+
+  it.effect("reports a missing or invalid Pi binary", () =>
+    withProcessResult(
+      Effect.fail({ _tag: "ProcessSpawnError" } as never),
+    ).pipe(
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.installed).toBe(false);
+          expect(snapshot.status).toBe("error");
+          expect(snapshot.message).toContain("could not be started");
+        }),
+      ),
+    ),
+  );
+
+  it.effect("reports output from a non-Pi executable as invalid", () =>
+    withProcessResult(
+      Effect.succeed({
+        stdout: "not a Pi version\n",
+        stderr: "",
+        code: 0,
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      }),
+    ).pipe(
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.installed).toBe(true);
+          expect(snapshot.status).toBe("error");
+          expect(snapshot.message).toContain("Could not determine");
+        }),
+      ),
+    ),
+  );
+});

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "@effect/vitest";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { PiSettings } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 
 import { ProcessRunner } from "../../processRunner.ts";
 import { checkPiProviderStatus } from "./PiProvider.ts";
@@ -37,6 +36,59 @@ describe("checkPiProviderStatus", () => {
           expect(snapshot.installed).toBe(true);
           expect(snapshot.status).toBe("ready");
           expect(snapshot.version).toBe("0.81.1");
+        }),
+      ),
+    ),
+  );
+
+  it.effect("discovers Pi provider/model groups and their valid thinking levels", () =>
+    checkPiProviderStatus(settings(), process.env, () =>
+      Effect.succeed([
+        {
+          model: {
+            provider: "custom-gateway",
+            id: "team/coder",
+            name: "Team Coder",
+          },
+          thinkingLevels: ["off", "high", "max"],
+          currentThinkingLevel: "high",
+        },
+      ]),
+    ).pipe(
+      Effect.provideService(
+        ProcessRunner,
+        ProcessRunner.of({
+          run: () =>
+            Effect.succeed({
+              stdout: "pi 0.81.1\\n",
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.models).toEqual([
+            expect.objectContaining({
+              slug: "custom-gateway/team%2Fcoder",
+              name: "Team Coder",
+              subProvider: "custom-gateway",
+            }),
+          ]);
+          expect(snapshot.models[0]?.capabilities?.optionDescriptors).toEqual([
+            expect.objectContaining({
+              id: "reasoningEffort",
+              currentValue: "high",
+              options: [
+                { id: "off", label: "Off" },
+                { id: "high", label: "High", isDefault: true },
+                { id: "max", label: "Max" },
+              ],
+            }),
+          ]);
         }),
       ),
     ),

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -36,6 +36,8 @@ describe("checkPiProviderStatus", () => {
           expect(snapshot.installed).toBe(true);
           expect(snapshot.status).toBe("ready");
           expect(snapshot.version).toBe("0.81.1");
+          expect(snapshot.showRuntimeModeSelector).toBe(false);
+          expect(snapshot.toolAccessDescription).toContain("Pi manages enabled tool access");
         }),
       ),
     ),

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -121,7 +121,7 @@ describe("checkPiProviderStatus", () => {
         Effect.sync(() => {
           expect(receivedEnvironment).toMatchObject({
             EXAMPLE: "value",
-            PI_AGENT_DIR: "/Users/example/.pi-work",
+            PI_CODING_AGENT_DIR: "/Users/example/.pi-work",
           });
         }),
       ),

--- a/apps/server/src/provider/Drivers/PiProvider.test.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.test.ts
@@ -43,6 +43,54 @@ describe("checkPiProviderStatus", () => {
     ),
   );
 
+  it.effect("passes the selected Pi config directory to the status probe", () => {
+    let receivedEnvironment: NodeJS.ProcessEnv | undefined;
+    return checkPiProviderStatus(
+      settings({ configDirectory: "/Users/example/.pi-work" }),
+      { EXAMPLE: "value" },
+    ).pipe(
+      Effect.provideService(
+        ProcessRunner,
+        ProcessRunner.of({
+          run: (input) => {
+            receivedEnvironment = input.env;
+            return Effect.succeed({
+              stdout: "pi 0.81.1\n",
+              stderr: "",
+              code: 0,
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            });
+          },
+        }),
+      ),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(receivedEnvironment).toMatchObject({
+            EXAMPLE: "value",
+            PI_AGENT_DIR: "/Users/example/.pi-work",
+          });
+        }),
+      ),
+    );
+  });
+
+  it.effect("rejects protected launch arguments before probing Pi", () =>
+    checkPiProviderStatus(settings({ launchArgs: "--mode json" }), process.env).pipe(
+      Effect.provideService(
+        ProcessRunner,
+        ProcessRunner.of({ run: () => Effect.die("must not run") }),
+      ),
+      Effect.tap((snapshot) =>
+        Effect.sync(() => {
+          expect(snapshot.status).toBe("error");
+          expect(snapshot.message).toContain("managed by T3 Code");
+        }),
+      ),
+    ),
+  );
+
   it.effect("reports an upgrade requirement for an old Pi binary", () =>
     withProcessResult(
       Effect.succeed({

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -74,16 +74,16 @@ export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function
   }
 
   const processRunner = yield* ProcessRunner;
-  const result = yield* processRunner
-    .run({
+  const versionExit = yield* Effect.exit(
+    processRunner.run({
       command: settings.binaryPath || "pi",
       args: ["--version"],
       env: settings.configDirectory
         ? { ...environment, PI_AGENT_DIR: settings.configDirectory }
         : environment,
-    })
-    .pipe(Effect.either);
-  if (result._tag === "Left") {
+    }),
+  );
+  if (versionExit._tag === "Failure") {
     return buildServerProvider({
       driver: PI_DRIVER,
       presentation: PI_PRESENTATION,
@@ -100,7 +100,8 @@ export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function
     });
   }
 
-  if (result.right.timedOut || result.right.code !== 0) {
+  const result = versionExit.value;
+  if (result.timedOut || result.code !== 0) {
     return buildServerProvider({
       driver: PI_DRIVER,
       presentation: PI_PRESENTATION,
@@ -112,14 +113,14 @@ export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function
         version: null,
         status: "error",
         auth: { status: "unknown" },
-        message: result.right.timedOut
+        message: result.timedOut
           ? "Pi CLI version check timed out. Check the selected binary and try again."
           : "Pi CLI version check failed. Check the selected binary and try again.",
       },
     });
   }
 
-  const parsed = parsePiVersion(`${result.right.stdout}\n${result.right.stderr}`);
+  const parsed = parsePiVersion(`${result.stdout}\n${result.stderr}`);
   if (parsed._tag === "Invalid") {
     return buildServerProvider({
       driver: PI_DRIVER,
@@ -148,10 +149,11 @@ export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function
       version: parsed.version,
       status: parsed._tag === "Supported" ? "ready" : "error",
       auth: { status: "unknown" },
-      message:
-        parsed._tag === "Supported"
-          ? undefined
-          : `Pi v${parsed.version} is too old. Upgrade to v${PI_MINIMUM_VERSION} or later.`,
+      ...(parsed._tag === "Unsupported"
+        ? {
+            message: `Pi v${parsed.version} is too old. Upgrade to v${PI_MINIMUM_VERSION} or later.`,
+          }
+        : {}),
     },
   });
 });

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -1,9 +1,13 @@
 import { PiSettings, ProviderDriverKind } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import { ProcessRunner } from "../../processRunner.ts";
 import { buildServerProvider, type ServerProviderDraft } from "../providerSnapshot.ts";
+import { mapPiModelCatalog, type PiModelCatalogEntry } from "./PiModels.ts";
+import { makePiSessionRuntime, type PiSessionRuntimeError } from "./PiSessionRuntime.ts";
 import { parsePiVersion, PI_MINIMUM_VERSION, validatePiLaunchArgs } from "./PiRuntime.ts";
 
 const PI_DRIVER = ProviderDriverKind.make("pi");
@@ -12,148 +16,224 @@ const PI_PRESENTATION = {
   showInteractionModeToggle: false,
 } as const;
 
-export const makePendingPiProvider = (settings: PiSettings): Effect.Effect<ServerProviderDraft> =>
-  Effect.gen(function* () {
-    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
-    return buildServerProvider({
-      driver: PI_DRIVER,
-      presentation: PI_PRESENTATION,
-      enabled: settings.enabled,
-      checkedAt,
-      models: [],
-      probe: {
-        installed: false,
-        version: null,
-        status: "warning",
-        auth: { status: "unknown" },
-        message: settings.enabled
-          ? "Pi provider status has not been checked in this session yet."
-          : "Pi is disabled in T3 Code settings.",
-      },
-    });
-  });
+export interface PiModelCatalogProbeInput {
+  readonly binaryPath: string;
+  readonly configDirectory: string;
+  readonly launchArgs: string;
+  readonly cwd: string;
+  readonly environment: NodeJS.ProcessEnv;
+}
 
-export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function* (
-  settings: PiSettings,
-  environment: NodeJS.ProcessEnv,
-): Effect.fn.Return<ServerProviderDraft, never, ProcessRunner> {
-  const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
-  if (!settings.enabled) {
-    return buildServerProvider({
-      driver: PI_DRIVER,
-      presentation: PI_PRESENTATION,
-      enabled: false,
-      checkedAt,
-      models: [],
-      probe: {
-        installed: false,
-        version: null,
-        status: "warning",
-        auth: { status: "unknown" },
-        message: "Pi is disabled in T3 Code settings.",
-      },
-    });
-  }
+export type PiModelCatalogProbe<R = never> = (
+  input: PiModelCatalogProbeInput,
+) => Effect.Effect<ReadonlyArray<PiModelCatalogEntry>, PiSessionRuntimeError, R>;
 
-  const launchArgsValidationError = validatePiLaunchArgs(settings.launchArgs);
-  if (launchArgsValidationError) {
-    return buildServerProvider({
-      driver: PI_DRIVER,
-      presentation: PI_PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: [],
-      probe: {
-        installed: false,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: launchArgsValidationError,
-      },
-    });
-  }
-
-  const processRunner = yield* ProcessRunner;
-  const versionExit = yield* Effect.exit(
-    processRunner.run({
-      command: settings.binaryPath || "pi",
-      args: ["--version"],
-      env: settings.configDirectory
-        ? { ...environment, PI_AGENT_DIR: settings.configDirectory }
-        : environment,
+/**
+ * Discover the exact model + thinking catalog from Pi RPC without creating a
+ * native session. Each catalog entry is selected before querying its valid
+ * thinking levels because Pi exposes that capability for the active model.
+ */
+export const discoverPiModelCatalog: PiModelCatalogProbe<
+  ChildProcessSpawner.ChildProcessSpawner
+> = (input) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const runtime = yield* makePiSessionRuntime({
+        binaryPath: input.binaryPath,
+        configDirectory: input.configDirectory,
+        launchArgs: input.launchArgs,
+        cwd: input.cwd,
+        environment: input.environment,
+      });
+      yield* runtime.start();
+      const models = yield* runtime.getAvailableModels();
+      return yield* Effect.forEach(
+        models,
+        (model) =>
+          Effect.gen(function* () {
+            yield* runtime.setModel({ provider: model.provider, modelId: model.id });
+            const [thinkingLevels, state] = yield* Effect.all(
+              [runtime.getAvailableThinkingLevels(), runtime.getState()],
+              { concurrency: 1 },
+            );
+            return {
+              model,
+              thinkingLevels,
+              ...(state.thinkingLevel ? { currentThinkingLevel: state.thinkingLevel } : {}),
+            } satisfies PiModelCatalogEntry;
+          }),
+        { concurrency: 1 },
+      );
     }),
   );
-  if (versionExit._tag === "Failure") {
-    return buildServerProvider({
-      driver: PI_DRIVER,
-      presentation: PI_PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: [],
-      probe: {
-        installed: false,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: `Pi CLI (${settings.binaryPath || "pi"}) is not installed or could not be started. Check the binary path.`,
-      },
-    });
-  }
 
-  const result = versionExit.value;
-  if (result.timedOut || result.code !== 0) {
-    return buildServerProvider({
-      driver: PI_DRIVER,
-      presentation: PI_PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: [],
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: result.timedOut
-          ? "Pi CLI version check timed out. Check the selected binary and try again."
-          : "Pi CLI version check failed. Check the selected binary and try again.",
-      },
-    });
-  }
-
-  const parsed = parsePiVersion(`${result.stdout}\n${result.stderr}`);
-  if (parsed._tag === "Invalid") {
-    return buildServerProvider({
-      driver: PI_DRIVER,
-      presentation: PI_PRESENTATION,
-      enabled: true,
-      checkedAt,
-      models: [],
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Could not determine the Pi CLI version. Check that the selected binary is Pi.",
-      },
-    });
-  }
-
+function piSnapshot(input: {
+  readonly enabled: boolean;
+  readonly checkedAt: string;
+  readonly models?: ServerProviderDraft["models"];
+  readonly installed: boolean;
+  readonly version: string | null;
+  readonly status: "ready" | "warning" | "error";
+  readonly message?: string | undefined;
+}): ServerProviderDraft {
   return buildServerProvider({
     driver: PI_DRIVER,
     presentation: PI_PRESENTATION,
-    enabled: true,
-    checkedAt,
-    models: [],
+    enabled: input.enabled,
+    checkedAt: input.checkedAt,
+    models: input.models ?? [],
     probe: {
-      installed: true,
-      version: parsed.version,
-      status: parsed._tag === "Supported" ? "ready" : "error",
+      installed: input.installed,
+      version: input.version,
+      status: input.status,
       auth: { status: "unknown" },
-      ...(parsed._tag === "Unsupported"
-        ? {
-            message: `Pi v${parsed.version} is too old. Upgrade to v${PI_MINIMUM_VERSION} or later.`,
-          }
-        : {}),
+      ...(input.message ? { message: input.message } : {}),
     },
   });
-});
+}
+
+export const makePendingPiProvider = (settings: PiSettings): Effect.Effect<ServerProviderDraft> =>
+  Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    return piSnapshot({
+      enabled: settings.enabled,
+      checkedAt,
+      installed: false,
+      version: null,
+      status: "warning",
+      message: settings.enabled
+        ? "Pi provider status has not been checked in this session yet."
+        : "Pi is disabled in T3 Code settings.",
+    });
+  });
+
+export function checkPiProviderStatus<R = never>(
+  settings: PiSettings,
+  environment: NodeJS.ProcessEnv,
+  discoverModels?: PiModelCatalogProbe<R>,
+  cwd = process.cwd(),
+): Effect.Effect<ServerProviderDraft, never, ProcessRunner | R> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    if (!settings.enabled) {
+      return piSnapshot({
+        enabled: false,
+        checkedAt,
+        installed: false,
+        version: null,
+        status: "warning",
+        message: "Pi is disabled in T3 Code settings.",
+      });
+    }
+
+    const launchArgsValidationError = validatePiLaunchArgs(settings.launchArgs);
+    if (launchArgsValidationError) {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: false,
+        version: null,
+        status: "error",
+        message: launchArgsValidationError,
+      });
+    }
+
+    const processRunner = yield* ProcessRunner;
+    const versionExit = yield* Effect.exit(
+      processRunner.run({
+        command: settings.binaryPath || "pi",
+        args: ["--version"],
+        env: settings.configDirectory
+          ? { ...environment, PI_AGENT_DIR: settings.configDirectory }
+          : environment,
+      }),
+    );
+    if (versionExit._tag === "Failure") {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: false,
+        version: null,
+        status: "error",
+        message: `Pi CLI (${settings.binaryPath || "pi"}) is not installed or could not be started. Check the binary path.`,
+      });
+    }
+
+    const versionResult = versionExit.value;
+    if (versionResult.timedOut || versionResult.code !== 0) {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: true,
+        version: null,
+        status: "error",
+        message: versionResult.timedOut
+          ? "Pi CLI version check timed out. Check the selected binary and try again."
+          : "Pi CLI version check failed. Check the selected binary and try again.",
+      });
+    }
+
+    const parsedVersion = parsePiVersion(`${versionResult.stdout}\n${versionResult.stderr}`);
+    if (parsedVersion._tag === "Invalid") {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: true,
+        version: null,
+        status: "error",
+        message: "Could not determine the Pi CLI version. Check that the selected binary is Pi.",
+      });
+    }
+
+    if (parsedVersion._tag === "Unsupported") {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: true,
+        version: parsedVersion.version,
+        status: "error",
+        message: `Pi v${parsedVersion.version} is too old. Upgrade to v${PI_MINIMUM_VERSION} or later.`,
+      });
+    }
+
+    if (!discoverModels) {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: true,
+        version: parsedVersion.version,
+        status: "ready",
+      });
+    }
+
+    const catalogExit = yield* Effect.exit(
+      discoverModels({
+        binaryPath: settings.binaryPath || "pi",
+        configDirectory: settings.configDirectory,
+        launchArgs: settings.launchArgs,
+        cwd,
+        environment,
+      }),
+    );
+    if (Exit.isFailure(catalogExit)) {
+      return piSnapshot({
+        enabled: true,
+        checkedAt,
+        installed: true,
+        version: parsedVersion.version,
+        status: "error",
+        message:
+          "Pi RPC model discovery failed. Check the selected Pi configuration and try again.",
+      });
+    }
+
+    return piSnapshot({
+      enabled: true,
+      checkedAt,
+      installed: true,
+      version: parsedVersion.version,
+      status: "ready",
+      models: mapPiModelCatalog(catalogExit.value),
+    });
+  });
+}

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 
 import { ProcessRunner } from "../../processRunner.ts";
 import { buildServerProvider, type ServerProviderDraft } from "../providerSnapshot.ts";
-import { parsePiVersion, PI_MINIMUM_VERSION } from "./PiRuntime.ts";
+import { parsePiVersion, PI_MINIMUM_VERSION, validatePiLaunchArgs } from "./PiRuntime.ts";
 
 const PI_DRIVER = ProviderDriverKind.make("pi");
 const PI_PRESENTATION = {
@@ -55,9 +55,33 @@ export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function
     });
   }
 
+  const launchArgsValidationError = validatePiLaunchArgs(settings.launchArgs);
+  if (launchArgsValidationError) {
+    return buildServerProvider({
+      driver: PI_DRIVER,
+      presentation: PI_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: [],
+      probe: {
+        installed: false,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: launchArgsValidationError,
+      },
+    });
+  }
+
   const processRunner = yield* ProcessRunner;
   const result = yield* processRunner
-    .run({ command: settings.binaryPath || "pi", args: ["--version"], env: environment })
+    .run({
+      command: settings.binaryPath || "pi",
+      args: ["--version"],
+      env: settings.configDirectory
+        ? { ...environment, PI_AGENT_DIR: settings.configDirectory }
+        : environment,
+    })
     .pipe(Effect.either);
   if (result._tag === "Left") {
     return buildServerProvider({

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -76,6 +76,25 @@ export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function
     });
   }
 
+  if (result.right.timedOut || result.right.code !== 0) {
+    return buildServerProvider({
+      driver: PI_DRIVER,
+      presentation: PI_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: [],
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: result.right.timedOut
+          ? "Pi CLI version check timed out. Check the selected binary and try again."
+          : "Pi CLI version check failed. Check the selected binary and try again.",
+      },
+    });
+  }
+
   const parsed = parsePiVersion(`${result.right.stdout}\n${result.right.stderr}`);
   if (parsed._tag === "Invalid") {
     return buildServerProvider({

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -1,0 +1,114 @@
+import { PiSettings, ProviderDriverKind } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+
+import { ProcessRunner } from "../../processRunner.ts";
+import { buildServerProvider, type ServerProviderDraft } from "../providerSnapshot.ts";
+import { parsePiVersion, PI_MINIMUM_VERSION } from "./PiRuntime.ts";
+
+const PI_DRIVER = ProviderDriverKind.make("pi");
+const PI_PRESENTATION = {
+  displayName: "Pi",
+  showInteractionModeToggle: false,
+} as const;
+
+export const makePendingPiProvider = (settings: PiSettings): Effect.Effect<ServerProviderDraft> =>
+  Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    return buildServerProvider({
+      driver: PI_DRIVER,
+      presentation: PI_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: [],
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: settings.enabled
+          ? "Pi provider status has not been checked in this session yet."
+          : "Pi is disabled in T3 Code settings.",
+      },
+    });
+  });
+
+export const checkPiProviderStatus = Effect.fn("checkPiProviderStatus")(function* (
+  settings: PiSettings,
+  environment: NodeJS.ProcessEnv,
+): Effect.fn.Return<ServerProviderDraft, never, ProcessRunner> {
+  const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+  if (!settings.enabled) {
+    return buildServerProvider({
+      driver: PI_DRIVER,
+      presentation: PI_PRESENTATION,
+      enabled: false,
+      checkedAt,
+      models: [],
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Pi is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  const processRunner = yield* ProcessRunner;
+  const result = yield* processRunner
+    .run({ command: settings.binaryPath || "pi", args: ["--version"], env: environment })
+    .pipe(Effect.either);
+  if (result._tag === "Left") {
+    return buildServerProvider({
+      driver: PI_DRIVER,
+      presentation: PI_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: [],
+      probe: {
+        installed: false,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: `Pi CLI (${settings.binaryPath || "pi"}) is not installed or could not be started. Check the binary path.`,
+      },
+    });
+  }
+
+  const parsed = parsePiVersion(`${result.right.stdout}\n${result.right.stderr}`);
+  if (parsed._tag === "Invalid") {
+    return buildServerProvider({
+      driver: PI_DRIVER,
+      presentation: PI_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models: [],
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "Could not determine the Pi CLI version. Check that the selected binary is Pi.",
+      },
+    });
+  }
+
+  return buildServerProvider({
+    driver: PI_DRIVER,
+    presentation: PI_PRESENTATION,
+    enabled: true,
+    checkedAt,
+    models: [],
+    probe: {
+      installed: true,
+      version: parsed.version,
+      status: parsed._tag === "Supported" ? "ready" : "error",
+      auth: { status: "unknown" },
+      message:
+        parsed._tag === "Supported"
+          ? undefined
+          : `Pi v${parsed.version} is too old. Upgrade to v${PI_MINIMUM_VERSION} or later.`,
+    },
+  });
+});

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -14,6 +14,9 @@ const PI_DRIVER = ProviderDriverKind.make("pi");
 const PI_PRESENTATION = {
   displayName: "Pi",
   showInteractionModeToggle: false,
+  showRuntimeModeSelector: false,
+  toolAccessDescription:
+    "Pi manages enabled tool access; Pi tools can run without a T3 Code per-tool confirmation.",
 } as const;
 
 export interface PiModelCatalogProbeInput {

--- a/apps/server/src/provider/Drivers/PiProvider.ts
+++ b/apps/server/src/provider/Drivers/PiProvider.ts
@@ -147,7 +147,7 @@ export function checkPiProviderStatus<R = never>(
         command: settings.binaryPath || "pi",
         args: ["--version"],
         env: settings.configDirectory
-          ? { ...environment, PI_AGENT_DIR: settings.configDirectory }
+          ? { ...environment, PI_CODING_AGENT_DIR: settings.configDirectory }
           : environment,
       }),
     );

--- a/apps/server/src/provider/Drivers/PiRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.test.ts
@@ -4,6 +4,7 @@ import {
   buildPiLaunchPlan,
   parsePiVersion,
   PI_MINIMUM_VERSION,
+  validatePiLaunchArgs,
 } from "./PiRuntime.ts";
 
 describe("Pi runtime launch plan", () => {
@@ -58,6 +59,14 @@ describe("Pi runtime launch plan", () => {
       ).toEqual({ _tag: "Failure", message: expect.stringContaining("managed by T3 Code") });
     },
   );
+});
+
+describe("validatePiLaunchArgs", () => {
+  it("rejects T3 Code managed flags before launching Pi", () => {
+    expect(validatePiLaunchArgs("--mode json")).toContain("managed by T3 Code");
+    expect(validatePiLaunchArgs("--session-dir=/tmp/other")).toContain("managed by T3 Code");
+    expect(validatePiLaunchArgs("--verbose")).toBeUndefined();
+  });
 });
 
 describe("parsePiVersion", () => {

--- a/apps/server/src/provider/Drivers/PiRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   buildPiLaunchPlan,
+  buildPiModelProbeLaunchPlan,
   parsePiVersion,
   PI_MINIMUM_VERSION,
   validatePiLaunchArgs,
@@ -24,7 +25,7 @@ describe("Pi runtime launch plan", () => {
         "rpc",
         "--session-dir",
         "/tmp/t3/pi/work",
-        "--session",
+        "--session-id",
         "thread_123",
       ],
       environment: { PI_AGENT_DIR: "/Users/example/.pi-work" },
@@ -41,30 +42,56 @@ describe("Pi runtime launch plan", () => {
 
     expect(plan).toEqual({
       _tag: "Success",
-      args: ["--mode", "rpc", "--session-dir", "/tmp/t3/pi/work", "--session", "thread_123"],
+      args: ["--mode", "rpc", "--session-dir", "/tmp/t3/pi/work", "--session-id", "thread_123"],
       environment: {},
     });
   });
 
-  it.each(["--mode json", "--session-dir /tmp/other", "--session=other"]) (
-    "rejects user launch arguments that override managed Pi parameters: %s",
-    (launchArgs) => {
-      expect(
-        buildPiLaunchPlan({
-          configDirectory: "",
-          launchArgs,
-          sessionDirectory: "/tmp/t3/pi/work",
-          sessionId: "thread_123",
-        }),
-      ).toEqual({ _tag: "Failure", message: expect.stringContaining("managed by T3 Code") });
-    },
-  );
+  it.each([
+    "--mode json",
+    "--session-dir /tmp/other",
+    "--session other",
+    "--session=other",
+    "--session-id=other",
+    "--no-session",
+    "--continue",
+    "-c",
+    "--resume",
+    "-r",
+    "--fork prior-session",
+  ])("rejects user launch arguments that override managed Pi parameters: %s", (launchArgs) => {
+    expect(
+      buildPiLaunchPlan({
+        configDirectory: "",
+        launchArgs,
+        sessionDirectory: "/tmp/t3/pi/work",
+        sessionId: "thread_123",
+      }),
+    ).toEqual({ _tag: "Failure", message: expect.stringContaining("managed by T3 Code") });
+  });
+});
+
+describe("Pi model probe launch plan", () => {
+  it("uses Pi RPC without creating a probe session", () => {
+    expect(
+      buildPiModelProbeLaunchPlan({
+        configDirectory: "/Users/example/.pi-work",
+        launchArgs: "--verbose",
+      }),
+    ).toEqual({
+      _tag: "Success",
+      args: ["--verbose", "--mode", "rpc", "--no-session"],
+      environment: { PI_AGENT_DIR: "/Users/example/.pi-work" },
+    });
+  });
 });
 
 describe("validatePiLaunchArgs", () => {
   it("rejects T3 Code managed flags before launching Pi", () => {
     expect(validatePiLaunchArgs("--mode json")).toContain("managed by T3 Code");
     expect(validatePiLaunchArgs("--session-dir=/tmp/other")).toContain("managed by T3 Code");
+    expect(validatePiLaunchArgs("--session-id=other")).toContain("managed by T3 Code");
+    expect(validatePiLaunchArgs("--no-session")).toContain("managed by T3 Code");
     expect(validatePiLaunchArgs("--verbose")).toBeUndefined();
   });
 });

--- a/apps/server/src/provider/Drivers/PiRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildPiLaunchPlan,
+  parsePiVersion,
+  PI_MINIMUM_VERSION,
+} from "./PiRuntime.ts";
+
+describe("Pi runtime launch plan", () => {
+  it("keeps the Pi configuration directory in PI_AGENT_DIR", () => {
+    const plan = buildPiLaunchPlan({
+      configDirectory: "/Users/example/.pi-work",
+      launchArgs: "--verbose",
+      sessionDirectory: "/tmp/t3/pi/work",
+      sessionId: "thread_123",
+    });
+
+    expect(plan).toEqual({
+      _tag: "Success",
+      args: [
+        "--verbose",
+        "--mode",
+        "rpc",
+        "--session-dir",
+        "/tmp/t3/pi/work",
+        "--session",
+        "thread_123",
+      ],
+      environment: { PI_AGENT_DIR: "/Users/example/.pi-work" },
+    });
+  });
+
+  it("leaves Pi's normal configuration untouched when no config directory is selected", () => {
+    const plan = buildPiLaunchPlan({
+      configDirectory: "",
+      launchArgs: "",
+      sessionDirectory: "/tmp/t3/pi/work",
+      sessionId: "thread_123",
+    });
+
+    expect(plan).toEqual({
+      _tag: "Success",
+      args: ["--mode", "rpc", "--session-dir", "/tmp/t3/pi/work", "--session", "thread_123"],
+      environment: {},
+    });
+  });
+
+  it.each(["--mode json", "--session-dir /tmp/other", "--session=other"]) (
+    "rejects user launch arguments that override managed Pi parameters: %s",
+    (launchArgs) => {
+      expect(
+        buildPiLaunchPlan({
+          configDirectory: "",
+          launchArgs,
+          sessionDirectory: "/tmp/t3/pi/work",
+          sessionId: "thread_123",
+        }),
+      ).toEqual({ _tag: "Failure", message: expect.stringContaining("managed by T3 Code") });
+    },
+  );
+});
+
+describe("parsePiVersion", () => {
+  it("accepts Pi 0.81.1 and newer", () => {
+    expect(parsePiVersion("pi 0.81.1")).toEqual({ _tag: "Supported", version: PI_MINIMUM_VERSION });
+    expect(parsePiVersion("pi 0.82.0")).toEqual({ _tag: "Supported", version: "0.82.0" });
+  });
+
+  it("reports an upgrade requirement for older Pi versions", () => {
+    expect(parsePiVersion("pi 0.81.0")).toEqual({ _tag: "Unsupported", version: "0.81.0" });
+    expect(parsePiVersion("pi 0.80.99")).toEqual({ _tag: "Unsupported", version: "0.80.99" });
+  });
+
+  it("reports invalid version output", () => {
+    expect(parsePiVersion("not a version")).toEqual({ _tag: "Invalid" });
+  });
+});

--- a/apps/server/src/provider/Drivers/PiRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./PiRuntime.ts";
 
 describe("Pi runtime launch plan", () => {
-  it("keeps the Pi configuration directory in PI_AGENT_DIR", () => {
+  it("keeps the Pi configuration directory in PI_CODING_AGENT_DIR", () => {
     const plan = buildPiLaunchPlan({
       configDirectory: "/Users/example/.pi-work",
       launchArgs: "--verbose",
@@ -23,16 +23,17 @@ describe("Pi runtime launch plan", () => {
         "--verbose",
         "--mode",
         "rpc",
+        "--no-extensions",
         "--session-dir",
         "/tmp/t3/pi/work",
         "--session-id",
         "thread_123",
       ],
-      environment: { PI_AGENT_DIR: "/Users/example/.pi-work" },
+      environment: { PI_CODING_AGENT_DIR: "/Users/example/.pi-work" },
     });
   });
 
-  it("leaves Pi's normal configuration untouched when no config directory is selected", () => {
+  it("disables discovered extensions when no config directory is selected", () => {
     const plan = buildPiLaunchPlan({
       configDirectory: "",
       launchArgs: "",
@@ -42,7 +43,43 @@ describe("Pi runtime launch plan", () => {
 
     expect(plan).toEqual({
       _tag: "Success",
-      args: ["--mode", "rpc", "--session-dir", "/tmp/t3/pi/work", "--session-id", "thread_123"],
+      args: [
+        "--mode",
+        "rpc",
+        "--no-extensions",
+        "--session-dir",
+        "/tmp/t3/pi/work",
+        "--session-id",
+        "thread_123",
+      ],
+      environment: {},
+    });
+    if (plan._tag === "Success") {
+      expect(plan.args).toContain("--no-extensions");
+    }
+  });
+
+  it("keeps explicit extension paths while disabling extension discovery", () => {
+    expect(
+      buildPiLaunchPlan({
+        configDirectory: "",
+        launchArgs: "--extension /tmp/t3-pi-extension.ts",
+        sessionDirectory: "/tmp/t3/pi/work",
+        sessionId: "thread_123",
+      }),
+    ).toEqual({
+      _tag: "Success",
+      args: [
+        "--extension",
+        "/tmp/t3-pi-extension.ts",
+        "--mode",
+        "rpc",
+        "--no-extensions",
+        "--session-dir",
+        "/tmp/t3/pi/work",
+        "--session-id",
+        "thread_123",
+      ],
       environment: {},
     });
   });
@@ -54,6 +91,7 @@ describe("Pi runtime launch plan", () => {
     "--session=other",
     "--session-id=other",
     "--no-session",
+    "--no-extensions",
     "--continue",
     "-c",
     "--resume",
@@ -80,8 +118,8 @@ describe("Pi model probe launch plan", () => {
       }),
     ).toEqual({
       _tag: "Success",
-      args: ["--verbose", "--mode", "rpc", "--no-session"],
-      environment: { PI_AGENT_DIR: "/Users/example/.pi-work" },
+      args: ["--verbose", "--mode", "rpc", "--no-extensions", "--no-session"],
+      environment: { PI_CODING_AGENT_DIR: "/Users/example/.pi-work" },
     });
   });
 });
@@ -92,6 +130,7 @@ describe("validatePiLaunchArgs", () => {
     expect(validatePiLaunchArgs("--session-dir=/tmp/other")).toContain("managed by T3 Code");
     expect(validatePiLaunchArgs("--session-id=other")).toContain("managed by T3 Code");
     expect(validatePiLaunchArgs("--no-session")).toContain("managed by T3 Code");
+    expect(validatePiLaunchArgs("--no-extensions")).toContain("managed by T3 Code");
     expect(validatePiLaunchArgs("--verbose")).toBeUndefined();
   });
 });

--- a/apps/server/src/provider/Drivers/PiRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.ts
@@ -2,7 +2,17 @@ import { tokenizeCliArgs } from "@t3tools/shared/cliArgs";
 
 export const PI_MINIMUM_VERSION = "0.81.1";
 
-const MANAGED_FLAGS = new Set(["mode", "session", "session-dir"]);
+const MANAGED_FLAGS = new Set([
+  "continue",
+  "fork",
+  "mode",
+  "no-session",
+  "resume",
+  "session",
+  "session-dir",
+  "session-id",
+]);
+const MANAGED_SHORT_FLAGS = new Set(["-c", "-r"]);
 
 export type PiLaunchPlan =
   | {
@@ -14,6 +24,7 @@ export type PiLaunchPlan =
 
 export function validatePiLaunchArgs(launchArgs: string): string | undefined {
   const managedFlag = tokenizeCliArgs(launchArgs).find((arg) => {
+    if (MANAGED_SHORT_FLAGS.has(arg)) return true;
     if (!arg.startsWith("--")) return false;
     return MANAGED_FLAGS.has(arg.slice(2).split("=", 1)[0]!);
   });
@@ -45,9 +56,28 @@ export function buildPiLaunchPlan(input: {
       "rpc",
       "--session-dir",
       input.sessionDirectory,
-      "--session",
+      "--session-id",
       input.sessionId,
     ],
+    environment: input.configDirectory ? { PI_AGENT_DIR: input.configDirectory } : {},
+  };
+}
+
+export function buildPiModelProbeLaunchPlan(input: {
+  readonly configDirectory: string;
+  readonly launchArgs: string;
+}): PiLaunchPlan {
+  const validationError = validatePiLaunchArgs(input.launchArgs);
+  if (validationError) {
+    return {
+      _tag: "Failure",
+      message: validationError,
+    };
+  }
+
+  return {
+    _tag: "Success",
+    args: [...tokenizeCliArgs(input.launchArgs), "--mode", "rpc", "--no-session"],
     environment: input.configDirectory ? { PI_AGENT_DIR: input.configDirectory } : {},
   };
 }

--- a/apps/server/src/provider/Drivers/PiRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.ts
@@ -12,6 +12,16 @@ export type PiLaunchPlan =
     }
   | { readonly _tag: "Failure"; readonly message: string };
 
+export function validatePiLaunchArgs(launchArgs: string): string | undefined {
+  const managedFlag = tokenizeCliArgs(launchArgs).find((arg) => {
+    if (!arg.startsWith("--")) return false;
+    return MANAGED_FLAGS.has(arg.slice(2).split("=", 1)[0]!);
+  });
+  return managedFlag
+    ? `${managedFlag} is managed by T3 Code and cannot be set in Pi launch arguments.`
+    : undefined;
+}
+
 export function buildPiLaunchPlan(input: {
   readonly configDirectory: string;
   readonly launchArgs: string;
@@ -19,14 +29,11 @@ export function buildPiLaunchPlan(input: {
   readonly sessionId: string;
 }): PiLaunchPlan {
   const userArgs = tokenizeCliArgs(input.launchArgs);
-  const managedFlag = userArgs.find((arg) => {
-    if (!arg.startsWith("--")) return false;
-    return MANAGED_FLAGS.has(arg.slice(2).split("=", 1)[0]!);
-  });
-  if (managedFlag) {
+  const validationError = validatePiLaunchArgs(input.launchArgs);
+  if (validationError) {
     return {
       _tag: "Failure",
-      message: `${managedFlag} is managed by T3 Code and cannot be set in Pi launch arguments.`,
+      message: validationError,
     };
   }
 

--- a/apps/server/src/provider/Drivers/PiRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.ts
@@ -6,6 +6,7 @@ const MANAGED_FLAGS = new Set([
   "continue",
   "fork",
   "mode",
+  "no-extensions",
   "no-session",
   "resume",
   "session",
@@ -54,12 +55,13 @@ export function buildPiLaunchPlan(input: {
       ...userArgs,
       "--mode",
       "rpc",
+      "--no-extensions",
       "--session-dir",
       input.sessionDirectory,
       "--session-id",
       input.sessionId,
     ],
-    environment: input.configDirectory ? { PI_AGENT_DIR: input.configDirectory } : {},
+    environment: input.configDirectory ? { PI_CODING_AGENT_DIR: input.configDirectory } : {},
   };
 }
 
@@ -77,8 +79,14 @@ export function buildPiModelProbeLaunchPlan(input: {
 
   return {
     _tag: "Success",
-    args: [...tokenizeCliArgs(input.launchArgs), "--mode", "rpc", "--no-session"],
-    environment: input.configDirectory ? { PI_AGENT_DIR: input.configDirectory } : {},
+    args: [
+      ...tokenizeCliArgs(input.launchArgs),
+      "--mode",
+      "rpc",
+      "--no-extensions",
+      "--no-session",
+    ],
+    environment: input.configDirectory ? { PI_CODING_AGENT_DIR: input.configDirectory } : {},
   };
 }
 

--- a/apps/server/src/provider/Drivers/PiRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiRuntime.ts
@@ -1,0 +1,66 @@
+import { tokenizeCliArgs } from "@t3tools/shared/cliArgs";
+
+export const PI_MINIMUM_VERSION = "0.81.1";
+
+const MANAGED_FLAGS = new Set(["mode", "session", "session-dir"]);
+
+export type PiLaunchPlan =
+  | {
+      readonly _tag: "Success";
+      readonly args: ReadonlyArray<string>;
+      readonly environment: NodeJS.ProcessEnv;
+    }
+  | { readonly _tag: "Failure"; readonly message: string };
+
+export function buildPiLaunchPlan(input: {
+  readonly configDirectory: string;
+  readonly launchArgs: string;
+  readonly sessionDirectory: string;
+  readonly sessionId: string;
+}): PiLaunchPlan {
+  const userArgs = tokenizeCliArgs(input.launchArgs);
+  const managedFlag = userArgs.find((arg) => {
+    if (!arg.startsWith("--")) return false;
+    return MANAGED_FLAGS.has(arg.slice(2).split("=", 1)[0]!);
+  });
+  if (managedFlag) {
+    return {
+      _tag: "Failure",
+      message: `${managedFlag} is managed by T3 Code and cannot be set in Pi launch arguments.`,
+    };
+  }
+
+  return {
+    _tag: "Success",
+    args: [
+      ...userArgs,
+      "--mode",
+      "rpc",
+      "--session-dir",
+      input.sessionDirectory,
+      "--session",
+      input.sessionId,
+    ],
+    environment: input.configDirectory ? { PI_AGENT_DIR: input.configDirectory } : {},
+  };
+}
+
+export type PiVersionStatus =
+  | { readonly _tag: "Supported"; readonly version: string }
+  | { readonly _tag: "Unsupported"; readonly version: string }
+  | { readonly _tag: "Invalid" };
+
+export function parsePiVersion(output: string): PiVersionStatus {
+  const match = output.match(/\b(\d+)\.(\d+)\.(\d+)\b/);
+  if (!match) return { _tag: "Invalid" };
+
+  const version = `${match[1]}.${match[2]}.${match[3]}`;
+  const parsed = match.slice(1).map(Number);
+  const minimum = PI_MINIMUM_VERSION.split(".").map(Number);
+  for (const [index, part] of parsed.entries()) {
+    const minimumPart = minimum[index]!;
+    if (part > minimumPart) return { _tag: "Supported", version };
+    if (part < minimumPart) return { _tag: "Unsupported", version };
+  }
+  return { _tag: "Supported", version };
+}

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
@@ -79,6 +79,10 @@ function handle(command) {
       respond(command);
       return;
     case "prompt":
+      if (process.env.PI_TEST_EXIT_ON_PROMPT === "true") {
+        process.stderr.write("simulated Pi process loss\\n");
+        process.exit(23);
+      }
       if (sessionDirectory) {
         mkdirSync(sessionDirectory, { recursive: true });
         writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId, message: command.message }) + "\\n");
@@ -236,5 +240,40 @@ it.effect("starts Pi in the configured project and extension configuration conte
     NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
     NodeFS.rmSync(projectDirectory, { recursive: true, force: true });
     NodeFS.rmSync(configDirectory, { recursive: true, force: true });
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("reports a diagnosable transport failure when Pi exits during an accepted prompt", () =>
+  Effect.gen(function* () {
+    const binaryPath = makeMockPiBinary();
+    const runtime = yield* makePiSessionRuntime({
+      binaryPath,
+      configDirectory: "",
+      launchArgs: "",
+      cwd: process.cwd(),
+      environment: { PI_TEST_EXIT_ON_PROMPT: "true" },
+    });
+    yield* runtime.start();
+    const eventFiber = yield* Stream.take(runtime.events, 1).pipe(
+      Stream.runCollect,
+      Effect.forkChild,
+    );
+    yield* Effect.yieldNow;
+
+    const promptFailure = yield* runtime
+      .prompt({ message: "Persist this prompt before the transport fails." })
+      .pipe(Effect.flip);
+    const events = Array.from(yield* Fiber.join(eventFiber).pipe(Effect.timeout("1 second")));
+
+    expect(["read-stdout", "process-exit"]).toContain(promptFailure.operation);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "pi_rpc_transport_failure",
+        operation: expect.stringMatching(/read-stdout|process-exit/),
+        detail: expect.stringContaining("Pi RPC"),
+      }),
+    ]);
+
+    NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
@@ -1,0 +1,127 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { makePiJsonlDecoder, makePiSessionRuntime } from "./PiSessionRuntime.ts";
+
+describe("Pi RPC JSONL decoder", () => {
+  it("uses LF as the only record delimiter", () => {
+    const decoder = makePiJsonlDecoder();
+
+    expect(decoder.push('{"message":"first\u2028still first"}\n{"message":"sec')).toEqual([
+      '{"message":"first\u2028still first"}',
+    ]);
+    expect(decoder.push('ond"}\r\n')).toEqual(['{"message":"second"}']);
+    expect(decoder.end()).toEqual([]);
+  });
+
+  it("returns one unterminated final record only when the stream ends", () => {
+    const decoder = makePiJsonlDecoder();
+
+    expect(decoder.push('{"type":"agent_settled"}')).toEqual([]);
+    expect(decoder.end()).toEqual(['{"type":"agent_settled"}']);
+    expect(decoder.end()).toEqual([]);
+  });
+});
+
+function makeMockPiBinary(): string {
+  const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-pi-runtime-"));
+  const agentPath = NodePath.join(directory, "agent.mjs");
+  const binaryPath = NodePath.join(directory, "fake-pi.sh");
+  NodeFS.writeFileSync(
+    agentPath,
+    `let buffer = "";
+let selected = { provider: "custom", id: "starter", name: "Starter" };
+let thinkingLevel = "high";
+
+function respond(command, data) {
+  process.stdout.write(JSON.stringify({ id: command.id, type: "response", command: command.type, success: true, ...(data === undefined ? {} : { data }) }) + "\\n");
+}
+
+function handle(command) {
+  switch (command.type) {
+    case "get_state":
+      respond(command, { sessionId: "thread-native", sessionFile: "/tmp/thread-native.jsonl", model: selected, thinkingLevel });
+      return;
+    case "get_available_models":
+      respond(command, { models: [selected, { provider: "custom", id: "team/coder", name: "Team Coder" }] });
+      return;
+    case "set_model":
+      selected = { provider: command.provider, id: command.modelId, name: command.modelId };
+      respond(command, selected);
+      return;
+    case "get_available_thinking_levels":
+      respond(command, { levels: ["off", "high", "max"] });
+      return;
+    case "set_thinking_level":
+      thinkingLevel = command.level;
+      respond(command);
+      return;
+    default:
+      process.stdout.write(JSON.stringify({ id: command.id, type: "response", command: command.type, success: false, error: "Unknown command" }) + "\\n");
+  }
+}
+
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline === -1) return;
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line) handle(JSON.parse(line));
+  }
+});
+`,
+    "utf8",
+  );
+  NodeFS.writeFileSync(
+    binaryPath,
+    `#!/bin/sh
+exec ${JSON.stringify(process.execPath)} ${JSON.stringify(agentPath)}\n`,
+    "utf8",
+  );
+  NodeFS.chmodSync(binaryPath, 0o755);
+  return binaryPath;
+}
+
+it.effect("starts a stable native session and drives Pi model RPC commands", () =>
+  Effect.gen(function* () {
+    const binaryPath = makeMockPiBinary();
+    const runtime = yield* makePiSessionRuntime({
+      binaryPath,
+      configDirectory: "/tmp/pi-config",
+      launchArgs: "",
+      cwd: process.cwd(),
+      sessionDirectory: "/tmp/t3-pi-sessions/instance-a",
+      sessionId: "thread-native",
+    });
+
+    const started = yield* runtime.start();
+    expect(started).toMatchObject({
+      sessionId: "thread-native",
+      sessionFile: "/tmp/thread-native.jsonl",
+      model: { provider: "custom", id: "starter" },
+    });
+
+    expect(yield* runtime.getAvailableModels()).toContainEqual({
+      provider: "custom",
+      id: "team/coder",
+      name: "Team Coder",
+    });
+    yield* runtime.setModel({ provider: "custom", modelId: "team/coder" });
+    expect(yield* runtime.getAvailableThinkingLevels()).toEqual(["off", "high", "max"]);
+    yield* runtime.setThinkingLevel("max");
+    expect(yield* runtime.getState()).toMatchObject({
+      model: { provider: "custom", id: "team/coder" },
+      thinkingLevel: "max",
+    });
+
+    NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
@@ -90,7 +90,7 @@ exec ${JSON.stringify(process.execPath)} ${JSON.stringify(agentPath)}\n`,
   return binaryPath;
 }
 
-it.effect("starts a stable native session and drives Pi model RPC commands", () =>
+it.effect("starts Pi persistent mode with a stable native ID and drives model RPC", () =>
   Effect.gen(function* () {
     const binaryPath = makeMockPiBinary();
     const runtime = yield* makePiSessionRuntime({

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
@@ -35,9 +35,19 @@ function makeMockPiBinary(): string {
   const binaryPath = NodePath.join(directory, "fake-pi.sh");
   NodeFS.writeFileSync(
     agentPath,
-    `let buffer = "";
+    `import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let buffer = "";
 let selected = { provider: "custom", id: "starter", name: "Starter" };
 let thinkingLevel = "high";
+const argumentValue = (name) => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+};
+const sessionDirectory = argumentValue("--session-dir");
+const sessionId = argumentValue("--session-id") ?? "thread-native";
+const sessionFile = sessionDirectory ? join(sessionDirectory, \`\${sessionId}.jsonl\`) : "/tmp/thread-native.jsonl";
 
 function respond(command, data) {
   process.stdout.write(JSON.stringify({ id: command.id, type: "response", command: command.type, success: true, ...(data === undefined ? {} : { data }) }) + "\\n");
@@ -46,7 +56,7 @@ function respond(command, data) {
 function handle(command) {
   switch (command.type) {
     case "get_state":
-      respond(command, { sessionId: "thread-native", sessionFile: "/tmp/thread-native.jsonl", model: selected, thinkingLevel });
+      respond(command, { sessionId, sessionFile, model: selected, thinkingLevel });
       return;
     case "get_available_models":
       respond(command, { models: [selected, { provider: "custom", id: "team/coder", name: "Team Coder" }] });
@@ -60,6 +70,16 @@ function handle(command) {
       return;
     case "set_thinking_level":
       thinkingLevel = command.level;
+      respond(command);
+      return;
+    case "prompt":
+      if (sessionDirectory) {
+        mkdirSync(sessionDirectory, { recursive: true });
+        writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId, message: command.message }) + "\\n");
+      }
+      respond(command);
+      return;
+    case "abort":
       respond(command);
       return;
     default:
@@ -83,7 +103,7 @@ process.stdin.on("data", (chunk) => {
   NodeFS.writeFileSync(
     binaryPath,
     `#!/bin/sh
-exec ${JSON.stringify(process.execPath)} ${JSON.stringify(agentPath)}\n`,
+exec ${JSON.stringify(process.execPath)} ${JSON.stringify(agentPath)} "$@"\n`,
     "utf8",
   );
   NodeFS.chmodSync(binaryPath, 0o755);
@@ -93,19 +113,25 @@ exec ${JSON.stringify(process.execPath)} ${JSON.stringify(agentPath)}\n`,
 it.effect("starts Pi persistent mode with a stable native ID and drives model RPC", () =>
   Effect.gen(function* () {
     const binaryPath = makeMockPiBinary();
+    const sessionDirectory = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3-pi-native-session-"),
+    );
+    const siblingInstanceDirectory = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3-pi-native-session-sibling-"),
+    );
     const runtime = yield* makePiSessionRuntime({
       binaryPath,
       configDirectory: "/tmp/pi-config",
       launchArgs: "",
       cwd: process.cwd(),
-      sessionDirectory: "/tmp/t3-pi-sessions/instance-a",
+      sessionDirectory,
       sessionId: "thread-native",
     });
 
     const started = yield* runtime.start();
     expect(started).toMatchObject({
       sessionId: "thread-native",
-      sessionFile: "/tmp/thread-native.jsonl",
+      sessionFile: NodePath.join(sessionDirectory, "thread-native.jsonl"),
       model: { provider: "custom", id: "starter" },
     });
 
@@ -117,11 +143,20 @@ it.effect("starts Pi persistent mode with a stable native ID and drives model RP
     yield* runtime.setModel({ provider: "custom", modelId: "team/coder" });
     expect(yield* runtime.getAvailableThinkingLevels()).toEqual(["off", "high", "max"]);
     yield* runtime.setThinkingLevel("max");
+    yield* runtime.prompt({ message: "Persist the first native Pi turn" });
+    const sessionFile = NodePath.join(sessionDirectory, "thread-native.jsonl");
+    expect(NodeFS.existsSync(sessionFile)).toBe(true);
+    expect(NodeFS.readFileSync(sessionFile, "utf8")).toContain("thread-native");
+    expect(NodeFS.existsSync(NodePath.join(siblingInstanceDirectory, "thread-native.jsonl"))).toBe(
+      false,
+    );
     expect(yield* runtime.getState()).toMatchObject({
       model: { provider: "custom", id: "team/coder" },
       thinkingLevel: "max",
     });
 
     NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
+    NodeFS.rmSync(sessionDirectory, { recursive: true, force: true });
+    NodeFS.rmSync(siblingInstanceDirectory, { recursive: true, force: true });
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.test.ts
@@ -6,6 +6,8 @@ import * as NodePath from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Stream from "effect/Stream";
 
 import { makePiJsonlDecoder, makePiSessionRuntime } from "./PiSessionRuntime.ts";
 
@@ -49,6 +51,10 @@ const sessionDirectory = argumentValue("--session-dir");
 const sessionId = argumentValue("--session-id") ?? "thread-native";
 const sessionFile = sessionDirectory ? join(sessionDirectory, \`\${sessionId}.jsonl\`) : "/tmp/thread-native.jsonl";
 
+if (process.env.PI_TEST_EMIT_LAUNCH_CONTEXT === "true") {
+  process.stdout.write(JSON.stringify({ type: "pi_test_launch_context", cwd: process.cwd(), piAgentDir: process.env.PI_CODING_AGENT_DIR ?? null }) + "\\n");
+}
+
 function respond(command, data) {
   process.stdout.write(JSON.stringify({ id: command.id, type: "response", command: command.type, success: true, ...(data === undefined ? {} : { data }) }) + "\\n");
 }
@@ -81,6 +87,9 @@ function handle(command) {
       return;
     case "abort":
       respond(command);
+      return;
+    case "extension_ui_response":
+      process.stdout.write(JSON.stringify({ type: "extension_ui_response_received", response: command }) + "\\n");
       return;
     default:
       process.stdout.write(JSON.stringify({ id: command.id, type: "response", command: command.type, success: false, error: "Unknown command" }) + "\\n");
@@ -158,5 +167,74 @@ it.effect("starts Pi persistent mode with a stable native ID and drives model RP
     NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
     NodeFS.rmSync(sessionDirectory, { recursive: true, force: true });
     NodeFS.rmSync(siblingInstanceDirectory, { recursive: true, force: true });
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("sends extension UI responses without waiting for a Pi RPC response", () =>
+  Effect.gen(function* () {
+    const binaryPath = makeMockPiBinary();
+    const runtime = yield* makePiSessionRuntime({
+      binaryPath,
+      configDirectory: "",
+      launchArgs: "",
+      cwd: process.cwd(),
+    });
+    yield* runtime.start();
+    const eventFiber = yield* Stream.take(runtime.events, 1).pipe(
+      Stream.runCollect,
+      Effect.forkChild,
+    );
+    yield* Effect.yieldNow;
+
+    yield* runtime.respondToExtensionUI({
+      id: "extension-dialog",
+      value: "Continue",
+    });
+
+    expect(Array.from(yield* Fiber.join(eventFiber).pipe(Effect.timeout("1 second")))).toEqual([
+      {
+        type: "extension_ui_response_received",
+        response: {
+          type: "extension_ui_response",
+          id: "extension-dialog",
+          value: "Continue",
+        },
+      },
+    ]);
+
+    NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("starts Pi in the configured project and extension configuration context", () =>
+  Effect.gen(function* () {
+    const binaryPath = makeMockPiBinary();
+    const projectDirectory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-pi-project-"));
+    const configDirectory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-pi-config-"));
+    const runtime = yield* makePiSessionRuntime({
+      binaryPath,
+      configDirectory,
+      launchArgs: "",
+      cwd: projectDirectory,
+      environment: { PI_TEST_EMIT_LAUNCH_CONTEXT: "true" },
+    });
+    const eventFiber = yield* Stream.take(runtime.events, 1).pipe(
+      Stream.runCollect,
+      Effect.forkChild,
+    );
+
+    yield* runtime.start();
+
+    expect(Array.from(yield* Fiber.join(eventFiber).pipe(Effect.timeout("1 second")))).toEqual([
+      {
+        type: "pi_test_launch_context",
+        cwd: NodeFS.realpathSync(projectDirectory),
+        piAgentDir: configDirectory,
+      },
+    ]);
+
+    NodeFS.rmSync(NodePath.dirname(binaryPath), { recursive: true, force: true });
+    NodeFS.rmSync(projectDirectory, { recursive: true, force: true });
+    NodeFS.rmSync(configDirectory, { recursive: true, force: true });
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.ts
@@ -1,0 +1,577 @@
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import type { PiRpcModel } from "./PiModels.ts";
+import { buildPiLaunchPlan, buildPiModelProbeLaunchPlan } from "./PiRuntime.ts";
+
+const PI_RPC_REQUEST_TIMEOUT = "15 seconds" as const;
+const PI_RPC_FORCE_KILL_AFTER = "2 seconds" as const;
+const decodeUnknownJson = Schema.decodeUnknownEffect(Schema.UnknownFromJsonString);
+const encodeUnknownJson = Schema.encodeUnknownEffect(Schema.UnknownFromJsonString);
+
+export class PiSessionRuntimeError extends Schema.TaggedErrorClass<PiSessionRuntimeError>()(
+  "PiSessionRuntimeError",
+  {
+    operation: Schema.String,
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Pi RPC ${this.operation} failed: ${this.detail}`;
+  }
+}
+
+const isPiSessionRuntimeError = Schema.is(PiSessionRuntimeError);
+
+export interface PiSessionRuntimeOptions {
+  readonly binaryPath: string;
+  readonly configDirectory: string;
+  readonly launchArgs: string;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv | undefined;
+  /** Both fields are set for a persisted native session and omitted for a model probe. */
+  readonly sessionDirectory?: string | undefined;
+  readonly sessionId?: string | undefined;
+}
+
+export interface PiSessionRuntimeState {
+  readonly sessionId: string;
+  readonly sessionFile?: string | undefined;
+  readonly model?: PiRpcModel | undefined;
+  readonly thinkingLevel?: string | undefined;
+}
+
+export interface PiSessionRuntimeShape {
+  readonly start: () => Effect.Effect<PiSessionRuntimeState, PiSessionRuntimeError>;
+  readonly getState: () => Effect.Effect<PiSessionRuntimeState, PiSessionRuntimeError>;
+  readonly getAvailableModels: () => Effect.Effect<
+    ReadonlyArray<PiRpcModel>,
+    PiSessionRuntimeError
+  >;
+  readonly setModel: (input: {
+    readonly provider: string;
+    readonly modelId: string;
+  }) => Effect.Effect<void, PiSessionRuntimeError>;
+  readonly getAvailableThinkingLevels: () => Effect.Effect<
+    ReadonlyArray<string>,
+    PiSessionRuntimeError
+  >;
+  readonly setThinkingLevel: (level: string) => Effect.Effect<void, PiSessionRuntimeError>;
+  /** Raw Pi protocol events retained for later lifecycle/diagnostic mapping. */
+  readonly events: Stream.Stream<unknown>;
+  readonly close: Effect.Effect<void>;
+}
+
+interface PendingRequest {
+  readonly command: string;
+  readonly deferred: Deferred.Deferred<unknown, PiSessionRuntimeError>;
+}
+
+interface PiRpcResponse {
+  readonly id: string;
+  readonly command?: string | undefined;
+  readonly success: boolean;
+  readonly data?: unknown;
+  readonly error?: string | undefined;
+}
+
+/**
+ * Strict LF-delimited JSONL decoder for Pi RPC stdout.
+ *
+ * Pi permits Unicode line separators inside JSON payloads, so this must not
+ * use `readline`, `Stream.splitLines`, or any other generic line reader.
+ */
+export interface PiJsonlDecoder {
+  readonly push: (chunk: string) => ReadonlyArray<string>;
+  readonly end: () => ReadonlyArray<string>;
+}
+
+export function makePiJsonlDecoder(): PiJsonlDecoder {
+  let buffer = "";
+
+  const normalize = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+  return {
+    push(chunk) {
+      buffer += chunk;
+      const records: string[] = [];
+      while (true) {
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) {
+          return records;
+        }
+        records.push(normalize(buffer.slice(0, newline)));
+        buffer = buffer.slice(newline + 1);
+      }
+    },
+    end() {
+      if (buffer.length === 0) {
+        return [];
+      }
+      const record = normalize(buffer);
+      buffer = "";
+      return [record];
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseModel(value: unknown): PiRpcModel | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const provider = stringValue(value.provider);
+  const id = stringValue(value.id);
+  if (!provider || !id) {
+    return undefined;
+  }
+  return {
+    provider,
+    id,
+    name: stringValue(value.name) ?? id,
+  };
+}
+
+function parseState(value: unknown): PiSessionRuntimeState | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const sessionId = stringValue(value.sessionId);
+  if (!sessionId) {
+    return undefined;
+  }
+  const model = parseModel(value.model);
+  const sessionFile = stringValue(value.sessionFile);
+  const thinkingLevel = stringValue(value.thinkingLevel);
+  return {
+    sessionId,
+    ...(sessionFile ? { sessionFile } : {}),
+    ...(model ? { model } : {}),
+    ...(thinkingLevel ? { thinkingLevel } : {}),
+  };
+}
+
+function parseResponse(value: unknown): PiRpcResponse | undefined {
+  if (!isRecord(value) || value.type !== "response") {
+    return undefined;
+  }
+  const id = stringValue(value.id);
+  if (!id || typeof value.success !== "boolean") {
+    return undefined;
+  }
+  const command = stringValue(value.command);
+  const error = stringValue(value.error);
+  return {
+    id,
+    success: value.success,
+    ...(command ? { command } : {}),
+    ...(Object.hasOwn(value, "data") ? { data: value.data } : {}),
+    ...(error ? { error } : {}),
+  };
+}
+
+function resolveLaunchPlan(input: PiSessionRuntimeOptions) {
+  const hasSessionDirectory = input.sessionDirectory !== undefined;
+  const hasSessionId = input.sessionId !== undefined;
+  if (hasSessionDirectory !== hasSessionId) {
+    return {
+      _tag: "Failure" as const,
+      message: "Pi session directory and session ID must be configured together.",
+    };
+  }
+  if (input.sessionDirectory !== undefined && input.sessionId !== undefined) {
+    return buildPiLaunchPlan({
+      configDirectory: input.configDirectory,
+      launchArgs: input.launchArgs,
+      sessionDirectory: input.sessionDirectory,
+      sessionId: input.sessionId,
+    });
+  }
+  return buildPiModelProbeLaunchPlan({
+    configDirectory: input.configDirectory,
+    launchArgs: input.launchArgs,
+  });
+}
+
+export const makePiSessionRuntime = (
+  options: PiSessionRuntimeOptions,
+): Effect.Effect<
+  PiSessionRuntimeShape,
+  PiSessionRuntimeError,
+  ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const launchPlan = resolveLaunchPlan(options);
+    if (launchPlan._tag === "Failure") {
+      return yield* new PiSessionRuntimeError({
+        operation: "build-launch-plan",
+        detail: launchPlan.message,
+      });
+    }
+
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const runtimeScope = yield* Scope.Scope;
+    const environment = {
+      ...options.environment,
+      ...launchPlan.environment,
+    };
+    const spawnCommand = yield* resolveSpawnCommand(options.binaryPath, launchPlan.args, {
+      env: environment,
+      extendEnv: true,
+    });
+    const child = yield* spawner
+      .spawn(
+        ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+          cwd: options.cwd,
+          env: environment,
+          extendEnv: true,
+          forceKillAfter: PI_RPC_FORCE_KILL_AFTER,
+          shell: spawnCommand.shell,
+          stdin: { stream: "pipe", endOnDone: false },
+        }),
+      )
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new PiSessionRuntimeError({
+              operation: "spawn",
+              detail: `Could not start '${options.binaryPath}' in RPC mode.`,
+              cause,
+            }),
+        ),
+      );
+
+    const pendingRequests = yield* Ref.make(new Map<string, PendingRequest>());
+    const requestNumber = yield* Ref.make(0);
+    const writeLock = yield* Semaphore.make(1);
+    const rawEvents = yield* Queue.unbounded<unknown>();
+    const closed = yield* Ref.make(false);
+    const decoder = makePiJsonlDecoder();
+
+    const failPendingRequests = (error: PiSessionRuntimeError) =>
+      Ref.getAndSet(pendingRequests, new Map<string, PendingRequest>()).pipe(
+        Effect.flatMap((pending) =>
+          Effect.forEach(
+            Array.from(pending.values()),
+            (request) => Deferred.fail(request.deferred, error).pipe(Effect.ignore),
+            { discard: true },
+          ),
+        ),
+      );
+
+    const removePendingRequest = (id: string) =>
+      Ref.update(pendingRequests, (pending) => {
+        if (!pending.has(id)) {
+          return pending;
+        }
+        const next = new Map(pending);
+        next.delete(id);
+        return next;
+      });
+
+    const handleResponse = (response: PiRpcResponse) =>
+      Ref.modify(pendingRequests, (pending) => {
+        const request = pending.get(response.id);
+        if (!request) {
+          return [undefined, pending] as const;
+        }
+        const next = new Map(pending);
+        next.delete(response.id);
+        return [request, next] as const;
+      }).pipe(
+        Effect.flatMap((request) => {
+          if (!request) {
+            return Effect.void;
+          }
+          if (response.success) {
+            return Deferred.succeed(request.deferred, response.data).pipe(Effect.asVoid);
+          }
+          return Deferred.fail(
+            request.deferred,
+            new PiSessionRuntimeError({
+              operation: request.command,
+              detail: response.error ?? "Pi rejected the RPC command.",
+            }),
+          ).pipe(Effect.asVoid);
+        }),
+      );
+
+    const handleRecord = (record: string) => {
+      if (record.length === 0) {
+        return Effect.void;
+      }
+      return decodeUnknownJson(record).pipe(
+        Effect.matchEffect({
+          onFailure: () =>
+            Queue.offer(rawEvents, {
+              type: "pi_rpc_invalid_json",
+              raw: record,
+            }).pipe(Effect.asVoid),
+          onSuccess: (value) => {
+            const response = parseResponse(value);
+            return response
+              ? handleResponse(response)
+              : Queue.offer(rawEvents, value).pipe(Effect.asVoid);
+          },
+        }),
+      );
+    };
+
+    const flushDecoder = () =>
+      Effect.forEach(decoder.end(), handleRecord, { discard: true }).pipe(Effect.asVoid);
+
+    const outputFiber = yield* child.stdout.pipe(
+      Stream.decodeText(),
+      Stream.runForEach((chunk) =>
+        Effect.forEach(decoder.push(chunk), handleRecord, { discard: true }).pipe(Effect.asVoid),
+      ),
+      Effect.ensuring(flushDecoder()),
+      Effect.catch(() =>
+        failPendingRequests(
+          new PiSessionRuntimeError({
+            operation: "read-stdout",
+            detail: "Pi RPC stdout closed unexpectedly.",
+          }),
+        ),
+      ),
+      Effect.forkIn(runtimeScope),
+    );
+
+    // Drain stderr even before lifecycle mapping/diagnostics is enabled. An
+    // unread stderr pipe can otherwise block an otherwise healthy Pi process.
+    yield* child.stderr.pipe(Stream.runDrain, Effect.ignore, Effect.forkIn(runtimeScope));
+
+    yield* child.exitCode.pipe(
+      Effect.matchEffect({
+        onFailure: (cause) =>
+          failPendingRequests(
+            new PiSessionRuntimeError({
+              operation: "process-exit",
+              detail: "Could not read Pi process exit status.",
+              cause,
+            }),
+          ),
+        onSuccess: (code) =>
+          failPendingRequests(
+            new PiSessionRuntimeError({
+              operation: "process-exit",
+              detail:
+                code === 0
+                  ? "Pi RPC process exited."
+                  : `Pi RPC process exited with code ${String(code)}.`,
+            }),
+          ),
+      }),
+      Effect.andThen(Queue.shutdown(rawEvents)),
+      Effect.forkIn(runtimeScope),
+    );
+
+    const writeCommand = (record: Record<string, unknown>) =>
+      encodeUnknownJson(record).pipe(
+        Effect.mapError(
+          (cause) =>
+            new PiSessionRuntimeError({
+              operation: "encode-command",
+              detail: "Could not encode Pi RPC command.",
+              cause,
+            }),
+        ),
+        Effect.flatMap((encoded) =>
+          writeLock.withPermit(
+            Stream.run(Stream.encodeText(Stream.make(`${encoded}\n`)), child.stdin),
+          ),
+        ),
+        Effect.mapError((cause) =>
+          isPiSessionRuntimeError(cause)
+            ? cause
+            : new PiSessionRuntimeError({
+                operation: "write-stdin",
+                detail: "Could not write Pi RPC command.",
+                cause,
+              }),
+        ),
+      );
+
+    const request = Effect.fn("PiSessionRuntime.request")(function* (
+      command: Record<string, unknown>,
+    ) {
+      const closedNow = yield* Ref.get(closed);
+      if (closedNow) {
+        return yield* new PiSessionRuntimeError({
+          operation: String(command.type ?? "command"),
+          detail: "Pi RPC session is closed.",
+        });
+      }
+
+      const sequence = yield* Ref.modify(requestNumber, (current) => [current + 1, current + 1]);
+      const id = `t3-pi-${sequence}`;
+      const deferred = yield* Deferred.make<unknown, PiSessionRuntimeError>();
+      const commandName = String(command.type ?? "command");
+      yield* Ref.update(pendingRequests, (pending) => {
+        const next = new Map(pending);
+        next.set(id, { command: commandName, deferred });
+        return next;
+      });
+
+      yield* writeCommand({ ...command, id }).pipe(Effect.onError(() => removePendingRequest(id)));
+
+      const response = yield* Deferred.await(deferred).pipe(
+        Effect.timeoutOption(PI_RPC_REQUEST_TIMEOUT),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              removePendingRequest(id).pipe(
+                Effect.andThen(
+                  new PiSessionRuntimeError({
+                    operation: commandName,
+                    detail: `Timed out waiting for Pi RPC response after ${PI_RPC_REQUEST_TIMEOUT}.`,
+                  }),
+                ),
+              ),
+            onSome: Effect.succeed,
+          }),
+        ),
+      );
+      return response;
+    });
+
+    const getState = () =>
+      request({ type: "get_state" }).pipe(
+        Effect.flatMap((response) => {
+          const state = parseState(response);
+          return state
+            ? Effect.succeed(state)
+            : Effect.fail(
+                new PiSessionRuntimeError({
+                  operation: "get_state",
+                  detail: "Pi returned an invalid session state response.",
+                }),
+              );
+        }),
+      );
+
+    const start = () =>
+      getState().pipe(
+        Effect.flatMap((state) => {
+          if (options.sessionId !== undefined && state.sessionId !== options.sessionId) {
+            return Effect.fail(
+              new PiSessionRuntimeError({
+                operation: "get_state",
+                detail: `Pi started session '${state.sessionId}' instead of required session '${options.sessionId}'.`,
+              }),
+            );
+          }
+          return Effect.succeed(state);
+        }),
+      );
+
+    const getAvailableModels = () =>
+      request({ type: "get_available_models" }).pipe(
+        Effect.flatMap((response) => {
+          if (!isRecord(response) || !Array.isArray(response.models)) {
+            return Effect.fail(
+              new PiSessionRuntimeError({
+                operation: "get_available_models",
+                detail: "Pi returned an invalid model catalog response.",
+              }),
+            );
+          }
+          return Effect.succeed(
+            response.models.flatMap((model) => {
+              const parsed = parseModel(model);
+              return parsed ? [parsed] : [];
+            }),
+          );
+        }),
+      );
+
+    const setModel = (input: { readonly provider: string; readonly modelId: string }) =>
+      request({
+        type: "set_model",
+        provider: input.provider,
+        modelId: input.modelId,
+      }).pipe(Effect.asVoid);
+
+    const getAvailableThinkingLevels = () =>
+      request({ type: "get_available_thinking_levels" }).pipe(
+        Effect.flatMap((response) => {
+          if (!isRecord(response) || !Array.isArray(response.levels)) {
+            return Effect.fail(
+              new PiSessionRuntimeError({
+                operation: "get_available_thinking_levels",
+                detail: "Pi returned an invalid thinking-level response.",
+              }),
+            );
+          }
+          const seen = new Set<string>();
+          const levels: string[] = [];
+          for (const value of response.levels) {
+            const level = stringValue(value);
+            if (!level || seen.has(level)) {
+              continue;
+            }
+            seen.add(level);
+            levels.push(level);
+          }
+          return Effect.succeed(levels);
+        }),
+      );
+
+    const setThinkingLevel = (level: string) =>
+      request({ type: "set_thinking_level", level }).pipe(Effect.asVoid);
+
+    const close = Ref.getAndSet(closed, true).pipe(
+      Effect.flatMap((wasClosed) => {
+        if (wasClosed) {
+          return Effect.void;
+        }
+        return child.kill({ forceKillAfter: PI_RPC_FORCE_KILL_AFTER }).pipe(
+          Effect.ignore,
+          Effect.andThen(
+            failPendingRequests(
+              new PiSessionRuntimeError({
+                operation: "close",
+                detail: "Pi RPC session was closed.",
+              }),
+            ),
+          ),
+          Effect.andThen(Queue.shutdown(rawEvents)),
+        );
+      }),
+    );
+
+    yield* Effect.addFinalizer(() => close);
+
+    // Keep the stdout fibre reachable through the runtime scope. The binding
+    // is intentionally retained to make the ownership explicit.
+    void outputFiber;
+
+    return {
+      start,
+      getState,
+      getAvailableModels,
+      setModel,
+      getAvailableThinkingLevels,
+      setThinkingLevel,
+      events: Stream.fromQueue(rawEvents),
+      close,
+    } satisfies PiSessionRuntimeShape;
+  });

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.ts
@@ -1,6 +1,8 @@
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
@@ -34,6 +36,23 @@ export class PiSessionRuntimeError extends Schema.TaggedErrorClass<PiSessionRunt
 }
 
 const isPiSessionRuntimeError = Schema.is(PiSessionRuntimeError);
+
+/** Synthetic raw event emitted when Pi's process or RPC transport becomes unusable. */
+export const PI_RPC_TRANSPORT_FAILURE_EVENT_TYPE = "pi_rpc_transport_failure";
+
+export interface PiRpcTransportFailureEvent {
+  readonly type: typeof PI_RPC_TRANSPORT_FAILURE_EVENT_TYPE;
+  readonly operation: string;
+  readonly detail: string;
+}
+
+export function isPiSessionRuntimeTransportError(error: PiSessionRuntimeError): boolean {
+  return (
+    error.operation === "read-stdout" ||
+    error.operation === "process-exit" ||
+    error.operation === "write-stdin"
+  );
+}
 
 export interface PiSessionRuntimeOptions {
   readonly binaryPath: string;
@@ -158,6 +177,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function isPiRpcTransportFailureEvent(value: unknown): value is PiRpcTransportFailureEvent {
+  return (
+    isRecord(value) &&
+    value.type === PI_RPC_TRANSPORT_FAILURE_EVENT_TYPE &&
+    stringValue(value.operation) !== undefined &&
+    stringValue(value.detail) !== undefined
+  );
 }
 
 function parseModel(value: unknown): PiRpcModel | undefined {
@@ -288,7 +316,7 @@ export const makePiSessionRuntime = (
     const pendingRequests = yield* Ref.make(new Map<string, PendingRequest>());
     const requestNumber = yield* Ref.make(0);
     const writeLock = yield* Semaphore.make(1);
-    const rawEvents = yield* Queue.unbounded<unknown>();
+    const rawEvents = yield* Queue.unbounded<unknown, Cause.Done>();
     const closed = yield* Ref.make(false);
     const decoder = makePiJsonlDecoder();
 
@@ -302,6 +330,26 @@ export const makePiSessionRuntime = (
           ),
         ),
       );
+
+    const finishUnexpectedTransportFailure = Effect.fn(
+      "PiSessionRuntime.finishUnexpectedTransportFailure",
+    )(function* (error: PiSessionRuntimeError) {
+      if (yield* Ref.getAndSet(closed, true)) {
+        return;
+      }
+
+      yield* Queue.offer(rawEvents, {
+        type: PI_RPC_TRANSPORT_FAILURE_EVENT_TYPE,
+        operation: error.operation,
+        detail: error.detail,
+      } satisfies PiRpcTransportFailureEvent);
+      yield* failPendingRequests(error);
+      yield* child.kill({ forceKillAfter: PI_RPC_FORCE_KILL_AFTER }).pipe(Effect.ignore);
+      // `end` drains the failure event before completing the event stream.
+      // `shutdown` would interrupt the adapter before it could mark an active
+      // T3 turn interrupted and retain the diagnostic payload.
+      yield* Queue.end(rawEvents);
+    });
 
     const removePendingRequest = (id: string) =>
       Ref.update(pendingRequests, (pending) => {
@@ -370,12 +418,19 @@ export const makePiSessionRuntime = (
         Effect.forEach(decoder.push(chunk), handleRecord, { discard: true }).pipe(Effect.asVoid),
       ),
       Effect.ensuring(flushDecoder()),
-      Effect.catch(() =>
-        failPendingRequests(
-          new PiSessionRuntimeError({
-            operation: "read-stdout",
-            detail: "Pi RPC stdout closed unexpectedly.",
-          }),
+      Effect.exit,
+      Effect.flatMap((exit) =>
+        finishUnexpectedTransportFailure(
+          Exit.isSuccess(exit)
+            ? new PiSessionRuntimeError({
+                operation: "read-stdout",
+                detail: "Pi RPC stdout closed unexpectedly.",
+              })
+            : new PiSessionRuntimeError({
+                operation: "read-stdout",
+                detail: "Pi RPC stdout connection failed.",
+                cause: exit.cause,
+              }),
         ),
       ),
       Effect.forkIn(runtimeScope),
@@ -388,7 +443,7 @@ export const makePiSessionRuntime = (
     yield* child.exitCode.pipe(
       Effect.matchEffect({
         onFailure: (cause) =>
-          failPendingRequests(
+          finishUnexpectedTransportFailure(
             new PiSessionRuntimeError({
               operation: "process-exit",
               detail: "Could not read Pi process exit status.",
@@ -396,7 +451,7 @@ export const makePiSessionRuntime = (
             }),
           ),
         onSuccess: (code) =>
-          failPendingRequests(
+          finishUnexpectedTransportFailure(
             new PiSessionRuntimeError({
               operation: "process-exit",
               detail:
@@ -406,7 +461,6 @@ export const makePiSessionRuntime = (
             }),
           ),
       }),
-      Effect.andThen(Queue.shutdown(rawEvents)),
       Effect.forkIn(runtimeScope),
     );
 
@@ -433,6 +487,9 @@ export const makePiSessionRuntime = (
                 detail: "Could not write Pi RPC command.",
                 cause,
               }),
+        ),
+        Effect.tapError((error) =>
+          error.operation === "write-stdin" ? finishUnexpectedTransportFailure(error) : Effect.void,
         ),
       );
 
@@ -480,7 +537,9 @@ export const makePiSessionRuntime = (
       return response;
     });
 
-    const getState = (timeout = PI_RPC_REQUEST_TIMEOUT) =>
+    const getState = (
+      timeout: typeof PI_RPC_REQUEST_TIMEOUT | typeof PI_RPC_START_TIMEOUT = PI_RPC_REQUEST_TIMEOUT,
+    ) =>
       request({ type: "get_state" }, timeout).pipe(
         Effect.flatMap((response) => {
           const state = parseState(response);

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.ts
@@ -52,6 +52,18 @@ export interface PiSessionRuntimeState {
   readonly thinkingLevel?: string | undefined;
 }
 
+export interface PiPromptImage {
+  readonly type: "image";
+  readonly data: string;
+  readonly mimeType: string;
+}
+
+export interface PiPromptInput {
+  readonly message: string;
+  readonly images?: ReadonlyArray<PiPromptImage> | undefined;
+  readonly streamingBehavior?: "steer" | "followUp" | undefined;
+}
+
 export interface PiSessionRuntimeShape {
   readonly start: () => Effect.Effect<PiSessionRuntimeState, PiSessionRuntimeError>;
   readonly getState: () => Effect.Effect<PiSessionRuntimeState, PiSessionRuntimeError>;
@@ -68,6 +80,10 @@ export interface PiSessionRuntimeShape {
     PiSessionRuntimeError
   >;
   readonly setThinkingLevel: (level: string) => Effect.Effect<void, PiSessionRuntimeError>;
+  /** Accept a normal Pi RPC prompt; lifecycle events continue asynchronously. */
+  readonly prompt: (input: PiPromptInput) => Effect.Effect<void, PiSessionRuntimeError>;
+  /** Invoke Pi's native abort command for the active operation. */
+  readonly abort: () => Effect.Effect<void, PiSessionRuntimeError>;
   /** Raw Pi protocol events retained for later lifecycle/diagnostic mapping. */
   readonly events: Stream.Stream<unknown>;
   readonly close: Effect.Effect<void>;
@@ -538,6 +554,16 @@ export const makePiSessionRuntime = (
     const setThinkingLevel = (level: string) =>
       request({ type: "set_thinking_level", level }).pipe(Effect.asVoid);
 
+    const prompt = (input: PiPromptInput) =>
+      request({
+        type: "prompt",
+        message: input.message,
+        ...(input.images && input.images.length > 0 ? { images: input.images } : {}),
+        ...(input.streamingBehavior ? { streamingBehavior: input.streamingBehavior } : {}),
+      }).pipe(Effect.asVoid);
+
+    const abort = () => request({ type: "abort" }).pipe(Effect.asVoid);
+
     const close = Ref.getAndSet(closed, true).pipe(
       Effect.flatMap((wasClosed) => {
         if (wasClosed) {
@@ -571,6 +597,8 @@ export const makePiSessionRuntime = (
       setModel,
       getAvailableThinkingLevels,
       setThinkingLevel,
+      prompt,
+      abort,
       events: Stream.fromQueue(rawEvents),
       close,
     } satisfies PiSessionRuntimeShape;

--- a/apps/server/src/provider/Drivers/PiSessionRuntime.ts
+++ b/apps/server/src/provider/Drivers/PiSessionRuntime.ts
@@ -15,6 +15,7 @@ import type { PiRpcModel } from "./PiModels.ts";
 import { buildPiLaunchPlan, buildPiModelProbeLaunchPlan } from "./PiRuntime.ts";
 
 const PI_RPC_REQUEST_TIMEOUT = "15 seconds" as const;
+const PI_RPC_START_TIMEOUT = "30 seconds" as const;
 const PI_RPC_FORCE_KILL_AFTER = "2 seconds" as const;
 const decodeUnknownJson = Schema.decodeUnknownEffect(Schema.UnknownFromJsonString);
 const encodeUnknownJson = Schema.encodeUnknownEffect(Schema.UnknownFromJsonString);
@@ -64,6 +65,11 @@ export interface PiPromptInput {
   readonly streamingBehavior?: "steer" | "followUp" | undefined;
 }
 
+export type PiExtensionUiResponse =
+  | { readonly id: string; readonly value: string }
+  | { readonly id: string; readonly confirmed: boolean }
+  | { readonly id: string; readonly cancelled: true };
+
 export interface PiSessionRuntimeShape {
   readonly start: () => Effect.Effect<PiSessionRuntimeState, PiSessionRuntimeError>;
   readonly getState: () => Effect.Effect<PiSessionRuntimeState, PiSessionRuntimeError>;
@@ -84,6 +90,10 @@ export interface PiSessionRuntimeShape {
   readonly prompt: (input: PiPromptInput) => Effect.Effect<void, PiSessionRuntimeError>;
   /** Invoke Pi's native abort command for the active operation. */
   readonly abort: () => Effect.Effect<void, PiSessionRuntimeError>;
+  /** Respond to a pending Pi extension UI dialog without awaiting an RPC response. */
+  readonly respondToExtensionUI: (
+    response: PiExtensionUiResponse,
+  ) => Effect.Effect<void, PiSessionRuntimeError>;
   /** Raw Pi protocol events retained for later lifecycle/diagnostic mapping. */
   readonly events: Stream.Stream<unknown>;
   readonly close: Effect.Effect<void>;
@@ -428,6 +438,7 @@ export const makePiSessionRuntime = (
 
     const request = Effect.fn("PiSessionRuntime.request")(function* (
       command: Record<string, unknown>,
+      timeout = PI_RPC_REQUEST_TIMEOUT,
     ) {
       const closedNow = yield* Ref.get(closed);
       if (closedNow) {
@@ -450,7 +461,7 @@ export const makePiSessionRuntime = (
       yield* writeCommand({ ...command, id }).pipe(Effect.onError(() => removePendingRequest(id)));
 
       const response = yield* Deferred.await(deferred).pipe(
-        Effect.timeoutOption(PI_RPC_REQUEST_TIMEOUT),
+        Effect.timeoutOption(timeout),
         Effect.flatMap(
           Option.match({
             onNone: () =>
@@ -458,7 +469,7 @@ export const makePiSessionRuntime = (
                 Effect.andThen(
                   new PiSessionRuntimeError({
                     operation: commandName,
-                    detail: `Timed out waiting for Pi RPC response after ${PI_RPC_REQUEST_TIMEOUT}.`,
+                    detail: `Timed out waiting for Pi RPC response after ${timeout}.`,
                   }),
                 ),
               ),
@@ -469,8 +480,8 @@ export const makePiSessionRuntime = (
       return response;
     });
 
-    const getState = () =>
-      request({ type: "get_state" }).pipe(
+    const getState = (timeout = PI_RPC_REQUEST_TIMEOUT) =>
+      request({ type: "get_state" }, timeout).pipe(
         Effect.flatMap((response) => {
           const state = parseState(response);
           return state
@@ -485,7 +496,7 @@ export const makePiSessionRuntime = (
       );
 
     const start = () =>
-      getState().pipe(
+      getState(PI_RPC_START_TIMEOUT).pipe(
         Effect.flatMap((state) => {
           if (options.sessionId !== undefined && state.sessionId !== options.sessionId) {
             return Effect.fail(
@@ -564,6 +575,19 @@ export const makePiSessionRuntime = (
 
     const abort = () => request({ type: "abort" }).pipe(Effect.asVoid);
 
+    const respondToExtensionUI = Effect.fn("PiSessionRuntime.respondToExtensionUI")(function* (
+      response: PiExtensionUiResponse,
+    ) {
+      const closedNow = yield* Ref.get(closed);
+      if (closedNow) {
+        return yield* new PiSessionRuntimeError({
+          operation: "extension_ui_response",
+          detail: "Pi RPC session is closed.",
+        });
+      }
+      yield* writeCommand({ type: "extension_ui_response", ...response });
+    });
+
     const close = Ref.getAndSet(closed, true).pipe(
       Effect.flatMap((wasClosed) => {
         if (wasClosed) {
@@ -599,6 +623,7 @@ export const makePiSessionRuntime = (
       setThinkingLevel,
       prompt,
       abort,
+      respondToExtensionUI,
       events: Stream.fromQueue(rawEvents),
       close,
     } satisfies PiSessionRuntimeShape;

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,6 @@
 import { assert, it } from "@effect/vitest";
 
-import { mapCodexModelCapabilities } from "./CodexProvider.ts";
+import { appendCustomCodexModels, mapCodexModelCapabilities } from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -101,4 +101,54 @@ it("uses standard routing when the catalog has no default service tier", () => {
       currentValue: "default",
     },
   ]);
+});
+
+it("adds Max to custom models that inherit a Codex reasoning selector", () => {
+  const models = appendCustomCodexModels(
+    [
+      {
+        slug: "gpt-5.4",
+        name: "GPT-5.4",
+        isCustom: false,
+        capabilities: mapCodexModelCapabilities({
+          additionalSpeedTiers: [],
+          defaultReasoningEffort: "xhigh",
+          defaultServiceTier: null,
+          description: "Test model",
+          displayName: "GPT-5.4",
+          hidden: false,
+          id: "gpt-5.4",
+          isDefault: true,
+          model: "gpt-5.4",
+          serviceTiers: [],
+          supportedReasoningEfforts: [
+            { description: "Low reasoning", reasoningEffort: "low" },
+            { description: "Medium reasoning", reasoningEffort: "medium" },
+            { description: "High reasoning", reasoningEffort: "high" },
+            { description: "Extra high reasoning", reasoningEffort: "xhigh" },
+          ],
+        }),
+      },
+    ],
+    ["gpt-5.6-terra-gwc"],
+  );
+
+  assert.deepStrictEqual(
+    models[1]?.capabilities?.optionDescriptors?.find(
+      (descriptor) => descriptor.id === "reasoningEffort",
+    ),
+    {
+      id: "reasoningEffort",
+      label: "Reasoning",
+      type: "select",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "medium", label: "Medium" },
+        { id: "high", label: "High" },
+        { id: "xhigh", label: "Extra High", isDefault: true },
+        { id: "max", label: "Max" },
+      ],
+      currentValue: "xhigh",
+    },
+  );
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -29,6 +29,7 @@ import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
   AUTH_PROBE_TIMEOUT_MS,
+  addMaxReasoningOptionForCustomModel,
   buildServerProvider,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
@@ -193,7 +194,7 @@ function parseCodexModelListResponse(
   }));
 }
 
-function appendCustomCodexModels(
+export function appendCustomCodexModels(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
 ): ReadonlyArray<ServerProviderModel> {
@@ -214,7 +215,9 @@ function appendCustomCodexModels(
       slug,
       name: slug,
       isCustom: true,
-      capabilities: fallbackCapabilities,
+      capabilities: fallbackCapabilities
+        ? addMaxReasoningOptionForCustomModel(fallbackCapabilities)
+        : null,
     });
   }
   return customEntries.length === 0 ? models : [...models, ...customEntries];

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "@effect/vitest";
-import { PiSettings, ProviderDriverKind, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import {
+  ApprovalRequestId,
+  PiSettings,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as PubSub from "effect/PubSub";
 import * as Schema from "effect/Schema";
@@ -7,6 +14,7 @@ import * as Stream from "effect/Stream";
 
 import { ProviderAdapterValidationError, type ProviderAdapterError } from "../Errors.ts";
 import type {
+  PiExtensionUiResponse,
   PiPromptInput,
   PiSessionRuntimeOptions,
   PiSessionRuntimeShape,
@@ -25,6 +33,7 @@ function makeRuntimeFactory(input?: { readonly thinkingLevels?: ReadonlyArray<st
     const modelCalls: Array<{ provider: string; modelId: string }> = [];
     const thinkingCalls: string[] = [];
     const prompts: PiPromptInput[] = [];
+    const extensionUiResponses: PiExtensionUiResponse[] = [];
     const events = yield* PubSub.unbounded<unknown>();
     let abortCount = 0;
     let closeCount = 0;
@@ -34,6 +43,7 @@ function makeRuntimeFactory(input?: { readonly thinkingLevels?: ReadonlyArray<st
       const runtime: PiSessionRuntimeShape & {
         readonly prompt: (input: PiPromptInput) => Effect.Effect<void>;
         readonly abort: () => Effect.Effect<void>;
+        readonly respondToExtensionUI: (response: PiExtensionUiResponse) => Effect.Effect<void>;
       } = {
         start: () =>
           Effect.succeed({
@@ -67,6 +77,10 @@ function makeRuntimeFactory(input?: { readonly thinkingLevels?: ReadonlyArray<st
           Effect.sync(() => {
             abortCount += 1;
           }),
+        respondToExtensionUI: (response) =>
+          Effect.sync(() => {
+            extensionUiResponses.push(response);
+          }),
         events: Stream.fromPubSub(events),
         close: Effect.sync(() => {
           closeCount += 1;
@@ -81,6 +95,7 @@ function makeRuntimeFactory(input?: { readonly thinkingLevels?: ReadonlyArray<st
       modelCalls,
       thinkingCalls,
       prompts,
+      getExtensionUiResponses: () => extensionUiResponses,
       emit: (event: unknown) => PubSub.publish(events, event).pipe(Effect.asVoid),
       getAbortCount: () => abortCount,
       getCloseCount: () => closeCount,
@@ -240,6 +255,231 @@ describe("PiAdapter", () => {
         resumeCursor: { schemaVersion: 1, sessionId: "thread-native" },
       });
       expect(started.turnId).toBeTruthy();
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("round-trips compatible Pi extension dialogs through T3 user input", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: ProviderRuntimeEvent[] = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+
+      yield* runtime.emit({
+        type: "extension_ui_request",
+        id: "dialog-confirm",
+        method: "confirm",
+        title: "Deploy release",
+        message: "Deploy this release to production?",
+      });
+      yield* runtime.emit({
+        type: "extension_ui_request",
+        id: "dialog-select",
+        method: "select",
+        title: "Choose environment",
+        options: ["Staging", "Production"],
+      });
+      yield* runtime.emit({
+        type: "extension_ui_request",
+        id: "dialog-input",
+        method: "input",
+        title: "Release summary",
+        placeholder: "Describe the release",
+      });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "user-input.requested",
+            requestId: "dialog-confirm",
+            payload: {
+              questions: [
+                {
+                  id: "dialog-confirm",
+                  header: "Deploy release",
+                  question: "Deploy this release to production?",
+                  options: [
+                    { label: "Confirm", description: "Confirm" },
+                    { label: "Cancel", description: "Cancel" },
+                  ],
+                  multiSelect: false,
+                },
+              ],
+            },
+          }),
+          expect.objectContaining({
+            type: "user-input.requested",
+            requestId: "dialog-select",
+            payload: {
+              questions: [
+                {
+                  id: "dialog-select",
+                  header: "Choose environment",
+                  question: "Choose an option.",
+                  options: [
+                    { label: "Staging", description: "Staging" },
+                    { label: "Production", description: "Production" },
+                  ],
+                  multiSelect: false,
+                },
+              ],
+            },
+          }),
+          expect.objectContaining({
+            type: "user-input.requested",
+            requestId: "dialog-input",
+            payload: {
+              questions: [
+                {
+                  id: "dialog-input",
+                  header: "Release summary",
+                  question: "Describe the release",
+                  options: [{ label: "Cancel", description: "Cancel this input request" }],
+                  cancelOptionLabel: "Cancel",
+                  multiSelect: false,
+                },
+              ],
+            },
+          }),
+        ]),
+      );
+
+      yield* adapter.respondToUserInput(THREAD_ID, ApprovalRequestId.make("dialog-confirm"), {
+        "dialog-confirm": "Confirm",
+      });
+      yield* adapter.respondToUserInput(THREAD_ID, ApprovalRequestId.make("dialog-select"), {
+        "dialog-select": "Production",
+      });
+      yield* adapter.respondToUserInput(THREAD_ID, ApprovalRequestId.make("dialog-input"), {
+        "dialog-input": { value: "Cancel" },
+      });
+      yield* Effect.yieldNow;
+
+      expect(runtime.getExtensionUiResponses()).toEqual([
+        { id: "dialog-confirm", confirmed: true },
+        { id: "dialog-select", value: "Production" },
+        { id: "dialog-input", value: "Cancel" },
+      ]);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "user-input.resolved",
+            requestId: "dialog-confirm",
+            payload: { answers: { "dialog-confirm": "Confirm" } },
+          }),
+          expect.objectContaining({
+            type: "user-input.resolved",
+            requestId: "dialog-select",
+            payload: { answers: { "dialog-select": "Production" } },
+          }),
+          expect.objectContaining({
+            type: "user-input.resolved",
+            requestId: "dialog-input",
+            payload: { answers: { "dialog-input": { value: "Cancel" } } },
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("maps selected Pi input cancellation back to the native RPC response", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      yield* runtime.emit({
+        type: "extension_ui_request",
+        id: "dialog-input-cancel",
+        method: "input",
+        title: "Release summary",
+      });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      yield* adapter.respondToUserInput(THREAD_ID, ApprovalRequestId.make("dialog-input-cancel"), {
+        "dialog-input-cancel": { cancelled: true },
+      });
+
+      expect(runtime.getExtensionUiResponses()).toEqual([
+        { id: "dialog-input-cancel", cancelled: true },
+      ]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("surfaces Pi extension UI that requires Pi's terminal interface", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: ProviderRuntimeEvent[] = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+
+      yield* runtime.emit({
+        type: "extension_ui_request",
+        id: "widget-status",
+        method: "setWidget",
+        widgetKey: "release-status",
+        widgetLines: ["Deploying..."],
+      });
+      yield* runtime.emit({
+        type: "extension_ui_request",
+        id: "editor-dialog",
+        method: "editor",
+        title: "Edit release notes",
+        prefill: "Initial notes",
+      });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "runtime.warning",
+            payload: expect.objectContaining({
+              message: "Pi extension UI 'setWidget' requires Pi's terminal interface.",
+            }),
+          }),
+          expect.objectContaining({
+            type: "runtime.warning",
+            payload: expect.objectContaining({
+              message: "Pi extension UI 'editor' requires Pi's terminal interface.",
+            }),
+          }),
+        ]),
+      );
+      expect(runtime.getExtensionUiResponses()).toEqual([{ id: "editor-dialog", cancelled: true }]);
     }).pipe(Effect.scoped),
   );
 

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -78,7 +78,7 @@ const sessionStart = (
 });
 
 describe("PiAdapter", () => {
-  it.effect("starts a native session with the T3 thread ID and applies Pi model capabilities", () =>
+  it.effect("starts Pi persistent mode with a stable T3 ID and applies model capabilities", () =>
     Effect.gen(function* () {
       const runtime = makeRuntimeFactory();
       const adapter = yield* makePiAdapter(

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -1109,4 +1109,123 @@ describe("PiAdapter", () => {
       expect(yield* second.hasSession(THREAD_ID)).toBe(false);
     }).pipe(Effect.scoped),
   );
+
+  it.effect(
+    "interrupts an accepted turn, closes Pi, and retains its transport failure in native logs",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* makeRuntimeFactory();
+        const nativeEvents: Array<{
+          readonly event?: {
+            readonly method?: string;
+            readonly payload?: unknown;
+            readonly provider?: string;
+            readonly providerThreadId?: string;
+            readonly threadId?: string;
+          };
+        }> = [];
+        const nativeThreadIds: Array<ThreadId | null> = [];
+        const adapter = yield* makePiAdapter(decodePiSettings({}), {
+          instanceId: INSTANCE_A,
+          sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+          nativeEventLogger: {
+            filePath: "memory://pi-native-events",
+            write: (event, threadId) =>
+              Effect.sync(() => {
+                nativeEvents.push(event as (typeof nativeEvents)[number]);
+                nativeThreadIds.push(threadId);
+              }),
+            close: () => Effect.void,
+          },
+          makeRuntime: runtime.factory,
+        });
+        const events: ProviderRuntimeEvent[] = [];
+        yield* adapter.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkScoped,
+        );
+        yield* adapter.startSession(sessionStart(INSTANCE_A));
+        yield* Effect.yieldNow;
+        const turn = yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "Persist this accepted prompt exactly once.",
+          attachments: [],
+        });
+
+        yield* runtime.emit({
+          type: "pi_rpc_transport_failure",
+          operation: "process-exit",
+          detail: "Pi RPC process exited with code 23.",
+        });
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        expect(events).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "turn.completed",
+              turnId: turn.turnId,
+              payload: expect.objectContaining({
+                state: "interrupted",
+                errorMessage: "Pi RPC process exited with code 23.",
+              }),
+            }),
+            expect.objectContaining({
+              type: "runtime.error",
+              turnId: turn.turnId,
+              payload: expect.objectContaining({
+                class: "transport_error",
+                message: "Pi RPC process exited with code 23.",
+              }),
+            }),
+            expect.objectContaining({
+              type: "session.exited",
+              payload: {
+                reason: "Pi RPC process exited with code 23.",
+                recoverable: true,
+                exitKind: "error",
+              },
+            }),
+          ]),
+        );
+        expect(runtime.getCloseCount()).toBe(1);
+        expect(yield* adapter.hasSession(THREAD_ID)).toBe(false);
+        expect(yield* adapter.listSessions()).toEqual([]);
+
+        const replayAttempt = yield* adapter
+          .sendTurn({
+            threadId: THREAD_ID,
+            input: "This must not be replayed automatically.",
+            attachments: [],
+          })
+          .pipe(Effect.flip);
+        expect(replayAttempt._tag).toBe("ProviderAdapterSessionNotFoundError");
+        expect(runtime.prompts).toEqual([
+          { message: "Persist this accepted prompt exactly once." },
+        ]);
+        expect(nativeEvents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: expect.objectContaining({
+                provider: "pi",
+                providerThreadId: THREAD_ID,
+                threadId: THREAD_ID,
+                method: "pi.rpc.transport.process-exit",
+                payload: {
+                  type: "pi_rpc_transport_failure",
+                  operation: "process-exit",
+                  detail: "Pi RPC process exited with code 23.",
+                },
+              }),
+            }),
+          ]),
+        );
+        expect(nativeThreadIds).toEqual([THREAD_ID]);
+      }).pipe(Effect.scoped),
+  );
 });

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "@effect/vitest";
+import { PiSettings, ProviderDriverKind, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import { ProviderAdapterValidationError, type ProviderAdapterError } from "../Errors.ts";
+import type {
+  PiSessionRuntimeOptions,
+  PiSessionRuntimeShape,
+} from "../Drivers/PiSessionRuntime.ts";
+import { makePiAdapter } from "./PiAdapter.ts";
+
+const decodePiSettings = Schema.decodeSync(PiSettings);
+const PI = ProviderDriverKind.make("pi");
+const INSTANCE_A = ProviderInstanceId.make("pi_personal");
+const INSTANCE_B = ProviderInstanceId.make("pi_work");
+const THREAD_ID = ThreadId.make("thread-native");
+
+function makeRuntimeFactory(input?: { readonly thinkingLevels?: ReadonlyArray<string> }) {
+  const options: PiSessionRuntimeOptions[] = [];
+  const modelCalls: Array<{ provider: string; modelId: string }> = [];
+  const thinkingCalls: string[] = [];
+  let closeCount = 0;
+
+  const factory = (runtimeOptions: PiSessionRuntimeOptions) => {
+    options.push(runtimeOptions);
+    const runtime: PiSessionRuntimeShape = {
+      start: () =>
+        Effect.succeed({
+          sessionId: runtimeOptions.sessionId ?? "probe",
+          sessionFile: "/tmp/pi-session.jsonl",
+          model: { provider: "custom", id: "starter", name: "Starter" },
+          thinkingLevel: "high",
+        }),
+      getState: () =>
+        Effect.succeed({
+          sessionId: runtimeOptions.sessionId ?? "probe",
+          model: { provider: "custom", id: "team/coder", name: "Team Coder" },
+          thinkingLevel: thinkingCalls.at(-1) ?? "high",
+        }),
+      getAvailableModels: () => Effect.succeed([]),
+      setModel: (model) =>
+        Effect.sync(() => {
+          modelCalls.push(model);
+        }),
+      getAvailableThinkingLevels: () =>
+        Effect.succeed(input?.thinkingLevels ?? ["off", "high", "max"]),
+      setThinkingLevel: (level) =>
+        Effect.sync(() => {
+          thinkingCalls.push(level);
+        }),
+      events: Stream.empty,
+      close: Effect.sync(() => {
+        closeCount += 1;
+      }),
+    };
+    return Effect.succeed(runtime);
+  };
+
+  return { factory, options, modelCalls, thinkingCalls, getCloseCount: () => closeCount };
+}
+
+const sessionStart = (
+  instanceId: ProviderInstanceId,
+  options?: ReadonlyArray<{ id: string; value: string }>,
+) => ({
+  threadId: THREAD_ID,
+  provider: PI,
+  providerInstanceId: instanceId,
+  cwd: "/workspace/project",
+  runtimeMode: "full-access" as const,
+  modelSelection: {
+    instanceId,
+    model: "custom/team%2Fcoder",
+    ...(options ? { options } : {}),
+  },
+});
+
+describe("PiAdapter", () => {
+  it.effect("starts a native session with the T3 thread ID and applies Pi model capabilities", () =>
+    Effect.gen(function* () {
+      const runtime = makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(
+        decodePiSettings({ binaryPath: "pi-custom", configDirectory: "/tmp/pi-config" }),
+        {
+          instanceId: INSTANCE_A,
+          sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+          environment: { EXAMPLE: "value" },
+          makeRuntime: runtime.factory,
+        },
+      );
+
+      const session = yield* adapter.startSession(
+        sessionStart(INSTANCE_A, [{ id: "reasoningEffort", value: "max" }]),
+      );
+
+      expect(runtime.options).toEqual([
+        {
+          binaryPath: "pi-custom",
+          configDirectory: "/tmp/pi-config",
+          launchArgs: "",
+          cwd: "/workspace/project",
+          environment: { EXAMPLE: "value" },
+          sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+          sessionId: "thread-native",
+        },
+      ]);
+      expect(runtime.modelCalls).toEqual([{ provider: "custom", modelId: "team/coder" }]);
+      expect(runtime.thinkingCalls).toEqual(["max"]);
+      expect(session).toMatchObject({
+        provider: "pi",
+        providerInstanceId: INSTANCE_A,
+        threadId: THREAD_ID,
+        model: "custom/team%2Fcoder",
+        resumeCursor: { schemaVersion: 1, sessionId: "thread-native" },
+      });
+
+      yield* adapter.stopSession(THREAD_ID);
+      expect(runtime.getCloseCount()).toBe(1);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("rejects a session start routed to another Pi runtime instance", () =>
+    Effect.gen(function* () {
+      const runtime = makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+
+      const error = yield* adapter.startSession(sessionStart(INSTANCE_B)).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ProviderAdapterValidationError);
+      expect((error as ProviderAdapterError).message).toContain("Expected Pi runtime instance");
+      expect(runtime.options).toEqual([]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("rejects a thinking level Pi did not report for the selected model", () =>
+    Effect.gen(function* () {
+      const runtime = makeRuntimeFactory({ thinkingLevels: ["off", "high"] });
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+
+      const error = yield* adapter
+        .startSession(sessionStart(INSTANCE_A, [{ id: "reasoningEffort", value: "max" }]))
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ProviderAdapterValidationError);
+      expect((error as ProviderAdapterError).message).toContain(
+        "does not support thinking level 'max'",
+      );
+      expect(runtime.thinkingCalls).toEqual([]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("switches the live Pi session through native model and thinking RPC commands", () =>
+    Effect.gen(function* () {
+      const runtime = makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+
+      yield* adapter
+        .sendTurn({
+          threadId: THREAD_ID,
+          input: "switch model before prompt delivery",
+          attachments: [],
+          modelSelection: {
+            instanceId: INSTANCE_A,
+            model: "custom/team%2Fcoder",
+            options: [{ id: "reasoningEffort", value: "max" }],
+          },
+        })
+        .pipe(Effect.flip);
+
+      expect(runtime.modelCalls).toEqual([
+        { provider: "custom", modelId: "team/coder" },
+        { provider: "custom", modelId: "team/coder" },
+      ]);
+      expect(runtime.thinkingCalls).toEqual(["max"]);
+      expect((yield* adapter.listSessions())[0]?.model).toBe("custom/team%2Fcoder");
+      expect(adapter.capabilities.sessionModelSwitch).toBe("in-session");
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("restarts the same native session only inside its originating runtime instance", () =>
+    Effect.gen(function* () {
+      const firstRuntime = makeRuntimeFactory();
+      const secondRuntime = makeRuntimeFactory();
+      const first = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: firstRuntime.factory,
+      });
+      const second = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_B,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_work",
+        makeRuntime: secondRuntime.factory,
+      });
+
+      yield* first.startSession(sessionStart(INSTANCE_A));
+      yield* first.stopSession(THREAD_ID);
+      yield* first.startSession(sessionStart(INSTANCE_A));
+
+      expect(firstRuntime.options.map((entry) => entry.sessionId)).toEqual([
+        "thread-native",
+        "thread-native",
+      ]);
+      expect(firstRuntime.options.map((entry) => entry.sessionDirectory)).toEqual([
+        "/tmp/t3-pi-sessions/pi_personal",
+        "/tmp/t3-pi-sessions/pi_personal",
+      ]);
+      expect(secondRuntime.options).toEqual([]);
+      expect(yield* second.hasSession(THREAD_ID)).toBe(false);
+    }).pipe(Effect.scoped),
+  );
+});

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
 import { PiSettings, ProviderDriverKind, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as PubSub from "effect/PubSub";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
 import { ProviderAdapterValidationError, type ProviderAdapterError } from "../Errors.ts";
 import type {
+  PiPromptInput,
   PiSessionRuntimeOptions,
   PiSessionRuntimeShape,
 } from "../Drivers/PiSessionRuntime.ts";
@@ -18,47 +20,72 @@ const INSTANCE_B = ProviderInstanceId.make("pi_work");
 const THREAD_ID = ThreadId.make("thread-native");
 
 function makeRuntimeFactory(input?: { readonly thinkingLevels?: ReadonlyArray<string> }) {
-  const options: PiSessionRuntimeOptions[] = [];
-  const modelCalls: Array<{ provider: string; modelId: string }> = [];
-  const thinkingCalls: string[] = [];
-  let closeCount = 0;
+  return Effect.gen(function* () {
+    const options: PiSessionRuntimeOptions[] = [];
+    const modelCalls: Array<{ provider: string; modelId: string }> = [];
+    const thinkingCalls: string[] = [];
+    const prompts: PiPromptInput[] = [];
+    const events = yield* PubSub.unbounded<unknown>();
+    let abortCount = 0;
+    let closeCount = 0;
 
-  const factory = (runtimeOptions: PiSessionRuntimeOptions) => {
-    options.push(runtimeOptions);
-    const runtime: PiSessionRuntimeShape = {
-      start: () =>
-        Effect.succeed({
-          sessionId: runtimeOptions.sessionId ?? "probe",
-          sessionFile: "/tmp/pi-session.jsonl",
-          model: { provider: "custom", id: "starter", name: "Starter" },
-          thinkingLevel: "high",
+    const factory = (runtimeOptions: PiSessionRuntimeOptions) => {
+      options.push(runtimeOptions);
+      const runtime: PiSessionRuntimeShape & {
+        readonly prompt: (input: PiPromptInput) => Effect.Effect<void>;
+        readonly abort: () => Effect.Effect<void>;
+      } = {
+        start: () =>
+          Effect.succeed({
+            sessionId: runtimeOptions.sessionId ?? "probe",
+            sessionFile: "/tmp/pi-session.jsonl",
+            model: { provider: "custom", id: "starter", name: "Starter" },
+            thinkingLevel: "high",
+          }),
+        getState: () =>
+          Effect.succeed({
+            sessionId: runtimeOptions.sessionId ?? "probe",
+            model: { provider: "custom", id: "team/coder", name: "Team Coder" },
+            thinkingLevel: thinkingCalls.at(-1) ?? "high",
+          }),
+        getAvailableModels: () => Effect.succeed([]),
+        setModel: (model) =>
+          Effect.sync(() => {
+            modelCalls.push(model);
+          }),
+        getAvailableThinkingLevels: () =>
+          Effect.succeed(input?.thinkingLevels ?? ["off", "high", "max"]),
+        setThinkingLevel: (level) =>
+          Effect.sync(() => {
+            thinkingCalls.push(level);
+          }),
+        prompt: (prompt) =>
+          Effect.sync(() => {
+            prompts.push(prompt);
+          }),
+        abort: () =>
+          Effect.sync(() => {
+            abortCount += 1;
+          }),
+        events: Stream.fromPubSub(events),
+        close: Effect.sync(() => {
+          closeCount += 1;
         }),
-      getState: () =>
-        Effect.succeed({
-          sessionId: runtimeOptions.sessionId ?? "probe",
-          model: { provider: "custom", id: "team/coder", name: "Team Coder" },
-          thinkingLevel: thinkingCalls.at(-1) ?? "high",
-        }),
-      getAvailableModels: () => Effect.succeed([]),
-      setModel: (model) =>
-        Effect.sync(() => {
-          modelCalls.push(model);
-        }),
-      getAvailableThinkingLevels: () =>
-        Effect.succeed(input?.thinkingLevels ?? ["off", "high", "max"]),
-      setThinkingLevel: (level) =>
-        Effect.sync(() => {
-          thinkingCalls.push(level);
-        }),
-      events: Stream.empty,
-      close: Effect.sync(() => {
-        closeCount += 1;
-      }),
+      };
+      return Effect.succeed(runtime);
     };
-    return Effect.succeed(runtime);
-  };
 
-  return { factory, options, modelCalls, thinkingCalls, getCloseCount: () => closeCount };
+    return {
+      factory,
+      options,
+      modelCalls,
+      thinkingCalls,
+      prompts,
+      emit: (event: unknown) => PubSub.publish(events, event).pipe(Effect.asVoid),
+      getAbortCount: () => abortCount,
+      getCloseCount: () => closeCount,
+    };
+  });
 }
 
 const sessionStart = (
@@ -80,7 +107,7 @@ const sessionStart = (
 describe("PiAdapter", () => {
   it.effect("starts Pi persistent mode with a stable T3 ID and applies model capabilities", () =>
     Effect.gen(function* () {
-      const runtime = makeRuntimeFactory();
+      const runtime = yield* makeRuntimeFactory();
       const adapter = yield* makePiAdapter(
         decodePiSettings({ binaryPath: "pi-custom", configDirectory: "/tmp/pi-config" }),
         {
@@ -123,7 +150,7 @@ describe("PiAdapter", () => {
 
   it.effect("rejects a session start routed to another Pi runtime instance", () =>
     Effect.gen(function* () {
-      const runtime = makeRuntimeFactory();
+      const runtime = yield* makeRuntimeFactory();
       const adapter = yield* makePiAdapter(decodePiSettings({}), {
         instanceId: INSTANCE_A,
         sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
@@ -140,7 +167,7 @@ describe("PiAdapter", () => {
 
   it.effect("rejects a thinking level Pi did not report for the selected model", () =>
     Effect.gen(function* () {
-      const runtime = makeRuntimeFactory({ thinkingLevels: ["off", "high"] });
+      const runtime = yield* makeRuntimeFactory({ thinkingLevels: ["off", "high"] });
       const adapter = yield* makePiAdapter(decodePiSettings({}), {
         instanceId: INSTANCE_A,
         sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
@@ -161,7 +188,7 @@ describe("PiAdapter", () => {
 
   it.effect("switches the live Pi session through native model and thinking RPC commands", () =>
     Effect.gen(function* () {
-      const runtime = makeRuntimeFactory();
+      const runtime = yield* makeRuntimeFactory();
       const adapter = yield* makePiAdapter(decodePiSettings({}), {
         instanceId: INSTANCE_A,
         sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
@@ -169,33 +196,652 @@ describe("PiAdapter", () => {
       });
       yield* adapter.startSession(sessionStart(INSTANCE_A));
 
-      yield* adapter
-        .sendTurn({
-          threadId: THREAD_ID,
-          input: "switch model before prompt delivery",
-          attachments: [],
-          modelSelection: {
-            instanceId: INSTANCE_A,
-            model: "custom/team%2Fcoder",
-            options: [{ id: "reasoningEffort", value: "max" }],
-          },
-        })
-        .pipe(Effect.flip);
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "switch model before prompt delivery",
+        attachments: [],
+        modelSelection: {
+          instanceId: INSTANCE_A,
+          model: "custom/team%2Fcoder",
+          options: [{ id: "reasoningEffort", value: "max" }],
+        },
+      });
 
       expect(runtime.modelCalls).toEqual([
         { provider: "custom", modelId: "team/coder" },
         { provider: "custom", modelId: "team/coder" },
       ]);
       expect(runtime.thinkingCalls).toEqual(["max"]);
+      expect(runtime.prompts).toEqual([{ message: "switch model before prompt delivery" }]);
       expect((yield* adapter.listSessions())[0]?.model).toBe("custom/team%2Fcoder");
       expect(adapter.capabilities.sessionModelSwitch).toBe("in-session");
     }).pipe(Effect.scoped),
   );
 
+  it.effect("delivers a native Pi prompt and starts a normal T3 turn", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+
+      const started = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Inspect the project",
+        attachments: [],
+      });
+
+      expect(runtime.prompts).toEqual([{ message: "Inspect the project" }]);
+      expect(started).toMatchObject({
+        threadId: THREAD_ID,
+        resumeCursor: { schemaVersion: 1, sessionId: "thread-native" },
+      });
+      expect(started.turnId).toBeTruthy();
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("streams Pi text into a completed T3 turn", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      const turn = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Say hello",
+        attachments: [],
+      });
+
+      yield* runtime.emit({ type: "message_start", message: { role: "assistant" } });
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "Hello from Pi" },
+      });
+      yield* runtime.emit({ type: "message_end", message: { role: "assistant" } });
+      yield* runtime.emit({ type: "agent_settled" });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "turn.started", turnId: turn.turnId }),
+          expect.objectContaining({
+            type: "content.delta",
+            turnId: turn.turnId,
+            payload: expect.objectContaining({
+              streamKind: "assistant_text",
+              delta: "Hello from Pi",
+            }),
+          }),
+          expect.objectContaining({
+            type: "turn.completed",
+            turnId: turn.turnId,
+            payload: { state: "completed" },
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("maps Pi thinking deltas into visible work-log progress", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Think through the implementation",
+        attachments: [],
+      });
+
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: { type: "thinking_start", contentIndex: 0 },
+      });
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          contentIndex: 0,
+          delta: "First inspect the session state.",
+        },
+      });
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: { type: "thinking_end", contentIndex: 0 },
+      });
+      yield* runtime.emit({ type: "agent_settled" });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "task.started",
+            payload: expect.objectContaining({ description: "Thinking" }),
+          }),
+          expect.objectContaining({
+            type: "task.progress",
+            payload: expect.objectContaining({
+              description: "Thinking",
+              summary: "First inspect the session state.",
+            }),
+          }),
+          expect.objectContaining({
+            type: "task.completed",
+            payload: expect.objectContaining({
+              status: "completed",
+              summary: "First inspect the session state.",
+            }),
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("maps Pi tool execution progress and results into work-log lifecycle events", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Run the status command",
+        attachments: [],
+      });
+
+      yield* runtime.emit({
+        type: "tool_execution_start",
+        toolCallId: "call-status",
+        toolName: "bash",
+        args: { command: "git status --short" },
+      });
+      yield* runtime.emit({
+        type: "tool_execution_update",
+        toolCallId: "call-status",
+        toolName: "bash",
+        args: { command: "git status --short" },
+        partialResult: { content: [{ type: "text", text: "M package.json" }] },
+      });
+      yield* runtime.emit({
+        type: "tool_execution_end",
+        toolCallId: "call-status",
+        toolName: "bash",
+        result: { content: [{ type: "text", text: "M package.json\n" }] },
+        isError: false,
+      });
+      yield* runtime.emit({ type: "agent_settled" });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "item.started",
+            payload: expect.objectContaining({
+              itemType: "command_execution",
+              status: "inProgress",
+              title: "bash",
+              data: expect.objectContaining({
+                toolCallId: "call-status",
+                command: "git status --short",
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "item.updated",
+            payload: expect.objectContaining({
+              itemType: "command_execution",
+              status: "inProgress",
+              detail: "M package.json",
+            }),
+          }),
+          expect.objectContaining({
+            type: "item.completed",
+            payload: expect.objectContaining({
+              itemType: "command_execution",
+              status: "completed",
+              detail: "M package.json",
+            }),
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("maps Pi constructed tool calls before native execution begins", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Construct a status command",
+        attachments: [],
+      });
+
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: {
+          type: "toolcall_start",
+          contentIndex: 0,
+          id: "call-constructed-status",
+          toolName: "bash",
+        },
+      });
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: {
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: '{"command":"git status --short"}',
+        },
+      });
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: {
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: {
+            type: "toolCall",
+            id: "call-constructed-status",
+            name: "bash",
+            arguments: { command: "git status --short" },
+          },
+        },
+      });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "item.started",
+            payload: expect.objectContaining({
+              itemType: "command_execution",
+              status: "inProgress",
+              title: "bash",
+              data: expect.objectContaining({ toolCallId: "call-constructed-status" }),
+            }),
+            raw: expect.objectContaining({
+              messageType: "message_update",
+              payload: expect.objectContaining({
+                assistantMessageEvent: expect.objectContaining({ type: "toolcall_start" }),
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "item.updated",
+            payload: expect.objectContaining({
+              itemType: "command_execution",
+              status: "inProgress",
+              title: "bash",
+              detail: "git status --short",
+              data: expect.objectContaining({
+                toolCallId: "call-constructed-status",
+                command: "git status --short",
+              }),
+            }),
+            raw: expect.objectContaining({
+              messageType: "message_update",
+              payload: expect.objectContaining({
+                assistantMessageEvent: expect.objectContaining({ type: "toolcall_end" }),
+              }),
+            }),
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("maps Pi terminal response errors into an errored work log and failed turn", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      const turn = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Call the unavailable model",
+        attachments: [],
+      });
+
+      yield* runtime.emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: {
+          type: "error",
+          reason: "error",
+          error: { role: "assistant", errorMessage: "Provider rate limit exceeded" },
+        },
+      });
+      yield* runtime.emit({ type: "agent_settled" });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "runtime.error",
+            turnId: turn.turnId,
+            payload: expect.objectContaining({ message: "Provider rate limit exceeded" }),
+          }),
+          expect.objectContaining({
+            type: "turn.completed",
+            turnId: turn.turnId,
+            payload: expect.objectContaining({
+              state: "failed",
+              errorMessage: "Provider rate limit exceeded",
+            }),
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect(
+    "queues a second Pi prompt through native follow-up behavior while work is active",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* makeRuntimeFactory();
+        const adapter = yield* makePiAdapter(decodePiSettings({}), {
+          instanceId: INSTANCE_A,
+          sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+          makeRuntime: runtime.factory,
+        });
+        yield* adapter.startSession(sessionStart(INSTANCE_A));
+
+        const first = yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "First task",
+          attachments: [],
+        });
+        const queued = yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "Follow up after the first task",
+          attachments: [],
+        });
+
+        expect(queued.turnId).toBe(first.turnId);
+        expect(runtime.prompts).toEqual([
+          { message: "First task" },
+          {
+            message: "Follow up after the first task",
+            streamingBehavior: "followUp",
+          },
+        ]);
+      }).pipe(Effect.scoped),
+  );
+
+  it.effect("maps Pi queueing, compaction, and retries into visible lifecycle work", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Continue with queued work",
+        attachments: [],
+      });
+
+      yield* runtime.emit({
+        type: "queue_update",
+        steering: ["Focus on tests"],
+        followUp: ["Summarize afterwards"],
+      });
+      yield* runtime.emit({ type: "compaction_start", reason: "threshold" });
+      yield* runtime.emit({
+        type: "auto_retry_start",
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 500,
+        errorMessage: "Temporary overload",
+      });
+      yield* runtime.emit({ type: "auto_retry_end", success: true, attempt: 1 });
+      yield* runtime.emit({
+        type: "compaction_end",
+        reason: "threshold",
+        result: { summary: "Condensed earlier context" },
+        aborted: false,
+        willRetry: false,
+      });
+      yield* runtime.emit({ type: "queue_update", steering: [], followUp: [] });
+      yield* runtime.emit({ type: "agent_settled" });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "task.progress",
+            payload: expect.objectContaining({
+              description: "Queued work",
+              summary: "1 steering message and 1 follow-up message queued",
+            }),
+          }),
+          expect.objectContaining({
+            type: "item.started",
+            payload: expect.objectContaining({
+              itemType: "context_compaction",
+              title: "Compacting conversation",
+            }),
+          }),
+          expect.objectContaining({
+            type: "task.started",
+            payload: expect.objectContaining({
+              taskType: "retry",
+              description: "Retrying Pi request",
+            }),
+          }),
+          expect.objectContaining({
+            type: "task.completed",
+            payload: expect.objectContaining({ status: "completed" }),
+          }),
+          expect.objectContaining({
+            type: "item.completed",
+            payload: expect.objectContaining({
+              itemType: "context_compaction",
+              status: "completed",
+              detail: "Condensed earlier context",
+            }),
+          }),
+        ]),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("uses Pi's native abort command and marks the active turn interrupted", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        makeRuntime: runtime.factory,
+      });
+      const events: Array<{ readonly type: string; readonly payload: unknown }> = [];
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        ),
+        Effect.forkScoped,
+      );
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+      yield* Effect.yieldNow;
+      const turn = yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "Start a long task",
+        attachments: [],
+      });
+
+      yield* adapter.interruptTurn(THREAD_ID, turn.turnId);
+      yield* runtime.emit({ type: "agent_settled" });
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+
+      expect(runtime.getAbortCount()).toBe(1);
+      const interruptedTurns = events.filter(
+        (event) =>
+          event.type === "turn.completed" &&
+          event.payload !== null &&
+          typeof event.payload === "object" &&
+          "state" in event.payload &&
+          event.payload.state === "interrupted",
+      );
+      expect(interruptedTurns).toHaveLength(1);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("delivers persisted image attachments through Pi's native prompt shape", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeRuntimeFactory();
+      const loadImageAttachment = vi.fn((attachment: { readonly mimeType: string }) =>
+        Effect.succeed({
+          type: "image" as const,
+          data: "aW1hZ2UtYnl0ZXM=",
+          mimeType: attachment.mimeType,
+        }),
+      );
+      const adapter = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: INSTANCE_A,
+        sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",
+        loadImageAttachment,
+        makeRuntime: runtime.factory,
+      });
+      yield* adapter.startSession(sessionStart(INSTANCE_A));
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "What is in this image?",
+        attachments: [
+          {
+            type: "image",
+            id: "thread-native-550e8400-e29b-41d4-a716-446655440000",
+            name: "diagram.png",
+            mimeType: "image/png",
+            sizeBytes: 11,
+          },
+        ],
+      });
+
+      expect(loadImageAttachment).toHaveBeenCalledTimes(1);
+      expect(runtime.prompts).toEqual([
+        {
+          message: "What is in this image?",
+          images: [
+            {
+              type: "image",
+              data: "aW1hZ2UtYnl0ZXM=",
+              mimeType: "image/png",
+            },
+          ],
+        },
+      ]);
+    }).pipe(Effect.scoped),
+  );
+
   it.effect("restarts the same native session only inside its originating runtime instance", () =>
     Effect.gen(function* () {
-      const firstRuntime = makeRuntimeFactory();
-      const secondRuntime = makeRuntimeFactory();
+      const firstRuntime = yield* makeRuntimeFactory();
+      const secondRuntime = yield* makeRuntimeFactory();
       const first = yield* makePiAdapter(decodePiSettings({}), {
         instanceId: INSTANCE_A,
         sessionDirectory: "/tmp/t3-pi-sessions/pi_personal",

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -37,12 +37,16 @@ import {
 } from "../Errors.ts";
 import { parsePiModelSlug, makePiModelSlug } from "../Drivers/PiModels.ts";
 import {
+  isPiRpcTransportFailureEvent,
+  isPiSessionRuntimeTransportError,
   type PiPromptImage,
+  type PiRpcTransportFailureEvent,
   type PiSessionRuntimeError,
   type PiSessionRuntimeOptions,
   type PiSessionRuntimeShape,
 } from "../Drivers/PiSessionRuntime.ts";
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import type { EventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
 const PROVIDER = ProviderDriverKind.make("pi");
 const UNSUPPORTED_OPERATION_MESSAGE =
@@ -60,6 +64,8 @@ export interface PiAdapterOptions<R = never> {
   readonly instanceId: ProviderInstanceId;
   readonly sessionDirectory: string;
   readonly environment?: NodeJS.ProcessEnv | undefined;
+  /** Retains raw Pi RPC events and transport failures in provider diagnostics. */
+  readonly nativeEventLogger?: EventNdjsonLogger | undefined;
   /** Resolves persisted T3 image attachments into Pi's native prompt images. */
   readonly loadImageAttachment?: PiImageAttachmentLoader | undefined;
   readonly makeRuntime: PiRuntimeFactory<R>;
@@ -515,6 +521,48 @@ export function makePiAdapter<R>(
       messageType,
       payload: event,
     });
+    const piNativeEventMethod = (event: unknown) => {
+      if (isPiRpcTransportFailureEvent(event)) {
+        return `pi.rpc.transport.${event.operation}`;
+      }
+      return `pi.rpc.${piEventType(event) ?? "unknown"}`;
+    };
+    const writeNativePiEvent = Effect.fn("PiAdapter.writeNativePiEvent")(function* (
+      context: PiAdapterSessionContext,
+      event: unknown,
+    ) {
+      if (!options.nativeEventLogger) {
+        return;
+      }
+      const observedAt = DateTime.formatIso(yield* DateTime.now);
+      yield* options.nativeEventLogger
+        .write(
+          {
+            observedAt,
+            event: {
+              id: NodeCrypto.randomUUID(),
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method: piNativeEventMethod(event),
+              threadId: context.threadId,
+              providerThreadId: context.threadId,
+              ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+              payload: event,
+            },
+          },
+          context.threadId,
+        )
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("Failed to write native Pi RPC event log.", {
+              cause,
+              threadId: context.threadId,
+              method: piNativeEventMethod(event),
+            }),
+          ),
+        );
+    });
     const newSyntheticItemId = (context: PiAdapterSessionContext, kind: string) => {
       context.nextSyntheticItemId += 1;
       return RuntimeItemId.make(
@@ -608,6 +656,10 @@ export function makePiAdapter<R>(
     const mapPiRuntimeEvent = (context: PiAdapterSessionContext, raw: unknown) =>
       Effect.gen(function* () {
         if (context.stopped) {
+          return;
+        }
+        if (isPiRpcTransportFailureEvent(raw)) {
+          yield* handlePiTransportFailure(context, raw);
           return;
         }
         const type = piEventType(raw);
@@ -1441,25 +1493,81 @@ export function makePiAdapter<R>(
         }
       });
 
+    const detachStoppedSession = (context: PiAdapterSessionContext) => {
+      context.stopped = true;
+      context.pendingExtensionDialogs.clear();
+      if (sessions.get(context.threadId) === context) {
+        sessions.delete(context.threadId);
+      }
+    };
+
+    const releaseSessionResources = (context: PiAdapterSessionContext) =>
+      context.runtime.close.pipe(
+        Effect.ignore,
+        Effect.andThen(Scope.close(context.scope, Exit.void).pipe(Effect.ignore)),
+      );
+
     const stopSessionInternal = (context: PiAdapterSessionContext): Effect.Effect<void> =>
       Effect.suspend(() => {
         if (context.stopped) {
           return Effect.void;
         }
-        context.stopped = true;
-        context.pendingExtensionDialogs.clear();
-        return context.runtime.close.pipe(
-          Effect.ignore,
-          Effect.andThen(Scope.close(context.scope, Exit.void).pipe(Effect.ignore)),
-          Effect.andThen(
-            Effect.sync(() => {
-              if (sessions.get(context.threadId) === context) {
-                sessions.delete(context.threadId);
-              }
-            }),
-          ),
-        );
+        detachStoppedSession(context);
+        return releaseSessionResources(context);
       });
+
+    const handlePiTransportFailure = Effect.fn("PiAdapter.handlePiTransportFailure")(function* (
+      context: PiAdapterSessionContext,
+      failure: PiRpcTransportFailureEvent,
+    ) {
+      if (context.stopped) {
+        return;
+      }
+      const turnId = context.activeTurnId;
+      // Claim the session before emitting lifecycle events. This prevents a
+      // concurrent stop from closing this event fiber and dropping the
+      // interruption/diagnostic sequence below.
+      detachStoppedSession(context);
+      // A lost transport leaves Pi's last command outcome unknowable. Never
+      // reinterpret a prior terminal hint as a completed/failed turn: the
+      // safe T3 outcome is interruption and explicit user continuation.
+      context.terminalOutcome = undefined;
+      if (turnId) {
+        yield* completeActiveTurn(
+          context,
+          failure,
+          "pi_rpc_transport_failure",
+          "interrupted",
+          failure.detail,
+        );
+      }
+      yield* publishRuntimeEvent({
+        type: "runtime.error",
+        ...(yield* makeEventStamp()),
+        provider: PROVIDER,
+        threadId: context.threadId,
+        ...(turnId ? { turnId } : {}),
+        payload: {
+          message: failure.detail,
+          class: "transport_error",
+          detail: { operation: failure.operation },
+        },
+        raw: rawPiEvent(failure, "pi_rpc_transport_failure"),
+      });
+      yield* publishRuntimeEvent({
+        type: "session.exited",
+        ...(yield* makeEventStamp()),
+        provider: PROVIDER,
+        threadId: context.threadId,
+        payload: {
+          reason: failure.detail,
+          recoverable: true,
+          exitKind: "error",
+        },
+        raw: rawPiEvent(failure, "pi_rpc_transport_failure"),
+      });
+      yield* releaseSessionResources(context);
+    });
 
     const requireSession = (
       threadId: ThreadId,
@@ -1621,8 +1729,26 @@ export function makePiAdapter<R>(
           };
           sessions.set(input.threadId, context);
           yield* Stream.runForEach(runtime.events, (event) =>
-            mapPiRuntimeEvent(context, event),
+            writeNativePiEvent(context, event).pipe(
+              Effect.andThen(mapPiRuntimeEvent(context, event)),
+            ),
           ).pipe(
+            Effect.exit,
+            Effect.flatMap((exit) => {
+              if (context.stopped) {
+                return Effect.void;
+              }
+              const failure = {
+                type: "pi_rpc_transport_failure" as const,
+                operation: "event-stream",
+                detail: Exit.isSuccess(exit)
+                  ? "Pi RPC event stream ended unexpectedly."
+                  : "Pi RPC event stream failed unexpectedly.",
+              };
+              return writeNativePiEvent(context, failure).pipe(
+                Effect.andThen(mapPiRuntimeEvent(context, failure)),
+              );
+            }),
             Effect.catchCause((cause) =>
               Effect.logWarning("Failed to map Pi RPC runtime event.", {
                 cause,
@@ -1690,9 +1816,8 @@ export function makePiAdapter<R>(
                 ...(activeTurnId ? { streamingBehavior: "followUp" as const } : {}),
               })
               .pipe(
-                Effect.mapError((error) => runtimeRequestError("prompt", error)),
                 Effect.tapError((error) =>
-                  activeTurnId
+                  activeTurnId || isPiSessionRuntimeTransportError(error)
                     ? Effect.void
                     : completeActiveTurn(
                         context,
@@ -1702,6 +1827,7 @@ export function makePiAdapter<R>(
                         error.message,
                       ),
                 ),
+                Effect.mapError((error) => runtimeRequestError("prompt", error)),
               );
             return {
               threadId: input.threadId,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -224,6 +224,9 @@ export function makePiAdapter<R>(
           const state = yield* runtime
             .start()
             .pipe(Effect.mapError((error) => runtimeProcessError(input.threadId, error)));
+          // Pi allocates the persistent native session identity/path at
+          // startup but flushes its session file lazily while persisting the
+          // first accepted prompt's turn. Prompt delivery owns that flow.
           const initialModel = state.model
             ? makePiModelSlug({ provider: state.model.provider, modelId: state.model.id })
             : undefined;

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1,18 +1,29 @@
+import * as NodeCrypto from "node:crypto";
+
 import {
+  type ChatImageAttachment,
+  EventId,
   type ModelSelection,
   type PiSettings,
   ProviderDriverKind,
   type ProviderInstanceId,
+  type ProviderRuntimeEvent,
   type ProviderSession,
+  RuntimeItemId,
+  RuntimeTaskId,
   type ThreadId,
+  TurnId,
 } from "@t3tools/contracts";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Exit from "effect/Exit";
+import * as PubSub from "effect/PubSub";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import {
   ProviderAdapterProcessError,
   ProviderAdapterRequestError,
@@ -22,6 +33,7 @@ import {
 } from "../Errors.ts";
 import { parsePiModelSlug, makePiModelSlug } from "../Drivers/PiModels.ts";
 import {
+  type PiPromptImage,
   type PiSessionRuntimeError,
   type PiSessionRuntimeOptions,
   type PiSessionRuntimeShape,
@@ -29,8 +41,6 @@ import {
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 
 const PROVIDER = ProviderDriverKind.make("pi");
-const TURN_DELIVERY_MESSAGE =
-  "Pi prompt delivery is not enabled until conversation streaming support is installed.";
 const UNSUPPORTED_OPERATION_MESSAGE =
   "This Pi operation is not available until conversation controls are installed.";
 
@@ -38,11 +48,53 @@ export type PiRuntimeFactory<R = never> = (
   options: PiSessionRuntimeOptions,
 ) => Effect.Effect<PiSessionRuntimeShape, PiSessionRuntimeError, R | Scope.Scope>;
 
+export type PiImageAttachmentLoader = (
+  attachment: ChatImageAttachment,
+) => Effect.Effect<PiPromptImage, ProviderAdapterRequestError>;
+
 export interface PiAdapterOptions<R = never> {
   readonly instanceId: ProviderInstanceId;
   readonly sessionDirectory: string;
   readonly environment?: NodeJS.ProcessEnv | undefined;
+  /** Resolves persisted T3 image attachments into Pi's native prompt images. */
+  readonly loadImageAttachment?: PiImageAttachmentLoader | undefined;
   readonly makeRuntime: PiRuntimeFactory<R>;
+}
+
+export function makePiImageAttachmentLoader(input: {
+  readonly attachmentsDir: string;
+  readonly fileSystem: FileSystem.FileSystem;
+}): PiImageAttachmentLoader {
+  return (attachment) =>
+    Effect.gen(function* () {
+      const attachmentPath = resolveAttachmentPath({
+        attachmentsDir: input.attachmentsDir,
+        attachment,
+      });
+      if (!attachmentPath) {
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "prompt",
+          detail: `Invalid attachment id '${attachment.id}'.`,
+        });
+      }
+      const bytes = yield* input.fileSystem.readFile(attachmentPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "prompt",
+              detail: "Failed to read Pi image attachment.",
+              cause,
+            }),
+        ),
+      );
+      return {
+        type: "image",
+        data: Buffer.from(bytes).toString("base64"),
+        mimeType: attachment.mimeType,
+      } satisfies PiPromptImage;
+    });
 }
 
 interface PiAdapterSessionContext {
@@ -50,7 +102,235 @@ interface PiAdapterSessionContext {
   readonly scope: Scope.Closeable;
   readonly runtime: PiSessionRuntimeShape;
   session: ProviderSession;
+  activeTurnId: TurnId | undefined;
+  assistantItemId: RuntimeItemId | undefined;
+  readonly thinkingTasks: Map<number, { readonly taskId: RuntimeTaskId; text: string }>;
+  readonly toolCalls: Map<
+    string,
+    { readonly toolCallId: string; readonly toolName: string; readonly contentIndex: number }
+  >;
+  readonly toolCallIdsByContentIndex: Map<number, string>;
+  terminalOutcome:
+    | { readonly state: "failed" | "interrupted"; readonly errorMessage?: string }
+    | undefined;
+  queueTaskId: RuntimeTaskId | undefined;
+  compactionItemId: RuntimeItemId | undefined;
+  readonly retryTaskIds: Map<number, RuntimeTaskId>;
+  summarizationRetryTaskId: RuntimeTaskId | undefined;
+  nextSyntheticItemId: number;
+  nextSyntheticTaskId: number;
   stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function piEventType(value: unknown): string | undefined {
+  return isRecord(value) ? nonEmptyString(value.type) : undefined;
+}
+
+function piAssistantMessageRole(value: unknown): string | undefined {
+  return isRecord(value) ? nonEmptyString(value.role) : undefined;
+}
+
+function piTextDelta(
+  value: unknown,
+): { readonly contentIndex?: number; readonly delta: string } | undefined {
+  if (!isRecord(value) || value.type !== "text_delta" || typeof value.delta !== "string") {
+    return undefined;
+  }
+  return {
+    delta: value.delta,
+    ...(typeof value.contentIndex === "number" && Number.isInteger(value.contentIndex)
+      ? { contentIndex: value.contentIndex }
+      : {}),
+  };
+}
+
+function piThinkingEvent(
+  value: unknown,
+):
+  | { readonly type: "start" | "end"; readonly contentIndex: number }
+  | { readonly type: "delta"; readonly contentIndex: number; readonly delta: string }
+  | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const contentIndex =
+    typeof value.contentIndex === "number" && Number.isInteger(value.contentIndex)
+      ? value.contentIndex
+      : 0;
+  if (value.type === "thinking_start") {
+    return { type: "start", contentIndex };
+  }
+  if (value.type === "thinking_end") {
+    return { type: "end", contentIndex };
+  }
+  if (value.type === "thinking_delta" && typeof value.delta === "string") {
+    return { type: "delta", contentIndex, delta: value.delta };
+  }
+  return undefined;
+}
+
+function piToolCallEvent(value: unknown):
+  | {
+      readonly type: "start";
+      readonly contentIndex: number;
+      readonly toolCallId: string;
+      readonly toolName: string;
+    }
+  | { readonly type: "delta"; readonly contentIndex: number; readonly delta: string }
+  | {
+      readonly type: "end";
+      readonly contentIndex: number;
+      readonly toolCallId: string;
+      readonly toolName: string;
+      readonly args: unknown;
+    }
+  | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.contentIndex !== "number" ||
+    !Number.isInteger(value.contentIndex)
+  ) {
+    return undefined;
+  }
+  if (value.type === "toolcall_start") {
+    const toolCallId = nonEmptyString(value.id);
+    const toolName = nonEmptyString(value.toolName);
+    return toolCallId && toolName
+      ? { type: "start", contentIndex: value.contentIndex, toolCallId, toolName }
+      : undefined;
+  }
+  if (value.type === "toolcall_delta" && typeof value.delta === "string") {
+    return { type: "delta", contentIndex: value.contentIndex, delta: value.delta };
+  }
+  if (value.type !== "toolcall_end" || !isRecord(value.toolCall)) {
+    return undefined;
+  }
+  const toolCallId = nonEmptyString(value.toolCall.id);
+  const toolName = nonEmptyString(value.toolCall.name);
+  if (!toolCallId || !toolName || !Object.hasOwn(value.toolCall, "arguments")) {
+    return undefined;
+  }
+  return {
+    type: "end",
+    contentIndex: value.contentIndex,
+    toolCallId,
+    toolName,
+    args: value.toolCall.arguments,
+  };
+}
+
+function piAssistantErrorMessage(assistantMessageEvent: Record<string, unknown>, message: unknown) {
+  return (
+    nonEmptyString(
+      isRecord(assistantMessageEvent.error) ? assistantMessageEvent.error.errorMessage : undefined,
+    ) ?? nonEmptyString(isRecord(message) ? message.errorMessage : undefined)
+  );
+}
+
+type PiToolItemType =
+  | "command_execution"
+  | "file_change"
+  | "mcp_tool_call"
+  | "dynamic_tool_call"
+  | "collab_agent_tool_call"
+  | "web_search"
+  | "image_view";
+
+function piToolItemType(toolName: string): PiToolItemType {
+  const normalized = toolName.toLowerCase();
+  if (normalized.includes("agent") || normalized.includes("subagent")) {
+    return "collab_agent_tool_call";
+  }
+  if (
+    normalized.includes("bash") ||
+    normalized.includes("command") ||
+    normalized.includes("shell") ||
+    normalized.includes("terminal")
+  ) {
+    return "command_execution";
+  }
+  if (
+    normalized.includes("edit") ||
+    normalized.includes("write") ||
+    normalized.includes("file") ||
+    normalized.includes("patch") ||
+    normalized.includes("replace") ||
+    normalized.includes("create") ||
+    normalized.includes("delete")
+  ) {
+    return "file_change";
+  }
+  if (normalized.includes("mcp")) {
+    return "mcp_tool_call";
+  }
+  if (normalized.includes("websearch") || normalized.includes("web search")) {
+    return "web_search";
+  }
+  if (normalized.includes("image")) {
+    return "image_view";
+  }
+  return "dynamic_tool_call";
+}
+
+function piToolResultText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return nonEmptyString(value);
+  }
+  if (!isRecord(value) || !Array.isArray(value.content)) {
+    return undefined;
+  }
+  const text = value.content
+    .flatMap((part) => {
+      if (!isRecord(part) || part.type !== "text" || typeof part.text !== "string") {
+        return [];
+      }
+      return [part.text];
+    })
+    .join("")
+    .trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function piToolCommand(value: unknown): string | undefined {
+  return isRecord(value) ? nonEmptyString(value.command) : undefined;
+}
+
+function piToolExecution(value: unknown):
+  | {
+      readonly toolCallId: string;
+      readonly toolName: string;
+      readonly args?: unknown;
+      readonly result?: unknown;
+      readonly isError?: boolean;
+    }
+  | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const toolCallId = nonEmptyString(value.toolCallId);
+  const toolName = nonEmptyString(value.toolName);
+  if (!toolCallId || !toolName) {
+    return undefined;
+  }
+  return {
+    toolCallId,
+    toolName,
+    ...(Object.hasOwn(value, "args") ? { args: value.args } : {}),
+    ...(Object.hasOwn(value, "result")
+      ? { result: value.result }
+      : Object.hasOwn(value, "partialResult")
+        ? { result: value.partialResult }
+        : {}),
+    ...(typeof value.isError === "boolean" ? { isError: value.isError } : {}),
+  };
 }
 
 function runtimeProcessError(
@@ -94,6 +374,904 @@ export function makePiAdapter<R>(
     // instance, then re-provide it when a thread starts later.
     const runtimeContext = yield* Effect.context<R>();
     const sessions = new Map<ThreadId, PiAdapterSessionContext>();
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+    const makeEventStamp = () =>
+      Effect.map(DateTime.now, (now) => ({
+        eventId: EventId.make(NodeCrypto.randomUUID()),
+        createdAt: DateTime.formatIso(now),
+      }));
+    const publishRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+    const rawPiEvent = (event: unknown, messageType: string) => ({
+      source: "pi.rpc.event" as const,
+      messageType,
+      payload: event,
+    });
+    const newSyntheticItemId = (context: PiAdapterSessionContext, kind: string) => {
+      context.nextSyntheticItemId += 1;
+      return RuntimeItemId.make(
+        `pi:${context.threadId}:${kind}:${String(context.nextSyntheticItemId)}`,
+      );
+    };
+    const newAssistantItemId = (context: PiAdapterSessionContext) =>
+      newSyntheticItemId(context, "assistant");
+    const newSyntheticTaskId = (context: PiAdapterSessionContext, kind: string) => {
+      context.nextSyntheticTaskId += 1;
+      return RuntimeTaskId.make(
+        `pi:${context.threadId}:${kind}:${String(context.nextSyntheticTaskId)}`,
+      );
+    };
+    const newThinkingTask = (context: PiAdapterSessionContext, contentIndex: number) => {
+      const task = {
+        taskId: newSyntheticTaskId(context, "thinking"),
+        text: "",
+      };
+      context.thinkingTasks.set(contentIndex, task);
+      return task;
+    };
+    const ensureAssistantItem = (context: PiAdapterSessionContext, raw: unknown, type: string) =>
+      Effect.gen(function* () {
+        const turnId = context.activeTurnId;
+        if (!turnId) {
+          return undefined;
+        }
+        if (context.assistantItemId) {
+          return context.assistantItemId;
+        }
+        const itemId = newAssistantItemId(context);
+        context.assistantItemId = itemId;
+        yield* publishRuntimeEvent({
+          type: "item.started",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: context.threadId,
+          turnId,
+          itemId,
+          payload: {
+            itemType: "assistant_message",
+            status: "inProgress",
+          },
+          raw: rawPiEvent(raw, type),
+        });
+        return itemId;
+      });
+    const completeActiveTurn = (
+      context: PiAdapterSessionContext,
+      raw: unknown,
+      messageType: string,
+      state: "completed" | "failed" | "interrupted" = "completed",
+      errorMessage?: string,
+    ) =>
+      Effect.gen(function* () {
+        const turnId = context.activeTurnId;
+        if (!turnId) {
+          return;
+        }
+        const outcome = context.terminalOutcome;
+        const effectiveState = outcome?.state ?? state;
+        const effectiveErrorMessage = outcome?.errorMessage ?? errorMessage;
+        context.activeTurnId = undefined;
+        context.assistantItemId = undefined;
+        context.toolCalls.clear();
+        context.toolCallIdsByContentIndex.clear();
+        context.terminalOutcome = undefined;
+        const { activeTurnId: _activeTurnId, ...readySession } = context.session;
+        context.session = {
+          ...readySession,
+          status: effectiveState === "failed" ? "error" : "ready",
+          updatedAt: DateTime.formatIso(yield* DateTime.now),
+          ...(effectiveState === "failed" && effectiveErrorMessage
+            ? { lastError: effectiveErrorMessage }
+            : {}),
+        };
+        yield* publishRuntimeEvent({
+          type: "turn.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: context.threadId,
+          turnId,
+          payload: {
+            state: effectiveState,
+            ...(effectiveErrorMessage ? { errorMessage: effectiveErrorMessage } : {}),
+          },
+          raw: rawPiEvent(raw, messageType),
+        });
+      });
+    const mapPiRuntimeEvent = (context: PiAdapterSessionContext, raw: unknown) =>
+      Effect.gen(function* () {
+        if (context.stopped) {
+          return;
+        }
+        const type = piEventType(raw);
+        if (!type || !isRecord(raw)) {
+          return;
+        }
+        switch (type) {
+          case "message_start": {
+            if (piAssistantMessageRole(raw.message) === "assistant") {
+              yield* ensureAssistantItem(context, raw, type);
+            }
+            return;
+          }
+          case "message_update": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const assistantMessageEvent = isRecord(raw.assistantMessageEvent)
+              ? raw.assistantMessageEvent
+              : undefined;
+            if (assistantMessageEvent?.type === "error") {
+              const wasAborted = assistantMessageEvent.reason === "aborted";
+              const errorMessage =
+                piAssistantErrorMessage(assistantMessageEvent, raw.message) ??
+                (wasAborted
+                  ? "Pi assistant response was aborted."
+                  : "Pi assistant response failed.");
+              context.terminalOutcome = {
+                state: wasAborted ? "interrupted" : "failed",
+                ...(wasAborted ? {} : { errorMessage }),
+              };
+              if (!wasAborted) {
+                yield* publishRuntimeEvent({
+                  type: "runtime.error",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  payload: { message: errorMessage },
+                  raw: rawPiEvent(raw, type),
+                });
+              }
+              return;
+            }
+            const textDelta = piTextDelta(raw.assistantMessageEvent);
+            if (textDelta) {
+              const itemId = yield* ensureAssistantItem(context, raw, type);
+              if (!itemId) {
+                return;
+              }
+              yield* publishRuntimeEvent({
+                type: "content.delta",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                itemId,
+                payload: {
+                  streamKind: "assistant_text",
+                  delta: textDelta.delta,
+                  ...(textDelta.contentIndex !== undefined
+                    ? { contentIndex: textDelta.contentIndex }
+                    : {}),
+                },
+                raw: rawPiEvent(raw, type),
+              });
+              return;
+            }
+
+            const toolCall = piToolCallEvent(raw.assistantMessageEvent);
+            if (toolCall) {
+              if (toolCall.type === "start") {
+                context.toolCalls.set(toolCall.toolCallId, toolCall);
+                context.toolCallIdsByContentIndex.set(toolCall.contentIndex, toolCall.toolCallId);
+                yield* publishRuntimeEvent({
+                  type: "item.started",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  itemId: RuntimeItemId.make(toolCall.toolCallId),
+                  payload: {
+                    itemType: piToolItemType(toolCall.toolName),
+                    status: "inProgress",
+                    title: toolCall.toolName,
+                    data: {
+                      toolCallId: toolCall.toolCallId,
+                      toolName: toolCall.toolName,
+                      contentIndex: toolCall.contentIndex,
+                    },
+                  },
+                  raw: rawPiEvent(raw, type),
+                });
+                return;
+              }
+              if (toolCall.type === "delta") {
+                const toolCallId = context.toolCallIdsByContentIndex.get(toolCall.contentIndex);
+                const startedToolCall = toolCallId ? context.toolCalls.get(toolCallId) : undefined;
+                if (!startedToolCall) {
+                  return;
+                }
+                yield* publishRuntimeEvent({
+                  type: "item.updated",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  itemId: RuntimeItemId.make(startedToolCall.toolCallId),
+                  payload: {
+                    itemType: piToolItemType(startedToolCall.toolName),
+                    status: "inProgress",
+                    title: startedToolCall.toolName,
+                    data: {
+                      toolCallId: startedToolCall.toolCallId,
+                      toolName: startedToolCall.toolName,
+                      contentIndex: startedToolCall.contentIndex,
+                      argumentDelta: toolCall.delta,
+                    },
+                  },
+                  raw: rawPiEvent(raw, type),
+                });
+                return;
+              }
+              const existingToolCall = context.toolCalls.get(toolCall.toolCallId);
+              context.toolCalls.set(toolCall.toolCallId, toolCall);
+              context.toolCallIdsByContentIndex.set(toolCall.contentIndex, toolCall.toolCallId);
+              const command = piToolCommand(toolCall.args);
+              const payload = {
+                itemType: piToolItemType(toolCall.toolName),
+                status: "inProgress" as const,
+                title: toolCall.toolName,
+                ...(command ? { detail: command } : {}),
+                data: {
+                  toolCallId: toolCall.toolCallId,
+                  toolName: toolCall.toolName,
+                  contentIndex: toolCall.contentIndex,
+                  args: toolCall.args,
+                  ...(command ? { command } : {}),
+                },
+              };
+              if (existingToolCall) {
+                yield* publishRuntimeEvent({
+                  type: "item.updated",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  itemId: RuntimeItemId.make(toolCall.toolCallId),
+                  payload,
+                  raw: rawPiEvent(raw, type),
+                });
+              } else {
+                yield* publishRuntimeEvent({
+                  type: "item.started",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  itemId: RuntimeItemId.make(toolCall.toolCallId),
+                  payload,
+                  raw: rawPiEvent(raw, type),
+                });
+              }
+              return;
+            }
+
+            const thinking = piThinkingEvent(raw.assistantMessageEvent);
+            if (!thinking) {
+              return;
+            }
+            let task = context.thinkingTasks.get(thinking.contentIndex);
+            if (!task) {
+              task = newThinkingTask(context, thinking.contentIndex);
+              yield* publishRuntimeEvent({
+                type: "task.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: {
+                  taskId: task.taskId,
+                  description: "Thinking",
+                  taskType: "thinking",
+                },
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            if (thinking.type === "start") {
+              return;
+            }
+            if (thinking.type === "delta") {
+              task.text += thinking.delta;
+              const itemId = yield* ensureAssistantItem(context, raw, type);
+              if (itemId) {
+                yield* publishRuntimeEvent({
+                  type: "content.delta",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: context.threadId,
+                  turnId,
+                  itemId,
+                  payload: {
+                    streamKind: "reasoning_text",
+                    delta: thinking.delta,
+                    contentIndex: thinking.contentIndex,
+                  },
+                  raw: rawPiEvent(raw, type),
+                });
+              }
+              yield* publishRuntimeEvent({
+                type: "task.progress",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: {
+                  taskId: task.taskId,
+                  description: "Thinking",
+                  ...(task.text ? { summary: task.text } : {}),
+                },
+                raw: rawPiEvent(raw, type),
+              });
+              return;
+            }
+            context.thinkingTasks.delete(thinking.contentIndex);
+            yield* publishRuntimeEvent({
+              type: "task.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId: task.taskId,
+                status: "completed",
+                ...(task.text ? { summary: task.text } : {}),
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "message_end": {
+            if (piAssistantMessageRole(raw.message) !== "assistant") {
+              return;
+            }
+            const turnId = context.activeTurnId;
+            const itemId = context.assistantItemId;
+            if (!turnId || !itemId) {
+              return;
+            }
+            context.assistantItemId = undefined;
+            yield* publishRuntimeEvent({
+              type: "item.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              itemId,
+              payload: {
+                itemType: "assistant_message",
+                status: "completed",
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "tool_execution_start": {
+            const turnId = context.activeTurnId;
+            const execution = piToolExecution(raw);
+            if (!turnId || !execution) {
+              return;
+            }
+            const constructedToolCall = context.toolCalls.get(execution.toolCallId);
+            if (!constructedToolCall) {
+              context.toolCalls.set(execution.toolCallId, {
+                toolCallId: execution.toolCallId,
+                toolName: execution.toolName,
+                contentIndex: -1,
+              });
+            }
+            const command = piToolCommand(execution.args);
+            const payload = {
+              itemType: piToolItemType(execution.toolName),
+              status: "inProgress" as const,
+              title: execution.toolName,
+              ...(command ? { detail: command } : {}),
+              data: {
+                toolCallId: execution.toolCallId,
+                toolName: execution.toolName,
+                ...(execution.args !== undefined ? { args: execution.args } : {}),
+                ...(command ? { command } : {}),
+              },
+            };
+            if (constructedToolCall) {
+              yield* publishRuntimeEvent({
+                type: "item.updated",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                itemId: RuntimeItemId.make(execution.toolCallId),
+                payload,
+                raw: rawPiEvent(raw, type),
+              });
+            } else {
+              yield* publishRuntimeEvent({
+                type: "item.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                itemId: RuntimeItemId.make(execution.toolCallId),
+                payload,
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            return;
+          }
+          case "tool_execution_update": {
+            const turnId = context.activeTurnId;
+            const execution = piToolExecution(raw);
+            if (!turnId || !execution) {
+              return;
+            }
+            const command = piToolCommand(execution.args);
+            const detail = piToolResultText(execution.result);
+            yield* publishRuntimeEvent({
+              type: "item.updated",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              itemId: RuntimeItemId.make(execution.toolCallId),
+              payload: {
+                itemType: piToolItemType(execution.toolName),
+                status: "inProgress",
+                title: execution.toolName,
+                ...(detail ? { detail } : {}),
+                data: {
+                  toolCallId: execution.toolCallId,
+                  toolName: execution.toolName,
+                  ...(execution.args !== undefined ? { args: execution.args } : {}),
+                  ...(command ? { command } : {}),
+                  ...(execution.result !== undefined ? { result: execution.result } : {}),
+                },
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "tool_execution_end": {
+            const turnId = context.activeTurnId;
+            const execution = piToolExecution(raw);
+            if (!turnId || !execution) {
+              return;
+            }
+            const detail = piToolResultText(execution.result);
+            const command = piToolCommand(execution.args);
+            const failed = execution.isError === true;
+            yield* publishRuntimeEvent({
+              type: "item.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              itemId: RuntimeItemId.make(execution.toolCallId),
+              payload: {
+                itemType: piToolItemType(execution.toolName),
+                status: failed ? "failed" : "completed",
+                title: execution.toolName,
+                ...(detail ? { detail } : {}),
+                data: {
+                  toolCallId: execution.toolCallId,
+                  toolName: execution.toolName,
+                  ...(command ? { command } : {}),
+                  ...(execution.result !== undefined ? { result: execution.result } : {}),
+                },
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            if (failed) {
+              yield* publishRuntimeEvent({
+                type: "runtime.error",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: {
+                  message: `Pi tool '${execution.toolName}' failed.`,
+                  ...(detail ? { detail } : {}),
+                },
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            const constructedToolCall = context.toolCalls.get(execution.toolCallId);
+            context.toolCalls.delete(execution.toolCallId);
+            if (
+              constructedToolCall &&
+              context.toolCallIdsByContentIndex.get(constructedToolCall.contentIndex) ===
+                execution.toolCallId
+            ) {
+              context.toolCallIdsByContentIndex.delete(constructedToolCall.contentIndex);
+            }
+            return;
+          }
+          case "queue_update": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const steeringCount = Array.isArray(raw.steering) ? raw.steering.length : 0;
+            const followUpCount = Array.isArray(raw.followUp) ? raw.followUp.length : 0;
+            if (steeringCount + followUpCount === 0) {
+              const taskId = context.queueTaskId;
+              if (!taskId) {
+                return;
+              }
+              context.queueTaskId = undefined;
+              yield* publishRuntimeEvent({
+                type: "task.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: {
+                  taskId,
+                  status: "completed",
+                  summary: "Queued work processed",
+                },
+                raw: rawPiEvent(raw, type),
+              });
+              return;
+            }
+            const taskId = context.queueTaskId ?? newSyntheticTaskId(context, "queue");
+            if (!context.queueTaskId) {
+              context.queueTaskId = taskId;
+              yield* publishRuntimeEvent({
+                type: "task.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: {
+                  taskId,
+                  description: "Queued work",
+                  taskType: "queued_work",
+                },
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            const queueParts = [
+              ...(steeringCount > 0
+                ? [`${String(steeringCount)} steering message${steeringCount === 1 ? "" : "s"}`]
+                : []),
+              ...(followUpCount > 0
+                ? [
+                    `${String(followUpCount)} follow-up${
+                      followUpCount === 1 ? " message" : " messages"
+                    }`,
+                  ]
+                : []),
+            ];
+            yield* publishRuntimeEvent({
+              type: "task.progress",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                description: "Queued work",
+                summary: `${queueParts.join(" and ")} queued`,
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "compaction_start": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const itemId = context.compactionItemId ?? newSyntheticItemId(context, "compaction");
+            context.compactionItemId = itemId;
+            const reason = nonEmptyString(raw.reason);
+            yield* publishRuntimeEvent({
+              type: "item.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              itemId,
+              payload: {
+                itemType: "context_compaction",
+                status: "inProgress",
+                title: "Compacting conversation",
+                ...(reason ? { detail: `Reason: ${reason}` } : {}),
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "compaction_end": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const itemId = context.compactionItemId ?? newSyntheticItemId(context, "compaction");
+            context.compactionItemId = undefined;
+            const result = isRecord(raw.result) ? raw.result : undefined;
+            const detail =
+              nonEmptyString(result?.summary) ??
+              nonEmptyString(raw.errorMessage) ??
+              (raw.aborted === true ? "Compaction was aborted." : undefined);
+            const failed = raw.aborted !== true && nonEmptyString(raw.errorMessage) !== undefined;
+            yield* publishRuntimeEvent({
+              type: "item.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              itemId,
+              payload: {
+                itemType: "context_compaction",
+                status: failed ? "failed" : "completed",
+                title: failed ? "Context compaction failed" : "Context compacted",
+                ...(detail ? { detail } : {}),
+                ...(result ? { data: result } : {}),
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            if (failed && detail) {
+              context.terminalOutcome = { state: "failed", errorMessage: detail };
+              yield* publishRuntimeEvent({
+                type: "runtime.error",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: { message: detail },
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            return;
+          }
+          case "auto_retry_start": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const attempt = typeof raw.attempt === "number" ? raw.attempt : 0;
+            const taskId = newSyntheticTaskId(context, "retry");
+            context.retryTaskIds.set(attempt, taskId);
+            const errorMessage = nonEmptyString(raw.errorMessage);
+            const maxAttempts = typeof raw.maxAttempts === "number" ? raw.maxAttempts : undefined;
+            const delayMs = typeof raw.delayMs === "number" ? raw.delayMs : undefined;
+            yield* publishRuntimeEvent({
+              type: "task.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                description: "Retrying Pi request",
+                taskType: "retry",
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            yield* publishRuntimeEvent({
+              type: "task.progress",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                description: "Retrying Pi request",
+                summary: `Attempt ${String(attempt)}${
+                  maxAttempts !== undefined ? ` of ${String(maxAttempts)}` : ""
+                }${delayMs !== undefined ? ` after ${String(delayMs)} ms` : ""}${
+                  errorMessage ? `: ${errorMessage}` : ""
+                }`,
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "auto_retry_end": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const attempt = typeof raw.attempt === "number" ? raw.attempt : 0;
+            const taskId =
+              context.retryTaskIds.get(attempt) ?? newSyntheticTaskId(context, "retry");
+            context.retryTaskIds.delete(attempt);
+            const success = raw.success === true;
+            const errorMessage = nonEmptyString(raw.finalError);
+            yield* publishRuntimeEvent({
+              type: "task.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                status: success ? "completed" : "failed",
+                ...(success ? { summary: "Pi request retry succeeded" } : {}),
+                ...(!success && errorMessage ? { summary: errorMessage } : {}),
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            if (!success && errorMessage) {
+              context.terminalOutcome = { state: "failed", errorMessage };
+              yield* publishRuntimeEvent({
+                type: "runtime.error",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: { message: errorMessage },
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            return;
+          }
+          case "summarization_retry_scheduled": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const taskId = newSyntheticTaskId(context, "summarization-retry");
+            context.summarizationRetryTaskId = taskId;
+            const attempt = typeof raw.attempt === "number" ? raw.attempt : 0;
+            const maxAttempts = typeof raw.maxAttempts === "number" ? raw.maxAttempts : undefined;
+            yield* publishRuntimeEvent({
+              type: "task.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                description: "Retrying Pi summarization",
+                taskType: "retry",
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            yield* publishRuntimeEvent({
+              type: "task.progress",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                description: "Retrying Pi summarization",
+                summary: `Attempt ${String(attempt)}${
+                  maxAttempts !== undefined ? ` of ${String(maxAttempts)}` : ""
+                }`,
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "summarization_retry_attempt_start": {
+            const turnId = context.activeTurnId;
+            const taskId = context.summarizationRetryTaskId;
+            if (!turnId || !taskId) {
+              return;
+            }
+            const source = nonEmptyString(raw.source) ?? "summarization";
+            yield* publishRuntimeEvent({
+              type: "task.progress",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                description: "Retrying Pi summarization",
+                summary: `Retrying ${source}`,
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "summarization_retry_finished": {
+            const turnId = context.activeTurnId;
+            const taskId = context.summarizationRetryTaskId;
+            if (!turnId || !taskId) {
+              return;
+            }
+            context.summarizationRetryTaskId = undefined;
+            yield* publishRuntimeEvent({
+              type: "task.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                taskId,
+                status: "completed",
+                summary: "Pi summarization retry finished",
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "agent_end": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            if (raw.willRetry === true) {
+              yield* publishRuntimeEvent({
+                type: "runtime.warning",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: { message: "Pi will retry a transient provider error." },
+                raw: rawPiEvent(raw, type),
+              });
+              return;
+            }
+            const messages = Array.isArray(raw.messages) ? raw.messages : [];
+            const lastAssistantMessage = messages
+              .toReversed()
+              .find((message) => isRecord(message) && message.role === "assistant");
+            if (!isRecord(lastAssistantMessage)) {
+              return;
+            }
+            const stopReason = nonEmptyString(lastAssistantMessage.stopReason);
+            if (stopReason !== "error" && stopReason !== "aborted") {
+              return;
+            }
+            const wasAborted = stopReason === "aborted";
+            const errorMessage =
+              nonEmptyString(lastAssistantMessage.errorMessage) ??
+              (wasAborted ? "Pi assistant response was aborted." : "Pi assistant response failed.");
+            context.terminalOutcome = {
+              state: wasAborted ? "interrupted" : "failed",
+              ...(wasAborted ? {} : { errorMessage }),
+            };
+            if (!wasAborted) {
+              yield* publishRuntimeEvent({
+                type: "runtime.error",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                turnId,
+                payload: { message: errorMessage },
+                raw: rawPiEvent(raw, type),
+              });
+            }
+            return;
+          }
+          case "extension_error": {
+            const turnId = context.activeTurnId;
+            if (!turnId) {
+              return;
+            }
+            const errorMessage = nonEmptyString(raw.error) ?? "Pi extension failed.";
+            yield* publishRuntimeEvent({
+              type: "runtime.error",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              turnId,
+              payload: {
+                message: errorMessage,
+                detail: {
+                  ...(nonEmptyString(raw.extensionPath)
+                    ? { extensionPath: nonEmptyString(raw.extensionPath) }
+                    : {}),
+                  ...(nonEmptyString(raw.event) ? { event: nonEmptyString(raw.event) } : {}),
+                },
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            return;
+          }
+          case "agent_settled": {
+            yield* completeActiveTurn(context, raw, type);
+            return;
+          }
+          default:
+            return;
+        }
+      });
 
     const stopSessionInternal = (context: PiAdapterSessionContext): Effect.Effect<void> =>
       Effect.suspend(() => {
@@ -257,9 +1435,32 @@ export function makePiAdapter<R>(
             scope: sessionScope,
             runtime,
             session,
+            activeTurnId: undefined,
+            assistantItemId: undefined,
+            thinkingTasks: new Map(),
+            toolCalls: new Map(),
+            toolCallIdsByContentIndex: new Map(),
+            terminalOutcome: undefined,
+            queueTaskId: undefined,
+            compactionItemId: undefined,
+            retryTaskIds: new Map(),
+            summarizationRetryTaskId: undefined,
+            nextSyntheticItemId: 0,
+            nextSyntheticTaskId: 0,
             stopped: false,
           };
           sessions.set(input.threadId, context);
+          yield* Stream.runForEach(runtime.events, (event) =>
+            mapPiRuntimeEvent(context, event),
+          ).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("Failed to map Pi RPC runtime event.", {
+                cause,
+                threadId: context.threadId,
+              }),
+            ),
+            Effect.forkIn(sessionScope),
+          );
           transferred = true;
           return session;
         }),
@@ -268,33 +1469,97 @@ export function makePiAdapter<R>(
     const sendTurn: ProviderAdapterShape<ProviderAdapterError>["sendTurn"] = (input) =>
       requireSession(input.threadId).pipe(
         Effect.flatMap((context) =>
-          applyModelSelection({
-            runtime: context.runtime,
-            modelSelection: input.modelSelection,
-            initialModel: context.session.model,
-            operation: "sendTurn",
-          }).pipe(
-            Effect.tap((model) =>
-              Effect.map(DateTime.now, DateTime.formatIso).pipe(
-                Effect.tap((updatedAt) =>
-                  Effect.sync(() => {
-                    context.session = {
-                      ...context.session,
-                      ...(model ? { model } : {}),
-                      updatedAt,
-                    };
-                  }),
-                ),
-              ),
-            ),
-            Effect.andThen(
-              new ProviderAdapterRequestError({
+          Effect.gen(function* () {
+            const model = yield* applyModelSelection({
+              runtime: context.runtime,
+              modelSelection: input.modelSelection,
+              initialModel: context.session.model,
+              operation: "sendTurn",
+            });
+            const attachments = input.attachments ?? [];
+            const loadImageAttachment = options.loadImageAttachment;
+            if (attachments.length > 0 && !loadImageAttachment) {
+              return yield* new ProviderAdapterRequestError({
                 provider: PROVIDER,
                 method: "prompt",
-                detail: TURN_DELIVERY_MESSAGE,
-              }),
-            ),
-          ),
+                detail: "Pi image attachment loading is not configured.",
+              });
+            }
+            const images = loadImageAttachment
+              ? yield* Effect.forEach(attachments, loadImageAttachment)
+              : [];
+            const activeTurnId = context.activeTurnId;
+            const turnId = activeTurnId ?? TurnId.make(NodeCrypto.randomUUID());
+            const updatedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+            if (!activeTurnId) {
+              context.toolCalls.clear();
+              context.toolCallIdsByContentIndex.clear();
+            }
+            context.activeTurnId = turnId;
+            context.session = {
+              ...context.session,
+              status: "running",
+              activeTurnId: turnId,
+              ...(model ? { model } : {}),
+              updatedAt,
+            };
+            if (!activeTurnId) {
+              yield* publishRuntimeEvent({
+                type: "turn.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: model ? { model } : {},
+              });
+            }
+            yield* context.runtime
+              .prompt({
+                message: input.input ?? "",
+                ...(images.length > 0 ? { images } : {}),
+                ...(activeTurnId ? { streamingBehavior: "followUp" as const } : {}),
+              })
+              .pipe(
+                Effect.mapError((error) => runtimeRequestError("prompt", error)),
+                Effect.tapError((error) =>
+                  activeTurnId
+                    ? Effect.void
+                    : completeActiveTurn(
+                        context,
+                        { type: "prompt", error: error.message },
+                        "prompt",
+                        "failed",
+                        error.message,
+                      ),
+                ),
+              );
+            return {
+              threadId: input.threadId,
+              turnId,
+              ...(context.session.resumeCursor
+                ? { resumeCursor: context.session.resumeCursor }
+                : {}),
+            };
+          }),
+        ),
+      );
+
+    const interruptTurn: ProviderAdapterShape<ProviderAdapterError>["interruptTurn"] = (
+      threadId,
+      requestedTurnId,
+    ) =>
+      requireSession(threadId).pipe(
+        Effect.flatMap((context) =>
+          Effect.gen(function* () {
+            const activeTurnId = context.activeTurnId;
+            if (requestedTurnId !== undefined && activeTurnId !== requestedTurnId) {
+              return;
+            }
+            yield* context.runtime
+              .abort()
+              .pipe(Effect.mapError((error) => runtimeRequestError("abort", error)));
+            yield* completeActiveTurn(context, { type: "abort" }, "abort", "interrupted");
+          }),
         ),
       );
 
@@ -317,7 +1582,7 @@ export function makePiAdapter<R>(
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
       sendTurn,
-      interruptTurn: (threadId) => unavailableOperation("abort", threadId),
+      interruptTurn,
       respondToRequest: (threadId) => unavailableOperation("extension_ui_response", threadId),
       respondToUserInput: (threadId) => unavailableOperation("extension_ui_response", threadId),
       stopSession: (threadId) =>
@@ -333,9 +1598,7 @@ export function makePiAdapter<R>(
       rollbackThread: (threadId) => unavailableOperation("rollback", threadId),
       stopAll: () =>
         Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true }),
-      // Runtime event mapping is deliberately introduced with Pi prompt
-      // delivery. Preserve raw transport events on the runtime until then.
-      streamEvents: Stream.empty,
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
     };
 
     yield* Effect.addFinalizer(() => adapter.stopAll().pipe(Effect.ignore));

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1,6 +1,7 @@
 import * as NodeCrypto from "node:crypto";
 
 import {
+  ApprovalRequestId,
   type ChatImageAttachment,
   EventId,
   type ModelSelection,
@@ -8,11 +9,14 @@ import {
   ProviderDriverKind,
   type ProviderInstanceId,
   type ProviderRuntimeEvent,
+  type ProviderUserInputAnswers,
   type ProviderSession,
   RuntimeItemId,
+  RuntimeRequestId,
   RuntimeTaskId,
   type ThreadId,
   TurnId,
+  type UserInputQuestion,
 } from "@t3tools/contracts";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import * as DateTime from "effect/DateTime";
@@ -117,6 +121,7 @@ interface PiAdapterSessionContext {
   compactionItemId: RuntimeItemId | undefined;
   readonly retryTaskIds: Map<number, RuntimeTaskId>;
   summarizationRetryTaskId: RuntimeTaskId | undefined;
+  readonly pendingExtensionDialogs: Map<ApprovalRequestId, PiExtensionDialog>;
   nextSyntheticItemId: number;
   nextSyntheticTaskId: number;
   stopped: boolean;
@@ -331,6 +336,129 @@ function piToolExecution(value: unknown):
         : {}),
     ...(typeof value.isError === "boolean" ? { isError: value.isError } : {}),
   };
+}
+
+const PI_EXTENSION_CONFIRM_LABEL = "Confirm";
+const PI_EXTENSION_CANCEL_LABEL = "Cancel";
+
+type PiExtensionDialog =
+  | {
+      readonly id: string;
+      readonly method: "confirm";
+      readonly question: UserInputQuestion;
+    }
+  | {
+      readonly id: string;
+      readonly method: "select";
+      readonly options: ReadonlyArray<string>;
+      readonly question: UserInputQuestion;
+    }
+  | {
+      readonly id: string;
+      readonly method: "input";
+      readonly question: UserInputQuestion;
+    };
+
+function piExtensionDialog(value: Record<string, unknown>): PiExtensionDialog | undefined {
+  const id = nonEmptyString(value.id);
+  const method = nonEmptyString(value.method);
+  const title = nonEmptyString(value.title);
+  if (!id || !method || !title) {
+    return undefined;
+  }
+
+  if (method === "confirm") {
+    const message = nonEmptyString(value.message) ?? title;
+    return {
+      id,
+      method,
+      question: {
+        id,
+        header: title,
+        question: message,
+        options: [
+          { label: PI_EXTENSION_CONFIRM_LABEL, description: PI_EXTENSION_CONFIRM_LABEL },
+          { label: PI_EXTENSION_CANCEL_LABEL, description: PI_EXTENSION_CANCEL_LABEL },
+        ],
+        multiSelect: false,
+      },
+    };
+  }
+
+  if (method === "select") {
+    const options = Array.isArray(value.options)
+      ? Array.from(
+          new Set(
+            value.options.flatMap((option) => {
+              const label = nonEmptyString(option);
+              return label ? [label] : [];
+            }),
+          ),
+        )
+      : [];
+    if (options.length === 0) {
+      return undefined;
+    }
+    return {
+      id,
+      method,
+      options,
+      question: {
+        id,
+        header: title,
+        question: "Choose an option.",
+        options: options.map((label) => ({ label, description: label })),
+        multiSelect: false,
+      },
+    };
+  }
+
+  if (method === "input") {
+    return {
+      id,
+      method,
+      question: {
+        id,
+        header: title,
+        question: nonEmptyString(value.placeholder) ?? "Type your response in the composer.",
+        options: [
+          {
+            label: PI_EXTENSION_CANCEL_LABEL,
+            description: "Cancel this input request",
+          },
+        ],
+        cancelOptionLabel: PI_EXTENSION_CANCEL_LABEL,
+        multiSelect: false,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function piExtensionDialogResponse(dialog: PiExtensionDialog, answers: ProviderUserInputAnswers) {
+  const answer = answers[dialog.question.id];
+  if (dialog.method === "confirm") {
+    return {
+      id: dialog.id,
+      confirmed: answer === PI_EXTENSION_CONFIRM_LABEL,
+    } as const;
+  }
+  if (dialog.method === "select") {
+    return typeof answer === "string" && dialog.options.includes(answer)
+      ? ({ id: dialog.id, value: answer } as const)
+      : ({ id: dialog.id, cancelled: true } as const);
+  }
+
+  if (isRecord(answer) && answer.cancelled === true) {
+    return { id: dialog.id, cancelled: true } as const;
+  }
+  if (isRecord(answer) && typeof answer.value === "string") {
+    return { id: dialog.id, value: answer.value } as const;
+  }
+  return typeof answer === "string"
+    ? ({ id: dialog.id, value: answer } as const)
+    : ({ id: dialog.id, cancelled: true } as const);
 }
 
 function runtimeProcessError(
@@ -1264,6 +1392,46 @@ export function makePiAdapter<R>(
             });
             return;
           }
+          case "extension_ui_request": {
+            const extensionId = nonEmptyString(raw.id);
+            const method = nonEmptyString(raw.method) ?? "unknown";
+            const dialog = piExtensionDialog(raw);
+            if (dialog) {
+              const requestId = ApprovalRequestId.make(dialog.id);
+              context.pendingExtensionDialogs.set(requestId, dialog);
+              yield* publishRuntimeEvent({
+                type: "user-input.requested",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: context.threadId,
+                ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+                requestId: RuntimeRequestId.make(dialog.id),
+                payload: { questions: [dialog.question] },
+                raw: rawPiEvent(raw, type),
+              });
+              return;
+            }
+
+            yield* publishRuntimeEvent({
+              type: "runtime.warning",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: context.threadId,
+              ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+              payload: {
+                message: `Pi extension UI '${method}' requires Pi's terminal interface.`,
+              },
+              raw: rawPiEvent(raw, type),
+            });
+            if (extensionId && method === "editor") {
+              yield* context.runtime
+                .respondToExtensionUI({ id: extensionId, cancelled: true })
+                .pipe(
+                  Effect.mapError((error) => runtimeRequestError("extension_ui_response", error)),
+                );
+            }
+            return;
+          }
           case "agent_settled": {
             yield* completeActiveTurn(context, raw, type);
             return;
@@ -1279,6 +1447,7 @@ export function makePiAdapter<R>(
           return Effect.void;
         }
         context.stopped = true;
+        context.pendingExtensionDialogs.clear();
         return context.runtime.close.pipe(
           Effect.ignore,
           Effect.andThen(Scope.close(context.scope, Exit.void).pipe(Effect.ignore)),
@@ -1445,6 +1614,7 @@ export function makePiAdapter<R>(
             compactionItemId: undefined,
             retryTaskIds: new Map(),
             summarizationRetryTaskId: undefined,
+            pendingExtensionDialogs: new Map(),
             nextSyntheticItemId: 0,
             nextSyntheticTaskId: 0,
             stopped: false,
@@ -1576,6 +1746,34 @@ export function makePiAdapter<R>(
         ),
       );
 
+    const respondToUserInput: ProviderAdapterShape<ProviderAdapterError>["respondToUserInput"] =
+      Effect.fn("PiAdapter.respondToUserInput")(function* (threadId, requestId, answers) {
+        const context = yield* requireSession(threadId);
+        const dialog = context.pendingExtensionDialogs.get(requestId);
+        if (!dialog) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "extension_ui_response",
+            detail: `Unknown pending Pi extension dialog: ${requestId}`,
+          });
+        }
+        const response = piExtensionDialogResponse(dialog, answers);
+        yield* context.runtime
+          .respondToExtensionUI(response)
+          .pipe(Effect.mapError((error) => runtimeRequestError("extension_ui_response", error)));
+        context.pendingExtensionDialogs.delete(requestId);
+        yield* publishRuntimeEvent({
+          type: "user-input.resolved",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: context.threadId,
+          ...(context.activeTurnId ? { turnId: context.activeTurnId } : {}),
+          requestId: RuntimeRequestId.make(dialog.id),
+          payload: { answers },
+          raw: rawPiEvent(response, "extension_ui_response"),
+        });
+      });
+
     const adapter: ProviderAdapterShape<ProviderAdapterError> = {
       provider: PROVIDER,
       // Pi natively applies model/thinking changes to a live RPC session.
@@ -1584,7 +1782,7 @@ export function makePiAdapter<R>(
       sendTurn,
       interruptTurn,
       respondToRequest: (threadId) => unavailableOperation("extension_ui_response", threadId),
-      respondToUserInput: (threadId) => unavailableOperation("extension_ui_response", threadId),
+      respondToUserInput,
       stopSession: (threadId) =>
         requireSession(threadId).pipe(Effect.flatMap(stopSessionInternal), Effect.asVoid),
       listSessions: () =>

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1,0 +1,341 @@
+import {
+  type ModelSelection,
+  type PiSettings,
+  ProviderDriverKind,
+  type ProviderInstanceId,
+  type ProviderSession,
+  type ThreadId,
+} from "@t3tools/contracts";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Scope from "effect/Scope";
+import * as Stream from "effect/Stream";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import { parsePiModelSlug, makePiModelSlug } from "../Drivers/PiModels.ts";
+import {
+  type PiSessionRuntimeError,
+  type PiSessionRuntimeOptions,
+  type PiSessionRuntimeShape,
+} from "../Drivers/PiSessionRuntime.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+
+const PROVIDER = ProviderDriverKind.make("pi");
+const TURN_DELIVERY_MESSAGE =
+  "Pi prompt delivery is not enabled until conversation streaming support is installed.";
+const UNSUPPORTED_OPERATION_MESSAGE =
+  "This Pi operation is not available until conversation controls are installed.";
+
+export type PiRuntimeFactory<R = never> = (
+  options: PiSessionRuntimeOptions,
+) => Effect.Effect<PiSessionRuntimeShape, PiSessionRuntimeError, R | Scope.Scope>;
+
+export interface PiAdapterOptions<R = never> {
+  readonly instanceId: ProviderInstanceId;
+  readonly sessionDirectory: string;
+  readonly environment?: NodeJS.ProcessEnv | undefined;
+  readonly makeRuntime: PiRuntimeFactory<R>;
+}
+
+interface PiAdapterSessionContext {
+  readonly threadId: ThreadId;
+  readonly scope: Scope.Closeable;
+  readonly runtime: PiSessionRuntimeShape;
+  session: ProviderSession;
+  stopped: boolean;
+}
+
+function runtimeProcessError(
+  threadId: ThreadId,
+  error: PiSessionRuntimeError,
+): ProviderAdapterProcessError {
+  return new ProviderAdapterProcessError({
+    provider: PROVIDER,
+    threadId,
+    detail: error.message,
+    cause: error,
+  });
+}
+
+function runtimeRequestError(
+  method: string,
+  error: PiSessionRuntimeError,
+): ProviderAdapterRequestError {
+  return new ProviderAdapterRequestError({
+    provider: PROVIDER,
+    method,
+    detail: error.message,
+    cause: error,
+  });
+}
+
+/**
+ * Build a Pi provider adapter bound to a single Pi Runtime Instance.
+ *
+ * Each adapter closure owns a separate session map and Pi Session Directory;
+ * the T3 thread ID is always supplied to Pi as its native session ID.
+ */
+export function makePiAdapter<R>(
+  piSettings: PiSettings,
+  options: PiAdapterOptions<R>,
+): Effect.Effect<ProviderAdapterShape<ProviderAdapterError>, never, R | Scope.Scope> {
+  return Effect.gen(function* () {
+    const runtimeFactory = options.makeRuntime;
+    // Provider adapter methods cannot require services at call time. Capture
+    // the runtime factory's infrastructure while the driver materializes this
+    // instance, then re-provide it when a thread starts later.
+    const runtimeContext = yield* Effect.context<R>();
+    const sessions = new Map<ThreadId, PiAdapterSessionContext>();
+
+    const stopSessionInternal = (context: PiAdapterSessionContext): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        if (context.stopped) {
+          return Effect.void;
+        }
+        context.stopped = true;
+        return context.runtime.close.pipe(
+          Effect.ignore,
+          Effect.andThen(Scope.close(context.scope, Exit.void).pipe(Effect.ignore)),
+          Effect.andThen(
+            Effect.sync(() => {
+              if (sessions.get(context.threadId) === context) {
+                sessions.delete(context.threadId);
+              }
+            }),
+          ),
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<PiAdapterSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const session = sessions.get(threadId);
+      if (session && !session.stopped) {
+        return Effect.succeed(session);
+      }
+      return Effect.fail(new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }));
+    };
+
+    const applyModelSelection = (input: {
+      readonly runtime: PiSessionRuntimeShape;
+      readonly modelSelection: ModelSelection | undefined;
+      readonly initialModel: string | undefined;
+      readonly operation: "startSession" | "sendTurn";
+    }) =>
+      Effect.gen(function* () {
+        const selection = input.modelSelection;
+        if (!selection || selection.instanceId !== options.instanceId) {
+          return input.initialModel;
+        }
+
+        const piModel = parsePiModelSlug(selection.model);
+        if (!piModel) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: input.operation,
+            issue: `Model '${selection.model}' is not a valid Pi provider/model selection.`,
+          });
+        }
+
+        yield* input.runtime
+          .setModel(piModel)
+          .pipe(Effect.mapError((error) => runtimeRequestError("set_model", error)));
+
+        const requestedThinkingLevel = getModelSelectionStringOptionValue(
+          selection,
+          "reasoningEffort",
+        );
+        if (!requestedThinkingLevel) {
+          return makePiModelSlug(piModel);
+        }
+
+        const levels = yield* input.runtime
+          .getAvailableThinkingLevels()
+          .pipe(
+            Effect.mapError((error) => runtimeRequestError("get_available_thinking_levels", error)),
+          );
+        if (!levels.includes(requestedThinkingLevel)) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: input.operation,
+            issue: `Pi model '${selection.model}' does not support thinking level '${requestedThinkingLevel}'.`,
+          });
+        }
+
+        yield* input.runtime
+          .setThinkingLevel(requestedThinkingLevel)
+          .pipe(Effect.mapError((error) => runtimeRequestError("set_thinking_level", error)));
+        return makePiModelSlug(piModel);
+      });
+
+    const startSession: ProviderAdapterShape<ProviderAdapterError>["startSession"] = (input) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (
+            input.providerInstanceId !== undefined &&
+            input.providerInstanceId !== options.instanceId
+          ) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected Pi runtime instance '${options.instanceId}' but received '${input.providerInstanceId}'.`,
+            });
+          }
+
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const sessionScope = yield* Scope.make("sequential");
+          let transferred = false;
+          yield* Effect.addFinalizer(() =>
+            transferred ? Effect.void : Scope.close(sessionScope, Exit.void).pipe(Effect.ignore),
+          );
+
+          const runtime = yield* runtimeFactory({
+            binaryPath: piSettings.binaryPath,
+            configDirectory: piSettings.configDirectory,
+            launchArgs: piSettings.launchArgs,
+            cwd: input.cwd ?? process.cwd(),
+            ...(options.environment ? { environment: options.environment } : {}),
+            sessionDirectory: options.sessionDirectory,
+            sessionId: input.threadId,
+          }).pipe(
+            Effect.provideContext(runtimeContext),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError((error) => runtimeProcessError(input.threadId, error)),
+          );
+          const state = yield* runtime
+            .start()
+            .pipe(Effect.mapError((error) => runtimeProcessError(input.threadId, error)));
+          const initialModel = state.model
+            ? makePiModelSlug({ provider: state.model.provider, modelId: state.model.id })
+            : undefined;
+          const model = yield* applyModelSelection({
+            runtime,
+            modelSelection: input.modelSelection,
+            initialModel,
+            operation: "startSession",
+          });
+          const now = DateTime.formatIso(yield* DateTime.now);
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: options.instanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            ...(input.cwd ? { cwd: input.cwd } : {}),
+            ...(model ? { model } : {}),
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: 1,
+              sessionId: input.threadId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+          const context: PiAdapterSessionContext = {
+            threadId: input.threadId,
+            scope: sessionScope,
+            runtime,
+            session,
+            stopped: false,
+          };
+          sessions.set(input.threadId, context);
+          transferred = true;
+          return session;
+        }),
+      );
+
+    const sendTurn: ProviderAdapterShape<ProviderAdapterError>["sendTurn"] = (input) =>
+      requireSession(input.threadId).pipe(
+        Effect.flatMap((context) =>
+          applyModelSelection({
+            runtime: context.runtime,
+            modelSelection: input.modelSelection,
+            initialModel: context.session.model,
+            operation: "sendTurn",
+          }).pipe(
+            Effect.tap((model) =>
+              Effect.map(DateTime.now, DateTime.formatIso).pipe(
+                Effect.tap((updatedAt) =>
+                  Effect.sync(() => {
+                    context.session = {
+                      ...context.session,
+                      ...(model ? { model } : {}),
+                      updatedAt,
+                    };
+                  }),
+                ),
+              ),
+            ),
+            Effect.andThen(
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "prompt",
+                detail: TURN_DELIVERY_MESSAGE,
+              }),
+            ),
+          ),
+        ),
+      );
+
+    const unavailableOperation = (method: string, threadId: ThreadId) =>
+      requireSession(threadId).pipe(
+        Effect.flatMap(() =>
+          Effect.fail(
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method,
+              detail: UNSUPPORTED_OPERATION_MESSAGE,
+            }),
+          ),
+        ),
+      );
+
+    const adapter: ProviderAdapterShape<ProviderAdapterError> = {
+      provider: PROVIDER,
+      // Pi natively applies model/thinking changes to a live RPC session.
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn: (threadId) => unavailableOperation("abort", threadId),
+      respondToRequest: (threadId) => unavailableOperation("extension_ui_response", threadId),
+      respondToUserInput: (threadId) => unavailableOperation("extension_ui_response", threadId),
+      stopSession: (threadId) =>
+        requireSession(threadId).pipe(Effect.flatMap(stopSessionInternal), Effect.asVoid),
+      listSessions: () =>
+        Effect.sync(() =>
+          Array.from(sessions.values(), (context) => context.session).filter(
+            (session) => !sessions.get(session.threadId)?.stopped,
+          ),
+        ),
+      hasSession: (threadId) => Effect.succeed(Boolean(sessions.get(threadId)?.stopped === false)),
+      readThread: (threadId) => unavailableOperation("get_messages", threadId),
+      rollbackThread: (threadId) => unavailableOperation("rollback", threadId),
+      stopAll: () =>
+        Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true }),
+      // Runtime event mapping is deliberately introduced with Pi prompt
+      // delivery. Preserve raw transport events on the runtime until then.
+      streamEvents: Stream.empty,
+    };
+
+    yield* Effect.addFinalizer(() => adapter.stopAll().pipe(Effect.ignore));
+    return adapter;
+  });
+}

--- a/apps/server/src/provider/Layers/PiContinuation.test.ts
+++ b/apps/server/src/provider/Layers/PiContinuation.test.ts
@@ -11,7 +11,11 @@ import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntim
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import * as ServerSettings from "../../serverSettings.ts";
 import * as AnalyticsService from "../../telemetry/AnalyticsService.ts";
-import { ProviderUnsupportedError, type ProviderAdapterError } from "../Errors.ts";
+import {
+  ProviderUnsupportedError,
+  ProviderValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
 import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 import type { ProviderAdapterRegistryShape } from "../Services/ProviderAdapterRegistry.ts";
 import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
@@ -105,7 +109,7 @@ function makeInstanceRegistry(input: {
  * registry.
  */
 describe("Pi native continuation", () => {
-  it.effect("reopens the original runtime instance and native session ID", () =>
+  it.effect("rejects an incompatible instance and reopens the original native session", () =>
     Effect.gen(function* () {
       const personalRuntime = makePiRuntimeFactory();
       const workRuntime = makePiRuntimeFactory();
@@ -152,6 +156,25 @@ describe("Pi native continuation", () => {
           },
         });
         yield* provider.stopSession({ threadId: THREAD_ID });
+
+        const incompatibleInstanceError = yield* provider
+          .startSession(THREAD_ID, {
+            threadId: THREAD_ID,
+            provider: PI,
+            providerInstanceId: WORK,
+            cwd: "/workspace/pi-project",
+            runtimeMode: "full-access",
+            modelSelection: {
+              instanceId: WORK,
+              model: "pi-provider/model",
+            },
+          })
+          .pipe(Effect.flip);
+        expect(incompatibleInstanceError).toBeInstanceOf(ProviderValidationError);
+        expect(incompatibleInstanceError.message).toContain(
+          "provider resume state is incompatible",
+        );
+        expect(workRuntime.options).toEqual([]);
 
         // Prompt delivery is introduced by the following Pi slice. Reaching
         // this adapter error proves ProviderService first recovered the native

--- a/apps/server/src/provider/Layers/PiContinuation.test.ts
+++ b/apps/server/src/provider/Layers/PiContinuation.test.ts
@@ -22,6 +22,7 @@ import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts
 import * as ProviderService from "../Services/ProviderService.ts";
 import { makePiAdapter } from "./PiAdapter.ts";
 import type {
+  PiPromptInput,
   PiSessionRuntimeOptions,
   PiSessionRuntimeShape,
 } from "../Drivers/PiSessionRuntime.ts";
@@ -36,37 +37,46 @@ const WORK = ProviderInstanceId.make("pi_work");
 const THREAD_ID = ThreadId.make("thread-pi-continuation");
 
 function makePiRuntimeFactory() {
-  const options: PiSessionRuntimeOptions[] = [];
+  return Effect.gen(function* () {
+    const options: PiSessionRuntimeOptions[] = [];
+    const prompts: PiPromptInput[] = [];
+    const events = yield* PubSub.unbounded<unknown>();
 
-  return {
-    options,
-    factory: (runtimeOptions: PiSessionRuntimeOptions) => {
-      options.push(runtimeOptions);
-      const runtime: PiSessionRuntimeShape = {
-        start: () =>
-          Effect.succeed({
-            sessionId: runtimeOptions.sessionId ?? "model-probe",
-            sessionFile: `/tmp/${runtimeOptions.sessionId ?? "model-probe"}.jsonl`,
-            model: { provider: "pi-provider", id: "model", name: "Pi Model" },
-          }),
-        getState: () =>
-          Effect.succeed({
-            sessionId: runtimeOptions.sessionId ?? "model-probe",
-            model: { provider: "pi-provider", id: "model", name: "Pi Model" },
-          }),
-        getAvailableModels: () => Effect.succeed([]),
-        setModel: () => Effect.void,
-        getAvailableThinkingLevels: () => Effect.succeed(["off", "high"]),
-        setThinkingLevel: () => Effect.void,
-        prompt: () => Effect.void,
-        abort: () => Effect.void,
-        respondToExtensionUI: () => Effect.void,
-        events: Stream.empty,
-        close: Effect.void,
-      };
-      return Effect.succeed(runtime);
-    },
-  };
+    return {
+      options,
+      prompts,
+      emit: (event: unknown) => PubSub.publish(events, event).pipe(Effect.asVoid),
+      factory: (runtimeOptions: PiSessionRuntimeOptions) => {
+        options.push(runtimeOptions);
+        const runtime: PiSessionRuntimeShape = {
+          start: () =>
+            Effect.succeed({
+              sessionId: runtimeOptions.sessionId ?? "model-probe",
+              sessionFile: `/tmp/${runtimeOptions.sessionId ?? "model-probe"}.jsonl`,
+              model: { provider: "pi-provider", id: "model", name: "Pi Model" },
+            }),
+          getState: () =>
+            Effect.succeed({
+              sessionId: runtimeOptions.sessionId ?? "model-probe",
+              model: { provider: "pi-provider", id: "model", name: "Pi Model" },
+            }),
+          getAvailableModels: () => Effect.succeed([]),
+          setModel: () => Effect.void,
+          getAvailableThinkingLevels: () => Effect.succeed(["off", "high"]),
+          setThinkingLevel: () => Effect.void,
+          prompt: (input) =>
+            Effect.sync(() => {
+              prompts.push(input);
+            }),
+          abort: () => Effect.void,
+          respondToExtensionUI: () => Effect.void,
+          events: Stream.fromPubSub(events),
+          close: Effect.void,
+        };
+        return Effect.succeed(runtime);
+      },
+    };
+  });
 }
 
 function makeInstanceRegistry(input: {
@@ -107,15 +117,15 @@ function makeInstanceRegistry(input: {
 
 /**
  * ProviderService owns persisted continuation routing. This contract test uses
- * two real Pi adapters and proves that recovering a stopped thread never
- * starts the other runtime instance, even though it is available in the
- * registry.
+ * two real Pi adapters and proves that a lost Pi transport does not replay an
+ * accepted prompt, then recovers only after an explicit later continuation on
+ * the originating runtime instance.
  */
 describe("Pi native continuation", () => {
-  it.effect("rejects an incompatible instance and reopens the original native session", () =>
+  it.effect("does not replay after loss and resumes the original session", () =>
     Effect.gen(function* () {
-      const personalRuntime = makePiRuntimeFactory();
-      const workRuntime = makePiRuntimeFactory();
+      const personalRuntime = yield* makePiRuntimeFactory();
+      const workRuntime = yield* makePiRuntimeFactory();
       const personal = yield* makePiAdapter(decodePiSettings({}), {
         instanceId: PERSONAL,
         sessionDirectory: "/tmp/t3/pi-sessions/pi_personal",
@@ -158,7 +168,28 @@ describe("Pi native continuation", () => {
             model: "pi-provider/model",
           },
         });
-        yield* provider.stopSession({ threadId: THREAD_ID });
+        yield* Effect.yieldNow;
+        yield* provider.sendTurn({
+          threadId: THREAD_ID,
+          input: "Persist this accepted Pi prompt exactly once.",
+          attachments: [],
+        });
+        yield* personalRuntime.emit({
+          type: "pi_rpc_transport_failure",
+          operation: "process-exit",
+          detail: "Pi RPC process exited with code 23.",
+        });
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        // A transport loss closes the live adapter but cannot trigger a new
+        // process or re-send the accepted prompt by itself.
+        expect(personalRuntime.options).toHaveLength(1);
+        expect(personalRuntime.prompts).toEqual([
+          { message: "Persist this accepted Pi prompt exactly once." },
+        ]);
+        expect(yield* provider.listSessions()).toEqual([]);
 
         const incompatibleInstanceError = yield* provider
           .startSession(THREAD_ID, {
@@ -179,11 +210,11 @@ describe("Pi native continuation", () => {
         );
         expect(workRuntime.options).toEqual([]);
 
-        // Prompt delivery recovers the persisted native session through its
-        // original runtime binding before it reaches Pi.
+        // A later user action explicitly recovers the persisted native session
+        // through its original runtime binding, delivering only that new prompt.
         yield* provider.sendTurn({
           threadId: THREAD_ID,
-          input: "continue this native session",
+          input: "Continue this native session after checking the interruption.",
           attachments: [],
         });
 
@@ -196,6 +227,10 @@ describe("Pi native continuation", () => {
         expect(personalRuntime.options.map((options) => options.sessionDirectory)).toEqual([
           "/tmp/t3/pi-sessions/pi_personal",
           "/tmp/t3/pi-sessions/pi_personal",
+        ]);
+        expect(personalRuntime.prompts).toEqual([
+          { message: "Persist this accepted Pi prompt exactly once." },
+          { message: "Continue this native session after checking the interruption." },
         ]);
         expect(workRuntime.options).toEqual([]);
       }).pipe(Effect.provide(providerLayer));

--- a/apps/server/src/provider/Layers/PiContinuation.test.ts
+++ b/apps/server/src/provider/Layers/PiContinuation.test.ts
@@ -60,6 +60,7 @@ function makePiRuntimeFactory() {
         setThinkingLevel: () => Effect.void,
         prompt: () => Effect.void,
         abort: () => Effect.void,
+        respondToExtensionUI: () => Effect.void,
         events: Stream.empty,
         close: Effect.void,
       };

--- a/apps/server/src/provider/Layers/PiContinuation.test.ts
+++ b/apps/server/src/provider/Layers/PiContinuation.test.ts
@@ -1,0 +1,181 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import { PiSettings, ProviderDriverKind, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import * as ServerSettings from "../../serverSettings.ts";
+import * as AnalyticsService from "../../telemetry/AnalyticsService.ts";
+import { ProviderUnsupportedError, type ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import type { ProviderAdapterRegistryShape } from "../Services/ProviderAdapterRegistry.ts";
+import * as ProviderAdapterRegistry from "../Services/ProviderAdapterRegistry.ts";
+import * as ProviderService from "../Services/ProviderService.ts";
+import { makePiAdapter } from "./PiAdapter.ts";
+import type {
+  PiSessionRuntimeOptions,
+  PiSessionRuntimeShape,
+} from "../Drivers/PiSessionRuntime.ts";
+import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
+import { makeProviderServiceLive } from "./ProviderService.ts";
+import * as ProviderEventLoggers from "./ProviderEventLoggers.ts";
+
+const decodePiSettings = Schema.decodeSync(PiSettings);
+const PI = ProviderDriverKind.make("pi");
+const PERSONAL = ProviderInstanceId.make("pi_personal");
+const WORK = ProviderInstanceId.make("pi_work");
+const THREAD_ID = ThreadId.make("thread-pi-continuation");
+
+function makePiRuntimeFactory() {
+  const options: PiSessionRuntimeOptions[] = [];
+
+  return {
+    options,
+    factory: (runtimeOptions: PiSessionRuntimeOptions) => {
+      options.push(runtimeOptions);
+      const runtime: PiSessionRuntimeShape = {
+        start: () =>
+          Effect.succeed({
+            sessionId: runtimeOptions.sessionId ?? "model-probe",
+            sessionFile: `/tmp/${runtimeOptions.sessionId ?? "model-probe"}.jsonl`,
+            model: { provider: "pi-provider", id: "model", name: "Pi Model" },
+          }),
+        getState: () =>
+          Effect.succeed({
+            sessionId: runtimeOptions.sessionId ?? "model-probe",
+            model: { provider: "pi-provider", id: "model", name: "Pi Model" },
+          }),
+        getAvailableModels: () => Effect.succeed([]),
+        setModel: () => Effect.void,
+        getAvailableThinkingLevels: () => Effect.succeed(["off", "high"]),
+        setThinkingLevel: () => Effect.void,
+        events: Stream.empty,
+        close: Effect.void,
+      };
+      return Effect.succeed(runtime);
+    },
+  };
+}
+
+function makeInstanceRegistry(input: {
+  readonly personal: ProviderAdapterShape<ProviderAdapterError>;
+  readonly work: ProviderAdapterShape<ProviderAdapterError>;
+}): ProviderAdapterRegistryShape {
+  const adapters = new Map([
+    [PERSONAL, input.personal],
+    [WORK, input.work],
+  ]);
+  const unsupported = (instanceId: ProviderInstanceId) =>
+    new ProviderUnsupportedError({ provider: String(instanceId) });
+
+  return {
+    getByInstance: (instanceId) => {
+      const adapter = adapters.get(instanceId);
+      return adapter ? Effect.succeed(adapter) : Effect.fail(unsupported(instanceId));
+    },
+    getInstanceInfo: (instanceId) =>
+      adapters.has(instanceId)
+        ? Effect.succeed({
+            instanceId,
+            driverKind: PI,
+            displayName: undefined,
+            enabled: true,
+            continuationIdentity: {
+              driverKind: PI,
+              continuationKey: `pi:instance:${instanceId}`,
+            },
+          })
+        : Effect.fail(unsupported(instanceId)),
+    listInstances: () => Effect.succeed([PERSONAL, WORK]),
+    listProviders: () => Effect.succeed([PI]),
+    streamChanges: Stream.empty,
+    subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+  };
+}
+
+/**
+ * ProviderService owns persisted continuation routing. This contract test uses
+ * two real Pi adapters and proves that recovering a stopped thread never
+ * starts the other runtime instance, even though it is available in the
+ * registry.
+ */
+describe("Pi native continuation", () => {
+  it.effect("reopens the original runtime instance and native session ID", () =>
+    Effect.gen(function* () {
+      const personalRuntime = makePiRuntimeFactory();
+      const workRuntime = makePiRuntimeFactory();
+      const personal = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: PERSONAL,
+        sessionDirectory: "/tmp/t3/pi-sessions/pi_personal",
+        makeRuntime: personalRuntime.factory,
+      });
+      const work = yield* makePiAdapter(decodePiSettings({}), {
+        instanceId: WORK,
+        sessionDirectory: "/tmp/t3/pi-sessions/pi_work",
+        makeRuntime: workRuntime.factory,
+      });
+      const registry = makeInstanceRegistry({ personal, work });
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const directoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry.ProviderAdapterRegistry, registry)),
+        Layer.provide(directoryLayer),
+        Layer.provide(ServerSettings.ServerSettingsService.layerTest()),
+        Layer.provide(AnalyticsService.layerTest),
+        Layer.provide(
+          Layer.succeed(
+            ProviderEventLoggers.ProviderEventLoggers,
+            ProviderEventLoggers.NoOpProviderEventLoggers,
+          ),
+        ),
+      );
+      yield* Effect.gen(function* () {
+        const provider = yield* ProviderService.ProviderService;
+        const initial = yield* provider.startSession(THREAD_ID, {
+          threadId: THREAD_ID,
+          provider: PI,
+          providerInstanceId: PERSONAL,
+          cwd: "/workspace/pi-project",
+          runtimeMode: "full-access",
+          modelSelection: {
+            instanceId: PERSONAL,
+            model: "pi-provider/model",
+          },
+        });
+        yield* provider.stopSession({ threadId: THREAD_ID });
+
+        // Prompt delivery is introduced by the following Pi slice. Reaching
+        // this adapter error proves ProviderService first recovered the native
+        // session using its persisted runtime binding.
+        yield* provider
+          .sendTurn({
+            threadId: THREAD_ID,
+            input: "continue this native session",
+            attachments: [],
+          })
+          .pipe(Effect.flip);
+
+        expect(initial.resumeCursor).toEqual({ schemaVersion: 1, sessionId: THREAD_ID });
+        expect(personalRuntime.options).toHaveLength(2);
+        expect(personalRuntime.options.map((options) => options.sessionId)).toEqual([
+          THREAD_ID,
+          THREAD_ID,
+        ]);
+        expect(personalRuntime.options.map((options) => options.sessionDirectory)).toEqual([
+          "/tmp/t3/pi-sessions/pi_personal",
+          "/tmp/t3/pi-sessions/pi_personal",
+        ]);
+        expect(workRuntime.options).toEqual([]);
+      }).pipe(Effect.provide(providerLayer));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/provider/Layers/PiContinuation.test.ts
+++ b/apps/server/src/provider/Layers/PiContinuation.test.ts
@@ -58,6 +58,8 @@ function makePiRuntimeFactory() {
         setModel: () => Effect.void,
         getAvailableThinkingLevels: () => Effect.succeed(["off", "high"]),
         setThinkingLevel: () => Effect.void,
+        prompt: () => Effect.void,
+        abort: () => Effect.void,
         events: Stream.empty,
         close: Effect.void,
       };
@@ -176,16 +178,13 @@ describe("Pi native continuation", () => {
         );
         expect(workRuntime.options).toEqual([]);
 
-        // Prompt delivery is introduced by the following Pi slice. Reaching
-        // this adapter error proves ProviderService first recovered the native
-        // session using its persisted runtime binding.
-        yield* provider
-          .sendTurn({
-            threadId: THREAD_ID,
-            input: "continue this native session",
-            attachments: [],
-          })
-          .pipe(Effect.flip);
+        // Prompt delivery recovers the persisted native session through its
+        // original runtime binding before it reaches Pi.
+        yield* provider.sendTurn({
+          threadId: THREAD_ID,
+          input: "continue this native session",
+          attachments: [],
+        });
 
         expect(initial.resumeCursor).toEqual({ schemaVersion: 1, sessionId: THREAD_ID });
         expect(personalRuntime.options).toHaveLength(2);

--- a/apps/server/src/provider/Layers/PiRuntimeContract.test.ts
+++ b/apps/server/src/provider/Layers/PiRuntimeContract.test.ts
@@ -1,0 +1,486 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
+import * as Stream from "effect/Stream";
+
+import { ServerConfig } from "../../config.ts";
+import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
+import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
+import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
+import * as ServerSettings from "../../serverSettings.ts";
+import * as AnalyticsService from "../../telemetry/AnalyticsService.ts";
+import { OrchestrationEngineLive } from "../../orchestration/Layers/OrchestrationEngine.ts";
+import { OrchestrationProjectionPipelineLive } from "../../orchestration/Layers/ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "../../orchestration/Layers/ProjectionSnapshotQuery.ts";
+import { ProviderRuntimeIngestionLive } from "../../orchestration/Layers/ProviderRuntimeIngestion.ts";
+import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProviderRuntimeIngestionService } from "../../orchestration/Services/ProviderRuntimeIngestion.ts";
+import { type ProviderAdapterError, ProviderUnsupportedError } from "../Errors.ts";
+import type {
+  PiSessionRuntimeOptions,
+  PiSessionRuntimeShape,
+} from "../Drivers/PiSessionRuntime.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import {
+  ProviderAdapterRegistry,
+  type ProviderAdapterRegistryShape,
+} from "../Services/ProviderAdapterRegistry.ts";
+import { ProviderService } from "../Services/ProviderService.ts";
+import { makePiAdapter } from "./PiAdapter.ts";
+import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
+import { makeProviderServiceLive } from "./ProviderService.ts";
+import * as ProviderEventLoggers from "./ProviderEventLoggers.ts";
+
+const PI = ProviderDriverKind.make("pi");
+const INSTANCE = ProviderInstanceId.make("pi_contract");
+const THREAD = ThreadId.make("thread-pi-contract");
+const PROJECT = ProjectId.make("project-pi-contract");
+
+const makeControlledPiRuntime = Effect.fn("makeControlledPiRuntime")(function* () {
+  const events = yield* PubSub.unbounded<unknown>();
+  const prompts: Array<{
+    readonly message: string;
+    readonly images?:
+      | ReadonlyArray<{
+          readonly type: "image";
+          readonly data: string;
+          readonly mimeType: string;
+        }>
+      | undefined;
+    readonly streamingBehavior?: "steer" | "followUp" | undefined;
+  }> = [];
+  const runtimeOptions: PiSessionRuntimeOptions[] = [];
+  let aborts = 0;
+
+  const factory = (options: PiSessionRuntimeOptions) => {
+    runtimeOptions.push(options);
+    const sessionId = options.sessionId ?? THREAD;
+    const sessionFile = options.sessionDirectory
+      ? NodePath.join(options.sessionDirectory, `${sessionId}.jsonl`)
+      : `/tmp/${sessionId}.jsonl`;
+    return Effect.succeed({
+      start: () =>
+        Effect.succeed({
+          sessionId,
+          sessionFile,
+          model: { provider: "custom", id: "team/coder", name: "Team Coder" },
+        }),
+      getState: () =>
+        Effect.succeed({
+          sessionId: THREAD,
+          model: { provider: "custom", id: "team/coder", name: "Team Coder" },
+        }),
+      getAvailableModels: () => Effect.succeed([]),
+      setModel: () => Effect.void,
+      getAvailableThinkingLevels: () => Effect.succeed(["off", "high"]),
+      setThinkingLevel: () => Effect.void,
+      prompt: (input) =>
+        Effect.sync(() => {
+          prompts.push(input);
+          if (options.sessionDirectory) {
+            NodeFS.mkdirSync(options.sessionDirectory, { recursive: true });
+            NodeFS.writeFileSync(sessionFile, `session ${sessionId} ${input.message}\n`);
+          }
+        }),
+      abort: () =>
+        Effect.sync(() => {
+          aborts += 1;
+        }),
+      events: Stream.fromPubSub(events),
+      close: Effect.void,
+    } satisfies PiSessionRuntimeShape);
+  };
+
+  return {
+    factory,
+    runtimeOptions,
+    prompts,
+    emit: (event: unknown) => PubSub.publish(events, event).pipe(Effect.asVoid),
+    abortCount: () => aborts,
+  };
+});
+
+function makeRegistry(
+  adapter: ProviderAdapterShape<ProviderAdapterError>,
+): ProviderAdapterRegistryShape {
+  const unsupported = () => new ProviderUnsupportedError({ provider: INSTANCE });
+  return {
+    getByInstance: (instanceId) =>
+      instanceId === INSTANCE ? Effect.succeed(adapter) : Effect.fail(unsupported()),
+    getInstanceInfo: (instanceId) =>
+      instanceId === INSTANCE
+        ? Effect.succeed({
+            instanceId: INSTANCE,
+            driverKind: PI,
+            displayName: "Pi contract",
+            enabled: true,
+            continuationIdentity: {
+              driverKind: PI,
+              continuationKey: `pi:instance:${INSTANCE}`,
+            },
+          })
+        : Effect.fail(unsupported()),
+    listInstances: () => Effect.succeed([INSTANCE]),
+    listProviders: () => Effect.succeed([PI]),
+    streamChanges: Stream.empty,
+    subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+  };
+}
+
+function makeContractLayer(adapter: ProviderAdapterShape<ProviderAdapterError>) {
+  const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+    Layer.provide(SqlitePersistenceMemory),
+  );
+  const directoryLayer = ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer));
+  const providerLayer = makeProviderServiceLive().pipe(
+    Layer.provide(Layer.succeed(ProviderAdapterRegistry, makeRegistry(adapter))),
+    Layer.provide(directoryLayer),
+    Layer.provide(ServerSettings.ServerSettingsService.layerTest()),
+    Layer.provide(AnalyticsService.layerTest),
+    Layer.provide(
+      Layer.succeed(
+        ProviderEventLoggers.ProviderEventLoggers,
+        ProviderEventLoggers.NoOpProviderEventLoggers,
+      ),
+    ),
+  );
+  const orchestrationLayer = OrchestrationEngineLive.pipe(
+    Layer.provide(OrchestrationProjectionSnapshotQueryLive),
+    Layer.provide(OrchestrationProjectionPipelineLive),
+    Layer.provide(OrchestrationEventStoreLive),
+    Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+    Layer.provide(RepositoryIdentityResolver.layer),
+    Layer.provide(SqlitePersistenceMemory),
+  );
+  const snapshotLayer = OrchestrationProjectionSnapshotQueryLive.pipe(
+    Layer.provide(RepositoryIdentityResolver.layer),
+    Layer.provide(SqlitePersistenceMemory),
+  );
+
+  return ProviderRuntimeIngestionLive.pipe(
+    Layer.provideMerge(orchestrationLayer),
+    Layer.provideMerge(snapshotLayer),
+    Layer.provideMerge(providerLayer),
+    Layer.provideMerge(SqlitePersistenceMemory),
+    Layer.provideMerge(ServerSettings.ServerSettingsService.layerTest()),
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+
+const drainRuntime = Effect.fn("drainRuntime")(function* (
+  ingestion: ProviderRuntimeIngestionService["Service"],
+) {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    yield* Effect.yieldNow;
+    yield* ingestion.drain;
+  }
+});
+
+describe("Pi runtime contract", () => {
+  it.effect(
+    "projects native Pi prompt, work-log, image, and abort behavior through ProviderService",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const controlled = yield* makeControlledPiRuntime();
+          const nativeSessionsRoot = NodeFS.mkdtempSync(
+            NodePath.join(NodeOS.tmpdir(), "t3-pi-contract-sessions-"),
+          );
+          const sessionDirectory = NodePath.join(nativeSessionsRoot, String(INSTANCE));
+          const siblingInstanceDirectory = NodePath.join(nativeSessionsRoot, "pi_other");
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              NodeFS.rmSync(nativeSessionsRoot, { recursive: true, force: true });
+            }),
+          );
+          const adapter = yield* makePiAdapter(
+            { enabled: true, binaryPath: "pi", configDirectory: "", launchArgs: "" },
+            {
+              instanceId: INSTANCE,
+              sessionDirectory,
+              loadImageAttachment: (attachment) =>
+                Effect.succeed({
+                  type: "image",
+                  data: `base64:${attachment.id}`,
+                  mimeType: attachment.mimeType,
+                }),
+              makeRuntime: controlled.factory,
+            },
+          );
+          const workspaceRoot = NodeFS.mkdtempSync(
+            NodePath.join(NodeOS.tmpdir(), "t3-pi-contract-"),
+          );
+          NodeFS.mkdirSync(NodePath.join(workspaceRoot, ".git"));
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              NodeFS.rmSync(workspaceRoot, { recursive: true, force: true });
+            }),
+          );
+
+          const services = yield* Layer.build(makeContractLayer(adapter));
+          return yield* Effect.gen(function* () {
+            const engine = yield* OrchestrationEngineService;
+            const snapshots = yield* ProjectionSnapshotQuery;
+            const ingestion = yield* ProviderRuntimeIngestionService;
+            const provider = yield* ProviderService;
+            yield* ingestion.start();
+
+            const createdAt = "2026-01-01T00:00:00.000Z";
+            yield* engine.dispatch({
+              type: "project.create",
+              commandId: CommandId.make("cmd-pi-contract-project"),
+              projectId: PROJECT,
+              title: "Pi contract project",
+              workspaceRoot,
+              defaultModelSelection: { instanceId: INSTANCE, model: "custom/team%2Fcoder" },
+              createdAt,
+            });
+            yield* engine.dispatch({
+              type: "thread.create",
+              commandId: CommandId.make("cmd-pi-contract-thread"),
+              threadId: THREAD,
+              projectId: PROJECT,
+              title: "Pi contract thread",
+              modelSelection: { instanceId: INSTANCE, model: "custom/team%2Fcoder" },
+              interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+              runtimeMode: "full-access",
+              branch: null,
+              worktreePath: null,
+              createdAt,
+            });
+            yield* provider.startSession(THREAD, {
+              threadId: THREAD,
+              provider: PI,
+              providerInstanceId: INSTANCE,
+              cwd: workspaceRoot,
+              runtimeMode: "full-access",
+              modelSelection: { instanceId: INSTANCE, model: "custom/team%2Fcoder" },
+            });
+            yield* engine.dispatch({
+              type: "thread.session.set",
+              commandId: CommandId.make("cmd-pi-contract-session"),
+              threadId: THREAD,
+              session: {
+                threadId: THREAD,
+                status: "ready",
+                providerName: PI,
+                providerInstanceId: INSTANCE,
+                runtimeMode: "full-access",
+                activeTurnId: null,
+                updatedAt: createdAt,
+                lastError: null,
+              },
+              createdAt,
+            });
+
+            yield* Effect.yieldNow;
+            const firstTurn = yield* provider.sendTurn({
+              threadId: THREAD,
+              input: "Inspect this screenshot and report the repository status.",
+              attachments: [
+                {
+                  type: "image",
+                  id: "thread-pi-contract-550e8400-e29b-41d4-a716-446655440000",
+                  name: "status.png",
+                  mimeType: "image/png",
+                  sizeBytes: 12,
+                },
+              ],
+            });
+            expect(controlled.prompts).toEqual([
+              {
+                message: "Inspect this screenshot and report the repository status.",
+                images: [
+                  {
+                    type: "image",
+                    data: "base64:thread-pi-contract-550e8400-e29b-41d4-a716-446655440000",
+                    mimeType: "image/png",
+                  },
+                ],
+              },
+            ]);
+            expect(controlled.runtimeOptions).toEqual([
+              expect.objectContaining({
+                sessionId: THREAD,
+                sessionDirectory,
+              }),
+            ]);
+            const nativeSessionFile = NodePath.join(sessionDirectory, `${THREAD}.jsonl`);
+            expect(NodeFS.existsSync(nativeSessionFile)).toBe(true);
+            expect(NodeFS.readFileSync(nativeSessionFile, "utf8")).toContain(THREAD);
+            expect(
+              NodeFS.existsSync(NodePath.join(siblingInstanceDirectory, `${THREAD}.jsonl`)),
+            ).toBe(false);
+
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: { type: "thinking_start", contentIndex: 0 },
+            });
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: {
+                type: "thinking_delta",
+                contentIndex: 0,
+                delta: "Checking the repository before responding.",
+              },
+            });
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: { type: "thinking_end", contentIndex: 0 },
+            });
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: {
+                type: "toolcall_start",
+                contentIndex: 1,
+                id: "call-status",
+                toolName: "bash",
+              },
+            });
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: {
+                type: "toolcall_delta",
+                contentIndex: 1,
+                delta: '{"command":"git status --short"}',
+              },
+            });
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: {
+                type: "toolcall_end",
+                contentIndex: 1,
+                toolCall: {
+                  type: "toolCall",
+                  id: "call-status",
+                  name: "bash",
+                  arguments: { command: "git status --short" },
+                },
+              },
+            });
+            yield* controlled.emit({
+              type: "tool_execution_start",
+              toolCallId: "call-status",
+              toolName: "bash",
+              args: { command: "git status --short" },
+            });
+            yield* controlled.emit({
+              type: "tool_execution_update",
+              toolCallId: "call-status",
+              toolName: "bash",
+              args: { command: "git status --short" },
+              partialResult: { content: [{ type: "text", text: "M package.json" }] },
+            });
+            yield* controlled.emit({
+              type: "tool_execution_end",
+              toolCallId: "call-status",
+              toolName: "bash",
+              result: { content: [{ type: "text", text: "M package.json" }] },
+              isError: false,
+            });
+            yield* controlled.emit({
+              type: "queue_update",
+              steering: ["Focus on tests"],
+              followUp: [],
+            });
+            yield* controlled.emit({ type: "compaction_start", reason: "threshold" });
+            yield* controlled.emit({
+              type: "compaction_end",
+              reason: "threshold",
+              result: { summary: "Condensed earlier context" },
+              aborted: false,
+              willRetry: false,
+            });
+            yield* controlled.emit({
+              type: "auto_retry_start",
+              attempt: 1,
+              maxAttempts: 3,
+              delayMs: 1,
+              errorMessage: "Temporary overload",
+            });
+            yield* controlled.emit({ type: "auto_retry_end", success: true, attempt: 1 });
+            yield* controlled.emit({ type: "queue_update", steering: [], followUp: [] });
+            yield* controlled.emit({ type: "message_start", message: { role: "assistant" } });
+            yield* controlled.emit({
+              type: "message_update",
+              message: { role: "assistant" },
+              assistantMessageEvent: {
+                type: "text_delta",
+                contentIndex: 0,
+                delta: "Repository is clean.",
+              },
+            });
+            yield* controlled.emit({ type: "message_end", message: { role: "assistant" } });
+            yield* controlled.emit({ type: "agent_settled" });
+            yield* drainRuntime(ingestion);
+
+            let snapshot = yield* snapshots.getSnapshot();
+            let thread = snapshot.threads.find((entry) => entry.id === THREAD);
+            expect(thread?.messages).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  role: "assistant",
+                  turnId: firstTurn.turnId,
+                  text: "Repository is clean.",
+                }),
+              ]),
+            );
+            expect(thread?.activities).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({ kind: "task.progress", summary: "Thinking" }),
+                expect.objectContaining({ kind: "tool.updated", summary: "bash" }),
+                expect.objectContaining({ kind: "tool.completed", summary: "bash" }),
+                expect.objectContaining({
+                  kind: "context-compaction",
+                  summary: "Context compacted",
+                }),
+                expect.objectContaining({ kind: "task.progress", summary: "Queued work" }),
+                expect.objectContaining({ kind: "task.progress", summary: "Retrying Pi request" }),
+              ]),
+            );
+            expect(thread?.session).toMatchObject({ status: "ready", activeTurnId: null });
+
+            const interrupted = yield* provider.sendTurn({
+              threadId: THREAD,
+              input: "Start another task and stop it.",
+              attachments: [],
+            });
+            yield* provider.interruptTurn({ threadId: THREAD, turnId: interrupted.turnId });
+            yield* controlled.emit({ type: "agent_settled" });
+            yield* drainRuntime(ingestion);
+
+            snapshot = yield* snapshots.getSnapshot();
+            thread = snapshot.threads.find((entry) => entry.id === THREAD);
+            expect(controlled.abortCount()).toBe(1);
+            expect(thread?.session).toMatchObject({ status: "ready", activeTurnId: null });
+            expect(interrupted.turnId).toBeTruthy();
+          }).pipe(Effect.provide(services));
+        }),
+      ),
+  );
+});

--- a/apps/server/src/provider/Layers/PiRuntimeContract.test.ts
+++ b/apps/server/src/provider/Layers/PiRuntimeContract.test.ts
@@ -104,6 +104,7 @@ const makeControlledPiRuntime = Effect.fn("makeControlledPiRuntime")(function* (
         Effect.sync(() => {
           aborts += 1;
         }),
+      respondToExtensionUI: () => Effect.void,
       events: Stream.fromPubSub(events),
       close: Effect.void,
     } satisfies PiSessionRuntimeShape);

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -30,6 +30,7 @@ import {
   type CursorSettings,
   type GrokSettings,
   type OpenCodeSettings,
+  type PiSettings,
   ProviderDriverKind,
   type ProviderInstanceConfigMap,
   ProviderInstanceId,
@@ -39,12 +40,15 @@ import * as Layer from "effect/Layer";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../../config.ts";
+import * as ProcessRunner from "../../processRunner.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ClaudeDriver } from "../Drivers/ClaudeDriver.ts";
 import { CodexDriver } from "../Drivers/CodexDriver.ts";
 import { CursorDriver } from "../Drivers/CursorDriver.ts";
 import { GrokDriver } from "../Drivers/GrokDriver.ts";
 import { OpenCodeDriver } from "../Drivers/OpenCodeDriver.ts";
+import { PiDriver } from "../Drivers/PiDriver.ts";
+import { BUILT_IN_DRIVERS } from "../builtInDrivers.ts";
 import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
 import { NoOpProviderEventLoggers, ProviderEventLoggers } from "./ProviderEventLoggers.ts";
 import { makeProviderInstanceRegistry } from "./ProviderInstanceRegistryLive.ts";
@@ -96,6 +100,14 @@ const makeOpenCodeConfig = (overrides: Partial<OpenCodeSettings>): OpenCodeSetti
   serverUrl: "",
   serverPassword: "",
   customModels: [],
+  ...overrides,
+});
+
+const makePiConfig = (overrides: Partial<PiSettings>): PiSettings => ({
+  enabled: false,
+  binaryPath: "pi",
+  configDirectory: "",
+  launchArgs: "",
   ...overrides,
 });
 
@@ -247,6 +259,12 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
     prefix: "provider-instance-registry-all-drivers-test",
   }).pipe(
     Layer.provideMerge(infraLayer),
+    Layer.provideMerge(
+      Layer.succeed(
+        ProcessRunner.ProcessRunner,
+        ProcessRunner.ProcessRunner.of({ run: () => Effect.die("Pi probe must not run") }),
+      ),
+    ),
     Layer.provideMerge(ServerSettingsService.layerTest()),
     Layer.provideMerge(TestHttpClientLive),
     Layer.provideMerge(Layer.succeed(ProviderEventLoggers, NoOpProviderEventLoggers)),
@@ -259,12 +277,14 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const cursorId = ProviderInstanceId.make("cursor_default");
       const grokId = ProviderInstanceId.make("grok_default");
       const openCodeId = ProviderInstanceId.make("opencode_default");
+      const piId = ProviderInstanceId.make("pi_default");
 
       const codexDriverKind = ProviderDriverKind.make("codex");
       const claudeDriverKind = ProviderDriverKind.make("claudeAgent");
       const cursorDriverKind = ProviderDriverKind.make("cursor");
       const grokDriverKind = ProviderDriverKind.make("grok");
       const openCodeDriverKind = ProviderDriverKind.make("opencode");
+      const piDriverKind = ProviderDriverKind.make("pi");
 
       const configMap: ProviderInstanceConfigMap = {
         [codexId]: {
@@ -300,10 +320,16 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
           enabled: false,
           config: makeOpenCodeConfig({}),
         },
+        [piId]: {
+          driver: piDriverKind,
+          displayName: "Pi",
+          enabled: false,
+          config: makePiConfig({}),
+        },
       };
 
       const { registry } = yield* makeProviderInstanceRegistry({
-        drivers: [CodexDriver, ClaudeDriver, CursorDriver, GrokDriver, OpenCodeDriver],
+        drivers: BUILT_IN_DRIVERS,
         configMap,
       });
 
@@ -313,9 +339,9 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(unavailable).toEqual([]);
 
       const instances = yield* registry.listInstances;
-      expect(instances).toHaveLength(5);
+      expect(instances).toHaveLength(6);
       expect(instances.map((instance) => instance.instanceId).toSorted()).toEqual(
-        [codexId, claudeId, cursorId, grokId, openCodeId].toSorted(),
+        [codexId, claudeId, cursorId, grokId, openCodeId, piId].toSorted(),
       );
 
       // Instance lookup by id resolves each instance to its own bundle —
@@ -326,16 +352,19 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       const cursor = yield* registry.getInstance(cursorId);
       const grok = yield* registry.getInstance(grokId);
       const openCode = yield* registry.getInstance(openCodeId);
+      const pi = yield* registry.getInstance(piId);
       expect(codex?.driverKind).toBe(codexDriverKind);
       expect(claude?.driverKind).toBe(claudeDriverKind);
       expect(cursor?.driverKind).toBe(cursorDriverKind);
       expect(grok?.driverKind).toBe(grokDriverKind);
       expect(openCode?.driverKind).toBe(openCodeDriverKind);
+      expect(pi?.driverKind).toBe(piDriverKind);
       expect(codex?.displayName).toBe("Codex");
       expect(claude?.displayName).toBe("Claude");
       expect(cursor?.displayName).toBe("Cursor");
       expect(grok?.displayName).toBe("Grok");
       expect(openCode?.displayName).toBe("OpenCode");
+      expect(pi?.displayName).toBe("Pi");
 
       // Every instance owns its own set of closures — no sharing across
       // drivers. `adapter` / `textGeneration` / `snapshot` are all
@@ -348,6 +377,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         cursor!.adapter,
         grok!.adapter,
         openCode!.adapter,
+        pi!.adapter,
       ];
       expect(new Set(adapters).size).toBe(adapters.length);
       const textGenerations = [
@@ -356,6 +386,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         cursor!.textGeneration,
         grok!.textGeneration,
         openCode!.textGeneration,
+        pi!.textGeneration,
       ];
       expect(new Set(textGenerations).size).toBe(textGenerations.length);
       const snapshots = [
@@ -364,6 +395,7 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
         cursor!.snapshot,
         grok!.snapshot,
         openCode!.snapshot,
+        pi!.snapshot,
       ];
       expect(new Set(snapshots).size).toBe(snapshots.length);
 
@@ -406,6 +438,12 @@ describe("ProviderInstanceRegistryLive — all drivers slice", () => {
       expect(openCodeSnapshot.continuation?.groupKey).toBe(
         `${openCodeDriverKind}:instance:${openCodeId}`,
       );
+
+      const piSnapshot = yield* pi!.snapshot.getSnapshot;
+      expect(piSnapshot.instanceId).toBe(piId);
+      expect(piSnapshot.driver).toBe(piDriverKind);
+      expect(piSnapshot.enabled).toBe(false);
+      expect(piSnapshot.continuation?.groupKey).toBe(`${piDriverKind}:instance:${piId}`);
     }).pipe(Effect.provide(testLayer)),
   );
 });

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -43,6 +43,7 @@ import {
   selectProvidersByKind,
 } from "./ProviderRegistry.ts";
 import * as ServerConfig from "../../config.ts";
+import * as ProcessRunner from "../../processRunner.ts";
 import * as ServerSettingsModule from "../../serverSettings.ts";
 import { readProviderStatusCache, resolveProviderStatusCachePath } from "../providerStatusCache.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
@@ -301,1678 +302,1670 @@ function makeMutableServerSettingsService(
   });
 }
 
-it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), TestHttpClientLive))(
-  "ProviderRegistry",
-  (it) => {
-    describe("checkCodexProviderStatus", () => {
-      it.effect("uses the app-server account and model list for provider status", () =>
-        Effect.gen(function* () {
-          const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
-            Effect.succeed(
-              makeCodexProbeSnapshot({
-                skills: [
-                  {
-                    name: "github:gh-fix-ci",
-                    path: "/Users/test/.codex/skills/gh-fix-ci/SKILL.md",
-                    enabled: true,
-                    displayName: "CI Debug",
-                    shortDescription: "Debug failing GitHub Actions checks",
-                  },
-                ],
-              }),
-            ),
-          );
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.installed, true);
-          assert.strictEqual(status.version, "1.0.0");
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "chatgpt");
-          assert.strictEqual(status.auth.label, "ChatGPT Pro 20x Subscription");
-          assert.strictEqual(status.auth.email, "test@example.com");
-          assert.deepStrictEqual(status.models, [
-            {
-              slug: "gpt-live-codex",
-              name: "GPT Live Codex",
-              isCustom: false,
-              capabilities: codexModelCapabilities,
-            },
-          ]);
-          assert.deepStrictEqual(status.skills, [
-            {
-              name: "github:gh-fix-ci",
-              path: "/Users/test/.codex/skills/gh-fix-ci/SKILL.md",
-              enabled: true,
-              displayName: "CI Debug",
-              shortDescription: "Debug failing GitHub Actions checks",
-            },
-          ]);
-        }),
-      );
-
-      it.effect("passes configured launch args to the Codex provider probe", () =>
-        Effect.gen(function* () {
-          let observedLaunchArgs: string | undefined;
-          const settings = decodeCodexSettings({ launchArgs: "--strict-config --enable foo" });
-
-          const status = yield* checkCodexProviderStatus(settings, (input) => {
-            observedLaunchArgs = input.launchArgs;
-            return Effect.succeed(makeCodexProbeSnapshot());
-          });
-
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(observedLaunchArgs, "--strict-config --enable foo");
-        }),
-      );
-
-      it.effect("returns unauthenticated when app-server requires OpenAI auth", () =>
-        Effect.gen(function* () {
-          const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
-            Effect.succeed(
-              makeCodexProbeSnapshot({
-                account: {
-                  account: null,
-                  requiresOpenaiAuth: true,
+it.layer(
+  Layer.mergeAll(
+    NodeServices.layer,
+    ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer)),
+    ServerSettingsModule.layerTest(),
+    TestHttpClientLive,
+  ),
+)("ProviderRegistry", (it) => {
+  describe("checkCodexProviderStatus", () => {
+    it.effect("uses the app-server account and model list for provider status", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+          Effect.succeed(
+            makeCodexProbeSnapshot({
+              skills: [
+                {
+                  name: "github:gh-fix-ci",
+                  path: "/Users/test/.codex/skills/gh-fix-ci/SKILL.md",
+                  enabled: true,
+                  displayName: "CI Debug",
+                  shortDescription: "Debug failing GitHub Actions checks",
                 },
-              }),
-            ),
-          );
-
-          assert.strictEqual(status.status, "error");
-          assert.strictEqual(status.auth.status, "unauthenticated");
-          assert.strictEqual(
-            status.message,
-            "Codex CLI is not authenticated. Run `codex login` and try again.",
-          );
-        }),
-      );
-
-      it.effect(
-        "returns ready with unknown auth when app-server does not require OpenAI auth",
-        () =>
-          Effect.gen(function* () {
-            const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
-              Effect.succeed(
-                makeCodexProbeSnapshot({
-                  account: {
-                    account: null,
-                    requiresOpenaiAuth: false,
-                  },
-                }),
-              ),
-            );
-
-            assert.strictEqual(status.status, "ready");
-            assert.strictEqual(status.auth.status, "unknown");
-          }),
-      );
-
-      it.effect("returns an api key label for codex api key auth", () =>
-        Effect.gen(function* () {
-          const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
-            Effect.succeed(
-              makeCodexProbeSnapshot({
-                account: {
-                  account: { type: "apiKey" },
-                  requiresOpenaiAuth: false,
-                },
-              }),
-            ),
-          );
-
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "apiKey");
-          assert.strictEqual(status.auth.label, "OpenAI API Key");
-        }),
-      );
-
-      it.effect("returns an Amazon Bedrock label for codex Bedrock auth", () =>
-        Effect.gen(function* () {
-          const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
-            Effect.succeed(
-              makeCodexProbeSnapshot({
-                account: {
-                  account: { type: "amazonBedrock" },
-                  requiresOpenaiAuth: false,
-                },
-              }),
-            ),
-          );
-
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "amazonBedrock");
-          assert.strictEqual(status.auth.label, "Amazon Bedrock");
-        }),
-      );
-
-      it.effect("returns unavailable when codex is missing", () =>
-        Effect.gen(function* () {
-          const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
-            Effect.fail(
-              new CodexErrors.CodexAppServerSpawnError({
-                command: "codex app-server",
-                cause: new Error("spawn codex ENOENT"),
-              }),
-            ),
-          );
-          assert.strictEqual(status.status, "error");
-          assert.strictEqual(status.installed, false);
-          assert.strictEqual(status.auth.status, "unknown");
-          assert.strictEqual(
-            status.message,
-            "Codex CLI (`codex`) is not installed or not on PATH.",
-          );
-        }),
-      );
-
-      it.effect("closes the app-server probe scope when provider status times out", () =>
-        Effect.gen(function* () {
-          const killCalls = yield* Ref.make(0);
-          const statusFiber = yield* checkCodexProviderStatus(defaultCodexSettings).pipe(
-            Effect.provide(hangingScopedSpawnerLayer(killCalls)),
-            Effect.forkChild,
-          );
-
-          yield* Effect.yieldNow;
-          yield* TestClock.adjust("11 seconds");
-          yield* Effect.yieldNow;
-
-          const status = yield* Fiber.join(statusFiber);
-          assert.strictEqual(status.status, "error");
-          assert.strictEqual(
-            status.message,
-            "Timed out while checking Codex app-server provider status.",
-          );
-          assert.strictEqual(yield* Ref.get(killCalls), 1);
-        }),
-      );
-    });
-
-    describe("ProviderRegistryLive", () => {
-      it("treats equal provider snapshots as unchanged", () => {
-        const providers = [
-          {
-            instanceId: ProviderInstanceId.make("codex"),
-            driver: ProviderDriverKind.make("codex"),
-            status: "ready",
-            enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-03-25T00:00:00.000Z",
-            version: "1.0.0",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          },
-          {
-            instanceId: ProviderInstanceId.make("claudeAgent"),
-            driver: ProviderDriverKind.make("claudeAgent"),
-            status: "warning",
-            enabled: true,
-            installed: true,
-            auth: { status: "unknown" },
-            checkedAt: "2026-03-25T00:00:00.000Z",
-            version: "1.0.0",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          },
-        ] as const satisfies ReadonlyArray<ServerProvider>;
-
-        assert.strictEqual(haveProvidersChanged(providers, [...providers]), false);
-      });
-
-      it("preserves previously discovered provider models when a refresh returns none", () => {
-        const previousProvider = {
-          instanceId: ProviderInstanceId.make("cursor"),
-          driver: ProviderDriverKind.make("cursor"),
-          status: "ready",
-          enabled: true,
-          installed: true,
-          auth: { status: "authenticated" },
-          checkedAt: "2026-04-14T00:00:00.000Z",
-          version: "2026.04.09-f2b0fcd",
-          models: [
-            {
-              slug: "claude-opus-4-6",
-              name: "Opus 4.6",
-              isCustom: false,
-              capabilities: createModelCapabilities({
-                optionDescriptors: [
-                  selectDescriptor("reasoning", "Reasoning", [
-                    { id: "high", label: "High", isDefault: true },
-                  ]),
-                  booleanDescriptor("fastMode", "Fast Mode"),
-                  booleanDescriptor("thinking", "Thinking"),
-                ],
-              }),
-            },
-          ],
-          slashCommands: [],
-          skills: [],
-        } as const satisfies ServerProvider;
-        const refreshedProvider = {
-          ...previousProvider,
-          checkedAt: "2026-04-14T00:01:00.000Z",
-          models: [],
-        } satisfies ServerProvider;
-
-        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
-          ...previousProvider.models,
-        ]);
-      });
-
-      it("fills missing capabilities from the previous provider snapshot", () => {
-        const previousProvider = {
-          instanceId: ProviderInstanceId.make("cursor"),
-          driver: ProviderDriverKind.make("cursor"),
-          status: "ready",
-          enabled: true,
-          installed: true,
-          auth: { status: "authenticated" },
-          checkedAt: "2026-04-14T00:00:00.000Z",
-          version: "2026.04.09-f2b0fcd",
-          models: [
-            {
-              slug: "claude-opus-4-6",
-              name: "Opus 4.6",
-              isCustom: false,
-              capabilities: createModelCapabilities({
-                optionDescriptors: [
-                  selectDescriptor("reasoning", "Reasoning", [
-                    { id: "high", label: "High", isDefault: true },
-                  ]),
-                  booleanDescriptor("fastMode", "Fast Mode"),
-                  booleanDescriptor("thinking", "Thinking"),
-                ],
-              }),
-            },
-          ],
-          slashCommands: [],
-          skills: [],
-        } as const satisfies ServerProvider;
-        const refreshedProvider = {
-          ...previousProvider,
-          checkedAt: "2026-04-14T00:01:00.000Z",
-          models: [
-            {
-              slug: "claude-opus-4-6",
-              name: "Opus 4.6",
-              isCustom: false,
-              capabilities: createModelCapabilities({
-                optionDescriptors: [],
-              }),
-            },
-          ],
-        } satisfies ServerProvider;
-
-        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
-          ...previousProvider.models,
-        ]);
-      });
-
-      it.effect("does not run provider probes during layer construction", () =>
-        Effect.gen(function* () {
-          const codexDriver = ProviderDriverKind.make("codex");
-          const codexInstanceId = ProviderInstanceId.make("codex");
-          const initialProvider = {
-            instanceId: codexInstanceId,
-            driver: codexDriver,
-            status: "warning",
-            enabled: true,
-            installed: false,
-            auth: { status: "unknown" },
-            checkedAt: "2026-06-10T00:00:00.000Z",
-            version: null,
-            message: "Checking Codex provider status.",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          } as const satisfies ServerProvider;
-          const refreshCalls = yield* Ref.make(0);
-          const instance = {
-            instanceId: codexInstanceId,
-            driverKind: codexDriver,
-            continuationIdentity: {
-              driverKind: codexDriver,
-              continuationKey: "codex:instance:codex",
-            },
-            displayName: undefined,
-            enabled: true,
-            snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: codexDriver,
-                packageName: null,
-              }),
-              getSnapshot: Effect.succeed(initialProvider),
-              refresh: Ref.update(refreshCalls, (count) => count + 1).pipe(
-                Effect.andThen(Effect.never),
-              ),
-              streamChanges: Stream.empty,
-            },
-            adapter: {} as ProviderInstance["adapter"],
-            textGeneration: {} as ProviderInstance["textGeneration"],
-          } satisfies ProviderInstance;
-          const instanceRegistryLayer = Layer.succeed(
-            ProviderInstanceRegistry.ProviderInstanceRegistry,
-            {
-              getInstance: (instanceId) =>
-                Effect.succeed(instanceId === codexInstanceId ? instance : undefined),
-              listInstances: Effect.succeed([instance]),
-              listUnavailable: Effect.succeed([]),
-              streamChanges: Stream.empty,
-              subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
-            },
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const runtimeServices = yield* Layer.build(
-            ProviderRegistryLive.pipe(
-              Layer.provideMerge(instanceRegistryLayer),
-              Layer.provideMerge(
-                ServerConfig.layerTest(process.cwd(), {
-                  prefix: "t3-provider-registry-background-refresh-",
-                }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ).pipe(Scope.provide(scope));
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-            assert.deepStrictEqual(yield* registry.getProviders, [initialProvider]);
-            assert.strictEqual(yield* Ref.get(refreshCalls), 0);
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      it("persists merged provider snapshots for the providers that were refreshed", () => {
-        const previousProviders = [
-          {
-            instanceId: ProviderInstanceId.make("cursor"),
-            driver: ProviderDriverKind.make("cursor"),
-            status: "ready",
-            enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-04-14T00:00:00.000Z",
-            version: "2026.04.09-f2b0fcd",
-            models: [
-              {
-                slug: "claude-opus-4-6",
-                name: "Opus 4.6",
-                isCustom: false,
-                capabilities: createModelCapabilities({
-                  optionDescriptors: [
-                    selectDescriptor("reasoning", "Reasoning", [
-                      { id: "high", label: "High", isDefault: true },
-                    ]),
-                    booleanDescriptor("fastMode", "Fast Mode"),
-                    booleanDescriptor("thinking", "Thinking"),
-                  ],
-                }),
-              },
-            ],
-            slashCommands: [],
-            skills: [],
-          },
-          {
-            instanceId: ProviderInstanceId.make("codex"),
-            driver: ProviderDriverKind.make("codex"),
-            status: "ready",
-            enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-04-14T00:00:00.000Z",
-            version: "1.0.0",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          },
-        ] as const satisfies ReadonlyArray<ServerProvider>;
-        const refreshedCursor = {
-          ...previousProviders[0],
-          checkedAt: "2026-04-14T00:01:00.000Z",
-          models: [],
-        } satisfies ServerProvider;
-
-        const mergedProviders = mergeProviderSnapshots(previousProviders, [refreshedCursor]);
-        const persistedProviders = selectProvidersByKind(
-          mergedProviders,
-          new Set([ProviderDriverKind.make("cursor")]),
+              ],
+            }),
+          ),
         );
-
-        assert.deepStrictEqual(persistedProviders, [
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.installed, true);
+        assert.strictEqual(status.version, "1.0.0");
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "chatgpt");
+        assert.strictEqual(status.auth.label, "ChatGPT Pro 20x Subscription");
+        assert.strictEqual(status.auth.email, "test@example.com");
+        assert.deepStrictEqual(status.models, [
           {
-            ...refreshedCursor,
-            models: [...previousProviders[0].models],
+            slug: "gpt-live-codex",
+            name: "GPT Live Codex",
+            isCustom: false,
+            capabilities: codexModelCapabilities,
           },
         ]);
-      });
-
-      it.effect("persists the merged snapshot when a live update has empty models", () =>
-        Effect.gen(function* () {
-          const cursorDriver = ProviderDriverKind.make("cursor");
-          const cursorInstanceId = ProviderInstanceId.make("cursor");
-          const initialProvider = {
-            instanceId: cursorInstanceId,
-            driver: cursorDriver,
-            status: "ready",
+        assert.deepStrictEqual(status.skills, [
+          {
+            name: "github:gh-fix-ci",
+            path: "/Users/test/.codex/skills/gh-fix-ci/SKILL.md",
             enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-04-14T00:00:00.000Z",
-            version: "2026.04.09-f2b0fcd",
-            models: [
-              {
-                slug: "claude-opus-4-6",
-                name: "Opus 4.6",
-                isCustom: false,
-                capabilities: createModelCapabilities({
-                  optionDescriptors: [
-                    selectDescriptor("reasoning", "Reasoning", [
-                      { id: "high", label: "High", isDefault: true },
-                    ]),
-                  ],
-                }),
-              },
-            ],
-            slashCommands: [],
-            skills: [],
-          } as const satisfies ServerProvider;
-          const refreshedProvider = {
-            ...initialProvider,
-            checkedAt: "2026-04-14T00:01:00.000Z",
-            models: [],
-          } satisfies ServerProvider;
-          const changes = yield* PubSub.unbounded<ServerProvider>();
-          const instance = {
-            instanceId: cursorInstanceId,
-            driverKind: cursorDriver,
-            continuationIdentity: {
-              driverKind: cursorDriver,
-              continuationKey: "cursor:instance:cursor",
-            },
-            displayName: undefined,
-            enabled: true,
-            snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: cursorDriver,
-                packageName: null,
-              }),
-              getSnapshot: Effect.succeed(initialProvider),
-              refresh: Effect.succeed(refreshedProvider),
-              streamChanges: Stream.fromPubSub(changes),
-            },
-            adapter: {} as ProviderInstance["adapter"],
-            textGeneration: {} as ProviderInstance["textGeneration"],
-          } satisfies ProviderInstance;
-          const instanceRegistryLayer = Layer.succeed(
-            ProviderInstanceRegistry.ProviderInstanceRegistry,
-            {
-              getInstance: (instanceId) =>
-                Effect.succeed(instanceId === cursorInstanceId ? instance : undefined),
-              listInstances: Effect.succeed([instance]),
-              listUnavailable: Effect.succeed([]),
-              streamChanges: Stream.empty,
-              subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
-                PubSub.subscribe(pubsub),
-              ),
-            },
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const runtimeServices = yield* Layer.build(
-            ProviderRegistryLive.pipe(
-              Layer.provideMerge(instanceRegistryLayer),
-              Layer.provideMerge(
-                ServerConfig.layerTest(process.cwd(), {
-                  prefix: "t3-provider-registry-merged-persist-",
-                }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ).pipe(Scope.provide(scope));
+            displayName: "CI Debug",
+            shortDescription: "Debug failing GitHub Actions checks",
+          },
+        ]);
+      }),
+    );
 
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-            const config = yield* ServerConfig.ServerConfig;
-            const filePath = yield* resolveProviderStatusCachePath({
-              cacheDir: config.providerStatusCacheDir,
-              instanceId: cursorInstanceId,
-            });
+    it.effect("passes configured launch args to the Codex provider probe", () =>
+      Effect.gen(function* () {
+        let observedLaunchArgs: string | undefined;
+        const settings = decodeCodexSettings({ launchArgs: "--strict-config --enable foo" });
 
-            assert.deepStrictEqual((yield* registry.getProviders)[0]?.models, [
-              ...initialProvider.models,
-            ]);
-            yield* PubSub.publish(changes, refreshedProvider);
-
-            let cachedProvider = yield* readProviderStatusCache(filePath);
-            for (
-              let attempt = 0;
-              attempt < 50 && cachedProvider?.checkedAt !== refreshedProvider.checkedAt;
-              attempt += 1
-            ) {
-              yield* TestClock.adjust("10 millis");
-              yield* Effect.yieldNow;
-              cachedProvider = yield* readProviderStatusCache(filePath);
-            }
-
-            assert.deepStrictEqual(cachedProvider, {
-              ...refreshedProvider,
-              models: [...initialProvider.models],
-            });
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      it.effect("returns the cached provider list when a manual refresh fails", () =>
-        Effect.gen(function* () {
-          const codexDriver = ProviderDriverKind.make("codex");
-          const codexInstanceId = ProviderInstanceId.make("codex");
-          const cachedProvider = {
-            instanceId: codexInstanceId,
-            driver: codexDriver,
-            status: "ready",
-            enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-04-29T10:00:00.000Z",
-            version: "1.0.0",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          } as const satisfies ServerProvider;
-          const instance = {
-            instanceId: codexInstanceId,
-            driverKind: codexDriver,
-            continuationIdentity: {
-              driverKind: codexDriver,
-              continuationKey: "codex:instance:codex",
-            },
-            displayName: undefined,
-            enabled: true,
-            snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: codexDriver,
-                packageName: null,
-              }),
-              getSnapshot: Effect.succeed(cachedProvider),
-              refresh: Effect.die(new Error("simulated refresh failure")),
-              streamChanges: Stream.empty,
-            },
-            adapter: {} as ProviderInstance["adapter"],
-            textGeneration: {} as ProviderInstance["textGeneration"],
-          } satisfies ProviderInstance;
-          const instanceRegistryLayer = Layer.succeed(
-            ProviderInstanceRegistry.ProviderInstanceRegistry,
-            {
-              getInstance: (instanceId) =>
-                Effect.succeed(instanceId === codexInstanceId ? instance : undefined),
-              listInstances: Effect.succeed([instance]),
-              listUnavailable: Effect.succeed([]),
-              streamChanges: Stream.empty,
-              subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
-                PubSub.subscribe(pubsub),
-              ),
-            },
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const runtimeServices = yield* Layer.build(
-            ProviderRegistryLive.pipe(
-              Layer.provideMerge(instanceRegistryLayer),
-              Layer.provideMerge(
-                ServerConfig.layerTest(process.cwd(), {
-                  prefix: "t3-provider-registry-refresh-failure-",
-                }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ).pipe(Scope.provide(scope));
-
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-
-            assert.deepStrictEqual(yield* registry.getProviders, [cachedProvider]);
-            assert.deepStrictEqual(yield* registry.refresh(codexDriver), [cachedProvider]);
-            assert.deepStrictEqual(yield* registry.refreshInstance(codexInstanceId), [
-              cachedProvider,
-            ]);
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      it.effect("keeps consuming registry changes after one sync fails", () =>
-        Effect.gen(function* () {
-          const codexDriver = ProviderDriverKind.make("codex");
-          const codexInstanceId = ProviderInstanceId.make("codex");
-          const claudeDriver = ProviderDriverKind.make("claudeAgent");
-          const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
-          const codexProvider = {
-            instanceId: codexInstanceId,
-            driver: codexDriver,
-            status: "ready",
-            enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-04-29T10:00:00.000Z",
-            version: "1.0.0",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          } as const satisfies ServerProvider;
-          const claudeProvider = {
-            instanceId: claudeInstanceId,
-            driver: claudeDriver,
-            status: "ready",
-            enabled: true,
-            installed: true,
-            auth: { status: "authenticated" },
-            checkedAt: "2026-04-29T10:01:00.000Z",
-            version: "1.0.0",
-            models: [],
-            slashCommands: [],
-            skills: [],
-          } as const satisfies ServerProvider;
-          const makeInstance = (provider: ServerProvider): ProviderInstance => ({
-            instanceId: provider.instanceId,
-            driverKind: provider.driver,
-            continuationIdentity: {
-              driverKind: provider.driver,
-              continuationKey: `${provider.driver}:instance:${provider.instanceId}`,
-            },
-            displayName: undefined,
-            enabled: true,
-            snapshot: {
-              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
-                provider: provider.driver,
-                packageName: null,
-              }),
-              getSnapshot: Effect.succeed(provider),
-              refresh: Effect.succeed(provider),
-              streamChanges: Stream.empty,
-            },
-            adapter: {} as ProviderInstance["adapter"],
-            textGeneration: {} as ProviderInstance["textGeneration"],
-          });
-          const codexInstance = makeInstance(codexProvider);
-          const claudeInstance = makeInstance(claudeProvider);
-          const changes = yield* PubSub.unbounded<void>();
-          const instancesRef = yield* Ref.make<ReadonlyArray<ProviderInstance>>([codexInstance]);
-          const failNextList = yield* Ref.make(false);
-          const wait = () => Effect.yieldNow;
-          const instanceRegistryLayer = Layer.succeed(
-            ProviderInstanceRegistry.ProviderInstanceRegistry,
-            {
-              getInstance: (instanceId) =>
-                Ref.get(instancesRef).pipe(
-                  Effect.map((instances) =>
-                    instances.find((instance) => instance.instanceId === instanceId),
-                  ),
-                ),
-              listInstances: Effect.gen(function* () {
-                const shouldFail = yield* Ref.get(failNextList);
-                if (shouldFail) {
-                  yield* Ref.set(failNextList, false);
-                  return yield* Effect.die(new Error("simulated registry list failure"));
-                }
-                return yield* Ref.get(instancesRef);
-              }),
-              listUnavailable: Effect.succeed([]),
-              streamChanges: Stream.fromPubSub(changes),
-              subscribeChanges: PubSub.subscribe(changes),
-            },
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const runtimeServices = yield* Layer.build(
-            ProviderRegistryLive.pipe(
-              Layer.provideMerge(instanceRegistryLayer),
-              Layer.provideMerge(
-                ServerConfig.layerTest(process.cwd(), {
-                  prefix: "t3-provider-registry-sync-failure-",
-                }),
-              ),
-              Layer.provideMerge(NodeServices.layer),
-            ),
-          ).pipe(Scope.provide(scope));
-
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-            assert.deepStrictEqual(yield* registry.getProviders, [codexProvider]);
-
-            yield* Ref.set(failNextList, true);
-            yield* PubSub.publish(changes, undefined);
-
-            yield* Ref.set(instancesRef, [codexInstance, claudeInstance]);
-            yield* PubSub.publish(changes, undefined);
-
-            let providers = yield* registry.getProviders;
-            for (
-              let attempt = 0;
-              attempt < 50 &&
-              !providers.some((provider) => provider.instanceId === claudeInstanceId);
-              attempt += 1
-            ) {
-              yield* wait();
-              providers = yield* registry.getProviders;
-            }
-
-            assert.deepStrictEqual(
-              providers.map((provider) => provider.instanceId).toSorted(),
-              [codexInstanceId, claudeInstanceId].toSorted(),
-            );
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      // This test intentionally avoids `mockCommandSpawnerLayer` so the real
-      // `probeCodexAppServerProvider` path runs — including the full
-      // `codex app-server` RPC handshake via `CodexClient.layerChildProcess`.
-      // We point `binaryPath` at a name that cannot exist on any machine so
-      // the real `ChildProcessSpawner` deterministically returns ENOENT; the
-      // probe wraps that as `CodexAppServerSpawnError` and
-      // `checkCodexProviderStatus` turns it into the user-visible "not
-      // installed" error snapshot. If the aggregator's `syncLiveSources`
-      // breaks — the `codex_personal`-never-probes bug we are guarding
-      // against — that snapshot never lands in `getProviders` and the
-      // assertions below fail.
-      it.effect("propagates real Codex probe failures to the aggregator at boot", () =>
-        Effect.gen(function* () {
-          const missingBinary = `t3code_codex_missing_`;
-          const serverSettings = yield* makeMutableServerSettingsService(
-            decodeServerSettings(
-              deepMerge(encodedDefaultServerSettings, {
-                providers: {
-                  // Disable every built-in probe that would otherwise spawn
-                  // on the CI host. `enabled: false` short-circuits each
-                  // driver's probe *before* it touches the spawner, so the
-                  // test environment stays isolated from the dev
-                  // machine's PATH.
-                  codex: { enabled: false },
-                  claudeAgent: { enabled: false },
-                  cursor: { enabled: false },
-                  grok: { enabled: false },
-                  opencode: { enabled: false },
-                },
-                // `providerInstances` keys are branded `ProviderInstanceId`;
-                // the branded index signature rejects plain string literals
-                // at the TS level even though the runtime schema happily
-                // accepts + decodes them. Cast the patch to `unknown` so
-                // the `Schema.decodeSync` below does the real validation.
-                providerInstances: {
-                  // Matches the shape the user had in `.t3/dev/settings.json`
-                  // when the bug was reported: a custom enabled Codex instance
-                  // pointing at a binary the server has to actually spawn.
-                  codex_personal: {
-                    driver: "codex",
-                    displayName: "Codex Personal",
-                    enabled: true,
-                    config: {
-                      binaryPath: missingBinary,
-                      homePath: `/tmp/${missingBinary}_home`,
-                    },
-                  },
-                } as unknown as ContractServerSettings["providerInstances"],
-              }),
-            ),
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const providerRegistryLayer = ProviderRegistryLive.pipe(
-            Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
-            Layer.provideMerge(
-              Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
-            ),
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), {
-                prefix: "t3-provider-registry-",
-              }),
-            ),
-            Layer.provideMerge(TestHttpClientLive),
-            Layer.provideMerge(
-              Layer.succeed(
-                ProviderEventLoggers.ProviderEventLoggers,
-                ProviderEventLoggers.NoOpProviderEventLoggers,
-              ),
-            ),
-            Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
-            // NO spawner mock — `ChildProcessSpawner` is supplied by the
-            // outer `NodeServices.layer` on `it.layer(...)` and will
-            // genuinely spawn a subprocess. The missing-binary ENOENT is
-            // what exercises the same failure mode as a misconfigured
-            // production `binaryPath`.
-          );
-          const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
-            Scope.provide(scope),
-          );
-
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-            let providers = yield* registry.getProviders;
-            for (
-              let attempts = 0;
-              attempts < 50 &&
-              providers.find((provider) => provider.instanceId === "codex_personal")?.status !==
-                "error";
-              attempts += 1
-            ) {
-              yield* Effect.yieldNow;
-              providers = yield* registry.getProviders;
-            }
-            const codexPersonal = providers.find(
-              (provider) => provider.instanceId === "codex_personal",
-            );
-            assert.notStrictEqual(
-              codexPersonal,
-              undefined,
-              `Expected the aggregator to know about codex_personal; instead saw: ${providers
-                .map((provider) => provider.instanceId)
-                .join(", ")}`,
-            );
-            assert.strictEqual(
-              codexPersonal?.status,
-              "error",
-              "Real Codex probe against a missing binary should surface as 'error' in the aggregator",
-            );
-            assert.strictEqual(codexPersonal?.installed, false);
-            assert.strictEqual(
-              codexPersonal?.message,
-              "Codex CLI (`codex`) is not installed or not on PATH.",
-            );
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      // Guards the second half of the reported bug: changing
-      // `providers.codex.binaryPath` in settings must tear down the live
-      // instance and rebuild it so a fresh probe runs with the new binary.
-      // This test drives the real settings stream → registry reconcile →
-      // aggregator sync pipeline and asserts that `getProviders` reflects
-      // the new background probe's outcome.
-      //
-      it.effect("re-probes when settings change the codex binaryPath", () =>
-        Effect.gen(function* () {
-          const firstMissing = `t3code_codex_first_`;
-          const secondMissing = `t3code_codex_second_`;
-          const spawnedCommands: Array<string> = [];
-          const serverSettings = yield* makeMutableServerSettingsService(
-            decodeServerSettings(
-              deepMerge(encodedDefaultServerSettings, {
-                providers: {
-                  codex: { enabled: true, binaryPath: firstMissing },
-                  claudeAgent: { enabled: false },
-                  cursor: { enabled: false },
-                  grok: { enabled: false },
-                  opencode: { enabled: false },
-                },
-              }),
-            ),
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const providerRegistryLayer = ProviderRegistryLive.pipe(
-            Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
-            Layer.provideMerge(
-              Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
-            ),
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), {
-                prefix: "t3-provider-registry-",
-              }),
-            ),
-            Layer.provideMerge(TestHttpClientLive),
-            Layer.provideMerge(
-              Layer.succeed(
-                ProviderEventLoggers.ProviderEventLoggers,
-                ProviderEventLoggers.NoOpProviderEventLoggers,
-              ),
-            ),
-            Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
-            Layer.updateService(ChildProcessSpawner.ChildProcessSpawner, (spawner) =>
-              ChildProcessSpawner.make((command) => {
-                spawnedCommands.push((command as { readonly command: string }).command);
-                return spawner.spawn(command);
-              }),
-            ),
-            Layer.provideMerge(NodeServices.layer),
-          );
-          const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
-            Scope.provide(scope),
-          );
-
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-            // Boot-time probe: the default codex instance is enabled with
-            // `firstMissing`, so the real spawner yields ENOENT and the
-            // snapshot should be `status: "error"`.
-            let initialProviders = yield* registry.getProviders;
-            for (
-              let attempts = 0;
-              attempts < 50 &&
-              initialProviders.find((provider) => provider.instanceId === "codex")?.status !==
-                "error";
-              attempts += 1
-            ) {
-              yield* TestClock.adjust("10 millis");
-              yield* Effect.yieldNow;
-              initialProviders = yield* registry.getProviders;
-            }
-            const initialCodex = initialProviders.find(
-              (provider) => provider.instanceId === "codex",
-            );
-            assert.strictEqual(initialCodex?.status, "error");
-            assert.strictEqual(initialCodex?.installed, false);
-            assert.deepStrictEqual(spawnedCommands, [firstMissing]);
-
-            // Drive a settings change. The Hydration layer's
-            // `SettingsWatcherLive` consumes this via `streamChanges`,
-            // calls `reconcile`, which rebuilds the codex instance (the
-            // envelope changed because `binaryPath` differs → `entryEqual`
-            // is false). The registry's `Stream.runForEach(
-            // instanceRegistry.streamChanges, () => syncLiveSources)`
-            // fires `syncLiveSources`, which subscribes and launches a fresh
-            // background refresh on the rebuilt instance.
-            yield* serverSettings.updateSettings({
-              providers: {
-                codex: { enabled: true, binaryPath: secondMissing },
-              },
-            });
-
-            // Poll until the injected process boundary observes the new
-            // executable. This verifies the public settings-to-probe behavior
-            // without depending on timestamps assigned by TestClock.
-            const refreshed = yield* Effect.gen(function* () {
-              for (let attempts = 0; attempts < 60; attempts += 1) {
-                const providers = yield* registry.getProviders;
-                const codex = providers.find((provider) => provider.instanceId === "codex");
-                if (
-                  codex !== undefined &&
-                  codex.status === "error" &&
-                  spawnedCommands.includes(secondMissing)
-                ) {
-                  return providers;
-                }
-                yield* TestClock.adjust("50 millis");
-                yield* Effect.yieldNow;
-              }
-              return yield* registry.getProviders;
-            });
-
-            const reprobedCodex = refreshed.find((provider) => provider.instanceId === "codex");
-            assert.deepStrictEqual(spawnedCommands, [firstMissing, secondMissing]);
-            assert.strictEqual(reprobedCodex?.status, "error");
-            assert.strictEqual(reprobedCodex?.installed, false);
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      it.effect("includes unavailable instance snapshots in getProviders", () =>
-        Effect.gen(function* () {
-          const serverSettings = yield* makeMutableServerSettingsService(
-            decodeServerSettings(
-              deepMerge(encodedDefaultServerSettings, {
-                providers: {
-                  codex: { enabled: false },
-                  claudeAgent: { enabled: false },
-                  cursor: { enabled: false },
-                  grok: { enabled: false },
-                  opencode: { enabled: false },
-                },
-                providerInstances: {
-                  ghost_main: {
-                    driver: "ghostDriver",
-                    displayName: "A fork-only driver we don't ship",
-                    enabled: false,
-                    config: { arbitrary: "payload" },
-                  },
-                } as unknown as ContractServerSettings["providerInstances"],
-              }),
-            ),
-          );
-          const scope = yield* Scope.make();
-          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-          const providerRegistryLayer = ProviderRegistryLive.pipe(
-            Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
-            Layer.provideMerge(
-              Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
-            ),
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), {
-                prefix: "t3-provider-registry-",
-              }),
-            ),
-            Layer.provideMerge(TestHttpClientLive),
-            Layer.provideMerge(
-              Layer.succeed(
-                ProviderEventLoggers.ProviderEventLoggers,
-                ProviderEventLoggers.NoOpProviderEventLoggers,
-              ),
-            ),
-            Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
-            Layer.provideMerge(NodeServices.layer),
-          );
-          const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
-            Scope.provide(scope),
-          );
-
-          yield* Effect.gen(function* () {
-            const registry = yield* ProviderRegistry.ProviderRegistry;
-            const providers = yield* registry.getProviders;
-            const ghost = providers.find((provider) => provider.instanceId === "ghost_main");
-
-            assert.notStrictEqual(ghost, undefined);
-            assert.strictEqual(ghost?.driver, "ghostDriver");
-            assert.strictEqual(ghost?.availability, "unavailable");
-            assert.match(ghost?.unavailableReason ?? "", /ghostDriver/);
-          }).pipe(Effect.provide(runtimeServices));
-        }),
-      );
-
-      it.effect(
-        "keeps cursor disabled and skips probing when the provider setting is disabled",
-        () =>
-          Effect.gen(function* () {
-            const serverSettings = yield* makeMutableServerSettingsService(
-              decodeServerSettings(
-                deepMerge(encodedDefaultServerSettings, {
-                  providers: {
-                    codex: {
-                      enabled: false,
-                    },
-                    cursor: {
-                      enabled: false,
-                    },
-                    grok: {
-                      enabled: false,
-                    },
-                  },
-                }),
-              ),
-            );
-            let cursorSpawned = false;
-            const scope = yield* Scope.make();
-            yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
-            const providerRegistryLayer = ProviderRegistryLive.pipe(
-              Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
-              Layer.provideMerge(
-                Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
-              ),
-              Layer.provideMerge(
-                ServerConfig.layerTest(process.cwd(), {
-                  prefix: "t3-provider-registry-",
-                }),
-              ),
-              Layer.provideMerge(TestHttpClientLive),
-              Layer.provideMerge(
-                Layer.succeed(
-                  ProviderEventLoggers.ProviderEventLoggers,
-                  ProviderEventLoggers.NoOpProviderEventLoggers,
-                ),
-              ),
-              Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
-              Layer.provideMerge(
-                mockCommandSpawnerLayer((command, args) => {
-                  if (command === "cursor-agent") {
-                    cursorSpawned = true;
-                  }
-                  const joined = args.join(" ");
-                  if (joined === "--version") {
-                    return {
-                      stdout: `${command} 1.0.0\n`,
-                      stderr: "",
-                      code: 0,
-                    };
-                  }
-                  if (joined === "auth status") {
-                    return {
-                      stdout: '{"authenticated":true}\n',
-                      stderr: "",
-                      code: 0,
-                    };
-                  }
-                  throw new Error(`Unexpected args: ${command} ${joined}`);
-                }),
-              ),
-            );
-            const runtimeServices = yield* Layer.build(
-              Layer.mergeAll(
-                Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
-                providerRegistryLayer,
-              ),
-            ).pipe(Scope.provide(scope));
-
-            yield* Effect.gen(function* () {
-              const registry = yield* ProviderRegistry.ProviderRegistry;
-              const providers = yield* registry.getProviders;
-              const cursorProvider = providers.find(
-                (provider) => provider.instanceId === ProviderInstanceId.make("cursor"),
-              );
-
-              assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
-                "claudeAgent",
-                "codex",
-                "cursor",
-                "grok",
-                "opencode",
-              ]);
-              assert.strictEqual(cursorProvider?.enabled, false);
-              assert.strictEqual(cursorProvider?.status, "disabled");
-              assert.strictEqual(
-                cursorProvider?.message,
-                "Cursor is disabled in T3 Code settings.",
-              );
-              assert.strictEqual(cursorSpawned, false);
-            }).pipe(Effect.provide(runtimeServices));
-          }),
-      );
-
-      it.effect("skips codex probes entirely when the provider is disabled", () =>
-        Effect.gen(function* () {
-          const status = yield* checkCodexProviderStatus(disabledCodexSettings).pipe(
-            Effect.provide(failingSpawnerLayer("spawn codex ENOENT")),
-          );
-          assert.strictEqual(status.enabled, false);
-          assert.strictEqual(status.status, "disabled");
-          assert.strictEqual(status.installed, false);
-          assert.strictEqual(status.message, "Codex is disabled in T3 Code settings.");
-        }),
-      );
-    });
-
-    // ── checkClaudeProviderStatus tests ──────────────────────────
-
-    describe("checkClaudeProviderStatus", () => {
-      it.effect("returns ready when claude is installed and authenticated", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.installed, true);
-          assert.strictEqual(status.auth.status, "authenticated");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("returns ready and labels Bedrock-backed Claude as authenticated", () =>
-        Effect.gen(function* () {
-          // Bedrock authenticates via external AWS credentials, so the SDK init
-          // reports only `apiProvider` with no subscription or token.
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({ apiProvider: "bedrock" }),
-          );
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.installed, true);
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "bedrock");
-          assert.strictEqual(status.auth.label, "Amazon Bedrock");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("includes Claude Fable 5 on supported Claude Code versions", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          const fable5 = status.models.find((model) => model.slug === "claude-fable-5");
-          assert.strictEqual(fable5?.name, "Claude Fable 5");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "2.1.169\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("hides Claude Fable 5 on older Claude Code versions", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          assert.strictEqual(
-            status.models.some((model) => model.slug === "claude-fable-5"),
-            false,
-          );
-          assert.strictEqual(
-            status.message,
-            "Claude Code v2.1.168 is too old for Claude Fable 5. Upgrade to v2.1.169 or newer to access it.",
-          );
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "2.1.168\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect(
-        "includes Claude Opus 4.7 with xhigh as the default effort on supported versions",
-        () =>
-          Effect.gen(function* () {
-            const status = yield* checkClaudeProviderStatus(
-              defaultClaudeSettings,
-              claudeCapabilities(),
-            );
-            const opus47 = status.models.find((model) => model.slug === "claude-opus-4-7");
-            if (!opus47) {
-              assert.fail("Expected Claude Opus 4.7 to be present for Claude Code v2.1.111.");
-            }
-            if (!opus47.capabilities) {
-              assert.fail(
-                "Expected Claude Opus 4.7 capabilities to be present for Claude Code v2.1.111.",
-              );
-            }
-            const effortDescriptor = opus47.capabilities.optionDescriptors?.find(
-              (descriptor) => descriptor.type === "select" && descriptor.id === "effort",
-            );
-            assert.deepStrictEqual(
-              effortDescriptor?.type === "select"
-                ? effortDescriptor.options.find((option) => option.isDefault)
-                : undefined,
-              { id: "xhigh", label: "Extra High", isDefault: true },
-            );
-          }).pipe(
-            Effect.provide(
-              mockSpawnerLayer((args) => {
-                const joined = args.join(" ");
-                if (joined === "--version") return { stdout: "2.1.111\n", stderr: "", code: 0 };
-                if (joined === "auth status")
-                  return {
-                    stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                    stderr: "",
-                    code: 0,
-                  };
-                throw new Error(`Unexpected args: ${joined}`);
-              }),
-            ),
-          ),
-      );
-
-      it.effect("hides Claude Opus 4.7 on older Claude Code versions", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          assert.strictEqual(
-            status.models.some((model) => model.slug === "claude-opus-4-7"),
-            false,
-          );
-          assert.strictEqual(
-            status.message,
-            "Claude Code v2.1.110 is too old for Claude Opus 4.7. Upgrade to v2.1.111 or newer to access it.",
-          );
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "2.1.110\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("returns a display label for claude subscription types", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({ subscriptionType: "maxplan" }),
-          );
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "maxplan");
-          assert.strictEqual(status.auth.label, "Claude Max Subscription");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("does not duplicate Claude in full subscription labels", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({
-              subscriptionType: "Claude Max Subscription",
-            }),
-          );
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "Claude Max Subscription");
-          assert.strictEqual(status.auth.label, "Claude Max Subscription");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("does not duplicate Claude in provider-prefixed subscription names", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({
-              subscriptionType: "Claude Max",
-            }),
-          );
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "Claude Max");
-          assert.strictEqual(status.auth.label, "Claude Max Subscription");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("returns claude auth email from initialization result", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({ email: "claude@example.com" }),
-          );
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.email, "claude@example.com");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout:
-                    '{"loggedIn":true,"authMethod":"claude.ai","account":{"email":"claude@example.com"}}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("runs Claude status probes with the configured CLAUDE_CONFIG_DIR", () => {
-        const claudeConfigDir = "/tmp/t3code-claude-home";
-        const recorded = recordingMockSpawnerLayer((args) => {
-          const joined = args.join(" ");
-          if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-          if (joined === "auth status")
-            return {
-              stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-              stderr: "",
-              code: 0,
-            };
-          throw new Error(`Unexpected args: ${joined}`);
+        const status = yield* checkCodexProviderStatus(settings, (input) => {
+          observedLaunchArgs = input.launchArgs;
+          return Effect.succeed(makeCodexProbeSnapshot());
         });
 
-        return Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            {
-              ...defaultClaudeSettings,
-              homePath: claudeConfigDir,
-            },
-            claudeCapabilities(),
-          );
-          assert.strictEqual(status.status, "ready");
-          assert.deepStrictEqual(
-            recorded.commands.map((command) => command.env?.CLAUDE_CONFIG_DIR),
-            [claudeConfigDir],
-          );
-        }).pipe(Effect.provide(recorded.layer));
-      });
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(observedLaunchArgs, "--strict-config --enable foo");
+      }),
+    );
 
-      it.effect("includes probed claude slash commands in the provider snapshot", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({
-              subscriptionType: "maxplan",
-              slashCommands: [
-                {
-                  name: "review",
-                  description: "Review a pull request",
-                  input: { hint: "pr-or-branch" },
-                },
-              ],
-            }),
-          );
-
-          assert.deepStrictEqual(status.slashCommands, [
-            {
-              name: "review",
-              description: "Review a pull request",
-              input: { hint: "pr-or-branch" },
-            },
-          ]);
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("deduplicates probed claude slash commands by name", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({
-              subscriptionType: "maxplan",
-              slashCommands: [
-                {
-                  name: "ui",
-                  description: "Explore and refine UI",
-                },
-                {
-                  name: "ui",
-                  input: { hint: "component-or-screen" },
-                },
-              ],
-            }),
-          );
-
-          assert.deepStrictEqual(status.slashCommands, [
-            {
-              name: "ui",
-              description: "Explore and refine UI",
-              input: { hint: "component-or-screen" },
-            },
-          ]);
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("returns an api key label for claude api key auth", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities({ tokenSource: "ANTHROPIC_AUTH_TOKEN" }),
-          );
-          assert.strictEqual(status.status, "ready");
-          assert.strictEqual(status.auth.status, "authenticated");
-          assert.strictEqual(status.auth.type, "apiKey");
-          assert.strictEqual(status.auth.label, "Claude API Key");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"api-key"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("returns unavailable when claude is missing", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          assert.strictEqual(status.status, "error");
-          assert.strictEqual(status.installed, false);
-          assert.strictEqual(status.auth.status, "unknown");
-          assert.strictEqual(
-            status.message,
-            "Claude Agent CLI (`claude`) is not installed or not on PATH.",
-          );
-        }).pipe(Effect.provide(failingSpawnerLayer("spawn claude ENOENT"))),
-      );
-
-      it.effect("returns error when version check fails with non-zero exit code", () => {
-        const secretStderr = "Something went wrong: secret-token-value";
-        return Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
-            claudeCapabilities(),
-          );
-          assert.strictEqual(status.status, "error");
-          assert.strictEqual(status.installed, true);
-          assert.strictEqual(status.message, "Claude Agent CLI is installed but failed to run.");
-          assert.ok(!(status.message ?? "").includes(secretStderr));
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version")
-                return {
-                  stdout: "",
-                  stderr: secretStderr,
-                  code: 1,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
+    it.effect("returns unauthenticated when app-server requires OpenAI auth", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+          Effect.succeed(
+            makeCodexProbeSnapshot({
+              account: {
+                account: null,
+                requiresOpenaiAuth: true,
+              },
             }),
           ),
         );
-      });
 
-      it.effect("returns warning when the Claude initialization result is unavailable", () =>
+        assert.strictEqual(status.status, "error");
+        assert.strictEqual(status.auth.status, "unauthenticated");
+        assert.strictEqual(
+          status.message,
+          "Codex CLI is not authenticated. Run `codex login` and try again.",
+        );
+      }),
+    );
+
+    it.effect("returns ready with unknown auth when app-server does not require OpenAI auth", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+          Effect.succeed(
+            makeCodexProbeSnapshot({
+              account: {
+                account: null,
+                requiresOpenaiAuth: false,
+              },
+            }),
+          ),
+        );
+
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.auth.status, "unknown");
+      }),
+    );
+
+    it.effect("returns an api key label for codex api key auth", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+          Effect.succeed(
+            makeCodexProbeSnapshot({
+              account: {
+                account: { type: "apiKey" },
+                requiresOpenaiAuth: false,
+              },
+            }),
+          ),
+        );
+
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "apiKey");
+        assert.strictEqual(status.auth.label, "OpenAI API Key");
+      }),
+    );
+
+    it.effect("returns an Amazon Bedrock label for codex Bedrock auth", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+          Effect.succeed(
+            makeCodexProbeSnapshot({
+              account: {
+                account: { type: "amazonBedrock" },
+                requiresOpenaiAuth: false,
+              },
+            }),
+          ),
+        );
+
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "amazonBedrock");
+        assert.strictEqual(status.auth.label, "Amazon Bedrock");
+      }),
+    );
+
+    it.effect("returns unavailable when codex is missing", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+          Effect.fail(
+            new CodexErrors.CodexAppServerSpawnError({
+              command: "codex app-server",
+              cause: new Error("spawn codex ENOENT"),
+            }),
+          ),
+        );
+        assert.strictEqual(status.status, "error");
+        assert.strictEqual(status.installed, false);
+        assert.strictEqual(status.auth.status, "unknown");
+        assert.strictEqual(status.message, "Codex CLI (`codex`) is not installed or not on PATH.");
+      }),
+    );
+
+    it.effect("closes the app-server probe scope when provider status times out", () =>
+      Effect.gen(function* () {
+        const killCalls = yield* Ref.make(0);
+        const statusFiber = yield* checkCodexProviderStatus(defaultCodexSettings).pipe(
+          Effect.provide(hangingScopedSpawnerLayer(killCalls)),
+          Effect.forkChild,
+        );
+
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust("11 seconds");
+        yield* Effect.yieldNow;
+
+        const status = yield* Fiber.join(statusFiber);
+        assert.strictEqual(status.status, "error");
+        assert.strictEqual(
+          status.message,
+          "Timed out while checking Codex app-server provider status.",
+        );
+        assert.strictEqual(yield* Ref.get(killCalls), 1);
+      }),
+    );
+  });
+
+  describe("ProviderRegistryLive", () => {
+    it("treats equal provider snapshots as unchanged", () => {
+      const providers = [
+        {
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-03-25T00:00:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        },
+        {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          driver: ProviderDriverKind.make("claudeAgent"),
+          status: "warning",
+          enabled: true,
+          installed: true,
+          auth: { status: "unknown" },
+          checkedAt: "2026-03-25T00:00:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        },
+      ] as const satisfies ReadonlyArray<ServerProvider>;
+
+      assert.strictEqual(haveProvidersChanged(providers, [...providers]), false);
+    });
+
+    it("preserves previously discovered provider models when a refresh returns none", () => {
+      const previousProvider = {
+        instanceId: ProviderInstanceId.make("cursor"),
+        driver: ProviderDriverKind.make("cursor"),
+        status: "ready",
+        enabled: true,
+        installed: true,
+        auth: { status: "authenticated" },
+        checkedAt: "2026-04-14T00:00:00.000Z",
+        version: "2026.04.09-f2b0fcd",
+        models: [
+          {
+            slug: "claude-opus-4-6",
+            name: "Opus 4.6",
+            isCustom: false,
+            capabilities: createModelCapabilities({
+              optionDescriptors: [
+                selectDescriptor("reasoning", "Reasoning", [
+                  { id: "high", label: "High", isDefault: true },
+                ]),
+                booleanDescriptor("fastMode", "Fast Mode"),
+                booleanDescriptor("thinking", "Thinking"),
+              ],
+            }),
+          },
+        ],
+        slashCommands: [],
+        skills: [],
+      } as const satisfies ServerProvider;
+      const refreshedProvider = {
+        ...previousProvider,
+        checkedAt: "2026-04-14T00:01:00.000Z",
+        models: [],
+      } satisfies ServerProvider;
+
+      assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
+        ...previousProvider.models,
+      ]);
+    });
+
+    it("fills missing capabilities from the previous provider snapshot", () => {
+      const previousProvider = {
+        instanceId: ProviderInstanceId.make("cursor"),
+        driver: ProviderDriverKind.make("cursor"),
+        status: "ready",
+        enabled: true,
+        installed: true,
+        auth: { status: "authenticated" },
+        checkedAt: "2026-04-14T00:00:00.000Z",
+        version: "2026.04.09-f2b0fcd",
+        models: [
+          {
+            slug: "claude-opus-4-6",
+            name: "Opus 4.6",
+            isCustom: false,
+            capabilities: createModelCapabilities({
+              optionDescriptors: [
+                selectDescriptor("reasoning", "Reasoning", [
+                  { id: "high", label: "High", isDefault: true },
+                ]),
+                booleanDescriptor("fastMode", "Fast Mode"),
+                booleanDescriptor("thinking", "Thinking"),
+              ],
+            }),
+          },
+        ],
+        slashCommands: [],
+        skills: [],
+      } as const satisfies ServerProvider;
+      const refreshedProvider = {
+        ...previousProvider,
+        checkedAt: "2026-04-14T00:01:00.000Z",
+        models: [
+          {
+            slug: "claude-opus-4-6",
+            name: "Opus 4.6",
+            isCustom: false,
+            capabilities: createModelCapabilities({
+              optionDescriptors: [],
+            }),
+          },
+        ],
+      } satisfies ServerProvider;
+
+      assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).models, [
+        ...previousProvider.models,
+      ]);
+    });
+
+    it.effect("does not run provider probes during layer construction", () =>
+      Effect.gen(function* () {
+        const codexDriver = ProviderDriverKind.make("codex");
+        const codexInstanceId = ProviderInstanceId.make("codex");
+        const initialProvider = {
+          instanceId: codexInstanceId,
+          driver: codexDriver,
+          status: "warning",
+          enabled: true,
+          installed: false,
+          auth: { status: "unknown" },
+          checkedAt: "2026-06-10T00:00:00.000Z",
+          version: null,
+          message: "Checking Codex provider status.",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshCalls = yield* Ref.make(0);
+        const instance = {
+          instanceId: codexInstanceId,
+          driverKind: codexDriver,
+          continuationIdentity: {
+            driverKind: codexDriver,
+            continuationKey: "codex:instance:codex",
+          },
+          displayName: undefined,
+          enabled: true,
+          snapshot: {
+            maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+              provider: codexDriver,
+              packageName: null,
+            }),
+            getSnapshot: Effect.succeed(initialProvider),
+            refresh: Ref.update(refreshCalls, (count) => count + 1).pipe(
+              Effect.andThen(Effect.never),
+            ),
+            streamChanges: Stream.empty,
+          },
+          adapter: {} as ProviderInstance["adapter"],
+          textGeneration: {} as ProviderInstance["textGeneration"],
+        } satisfies ProviderInstance;
+        const instanceRegistryLayer = Layer.succeed(
+          ProviderInstanceRegistry.ProviderInstanceRegistry,
+          {
+            getInstance: (instanceId) =>
+              Effect.succeed(instanceId === codexInstanceId ? instance : undefined),
+            listInstances: Effect.succeed([instance]),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.empty,
+            subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+          },
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const runtimeServices = yield* Layer.build(
+          ProviderRegistryLive.pipe(
+            Layer.provideMerge(instanceRegistryLayer),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), {
+                prefix: "t3-provider-registry-background-refresh-",
+              }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ).pipe(Scope.provide(scope));
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          assert.deepStrictEqual(yield* registry.getProviders, [initialProvider]);
+          assert.strictEqual(yield* Ref.get(refreshCalls), 0);
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    it("persists merged provider snapshots for the providers that were refreshed", () => {
+      const previousProviders = [
+        {
+          instanceId: ProviderInstanceId.make("cursor"),
+          driver: ProviderDriverKind.make("cursor"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-14T00:00:00.000Z",
+          version: "2026.04.09-f2b0fcd",
+          models: [
+            {
+              slug: "claude-opus-4-6",
+              name: "Opus 4.6",
+              isCustom: false,
+              capabilities: createModelCapabilities({
+                optionDescriptors: [
+                  selectDescriptor("reasoning", "Reasoning", [
+                    { id: "high", label: "High", isDefault: true },
+                  ]),
+                  booleanDescriptor("fastMode", "Fast Mode"),
+                  booleanDescriptor("thinking", "Thinking"),
+                ],
+              }),
+            },
+          ],
+          slashCommands: [],
+          skills: [],
+        },
+        {
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-14T00:00:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        },
+      ] as const satisfies ReadonlyArray<ServerProvider>;
+      const refreshedCursor = {
+        ...previousProviders[0],
+        checkedAt: "2026-04-14T00:01:00.000Z",
+        models: [],
+      } satisfies ServerProvider;
+
+      const mergedProviders = mergeProviderSnapshots(previousProviders, [refreshedCursor]);
+      const persistedProviders = selectProvidersByKind(
+        mergedProviders,
+        new Set([ProviderDriverKind.make("cursor")]),
+      );
+
+      assert.deepStrictEqual(persistedProviders, [
+        {
+          ...refreshedCursor,
+          models: [...previousProviders[0].models],
+        },
+      ]);
+    });
+
+    it.effect("persists the merged snapshot when a live update has empty models", () =>
+      Effect.gen(function* () {
+        const cursorDriver = ProviderDriverKind.make("cursor");
+        const cursorInstanceId = ProviderInstanceId.make("cursor");
+        const initialProvider = {
+          instanceId: cursorInstanceId,
+          driver: cursorDriver,
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-14T00:00:00.000Z",
+          version: "2026.04.09-f2b0fcd",
+          models: [
+            {
+              slug: "claude-opus-4-6",
+              name: "Opus 4.6",
+              isCustom: false,
+              capabilities: createModelCapabilities({
+                optionDescriptors: [
+                  selectDescriptor("reasoning", "Reasoning", [
+                    { id: "high", label: "High", isDefault: true },
+                  ]),
+                ],
+              }),
+            },
+          ],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...initialProvider,
+          checkedAt: "2026-04-14T00:01:00.000Z",
+          models: [],
+        } satisfies ServerProvider;
+        const changes = yield* PubSub.unbounded<ServerProvider>();
+        const instance = {
+          instanceId: cursorInstanceId,
+          driverKind: cursorDriver,
+          continuationIdentity: {
+            driverKind: cursorDriver,
+            continuationKey: "cursor:instance:cursor",
+          },
+          displayName: undefined,
+          enabled: true,
+          snapshot: {
+            maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+              provider: cursorDriver,
+              packageName: null,
+            }),
+            getSnapshot: Effect.succeed(initialProvider),
+            refresh: Effect.succeed(refreshedProvider),
+            streamChanges: Stream.fromPubSub(changes),
+          },
+          adapter: {} as ProviderInstance["adapter"],
+          textGeneration: {} as ProviderInstance["textGeneration"],
+        } satisfies ProviderInstance;
+        const instanceRegistryLayer = Layer.succeed(
+          ProviderInstanceRegistry.ProviderInstanceRegistry,
+          {
+            getInstance: (instanceId) =>
+              Effect.succeed(instanceId === cursorInstanceId ? instance : undefined),
+            listInstances: Effect.succeed([instance]),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.empty,
+            subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+              PubSub.subscribe(pubsub),
+            ),
+          },
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const runtimeServices = yield* Layer.build(
+          ProviderRegistryLive.pipe(
+            Layer.provideMerge(instanceRegistryLayer),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), {
+                prefix: "t3-provider-registry-merged-persist-",
+              }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ).pipe(Scope.provide(scope));
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          const config = yield* ServerConfig.ServerConfig;
+          const filePath = yield* resolveProviderStatusCachePath({
+            cacheDir: config.providerStatusCacheDir,
+            instanceId: cursorInstanceId,
+          });
+
+          assert.deepStrictEqual((yield* registry.getProviders)[0]?.models, [
+            ...initialProvider.models,
+          ]);
+          yield* PubSub.publish(changes, refreshedProvider);
+
+          let cachedProvider = yield* readProviderStatusCache(filePath);
+          for (
+            let attempt = 0;
+            attempt < 50 && cachedProvider?.checkedAt !== refreshedProvider.checkedAt;
+            attempt += 1
+          ) {
+            yield* TestClock.adjust("10 millis");
+            yield* Effect.yieldNow;
+            cachedProvider = yield* readProviderStatusCache(filePath);
+          }
+
+          assert.deepStrictEqual(cachedProvider, {
+            ...refreshedProvider,
+            models: [...initialProvider.models],
+          });
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    it.effect("returns the cached provider list when a manual refresh fails", () =>
+      Effect.gen(function* () {
+        const codexDriver = ProviderDriverKind.make("codex");
+        const codexInstanceId = ProviderInstanceId.make("codex");
+        const cachedProvider = {
+          instanceId: codexInstanceId,
+          driver: codexDriver,
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-29T10:00:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const instance = {
+          instanceId: codexInstanceId,
+          driverKind: codexDriver,
+          continuationIdentity: {
+            driverKind: codexDriver,
+            continuationKey: "codex:instance:codex",
+          },
+          displayName: undefined,
+          enabled: true,
+          snapshot: {
+            maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+              provider: codexDriver,
+              packageName: null,
+            }),
+            getSnapshot: Effect.succeed(cachedProvider),
+            refresh: Effect.die(new Error("simulated refresh failure")),
+            streamChanges: Stream.empty,
+          },
+          adapter: {} as ProviderInstance["adapter"],
+          textGeneration: {} as ProviderInstance["textGeneration"],
+        } satisfies ProviderInstance;
+        const instanceRegistryLayer = Layer.succeed(
+          ProviderInstanceRegistry.ProviderInstanceRegistry,
+          {
+            getInstance: (instanceId) =>
+              Effect.succeed(instanceId === codexInstanceId ? instance : undefined),
+            listInstances: Effect.succeed([instance]),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.empty,
+            subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+              PubSub.subscribe(pubsub),
+            ),
+          },
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const runtimeServices = yield* Layer.build(
+          ProviderRegistryLive.pipe(
+            Layer.provideMerge(instanceRegistryLayer),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), {
+                prefix: "t3-provider-registry-refresh-failure-",
+              }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ).pipe(Scope.provide(scope));
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+
+          assert.deepStrictEqual(yield* registry.getProviders, [cachedProvider]);
+          assert.deepStrictEqual(yield* registry.refresh(codexDriver), [cachedProvider]);
+          assert.deepStrictEqual(yield* registry.refreshInstance(codexInstanceId), [
+            cachedProvider,
+          ]);
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    it.effect("keeps consuming registry changes after one sync fails", () =>
+      Effect.gen(function* () {
+        const codexDriver = ProviderDriverKind.make("codex");
+        const codexInstanceId = ProviderInstanceId.make("codex");
+        const claudeDriver = ProviderDriverKind.make("claudeAgent");
+        const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
+        const codexProvider = {
+          instanceId: codexInstanceId,
+          driver: codexDriver,
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-29T10:00:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const claudeProvider = {
+          instanceId: claudeInstanceId,
+          driver: claudeDriver,
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: { status: "authenticated" },
+          checkedAt: "2026-04-29T10:01:00.000Z",
+          version: "1.0.0",
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const makeInstance = (provider: ServerProvider): ProviderInstance => ({
+          instanceId: provider.instanceId,
+          driverKind: provider.driver,
+          continuationIdentity: {
+            driverKind: provider.driver,
+            continuationKey: `${provider.driver}:instance:${provider.instanceId}`,
+          },
+          displayName: undefined,
+          enabled: true,
+          snapshot: {
+            maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+              provider: provider.driver,
+              packageName: null,
+            }),
+            getSnapshot: Effect.succeed(provider),
+            refresh: Effect.succeed(provider),
+            streamChanges: Stream.empty,
+          },
+          adapter: {} as ProviderInstance["adapter"],
+          textGeneration: {} as ProviderInstance["textGeneration"],
+        });
+        const codexInstance = makeInstance(codexProvider);
+        const claudeInstance = makeInstance(claudeProvider);
+        const changes = yield* PubSub.unbounded<void>();
+        const instancesRef = yield* Ref.make<ReadonlyArray<ProviderInstance>>([codexInstance]);
+        const failNextList = yield* Ref.make(false);
+        const wait = () => Effect.yieldNow;
+        const instanceRegistryLayer = Layer.succeed(
+          ProviderInstanceRegistry.ProviderInstanceRegistry,
+          {
+            getInstance: (instanceId) =>
+              Ref.get(instancesRef).pipe(
+                Effect.map((instances) =>
+                  instances.find((instance) => instance.instanceId === instanceId),
+                ),
+              ),
+            listInstances: Effect.gen(function* () {
+              const shouldFail = yield* Ref.get(failNextList);
+              if (shouldFail) {
+                yield* Ref.set(failNextList, false);
+                return yield* Effect.die(new Error("simulated registry list failure"));
+              }
+              return yield* Ref.get(instancesRef);
+            }),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.fromPubSub(changes),
+            subscribeChanges: PubSub.subscribe(changes),
+          },
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const runtimeServices = yield* Layer.build(
+          ProviderRegistryLive.pipe(
+            Layer.provideMerge(instanceRegistryLayer),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), {
+                prefix: "t3-provider-registry-sync-failure-",
+              }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ).pipe(Scope.provide(scope));
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          assert.deepStrictEqual(yield* registry.getProviders, [codexProvider]);
+
+          yield* Ref.set(failNextList, true);
+          yield* PubSub.publish(changes, undefined);
+
+          yield* Ref.set(instancesRef, [codexInstance, claudeInstance]);
+          yield* PubSub.publish(changes, undefined);
+
+          let providers = yield* registry.getProviders;
+          for (
+            let attempt = 0;
+            attempt < 50 && !providers.some((provider) => provider.instanceId === claudeInstanceId);
+            attempt += 1
+          ) {
+            yield* wait();
+            providers = yield* registry.getProviders;
+          }
+
+          assert.deepStrictEqual(
+            providers.map((provider) => provider.instanceId).toSorted(),
+            [codexInstanceId, claudeInstanceId].toSorted(),
+          );
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    // This test intentionally avoids `mockCommandSpawnerLayer` so the real
+    // `probeCodexAppServerProvider` path runs — including the full
+    // `codex app-server` RPC handshake via `CodexClient.layerChildProcess`.
+    // We point `binaryPath` at a name that cannot exist on any machine so
+    // the real `ChildProcessSpawner` deterministically returns ENOENT; the
+    // probe wraps that as `CodexAppServerSpawnError` and
+    // `checkCodexProviderStatus` turns it into the user-visible "not
+    // installed" error snapshot. If the aggregator's `syncLiveSources`
+    // breaks — the `codex_personal`-never-probes bug we are guarding
+    // against — that snapshot never lands in `getProviders` and the
+    // assertions below fail.
+    it.effect("propagates real Codex probe failures to the aggregator at boot", () =>
+      Effect.gen(function* () {
+        const missingBinary = `t3code_codex_missing_`;
+        const serverSettings = yield* makeMutableServerSettingsService(
+          decodeServerSettings(
+            deepMerge(encodedDefaultServerSettings, {
+              providers: {
+                // Disable every built-in probe that would otherwise spawn
+                // on the CI host. `enabled: false` short-circuits each
+                // driver's probe *before* it touches the spawner, so the
+                // test environment stays isolated from the dev
+                // machine's PATH.
+                codex: { enabled: false },
+                claudeAgent: { enabled: false },
+                cursor: { enabled: false },
+                grok: { enabled: false },
+                opencode: { enabled: false },
+              },
+              // `providerInstances` keys are branded `ProviderInstanceId`;
+              // the branded index signature rejects plain string literals
+              // at the TS level even though the runtime schema happily
+              // accepts + decodes them. Cast the patch to `unknown` so
+              // the `Schema.decodeSync` below does the real validation.
+              providerInstances: {
+                // Matches the shape the user had in `.t3/dev/settings.json`
+                // when the bug was reported: a custom enabled Codex instance
+                // pointing at a binary the server has to actually spawn.
+                codex_personal: {
+                  driver: "codex",
+                  displayName: "Codex Personal",
+                  enabled: true,
+                  config: {
+                    binaryPath: missingBinary,
+                    homePath: `/tmp/${missingBinary}_home`,
+                  },
+                },
+              } as unknown as ContractServerSettings["providerInstances"],
+            }),
+          ),
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const providerRegistryLayer = ProviderRegistryLive.pipe(
+          Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+          Layer.provideMerge(
+            Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
+          ),
+          Layer.provideMerge(
+            ServerConfig.layerTest(process.cwd(), {
+              prefix: "t3-provider-registry-",
+            }),
+          ),
+          Layer.provideMerge(TestHttpClientLive),
+          Layer.provideMerge(
+            Layer.succeed(
+              ProviderEventLoggers.ProviderEventLoggers,
+              ProviderEventLoggers.NoOpProviderEventLoggers,
+            ),
+          ),
+          Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+          // NO spawner mock — `ChildProcessSpawner` is supplied by the
+          // outer `NodeServices.layer` on `it.layer(...)` and will
+          // genuinely spawn a subprocess. The missing-binary ENOENT is
+          // what exercises the same failure mode as a misconfigured
+          // production `binaryPath`.
+        );
+        const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
+          Scope.provide(scope),
+        );
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          let providers = yield* registry.getProviders;
+          for (
+            let attempts = 0;
+            attempts < 50 &&
+            providers.find((provider) => provider.instanceId === "codex_personal")?.status !==
+              "error";
+            attempts += 1
+          ) {
+            yield* Effect.yieldNow;
+            providers = yield* registry.getProviders;
+          }
+          const codexPersonal = providers.find(
+            (provider) => provider.instanceId === "codex_personal",
+          );
+          assert.notStrictEqual(
+            codexPersonal,
+            undefined,
+            `Expected the aggregator to know about codex_personal; instead saw: ${providers
+              .map((provider) => provider.instanceId)
+              .join(", ")}`,
+          );
+          assert.strictEqual(
+            codexPersonal?.status,
+            "error",
+            "Real Codex probe against a missing binary should surface as 'error' in the aggregator",
+          );
+          assert.strictEqual(codexPersonal?.installed, false);
+          assert.strictEqual(
+            codexPersonal?.message,
+            "Codex CLI (`codex`) is not installed or not on PATH.",
+          );
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    // Guards the second half of the reported bug: changing
+    // `providers.codex.binaryPath` in settings must tear down the live
+    // instance and rebuild it so a fresh probe runs with the new binary.
+    // This test drives the real settings stream → registry reconcile →
+    // aggregator sync pipeline and asserts that `getProviders` reflects
+    // the new background probe's outcome.
+    //
+    it.effect("re-probes when settings change the codex binaryPath", () =>
+      Effect.gen(function* () {
+        const firstMissing = `t3code_codex_first_`;
+        const secondMissing = `t3code_codex_second_`;
+        const spawnedCommands: Array<string> = [];
+        const serverSettings = yield* makeMutableServerSettingsService(
+          decodeServerSettings(
+            deepMerge(encodedDefaultServerSettings, {
+              providers: {
+                codex: { enabled: true, binaryPath: firstMissing },
+                claudeAgent: { enabled: false },
+                cursor: { enabled: false },
+                grok: { enabled: false },
+                opencode: { enabled: false },
+              },
+            }),
+          ),
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const providerRegistryLayer = ProviderRegistryLive.pipe(
+          Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+          Layer.provideMerge(
+            Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
+          ),
+          Layer.provideMerge(
+            ServerConfig.layerTest(process.cwd(), {
+              prefix: "t3-provider-registry-",
+            }),
+          ),
+          Layer.provideMerge(TestHttpClientLive),
+          Layer.provideMerge(
+            Layer.succeed(
+              ProviderEventLoggers.ProviderEventLoggers,
+              ProviderEventLoggers.NoOpProviderEventLoggers,
+            ),
+          ),
+          Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+          Layer.updateService(ChildProcessSpawner.ChildProcessSpawner, (spawner) =>
+            ChildProcessSpawner.make((command) => {
+              spawnedCommands.push((command as { readonly command: string }).command);
+              return spawner.spawn(command);
+            }),
+          ),
+          Layer.provideMerge(NodeServices.layer),
+        );
+        const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
+          Scope.provide(scope),
+        );
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          // Boot-time probe: the default codex instance is enabled with
+          // `firstMissing`, so the real spawner yields ENOENT and the
+          // snapshot should be `status: "error"`.
+          let initialProviders = yield* registry.getProviders;
+          for (
+            let attempts = 0;
+            attempts < 50 &&
+            initialProviders.find((provider) => provider.instanceId === "codex")?.status !==
+              "error";
+            attempts += 1
+          ) {
+            yield* TestClock.adjust("10 millis");
+            yield* Effect.yieldNow;
+            initialProviders = yield* registry.getProviders;
+          }
+          const initialCodex = initialProviders.find((provider) => provider.instanceId === "codex");
+          assert.strictEqual(initialCodex?.status, "error");
+          assert.strictEqual(initialCodex?.installed, false);
+          assert.deepStrictEqual(spawnedCommands, [firstMissing]);
+
+          // Drive a settings change. The Hydration layer's
+          // `SettingsWatcherLive` consumes this via `streamChanges`,
+          // calls `reconcile`, which rebuilds the codex instance (the
+          // envelope changed because `binaryPath` differs → `entryEqual`
+          // is false). The registry's `Stream.runForEach(
+          // instanceRegistry.streamChanges, () => syncLiveSources)`
+          // fires `syncLiveSources`, which subscribes and launches a fresh
+          // background refresh on the rebuilt instance.
+          yield* serverSettings.updateSettings({
+            providers: {
+              codex: { enabled: true, binaryPath: secondMissing },
+            },
+          });
+
+          // Poll until the injected process boundary observes the new
+          // executable. This verifies the public settings-to-probe behavior
+          // without depending on timestamps assigned by TestClock.
+          const refreshed = yield* Effect.gen(function* () {
+            for (let attempts = 0; attempts < 60; attempts += 1) {
+              const providers = yield* registry.getProviders;
+              const codex = providers.find((provider) => provider.instanceId === "codex");
+              if (
+                codex !== undefined &&
+                codex.status === "error" &&
+                spawnedCommands.includes(secondMissing)
+              ) {
+                return providers;
+              }
+              yield* TestClock.adjust("50 millis");
+              yield* Effect.yieldNow;
+            }
+            return yield* registry.getProviders;
+          });
+
+          const reprobedCodex = refreshed.find((provider) => provider.instanceId === "codex");
+          assert.deepStrictEqual(spawnedCommands, [firstMissing, secondMissing]);
+          assert.strictEqual(reprobedCodex?.status, "error");
+          assert.strictEqual(reprobedCodex?.installed, false);
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    it.effect("includes unavailable instance snapshots in getProviders", () =>
+      Effect.gen(function* () {
+        const serverSettings = yield* makeMutableServerSettingsService(
+          decodeServerSettings(
+            deepMerge(encodedDefaultServerSettings, {
+              providers: {
+                codex: { enabled: false },
+                claudeAgent: { enabled: false },
+                cursor: { enabled: false },
+                grok: { enabled: false },
+                opencode: { enabled: false },
+              },
+              providerInstances: {
+                ghost_main: {
+                  driver: "ghostDriver",
+                  displayName: "A fork-only driver we don't ship",
+                  enabled: false,
+                  config: { arbitrary: "payload" },
+                },
+              } as unknown as ContractServerSettings["providerInstances"],
+            }),
+          ),
+        );
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const providerRegistryLayer = ProviderRegistryLive.pipe(
+          Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+          Layer.provideMerge(
+            Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
+          ),
+          Layer.provideMerge(
+            ServerConfig.layerTest(process.cwd(), {
+              prefix: "t3-provider-registry-",
+            }),
+          ),
+          Layer.provideMerge(TestHttpClientLive),
+          Layer.provideMerge(
+            Layer.succeed(
+              ProviderEventLoggers.ProviderEventLoggers,
+              ProviderEventLoggers.NoOpProviderEventLoggers,
+            ),
+          ),
+          Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+          Layer.provideMerge(NodeServices.layer),
+        );
+        const runtimeServices = yield* Layer.build(providerRegistryLayer).pipe(
+          Scope.provide(scope),
+        );
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          const providers = yield* registry.getProviders;
+          const ghost = providers.find((provider) => provider.instanceId === "ghost_main");
+
+          assert.notStrictEqual(ghost, undefined);
+          assert.strictEqual(ghost?.driver, "ghostDriver");
+          assert.strictEqual(ghost?.availability, "unavailable");
+          assert.match(ghost?.unavailableReason ?? "", /ghostDriver/);
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    it.effect("keeps cursor disabled and skips probing when the provider setting is disabled", () =>
+      Effect.gen(function* () {
+        const serverSettings = yield* makeMutableServerSettingsService(
+          decodeServerSettings(
+            deepMerge(encodedDefaultServerSettings, {
+              providers: {
+                codex: {
+                  enabled: false,
+                },
+                cursor: {
+                  enabled: false,
+                },
+                grok: {
+                  enabled: false,
+                },
+              },
+            }),
+          ),
+        );
+        let cursorSpawned = false;
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const providerRegistryLayer = ProviderRegistryLive.pipe(
+          Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+          Layer.provideMerge(
+            Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
+          ),
+          Layer.provideMerge(
+            ServerConfig.layerTest(process.cwd(), {
+              prefix: "t3-provider-registry-",
+            }),
+          ),
+          Layer.provideMerge(TestHttpClientLive),
+          Layer.provideMerge(
+            Layer.succeed(
+              ProviderEventLoggers.ProviderEventLoggers,
+              ProviderEventLoggers.NoOpProviderEventLoggers,
+            ),
+          ),
+          Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+          Layer.provideMerge(
+            mockCommandSpawnerLayer((command, args) => {
+              if (command === "cursor-agent") {
+                cursorSpawned = true;
+              }
+              const joined = args.join(" ");
+              if (joined === "--version") {
+                return {
+                  stdout: `${command} 1.0.0\n`,
+                  stderr: "",
+                  code: 0,
+                };
+              }
+              if (joined === "auth status") {
+                return {
+                  stdout: '{"authenticated":true}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              }
+              throw new Error(`Unexpected args: ${command} ${joined}`);
+            }),
+          ),
+        );
+        const runtimeServices = yield* Layer.build(
+          Layer.mergeAll(
+            Layer.succeed(ServerSettingsModule.ServerSettingsService, serverSettings),
+            providerRegistryLayer,
+          ),
+        ).pipe(Scope.provide(scope));
+
+        yield* Effect.gen(function* () {
+          const registry = yield* ProviderRegistry.ProviderRegistry;
+          const providers = yield* registry.getProviders;
+          const cursorProvider = providers.find(
+            (provider) => provider.instanceId === ProviderInstanceId.make("cursor"),
+          );
+
+          assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
+            "claudeAgent",
+            "codex",
+            "cursor",
+            "grok",
+            "opencode",
+            "pi",
+          ]);
+          assert.strictEqual(cursorProvider?.enabled, false);
+          assert.strictEqual(cursorProvider?.status, "disabled");
+          assert.strictEqual(cursorProvider?.message, "Cursor is disabled in T3 Code settings.");
+          assert.strictEqual(cursorSpawned, false);
+        }).pipe(Effect.provide(runtimeServices));
+      }),
+    );
+
+    it.effect("skips codex probes entirely when the provider is disabled", () =>
+      Effect.gen(function* () {
+        const status = yield* checkCodexProviderStatus(disabledCodexSettings).pipe(
+          Effect.provide(failingSpawnerLayer("spawn codex ENOENT")),
+        );
+        assert.strictEqual(status.enabled, false);
+        assert.strictEqual(status.status, "disabled");
+        assert.strictEqual(status.installed, false);
+        assert.strictEqual(status.message, "Codex is disabled in T3 Code settings.");
+      }),
+    );
+  });
+
+  // ── checkClaudeProviderStatus tests ──────────────────────────
+
+  describe("checkClaudeProviderStatus", () => {
+    it.effect("returns ready when claude is installed and authenticated", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities(),
+        );
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.installed, true);
+        assert.strictEqual(status.auth.status, "authenticated");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns ready and labels Bedrock-backed Claude as authenticated", () =>
+      Effect.gen(function* () {
+        // Bedrock authenticates via external AWS credentials, so the SDK init
+        // reports only `apiProvider` with no subscription or token.
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({ apiProvider: "bedrock" }),
+        );
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.installed, true);
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "bedrock");
+        assert.strictEqual(status.auth.label, "Amazon Bedrock");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("includes Claude Fable 5 on supported Claude Code versions", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities(),
+        );
+        const fable5 = status.models.find((model) => model.slug === "claude-fable-5");
+        assert.strictEqual(fable5?.name, "Claude Fable 5");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "2.1.169\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("hides Claude Fable 5 on older Claude Code versions", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities(),
+        );
+        assert.strictEqual(
+          status.models.some((model) => model.slug === "claude-fable-5"),
+          false,
+        );
+        assert.strictEqual(
+          status.message,
+          "Claude Code v2.1.168 is too old for Claude Fable 5. Upgrade to v2.1.169 or newer to access it.",
+        );
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "2.1.168\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect(
+      "includes Claude Opus 4.7 with xhigh as the default effort on supported versions",
+      () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(
             defaultClaudeSettings,
-            noClaudeCapabilities,
+            claudeCapabilities(),
           );
-          assert.strictEqual(status.status, "warning");
-          assert.strictEqual(status.installed, true);
-          assert.strictEqual(status.auth.status, "unknown");
-          assert.strictEqual(
-            status.message,
-            "Could not verify Claude authentication status from initialization result.",
+          const opus47 = status.models.find((model) => model.slug === "claude-opus-4-7");
+          if (!opus47) {
+            assert.fail("Expected Claude Opus 4.7 to be present for Claude Code v2.1.111.");
+          }
+          if (!opus47.capabilities) {
+            assert.fail(
+              "Expected Claude Opus 4.7 capabilities to be present for Claude Code v2.1.111.",
+            );
+          }
+          const effortDescriptor = opus47.capabilities.optionDescriptors?.find(
+            (descriptor) => descriptor.type === "select" && descriptor.id === "effort",
+          );
+          assert.deepStrictEqual(
+            effortDescriptor?.type === "select"
+              ? effortDescriptor.options.find((option) => option.isDefault)
+              : undefined,
+            { id: "xhigh", label: "Extra High", isDefault: true },
           );
         }).pipe(
           Effect.provide(
             mockSpawnerLayer((args) => {
               const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "--version") return { stdout: "2.1.111\n", stderr: "", code: 0 };
               if (joined === "auth status")
                 return {
-                  stdout: '{"loggedIn":false}\n',
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
                   stderr: "",
-                  code: 1,
+                  code: 0,
                 };
               throw new Error(`Unexpected args: ${joined}`);
             }),
           ),
         ),
+    );
+
+    it.effect("hides Claude Opus 4.7 on older Claude Code versions", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities(),
+        );
+        assert.strictEqual(
+          status.models.some((model) => model.slug === "claude-opus-4-7"),
+          false,
+        );
+        assert.strictEqual(
+          status.message,
+          "Claude Code v2.1.110 is too old for Claude Opus 4.7. Upgrade to v2.1.111 or newer to access it.",
+        );
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "2.1.110\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns a display label for claude subscription types", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({ subscriptionType: "maxplan" }),
+        );
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "maxplan");
+        assert.strictEqual(status.auth.label, "Claude Max Subscription");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("does not duplicate Claude in full subscription labels", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({
+            subscriptionType: "Claude Max Subscription",
+          }),
+        );
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "Claude Max Subscription");
+        assert.strictEqual(status.auth.label, "Claude Max Subscription");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("does not duplicate Claude in provider-prefixed subscription names", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({
+            subscriptionType: "Claude Max",
+          }),
+        );
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "Claude Max");
+        assert.strictEqual(status.auth.label, "Claude Max Subscription");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns claude auth email from initialization result", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({ email: "claude@example.com" }),
+        );
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.email, "claude@example.com");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout:
+                  '{"loggedIn":true,"authMethod":"claude.ai","account":{"email":"claude@example.com"}}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("runs Claude status probes with the configured CLAUDE_CONFIG_DIR", () => {
+      const claudeConfigDir = "/tmp/t3code-claude-home";
+      const recorded = recordingMockSpawnerLayer((args) => {
+        const joined = args.join(" ");
+        if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+        if (joined === "auth status")
+          return {
+            stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+            stderr: "",
+            code: 0,
+          };
+        throw new Error(`Unexpected args: ${joined}`);
+      });
+
+      return Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          {
+            ...defaultClaudeSettings,
+            homePath: claudeConfigDir,
+          },
+          claudeCapabilities(),
+        );
+        assert.strictEqual(status.status, "ready");
+        assert.deepStrictEqual(
+          recorded.commands.map((command) => command.env?.CLAUDE_CONFIG_DIR),
+          [claudeConfigDir],
+        );
+      }).pipe(Effect.provide(recorded.layer));
+    });
+
+    it.effect("includes probed claude slash commands in the provider snapshot", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({
+            subscriptionType: "maxplan",
+            slashCommands: [
+              {
+                name: "review",
+                description: "Review a pull request",
+                input: { hint: "pr-or-branch" },
+              },
+            ],
+          }),
+        );
+
+        assert.deepStrictEqual(status.slashCommands, [
+          {
+            name: "review",
+            description: "Review a pull request",
+            input: { hint: "pr-or-branch" },
+          },
+        ]);
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("deduplicates probed claude slash commands by name", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({
+            subscriptionType: "maxplan",
+            slashCommands: [
+              {
+                name: "ui",
+                description: "Explore and refine UI",
+              },
+              {
+                name: "ui",
+                input: { hint: "component-or-screen" },
+              },
+            ],
+          }),
+        );
+
+        assert.deepStrictEqual(status.slashCommands, [
+          {
+            name: "ui",
+            description: "Explore and refine UI",
+            input: { hint: "component-or-screen" },
+          },
+        ]);
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns an api key label for claude api key auth", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities({ tokenSource: "ANTHROPIC_AUTH_TOKEN" }),
+        );
+        assert.strictEqual(status.status, "ready");
+        assert.strictEqual(status.auth.status, "authenticated");
+        assert.strictEqual(status.auth.type, "apiKey");
+        assert.strictEqual(status.auth.label, "Claude API Key");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":true,"authMethod":"api-key"}\n',
+                stderr: "",
+                code: 0,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
+    it.effect("returns unavailable when claude is missing", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities(),
+        );
+        assert.strictEqual(status.status, "error");
+        assert.strictEqual(status.installed, false);
+        assert.strictEqual(status.auth.status, "unknown");
+        assert.strictEqual(
+          status.message,
+          "Claude Agent CLI (`claude`) is not installed or not on PATH.",
+        );
+      }).pipe(Effect.provide(failingSpawnerLayer("spawn claude ENOENT"))),
+    );
+
+    it.effect("returns error when version check fails with non-zero exit code", () => {
+      const secretStderr = "Something went wrong: secret-token-value";
+      return Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          claudeCapabilities(),
+        );
+        assert.strictEqual(status.status, "error");
+        assert.strictEqual(status.installed, true);
+        assert.strictEqual(status.message, "Claude Agent CLI is installed but failed to run.");
+        assert.ok(!(status.message ?? "").includes(secretStderr));
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version")
+              return {
+                stdout: "",
+                stderr: secretStderr,
+                code: 1,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
       );
     });
-  },
-);
+
+    it.effect("returns warning when the Claude initialization result is unavailable", () =>
+      Effect.gen(function* () {
+        const status = yield* checkClaudeProviderStatus(
+          defaultClaudeSettings,
+          noClaudeCapabilities,
+        );
+        assert.strictEqual(status.status, "warning");
+        assert.strictEqual(status.installed, true);
+        assert.strictEqual(status.auth.status, "unknown");
+        assert.strictEqual(
+          status.message,
+          "Could not verify Claude authentication status from initialization result.",
+        );
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args) => {
+            const joined = args.join(" ");
+            if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+            if (joined === "auth status")
+              return {
+                stdout: '{"loggedIn":false}\n',
+                stderr: "",
+                code: 1,
+              };
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+  });
+});

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -256,6 +256,46 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           ),
         );
 
+  const rejectIncompatibleContinuation = Effect.fn("rejectIncompatibleContinuation")(
+    function* (input: {
+      readonly operation: string;
+      readonly persistedBinding: ProviderSessionDirectory.ProviderRuntimeBinding | undefined;
+      readonly target: ProviderAdapterRegistry.ProviderInstanceRoutingInfo;
+    }) {
+      const binding = input.persistedBinding;
+      // A request for another driver is a deliberate provider replacement,
+      // handled by the caller/orchestration policy. A request for the same
+      // driver must instead prove that its persisted native resume state is
+      // compatible. Bindings without a resume cursor have nothing to resume.
+      if (
+        !binding ||
+        binding.provider !== input.target.driverKind ||
+        binding.resumeCursor === null ||
+        binding.resumeCursor === undefined
+      ) {
+        return;
+      }
+
+      const boundInstanceId = yield* requireBindingInstanceId(input.operation, binding);
+      if (boundInstanceId === input.target.instanceId) {
+        return;
+      }
+
+      const boundInstance = yield* registry.getInstanceInfo(boundInstanceId);
+      if (
+        boundInstance.continuationIdentity.continuationKey ===
+        input.target.continuationIdentity.continuationKey
+      ) {
+        return;
+      }
+
+      return yield* toValidationError(
+        input.operation,
+        `Thread '${binding.threadId}' cannot switch from instance '${boundInstanceId}' to '${input.target.instanceId}' because their provider resume state is incompatible.`,
+      );
+    },
+  );
+
   const upsertSessionBinding = (
     session: ProviderSession,
     threadId: ThreadId,
@@ -560,6 +600,11 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           );
         }
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        yield* rejectIncompatibleContinuation({
+          operation: "ProviderService.startSession",
+          persistedBinding,
+          target: instanceInfo,
+        });
         const effectiveResumeCursor =
           input.resumeCursor ??
           (persistedBinding?.providerInstanceId === resolvedInstanceId

--- a/apps/server/src/provider/builtInDrivers.test.ts
+++ b/apps/server/src/provider/builtInDrivers.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from "vite-plus/test";
+
+import { BUILT_IN_DRIVERS } from "./builtInDrivers.ts";
+
+it("registers Pi as a built-in provider driver", () => {
+  expect(BUILT_IN_DRIVERS.map((driver) => driver.driverKind)).toContain("pi");
+});

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -25,6 +25,7 @@ import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
+import { PiDriver, type PiDriverEnv } from "./Drivers/PiDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
 /**
@@ -37,7 +38,8 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | PiDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -47,6 +49,7 @@ export type BuiltInDriversEnv =
 export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv>> = [
   CodexDriver,
   ClaudeDriver,
+  PiDriver,
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -10,6 +10,7 @@ import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import {
+  addMaxReasoningOptionForCustomModel,
   isCommandMissingCause,
   providerModelsFromSettings,
   spawnAndCollect,
@@ -69,6 +70,109 @@ describe("providerModelsFromSettings", () => {
 
     expect(models.map((model) => model.slug)).toEqual(["claude-opus-4-8", "opus"]);
     expect(models[1]?.isCustom).toBe(true);
+  });
+});
+
+describe("addMaxReasoningOptionForCustomModel", () => {
+  it("adds Max to an existing reasoning effort selector", () => {
+    expect(
+      addMaxReasoningOptionForCustomModel(
+        createModelCapabilities({
+          optionDescriptors: [
+            {
+              id: "reasoningEffort",
+              label: "Reasoning",
+              type: "select",
+              options: [{ id: "medium", label: "Medium", isDefault: true }],
+              currentValue: "medium",
+            },
+          ],
+        }),
+      ),
+    ).toEqual(
+      createModelCapabilities({
+        optionDescriptors: [
+          {
+            id: "reasoningEffort",
+            label: "Reasoning",
+            type: "select",
+            options: [
+              { id: "medium", label: "Medium", isDefault: true },
+              { id: "max", label: "Max" },
+            ],
+            currentValue: "medium",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("adds Max to an existing effort selector", () => {
+    expect(
+      addMaxReasoningOptionForCustomModel(
+        createModelCapabilities({
+          optionDescriptors: [
+            {
+              id: "effort",
+              label: "Reasoning",
+              type: "select",
+              options: [{ id: "medium", label: "Medium", isDefault: true }],
+              currentValue: "medium",
+            },
+          ],
+        }),
+      ),
+    ).toEqual(
+      createModelCapabilities({
+        optionDescriptors: [
+          {
+            id: "effort",
+            label: "Reasoning",
+            type: "select",
+            options: [
+              { id: "medium", label: "Medium", isDefault: true },
+              { id: "max", label: "Max" },
+            ],
+            currentValue: "medium",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("does not duplicate an existing Max option", () => {
+    const capabilities = createModelCapabilities({
+      optionDescriptors: [
+        {
+          id: "effort",
+          label: "Reasoning",
+          type: "select",
+          options: [
+            { id: "high", label: "High", isDefault: true },
+            { id: "max", label: "Max" },
+          ],
+          currentValue: "high",
+        },
+      ],
+    });
+
+    expect(addMaxReasoningOptionForCustomModel(capabilities)).toEqual(capabilities);
+  });
+
+  it("leaves models without an existing reasoning selector unchanged", () => {
+    const capabilities = createModelCapabilities({
+      optionDescriptors: [
+        {
+          id: "variant",
+          label: "Variant",
+          type: "select",
+          options: [{ id: "medium", label: "Medium", isDefault: true }],
+          currentValue: "medium",
+        },
+      ],
+    });
+
+    expect(addMaxReasoningOptionForCustomModel(capabilities)).toEqual(capabilities);
   });
 });
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -57,6 +57,8 @@ export interface ServerProviderPresentation {
   readonly displayName: string;
   readonly badgeLabel?: string;
   readonly showInteractionModeToggle?: boolean;
+  readonly showRuntimeModeSelector?: boolean;
+  readonly toolAccessDescription?: string;
   readonly requiresNewThreadForModelChange?: boolean;
 }
 
@@ -261,6 +263,12 @@ export function buildServerProvider(input: {
     ...(input.presentation.badgeLabel ? { badgeLabel: input.presentation.badgeLabel } : {}),
     ...(typeof input.presentation.showInteractionModeToggle === "boolean"
       ? { showInteractionModeToggle: input.presentation.showInteractionModeToggle }
+      : {}),
+    ...(typeof input.presentation.showRuntimeModeSelector === "boolean"
+      ? { showRuntimeModeSelector: input.presentation.showRuntimeModeSelector }
+      : {}),
+    ...(input.presentation.toolAccessDescription
+      ? { toolAccessDescription: input.presentation.toolAccessDescription }
       : {}),
     ...(typeof input.presentation.requiresNewThreadForModelChange === "boolean"
       ? { requiresNewThreadForModelChange: input.presentation.requiresNewThreadForModelChange }

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -1,6 +1,7 @@
 import type {
   ProviderDriverKind,
   ModelCapabilities,
+  ProviderOptionDescriptor,
   ServerProvider,
   ServerProviderAuth,
   ServerProviderSkill,
@@ -138,6 +139,37 @@ export function parseGenericCliVersion(output: string): string | null {
   return match?.[1] ?? null;
 }
 
+const REASONING_OPTION_IDS = new Set(["effort", "reasoningEffort"]);
+
+export function addMaxReasoningOptionForCustomModel(
+  capabilities: ModelCapabilities,
+): ModelCapabilities {
+  const optionDescriptors = capabilities.optionDescriptors;
+  if (!optionDescriptors) {
+    return capabilities;
+  }
+
+  let changed = false;
+  const updatedOptionDescriptors: ProviderOptionDescriptor[] = optionDescriptors.map(
+    (descriptor) => {
+      if (
+        descriptor.type !== "select" ||
+        !REASONING_OPTION_IDS.has(descriptor.id) ||
+        descriptor.options.some((option) => option.id === "max")
+      ) {
+        return descriptor;
+      }
+      changed = true;
+      return {
+        ...descriptor,
+        options: [...descriptor.options, { id: "max", label: "Max" }],
+      };
+    },
+  );
+
+  return changed ? { ...capabilities, optionDescriptors: updatedOptionDescriptors } : capabilities;
+}
+
 export function providerModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
@@ -157,7 +189,7 @@ export function providerModelsFromSettings(
       slug: normalized,
       name: normalized,
       isCustom: true,
-      capabilities: customModelCapabilities,
+      capabilities: addMaxReasoningOptionForCustomModel(customModelCapabilities),
     });
   }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -301,6 +301,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // `providerInstances` hydration merges `settings.providers.<kind>`
   // with explicit `providerInstances` entries on boot.
   Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+  Layer.provideMerge(ProcessRunner.layer),
   // Shared native/canonical NDJSON writers used by both the per-instance
   // drivers (native stream, written from inside each `<X>Adapter`) and
   // `ProviderService` (canonical stream, written after event normalization).

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -110,7 +110,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { proposedPlanTitle } from "../../proposedPlan";
-import { getProviderDisplayName, getProviderInteractionModeToggle } from "../../providerModels";
+import { getProviderDisplayName } from "../../providerModels";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -198,6 +198,8 @@ function isInsideComposerFloatingLayer(element: Element): boolean {
 
 const ComposerFooterModeControls = memo(function ComposerFooterModeControls(props: {
   showInteractionModeToggle: boolean;
+  showRuntimeModeSelector: boolean;
+  toolAccessDescription?: string | undefined;
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
   showPlanToggle: boolean;
@@ -252,7 +254,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
     </>
   ) : null;
 
-  return (
+  const runtimeModeSelector = props.showRuntimeModeSelector ? (
     <>
       <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
 
@@ -305,7 +307,33 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
         </Select>
         <TooltipPopup side="top">{runtimeModeOption.description}</TooltipPopup>
       </Tooltip>
+    </>
+  ) : null;
+  const toolAccessNotice = props.toolAccessDescription ? (
+    <>
+      <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span
+              className="inline-flex shrink-0 items-center gap-1.5 px-2 text-muted-foreground/80 text-xs"
+              aria-label="Pi-managed tool access"
+              tabIndex={0}
+            />
+          }
+        >
+          <CircleAlertIcon className="size-3.5" />
+          <span className="hidden sm:inline">Pi-managed tools</span>
+        </TooltipTrigger>
+        <TooltipPopup side="top">{props.toolAccessDescription}</TooltipPopup>
+      </Tooltip>
+    </>
+  ) : null;
 
+  return (
+    <>
+      {runtimeModeSelector}
+      {toolAccessNotice}
       {interactionModeToggle}
 
       {props.showPlanToggle ? (
@@ -832,12 +860,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
   const composerProviderControls = useMemo(
     () => ({
-      showInteractionModeToggle: getProviderInteractionModeToggle(
-        providerStatuses,
-        selectedProvider,
-      ),
+      showInteractionModeToggle: selectedProviderStatus?.showInteractionModeToggle ?? true,
+      showRuntimeModeSelector: selectedProviderStatus?.showRuntimeModeSelector ?? true,
+      toolAccessDescription: selectedProviderStatus?.toolAccessDescription,
     }),
-    [providerStatuses, selectedProvider],
+    [selectedProviderStatus],
   );
   const selectedModelSelection = useMemo<ModelSelection>(
     () => createModelSelection(selectedInstanceId, selectedModel, selectedModelOptionsForDispatch),
@@ -2589,6 +2616,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     planSidebarOpen={planSidebarOpen}
                     runtimeMode={runtimeMode}
                     showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
+                    showRuntimeModeSelector={composerProviderControls.showRuntimeModeSelector}
+                    toolAccessDescription={composerProviderControls.toolAccessDescription}
                     traitsMenuContent={providerTraitsMenuContent}
                     onToggleInteractionMode={toggleInteractionMode}
                     onTogglePlanSidebar={togglePlanSidebar}
@@ -2604,6 +2633,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     ) : null}
                     <ComposerFooterModeControls
                       showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
+                      showRuntimeModeSelector={composerProviderControls.showRuntimeModeSelector}
+                      toolAccessDescription={composerProviderControls.toolAccessDescription}
                       interactionMode={interactionMode}
                       runtimeMode={runtimeMode}
                       showPlanToggle={showPlanSidebarToggle}

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.test.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { CompactComposerAccessControls } from "./CompactComposerControlsMenu";
+
+describe("CompactComposerAccessControls", () => {
+  it("shows Pi-managed tool access without a misleading runtime-mode selector", () => {
+    const markup = renderToStaticMarkup(
+      <CompactComposerAccessControls
+        runtimeMode="full-access"
+        showRuntimeModeSelector={false}
+        toolAccessDescription="Pi manages enabled tool access; Pi tools can run without a T3 Code per-tool confirmation."
+        onRuntimeModeChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Pi-managed tools");
+    expect(markup).toContain("Pi manages enabled tool access");
+    expect(markup).not.toContain("Supervised");
+    expect(markup).not.toContain("Auto-accept edits");
+    expect(markup).not.toContain("Full access");
+  });
+});

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -12,6 +12,40 @@ import {
   MenuTrigger,
 } from "../ui/menu";
 
+export const CompactComposerAccessControls = memo(function CompactComposerAccessControls(props: {
+  runtimeMode: RuntimeMode;
+  showRuntimeModeSelector: boolean;
+  toolAccessDescription?: string | undefined;
+  onRuntimeModeChange: (mode: RuntimeMode) => void;
+}) {
+  return (
+    <>
+      {props.showRuntimeModeSelector ? (
+        <>
+          <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Access</div>
+          <MenuRadioGroup
+            value={props.runtimeMode}
+            onValueChange={(value) => {
+              if (!value || value === props.runtimeMode) return;
+              props.onRuntimeModeChange(value as RuntimeMode);
+            }}
+          >
+            <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
+            <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
+            <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          </MenuRadioGroup>
+        </>
+      ) : null}
+      {props.toolAccessDescription ? (
+        <div className="max-w-64 px-2 py-1.5 text-muted-foreground text-xs leading-4">
+          <span className="font-medium text-foreground">Pi-managed tools</span>
+          <p className="mt-0.5">{props.toolAccessDescription}</p>
+        </div>
+      ) : null}
+    </>
+  );
+});
+
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   activePlan: boolean;
   interactionMode: ProviderInteractionMode;
@@ -19,6 +53,8 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   planSidebarOpen: boolean;
   runtimeMode: RuntimeMode;
   showInteractionModeToggle: boolean;
+  showRuntimeModeSelector: boolean;
+  toolAccessDescription?: string | undefined;
   traitsMenuContent?: ReactNode;
   onToggleInteractionMode: () => void;
   onTogglePlanSidebar: () => void;
@@ -61,18 +97,12 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             <MenuDivider />
           </>
         ) : null}
-        <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Access</div>
-        <MenuRadioGroup
-          value={props.runtimeMode}
-          onValueChange={(value) => {
-            if (!value || value === props.runtimeMode) return;
-            props.onRuntimeModeChange(value as RuntimeMode);
-          }}
-        >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
-        </MenuRadioGroup>
+        <CompactComposerAccessControls
+          runtimeMode={props.runtimeMode}
+          showRuntimeModeSelector={props.showRuntimeModeSelector}
+          toolAccessDescription={props.toolAccessDescription}
+          onRuntimeModeChange={props.onRuntimeModeChange}
+        />
         {props.activePlan ? (
           <>
             <MenuDivider />

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -13,7 +13,7 @@ import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSet
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
-import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
+import { ACPRegistryIcon, Gemini, GithubCopilotIcon, type Icon } from "../Icons";
 import {
   Dialog,
   DialogDescription,
@@ -85,11 +85,6 @@ const COMING_SOON_DRIVER_OPTIONS: readonly ComingSoonDriverOption[] = [
     value: ProviderDriverKind.make("acpRegistry"),
     label: "ACP Registry",
     icon: ACPRegistryIcon,
-  },
-  {
-    value: ProviderDriverKind.make("piAgent"),
-    label: "Pi Agent",
-    icon: PiAgentIcon,
   },
 ];
 

--- a/apps/web/src/components/settings/providerDriverMeta.test.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vite-plus/test";
+
+import { getDriverOption } from "./providerDriverMeta.ts";
+
+it("registers Pi as a selectable provider driver", () => {
+  const pi = getDriverOption("pi" as never);
+
+  expect(pi).toMatchObject({ label: "Pi", value: "pi" });
+  expect(pi?.badgeLabel).toBeUndefined();
+});

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -4,10 +4,11 @@ import {
   CursorSettings,
   GrokSettings,
   OpenCodeSettings,
+  PiSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon, PiAgentIcon } from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -46,6 +47,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "Claude",
     icon: ClaudeAI,
     settingsSchema: ClaudeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("pi"),
+    label: "Pi",
+    icon: PiAgentIcon,
+    settingsSchema: PiSettings,
   },
   {
     value: ProviderDriverKind.make("cursor"),

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -64,7 +64,7 @@ function readInstanceCustomModels(
   }
   const legacyProviders = settings.providers as Record<
     string,
-    { readonly customModels: ReadonlyArray<string> } | undefined
+    { readonly customModels?: ReadonlyArray<string> } | undefined
   >;
   return legacyProviders[driverKind]?.customModels ?? [];
 }

--- a/apps/web/src/pendingUserInput.test.ts
+++ b/apps/web/src/pendingUserInput.test.ts
@@ -40,6 +40,20 @@ const multiSelectQuestion = {
   multiSelect: true,
 } as const;
 
+const cancellableInputQuestion = {
+  id: "release_summary",
+  header: "Release summary",
+  question: "Describe the release.",
+  options: [
+    {
+      label: "Cancel",
+      description: "Cancel this input request",
+    },
+  ],
+  cancelOptionLabel: "Cancel",
+  multiSelect: false,
+} as const;
+
 describe("resolvePendingUserInputAnswer", () => {
   it("prefers a custom answer over selected options", () => {
     expect(
@@ -152,6 +166,23 @@ describe("buildPendingUserInputAnswers", () => {
 
   it("returns null when any question is unanswered", () => {
     expect(buildPendingUserInputAnswers([singleSelectQuestion], {})).toBeNull();
+  });
+
+  it("distinguishes a custom value from a selected cancellation option", () => {
+    expect(
+      buildPendingUserInputAnswers([cancellableInputQuestion], {
+        release_summary: { customAnswer: "Cancel" },
+      }),
+    ).toEqual({
+      release_summary: { value: "Cancel" },
+    });
+    expect(
+      buildPendingUserInputAnswers([cancellableInputQuestion], {
+        release_summary: { selectedOptionLabels: ["Cancel"] },
+      }),
+    ).toEqual({
+      release_summary: { cancelled: true },
+    });
   });
 });
 

--- a/apps/web/src/pendingUserInput.ts
+++ b/apps/web/src/pendingUserInput.ts
@@ -1,4 +1,4 @@
-import type { UserInputQuestion } from "@t3tools/contracts";
+import type { ProviderUserInputAnswers, UserInputQuestion } from "@t3tools/contracts";
 
 export interface PendingUserInputDraftAnswer {
   selectedOptionLabels?: string[];
@@ -105,15 +105,22 @@ export function togglePendingUserInputOptionSelection(
 export function buildPendingUserInputAnswers(
   questions: ReadonlyArray<UserInputQuestion>,
   draftAnswers: Record<string, PendingUserInputDraftAnswer>,
-): Record<string, string | string[]> | null {
-  const answers: Record<string, string | string[]> = {};
+): ProviderUserInputAnswers | null {
+  const answers: Record<string, unknown> = {};
 
   for (const question of questions) {
-    const answer = resolvePendingUserInputAnswer(question, draftAnswers[question.id]);
+    const draft = draftAnswers[question.id];
+    const answer = resolvePendingUserInputAnswer(question, draft);
     if (!answer) {
       return null;
     }
-    answers[question.id] = answer;
+    const customAnswer = normalizeDraftAnswer(draft?.customAnswer);
+    answers[question.id] =
+      question.cancelOptionLabel && customAnswer
+        ? { value: customAnswer }
+        : question.cancelOptionLabel && answer === question.cancelOptionLabel
+          ? { cancelled: true }
+          : answer;
   }
 
   return answers;

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -756,6 +756,34 @@ describe("deriveWorkLogEntries", () => {
     expect(entries[0]?.label).toBe("Searching for API endpoints");
   });
 
+  it("collapses adjacent progress updates for the same task", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "thinking-progress-1",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "task.progress",
+        summary: "Thinking",
+        tone: "info",
+        payload: { taskId: "thinking-1", summary: "Inspecting the session" },
+      }),
+      makeActivity({
+        id: "thinking-progress-2",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "task.progress",
+        summary: "Thinking",
+        tone: "info",
+        payload: { taskId: "thinking-1", summary: "Inspecting the session and tools" },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "thinking-progress-2",
+      label: "Inspecting the session and tools",
+    });
+  });
+
   it("uses payload detail as label for task.completed and preserves error tone", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -178,6 +178,58 @@ describe("derivePendingApprovals", () => {
 });
 
 describe("derivePendingUserInputs", () => {
+  it("preserves cancellable free-text prompts", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open-cancellable-text",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-cancellable-text",
+          questions: [
+            {
+              id: "release_summary",
+              header: "Release summary",
+              question: "Describe the release.",
+              options: [
+                {
+                  label: "Cancel",
+                  description: "Cancel this input request",
+                },
+              ],
+              cancelOptionLabel: "Cancel",
+              multiSelect: false,
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(derivePendingUserInputs(activities)).toEqual([
+      {
+        requestId: "req-user-input-cancellable-text",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        questions: [
+          {
+            id: "release_summary",
+            header: "Release summary",
+            question: "Describe the release.",
+            options: [
+              {
+                label: "Cancel",
+                description: "Cancel this input request",
+              },
+            ],
+            cancelOptionLabel: "Cancel",
+            multiSelect: false,
+          },
+        ],
+      },
+    ]);
+  });
+
   it("tracks open structured prompts and removes resolved ones", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -83,6 +83,7 @@ export interface WorkLogEntry {
 interface DerivedWorkLogEntry extends WorkLogEntry {
   activityKind: OrchestrationThreadActivity["kind"];
   collapseKey?: string;
+  taskId?: string;
   toolCallId?: string;
 }
 
@@ -703,6 +704,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       ? stripTrailingExitCode(payload.detail).output
       : null
     : extractToolDetail(payload, title ?? activity.summary);
+  const taskId = isTaskActivity ? asTrimmedString(payload?.taskId) : null;
   const toolCallId = isTaskActivity ? null : extractToolCallId(payload);
   const entry: DerivedWorkLogEntry = {
     id: activity.id,
@@ -746,6 +748,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (requestKind) {
     entry.requestKind = requestKind;
   }
+  if (taskId) {
+    entry.taskId = taskId;
+  }
   if (toolCallId) {
     entry.toolCallId = toolCallId;
   }
@@ -769,7 +774,7 @@ function collapseDerivedWorkLogEntries(
   const collapsed: DerivedWorkLogEntry[] = [];
   for (const entry of entries) {
     const previous = collapsed.at(-1);
-    if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
+    if (previous && shouldCollapseWorkLogEntries(previous, entry)) {
       collapsed[collapsed.length - 1] = mergeDerivedWorkLogEntries(previous, entry);
       continue;
     }
@@ -778,10 +783,18 @@ function collapseDerivedWorkLogEntries(
   return collapsed;
 }
 
-function shouldCollapseToolLifecycleEntries(
+function shouldCollapseWorkLogEntries(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): boolean {
+  if (
+    previous.activityKind === "task.progress" &&
+    next.activityKind === "task.progress" &&
+    previous.taskId !== undefined &&
+    previous.taskId === next.taskId
+  ) {
+    return true;
+  }
   if (previous.activityKind !== "tool.updated" && previous.activityKind !== "tool.completed") {
     return false;
   }
@@ -815,6 +828,7 @@ function mergeDerivedWorkLogEntries(
   const itemType = next.itemType ?? previous.itemType;
   const requestKind = next.requestKind ?? previous.requestKind;
   const collapseKey = next.collapseKey ?? previous.collapseKey;
+  const taskId = next.taskId ?? previous.taskId;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
@@ -829,6 +843,7 @@ function mergeDerivedWorkLogEntries(
     ...(itemType ? { itemType } : {}),
     ...(requestKind ? { requestKind } : {}),
     ...(collapseKey ? { collapseKey } : {}),
+    ...(taskId ? { taskId } : {}),
     ...(toolCallId ? { toolCallId } : {}),
     ...(toolLifecycleStatus !== undefined ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -444,7 +444,13 @@ function parseUserInputQuestions(
           };
         })
         .filter((option): option is UserInputQuestion["options"][number] => option !== null);
-      if (options.length === 0) {
+      const cancelOptionLabel = question.cancelOptionLabel;
+      if (
+        options.length === 0 ||
+        (cancelOptionLabel !== undefined &&
+          (typeof cancelOptionLabel !== "string" ||
+            !options.some((option) => option.label === cancelOptionLabel)))
+      ) {
         return null;
       }
       return {
@@ -452,6 +458,7 @@ function parseUserInputQuestions(
         header: question.header,
         question: question.question,
         options,
+        ...(cancelOptionLabel !== undefined ? { cancelOptionLabel } : {}),
         multiSelect: question.multiSelect === true,
       };
     })

--- a/docs/adr/0001-pi-cli-rpc-provider.md
+++ b/docs/adr/0001-pi-cli-rpc-provider.md
@@ -1,0 +1,3 @@
+# Integrate Pi through its CLI RPC mode
+
+T3 Code will treat Pi as a first-class `pi` provider driver that starts the user-installed Pi CLI in `--mode rpc` and adapts its JSONL protocol. This follows the existing Codex app-server integration pattern while preserving the user's installed Pi version, credentials, settings, extensions, and native session behavior.

--- a/docs/adr/0002-isolate-pi-sessions-by-provider-instance.md
+++ b/docs/adr/0002-isolate-pi-sessions-by-provider-instance.md
@@ -1,0 +1,3 @@
+# Isolate Pi sessions by provider instance
+
+Each T3 Code Pi provider instance will use its own Pi `--session-dir`, and each T3 Code thread will use its thread ID as Pi's session ID. Threads therefore remain native, resumable Pi sessions while providers with different credentials or configurations cannot share session storage accidentally.

--- a/docs/adr/0002-isolate-pi-sessions-by-provider-instance.md
+++ b/docs/adr/0002-isolate-pi-sessions-by-provider-instance.md
@@ -1,3 +1,3 @@
 # Isolate Pi sessions by provider instance
 
-Each T3 Code Pi provider instance will use its own Pi `--session-dir`, and each T3 Code thread will use its thread ID as Pi's session ID. Threads therefore remain native, resumable Pi sessions while providers with different credentials or configurations cannot share session storage accidentally.
+Each T3 Code Pi provider instance will use its own Pi `--session-dir`, and each T3 Code thread will use its thread ID as Pi's session ID. T3 Code starts Pi in persistent-session mode immediately; Pi materializes the native session file lazily while persisting the first accepted prompt's turn. Threads therefore retain deterministic, resumable native-session identity while providers with different credentials or configurations cannot share session storage accidentally.

--- a/docs/adr/0003-delegate-pi-provider-configuration-to-pi.md
+++ b/docs/adr/0003-delegate-pi-provider-configuration-to-pi.md
@@ -1,0 +1,3 @@
+# Keep Pi as the source of provider configuration
+
+Pi remains the source of truth for credentials, custom providers, and its model catalog. T3 Code may still configure per-instance runtime concerns—such as the Pi binary, environment, configuration location, and session directory—and maintain UI-only preferences, following the distinction already used for OpenCode.

--- a/docs/adr/0004-support-multiple-pi-runtime-instances.md
+++ b/docs/adr/0004-support-multiple-pi-runtime-instances.md
@@ -1,0 +1,3 @@
+# Support multiple Pi runtime instances
+
+Pi will support multiple T3 Code runtime instances from its first release. Each instance may use an independent Pi executable, configuration environment, and session directory, while Pi remains the source of truth for providers, credentials, custom-provider definitions, and models.

--- a/docs/adr/0005-pi-initial-tool-access-is-pi-managed.md
+++ b/docs/adr/0005-pi-initial-tool-access-is-pi-managed.md
@@ -1,0 +1,3 @@
+# Keep initial Pi tool access Pi-managed
+
+The initial Pi provider will run Pi's enabled tools without a T3 Code per-tool approval UI or runtime-mode selector. Pi's tool allow/deny configuration remains effective; supervised execution is deferred until T3 Code can safely provide and maintain a Pi permission-gate extension over Pi's extension UI RPC protocol.

--- a/docs/adr/0006-preserve-user-pi-extensions.md
+++ b/docs/adr/0006-preserve-user-pi-extensions.md
@@ -1,0 +1,3 @@
+# Preserve user Pi extensions
+
+Pi runtime instances will load the user's normal trusted Pi extensions without T3 Code installing, modifying, or configuring them. T3 Code will render basic Pi RPC extension dialogs where possible and clearly report unsupported custom extension UI as requiring Pi's terminal interface.

--- a/docs/adr/0006-preserve-user-pi-extensions.md
+++ b/docs/adr/0006-preserve-user-pi-extensions.md
@@ -1,3 +1,3 @@
-# Preserve user Pi extensions
+# Isolate Pi from discovered user extensions
 
-Pi runtime instances will load the user's normal trusted Pi extensions without T3 Code installing, modifying, or configuring them. T3 Code will render basic Pi RPC extension dialogs where possible and clearly report unsupported custom extension UI as requiring Pi's terminal interface.
+Pi runtime instances will start with Pi's `--no-extensions` flag so arbitrary user extension hooks cannot alter T3 Code tool execution. Users may explicitly load a trusted extension with Pi's `--extension <path>` launch argument; T3 Code will render compatible RPC extension dialogs from those explicit extensions where possible and clearly report unsupported custom extension UI as requiring Pi's terminal interface.

--- a/docs/adr/0007-select-pi-configuration-per-runtime-instance.md
+++ b/docs/adr/0007-select-pi-configuration-per-runtime-instance.md
@@ -1,0 +1,3 @@
+# Select Pi configuration per runtime instance
+
+Each Pi runtime instance may optionally specify a Pi configuration directory. T3 Code passes it as `PI_AGENT_DIR`; when absent, Pi uses the user's normal configuration. Pi session storage stays separately isolated by T3 Code provider instance, so choosing a configuration home does not merge session histories.

--- a/docs/adr/0008-discover-pi-models-through-rpc.md
+++ b/docs/adr/0008-discover-pi-models-through-rpc.md
@@ -1,0 +1,3 @@
+# Discover Pi models through RPC
+
+T3 Code will query each Pi runtime instance through `get_available_models`, show its configured models in the standard picker, switch models through `set_model`, and expose only the thinking levels Pi reports for the selected model. This keeps Pi's provider and model configuration authoritative while allowing custom Pi models to work without duplicate T3 configuration.

--- a/docs/adr/0009-map-supported-pi-lifecycle-events.md
+++ b/docs/adr/0009-map-supported-pi-lifecycle-events.md
@@ -1,0 +1,3 @@
+# Map supported Pi lifecycle events into T3 Code
+
+The Pi adapter will map all Pi RPC lifecycle information with a clear T3 Code equivalent, including streaming text and thinking, tool calls and progress, turn completion, retries, compaction, and queued work. Provider-specific UI is deferred only when Pi exposes an interaction that has no safe or faithful T3 Code representation, such as a custom terminal widget.

--- a/docs/adr/0010-match-provider-session-loss-recovery.md
+++ b/docs/adr/0010-match-provider-session-loss-recovery.md
@@ -1,0 +1,3 @@
+# Match existing provider session-loss recovery
+
+When a Pi RPC process or connection ends, T3 Code will not replay an in-flight turn because that could duplicate tool calls. It will mark the active turn interrupted and close the live session, matching existing Codex and Claude provider behavior; when the user later continues, T3 Code starts Pi against the persisted native session using the same runtime-instance configuration.

--- a/docs/adr/0011-bind-pi-thread-continuation-to-its-runtime-instance.md
+++ b/docs/adr/0011-bind-pi-thread-continuation-to-its-runtime-instance.md
@@ -1,0 +1,3 @@
+# Bind Pi thread continuation to its runtime instance
+
+A Pi thread may continue only through its originating Pi runtime instance. The runtime instance defines the Pi configuration environment, extensions, credentials, model catalog, and isolated session directory required to interpret and safely resume its native Pi session.

--- a/docs/adr/0011-bind-pi-thread-continuation-to-its-runtime-instance.md
+++ b/docs/adr/0011-bind-pi-thread-continuation-to-its-runtime-instance.md
@@ -1,3 +1,3 @@
 # Bind Pi thread continuation to its runtime instance
 
-A Pi thread may continue only through its originating Pi runtime instance. The runtime instance defines the Pi configuration environment, extensions, credentials, model catalog, and isolated session directory required to interpret and safely resume its native Pi session.
+A Pi thread may continue only through its originating Pi runtime instance. The runtime instance defines the Pi configuration environment, extensions, credentials, model catalog, and isolated session directory required to interpret and safely resume its native Pi session. Provider-session routing rejects same-driver starts with a persisted resume cursor whose continuation identities differ, so this rule is enforced below the user-facing orchestration path as well.

--- a/docs/adr/0012-manage-pi-runtime-launch-in-t3-code.md
+++ b/docs/adr/0012-manage-pi-runtime-launch-in-t3-code.md
@@ -1,0 +1,3 @@
+# Manage Pi runtime launch in T3 Code
+
+Each Pi runtime instance will expose a binary path, optional Pi configuration directory, optional additional launch arguments, generic instance environment, display name, and accent color. T3 Code retains exclusive control of Pi's RPC mode, session directory, and thread session ID; settings validation rejects additional arguments that would override those managed launch parameters.

--- a/docs/adr/0013-require-pi-0-81-1-or-later.md
+++ b/docs/adr/0013-require-pi-0-81-1-or-later.md
@@ -1,0 +1,3 @@
+# Require Pi 0.81.1 or later
+
+The Pi integration is designed against Pi CLI 0.81.1, including its RPC model discovery, lifecycle events, extension UI protocol, native session handling, and tool-policy behavior. T3 Code will require Pi 0.81.1 or later and show an upgrade warning when a discovered installation is older.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/project/pi-first-class-provider-spec.md
+++ b/docs/project/pi-first-class-provider-spec.md
@@ -1,0 +1,110 @@
+## Problem Statement
+
+T3 Code users who prefer Pi cannot use it as a first-class coding-agent provider alongside Codex, Claude, OpenCode, Cursor, and Grok. They lose T3 Code's project/thread workflow, model picker, chat and work-log visibility, provider-instance management, and safe session continuation while also needing to preserve Pi's own provider configuration, custom providers, extensions, native session format, and tool behavior.
+
+## Solution
+
+Add Pi as a first-class `pi` provider driver for Pi CLI `0.81.1` or later. T3 Code will launch the user-installed `pi` executable in RPC mode and adapt its JSONL protocol into the existing provider lifecycle. Pi remains the source of truth for credentials, custom providers, models, extensions, and enabled-tool policy. T3 Code manages Pi runtime instances, native-session routing, thread lifecycle, presentation, diagnostics, and recovery.
+
+## User Stories
+
+1. As a T3 Code user, I want Pi to appear as an available provider, so that I can use Pi without leaving T3 Code.
+2. As a Pi user, I want T3 Code to run my installed Pi CLI rather than a bundled replacement, so that my Pi version, authentication, configuration, and extensions remain mine.
+3. As a user, I want to add multiple Pi runtime instances, so that I can keep independent Pi environments separate.
+4. As a user, I want each Pi runtime instance to have a display name and accent color, so that I can distinguish it in provider and model pickers.
+5. As a user, I want to choose a Pi executable path, so that T3 Code can use a non-default or managed Pi installation.
+6. As a user, I want an empty Pi config-directory setting to use my normal Pi configuration, so that the default setup is frictionless.
+7. As a user, I want to set a Pi config directory per runtime instance, so that I can use separate Pi credentials, providers, models, and extensions when needed.
+8. As a user, I want T3 Code to pass the selected config directory through `PI_AGENT_DIR`, so that Pi itself remains responsible for resolving its configuration.
+9. As a user, I want generic per-instance environment variables, so that Pi and its configured providers can receive the environment they require.
+10. As a Pi user, I want Pi to remain the source of truth for credentials, custom providers, and models, so that I do not have to duplicate configuration in T3 Code.
+11. As a user, I want T3 Code to discover the configured Pi model catalog, so that custom Pi models appear automatically.
+12. As a user, I want Pi models grouped by their Pi provider in the normal T3 model picker, so that I can select the intended provider/model combination.
+13. As a user, I want model changes to use Pi's native model-selection RPC operation, so that Pi owns the effective model state.
+14. As a user, I want only supported thinking levels to be selectable for the current Pi model, so that I cannot request an invalid reasoning mode.
+15. As a user, I want a new T3 Code thread using Pi to create a persisted native Pi session, so that the conversation is resumable by Pi.
+16. As a user, I want each T3 Code thread ID to map to a stable Pi session ID, so that restarts do not create duplicate or ambiguous Pi sessions.
+17. As a user, I want Pi sessions stored in a directory isolated to their Pi runtime instance, so that separate configurations do not accidentally share session storage.
+18. As a user, I want to understand where Pi sessions are stored, so that I can access them with Pi when necessary.
+19. As a user, I want Pi threads to continue only with the Pi runtime instance that created them, so that the original configuration, credentials, extensions, model catalog, and session storage are preserved.
+20. As a user, I want text responses to stream in T3 Code, so that Pi feels like the other first-class providers.
+21. As a user, I want Pi thinking streams to appear in the normal T3 Code experience, so that I can understand active reasoning where Pi provides it.
+22. As a user, I want Pi tool calls, live execution progress, output, and results to appear in the work log, so that I can observe what Pi is doing.
+23. As a user, I want retries, context compaction, and queued work to appear in the normal work log, so that known Pi lifecycle activity is not hidden or treated as unsupported.
+24. As a user, I want image attachments sent through T3 Code to reach Pi, so that I can use Pi's native image prompting.
+25. As a user, I want to interrupt an active Pi turn, so that I can stop unwanted work.
+26. As a user, I want an unexpected Pi process or connection loss to mark the active turn interrupted rather than replay it, so that T3 Code never duplicates tool calls.
+27. As a user, I want to continue a thread after a process or connection loss, so that T3 Code relaunches Pi against the persisted native session.
+28. As a Pi user, I want my trusted global and project-local Pi extensions to load normally, so that T3 Code does not disable my established Pi workflow.
+29. As a user, I want basic Pi extension dialogs such as confirmation, selection, and text input to appear in T3 Code when Pi exposes them through RPC, so that compatible extensions remain usable.
+30. As a user, I want unsupported custom extension terminal UI to be identified clearly, so that I know when an interaction requires Pi's terminal interface.
+31. As a user, I want T3 Code not to install, edit, or configure my Pi extensions, so that extension ownership and trust stay with Pi.
+32. As a user, I want Pi's configured enabled-tool policy to remain effective, so that T3 Code does not silently change which Pi tools are available.
+33. As a user, I want Pi tool access clearly labelled as Pi-managed, so that I understand enabled tools run without T3 Code's normal per-tool approval prompt.
+34. As a user, I want no misleading T3 runtime-mode selector for Pi, so that T3 Code does not imply it can supervise Pi tools when it cannot.
+35. As a user, I want advanced launch arguments where safe, so that I can use legitimate Pi options without sacrificing T3 Code session correctness.
+36. As a user, I want T3 Code to reserve Pi RPC mode, session directory, and session ID arguments, so that settings cannot break native-session routing or recovery.
+37. As a user, I want an actionable warning when Pi is missing, unavailable, or older than `0.81.1`, so that I can resolve compatibility issues before starting a thread.
+38. As a user, I want native Pi protocol events retained in diagnostics, so that provider and extension failures can be investigated without guessing.
+39. As a maintainer, I want the Pi integration to use the existing provider-driver architecture, so that it participates in the same registry, health, status, maintenance, session, and orchestration flows as other providers.
+40. As a maintainer, I want the initial implementation to have explicit deferrals, so that unsupported Pi-specific interactions can be revisited deliberately after the core adapter is stable.
+
+## Implementation Decisions
+
+- Add a built-in `pi` Provider Driver Kind and a first-class Pi Provider driver registered with the existing driver registry.
+- Require Pi CLI `0.81.1` or later. The provider status probe must inspect the selected executable, report its version, and present a clear unavailable or upgrade-required state when the executable is missing, invalid, or too old.
+- The driver launches the user-selected `pi` executable as a scoped child process using Pi RPC mode and JSONL stdin/stdout framing. It must use a strict LF-delimited JSONL parser rather than a generic line reader.
+- Use Pi RPC as the integration boundary; do not import Pi's Node package into the T3 Code server process and do not reconstruct Pi behavior from session files.
+- Add per-instance Pi settings for: enabled state, binary path (default `pi`), optional Pi config directory, optional additional launch arguments, and UI-only custom model preferences where the existing provider settings model requires them. Existing generic instance display name, accent color, and environment remain available.
+- When a Pi config directory is configured, pass it as `PI_AGENT_DIR`; otherwise allow Pi to use its normal user configuration. Pi configuration remains authoritative for credentials, external/custom providers, configured models, enabled tools, and extensions.
+- Support multiple Pi Runtime Instances from the first release. Each instance has independently resolved executable/configuration environment and an isolated Pi Session Directory.
+- T3 Code controls the required Pi launch parameters: RPC mode, the per-instance session directory, and the stable thread-derived Pi session ID. Validate additional launch arguments and reject attempts to override those parameters.
+- Map every T3 Code thread to a native persisted Pi session. Use the T3 Code thread ID as the Pi session ID and scope the session directory to the Pi Runtime Instance.
+- Bind Pi Continuation Compatibility to the originating Pi Runtime Instance. Continuation must not switch into a Pi instance with another configuration environment or session directory.
+- On session/process/connection loss, mark an active Pi turn interrupted and close the live session. Do not replay the active prompt automatically. A later explicit continuation restarts Pi using the stored native session and originating runtime-instance configuration.
+- Probe each Pi Runtime Instance through RPC for its configured model catalog. Convert available Pi models into the existing server model snapshot/picker representation, preserving provider grouping.
+- Map model selection to Pi `set_model` and use Pi's available-thinking-level RPC data to drive the existing model-option system. Do not invent unsupported thinking options.
+- Map supported Pi RPC events comprehensively into existing provider events and orchestration projections: session lifecycle, turn lifecycle, streamed text, streamed thinking, tool-call construction, tool-execution start/update/end, tool results/errors, agent settled, retries, compaction, and queued-work changes.
+- Render the mapped events with existing normal chat/work-log capabilities wherever semantics match. Retain native Pi event payloads in diagnostics/native event logs.
+- Translate image attachments from T3 Code's attachment representation to Pi RPC image prompt content.
+- Implement stop/interrupt with Pi's native abort RPC command.
+- Preserve normal trusted Pi global and project-local extension loading. T3 Code must not install, mutate, enable, disable, or otherwise configure extensions.
+- Support basic extension UI RPC requests for confirm, select, and input through the existing request/response UX contract. If Pi emits custom terminal UI that has no faithful T3 representation, show a clear terminal-required notice rather than silently discarding it.
+- Pi Tool Policy is Pi-managed for the initial release. T3 Code must not expose its normal runtime-mode selector for Pi and must clearly communicate that every tool enabled by Pi may run without a T3 per-tool confirmation.
+- Align Pi availability, snapshots, status refresh, maintenance/update advice, provider selection, settings, diagnostics, and icons with existing built-in provider conventions.
+- Respect the Pi domain language and the existing ADR sequence covering the integration boundary, session isolation, configuration ownership, multi-instance support, tool policy, extension behavior, config-directory selection, model discovery, lifecycle mapping, recovery, continuation compatibility, managed launch parameters, and version baseline.
+
+## Testing Decisions
+
+- Use one high-level provider-adapter contract seam: a controlled/fake Pi RPC transport is driven through the Pi provider adapter, provider service, and orchestration ingestion pipeline; tests assert externally observable T3 Code behavior rather than adapter-private calls or data structures.
+- Prefer the existing provider adapter, provider registry, provider status, and provider-runtime-ingestion test patterns as prior art. Reuse their harness style for fake runtime streams, scoped child process lifecycle, model snapshots, session bindings, and turn/activity projections.
+- Add focused contract tests for provider registration, default and multiple Pi Runtime Instances, configuration-directory propagation, isolated session directories, managed launch-argument validation, status/version outcomes, and thread-to-native-session identity.
+- Add focused model tests covering discovery of custom Pi providers/models, grouping/labels, model selection, valid thinking-level options, and rejection or surfacing of invalid Pi model operations.
+- Add focused runtime-event tests that feed Pi RPC events and assert visible chat/work-log state for text, thinking, tool calls, tool progress, tool results, retry, compaction, queued work, terminal errors, and settled/completed/interrupted turns.
+- Add focused attachment and abort tests asserting Pi receives image prompts and that a stop request reaches native abort behavior.
+- Add focused extension tests for normal extension preservation, basic confirm/select/input request round trips, and visible terminal-required treatment for unsupported custom UI.
+- Add focused safety/recovery tests proving enabled Pi tools are described as Pi-managed, no T3 runtime-mode selector is shown for Pi, a process/transport loss interrupts rather than replays an active turn, and explicit continuation resumes the same native session only through the originating Pi Runtime Instance.
+- Add focused settings/UI tests for Pi instance creation/editing, binary/config-directory/launch-argument fields, validation of reserved arguments, provider icon/picker visibility, and model-picker behavior.
+- Run the smallest affected server/contracts/web test sets. After the user-visible web flow is integrated, perform the required isolated web verification using the repository's T3 app testing workflow and stop its temporary dev server afterward.
+
+## Out of Scope
+
+- Building a new Pi API client or importing Pi's internal Node runtime into T3 Code.
+- Duplicating Pi credential, provider, custom-provider, model, extension, or enabled-tool configuration inside T3 Code.
+- Automatic migration or browsing of sessions from Pi's default global session directory.
+- Allowing a Pi thread to continue under another Pi Runtime Instance.
+- Silently replaying in-flight turns after process or transport loss.
+- A T3 Code runtime-mode selector or built-in supervised per-tool permission flow for Pi.
+- Installing, editing, enabling, disabling, or otherwise managing user Pi extensions.
+- Faithfully rendering arbitrary custom Pi terminal widgets in T3 Code.
+- Pi-specific session export, fork, rollback, browsing, or management controls in T3 Code.
+- Pi extension-command UI and custom extension interactions beyond basic RPC dialogs.
+- Pi-specific steering/follow-up controls beyond the normal T3 interaction model, unless a clean equivalent is implemented later.
+- Support for Pi versions older than `0.81.1`.
+
+## Further Notes
+
+- This specification is based on Pi CLI `0.81.1` and its documented RPC, model, session, extension UI, and tool-policy behavior.
+- The initial integration is intentionally comprehensive for all Pi behavior that has a known, semantically faithful T3 Code mapping. Items are deferred only where a safe equivalent does not exist, not merely to reduce implementation scope.
+- Pi has no built-in permission system that restricts filesystem, process, network, or credential access. Users who need stronger boundaries must use Pi's own tool configuration, extensions, or external sandbox/container controls. A future supervised T3 experience would require T3 Code to inject and maintain a Pi permission-gate extension over Pi's extension UI RPC protocol.
+- The implementation must preserve backwards-compatible provider instance and thread persistence behavior while adding the `pi` driver.

--- a/docs/providers/pi.md
+++ b/docs/providers/pi.md
@@ -1,0 +1,108 @@
+# Pi
+
+Pi is available in T3 Code as a first-class provider through Pi's CLI RPC mode.
+
+T3 Code requires Pi CLI `0.81.1` or later. The integration's supported behavior and deferred-feature
+list are defined against that version's RPC and extension protocols.
+
+Install and authenticate Pi before adding it in T3 Code:
+
+```bash
+npm install -g @earendil-works/pi-coding-agent
+pi
+```
+
+## Provider And Model Configuration
+
+Configure credentials, built-in providers, custom providers, and models in Pi. T3 Code uses the
+provider and model configuration Pi exposes, while separately managing runtime-instance settings and
+UI-only preferences.
+
+## Multiple Pi Instances
+
+T3 Code supports multiple Pi runtime instances. Use separate instances when you need isolated Pi
+configuration environments or session storage; configure the providers and models inside each Pi
+environment.
+
+An instance may optionally select a Pi configuration directory. When left empty, it uses the user's
+normal Pi configuration; when set, T3 Code passes the directory as `PI_AGENT_DIR`. Session storage
+remains isolated separately for every T3 Code Pi instance.
+
+## Models
+
+T3 Code discovers each instance's model catalog from Pi and shows it in the normal model picker.
+Custom Pi providers and models therefore appear without duplicate T3 Code configuration. Available
+thinking levels are supplied by Pi for the currently selected model.
+
+## Runtime Settings
+
+Each Pi runtime instance can set its binary path, an optional Pi configuration directory, optional
+additional launch arguments, environment variables, display name, and accent color. T3 Code always
+manages Pi's RPC mode, session directory, and thread session ID; additional arguments cannot override
+those values.
+
+## Initial Capability Scope
+
+The first release targets provider parity for normal coding work:
+
+- persistent, resumable Pi sessions
+- streaming assistant text and tool activity
+- image attachments
+- stop/abort
+- provider and model configuration
+- Pi's configured enabled-tool policy
+- streaming text and thinking
+- tool calls, execution progress, and results
+- retries, compaction, and queued work
+
+## Tool Access
+
+Pi manages tool access in the first release. Every tool enabled in the selected Pi runtime instance
+may run without a T3 Code confirmation prompt. Configure Pi's enabled and disabled tools in Pi; T3
+Code does not show its usual runtime-mode selector for Pi.
+
+## Extensions
+
+Pi loads the user's normal trusted global and project-local extensions. T3 Code does not install,
+modify, or configure those extensions. It renders basic extension dialogs when Pi sends them through
+RPC; custom terminal UI from an extension is reported as requiring Pi's terminal interface.
+
+## Activity And Lifecycle
+
+T3 Code maps Pi's supported RPC lifecycle events into its normal chat and work log, including text
+and thinking streams, tool calls and execution progress, completed turns, retries, context
+compaction, and queued work. Native Pi events are also retained in diagnostics for troubleshooting.
+
+## Recovery
+
+If a Pi RPC process or connection ends, T3 Code marks an in-flight turn interrupted and does not
+replay it, avoiding duplicate tool calls. Continuing the thread starts Pi again with the same runtime
+instance configuration and persisted native session.
+
+## Continuing Threads
+
+Pi threads continue only through the Pi runtime instance that created them. This preserves the Pi
+configuration directory, extensions, credentials, model catalog, and isolated session storage used
+by the thread.
+
+## Session Storage
+
+Threads created in T3 Code are native Pi sessions. T3 Code stores them in a Pi session directory
+isolated to the selected Pi provider instance, using the T3 Code thread ID as the Pi session ID.
+
+They do not appear in Pi's default session picker automatically. To access them directly through the
+Pi CLI, launch Pi with that provider instance's `--session-dir` and select the saved session. T3 Code
+will surface the exact location when the provider implementation is introduced.
+
+## Deferred Until The Integration Is Stable
+
+These are deliberate follow-up candidates, not unsupported-by-accident behavior:
+
+- Pi extension-command UI and custom extension interactions
+- Pi-specific session export, fork, and rollback controls
+- Pi-native session browsing and management in T3 Code
+- interactive per-tool approval: base Pi RPC auto-runs enabled tools; a supervised mode would require
+  T3 Code to supply and maintain a Pi permission-gate extension over Pi's extension UI RPC protocol
+
+Revisit this list after the core adapter has proven stable across session creation, resume, streaming,
+tool execution, interruption, and reconnection.

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -94,6 +94,7 @@ describe("ProviderRuntimeEvent", () => {
                 description: "Allow unrestricted access",
               },
             ],
+            cancelOptionLabel: "Cancel",
           },
         ],
       },
@@ -105,6 +106,7 @@ describe("ProviderRuntimeEvent", () => {
     }
     expect(parsed.payload.questions[0]?.id).toBe("sandbox_mode");
     expect(parsed.payload.questions[0]?.options).toHaveLength(2);
+    expect(parsed.payload.questions[0]?.cancelOptionLabel).toBe("Cancel");
   });
 
   it("decodes user-input.resolved with answer map", () => {

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -130,6 +130,25 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.answers.sandbox_mode).toBe("workspace-write");
   });
 
+  it("preserves Pi RPC payloads as canonical runtime-event diagnostics", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "runtime.warning",
+      eventId: "event-pi-raw-1",
+      provider: "pi",
+      createdAt: "2026-02-28T00:00:03.000Z",
+      threadId: "thread-pi-1",
+      payload: { message: "Pi will retry a transient provider error." },
+      raw: {
+        source: "pi.rpc.event",
+        messageType: "auto_retry_start",
+        payload: { type: "auto_retry_start", attempt: 1 },
+      },
+    });
+
+    expect(parsed.raw?.source).toBe("pi.rpc.event");
+    expect(parsed.raw?.messageType).toBe("auto_retry_start");
+  });
+
   it("rejects legacy message.delta type", () => {
     expect(() =>
       decodeRuntimeEvent({

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -26,6 +26,7 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("claude.sdk.permission"),
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
+  Schema.Literal("pi.rpc.event"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -444,6 +444,7 @@ export const UserInputQuestion = Schema.Struct({
   header: TrimmedNonEmptyStringSchema,
   question: TrimmedNonEmptyStringSchema,
   options: Schema.Array(UserInputQuestionOption),
+  cancelOptionLabel: Schema.optional(TrimmedNonEmptyStringSchema),
   multiSelect: Schema.optional(Schema.Boolean).pipe(
     Schema.withConstructorDefault(Effect.succeed(false)),
   ),

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -165,6 +165,10 @@ export const ServerProvider = Schema.Struct({
   badgeLabel: Schema.optional(TrimmedNonEmptyString),
   continuation: Schema.optional(ServerProviderContinuation),
   showInteractionModeToggle: Schema.optional(Schema.Boolean),
+  /** Whether T3 Code may present its provider-managed runtime access selector. */
+  showRuntimeModeSelector: Schema.optional(Schema.Boolean),
+  /** Provider-owned tool-access policy shown beside composer controls. */
+  toolAccessDescription: Schema.optional(TrimmedNonEmptyString),
   requiresNewThreadForModelChange: Schema.optional(Schema.Boolean),
   enabled: Schema.Boolean,
   installed: Schema.Boolean,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -5,6 +5,7 @@ import { ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
   DEFAULT_SERVER_SETTINGS,
+  PiSettings,
   ServerSettings,
   ServerSettingsPatch,
 } from "./settings.ts";
@@ -84,6 +85,25 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
         providerInstances: { "1bad": { driver: "codex" } },
       }),
     ).toThrow();
+  });
+});
+
+describe("PiSettings", () => {
+  it("keeps Pi runtime configuration instance-scoped", () => {
+    const decodePiSettings = Schema.decodeUnknownSync(PiSettings);
+
+    expect(
+      decodePiSettings({
+        binaryPath: "/opt/pi/bin/pi",
+        configDirectory: "~/.config/pi-work",
+        launchArgs: "--verbose",
+      }),
+    ).toMatchObject({
+      enabled: true,
+      binaryPath: "/opt/pi/bin/pi",
+      configDirectory: "~/.config/pi-work",
+      launchArgs: "--verbose",
+    });
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -271,7 +271,7 @@ export const PiSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "Pi config directory",
         description:
-          "Optional Pi configuration directory. T3 Code passes it to Pi as PI_AGENT_DIR.",
+          "Optional Pi configuration directory. T3 Code passes it to Pi as PI_CODING_AGENT_DIR.",
         providerSettingsForm: { placeholder: "~/.pi", clearWhenEmpty: "omit" },
       }),
     ),
@@ -280,7 +280,7 @@ export const PiSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "Launch arguments",
         description:
-          "Additional Pi arguments. RPC mode, session directory, and session ID are managed by T3 Code.",
+          "Additional Pi arguments. T3 Code disables discovered extensions; use --extension <path> to load a specific trusted extension. RPC mode, session directory, and session ID are managed by T3 Code.",
         providerSettingsForm: { placeholder: "e.g. --verbose", clearWhenEmpty: "omit" },
       }),
     ),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -253,6 +253,44 @@ export const ClaudeSettings = makeProviderSettingsSchema(
 );
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
+export const PiSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("pi").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Pi binary used by this instance.",
+        providerSettingsForm: { placeholder: "pi", clearWhenEmpty: "omit" },
+      }),
+    ),
+    configDirectory: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Pi config directory",
+        description:
+          "Optional Pi configuration directory. T3 Code passes it to Pi as PI_AGENT_DIR.",
+        providerSettingsForm: { placeholder: "~/.pi", clearWhenEmpty: "omit" },
+      }),
+    ),
+    launchArgs: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Launch arguments",
+        description:
+          "Additional Pi arguments. RPC mode, session directory, and session ID are managed by T3 Code.",
+        providerSettingsForm: { placeholder: "e.g. --verbose", clearWhenEmpty: "omit" },
+      }),
+    ),
+  },
+  {
+    order: ["binaryPath", "configDirectory", "launchArgs"],
+  },
+);
+export type PiSettings = typeof PiSettings.Type;
+
 export const CursorSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -403,6 +441,7 @@ export const ServerSettings = Schema.Struct({
   providers: Schema.Struct({
     codex: CodexSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    pi: PiSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
@@ -488,6 +527,13 @@ const ClaudeSettingsPatch = Schema.Struct({
   launchArgs: Schema.optionalKey(TrimmedString),
 });
 
+const PiSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  configDirectory: Schema.optionalKey(TrimmedString),
+  launchArgs: Schema.optionalKey(TrimmedString),
+});
+
 const CursorSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -528,6 +574,7 @@ export const ServerSettingsPatch = Schema.Struct({
     Schema.Struct({
       codex: Schema.optionalKey(CodexSettingsPatch),
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
+      pi: Schema.optionalKey(PiSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new subprocess/RPC provider path with session continuation rules and broad event-mapping surface; mistakes could affect thread lifecycle, prompts, or cross-instance session isolation.
> 
> **Overview**
> Introduces **Pi** as a first-class provider: managed RPC launch (`--mode rpc`, per-instance session dirs, blocked override flags), version gating (≥0.81.1), model/thinking catalog discovery, and a `PiAdapter` that maps streaming, tools, compaction, extension UI (confirm/select/input), interrupts, images, and transport failures into existing T3 provider events.
> 
> **User input** answers move from plain strings to `ProviderUserInputAnswers`, with `cancelOptionLabel` on questions and mobile `buildPendingUserInputAnswers` emitting `{ cancelled: true }` vs `{ value: ... }` for Pi-native extension dialogs.
> 
> Orchestration ingestion now surfaces **`context_compaction`** lifecycle activities and propagates **tool `status`** (including failed tone). Codex custom models can inherit reasoning pickers with an added **Max** option. Agent docs add `CONTEXT.md` Pi terminology and `AGENTS.md` issue-tracker/domain pointers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bef096a6b22c97ae37feaf8e02eada2cdabdbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Pi as a first-class provider with full RPC session runtime integration
> - Introduces a new `pi` provider driver with settings schema, model discovery via RPC, session isolation per provider instance, and a status probe that validates Pi CLI version (≥ 0.81.1) and launch arguments
> - Adds `PiAdapter` and `PiSessionRuntime` to manage Pi RPC lifecycle, including image attachment loading, event streaming, transport failure handling, and continuation identity validation
> - Extends the composer UI to hide the runtime mode selector and show a Pi-managed tools notice when the selected provider's presentation flags indicate it
> - Adds `cancelOptionLabel` support to user input questions so answers encode either `{ value }` or `{ cancelled: true }` instead of an ambiguous string
> - Augments custom model capabilities with a `Max` reasoning option via `addMaxReasoningOptionForCustomModel` when an `effort`/`reasoningEffort` selector is present
> - Adds 13 ADRs and project/provider docs covering the Pi integration design decisions
> - Risk: threads that have a persisted resume cursor will receive a validation error if routed to a Pi instance with a different continuation identity, which is a new hard failure mode in `ProviderService.startSession`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 52bef09. 45 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->