### PR TITLE
Add environment-first new task flow on mobile

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -39,6 +39,7 @@ import { AddProjectLocalRoute } from "./features/projects/AddProjectLocalRoute";
 import { AddProjectRepositoryRoute } from "./features/projects/AddProjectRepositoryRoute";
 import { AddProjectSourceRoute } from "./features/projects/AddProjectSourceRoute";
 import { NewTaskDraftRouteScreen } from "./features/threads/NewTaskDraftRouteScreen";
+import { NewTaskEnvironmentRouteScreen } from "./features/threads/NewTaskEnvironmentRouteScreen";
 import { NewTaskFlowProvider } from "./features/threads/new-task-flow-provider";
 import { NewTaskRouteScreen } from "./features/threads/NewTaskRouteScreen";
 import { SettingsAppearanceRouteScreen } from "./features/settings/SettingsAppearanceRouteScreen";
@@ -218,8 +219,15 @@ const NewTaskSheetStack = createNativeStackNavigator({
   },
   screens: {
     NewTask: createNativeStackScreen({
-      screen: NewTaskRouteScreen,
+      screen: NewTaskEnvironmentRouteScreen,
       linking: "",
+      options: {
+        title: "Choose environment",
+      },
+    }),
+    NewTaskProject: createNativeStackScreen({
+      screen: NewTaskRouteScreen,
+      linking: "projects/:environmentId",
       options: {
         title: "Choose project",
       },
@@ -532,7 +540,7 @@ export const RootStack = createNativeStackNavigator({
     NewTaskSheet: createNativeStackScreen({
       screen: NewTaskSheetStack,
       linking: "new",
-      // The whole new-task flow (choose project → draft → add project) shares
+      // The whole new-task flow (choose environment → project → draft → add project) shares
       // draft state via NewTaskFlowProvider. The expo-router era mounted it in
       // app/new/_layout.tsx; this layout wrapper is the native-stack equivalent.
       layout: ({ children }) => <NewTaskFlowProvider>{children}</NewTaskFlowProvider>,

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -246,12 +246,14 @@ function useEnvironmentOptions(): ReadonlyArray<EnvironmentOption> {
   }, [savedConnectionsById, serverConfigByEnvironmentId]);
 }
 
-function useSelectedEnvironment(): {
+function useSelectedEnvironment(initialEnvironmentId: EnvironmentId | null): {
   readonly environmentOptions: ReadonlyArray<EnvironmentOption>;
   readonly selectedEnvironment: EnvironmentOption | null;
   readonly setSelectedEnvironmentId: (environmentId: EnvironmentId) => void;
 } {
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(
+    initialEnvironmentId,
+  );
   const environmentOptions = useEnvironmentOptions();
   const selectedEnvironment =
     environmentOptions.find((environment) => environment.environmentId === selectedEnvironmentId) ??
@@ -331,12 +333,17 @@ function SourceControlRow(props: {
   );
 }
 
-export function AddProjectSourceScreen() {
+export function AddProjectSourceScreen({
+  environmentId,
+}: {
+  readonly environmentId?: string | string[];
+}) {
   const navigation = useNavigation();
   const accentColor = useThemeColor("--color-icon-muted");
   const iconColor = useThemeColor("--color-icon");
+  const initialEnvironmentId = stringParam(environmentId) as EnvironmentId | null;
   const { environmentOptions, selectedEnvironment, setSelectedEnvironmentId } =
-    useSelectedEnvironment();
+    useSelectedEnvironment(initialEnvironmentId);
   const discoveryState = useEnvironmentQuery(
     selectedEnvironment === null
       ? null

--- a/apps/mobile/src/features/projects/AddProjectSourceRoute.tsx
+++ b/apps/mobile/src/features/projects/AddProjectSourceRoute.tsx
@@ -1,5 +1,12 @@
 import { AddProjectSourceScreen } from "./AddProjectScreen";
+import type { StaticScreenProps } from "@react-navigation/native";
 
-export function AddProjectSourceRoute() {
-  return <AddProjectSourceScreen />;
+type AddProjectSourceRouteParams = {
+  readonly environmentId?: string | string[];
+};
+
+export function AddProjectSourceRoute({
+  route,
+}: StaticScreenProps<AddProjectSourceRouteParams | undefined>) {
+  return <AddProjectSourceScreen environmentId={route.params?.environmentId} />;
 }

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -165,8 +165,14 @@ export function NewTaskDraftScreen(props: {
     // Let usePreventRemove commit its disabled state before replacing this
     // route, otherwise the transfer guard can swallow the fallback action.
     const frame = requestAnimationFrame(() => {
+      const environmentId = props.initialProjectRef?.environmentId;
       navigation.dispatch(
-        StackActions.replace("NewTask", { incomingShareId: props.incomingShareId }),
+        environmentId
+          ? StackActions.replace("NewTaskProject", {
+              environmentId,
+              incomingShareId: props.incomingShareId,
+            })
+          : StackActions.replace("NewTask", { incomingShareId: props.incomingShareId }),
       );
     });
     return () => cancelAnimationFrame(frame);
@@ -174,6 +180,7 @@ export function NewTaskDraftScreen(props: {
     isReturningToProjectPicker,
     navigation,
     props.incomingShareId,
+    props.initialProjectRef?.environmentId,
     requestedInitialProjectAvailable,
   ]);
   useEffect(() => {

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -168,11 +168,11 @@ export function NewTaskDraftScreen(props: {
       const environmentId = props.initialProjectRef?.environmentId;
       navigation.dispatch(
         environmentId
-          ? StackActions.replace("NewTaskProject", {
+          ? StackActions.popTo("NewTaskProject", {
               environmentId,
               incomingShareId: props.incomingShareId,
             })
-          : StackActions.replace("NewTask", { incomingShareId: props.incomingShareId }),
+          : StackActions.popTo("NewTask", { incomingShareId: props.incomingShareId }),
       );
     });
     return () => cancelAnimationFrame(frame);

--- a/apps/mobile/src/features/threads/NewTaskEnvironmentRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskEnvironmentRouteScreen.tsx
@@ -1,68 +1,51 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useIsFocused, useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { SymbolView } from "../../components/AppSymbol";
-import type { EnvironmentId } from "@t3tools/contracts";
 import { useEffect, useMemo, useRef } from "react";
-import { ActivityIndicator, Alert, Platform, Pressable, ScrollView, View } from "react-native";
+import { ActivityIndicator, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useThemeColor } from "../../lib/useThemeColor";
-import { cn } from "../../lib/cn";
 
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
+import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text } from "../../components/AppText";
-import { ProjectFavicon } from "../../components/ProjectFavicon";
+import { cn } from "../../lib/cn";
+import { useThemeColor } from "../../lib/useThemeColor";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { useWorkspaceState } from "../../state/workspace";
+import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
-import { buildNewTaskProjectItems, deriveNewTaskPickerEmptyState } from "./newTaskPicker";
+import { buildNewTaskEnvironmentItems, deriveNewTaskPickerEmptyState } from "./newTaskPicker";
 
-type NewTaskRouteParams = {
-  readonly environmentId?: string | string[];
+type NewTaskEnvironmentRouteParams = {
   readonly incomingShareId?: string | string[];
 };
 
-export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRouteParams | undefined>) {
+export function NewTaskEnvironmentRouteScreen({
+  route,
+}: StaticScreenProps<NewTaskEnvironmentRouteParams | undefined>) {
   const projects = useProjects();
   const threads = useThreadShells();
   const workspace = useWorkspaceState();
   const navigation = useNavigation();
   const isFocused = useIsFocused();
+  const { layout } = useAdaptiveWorkspaceLayout();
   const insets = useSafeAreaInsets();
   const chevronColor = useThemeColor("--color-chevron");
   const accentColor = useThemeColor("--color-icon-muted");
-  const { getShare, releaseShareReservation } = useIncomingShare();
-  const environmentId = (
-    Array.isArray(route.params?.environmentId)
-      ? route.params.environmentId[0]
-      : route.params?.environmentId
-  ) as EnvironmentId | undefined;
-  const environmentLabel =
-    workspace.environments.find((environment) => environment.environmentId === environmentId)
-      ?.environmentLabel ?? null;
+  const { getShare } = useIncomingShare();
   const routeShareId = Array.isArray(route.params?.incomingShareId)
     ? route.params.incomingShareId[0]
     : route.params?.incomingShareId;
   const incomingShare = routeShareId ? getShare(routeShareId) : null;
-  const incomingShareSubtitle = incomingShare
-    ? incomingShare.attachments.length === 0
-      ? "Choose a project for what you shared"
-      : incomingShare.attachments.length === 1
-        ? "Choose a project for the image you shared"
-        : `Choose a project for the ${incomingShare.attachments.length} images you shared`
-    : null;
-  const screenTitle = incomingShare ? "Start a task" : "Choose project";
-  const items = useMemo(
+  const environmentItems = useMemo(
     () =>
-      environmentId
-        ? buildNewTaskProjectItems({
-            environmentId,
-            projects,
-            threads,
-          })
-        : [],
-    [environmentId, projects, threads],
+      buildNewTaskEnvironmentItems({
+        environments: workspace.environments,
+        projects,
+        threads,
+      }),
+    [projects, threads, workspace.environments],
   );
-  const projectEmptyState = deriveNewTaskPickerEmptyState(workspace.state);
+  const emptyState = deriveNewTaskPickerEmptyState(workspace.state);
   const resumedDestinationKeyRef = useRef<string | null>(null);
   const reservedDestinationProject = incomingShare?.destination
     ? (projects.find(
@@ -71,31 +54,14 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           project.id === incomingShare.destination?.projectId,
       ) ?? null)
     : null;
-
-  async function selectProject(item: (typeof items)[number]): Promise<void> {
-    if (incomingShare?.destination && !reservedDestinationProject) {
-      try {
-        await releaseShareReservation(incomingShare.id, incomingShare.destination);
-      } catch (error) {
-        Alert.alert(
-          "Could not change project",
-          error instanceof Error
-            ? error.message
-            : "The shared content reservation could not be updated.",
-        );
-        return;
-      }
-    }
-    navigation.navigate("NewTaskSheet", {
-      screen: "NewTaskDraft",
-      params: {
-        environmentId: item.environmentId,
-        projectId: item.id,
-        title: item.title,
-        incomingShareId: incomingShare?.id,
-      },
-    });
-  }
+  const incomingShareSubtitle = incomingShare
+    ? incomingShare.attachments.length === 0
+      ? "Choose where to run what you shared"
+      : incomingShare.attachments.length === 1
+        ? "Choose where to run the image you shared"
+        : `Choose where to run the ${incomingShare.attachments.length} images you shared`
+    : null;
+  const screenTitle = incomingShare ? "Start a task" : "Choose environment";
 
   useEffect(() => {
     const destination = incomingShare?.destination;
@@ -104,16 +70,14 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
       return;
     }
     if (!isFocused) {
-      // Returning from the reserved draft is a fresh resume attempt. Keeping
-      // this latch set would leave every project row disabled with no route.
       resumedDestinationKeyRef.current = null;
       return;
     }
     const destinationKey = `${incomingShare.id}:${destination.environmentId}:${destination.projectId}`;
-    if (resumedDestinationKeyRef.current === destinationKey) {
-      return;
-    }
-    if (!reservedDestinationProject) {
+    if (
+      resumedDestinationKeyRef.current === destinationKey ||
+      reservedDestinationProject === null
+    ) {
       return;
     }
     resumedDestinationKeyRef.current = destinationKey;
@@ -128,21 +92,22 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     });
   }, [incomingShare, isFocused, navigation, reservedDestinationProject]);
 
+  const addProject = () => navigation.navigate("NewTaskSheet", { screen: "AddProject" });
+
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
       {Platform.OS === "android" ? (
         <>
-          {/* Android renders its own in-screen header instead of the native bar. */}
           <NativeStackScreenOptions options={{ headerShown: false }} />
           <AndroidScreenHeader
             title={screenTitle}
-            subtitle={incomingShareSubtitle ?? environmentLabel}
-            onBack={() => navigation.goBack()}
+            subtitle={incomingShareSubtitle}
+            onBack={layout.usesSplitView ? () => navigation.goBack() : undefined}
             actions={[
               {
                 accessibilityLabel: "Add project",
                 icon: "plus",
-                onPress: () => navigation.navigate("NewTaskSheet", { screen: "AddProject" }),
+                onPress: addProject,
               },
             ]}
           />
@@ -152,15 +117,19 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           <NativeStackScreenOptions
             options={{
               title: screenTitle,
-              unstable_headerSubtitle: incomingShareSubtitle ?? environmentLabel ?? undefined,
+              unstable_headerSubtitle: incomingShareSubtitle ?? undefined,
             }}
           />
           <NativeHeaderToolbar placement="right">
-            <NativeHeaderToolbar.Button
-              icon="plus"
-              onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
-              separateBackground
-            />
+            {layout.usesSplitView ? (
+              <NativeHeaderToolbar.Button
+                accessibilityLabel="Close new task"
+                icon="xmark"
+                onPress={() => navigation.goBack()}
+                separateBackground
+              />
+            ) : null}
+            <NativeHeaderToolbar.Button icon="plus" onPress={addProject} separateBackground />
           </NativeHeaderToolbar>
         </>
       )}
@@ -176,14 +145,14 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           paddingTop: 8,
         }}
       >
-        {items.length === 0 ? (
+        {environmentItems.length === 0 ? (
           <View collapsable={false} className="items-center gap-3 rounded-[24px] bg-card px-6 py-8">
-            {projectEmptyState.loading ? <ActivityIndicator color={accentColor} /> : null}
+            {emptyState.loading ? <ActivityIndicator color={accentColor} /> : null}
             <Text className="text-center text-lg font-t3-bold text-foreground">
-              {projectEmptyState.title}
+              {emptyState.title}
             </Text>
             <Text className="text-center text-sm leading-normal text-foreground-muted">
-              {projectEmptyState.detail}
+              {emptyState.detail}
             </Text>
             {!workspace.state.hasReadyEnvironment ? (
               <Pressable
@@ -197,7 +166,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
             ) : (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
-                onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
+                onPress={addProject}
               >
                 <Text className="text-sm font-t3-bold text-primary-foreground">
                   Add new project
@@ -207,17 +176,27 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           </View>
         ) : (
           <View collapsable={false} className="overflow-hidden rounded-[24px] bg-card">
-            {items.map((item, index) => {
+            {environmentItems.map((item, index) => {
               const isFirst = index === 0;
-              const isLast = index === items.length - 1;
+              const isLast = index === environmentItems.length - 1;
 
               return (
                 <Pressable
-                  key={item.key}
-                  accessibilityLabel={item.title}
+                  key={item.environmentId}
+                  accessibilityLabel={`${item.environmentLabel}, ${item.projectCount} ${
+                    item.projectCount === 1 ? "project" : "projects"
+                  }`}
                   accessibilityRole="button"
                   disabled={reservedDestinationProject !== null}
-                  onPress={() => void selectProject(item)}
+                  onPress={() =>
+                    navigation.navigate("NewTaskSheet", {
+                      screen: "NewTaskProject",
+                      params: {
+                        environmentId: item.environmentId,
+                        incomingShareId: incomingShare?.id,
+                      },
+                    })
+                  }
                   className={cn(
                     "bg-card px-4 py-3.5",
                     !isFirst && "border-t border-border-subtle",
@@ -227,15 +206,20 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
                 >
                   <View className="flex-row items-center justify-between gap-3">
                     <View className="h-7 w-7 items-center justify-center">
-                      <ProjectFavicon
-                        environmentId={item.environmentId}
+                      <SymbolView
+                        name="desktopcomputer"
                         size={20}
-                        projectTitle={item.title}
-                        workspaceRoot={item.workspaceRoot}
+                        tintColor={accentColor}
+                        type="monochrome"
                       />
                     </View>
                     <View className="flex-1">
-                      <Text className="text-base leading-snug font-t3-bold">{item.title}</Text>
+                      <Text className="text-base leading-snug font-t3-bold">
+                        {item.environmentLabel}
+                      </Text>
+                      <Text className="text-sm text-foreground-muted">
+                        {item.projectCount} {item.projectCount === 1 ? "project" : "projects"}
+                      </Text>
                     </View>
                     <SymbolView
                       name="chevron.right"

--- a/apps/mobile/src/features/threads/NewTaskEnvironmentRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskEnvironmentRouteScreen.tsx
@@ -51,7 +51,8 @@ export function NewTaskEnvironmentRouteScreen({
   );
   const emptyState = deriveNewTaskPickerEmptyState(workspace.state);
   const emptyStateAction = deriveNewTaskProjectPickerAction({
-    hasSelectedEnvironment: workspace.state.hasConnections,
+    // This is the environment picker: saved connections are choices, not a selection.
+    hasSelectedEnvironment: false,
     canAddProject: workspace.state.hasReadyEnvironment && workspace.state.hasLoadedShellSnapshot,
     loading: emptyState.loading,
   });

--- a/apps/mobile/src/features/threads/NewTaskEnvironmentRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskEnvironmentRouteScreen.tsx
@@ -13,7 +13,11 @@ import { useProjects, useThreadShells } from "../../state/entities";
 import { useWorkspaceState } from "../../state/workspace";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
-import { buildNewTaskEnvironmentItems, deriveNewTaskPickerEmptyState } from "./newTaskPicker";
+import {
+  buildNewTaskEnvironmentItems,
+  deriveNewTaskPickerEmptyState,
+  deriveNewTaskProjectPickerAction,
+} from "./newTaskPicker";
 
 type NewTaskEnvironmentRouteParams = {
   readonly incomingShareId?: string | string[];
@@ -46,6 +50,11 @@ export function NewTaskEnvironmentRouteScreen({
     [projects, threads, workspace.environments],
   );
   const emptyState = deriveNewTaskPickerEmptyState(workspace.state);
+  const emptyStateAction = deriveNewTaskProjectPickerAction({
+    hasSelectedEnvironment: workspace.state.hasConnections,
+    canAddProject: workspace.state.hasReadyEnvironment && workspace.state.hasLoadedShellSnapshot,
+    loading: emptyState.loading,
+  });
   const resumedDestinationKeyRef = useRef<string | null>(null);
   const reservedDestinationProject = incomingShare?.destination
     ? (projects.find(
@@ -154,7 +163,7 @@ export function NewTaskEnvironmentRouteScreen({
             <Text className="text-center text-sm leading-normal text-foreground-muted">
               {emptyState.detail}
             </Text>
-            {!workspace.state.hasReadyEnvironment ? (
+            {emptyStateAction === "add-environment" ? (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={() => navigation.navigate("ConnectionsNew")}
@@ -163,7 +172,7 @@ export function NewTaskEnvironmentRouteScreen({
                   Add environment
                 </Text>
               </Pressable>
-            ) : (
+            ) : emptyStateAction === "add-project" ? (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={addProject}
@@ -172,7 +181,7 @@ export function NewTaskEnvironmentRouteScreen({
                   Add new project
                 </Text>
               </Pressable>
-            )}
+            ) : null}
           </View>
         ) : (
           <View collapsable={false} className="overflow-hidden rounded-[24px] bg-card">

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -15,7 +15,11 @@ import { useProjects, useThreadShells } from "../../state/entities";
 import { useWorkspaceState } from "../../state/workspace";
 import { useEnvironmentShellState } from "../../state/shell";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
-import { buildNewTaskProjectItems, deriveNewTaskProjectPickerEmptyState } from "./newTaskPicker";
+import {
+  buildNewTaskProjectItems,
+  deriveNewTaskProjectPickerAction,
+  deriveNewTaskProjectPickerEmptyState,
+} from "./newTaskPicker";
 import * as Option from "effect/Option";
 
 type NewTaskRouteParams = {
@@ -74,8 +78,12 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
     shellError: Option.getOrNull(environmentShellState.error),
     hasShellSnapshot: hasEnvironmentShellSnapshot,
   });
-  const canAddProject =
-    selectedEnvironment?.connectionState === "connected" && hasEnvironmentShellSnapshot;
+  const emptyStateAction = deriveNewTaskProjectPickerAction({
+    hasSelectedEnvironment: selectedEnvironment !== null,
+    canAddProject:
+      selectedEnvironment?.connectionState === "connected" && hasEnvironmentShellSnapshot,
+    loading: projectEmptyState.loading,
+  });
   const resumedDestinationKeyRef = useRef<string | null>(null);
   const reservedDestinationProject = incomingShare?.destination
     ? (projects.find(
@@ -207,7 +215,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
             <Text className="text-center text-sm leading-normal text-foreground-muted">
               {projectEmptyState.detail}
             </Text>
-            {!canAddProject ? (
+            {emptyStateAction === "add-environment" ? (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={() => navigation.navigate("ConnectionsNew")}
@@ -216,7 +224,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
                   Add environment
                 </Text>
               </Pressable>
-            ) : (
+            ) : emptyStateAction === "add-project" ? (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={() =>
@@ -230,7 +238,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
                   Add new project
                 </Text>
               </Pressable>
-            )}
+            ) : null}
           </View>
         ) : (
           <View collapsable={false} className="overflow-hidden rounded-[24px] bg-card">

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -13,8 +13,10 @@ import { AppText as Text } from "../../components/AppText";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { useWorkspaceState } from "../../state/workspace";
+import { useEnvironmentShellState } from "../../state/shell";
 import { useIncomingShare } from "../sharing/IncomingShareProvider";
-import { buildNewTaskProjectItems, deriveNewTaskPickerEmptyState } from "./newTaskPicker";
+import { buildNewTaskProjectItems, deriveNewTaskProjectPickerEmptyState } from "./newTaskPicker";
+import * as Option from "effect/Option";
 
 type NewTaskRouteParams = {
   readonly environmentId?: string | string[];
@@ -36,9 +38,11 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
       ? route.params.environmentId[0]
       : route.params?.environmentId
   ) as EnvironmentId | undefined;
-  const environmentLabel =
-    workspace.environments.find((environment) => environment.environmentId === environmentId)
-      ?.environmentLabel ?? null;
+  const selectedEnvironment =
+    workspace.environments.find((environment) => environment.environmentId === environmentId) ??
+    null;
+  const environmentLabel = selectedEnvironment?.environmentLabel ?? null;
+  const environmentShellState = useEnvironmentShellState(environmentId ?? null);
   const routeShareId = Array.isArray(route.params?.incomingShareId)
     ? route.params.incomingShareId[0]
     : route.params?.incomingShareId;
@@ -62,7 +66,16 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
         : [],
     [environmentId, projects, threads],
   );
-  const projectEmptyState = deriveNewTaskPickerEmptyState(workspace.state);
+  const hasEnvironmentShellSnapshot = Option.isSome(environmentShellState.snapshot);
+  const projectEmptyState = deriveNewTaskProjectPickerEmptyState({
+    environment: selectedEnvironment,
+    networkOffline: workspace.state.networkStatus === "offline",
+    shellStatus: environmentShellState.status,
+    shellError: Option.getOrNull(environmentShellState.error),
+    hasShellSnapshot: hasEnvironmentShellSnapshot,
+  });
+  const canAddProject =
+    selectedEnvironment?.connectionState === "connected" && hasEnvironmentShellSnapshot;
   const resumedDestinationKeyRef = useRef<string | null>(null);
   const reservedDestinationProject = incomingShare?.destination
     ? (projects.find(
@@ -142,7 +155,11 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
               {
                 accessibilityLabel: "Add project",
                 icon: "plus",
-                onPress: () => navigation.navigate("NewTaskSheet", { screen: "AddProject" }),
+                onPress: () =>
+                  navigation.navigate("NewTaskSheet", {
+                    screen: "AddProject",
+                    params: { environmentId },
+                  }),
               },
             ]}
           />
@@ -158,7 +175,12 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
           <NativeHeaderToolbar placement="right">
             <NativeHeaderToolbar.Button
               icon="plus"
-              onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
+              onPress={() =>
+                navigation.navigate("NewTaskSheet", {
+                  screen: "AddProject",
+                  params: { environmentId },
+                })
+              }
               separateBackground
             />
           </NativeHeaderToolbar>
@@ -185,7 +207,7 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
             <Text className="text-center text-sm leading-normal text-foreground-muted">
               {projectEmptyState.detail}
             </Text>
-            {!workspace.state.hasReadyEnvironment ? (
+            {!canAddProject ? (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={() => navigation.navigate("ConnectionsNew")}
@@ -197,7 +219,12 @@ export function NewTaskRouteScreen({ route }: StaticScreenProps<NewTaskRoutePara
             ) : (
               <Pressable
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
-                onPress={() => navigation.navigate("NewTaskSheet", { screen: "AddProject" })}
+                onPress={() =>
+                  navigation.navigate("NewTaskSheet", {
+                    screen: "AddProject",
+                    params: { environmentId },
+                  })
+                }
               >
                 <Text className="text-sm font-t3-bold text-primary-foreground">
                   Add new project

--- a/apps/mobile/src/features/threads/newTaskPicker.test.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type {
+  EnvironmentProject,
+  EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+
+import { buildNewTaskEnvironmentItems, buildNewTaskProjectItems } from "./newTaskPicker";
+
+function makeProject(
+  input: Partial<EnvironmentProject> & Pick<EnvironmentProject, "environmentId" | "id" | "title">,
+): EnvironmentProject {
+  return {
+    workspaceRoot: `/workspaces/${input.id}`,
+    repositoryIdentity: null,
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...input,
+  };
+}
+
+function makeThread(
+  input: Partial<EnvironmentThreadShell> &
+    Pick<EnvironmentThreadShell, "environmentId" | "id" | "projectId" | "title">,
+): EnvironmentThreadShell {
+  return {
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5.4",
+    },
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    archivedAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    settledOverride: null,
+    settledAt: null,
+    ...input,
+  };
+}
+
+describe("new task picker", () => {
+  const localEnvironmentId = EnvironmentId.make("environment-local");
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+  const repositoryIdentity = {
+    canonicalKey: "github.com/t3tools/t3code",
+    locator: {
+      source: "git-remote" as const,
+      remoteName: "origin",
+      remoteUrl: "git@github.com:t3tools/t3code.git",
+    },
+    provider: "github",
+    owner: "t3tools",
+    name: "t3code",
+    displayName: "T3 Code",
+  };
+  const localProject = makeProject({
+    environmentId: localEnvironmentId,
+    id: ProjectId.make("project-local"),
+    title: "T3 Code local",
+    repositoryIdentity,
+  });
+  const remoteProject = makeProject({
+    environmentId: remoteEnvironmentId,
+    id: ProjectId.make("project-remote"),
+    title: "T3 Code remote",
+    repositoryIdentity,
+  });
+  const localThread = makeThread({
+    environmentId: localEnvironmentId,
+    id: ThreadId.make("thread-local"),
+    projectId: localProject.id,
+    title: "Recent local work",
+    updatedAt: "2026-04-03T00:00:00.000Z",
+  });
+
+  it("keeps project choices scoped to the selected environment", () => {
+    const items = buildNewTaskProjectItems({
+      environmentId: remoteEnvironmentId,
+      projects: [localProject, remoteProject],
+      threads: [localThread],
+    });
+
+    expect(items).toEqual([
+      {
+        environmentId: remoteEnvironmentId,
+        id: remoteProject.id,
+        key: repositoryIdentity.canonicalKey,
+        title: remoteProject.title,
+        workspaceRoot: remoteProject.workspaceRoot,
+      },
+    ]);
+  });
+
+  it("lists only environments with projects and counts logical projects per environment", () => {
+    const scratchProject = makeProject({
+      environmentId: remoteEnvironmentId,
+      id: ProjectId.make("project-scratch"),
+      title: "Scratch",
+    });
+
+    const items = buildNewTaskEnvironmentItems({
+      environments: [
+        { environmentId: localEnvironmentId, environmentLabel: "Laptop" },
+        {
+          environmentId: remoteEnvironmentId,
+          environmentLabel: "Build server",
+        },
+        {
+          environmentId: EnvironmentId.make("environment-empty"),
+          environmentLabel: "Empty server",
+        },
+      ],
+      projects: [localProject, remoteProject, scratchProject],
+      threads: [localThread],
+    });
+
+    expect(items).toEqual([
+      {
+        environmentId: localEnvironmentId,
+        environmentLabel: "Laptop",
+        projectCount: 1,
+      },
+      {
+        environmentId: remoteEnvironmentId,
+        environmentLabel: "Build server",
+        projectCount: 2,
+      },
+    ]);
+  });
+});

--- a/apps/mobile/src/features/threads/newTaskPicker.test.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.test.ts
@@ -6,7 +6,11 @@ import type {
 } from "@t3tools/client-runtime/state/shell";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 
-import { buildNewTaskEnvironmentItems, buildNewTaskProjectItems } from "./newTaskPicker";
+import {
+  buildNewTaskEnvironmentItems,
+  buildNewTaskProjectItems,
+  deriveNewTaskProjectPickerEmptyState,
+} from "./newTaskPicker";
 
 function makeProject(
   input: Partial<EnvironmentProject> & Pick<EnvironmentProject, "environmentId" | "id" | "title">,
@@ -138,5 +142,41 @@ describe("new task picker", () => {
         projectCount: 2,
       },
     ]);
+  });
+
+  it("derives an empty state from the selected environment instead of another ready environment", () => {
+    expect(
+      deriveNewTaskProjectPickerEmptyState({
+        environment: {
+          connectionState: "offline",
+          connectionError: "Build server is stopped.",
+        },
+        networkOffline: false,
+        shellStatus: "empty",
+        shellError: null,
+        hasShellSnapshot: false,
+      }),
+    ).toEqual({
+      title: "Environment unavailable",
+      detail: "Build server is stopped.",
+      loading: false,
+    });
+
+    expect(
+      deriveNewTaskProjectPickerEmptyState({
+        environment: {
+          connectionState: "connected",
+          connectionError: null,
+        },
+        networkOffline: false,
+        shellStatus: "synchronizing",
+        shellError: null,
+        hasShellSnapshot: false,
+      }),
+    ).toEqual({
+      title: "Loading projects",
+      detail: "Loading projects from the selected environment.",
+      loading: true,
+    });
   });
 });

--- a/apps/mobile/src/features/threads/newTaskPicker.test.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.test.ts
@@ -179,4 +179,42 @@ describe("new task picker", () => {
       loading: true,
     });
   });
+
+  it("reports a shell failure on a connected environment instead of loading forever", () => {
+    expect(
+      deriveNewTaskProjectPickerEmptyState({
+        environment: {
+          connectionState: "connected",
+          connectionError: null,
+        },
+        networkOffline: false,
+        shellStatus: "empty",
+        shellError: "Could not synchronize environment data.",
+        hasShellSnapshot: false,
+      }),
+    ).toEqual({
+      title: "Could not load projects",
+      detail: "Could not synchronize environment data.",
+      loading: false,
+    });
+  });
+
+  it("keeps reporting an empty catalog when a shell error arrives with a snapshot", () => {
+    expect(
+      deriveNewTaskProjectPickerEmptyState({
+        environment: {
+          connectionState: "connected",
+          connectionError: null,
+        },
+        networkOffline: false,
+        shellStatus: "cached",
+        shellError: "Could not synchronize environment data.",
+        hasShellSnapshot: true,
+      }),
+    ).toEqual({
+      title: "No projects found",
+      detail: "The selected environment did not report any projects.",
+      loading: false,
+    });
+  });
 });

--- a/apps/mobile/src/features/threads/newTaskPicker.test.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.test.ts
@@ -9,6 +9,7 @@ import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools
 import {
   buildNewTaskEnvironmentItems,
   buildNewTaskProjectItems,
+  deriveNewTaskProjectPickerAction,
   deriveNewTaskProjectPickerEmptyState,
 } from "./newTaskPicker";
 
@@ -216,5 +217,45 @@ describe("new task picker", () => {
       detail: "The selected environment did not report any projects.",
       loading: false,
     });
+  });
+
+  it("offers adding an environment only when no environment is selected", () => {
+    expect(
+      deriveNewTaskProjectPickerAction({
+        hasSelectedEnvironment: false,
+        canAddProject: false,
+        loading: false,
+      }),
+    ).toBe("add-environment");
+  });
+
+  it("does not offer adding an environment for a selected environment that is unavailable", () => {
+    expect(
+      deriveNewTaskProjectPickerAction({
+        hasSelectedEnvironment: true,
+        canAddProject: false,
+        loading: false,
+      }),
+    ).toBe("none");
+  });
+
+  it("hides the empty state action while the selected environment is still loading", () => {
+    expect(
+      deriveNewTaskProjectPickerAction({
+        hasSelectedEnvironment: true,
+        canAddProject: false,
+        loading: true,
+      }),
+    ).toBe("none");
+  });
+
+  it("offers adding a project once the selected environment is ready", () => {
+    expect(
+      deriveNewTaskProjectPickerAction({
+        hasSelectedEnvironment: true,
+        canAddProject: true,
+        loading: false,
+      }),
+    ).toBe("add-project");
   });
 });

--- a/apps/mobile/src/features/threads/newTaskPicker.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.ts
@@ -1,0 +1,126 @@
+import type {
+  EnvironmentProject,
+  EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+
+import { groupProjectsByRepository } from "../../lib/repositoryGroups";
+import type { WorkspaceState } from "../../state/workspaceModel";
+
+export interface NewTaskPickerEnvironment {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+}
+
+export interface NewTaskEnvironmentItem extends NewTaskPickerEnvironment {
+  readonly projectCount: number;
+}
+
+export interface NewTaskProjectItem {
+  readonly environmentId: EnvironmentId;
+  readonly id: ProjectId;
+  readonly key: string;
+  readonly title: string;
+  readonly workspaceRoot: string;
+}
+
+export function deriveNewTaskPickerEmptyState(catalogState: WorkspaceState): {
+  readonly title: string;
+  readonly detail: string;
+  readonly loading: boolean;
+} {
+  if (catalogState.isLoadingConnections) {
+    return {
+      title: "Loading environments",
+      detail: "Checking saved environments on this device.",
+      loading: true,
+    };
+  }
+
+  if (!catalogState.hasConnections) {
+    return {
+      title: "No environments connected",
+      detail: "Add an environment before creating a task.",
+      loading: false,
+    };
+  }
+
+  if (
+    (catalogState.connectionState === "available" ||
+      catalogState.connectionState === "offline" ||
+      catalogState.connectionState === "error") &&
+    !catalogState.hasLoadedShellSnapshot
+  ) {
+    return {
+      title: "Environment unavailable",
+      detail:
+        catalogState.connectionError ??
+        "The saved environment is offline. Check the URL or start the environment, then retry.",
+      loading: false,
+    };
+  }
+
+  if (
+    catalogState.hasConnectingEnvironment &&
+    !catalogState.hasLoadedShellSnapshot &&
+    catalogState.connectionError === null
+  ) {
+    return {
+      title: "Connecting to environment",
+      detail: "Loading projects from the saved environment.",
+      loading: true,
+    };
+  }
+
+  return {
+    title: "No projects found",
+    detail: "The connected environment did not report any projects.",
+    loading: false,
+  };
+}
+
+export function buildNewTaskProjectItems(input: {
+  readonly environmentId: EnvironmentId;
+  readonly projects: ReadonlyArray<EnvironmentProject>;
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+}): ReadonlyArray<NewTaskProjectItem> {
+  const environmentProjects = input.projects.filter(
+    (project) => project.environmentId === input.environmentId,
+  );
+  const environmentThreads = input.threads.filter(
+    (thread) => thread.environmentId === input.environmentId,
+  );
+
+  return groupProjectsByRepository({
+    projects: environmentProjects,
+    threads: environmentThreads,
+  }).flatMap((group): ReadonlyArray<NewTaskProjectItem> => {
+    const project = group.projects[0]?.project;
+    return project
+      ? [
+          {
+            environmentId: project.environmentId,
+            id: project.id,
+            key: group.key,
+            title: project.title,
+            workspaceRoot: project.workspaceRoot,
+          },
+        ]
+      : [];
+  });
+}
+
+export function buildNewTaskEnvironmentItems(input: {
+  readonly environments: ReadonlyArray<NewTaskPickerEnvironment>;
+  readonly projects: ReadonlyArray<EnvironmentProject>;
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+}): ReadonlyArray<NewTaskEnvironmentItem> {
+  return input.environments.flatMap((environment): ReadonlyArray<NewTaskEnvironmentItem> => {
+    const projectCount = buildNewTaskProjectItems({
+      environmentId: environment.environmentId,
+      projects: input.projects,
+      threads: input.threads,
+    }).length;
+    return projectCount > 0 ? [{ ...environment, projectCount }] : [];
+  });
+}

--- a/apps/mobile/src/features/threads/newTaskPicker.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.ts
@@ -92,11 +92,11 @@ export function deriveNewTaskProjectPickerAction(input: {
   readonly canAddProject: boolean;
   readonly loading: boolean;
 }): NewTaskProjectPickerAction {
-  if (input.canAddProject) {
-    return "add-project";
-  }
   if (input.loading) {
     return "none";
+  }
+  if (input.canAddProject) {
+    return "add-project";
   }
   // Adding another connection is only useful when no environment was chosen.
   // Once one is selected the offer contradicts the screen the user is on, and
@@ -135,18 +135,30 @@ export function deriveNewTaskPickerEmptyState(catalogState: WorkspaceState): {
       title: "Environment unavailable",
       detail:
         catalogState.connectionError ??
+        catalogState.shellSnapshotError ??
         "The saved environment is offline. Check the URL or start the environment, then retry.",
       loading: false,
     };
   }
 
+  if (catalogState.shellSnapshotError !== null && !catalogState.hasLoadedShellSnapshot) {
+    return {
+      title: "Could not load projects",
+      detail: catalogState.shellSnapshotError,
+      loading: false,
+    };
+  }
+
   if (
-    catalogState.hasConnectingEnvironment &&
     !catalogState.hasLoadedShellSnapshot &&
-    catalogState.connectionError === null
+    (catalogState.hasConnectingEnvironment ||
+      catalogState.hasPendingShellSnapshot ||
+      catalogState.hasReadyEnvironment)
   ) {
     return {
-      title: "Connecting to environment",
+      title: catalogState.hasPendingShellSnapshot
+        ? "Loading projects"
+        : "Connecting to environment",
       detail: "Loading projects from the saved environment.",
       loading: true,
     };

--- a/apps/mobile/src/features/threads/newTaskPicker.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.ts
@@ -1,7 +1,9 @@
 import type {
   EnvironmentProject,
+  EnvironmentShellStatus,
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 
 import { groupProjectsByRepository } from "../../lib/repositoryGroups";
@@ -22,6 +24,54 @@ export interface NewTaskProjectItem {
   readonly key: string;
   readonly title: string;
   readonly workspaceRoot: string;
+}
+
+export function deriveNewTaskProjectPickerEmptyState(input: {
+  readonly environment: {
+    readonly connectionState: EnvironmentConnectionPhase;
+    readonly connectionError: string | null;
+  } | null;
+  readonly networkOffline: boolean;
+  readonly shellStatus: EnvironmentShellStatus;
+  readonly shellError: string | null;
+  readonly hasShellSnapshot: boolean;
+}): {
+  readonly title: string;
+  readonly detail: string;
+  readonly loading: boolean;
+} {
+  const connectionUnavailable =
+    input.environment === null ||
+    input.networkOffline ||
+    input.environment.connectionState === "available" ||
+    input.environment.connectionState === "offline" ||
+    input.environment.connectionState === "error";
+
+  if (connectionUnavailable && !input.hasShellSnapshot) {
+    return {
+      title: "Environment unavailable",
+      detail:
+        input.environment?.connectionError ??
+        input.shellError ??
+        "The saved environment is offline. Check the URL or start the environment, then retry.",
+      loading: false,
+    };
+  }
+
+  if (!input.hasShellSnapshot) {
+    return {
+      title:
+        input.shellStatus === "synchronizing" ? "Loading projects" : "Connecting to environment",
+      detail: "Loading projects from the selected environment.",
+      loading: true,
+    };
+  }
+
+  return {
+    title: "No projects found",
+    detail: "The selected environment did not report any projects.",
+    loading: false,
+  };
 }
 
 export function deriveNewTaskPickerEmptyState(catalogState: WorkspaceState): {

--- a/apps/mobile/src/features/threads/newTaskPicker.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.ts
@@ -85,6 +85,25 @@ export function deriveNewTaskProjectPickerEmptyState(input: {
   };
 }
 
+export type NewTaskProjectPickerAction = "none" | "add-environment" | "add-project";
+
+export function deriveNewTaskProjectPickerAction(input: {
+  readonly hasSelectedEnvironment: boolean;
+  readonly canAddProject: boolean;
+  readonly loading: boolean;
+}): NewTaskProjectPickerAction {
+  if (input.canAddProject) {
+    return "add-project";
+  }
+  if (input.loading) {
+    return "none";
+  }
+  // Adding another connection is only useful when no environment was chosen.
+  // Once one is selected the offer contradicts the screen the user is on, and
+  // adding a project needs that environment to be reachable first.
+  return input.hasSelectedEnvironment ? "none" : "add-environment";
+}
+
 export function deriveNewTaskPickerEmptyState(catalogState: WorkspaceState): {
   readonly title: string;
   readonly detail: string;

--- a/apps/mobile/src/features/threads/newTaskPicker.ts
+++ b/apps/mobile/src/features/threads/newTaskPicker.ts
@@ -58,6 +58,17 @@ export function deriveNewTaskProjectPickerEmptyState(input: {
     };
   }
 
+  if (input.shellError !== null && !input.hasShellSnapshot) {
+    // The connection itself can stay healthy while the shell subscription
+    // fails. Without this branch the picker spins on "Loading projects" and
+    // never reports why no project ever arrives.
+    return {
+      title: "Could not load projects",
+      detail: input.shellError,
+      loading: false,
+    };
+  }
+
   if (!input.hasShellSnapshot) {
     return {
       title:

--- a/apps/mobile/src/state/shell.ts
+++ b/apps/mobile/src/state/shell.ts
@@ -3,7 +3,12 @@ import {
   createEnvironmentShellSummaryAtom,
   createEnvironmentSnapshotAtom,
   createShellEnvironmentAtoms,
+  type EnvironmentShellState,
 } from "@t3tools/client-runtime/state/shell";
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { Atom } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
@@ -15,3 +20,19 @@ export const environmentShellSummaryAtom = createEnvironmentShellSummaryAtom({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
   shellStateValueAtom: environmentShell.stateValueAtom,
 });
+
+const EMPTY_ENVIRONMENT_SHELL_STATE_ATOM = Atom.make<EnvironmentShellState>({
+  snapshot: Option.none(),
+  status: "empty",
+  error: Option.none(),
+}).pipe(Atom.withLabel("mobile-environment-shell:empty"));
+
+export function useEnvironmentShellState(
+  environmentId: EnvironmentId | null,
+): EnvironmentShellState {
+  return useAtomValue(
+    environmentId === null
+      ? EMPTY_ENVIRONMENT_SHELL_STATE_ATOM
+      : environmentShell.stateValueAtom(environmentId),
+  );
+}


### PR DESCRIPTION
## What Changed

- Split the mobile new-task picker into environment and project stages.
- Scope logical project grouping to the selected environment so a newer project on another machine cannot replace the intended target.
- Preserve incoming-share continuation and add project flows across the new navigation stage.
- Add focused picker tests for environment scoping, project counts, and empty environments.

## Why

This brings the mobile new-task flow in line with #4426: users explicitly choose where a task will run before choosing the project.

## UI Changes

All shots: Android emulator (Pixel 6, API 35), light theme, same device and seeded environments for every image.

### Environment-first new task flow (new behavior)

Step 1 — choose the environment:

![Choose an environment](https://raw.githubusercontent.com/colonelpanic8/t3code/pr-assets/mobile-environment-first-new-task-0bad292c/mobile-environment-first-new-task-0bad292c/environment.png)

Step 2 — choose a project, scoped to that environment:

![Choose a project](https://raw.githubusercontent.com/colonelpanic8/t3code/pr-assets/mobile-environment-first-new-task-0bad292c/mobile-environment-first-new-task-0bad292c/project.png)

### Empty-state call to action when the selected environment is not ready

Same state in both images: an environment was already chosen from step 1, and its project list has not arrived yet.

Before — the picker offered "Add environment", pushing the user toward creating another connection instead of working with the one they had just selected:

![Before: Add environment call to action while the selected environment is still connecting](https://raw.githubusercontent.com/colonelpanic8/t3code/pr-assets/mobile-environment-first-new-task-0bad292c/mobile-environment-first-new-task-0bad292c/empty-state-cta-before.png)

After — no call to action while the selected environment is loading or unavailable; the back chevron to the environment picker is still the escape hatch:

![After: no call to action while the selected environment is still connecting](https://raw.githubusercontent.com/colonelpanic8/t3code/pr-assets/mobile-environment-first-new-task-0bad292c/mobile-environment-first-new-task-0bad292c/empty-state-cta-after.png)

## Verification

- `vp test run apps/mobile/src/features/threads/newTaskPicker.test.ts` (2 tests)
- `vp run --filter @t3tools/mobile typecheck`
- `vp run lint:mobile` (native linters unavailable on Linux; generated native projects skipped)
- `vp check` (zero errors; existing web warnings only)
- `vp run typecheck`
- Android emulator: verified environment → scoped project navigation across two connected environments, plus back navigation between stages.
- Android emulator (Pixel 6, API 35, Expo dev client from this branch): re-verified the environment → scoped project navigation and captured the before/after empty-state call to action above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core new-task navigation, incoming-share resume paths, and environment-scoped project selection; regressions could mis-route shares or show wrong projects, but logic is largely extracted and covered by focused tests.
> 
> **Overview**
> **Adds an environment-first step** to the mobile new-task sheet: `NewTaskEnvironmentRouteScreen` is now the initial route, and the existing project picker becomes `NewTaskProject` with a required `environmentId`.
> 
> **Project choices are scoped to the selected environment** via `buildNewTaskProjectItems` / `buildNewTaskEnvironmentItems` in `newTaskPicker.ts`, so cross-machine repo grouping cannot pick the wrong target. Empty and loading states use **per-environment shell state** (`useEnvironmentShellState`) and no longer suggest “Add environment” while a chosen environment is still connecting.
> 
> **Navigation and share flows** are updated: draft back-navigation returns to `NewTaskProject` when an environment was known; add-project can receive `environmentId` to preselect the environment. Unit tests cover scoping, counts, and empty-state actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d2d83992221e083528cdf9d54eb950a0d819b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add environment-first new task flow on mobile
> - Adds a new `NewTaskEnvironmentRouteScreen` as the first step in the new-task flow, letting users pick an environment before seeing projects. The project picker (`NewTaskRouteScreen`) is now scoped to a selected `environmentId`.
> - Introduces `buildNewTaskEnvironmentItems` and `buildNewTaskProjectItems` in [newTaskPicker.ts](https://github.com/pingdotgg/t3code/pull/4447/files#diff-c334dab8a0f5176742ac87ee85667a7c7a38f292ee135477d9994264a85c7262) to filter environments (those with at least one project) and projects (scoped to a given environment).
> - Adds `deriveNewTaskProjectPickerEmptyState` and `deriveNewTaskProjectPickerAction` to show environment-specific loading/error states and conditionally render add-project or add-environment actions.
> - Updates `NewTaskDraftScreen` to navigate back to the environment-aware project picker (`NewTaskProject`) when an environment was initially specified, or to the environment picker otherwise.
> - `AddProjectSourceScreen` and its route now accept an optional `environmentId` to preselect an environment when adding a project.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49d2d83.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
