### PR TITLE
[WIP] feat(usage): local usage analytics — ledger, RPC, settings page

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -18,6 +18,7 @@ import { OrchestrationEventStore } from "../../persistence/Services/Orchestratio
 import { ProjectionPendingApprovalRepository } from "../../persistence/Services/ProjectionPendingApprovals.ts";
 import { ProjectionProjectRepository } from "../../persistence/Services/ProjectionProjects.ts";
 import { ProjectionStateRepository } from "../../persistence/Services/ProjectionState.ts";
+import { ProjectionUsageRepository } from "../../persistence/Services/ProjectionUsage.ts";
 import { ProjectionThreadActivityRepository } from "../../persistence/Services/ProjectionThreadActivities.ts";
 import { type ProjectionThreadActivity } from "../../persistence/Services/ProjectionThreadActivities.ts";
 import {
@@ -37,6 +38,7 @@ import { ProjectionThreadRepository } from "../../persistence/Services/Projectio
 import { ProjectionPendingApprovalRepositoryLive } from "../../persistence/Layers/ProjectionPendingApprovals.ts";
 import { ProjectionProjectRepositoryLive } from "../../persistence/Layers/ProjectionProjects.ts";
 import { ProjectionStateRepositoryLive } from "../../persistence/Layers/ProjectionState.ts";
+import { ProjectionUsageRepositoryLive } from "../../persistence/Layers/ProjectionUsage.ts";
 import { ProjectionThreadActivityRepositoryLive } from "../../persistence/Layers/ProjectionThreadActivities.ts";
 import { ProjectionThreadMessageRepositoryLive } from "../../persistence/Layers/ProjectionThreadMessages.ts";
 import { ProjectionThreadProposedPlanRepositoryLive } from "../../persistence/Layers/ProjectionThreadProposedPlans.ts";
@@ -65,6 +67,7 @@ export const ORCHESTRATION_PROJECTOR_NAMES = {
   threadTurns: "projection.thread-turns",
   checkpoints: "projection.checkpoints",
   pendingApprovals: "projection.pending-approvals",
+  usage: "projection.usage",
 } as const;
 
 type ProjectorName =
@@ -480,6 +483,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
     const projectionThreadSessionRepository = yield* ProjectionThreadSessionRepository;
     const projectionTurnRepository = yield* ProjectionTurnRepository;
     const projectionPendingApprovalRepository = yield* ProjectionPendingApprovalRepository;
+    const projectionUsageRepository = yield* ProjectionUsageRepository;
 
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -1007,6 +1011,51 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       });
     });
 
+    const applyUsageProjection: ProjectorDefinition["apply"] = Effect.fn("applyUsageProjection")(
+      function* (event, _attachmentSideEffects) {
+        switch (event.type) {
+          case "thread.usage-recorded":
+            yield* Effect.forEach(
+              event.payload.facts,
+              (fact) =>
+                projectionUsageRepository.upsertFact({
+                  factId: fact.factId,
+                  threadId: event.payload.threadId,
+                  turnId: event.payload.turnId,
+                  projectId: event.payload.projectId,
+                  provider: fact.provider,
+                  providerInstanceId: fact.providerInstanceId ?? null,
+                  providerSessionId: fact.providerSessionId,
+                  model: fact.model,
+                  modelRaw: fact.modelRaw,
+                  reasoningEffort: fact.reasoningEffort ?? null,
+                  kind: fact.kind,
+                  inputTokens: fact.tokens.inputTokens,
+                  cachedInputTokens: fact.tokens.cachedInputTokens,
+                  cacheCreationTokens: fact.tokens.cacheCreationTokens,
+                  outputTokens: fact.tokens.outputTokens,
+                  reasoningOutputTokens: fact.tokens.reasoningOutputTokens,
+                  costMicroUsd: fact.costMicroUsd ?? null,
+                  stale: fact.stale ?? false,
+                  observedAt: fact.observedAt,
+                }),
+              { concurrency: 1 },
+            ).pipe(Effect.asVoid);
+            return;
+
+          case "thread.deleted":
+            yield* projectionUsageRepository.redactThread({
+              threadId: event.payload.threadId,
+            });
+            return;
+
+          // No thread.reverted case: usage facts are immutable billing history and survive reverts.
+          default:
+            return;
+        }
+      },
+    );
+
     const applyThreadTurnsProjection: ProjectorDefinition["apply"] = Effect.fn(
       "applyThreadTurnsProjection",
     )(function* (event, _attachmentSideEffects) {
@@ -1481,6 +1530,10 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         apply: applyThreadSessionsProjection,
       },
       {
+        name: ORCHESTRATION_PROJECTOR_NAMES.usage,
+        apply: applyUsageProjection,
+      },
+      {
         name: ORCHESTRATION_PROJECTOR_NAMES.threadTurns,
         apply: applyThreadTurnsProjection,
       },
@@ -1596,6 +1649,7 @@ export const OrchestrationProjectionPipelineLive = Layer.effect(
   Layer.provideMerge(ProjectionThreadProposedPlanRepositoryLive),
   Layer.provideMerge(ProjectionThreadActivityRepositoryLive),
   Layer.provideMerge(ProjectionThreadSessionRepositoryLive),
+  Layer.provideMerge(ProjectionUsageRepositoryLive),
   Layer.provideMerge(ProjectionTurnRepositoryLive),
   Layer.provideMerge(ProjectionPendingApprovalRepositoryLive),
   Layer.provideMerge(ProjectionStateRepositoryLive),

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.usage.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.usage.test.ts
@@ -1,0 +1,557 @@
+import {
+  CommandId,
+  EventId,
+  IsoDateTime,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type UsageFact,
+  UsageFactId,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
+import { ProjectionUsageRepository } from "../../persistence/Services/ProjectionUsage.ts";
+import { ServerConfig } from "../../config.ts";
+import { OrchestrationProjectionPipeline } from "../Services/ProjectionPipeline.ts";
+import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+
+const BaseTestLayer = OrchestrationProjectionPipelineLive.pipe(
+  Layer.provideMerge(OrchestrationEventStoreLive),
+  Layer.provideMerge(
+    ServerConfig.layerTest(process.cwd(), { prefix: "t3-projection-pipeline-usage-test-" }),
+  ),
+  Layer.provideMerge(SqlitePersistenceMemory),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const threadId = ThreadId.make("thread-usage");
+const turnId = TurnId.make("turn-usage");
+const projectId = ProjectId.make("project-usage");
+const observedAt = IsoDateTime.make("2026-04-01T12:00:00.000Z");
+
+function makeFact(factId: string, overrides: Partial<UsageFact> = {}): UsageFact {
+  return {
+    factId: UsageFactId.make(factId),
+    kind: "final",
+    provider: ProviderDriverKind.make("claudeAgent"),
+    providerInstanceId: ProviderInstanceId.make("claude-primary"),
+    providerSessionId: "session-claude-1",
+    model: "claude-fable-5",
+    modelRaw: "claude-fable-5[1m]",
+    reasoningEffort: "high",
+    tokens: {
+      inputTokens: 100,
+      cachedInputTokens: 1_000,
+      cacheCreationTokens: 200,
+      outputTokens: 50,
+      reasoningOutputTokens: 0,
+    },
+    costMicroUsd: 1_250_000,
+    observedAt,
+    ...overrides,
+  };
+}
+
+it.layer(BaseTestLayer)("usage projection", (it) => {
+  it.effect("projects every usage fact with exact persisted values", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "thread.usage-recorded",
+        eventId: EventId.make("evt-usage-single"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: observedAt,
+        commandId: CommandId.make("cmd-usage-single"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-single"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId,
+          projectId,
+          facts: [
+            makeFact("fact-final"),
+            makeFact("fact-interval", {
+              kind: "interval",
+              provider: ProviderDriverKind.make("codex"),
+              providerInstanceId: undefined,
+              providerSessionId: "session-codex-1",
+              model: "gpt-5.6",
+              modelRaw: "gpt-5.6",
+              reasoningEffort: undefined,
+              tokens: {
+                inputTokens: 300,
+                cachedInputTokens: 75,
+                cacheCreationTokens: 0,
+                outputTokens: 125,
+                reasoningOutputTokens: 40,
+              },
+              costMicroUsd: undefined,
+              observedAt: IsoDateTime.make("2026-04-01T12:00:01.000Z"),
+            }),
+          ],
+          recordedAt: IsoDateTime.make("2026-04-01T12:00:02.000Z"),
+        },
+      });
+
+      const rows = yield* sql<{
+        readonly factId: string;
+        readonly threadId: string;
+        readonly turnId: string | null;
+        readonly projectId: string | null;
+        readonly provider: string;
+        readonly providerInstanceId: string | null;
+        readonly providerSessionId: string;
+        readonly model: string;
+        readonly modelRaw: string;
+        readonly reasoningEffort: string | null;
+        readonly kind: string;
+        readonly inputTokens: number;
+        readonly cachedInputTokens: number;
+        readonly cacheCreationTokens: number;
+        readonly outputTokens: number;
+        readonly reasoningOutputTokens: number;
+        readonly costMicroUsd: number | null;
+        readonly stale: number;
+        readonly observedAt: string;
+      }>`
+        SELECT
+          fact_id AS "factId",
+          thread_id AS "threadId",
+          turn_id AS "turnId",
+          project_id AS "projectId",
+          provider,
+          provider_instance_id AS "providerInstanceId",
+          provider_session_id AS "providerSessionId",
+          model,
+          model_raw AS "modelRaw",
+          reasoning_effort AS "reasoningEffort",
+          kind,
+          input_tokens AS "inputTokens",
+          cached_input_tokens AS "cachedInputTokens",
+          cache_creation_tokens AS "cacheCreationTokens",
+          output_tokens AS "outputTokens",
+          reasoning_output_tokens AS "reasoningOutputTokens",
+          cost_micro_usd AS "costMicroUsd",
+          stale,
+          observed_at AS "observedAt"
+        FROM projection_usage_facts
+        ORDER BY fact_id ASC
+      `;
+
+      assert.deepEqual(rows, [
+        {
+          factId: "fact-final",
+          threadId: "thread-usage",
+          turnId: "turn-usage",
+          projectId: "project-usage",
+          provider: "claudeAgent",
+          providerInstanceId: "claude-primary",
+          providerSessionId: "session-claude-1",
+          model: "claude-fable-5",
+          modelRaw: "claude-fable-5[1m]",
+          reasoningEffort: "high",
+          kind: "final",
+          inputTokens: 100,
+          cachedInputTokens: 1_000,
+          cacheCreationTokens: 200,
+          outputTokens: 50,
+          reasoningOutputTokens: 0,
+          costMicroUsd: 1_250_000,
+          stale: 0,
+          observedAt: "2026-04-01T12:00:00.000Z",
+        },
+        {
+          factId: "fact-interval",
+          threadId: "thread-usage",
+          turnId: "turn-usage",
+          projectId: "project-usage",
+          provider: "codex",
+          providerInstanceId: null,
+          providerSessionId: "session-codex-1",
+          model: "gpt-5.6",
+          modelRaw: "gpt-5.6",
+          reasoningEffort: null,
+          kind: "interval",
+          inputTokens: 300,
+          cachedInputTokens: 75,
+          cacheCreationTokens: 0,
+          outputTokens: 125,
+          reasoningOutputTokens: 40,
+          costMicroUsd: null,
+          stale: 0,
+          observedAt: "2026-04-01T12:00:01.000Z",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("upserts repeated facts by fact id", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+      const facts = [makeFact("fact-replay-1"), makeFact("fact-replay-2", { kind: "interval" })];
+
+      for (const suffix of ["one", "two"] as const) {
+        yield* appendAndProject({
+          type: "thread.usage-recorded",
+          eventId: EventId.make(`evt-usage-replay-${suffix}`),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: observedAt,
+          commandId: CommandId.make(`cmd-usage-replay-${suffix}`),
+          causationEventId: null,
+          correlationId: CommandId.make(`cmd-usage-replay-${suffix}`),
+          metadata: {},
+          payload: {
+            threadId,
+            turnId,
+            projectId,
+            facts,
+            recordedAt: observedAt,
+          },
+        });
+      }
+
+      const rows = yield* sql<{ readonly factId: string }>`
+        SELECT fact_id AS "factId"
+        FROM projection_usage_facts
+        WHERE fact_id IN ('fact-replay-1', 'fact-replay-2')
+        ORDER BY fact_id ASC
+      `;
+      assert.deepEqual(rows, [{ factId: "fact-replay-1" }, { factId: "fact-replay-2" }]);
+    }),
+  );
+
+  it.effect("retains usage facts after a thread revert", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "thread.usage-recorded",
+        eventId: EventId.make("evt-usage-before-revert"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: observedAt,
+        commandId: CommandId.make("cmd-usage-before-revert"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-before-revert"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId,
+          projectId,
+          facts: [makeFact("fact-retained")],
+          recordedAt: observedAt,
+        },
+      });
+
+      const before = yield* sql<{
+        readonly factId: string;
+        readonly threadId: string;
+        readonly projectId: string | null;
+        readonly outputTokens: number;
+        readonly costMicroUsd: number | null;
+      }>`
+        SELECT
+          fact_id AS "factId",
+          thread_id AS "threadId",
+          project_id AS "projectId",
+          output_tokens AS "outputTokens",
+          cost_micro_usd AS "costMicroUsd"
+        FROM projection_usage_facts
+        WHERE fact_id = 'fact-retained'
+      `;
+
+      yield* appendAndProject({
+        type: "thread.reverted",
+        eventId: EventId.make("evt-usage-reverted"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: IsoDateTime.make("2026-04-01T12:01:00.000Z"),
+        commandId: CommandId.make("cmd-usage-reverted"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-reverted"),
+        metadata: {},
+        payload: { threadId, turnCount: 0 },
+      });
+
+      const after = yield* sql<{
+        readonly factId: string;
+        readonly threadId: string;
+        readonly projectId: string | null;
+        readonly outputTokens: number;
+        readonly costMicroUsd: number | null;
+      }>`
+        SELECT
+          fact_id AS "factId",
+          thread_id AS "threadId",
+          project_id AS "projectId",
+          output_tokens AS "outputTokens",
+          cost_micro_usd AS "costMicroUsd"
+        FROM projection_usage_facts
+        WHERE fact_id = 'fact-retained'
+      `;
+
+      assert.deepEqual(after, before);
+      assert.deepEqual(after, [
+        {
+          factId: "fact-retained",
+          threadId: "thread-usage",
+          projectId: "project-usage",
+          outputTokens: 50,
+          costMicroUsd: 1_250_000,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("redacts thread and project attribution after thread deletion", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "thread.usage-recorded",
+        eventId: EventId.make("evt-usage-before-delete"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: observedAt,
+        commandId: CommandId.make("cmd-usage-before-delete"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-before-delete"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId,
+          projectId,
+          facts: [makeFact("fact-redacted-1"), makeFact("fact-redacted-2")],
+          recordedAt: observedAt,
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.deleted",
+        eventId: EventId.make("evt-usage-deleted"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: IsoDateTime.make("2026-04-01T12:01:00.000Z"),
+        commandId: CommandId.make("cmd-usage-deleted"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-deleted"),
+        metadata: {},
+        payload: {
+          threadId,
+          deletedAt: IsoDateTime.make("2026-04-01T12:01:00.000Z"),
+        },
+      });
+
+      const rows = yield* sql<{
+        readonly factId: string;
+        readonly threadId: string;
+        readonly projectId: string | null;
+      }>`
+        SELECT
+          fact_id AS "factId",
+          thread_id AS "threadId",
+          project_id AS "projectId"
+        FROM projection_usage_facts
+        WHERE fact_id IN ('fact-redacted-1', 'fact-redacted-2')
+        ORDER BY fact_id ASC
+      `;
+      assert.deepEqual(rows, [
+        { factId: "fact-redacted-1", threadId: "deleted", projectId: null },
+        { factId: "fact-redacted-2", threadId: "deleted", projectId: null },
+      ]);
+    }),
+  );
+
+  it.effect("persists the stale flag", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "thread.usage-recorded",
+        eventId: EventId.make("evt-usage-stale"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: observedAt,
+        commandId: CommandId.make("cmd-usage-stale"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-stale"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId,
+          projectId: null,
+          facts: [makeFact("fact-stale", { stale: true })],
+          recordedAt: observedAt,
+        },
+      });
+
+      const rows = yield* sql<{ readonly factId: string; readonly stale: number }>`
+        SELECT fact_id AS "factId", stale
+        FROM projection_usage_facts
+        WHERE fact_id = 'fact-stale'
+      `;
+      assert.deepEqual(rows, [{ factId: "fact-stale", stale: 1 }]);
+    }),
+  );
+
+  it.effect("sums final and interval facts by session and model", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const usageRepository = yield* ProjectionUsageRepository;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "thread.usage-recorded",
+        eventId: EventId.make("evt-usage-sums"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: observedAt,
+        commandId: CommandId.make("cmd-usage-sums"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-usage-sums"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnId,
+          projectId,
+          facts: [
+            makeFact("fact-sum-fable-final", {
+              providerSessionId: "session-target",
+              tokens: {
+                inputTokens: 100,
+                cachedInputTokens: 10,
+                cacheCreationTokens: 5,
+                outputTokens: 20,
+                reasoningOutputTokens: 2,
+              },
+              costMicroUsd: 1_000,
+            }),
+            makeFact("fact-sum-fable-interval", {
+              kind: "interval",
+              providerSessionId: "session-target",
+              tokens: {
+                inputTokens: 50,
+                cachedInputTokens: 5,
+                cacheCreationTokens: 3,
+                outputTokens: 10,
+                reasoningOutputTokens: 1,
+              },
+              costMicroUsd: 500,
+            }),
+            makeFact("fact-sum-opus", {
+              providerSessionId: "session-target",
+              model: "claude-opus-4-8",
+              modelRaw: "claude-opus-4-8",
+              tokens: {
+                inputTokens: 200,
+                cachedInputTokens: 20,
+                cacheCreationTokens: 8,
+                outputTokens: 40,
+                reasoningOutputTokens: 4,
+              },
+              costMicroUsd: 2_000,
+            }),
+            makeFact("fact-sum-turn-total", {
+              kind: "turn-total",
+              providerSessionId: "session-target",
+              tokens: {
+                inputTokens: 9_999,
+                cachedInputTokens: 9_999,
+                cacheCreationTokens: 9_999,
+                outputTokens: 9_999,
+                reasoningOutputTokens: 9_999,
+              },
+              costMicroUsd: 9_999,
+            }),
+            makeFact("fact-sum-other-session", {
+              providerSessionId: "session-other",
+              tokens: {
+                inputTokens: 8_888,
+                cachedInputTokens: 8_888,
+                cacheCreationTokens: 8_888,
+                outputTokens: 8_888,
+                reasoningOutputTokens: 8_888,
+              },
+              costMicroUsd: 8_888,
+            }),
+          ],
+          recordedAt: observedAt,
+        },
+      });
+
+      const sums = yield* usageRepository.sumBySessionModel({
+        providerSessionId: "session-target",
+      });
+      assert.deepEqual(
+        [...sums].toSorted((left, right) => left.model.localeCompare(right.model)),
+        [
+          {
+            model: "claude-fable-5",
+            inputTokens: 150,
+            cachedInputTokens: 15,
+            cacheCreationTokens: 8,
+            outputTokens: 30,
+            reasoningOutputTokens: 3,
+            costMicroUsd: 1_500,
+          },
+          {
+            model: "claude-opus-4-8",
+            inputTokens: 200,
+            cachedInputTokens: 20,
+            cacheCreationTokens: 8,
+            outputTokens: 40,
+            reasoningOutputTokens: 4,
+            costMicroUsd: 2_000,
+          },
+        ],
+      );
+    }),
+  );
+});

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -3,6 +3,9 @@ import {
   type AssistantDeliveryMode,
   CommandId,
   MessageId,
+  type OrchestrationThreadShell,
+  type UsageFact,
+  UsageFactId,
   type OrchestrationEvent,
   type OrchestrationMessage,
   type OrchestrationProposedPlanId,
@@ -30,6 +33,17 @@ import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
+import { ProjectionUsageRepository } from "../../persistence/Services/ProjectionUsage.ts";
+import { ProjectionUsageRepositoryLive } from "../../persistence/Layers/ProjectionUsage.ts";
+import {
+  ZERO_USAGE_COUNTERS,
+  type UsageCumulativeCounters,
+  canonicalModelId,
+  claudeCumulativeByModel,
+  codexCumulativeFromSnapshot,
+  isZeroUsage,
+  usageDelta,
+} from "../usageAccounting.ts";
 import { isGitRepository } from "../../git/Utils.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -697,6 +711,7 @@ const make = Effect.gen(function* () {
     crypto.randomUUIDv4.pipe(
       Effect.map((uuid) => CommandId.make(`provider:${event.eventId}:${tag}:${uuid}`)),
     );
+  const projectionUsageRepository = yield* ProjectionUsageRepository;
 
   const turnMessageIdsByTurnKey = yield* Cache.make<string, Set<MessageId>>({
     capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
@@ -1290,6 +1305,194 @@ const make = Effect.gen(function* () {
     },
   );
 
+  // ---------------------------------------------------------------------
+  // Usage accounting: converts provider-cumulative counters into interval
+  // usage facts dispatched as thread.usage.record commands. Baselines are
+  // keyed by provider-native session id + model; on first sight of a session
+  // they are reseeded from projection_usage_facts sums so a server restart
+  // between samples never double counts.
+  // ---------------------------------------------------------------------
+  const usageBaselines = new Map<string, UsageCumulativeCounters>();
+  const seededUsageSessions = new Set<string>();
+  const usageBaselineKey = (providerSessionId: string, model: string) =>
+    `${providerSessionId}|${model}`;
+
+  const seedUsageBaselines = Effect.fn("seedUsageBaselines")(function* (providerSessionId: string) {
+    if (seededUsageSessions.has(providerSessionId)) {
+      return;
+    }
+    seededUsageSessions.add(providerSessionId);
+    const sums = yield* projectionUsageRepository.sumBySessionModel({ providerSessionId });
+    for (const sum of sums) {
+      const key = usageBaselineKey(providerSessionId, sum.model);
+      if (!usageBaselines.has(key)) {
+        usageBaselines.set(key, {
+          inputTokens: sum.inputTokens,
+          cachedInputTokens: sum.cachedInputTokens,
+          cacheCreationTokens: sum.cacheCreationTokens,
+          outputTokens: sum.outputTokens,
+          reasoningOutputTokens: sum.reasoningOutputTokens,
+          costMicroUsd: sum.costMicroUsd,
+        });
+      }
+    }
+  });
+
+  const reasoningEffortFromThread = (thread: OrchestrationThreadShell): string | undefined => {
+    const options = thread.modelSelection.options;
+    if (!options) return undefined;
+    for (const option of options) {
+      if (option.id === "reasoningEffort" && typeof option.value === "string") {
+        return option.value;
+      }
+    }
+    return undefined;
+  };
+
+  const dispatchUsageFacts = (input: {
+    readonly event: ProviderRuntimeEvent;
+    readonly threadId: ThreadId;
+    readonly projectId: OrchestrationThreadShell["projectId"] | null;
+    readonly turnId: TurnId | null;
+    readonly facts: ReadonlyArray<UsageFact>;
+  }) =>
+    providerCommandId(input.event, "usage-record").pipe(
+      Effect.flatMap((commandId) =>
+        orchestrationEngine.dispatch({
+          type: "thread.usage.record",
+          commandId,
+          threadId: input.threadId,
+          turnId: input.turnId,
+          projectId: input.projectId,
+          facts: input.facts,
+          createdAt: input.event.createdAt,
+        }),
+      ),
+      Effect.asVoid,
+    );
+
+  const recordUsageForRuntimeEvent = (
+    event: ProviderRuntimeEvent,
+    thread: OrchestrationThreadShell,
+    options: { readonly staleCompletion: boolean },
+  ) =>
+    Effect.gen(function* () {
+      // Codex path: cumulative totals ride every token-usage notification and
+      // are attributed by the provider-native thread id. Snapshots without
+      // native identity or cumulative fields are context-window telemetry
+      // only and carry no accounting weight.
+      if (event.type === "thread.token-usage.updated") {
+        const cumulative = codexCumulativeFromSnapshot(event.payload.usage);
+        const providerSessionId = event.providerRefs?.providerSessionId;
+        if (!cumulative || !providerSessionId || isZeroUsage(cumulative)) {
+          return;
+        }
+        const model = canonicalModelId(thread.modelSelection.model);
+        yield* seedUsageBaselines(providerSessionId);
+        const key = usageBaselineKey(providerSessionId, model);
+        const baseline = usageBaselines.get(key) ?? ZERO_USAGE_COUNTERS;
+        const { delta, nextBaseline } = usageDelta(baseline, cumulative);
+        usageBaselines.set(key, nextBaseline);
+        if (isZeroUsage(delta)) {
+          return;
+        }
+        const effort = reasoningEffortFromThread(thread);
+        const fact: UsageFact = {
+          factId: UsageFactId.make(`usage:${event.eventId}:${model}`),
+          kind: "interval",
+          provider: event.provider,
+          ...(event.providerInstanceId !== undefined
+            ? { providerInstanceId: event.providerInstanceId }
+            : {}),
+          providerSessionId,
+          model,
+          modelRaw: thread.modelSelection.model,
+          ...(effort !== undefined ? { reasoningEffort: effort } : {}),
+          tokens: {
+            inputTokens: delta.inputTokens,
+            cachedInputTokens: delta.cachedInputTokens,
+            cacheCreationTokens: delta.cacheCreationTokens,
+            outputTokens: delta.outputTokens,
+            reasoningOutputTokens: delta.reasoningOutputTokens,
+          },
+          observedAt: event.createdAt,
+        };
+        yield* dispatchUsageFacts({
+          event,
+          threadId: thread.id,
+          projectId: thread.projectId,
+          turnId: toTurnId(event.turnId) ?? null,
+          facts: [fact],
+        });
+        return;
+      }
+
+      // Claude path: turn.completed carries the SDK's session-cumulative
+      // per-model usage map (exact cost included). Settle each model's delta
+      // as a final fact; stale completions are recorded but flagged.
+      if (event.type === "turn.completed") {
+        const byModel = claudeCumulativeByModel(event.payload.modelUsage);
+        if (!byModel || byModel.size === 0) {
+          return;
+        }
+        const providerSessionId = event.providerRefs?.providerSessionId ?? thread.id;
+        yield* seedUsageBaselines(providerSessionId);
+        const facts: Array<UsageFact> = [];
+        for (const [rawModel, cumulative] of byModel) {
+          const model = canonicalModelId(rawModel);
+          const key = usageBaselineKey(providerSessionId, model);
+          const baseline = usageBaselines.get(key) ?? ZERO_USAGE_COUNTERS;
+          const { delta, nextBaseline } = usageDelta(baseline, cumulative);
+          usageBaselines.set(key, nextBaseline);
+          if (isZeroUsage(delta)) {
+            continue;
+          }
+          facts.push({
+            factId: UsageFactId.make(`usage:${event.eventId}:${model}`),
+            kind: "final",
+            provider: event.provider,
+            ...(event.providerInstanceId !== undefined
+              ? { providerInstanceId: event.providerInstanceId }
+              : {}),
+            providerSessionId,
+            model,
+            modelRaw: rawModel,
+            tokens: {
+              inputTokens: delta.inputTokens,
+              cachedInputTokens: delta.cachedInputTokens,
+              cacheCreationTokens: delta.cacheCreationTokens,
+              outputTokens: delta.outputTokens,
+              reasoningOutputTokens: delta.reasoningOutputTokens,
+            },
+            ...(delta.costMicroUsd > 0 ? { costMicroUsd: delta.costMicroUsd } : {}),
+            ...(options.staleCompletion ? { stale: true } : {}),
+            observedAt: event.createdAt,
+          });
+        }
+        if (facts.length === 0) {
+          return;
+        }
+        yield* dispatchUsageFacts({
+          event,
+          threadId: thread.id,
+          projectId: thread.projectId,
+          turnId: toTurnId(event.turnId) ?? null,
+          facts,
+        });
+      }
+    }).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.failCause(cause);
+        }
+        return Effect.logWarning("usage accounting failed for runtime event", {
+          eventId: event.eventId,
+          eventType: event.type,
+          cause: Cause.pretty(cause),
+        });
+      }),
+    );
+
   const processRuntimeEvent = (event: ProviderRuntimeEvent) =>
     Effect.gen(function* () {
       const thread = yield* resolveThreadShell(event.threadId);
@@ -1359,6 +1562,13 @@ const make = Effect.gen(function* () {
         event.type === "turn.started" && shouldApplyThreadLifecycle
           ? yield* getSourceProposedPlanReferenceForAcceptedTurnStart(thread.id, eventTurnId)
           : null;
+
+      // Usage accounting runs for every usage-bearing event, including
+      // lifecycle-rejected completions (recorded with stale: true) — tokens
+      // were consumed regardless of what the turn state machine thinks.
+      yield* recordUsageForRuntimeEvent(event, thread, {
+        staleCompletion: event.type === "turn.completed" && !shouldApplyThreadLifecycle,
+      });
 
       if (
         event.type === "session.started" ||
@@ -1822,4 +2032,4 @@ const make = Effect.gen(function* () {
 export const ProviderRuntimeIngestionLive = Layer.effect(
   ProviderRuntimeIngestionService,
   make,
-).pipe(Layer.provide(ProjectionTurnRepositoryLive));
+).pipe(Layer.provide(ProjectionTurnRepositoryLive), Layer.provide(ProjectionUsageRepositoryLive));

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -774,6 +774,30 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.usage.record": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.usage-recorded",
+        payload: {
+          threadId: command.threadId,
+          turnId: command.turnId,
+          projectId: command.projectId,
+          facts: command.facts,
+          recordedAt: command.createdAt,
+        },
+      };
+    }
+
     default: {
       command satisfies never;
       const fallback = command as never as { type: string };

--- a/apps/server/src/orchestration/runtimeLayer.ts
+++ b/apps/server/src/orchestration/runtimeLayer.ts
@@ -2,6 +2,7 @@ import * as Layer from "effect/Layer";
 
 import { OrchestrationCommandReceiptRepositoryLive } from "../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { OrchestrationEventStoreLive } from "../persistence/Layers/OrchestrationEventStore.ts";
+import { ProjectionUsageRepositoryLive } from "../persistence/Layers/ProjectionUsage.ts";
 import { OrchestrationEngineLive } from "./Layers/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./Layers/ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./Layers/ProjectionSnapshotQuery.ts";
@@ -19,6 +20,8 @@ export const OrchestrationInfrastructureLayerLive = Layer.mergeAll(
   OrchestrationProjectionSnapshotQueryLive,
   OrchestrationEventInfrastructureLayerLive,
   OrchestrationProjectionPipelineLayerLive,
+  // Exposed for the usage.getSummary RPC handler in ws.ts.
+  ProjectionUsageRepositoryLive,
 );
 
 export const OrchestrationLayerLive = Layer.mergeAll(

--- a/apps/server/src/orchestration/usageAccounting.test.ts
+++ b/apps/server/src/orchestration/usageAccounting.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  canonicalModelId,
+  claudeCumulativeByModel,
+  codexCumulativeFromSnapshot,
+  isZeroUsage,
+  usageDelta,
+  ZERO_USAGE_COUNTERS,
+} from "./usageAccounting.ts";
+
+describe("usageAccounting", () => {
+  describe("usageDelta", () => {
+    it("computes interval counters from cumulative counters", () => {
+      const result = usageDelta(
+        {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          cacheCreationTokens: 10,
+          outputTokens: 50,
+          reasoningOutputTokens: 5,
+          costMicroUsd: 1_000_000,
+        },
+        {
+          inputTokens: 175,
+          cachedInputTokens: 35,
+          cacheCreationTokens: 18,
+          outputTokens: 90,
+          reasoningOutputTokens: 12,
+          costMicroUsd: 1_750_000,
+        },
+      );
+
+      expect(result).toEqual({
+        delta: {
+          inputTokens: 75,
+          cachedInputTokens: 15,
+          cacheCreationTokens: 8,
+          outputTokens: 40,
+          reasoningOutputTokens: 7,
+          costMicroUsd: 750_000,
+        },
+        nextBaseline: {
+          inputTokens: 175,
+          cachedInputTokens: 35,
+          cacheCreationTokens: 18,
+          outputTokens: 90,
+          reasoningOutputTokens: 12,
+          costMicroUsd: 1_750_000,
+        },
+        reset: false,
+      });
+    });
+
+    it("returns a zero delta when baseline equals cumulative", () => {
+      const cumulative = {
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        cacheCreationTokens: 10,
+        outputTokens: 50,
+        reasoningOutputTokens: 5,
+        costMicroUsd: 1_000_000,
+      };
+
+      expect(usageDelta(cumulative, cumulative)).toEqual({
+        delta: ZERO_USAGE_COUNTERS,
+        nextBaseline: cumulative,
+        reset: false,
+      });
+    });
+
+    it("treats a counter regression as a provider session reset", () => {
+      const cumulative = {
+        inputTokens: 125,
+        cachedInputTokens: 25,
+        cacheCreationTokens: 12,
+        outputTokens: 10,
+        reasoningOutputTokens: 6,
+        costMicroUsd: 1_250_000,
+      };
+
+      expect(
+        usageDelta(
+          {
+            inputTokens: 100,
+            cachedInputTokens: 20,
+            cacheCreationTokens: 10,
+            outputTokens: 50,
+            reasoningOutputTokens: 5,
+            costMicroUsd: 1_000_000,
+          },
+          cumulative,
+        ),
+      ).toEqual({
+        delta: cumulative,
+        nextBaseline: cumulative,
+        reset: true,
+      });
+    });
+  });
+
+  describe("claudeCumulativeByModel", () => {
+    it("decodes per-model cumulative usage and converts USD to micro-USD", () => {
+      const result = claudeCumulativeByModel({
+        "claude-fable-5[1m]": {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadInputTokens: 1_000,
+          cacheCreationInputTokens: 200,
+          costUSD: 1.25,
+        },
+        "claude-opus-4-8": {
+          inputTokens: 80,
+          outputTokens: 30,
+          cacheReadInputTokens: 400,
+          cacheCreationInputTokens: 25,
+        },
+      });
+
+      expect(result).toEqual(
+        new Map([
+          [
+            "claude-fable-5[1m]",
+            {
+              inputTokens: 100,
+              cachedInputTokens: 1_000,
+              cacheCreationTokens: 200,
+              outputTokens: 50,
+              reasoningOutputTokens: 0,
+              costMicroUsd: 1_250_000,
+            },
+          ],
+          [
+            "claude-opus-4-8",
+            {
+              inputTokens: 80,
+              cachedInputTokens: 400,
+              cacheCreationTokens: 25,
+              outputTokens: 30,
+              reasoningOutputTokens: 0,
+              costMicroUsd: 0,
+            },
+          ],
+        ]),
+      );
+    });
+
+    it("returns undefined for malformed input", () => {
+      expect(claudeCumulativeByModel({ model: "not usage" })).toBeUndefined();
+      expect(claudeCumulativeByModel(null)).toBeUndefined();
+    });
+  });
+
+  describe("codexCumulativeFromSnapshot", () => {
+    it("stores only the uncached share in inputTokens", () => {
+      expect(
+        codexCumulativeFromSnapshot({
+          totalInputTokens: 1_000,
+          totalCachedInputTokens: 250,
+          totalOutputTokens: 400,
+          totalReasoningOutputTokens: 125,
+        }),
+      ).toEqual({
+        inputTokens: 750,
+        cachedInputTokens: 250,
+        cacheCreationTokens: 0,
+        outputTokens: 400,
+        reasoningOutputTokens: 125,
+        costMicroUsd: 0,
+      });
+    });
+
+    it("returns undefined when no cumulative total fields are present", () => {
+      expect(codexCumulativeFromSnapshot({})).toBeUndefined();
+      expect(
+        codexCumulativeFromSnapshot({
+          totalCachedInputTokens: 100,
+          totalReasoningOutputTokens: 20,
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("canonicalizes provider capacity suffixes", () => {
+    expect(canonicalModelId("claude-fable-5[1m]")).toBe("claude-fable-5");
+    expect(canonicalModelId("claude-opus-4-8")).toBe("claude-opus-4-8");
+  });
+
+  it("detects zero usage", () => {
+    expect(isZeroUsage(ZERO_USAGE_COUNTERS)).toBe(true);
+    expect(isZeroUsage({ ...ZERO_USAGE_COUNTERS, outputTokens: 1 })).toBe(false);
+    expect(isZeroUsage({ ...ZERO_USAGE_COUNTERS, costMicroUsd: 1 })).toBe(false);
+  });
+});

--- a/apps/server/src/orchestration/usageAccounting.ts
+++ b/apps/server/src/orchestration/usageAccounting.ts
@@ -1,0 +1,136 @@
+import * as Schema from "effect/Schema";
+import { ClaudeModelUsageMap, type UsageTokenCounters } from "@t3tools/contracts";
+
+/**
+ * Pure delta accounting for usage facts.
+ *
+ * Providers report session-cumulative counters (Codex `tokenUsage.total`,
+ * Claude `modelUsage`). A usage fact must carry interval counters, so every
+ * emission subtracts a baseline: the sum of everything already recorded for
+ * that provider-native session and model. Baselines survive restarts by
+ * reseeding from `projection_usage_facts` sums.
+ */
+
+export interface UsageCumulativeCounters extends UsageTokenCounters {
+  readonly costMicroUsd: number;
+}
+
+export const ZERO_USAGE_COUNTERS: UsageCumulativeCounters = {
+  inputTokens: 0,
+  cachedInputTokens: 0,
+  cacheCreationTokens: 0,
+  outputTokens: 0,
+  reasoningOutputTokens: 0,
+  costMicroUsd: 0,
+};
+
+export interface UsageDeltaResult {
+  readonly delta: UsageCumulativeCounters;
+  /** The cumulative counters that become the next baseline. */
+  readonly nextBaseline: UsageCumulativeCounters;
+  /** True when any counter went backwards (provider session reset); the
+   * absolute cumulative value is used as the delta in that case. */
+  readonly reset: boolean;
+}
+
+function nonNegative(value: number): number {
+  return value > 0 ? Math.round(value) : 0;
+}
+
+export function usageDelta(
+  baseline: UsageCumulativeCounters,
+  cumulative: UsageCumulativeCounters,
+): UsageDeltaResult {
+  const reset =
+    cumulative.inputTokens < baseline.inputTokens ||
+    cumulative.cachedInputTokens < baseline.cachedInputTokens ||
+    cumulative.outputTokens < baseline.outputTokens;
+
+  if (reset) {
+    return { delta: cumulative, nextBaseline: cumulative, reset: true };
+  }
+
+  return {
+    delta: {
+      inputTokens: nonNegative(cumulative.inputTokens - baseline.inputTokens),
+      cachedInputTokens: nonNegative(cumulative.cachedInputTokens - baseline.cachedInputTokens),
+      cacheCreationTokens: nonNegative(
+        cumulative.cacheCreationTokens - baseline.cacheCreationTokens,
+      ),
+      outputTokens: nonNegative(cumulative.outputTokens - baseline.outputTokens),
+      reasoningOutputTokens: nonNegative(
+        cumulative.reasoningOutputTokens - baseline.reasoningOutputTokens,
+      ),
+      costMicroUsd: nonNegative(cumulative.costMicroUsd - baseline.costMicroUsd),
+    },
+    nextBaseline: cumulative,
+    reset: false,
+  };
+}
+
+export function isZeroUsage(counters: UsageCumulativeCounters): boolean {
+  return (
+    counters.inputTokens === 0 &&
+    counters.cachedInputTokens === 0 &&
+    counters.cacheCreationTokens === 0 &&
+    counters.outputTokens === 0 &&
+    counters.reasoningOutputTokens === 0 &&
+    counters.costMicroUsd === 0
+  );
+}
+
+/** Strip provider capacity suffixes (`claude-fable-5[1m]` → `claude-fable-5`)
+ * while keeping the raw id available for display and pricing overrides. */
+export function canonicalModelId(rawModel: string): string {
+  return rawModel.replace(/\[[^\]]+\]$/, "");
+}
+
+const decodeClaudeModelUsage = Schema.decodeUnknownOption(ClaudeModelUsageMap);
+
+/** Claude's `modelUsage` map is cumulative per SDK session. Returns cumulative
+ * counters per raw model id, or undefined when the payload doesn't parse. */
+export function claudeCumulativeByModel(
+  modelUsage: unknown,
+): ReadonlyMap<string, UsageCumulativeCounters> | undefined {
+  const decoded = decodeClaudeModelUsage(modelUsage);
+  if (decoded._tag === "None") {
+    return undefined;
+  }
+  const result = new Map<string, UsageCumulativeCounters>();
+  for (const [rawModel, entry] of Object.entries(decoded.value)) {
+    result.set(rawModel, {
+      inputTokens: nonNegative(entry.inputTokens),
+      cachedInputTokens: nonNegative(entry.cacheReadInputTokens),
+      cacheCreationTokens: nonNegative(entry.cacheCreationInputTokens),
+      outputTokens: nonNegative(entry.outputTokens),
+      reasoningOutputTokens: 0,
+      costMicroUsd: entry.costUSD !== undefined ? nonNegative(entry.costUSD * 1_000_000) : 0,
+    });
+  }
+  return result;
+}
+
+/** Codex cumulative totals from a ThreadTokenUsageSnapshot's `total*` fields.
+ * Codex reports input inclusive of cached reads; the uncached share is the
+ * difference. Returns undefined when the snapshot has no cumulative fields
+ * (Claude context-window snapshots land here and are settled at turn end). */
+export function codexCumulativeFromSnapshot(usage: {
+  readonly totalInputTokens?: number | undefined;
+  readonly totalCachedInputTokens?: number | undefined;
+  readonly totalOutputTokens?: number | undefined;
+  readonly totalReasoningOutputTokens?: number | undefined;
+}): UsageCumulativeCounters | undefined {
+  if (usage.totalInputTokens === undefined && usage.totalOutputTokens === undefined) {
+    return undefined;
+  }
+  const totalInput = usage.totalInputTokens ?? 0;
+  const cached = usage.totalCachedInputTokens ?? 0;
+  return {
+    inputTokens: nonNegative(totalInput - cached),
+    cachedInputTokens: nonNegative(cached),
+    cacheCreationTokens: 0,
+    outputTokens: nonNegative(usage.totalOutputTokens ?? 0),
+    reasoningOutputTokens: nonNegative(usage.totalReasoningOutputTokens ?? 0),
+    costMicroUsd: 0,
+  };
+}

--- a/apps/server/src/orchestration/usageSummary.ts
+++ b/apps/server/src/orchestration/usageSummary.ts
@@ -1,0 +1,276 @@
+import type { UsageAggregate, UsageSummaryResponse } from "@t3tools/contracts";
+import { USAGE_PRICING_VERSION, estimateCostMicroUsd } from "@t3tools/shared/usagePricing";
+
+import type { ProjectionUsageFact } from "../persistence/Services/ProjectionUsage.ts";
+
+/**
+ * Pure aggregation of usage facts into the dashboard-shaped summary. Calendar
+ * bucketing happens in the requested IANA timezone via Intl (DST folds into
+ * the local calendar naturally). `turn-total` facts are reconciliation-only
+ * and excluded from all sums; stale facts count (tokens were consumed).
+ */
+
+interface MutableAggregate {
+  inputTokens: number;
+  cachedInputTokens: number;
+  cacheCreationTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+  totalTokens: number;
+  turns: number;
+  exactCostMicroUsd: number;
+  estimatedCostMicroUsd: number;
+}
+
+function newAggregate(): MutableAggregate {
+  return {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    cacheCreationTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+    totalTokens: 0,
+    turns: 0,
+    exactCostMicroUsd: 0,
+    estimatedCostMicroUsd: 0,
+  };
+}
+
+function addFact(
+  aggregate: MutableAggregate,
+  fact: ProjectionUsageFact,
+  estimatedMicroUsd: number | undefined,
+): void {
+  aggregate.inputTokens += fact.inputTokens;
+  aggregate.cachedInputTokens += fact.cachedInputTokens;
+  aggregate.cacheCreationTokens += fact.cacheCreationTokens;
+  aggregate.outputTokens += fact.outputTokens;
+  aggregate.reasoningOutputTokens += fact.reasoningOutputTokens;
+  aggregate.totalTokens +=
+    fact.inputTokens + fact.cachedInputTokens + fact.cacheCreationTokens + fact.outputTokens;
+  if (fact.costMicroUsd !== null) {
+    aggregate.exactCostMicroUsd += fact.costMicroUsd;
+  } else if (estimatedMicroUsd !== undefined) {
+    aggregate.estimatedCostMicroUsd += estimatedMicroUsd;
+  }
+}
+
+function toAggregate(mutable: MutableAggregate): UsageAggregate {
+  return { ...mutable };
+}
+
+function makeCalendarFormatter(timeZone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+    weekday: "short",
+  });
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+interface CalendarParts {
+  readonly day: string;
+  readonly hour: number;
+  readonly dayOfWeek: number;
+}
+
+function calendarParts(formatter: Intl.DateTimeFormat, iso: string): CalendarParts {
+  const parts = formatter.formatToParts(Date.parse(iso));
+  let year = "",
+    month = "",
+    day = "",
+    hour = 0,
+    dayOfWeek = 0;
+  for (const part of parts) {
+    switch (part.type) {
+      case "year":
+        year = part.value;
+        break;
+      case "month":
+        month = part.value;
+        break;
+      case "day":
+        day = part.value;
+        break;
+      case "hour":
+        hour = Number(part.value) % 24;
+        break;
+      case "weekday":
+        dayOfWeek = WEEKDAY_INDEX[part.value] ?? 0;
+        break;
+    }
+  }
+  return { day: `${year}-${month}-${day}`, hour, dayOfWeek };
+}
+
+export type UsageProjectTitleLookup = (projectId: string) => string | null;
+
+export function summarizeUsageFacts(input: {
+  readonly facts: ReadonlyArray<ProjectionUsageFact>;
+  readonly timeZone: string;
+  readonly earliestFactAt: string | null;
+  readonly projectTitle: UsageProjectTitleLookup;
+}): UsageSummaryResponse {
+  const formatter = makeCalendarFormatter(input.timeZone);
+
+  const totals = newAggregate();
+  const byModel = new Map<
+    string,
+    MutableAggregate & { provider: ProjectionUsageFact["provider"]; hasEstimate: boolean }
+  >();
+  const daily = new Map<
+    string,
+    MutableAggregate & {
+      day: string;
+      provider: ProjectionUsageFact["provider"];
+      model: string;
+    }
+  >();
+  const hourOfWeek = new Map<
+    string,
+    { dayOfWeek: number; hour: number; turns: number; totalTokens: number }
+  >();
+  const byProject = new Map<
+    string,
+    MutableAggregate & { projectId: ProjectionUsageFact["projectId"] }
+  >();
+  const unpricedModels = new Set<string>();
+  const turnKeys = new Set<string>();
+  const turnKeysByScope = new Map<string, Set<string>>();
+
+  const scopedTurnCount = (scope: string, turnKey: string): number => {
+    let keys = turnKeysByScope.get(scope);
+    if (!keys) {
+      keys = new Set();
+      turnKeysByScope.set(scope, keys);
+    }
+    const before = keys.size;
+    keys.add(turnKey);
+    return keys.size - before;
+  };
+
+  for (const fact of input.facts) {
+    if (fact.kind === "turn-total") {
+      continue;
+    }
+    const estimated =
+      fact.costMicroUsd === null
+        ? estimateCostMicroUsd(fact.model, fact.observedAt, {
+            inputTokens: fact.inputTokens,
+            cachedInputTokens: fact.cachedInputTokens,
+            cacheCreationTokens: fact.cacheCreationTokens,
+            outputTokens: fact.outputTokens,
+          })
+        : undefined;
+    if (fact.costMicroUsd === null && estimated === undefined) {
+      unpricedModels.add(fact.model);
+    }
+
+    const cal = calendarParts(formatter, fact.observedAt);
+    const turnKey = `${fact.threadId}|${fact.turnId ?? fact.factId}`;
+    const factTokens =
+      fact.inputTokens + fact.cachedInputTokens + fact.cacheCreationTokens + fact.outputTokens;
+
+    addFact(totals, fact, estimated);
+    if (!turnKeys.has(turnKey)) {
+      turnKeys.add(turnKey);
+      totals.turns += 1;
+    }
+
+    const modelKey = `${fact.provider}|${fact.model}`;
+    let model = byModel.get(modelKey);
+    if (!model) {
+      model = { ...newAggregate(), provider: fact.provider, hasEstimate: false };
+      byModel.set(modelKey, model);
+    }
+    addFact(model, fact, estimated);
+    if (estimated !== undefined) model.hasEstimate = true;
+    model.turns += scopedTurnCount(`model:${modelKey}`, turnKey);
+
+    const dayKey = `${cal.day}|${fact.provider}|${fact.model}`;
+    let dayBucket = daily.get(dayKey);
+    if (!dayBucket) {
+      dayBucket = { ...newAggregate(), day: cal.day, provider: fact.provider, model: fact.model };
+      daily.set(dayKey, dayBucket);
+    }
+    addFact(dayBucket, fact, estimated);
+    dayBucket.turns += scopedTurnCount(`day:${dayKey}`, turnKey);
+
+    const howKey = `${cal.dayOfWeek}|${cal.hour}`;
+    let how = hourOfWeek.get(howKey);
+    if (!how) {
+      how = { dayOfWeek: cal.dayOfWeek, hour: cal.hour, turns: 0, totalTokens: 0 };
+      hourOfWeek.set(howKey, how);
+    }
+    how.totalTokens += factTokens;
+    how.turns += scopedTurnCount(`how:${howKey}`, turnKey);
+
+    const projectKey = fact.projectId ?? "__none__";
+    let project = byProject.get(projectKey);
+    if (!project) {
+      project = { ...newAggregate(), projectId: fact.projectId };
+      byProject.set(projectKey, project);
+    }
+    addFact(project, fact, estimated);
+    project.turns += scopedTurnCount(`project:${projectKey}`, turnKey);
+  }
+
+  const modelBuckets = [...byModel.entries()]
+    .map(([key, aggregate]) => ({
+      ...toAggregate(aggregate),
+      provider: aggregate.provider,
+      model: key.slice(key.indexOf("|") + 1),
+      costSource:
+        aggregate.exactCostMicroUsd > 0
+          ? ("exact" as const)
+          : aggregate.hasEstimate
+            ? ("estimated" as const)
+            : ("none" as const),
+    }))
+    .sort((a, b) => b.totalTokens - a.totalTokens);
+
+  const dailyBuckets = [...daily.values()]
+    .map((bucket) => ({
+      ...toAggregate(bucket),
+      day: bucket.day,
+      provider: bucket.provider,
+      model: bucket.model,
+    }))
+    .sort((a, b) => (a.day === b.day ? b.totalTokens - a.totalTokens : a.day.localeCompare(b.day)));
+
+  const hourBuckets = [...hourOfWeek.values()].sort(
+    (a, b) => a.dayOfWeek - b.dayOfWeek || a.hour - b.hour,
+  );
+
+  const projectBuckets = [...byProject.values()]
+    .map((bucket) => ({
+      ...toAggregate(bucket),
+      projectId: bucket.projectId,
+      projectTitle: bucket.projectId ? input.projectTitle(bucket.projectId) : null,
+    }))
+    .sort((a, b) => b.totalTokens - a.totalTokens);
+
+  return {
+    totals: toAggregate(totals),
+    byModel: modelBuckets,
+    daily: dailyBuckets,
+    hourOfWeek: hourBuckets,
+    byProject: projectBuckets,
+    unpricedModels: [...unpricedModels].sort(),
+    pricingVersion: USAGE_PRICING_VERSION,
+    earliestFactAt: input.earliestFactAt,
+  } as UsageSummaryResponse;
+}

--- a/apps/server/src/persistence/Layers/ProjectionUsage.ts
+++ b/apps/server/src/persistence/Layers/ProjectionUsage.ts
@@ -1,0 +1,221 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as SqlSchema from "effect/unstable/sql/SqlSchema";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Struct from "effect/Struct";
+import { IsoDateTime } from "@t3tools/contracts";
+
+import { toPersistenceSqlError } from "../Errors.ts";
+import {
+  ListProjectionUsageFactsInput,
+  ProjectionUsageFact,
+  ProjectionUsageRepository,
+  type ProjectionUsageRepositoryShape,
+  ProjectionUsageSessionModelSum,
+  RedactProjectionUsageThreadInput,
+} from "../Services/ProjectionUsage.ts";
+
+const ProjectionUsageFactDbRowSchema = ProjectionUsageFact.mapFields(
+  Struct.assign({
+    stale: Schema.Number,
+  }),
+);
+
+const EarliestObservedAtRowSchema = Schema.Struct({
+  earliestObservedAt: Schema.NullOr(IsoDateTime),
+});
+
+function toProjectionUsageFact(
+  row: Schema.Schema.Type<typeof ProjectionUsageFactDbRowSchema>,
+): ProjectionUsageFact {
+  return {
+    ...row,
+    stale: row.stale === 1,
+  };
+}
+
+const makeProjectionUsageRepository = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const upsertProjectionUsageFactRow = SqlSchema.void({
+    Request: ProjectionUsageFact,
+    execute: (row) =>
+      sql`
+        INSERT INTO projection_usage_facts (
+          fact_id,
+          thread_id,
+          turn_id,
+          project_id,
+          provider,
+          provider_instance_id,
+          provider_session_id,
+          model,
+          model_raw,
+          reasoning_effort,
+          kind,
+          input_tokens,
+          cached_input_tokens,
+          cache_creation_tokens,
+          output_tokens,
+          reasoning_output_tokens,
+          cost_micro_usd,
+          stale,
+          observed_at
+        )
+        VALUES (
+          ${row.factId},
+          ${row.threadId},
+          ${row.turnId},
+          ${row.projectId},
+          ${row.provider},
+          ${row.providerInstanceId},
+          ${row.providerSessionId},
+          ${row.model},
+          ${row.modelRaw},
+          ${row.reasoningEffort},
+          ${row.kind},
+          ${row.inputTokens},
+          ${row.cachedInputTokens},
+          ${row.cacheCreationTokens},
+          ${row.outputTokens},
+          ${row.reasoningOutputTokens},
+          ${row.costMicroUsd},
+          ${row.stale ? 1 : 0},
+          ${row.observedAt}
+        )
+        ON CONFLICT (fact_id)
+        DO UPDATE SET
+          thread_id = excluded.thread_id,
+          turn_id = excluded.turn_id,
+          project_id = excluded.project_id,
+          provider = excluded.provider,
+          provider_instance_id = excluded.provider_instance_id,
+          provider_session_id = excluded.provider_session_id,
+          model = excluded.model,
+          model_raw = excluded.model_raw,
+          reasoning_effort = excluded.reasoning_effort,
+          kind = excluded.kind,
+          input_tokens = excluded.input_tokens,
+          cached_input_tokens = excluded.cached_input_tokens,
+          cache_creation_tokens = excluded.cache_creation_tokens,
+          output_tokens = excluded.output_tokens,
+          reasoning_output_tokens = excluded.reasoning_output_tokens,
+          cost_micro_usd = excluded.cost_micro_usd,
+          stale = excluded.stale,
+          observed_at = excluded.observed_at
+      `,
+  });
+
+  const redactProjectionUsageThreadRows = SqlSchema.void({
+    Request: RedactProjectionUsageThreadInput,
+    execute: ({ threadId }) =>
+      sql`
+        UPDATE projection_usage_facts
+        SET thread_id = 'deleted', project_id = NULL
+        WHERE thread_id = ${threadId}
+      `,
+  });
+
+  const listProjectionUsageFactRows = SqlSchema.findAll({
+    Request: ListProjectionUsageFactsInput,
+    Result: ProjectionUsageFactDbRowSchema,
+    execute: ({ sinceIso, untilIso }) =>
+      sql`
+        SELECT
+          fact_id AS "factId",
+          thread_id AS "threadId",
+          turn_id AS "turnId",
+          project_id AS "projectId",
+          provider,
+          provider_instance_id AS "providerInstanceId",
+          provider_session_id AS "providerSessionId",
+          model,
+          model_raw AS "modelRaw",
+          reasoning_effort AS "reasoningEffort",
+          kind,
+          input_tokens AS "inputTokens",
+          cached_input_tokens AS "cachedInputTokens",
+          cache_creation_tokens AS "cacheCreationTokens",
+          output_tokens AS "outputTokens",
+          reasoning_output_tokens AS "reasoningOutputTokens",
+          cost_micro_usd AS "costMicroUsd",
+          stale,
+          observed_at AS "observedAt"
+        FROM projection_usage_facts
+        WHERE (${sinceIso ?? null} IS NULL OR observed_at >= ${sinceIso ?? null})
+          AND (${untilIso ?? null} IS NULL OR observed_at < ${untilIso ?? null})
+        ORDER BY observed_at ASC
+      `,
+  });
+
+  const readSessionModelSums = SqlSchema.findAll({
+    Request: Schema.Struct({ providerSessionId: Schema.String }),
+    Result: ProjectionUsageSessionModelSum,
+    execute: ({ providerSessionId }) =>
+      sql`
+        SELECT
+          model,
+          COALESCE(SUM(input_tokens), 0) AS "inputTokens",
+          COALESCE(SUM(cached_input_tokens), 0) AS "cachedInputTokens",
+          COALESCE(SUM(cache_creation_tokens), 0) AS "cacheCreationTokens",
+          COALESCE(SUM(output_tokens), 0) AS "outputTokens",
+          COALESCE(SUM(reasoning_output_tokens), 0) AS "reasoningOutputTokens",
+          COALESCE(SUM(COALESCE(cost_micro_usd, 0)), 0) AS "costMicroUsd"
+        FROM projection_usage_facts
+        WHERE provider_session_id = ${providerSessionId}
+          AND kind IN ('final', 'interval')
+        GROUP BY model
+      `,
+  });
+
+  const readEarliestObservedAt = SqlSchema.findOne({
+    Request: Schema.Void,
+    Result: EarliestObservedAtRowSchema,
+    execute: () =>
+      sql`
+        SELECT MIN(observed_at) AS "earliestObservedAt"
+        FROM projection_usage_facts
+      `,
+  });
+
+  const upsertFact: ProjectionUsageRepositoryShape["upsertFact"] = (row) =>
+    upsertProjectionUsageFactRow(row).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionUsageRepository.upsertFact:query")),
+    );
+
+  const redactThread: ProjectionUsageRepositoryShape["redactThread"] = (input) =>
+    redactProjectionUsageThreadRows(input).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionUsageRepository.redactThread:query")),
+    );
+
+  const listFacts: ProjectionUsageRepositoryShape["listFacts"] = (input) =>
+    listProjectionUsageFactRows(input).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionUsageRepository.listFacts:query")),
+      Effect.map((rows) => rows.map(toProjectionUsageFact)),
+    );
+
+  const earliestObservedAt: ProjectionUsageRepositoryShape["earliestObservedAt"] = () =>
+    readEarliestObservedAt(undefined).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionUsageRepository.earliestObservedAt:query")),
+      Effect.map((row) => row.earliestObservedAt),
+    );
+
+  const sumBySessionModel: ProjectionUsageRepositoryShape["sumBySessionModel"] = (input) =>
+    readSessionModelSums(input).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionUsageRepository.sumBySessionModel:query")),
+    );
+
+  return {
+    upsertFact,
+    redactThread,
+    listFacts,
+    earliestObservedAt,
+    sumBySessionModel,
+  } satisfies ProjectionUsageRepositoryShape;
+});
+
+export const ProjectionUsageRepositoryLive = Layer.effect(
+  ProjectionUsageRepository,
+  makeProjectionUsageRepository,
+);

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -45,6 +45,7 @@ import Migration0029 from "./Migrations/029_ProjectionThreadDetailOrderingIndexe
 import Migration0030 from "./Migrations/030_ProjectionThreadShellArchiveIndexes.ts";
 import Migration0031 from "./Migrations/031_AuthAuthorizationScopes.ts";
 import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
+import Migration0033 from "./Migrations/033_ProjectionUsage.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -89,6 +90,7 @@ export const migrationEntries = [
   [30, "ProjectionThreadShellArchiveIndexes", Migration0030],
   [31, "AuthAuthorizationScopes", Migration0031],
   [32, "AuthPairingProofKeyThumbprint", Migration0032],
+  [33, "ProjectionUsage", Migration0033],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/033_ProjectionUsage.ts
+++ b/apps/server/src/persistence/Migrations/033_ProjectionUsage.ts
@@ -1,0 +1,45 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS projection_usage_facts (
+      fact_id TEXT PRIMARY KEY,
+      thread_id TEXT NOT NULL,
+      turn_id TEXT,
+      project_id TEXT,
+      provider TEXT NOT NULL,
+      provider_instance_id TEXT,
+      provider_session_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      model_raw TEXT NOT NULL,
+      reasoning_effort TEXT,
+      kind TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+      cost_micro_usd INTEGER,
+      stale INTEGER NOT NULL DEFAULT 0,
+      observed_at TEXT NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_usage_facts_observed_at
+    ON projection_usage_facts(observed_at)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_usage_facts_provider_model
+    ON projection_usage_facts(provider, model)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_usage_facts_thread_id
+    ON projection_usage_facts(thread_id)
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionUsage.ts
+++ b/apps/server/src/persistence/Services/ProjectionUsage.ts
@@ -1,0 +1,89 @@
+import {
+  IsoDateTime,
+  NonNegativeInt,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TrimmedNonEmptyString,
+  TurnId,
+  UsageFactId,
+  UsageFactKind,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import type { ProjectionRepositoryError } from "../Errors.ts";
+
+export const ProjectionUsageFact = Schema.Struct({
+  factId: UsageFactId,
+  threadId: ThreadId,
+  turnId: Schema.NullOr(TurnId),
+  projectId: Schema.NullOr(ProjectId),
+  provider: ProviderDriverKind,
+  providerInstanceId: Schema.NullOr(ProviderInstanceId),
+  providerSessionId: TrimmedNonEmptyString,
+  model: TrimmedNonEmptyString,
+  modelRaw: TrimmedNonEmptyString,
+  reasoningEffort: Schema.NullOr(TrimmedNonEmptyString),
+  kind: UsageFactKind,
+  inputTokens: NonNegativeInt,
+  cachedInputTokens: NonNegativeInt,
+  cacheCreationTokens: NonNegativeInt,
+  outputTokens: NonNegativeInt,
+  reasoningOutputTokens: NonNegativeInt,
+  costMicroUsd: Schema.NullOr(NonNegativeInt),
+  stale: Schema.Boolean,
+  observedAt: IsoDateTime,
+});
+export type ProjectionUsageFact = typeof ProjectionUsageFact.Type;
+
+export const RedactProjectionUsageThreadInput = Schema.Struct({
+  threadId: ThreadId,
+});
+export type RedactProjectionUsageThreadInput = typeof RedactProjectionUsageThreadInput.Type;
+
+export const ListProjectionUsageFactsInput = Schema.Struct({
+  sinceIso: Schema.optional(IsoDateTime),
+  untilIso: Schema.optional(IsoDateTime),
+});
+export type ListProjectionUsageFactsInput = typeof ListProjectionUsageFactsInput.Type;
+
+/** Per-model sums of everything already recorded for one provider-native
+ * session. Used as the durable baseline when converting a provider's
+ * cumulative counters into interval facts — after a restart the in-memory
+ * baseline is gone, and resuming from recorded sums prevents double counting. */
+export const ProjectionUsageSessionModelSum = Schema.Struct({
+  model: TrimmedNonEmptyString,
+  inputTokens: NonNegativeInt,
+  cachedInputTokens: NonNegativeInt,
+  cacheCreationTokens: NonNegativeInt,
+  outputTokens: NonNegativeInt,
+  reasoningOutputTokens: NonNegativeInt,
+  costMicroUsd: NonNegativeInt,
+});
+export type ProjectionUsageSessionModelSum = typeof ProjectionUsageSessionModelSum.Type;
+
+export interface ProjectionUsageRepositoryShape {
+  readonly upsertFact: (row: ProjectionUsageFact) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  readonly redactThread: (
+    input: RedactProjectionUsageThreadInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  readonly listFacts: (
+    input: ListProjectionUsageFactsInput,
+  ) => Effect.Effect<ReadonlyArray<ProjectionUsageFact>, ProjectionRepositoryError>;
+
+  readonly earliestObservedAt: () => Effect.Effect<string | null, ProjectionRepositoryError>;
+
+  readonly sumBySessionModel: (input: {
+    readonly providerSessionId: string;
+  }) => Effect.Effect<ReadonlyArray<ProjectionUsageSessionModelSum>, ProjectionRepositoryError>;
+}
+
+export class ProjectionUsageRepository extends Context.Service<
+  ProjectionUsageRepository,
+  ProjectionUsageRepositoryShape
+>()("t3/persistence/Services/ProjectionUsage/ProjectionUsageRepository") {}

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2802,9 +2802,7 @@ describe("ClaudeAdapterLive", () => {
       if (requested.value.type !== "request.opened") {
         return;
       }
-      assert.deepEqual(requested.value.providerRefs, {
-        providerItemId: ProviderItemId.make("tool-use-1"),
-      });
+      assert.equal(requested.value.providerRefs?.providerItemId, ProviderItemId.make("tool-use-1"));
       const runtimeRequestId = requested.value.requestId;
       assert.equal(typeof runtimeRequestId, "string");
       if (runtimeRequestId === undefined) {
@@ -2828,9 +2826,7 @@ describe("ClaudeAdapterLive", () => {
       }
       assert.equal(resolved.value.requestId, requested.value.requestId);
       assert.equal(resolved.value.payload.decision, "accept");
-      assert.deepEqual(resolved.value.providerRefs, {
-        providerItemId: ProviderItemId.make("tool-use-1"),
-      });
+      assert.equal(resolved.value.providerRefs?.providerItemId, ProviderItemId.make("tool-use-1"));
 
       const permissionResult = yield* Effect.promise(() => permissionPromise);
       assert.equal((permissionResult as PermissionResult).behavior, "allow");
@@ -3440,9 +3436,10 @@ describe("ClaudeAdapterLive", () => {
         return;
       }
       assert.equal(proposedEvent.value.payload.planMarkdown, "# Ship it\n\n- one\n- two");
-      assert.deepEqual(proposedEvent.value.providerRefs, {
-        providerItemId: ProviderItemId.make("tool-exit-1"),
-      });
+      assert.equal(
+        proposedEvent.value.providerRefs?.providerItemId,
+        ProviderItemId.make("tool-exit-1"),
+      );
 
       const permissionResult = yield* Effect.promise(() => permissionPromise);
       assert.equal((permissionResult as PermissionResult).behavior, "deny");
@@ -3518,9 +3515,10 @@ describe("ClaudeAdapterLive", () => {
         return;
       }
       assert.equal(proposedEvent.value.payload.planMarkdown, "# Final plan\n\n- capture it");
-      assert.deepEqual(proposedEvent.value.providerRefs, {
-        providerItemId: ProviderItemId.make("tool-exit-2"),
-      });
+      assert.equal(
+        proposedEvent.value.providerRefs?.providerItemId,
+        ProviderItemId.make("tool-exit-2"),
+      );
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -3612,9 +3610,10 @@ describe("ClaudeAdapterLive", () => {
       // Regression for #2388: `id` must equal the full question text so the
       // UI's draft-answer key matches what the SDK looks up downstream.
       assert.equal(requestedEvent.value.payload.questions[0]?.id, "Which framework?");
-      assert.deepEqual(requestedEvent.value.providerRefs, {
-        providerItemId: ProviderItemId.make("tool-ask-1"),
-      });
+      assert.equal(
+        requestedEvent.value.providerRefs?.providerItemId,
+        ProviderItemId.make("tool-ask-1"),
+      );
 
       // Respond with the user's answers.
       yield* adapter.respondToUserInput(session.threadId, ApprovalRequestId.make(requestId!), {
@@ -3634,9 +3633,10 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(resolvedEvent.value.payload.answers, {
         "Which framework?": "React",
       });
-      assert.deepEqual(resolvedEvent.value.providerRefs, {
-        providerItemId: ProviderItemId.make("tool-ask-1"),
-      });
+      assert.equal(
+        resolvedEvent.value.providerRefs?.providerItemId,
+        ProviderItemId.make("tool-ask-1"),
+      );
 
       // The canUseTool promise should resolve with the answers in SDK format.
       const permissionResult = yield* Effect.promise(() => permissionPromise);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1014,17 +1014,21 @@ function streamKindFromDeltaType(deltaType: string): ClaudeTextStreamKind {
 }
 
 function nativeProviderRefs(
-  _context: ClaudeSessionContext,
+  context: ClaudeSessionContext,
   options?: {
     readonly providerItemId?: string | undefined;
   },
 ): NonNullable<ProviderRuntimeEvent["providerRefs"]> {
+  // The Claude SDK session id is the provider-native identity that usage
+  // accounting keys cumulative counters on; carry it on every event.
+  const sessionRef = context.resumeSessionId ? { providerSessionId: context.resumeSessionId } : {};
   if (options?.providerItemId) {
     return {
+      ...sessionRef,
       providerItemId: ProviderItemId.make(options.providerItemId),
     };
   }
-  return {};
+  return sessionRef;
 }
 
 function extractAssistantTextBlocks(message: SDKMessage): Array<string> {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1136,6 +1136,10 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
       NodeAssert.deepEqual(firstEvent.value.payload.usage, {
         usedTokens: 126,
         totalProcessedTokens: 11_839,
+        totalInputTokens: 11_833,
+        totalCachedInputTokens: 3456,
+        totalOutputTokens: 6,
+        totalReasoningOutputTokens: 0,
         maxTokens: 258_400,
         inputTokens: 120,
         cachedInputTokens: 0,
@@ -1148,6 +1152,9 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         lastReasoningOutputTokens: 0,
         compactsAutomatically: true,
       });
+      // The Codex-native thread id must ride providerRefs so usage accounting
+      // can separate concurrent provider sessions on one canonical thread.
+      NodeAssert.equal(firstEvent.value.providerRefs?.providerSessionId, "thread-1");
     }),
   );
 });

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -168,9 +168,17 @@ function normalizeCodexTokenUsage(
   const cachedInputTokens = usage.last.cachedInputTokens;
   const outputTokens = usage.last.outputTokens;
   const reasoningOutputTokens = usage.last.reasoningOutputTokens;
+  const totalInputTokens = usage.total.inputTokens;
+  const totalCachedInputTokens = usage.total.cachedInputTokens;
+  const totalOutputTokens = usage.total.outputTokens;
+  const totalReasoningOutputTokens = usage.total.reasoningOutputTokens;
 
   return {
     usedTokens,
+    ...(totalInputTokens !== undefined ? { totalInputTokens } : {}),
+    ...(totalCachedInputTokens !== undefined ? { totalCachedInputTokens } : {}),
+    ...(totalOutputTokens !== undefined ? { totalOutputTokens } : {}),
+    ...(totalReasoningOutputTokens !== undefined ? { totalReasoningOutputTokens } : {}),
     ...(totalProcessedTokens !== undefined && totalProcessedTokens > usedTokens
       ? { totalProcessedTokens }
       : {}),
@@ -741,10 +749,17 @@ function mapToRuntimeEvents(
     if (!normalizedUsage) {
       return [];
     }
+    const base = runtimeEventBase(event, canonicalThreadId);
+    // The Codex-native thread id disambiguates cumulative counters when
+    // several provider sessions (subagents) share one canonical T3 thread.
+    const nativeThreadId = payload?.threadId;
     return [
       {
         type: "thread.token-usage.updated",
-        ...runtimeEventBase(event, canonicalThreadId),
+        ...base,
+        ...(nativeThreadId
+          ? { providerRefs: { ...base.providerRefs, providerSessionId: nativeThreadId } }
+          : {}),
         payload: {
           usage: normalizedUsage,
         },

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -80,6 +80,7 @@ import * as ExternalLauncher from "./process/externalLauncher.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import { OrchestrationListenerCallbackError } from "./orchestration/Errors.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProjectionUsageRepository } from "./persistence/Services/ProjectionUsage.ts";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
@@ -713,23 +714,32 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(CheckpointDiffQuery.CheckpointDiffQuery)({
-          getTurnDiff: () =>
-            Effect.succeed({
-              threadId: defaultThreadId,
-              fromTurnCount: 0,
-              toTurnCount: 0,
-              diff: "",
-            }),
-          getFullThreadDiff: () =>
-            Effect.succeed({
-              threadId: defaultThreadId,
-              fromTurnCount: 0,
-              toTurnCount: 0,
-              diff: "",
-            }),
-          ...options?.layers?.checkpointDiffQuery,
-        }),
+        Layer.mergeAll(
+          Layer.mock(ProjectionUsageRepository)({
+            upsertFact: () => Effect.void,
+            redactThread: () => Effect.void,
+            listFacts: () => Effect.succeed([]),
+            earliestObservedAt: () => Effect.succeed(null),
+            sumBySessionModel: () => Effect.succeed([]),
+          }),
+          Layer.mock(CheckpointDiffQuery.CheckpointDiffQuery)({
+            getTurnDiff: () =>
+              Effect.succeed({
+                threadId: defaultThreadId,
+                fromTurnCount: 0,
+                toTurnCount: 0,
+                diff: "",
+              }),
+            getFullThreadDiff: () =>
+              Effect.succeed({
+                threadId: defaultThreadId,
+                fromTurnCount: 0,
+                toTurnCount: 0,
+                diff: "",
+              }),
+            ...options?.layers?.checkpointDiffQuery,
+          }),
+        ),
       ),
     );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -71,6 +71,8 @@ import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { normalizeDispatchCommand } from "./orchestration/Normalizer.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProjectionUsageRepository } from "./persistence/Services/ProjectionUsage.ts";
+import { summarizeUsageFacts } from "./orchestration/usageSummary.ts";
 import {
   observeRpcEffect as instrumentRpcEffect,
   observeRpcStream as instrumentRpcStream,
@@ -302,6 +304,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.serverUpdateSettings, AuthOrchestrationOperateScope],
   [WS_METHODS.serverDiscoverSourceControl, AuthOrchestrationReadScope],
   [WS_METHODS.serverGetTraceDiagnostics, AuthOrchestrationReadScope],
+  [WS_METHODS.usageGetSummary, AuthOrchestrationReadScope],
   [WS_METHODS.serverGetProcessDiagnostics, AuthOrchestrationReadScope],
   [WS_METHODS.serverGetProcessResourceHistory, AuthOrchestrationReadScope],
   [WS_METHODS.serverSignalProcess, AuthOrchestrationOperateScope],
@@ -405,6 +408,7 @@ const makeWsRpcLayer = (
       const currentSessionId = currentSession.sessionId;
       const crypto = yield* Crypto.Crypto;
       const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+      const projectionUsageRepository = yield* ProjectionUsageRepository;
       const orchestrationEngine = yield* OrchestrationEngine.OrchestrationEngineService;
       const checkpointDiffQuery = yield* CheckpointDiffQuery.CheckpointDiffQuery;
       const keybindings = yield* Keybindings.Keybindings;
@@ -1532,6 +1536,38 @@ const makeWsRpcLayer = (
             {
               "rpc.aggregate": "server",
             },
+          ),
+        [WS_METHODS.usageGetSummary]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.usageGetSummary,
+            Effect.gen(function* () {
+              const facts = yield* projectionUsageRepository.listFacts({
+                ...(input.since !== undefined ? { sinceIso: input.since } : {}),
+                ...(input.until !== undefined ? { untilIso: input.until } : {}),
+              });
+              const earliestFactAt = yield* projectionUsageRepository.earliestObservedAt();
+              const projectIds = [
+                ...new Set(facts.flatMap((fact) => (fact.projectId ? [fact.projectId] : []))),
+              ];
+              const projectTitles = new Map<string, string | null>();
+              yield* Effect.forEach(
+                projectIds,
+                (projectId) =>
+                  projectionSnapshotQuery.getProjectShellById(projectId).pipe(
+                    Effect.map((shell) => {
+                      projectTitles.set(projectId, Option.isSome(shell) ? shell.value.title : null);
+                    }),
+                  ),
+                { concurrency: 4 },
+              );
+              return summarizeUsageFacts({
+                facts,
+                timeZone: input.timeZone,
+                earliestFactAt,
+                projectTitle: (projectId: string) => projectTitles.get(projectId) ?? null,
+              });
+            }).pipe(Effect.orDie),
+            { "rpc.aggregate": "usage" },
           ),
         [WS_METHODS.serverGetProcessDiagnostics]: (_input) =>
           observeRpcEffect(WS_METHODS.serverGetProcessDiagnostics, processDiagnostics.read, {

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -3,6 +3,7 @@ import {
   ArchiveIcon,
   ArrowLeftIcon,
   BotIcon,
+  ChartColumnIcon,
   GitBranchIcon,
   KeyboardIcon,
   Link2Icon,
@@ -28,6 +29,7 @@ export type SettingsSectionPath =
   | "/settings/providers"
   | "/settings/source-control"
   | "/settings/connections"
+  | "/settings/usage"
   | "/settings/archived";
 
 export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
@@ -40,6 +42,7 @@ export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
   { label: "Providers", to: "/settings/providers", icon: BotIcon },
   { label: "Source Control", to: "/settings/source-control", icon: GitBranchIcon },
   { label: "Connections", to: "/settings/connections", icon: Link2Icon },
+  { label: "Usage", to: "/settings/usage", icon: ChartColumnIcon },
   { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },
 ];
 

--- a/apps/web/src/components/settings/UsageSettings.tsx
+++ b/apps/web/src/components/settings/UsageSettings.tsx
@@ -1,0 +1,605 @@
+import { useMemo } from "react";
+import type { UsageDailyBucket, UsageModelBucket, UsageSummaryResponse } from "@t3tools/contracts";
+
+import { cn } from "../../lib/utils";
+import { useEnvironmentQuery } from "../../state/query";
+import { serverEnvironment } from "../../state/server";
+import { usePrimaryEnvironment } from "../../state/environments";
+import { ClaudeAI, OpenAI } from "../Icons";
+import { Button } from "../ui/button";
+import { SettingsPageContainer, SettingsSection } from "./settingsLayout";
+
+// Family color system from the approved mock: hue = harness, lightness =
+// model within the family. Codex renders as off-white on dark surfaces.
+const CLAUDE_COLOR = "#cf6b48";
+const CODEX_COLOR = "#e8e8e3";
+const harnessColor = (provider: string): string =>
+  provider === "claudeAgent" ? CLAUDE_COLOR : CODEX_COLOR;
+const CLAUDE_MODEL_SHADES = ["#cf6b48", "#f2c1a4", "#a3492a"];
+const CODEX_MODEL_SHADES = ["#e8e8e3", "#9c9c96"];
+const NEUTRAL_SHADE = "#8a8880";
+const T3_ACCENT = "#9085e9";
+
+function isClaudeProvider(provider: string): boolean {
+  return provider === "claudeAgent";
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
+  return `${value}`;
+}
+
+function formatMicroUsd(micro: number): string {
+  const usd = micro / 1_000_000;
+  if (usd >= 100) return `$${Math.round(usd).toLocaleString()}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function providerLogo(provider: string, className?: string) {
+  return isClaudeProvider(provider) ? (
+    <ClaudeAI className={cn("size-3.5 shrink-0", className)} />
+  ) : (
+    <OpenAI className={cn("size-3.5 shrink-0", className)} />
+  );
+}
+
+interface DonutSlice {
+  readonly key: string;
+  readonly value: number;
+  readonly color: string;
+  readonly estimated?: boolean;
+  readonly groupColor: string;
+  readonly groupShare: number;
+  readonly groupStart: boolean;
+}
+
+function assignModelShades(models: ReadonlyArray<UsageModelBucket>): Map<string, string> {
+  const shades = new Map<string, string>();
+  let claudeIndex = 0;
+  let codexIndex = 0;
+  for (const bucket of models) {
+    if (isClaudeProvider(bucket.provider)) {
+      shades.set(bucket.model, CLAUDE_MODEL_SHADES[claudeIndex] ?? NEUTRAL_SHADE);
+      claudeIndex += 1;
+    } else {
+      shades.set(bucket.model, CODEX_MODEL_SHADES[codexIndex] ?? NEUTRAL_SHADE);
+      codexIndex += 1;
+    }
+  }
+  return shades;
+}
+
+function Donut({
+  slices,
+  center,
+  centerSub,
+  ariaLabel,
+}: {
+  slices: ReadonlyArray<DonutSlice>;
+  center: string;
+  centerSub: string;
+  ariaLabel: string;
+}) {
+  const total = slices.reduce((sum, slice) => sum + slice.value, 0);
+  const cx = 150;
+  const cy = 150;
+  const outer = 140;
+  const inner = 96;
+  const tau = Math.PI * 2;
+  const point = (angle: number, radius: number) =>
+    `${(cx + Math.cos(angle) * radius).toFixed(2)} ${(cy + Math.sin(angle) * radius).toFixed(2)}`;
+
+  let angle = -Math.PI / 2;
+  const paths: Array<{ d: string; color: string; estimated: boolean; title: string }> = [];
+  const labels: Array<{ x: number; y: number; text: string; dark: boolean }> = [];
+  let groupStartAngle = angle;
+
+  for (const slice of slices) {
+    if (slice.groupStart) {
+      groupStartAngle = angle;
+    }
+    const sweep = total > 0 ? (slice.value / total) * tau : 0;
+    const end = angle + sweep;
+    const gap = Math.min(0.014, sweep * 0.3);
+    const from = angle + gap / 2;
+    const to = end - gap / 2;
+    if (to > from) {
+      const large = to - from > Math.PI ? 1 : 0;
+      paths.push({
+        d: `M ${point(from, outer)} A ${outer} ${outer} 0 ${large} 1 ${point(to, outer)} L ${point(to, inner)} A ${inner} ${inner} 0 ${large} 0 ${point(from, inner)} Z`,
+        color: slice.color,
+        estimated: slice.estimated ?? false,
+        title: slice.key,
+      });
+    }
+    angle = end;
+
+    const groupShare = slice.groupShare;
+    const isGroupEnd =
+      slices.indexOf(slice) === slices.length - 1 || slices[slices.indexOf(slice) + 1]?.groupStart;
+    if (isGroupEnd && groupShare >= 0.08) {
+      const mid = (groupStartAngle + angle) / 2;
+      const radius = (outer + inner) / 2;
+      const hex = slice.groupColor.replace("#", "");
+      const luminance =
+        parseInt(hex.slice(0, 2), 16) * 0.299 +
+        parseInt(hex.slice(2, 4), 16) * 0.587 +
+        parseInt(hex.slice(4, 6), 16) * 0.114;
+      labels.push({
+        x: cx + Math.cos(mid) * radius,
+        y: cy + Math.sin(mid) * radius,
+        text: `${Math.round(groupShare * 100)}%`,
+        dark: luminance > 150,
+      });
+    }
+  }
+
+  return (
+    <div className="relative mx-auto w-full max-w-[270px]">
+      <svg viewBox="0 0 300 300" role="img" aria-label={ariaLabel}>
+        <defs>
+          <pattern
+            id="usage-est-stripes"
+            patternUnits="userSpaceOnUse"
+            width="7"
+            height="7"
+            patternTransform="rotate(45)"
+          >
+            <line x1="0" y1="0" x2="0" y2="7" stroke="rgba(0,0,0,0.35)" strokeWidth="2.5" />
+          </pattern>
+        </defs>
+        {paths.map((path) => (
+          <g key={path.title + path.d.slice(0, 24)}>
+            <path d={path.d} fill={path.color}>
+              <title>{path.title}</title>
+            </path>
+            {path.estimated ? <path d={path.d} fill="url(#usage-est-stripes)" /> : null}
+          </g>
+        ))}
+        {labels.map((label) => (
+          <text
+            key={`${label.x}-${label.y}`}
+            x={label.x}
+            y={label.y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            style={{ fill: label.dark ? "#1a1a19" : "#fff", fontSize: 15, fontWeight: 680 }}
+          >
+            {label.text}
+          </text>
+        ))}
+      </svg>
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+        <div className="text-3xl font-semibold tracking-tight">{center}</div>
+        <div className="mt-1 text-[11px] text-muted-foreground">{centerSub}</div>
+      </div>
+    </div>
+  );
+}
+
+function DailyBars({ daily }: { daily: ReadonlyArray<UsageDailyBucket> }) {
+  const byDay = useMemo(() => {
+    const map = new Map<string, Array<UsageDailyBucket>>();
+    for (const bucket of daily) {
+      const list = map.get(bucket.day) ?? [];
+      list.push(bucket);
+      map.set(bucket.day, list);
+    }
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [daily]);
+
+  const maxDay = Math.max(
+    1,
+    ...byDay.map(([, buckets]) => buckets.reduce((sum, bucket) => sum + bucket.totalTokens, 0)),
+  );
+
+  if (byDay.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-40 items-end gap-[3px] overflow-x-auto rounded-md bg-black/20 p-3">
+      {byDay.map(([day, buckets]) => {
+        const dayTotal = buckets.reduce((sum, bucket) => sum + bucket.totalTokens, 0);
+        return (
+          <div
+            key={day}
+            className="flex min-w-[14px] flex-1 flex-col-reverse gap-px"
+            title={`${day}: ${formatTokens(dayTotal)} tokens`}
+          >
+            {buckets.map((bucket) => (
+              <div
+                key={`${day}-${bucket.provider}-${bucket.model}`}
+                style={{
+                  height: `${Math.max((bucket.totalTokens / maxDay) * 100, 1.5)}%`,
+                  background: harnessColor(bucket.provider),
+                }}
+                className="w-full rounded-[2px]"
+              />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function HourHeatmap({ summary }: { summary: UsageSummaryResponse }) {
+  const grid = useMemo(() => {
+    const cells = new Map<string, number>();
+    let max = 0;
+    for (const bucket of summary.hourOfWeek) {
+      cells.set(`${bucket.dayOfWeek}-${bucket.hour}`, bucket.turns);
+      max = Math.max(max, bucket.turns);
+    }
+    return { cells, max: Math.max(max, 1) };
+  }, [summary.hourOfWeek]);
+
+  const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="grid min-w-[560px] grid-cols-[34px_repeat(24,1fr)] gap-[2px]">
+        <div />
+        {Array.from({ length: 24 }, (_, hour) => (
+          <div key={hour} className="text-center text-[9px] text-muted-foreground">
+            {hour % 6 === 0
+              ? hour === 0
+                ? "12a"
+                : hour < 12
+                  ? `${hour}a`
+                  : hour === 12
+                    ? "12p"
+                    : `${hour - 12}p`
+              : ""}
+          </div>
+        ))}
+        {dayLabels.map((label, dayOfWeek) => (
+          <>
+            <div key={label} className="self-center text-[10px] text-muted-foreground">
+              {label}
+            </div>
+            {Array.from({ length: 24 }, (_, hour) => {
+              const turns = grid.cells.get(`${dayOfWeek}-${hour}`) ?? 0;
+              const alpha = turns === 0 ? 0 : 0.18 + 0.82 * Math.sqrt(turns / grid.max);
+              return (
+                <div
+                  key={`${label}-${hour}`}
+                  title={`${label} ${hour}:00 — ${turns} turn${turns === 1 ? "" : "s"}`}
+                  className="aspect-[1.5] min-w-[14px] rounded-[3px]"
+                  style={{
+                    background:
+                      turns === 0
+                        ? "rgba(255,255,255,0.03)"
+                        : `rgba(144,133,233,${alpha.toFixed(2)})`,
+                  }}
+                />
+              );
+            })}
+          </>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function UsageSettingsPanel() {
+  const primaryEnvironment = usePrimaryEnvironment();
+  const environmentId = primaryEnvironment?.environmentId ?? null;
+  const timeZone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone, []);
+
+  const { data, error, isPending, refresh } = useEnvironmentQuery(
+    environmentId === null
+      ? null
+      : serverEnvironment.usageSummary({ environmentId, input: { timeZone } }),
+  );
+
+  const summary = data ?? null;
+  const modelShades = useMemo(
+    () => (summary ? assignModelShades(summary.byModel) : new Map<string, string>()),
+    [summary],
+  );
+
+  const tokenSlices = useMemo(() => {
+    if (!summary) return [];
+    const claude = summary.byModel.filter((bucket) => isClaudeProvider(bucket.provider));
+    const codex = summary.byModel.filter((bucket) => !isClaudeProvider(bucket.provider));
+    const total = Math.max(summary.totals.totalTokens, 1);
+    const groupTotal = (buckets: ReadonlyArray<UsageModelBucket>) =>
+      buckets.reduce((sum, bucket) => sum + bucket.totalTokens, 0);
+    const slices: Array<DonutSlice> = [];
+    for (const [group, groupColor] of [
+      [claude, CLAUDE_COLOR],
+      [codex, CODEX_COLOR],
+    ] as const) {
+      group.forEach((bucket, index) => {
+        slices.push({
+          key: `${bucket.model}: ${formatTokens(bucket.totalTokens)} tokens`,
+          value: bucket.totalTokens,
+          color: modelShades.get(bucket.model) ?? NEUTRAL_SHADE,
+          groupColor,
+          groupShare: groupTotal(group) / total,
+          groupStart: index === 0,
+        });
+      });
+    }
+    return slices;
+  }, [summary, modelShades]);
+
+  const costSlices = useMemo(() => {
+    if (!summary) return [];
+    const priced = summary.byModel.filter(
+      (bucket) => bucket.exactCostMicroUsd > 0 || bucket.estimatedCostMicroUsd > 0,
+    );
+    const claude = priced.filter((bucket) => isClaudeProvider(bucket.provider));
+    const codex = priced.filter((bucket) => !isClaudeProvider(bucket.provider));
+    const total = Math.max(
+      priced.reduce(
+        (sum, bucket) => sum + bucket.exactCostMicroUsd + bucket.estimatedCostMicroUsd,
+        0,
+      ),
+      1,
+    );
+    const groupTotal = (buckets: ReadonlyArray<UsageModelBucket>) =>
+      buckets.reduce(
+        (sum, bucket) => sum + bucket.exactCostMicroUsd + bucket.estimatedCostMicroUsd,
+        0,
+      );
+    const slices: Array<DonutSlice> = [];
+    for (const [group, groupColor] of [
+      [claude, CLAUDE_COLOR],
+      [codex, CODEX_COLOR],
+    ] as const) {
+      group.forEach((bucket, index) => {
+        const value = bucket.exactCostMicroUsd + bucket.estimatedCostMicroUsd;
+        const estimated = bucket.exactCostMicroUsd === 0;
+        slices.push({
+          key: `${bucket.model}: ${formatMicroUsd(value)}${estimated ? " (est.)" : ""}`,
+          value,
+          color: modelShades.get(bucket.model) ?? NEUTRAL_SHADE,
+          estimated,
+          groupColor,
+          groupShare: groupTotal(group) / total,
+          groupStart: index === 0,
+        });
+      });
+    }
+    return slices;
+  }, [summary, modelShades]);
+
+  if (environmentId === null) {
+    return (
+      <SettingsPageContainer>
+        <UsagePageHeader />
+        <p className="text-sm text-muted-foreground">Connect an environment to see usage.</p>
+      </SettingsPageContainer>
+    );
+  }
+
+  if (isPending && !summary) {
+    return (
+      <SettingsPageContainer>
+        <UsagePageHeader />
+        <p className="text-sm text-muted-foreground">Loading usage…</p>
+      </SettingsPageContainer>
+    );
+  }
+
+  if (error || !summary) {
+    return (
+      <SettingsPageContainer>
+        <UsagePageHeader />
+        <div>
+          <p className="text-sm text-muted-foreground">Could not load usage data.</p>
+          <Button variant="outline" size="sm" className="mt-3" onClick={() => refresh()}>
+            Retry
+          </Button>
+        </div>
+      </SettingsPageContainer>
+    );
+  }
+
+  const exactCost = summary.totals.exactCostMicroUsd;
+  const estimatedCost = summary.totals.estimatedCostMicroUsd;
+  const cacheHitRate =
+    summary.totals.inputTokens + summary.totals.cachedInputTokens > 0
+      ? (summary.totals.cachedInputTokens /
+          (summary.totals.inputTokens +
+            summary.totals.cachedInputTokens +
+            summary.totals.cacheCreationTokens)) *
+        100
+      : 0;
+
+  return (
+    <SettingsPageContainer>
+      <UsagePageHeader />
+      <SettingsSection title="Overview">
+        <div className="grid gap-8 md:grid-cols-2">
+          <div>
+            <div className="mb-3 text-center text-[13px] font-semibold">
+              Tokens
+              <span className="block text-[11px] font-normal text-muted-foreground">
+                all processed, by harness
+              </span>
+            </div>
+            <Donut
+              slices={tokenSlices}
+              center={formatTokens(summary.totals.totalTokens)}
+              centerSub={
+                summary.earliestFactAt ? `since ${summary.earliestFactAt.slice(0, 10)}` : "all time"
+              }
+              ariaLabel="Tokens by harness and model"
+            />
+          </div>
+          <div>
+            <div className="mb-3 text-center text-[13px] font-semibold">
+              Cost
+              <span className="block text-[11px] font-normal text-muted-foreground">
+                exact where metered · striped slices are list-price estimates
+              </span>
+            </div>
+            <Donut
+              slices={costSlices}
+              center={formatMicroUsd(exactCost + estimatedCost)}
+              centerSub={`${formatMicroUsd(exactCost)} exact + ${formatMicroUsd(estimatedCost)} est.`}
+              ariaLabel="Cost by harness and model"
+            />
+          </div>
+        </div>
+        <div className="mt-6 grid grid-cols-2 gap-2 lg:grid-cols-5">
+          <StatTile
+            label="Output tokens"
+            value={formatTokens(summary.totals.outputTokens)}
+            sub="generated text"
+          />
+          <StatTile label="Exact spend" value={formatMicroUsd(exactCost)} sub="provider-metered" />
+          <StatTile
+            label="Estimated value"
+            value={`~${formatMicroUsd(estimatedCost)}`}
+            sub="list price · plan-covered"
+          />
+          <StatTile label="Turns" value={`${summary.totals.turns}`} sub="recorded in ledger" />
+          <StatTile
+            label="Cache hit rate"
+            value={`${cacheHitRate.toFixed(1)}%`}
+            sub="of input tokens"
+            accent
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title="Tokens per day">
+        <DailyBars daily={summary.daily} />
+      </SettingsSection>
+
+      <SettingsSection title="When you use T3 Code">
+        <p className="mb-3 text-xs text-muted-foreground">
+          Turn starts by local hour and weekday ({timeZone}). Darker means more turns.
+        </p>
+        <HourHeatmap summary={summary} />
+      </SettingsSection>
+
+      <SettingsSection title="Models">
+        <table className="w-full text-[13px]">
+          <thead>
+            <tr className="border-b border-border/60 text-[11px] text-muted-foreground">
+              <th className="py-1.5 text-left font-medium">Model</th>
+              <th className="py-1.5 text-right font-medium">Turns</th>
+              <th className="py-1.5 text-right font-medium">Tokens</th>
+              <th className="py-1.5 text-right font-medium">Output</th>
+              <th className="py-1.5 text-right font-medium">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summary.byModel.map((bucket) => (
+              <tr key={`${bucket.provider}-${bucket.model}`} className="border-b border-border/40">
+                <td className="flex items-center gap-2 py-2">
+                  {providerLogo(bucket.provider)}
+                  <span
+                    className="inline-block size-2.5 rounded-[3px]"
+                    style={{ background: modelShades.get(bucket.model) ?? NEUTRAL_SHADE }}
+                  />
+                  {bucket.model}
+                </td>
+                <td className="py-2 text-right tabular-nums text-muted-foreground">
+                  {bucket.turns}
+                </td>
+                <td className="py-2 text-right tabular-nums text-muted-foreground">
+                  {formatTokens(bucket.totalTokens)}
+                </td>
+                <td className="py-2 text-right tabular-nums text-muted-foreground">
+                  {formatTokens(bucket.outputTokens)}
+                </td>
+                <td className="py-2 text-right tabular-nums text-muted-foreground">
+                  {bucket.costSource === "exact"
+                    ? formatMicroUsd(bucket.exactCostMicroUsd)
+                    : bucket.costSource === "estimated"
+                      ? `~${formatMicroUsd(bucket.estimatedCostMicroUsd)} est.`
+                      : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {summary.unpricedModels.length > 0 ? (
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            No pricing data for: {summary.unpricedModels.join(", ")} — shown as tokens only, never
+            $0.
+          </p>
+        ) : null}
+      </SettingsSection>
+
+      <SettingsSection title="Projects">
+        <div className="flex flex-col gap-2">
+          {summary.byProject.slice(0, 8).map((bucket) => {
+            const max = Math.max(summary.byProject[0]?.totalTokens ?? 1, 1);
+            return (
+              <div
+                key={bucket.projectId ?? "none"}
+                className="grid grid-cols-[140px_1fr_72px] items-center gap-3 text-[12.5px]"
+              >
+                <span className="truncate text-muted-foreground">
+                  {bucket.projectTitle ?? (bucket.projectId ? "(unknown)" : "(no project)")}
+                </span>
+                <div className="h-4 rounded bg-black/20">
+                  <div
+                    className="h-full rounded"
+                    style={{
+                      width: `${Math.max((bucket.totalTokens / max) * 100, 1.5)}%`,
+                      background: T3_ACCENT,
+                    }}
+                  />
+                </div>
+                <span className="text-right tabular-nums text-muted-foreground">
+                  {formatTokens(bucket.totalTokens)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </SettingsSection>
+
+      <p className="mt-4 text-[11px] leading-relaxed text-muted-foreground">
+        Usage facts are recorded from live provider events into this environment's local ledger
+        (history begins when this feature shipped). Claude costs are exact, reported by the SDK per
+        turn. Codex reports no cost over its protocol; its dollars are list-price estimates and
+        always marked as such. Pricing catalog {summary.pricingVersion}.
+      </p>
+    </SettingsPageContainer>
+  );
+}
+
+function UsagePageHeader() {
+  return (
+    <div>
+      <h1 className="text-lg font-semibold">Usage</h1>
+      <p className="text-[13px] text-muted-foreground">
+        Local analytics from this environment's usage ledger. Nothing leaves your machines.
+      </p>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-black/20 px-3 py-2.5">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className={cn("text-lg font-semibold tracking-tight", accent && "text-emerald-500")}>
+        {value}
+      </div>
+      <div className="text-[10.5px] text-muted-foreground/80">{sub}</div>
+    </div>
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as PairRouteImport } from './routes/pair'
 import { Route as ConnectRouteImport } from './routes/connect'
 import { Route as ChatRouteImport } from './routes/_chat'
 import { Route as ChatIndexRouteImport } from './routes/_chat.index'
+import { Route as SettingsUsageRouteImport } from './routes/settings.usage'
 import { Route as SettingsSourceControlRouteImport } from './routes/settings.source-control'
 import { Route as SettingsProvidersRouteImport } from './routes/settings.providers'
 import { Route as SettingsKeybindingsRouteImport } from './routes/settings.keybindings'
@@ -48,6 +49,11 @@ const ChatIndexRoute = ChatIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => ChatRoute,
+} as any)
+const SettingsUsageRoute = SettingsUsageRouteImport.update({
+  id: '/usage',
+  path: '/usage',
+  getParentRoute: () => SettingsRoute,
 } as any)
 const SettingsSourceControlRoute = SettingsSourceControlRouteImport.update({
   id: '/source-control',
@@ -114,6 +120,7 @@ export interface FileRoutesByFullPath {
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
+  '/settings/usage': typeof SettingsUsageRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
 }
@@ -129,6 +136,7 @@ export interface FileRoutesByTo {
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
+  '/settings/usage': typeof SettingsUsageRoute
   '/': typeof ChatIndexRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
@@ -147,6 +155,7 @@ export interface FileRoutesById {
   '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/providers': typeof SettingsProvidersRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
+  '/settings/usage': typeof SettingsUsageRoute
   '/_chat/': typeof ChatIndexRoute
   '/_chat/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/_chat/draft/$draftId': typeof ChatDraftDraftIdRoute
@@ -166,6 +175,7 @@ export interface FileRouteTypes {
     | '/settings/keybindings'
     | '/settings/providers'
     | '/settings/source-control'
+    | '/settings/usage'
     | '/$environmentId/$threadId'
     | '/draft/$draftId'
   fileRoutesByTo: FileRoutesByTo
@@ -181,6 +191,7 @@ export interface FileRouteTypes {
     | '/settings/keybindings'
     | '/settings/providers'
     | '/settings/source-control'
+    | '/settings/usage'
     | '/'
     | '/$environmentId/$threadId'
     | '/draft/$draftId'
@@ -198,6 +209,7 @@ export interface FileRouteTypes {
     | '/settings/keybindings'
     | '/settings/providers'
     | '/settings/source-control'
+    | '/settings/usage'
     | '/_chat/'
     | '/_chat/$environmentId/$threadId'
     | '/_chat/draft/$draftId'
@@ -283,6 +295,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsDiagnosticsRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/usage': {
+      id: '/settings/usage'
+      path: '/usage'
+      fullPath: '/settings/usage'
+      preLoaderRoute: typeof SettingsUsageRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/connections': {
       id: '/settings/connections'
       path: '/connections'
@@ -343,6 +362,7 @@ interface SettingsRouteChildren {
   SettingsKeybindingsRoute: typeof SettingsKeybindingsRoute
   SettingsProvidersRoute: typeof SettingsProvidersRoute
   SettingsSourceControlRoute: typeof SettingsSourceControlRoute
+  SettingsUsageRoute: typeof SettingsUsageRoute
 }
 
 const SettingsRouteChildren: SettingsRouteChildren = {
@@ -353,6 +373,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsKeybindingsRoute: SettingsKeybindingsRoute,
   SettingsProvidersRoute: SettingsProvidersRoute,
   SettingsSourceControlRoute: SettingsSourceControlRoute,
+  SettingsUsageRoute: SettingsUsageRoute,
 }
 
 const SettingsRouteWithChildren = SettingsRoute._addFileChildren(

--- a/apps/web/src/routes/settings.usage.tsx
+++ b/apps/web/src/routes/settings.usage.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { UsageSettingsPanel } from "../components/settings/UsageSettings";
+
+export const Route = createFileRoute("/settings/usage")({
+  component: UsageSettingsPanel,
+});

--- a/docs/t3-code-usage-plan.html
+++ b/docs/t3-code-usage-plan.html
@@ -1,0 +1,2810 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Evidence-backed implementation plan for a local-first usage dashboard in T3 Code."
+    />
+    <title>T3 Code Usage — Implementation Plan</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --page: #000;
+        --ink: #fff;
+        --muted: #9a9a9a;
+        --faint: #666;
+        --panel: #0a0a0a;
+        --panel-2: #111;
+        --line: #262626;
+        --blue: #76a9ff;
+        --cyan: #69e1ff;
+        --green: #63e6a5;
+        --amber: #ffd166;
+        --red: #ff7b7b;
+        --violet: #bc9cff;
+        --radius: 14px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        background: #000;
+        color: var(--ink);
+        font-family:
+          Inter,
+          ui-sans-serif,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        font-size: 15px;
+        line-height: 1.55;
+      }
+
+      a {
+        color: var(--blue);
+      }
+
+      code,
+      pre,
+      .mono {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      }
+
+      code {
+        color: #d8e7ff;
+        font-size: 0.92em;
+      }
+
+      pre {
+        overflow-x: auto;
+        margin: 14px 0 0;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: #050505;
+        padding: 16px;
+        color: #d7d7d7;
+        font-size: 12px;
+        line-height: 1.6;
+      }
+
+      .shell {
+        width: min(1260px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 34px 0 80px;
+      }
+
+      header {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 28px;
+        align-items: end;
+        border-bottom: 1px solid var(--line);
+        padding: 30px 0 34px;
+      }
+
+      .eyebrow {
+        color: var(--green);
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        max-width: 900px;
+        margin: 10px 0 14px;
+        font-size: clamp(42px, 7vw, 82px);
+        font-weight: 760;
+        letter-spacing: -0.055em;
+        line-height: 0.95;
+      }
+
+      h2 {
+        margin: 0 0 14px;
+        font-size: clamp(25px, 3vw, 36px);
+        letter-spacing: -0.03em;
+        line-height: 1.05;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        font-size: 17px;
+        letter-spacing: -0.015em;
+      }
+
+      p {
+        margin: 0 0 12px;
+      }
+
+      ul,
+      ol {
+        margin: 10px 0 0;
+        padding-left: 20px;
+      }
+
+      li + li {
+        margin-top: 7px;
+      }
+
+      .lede {
+        max-width: 900px;
+        color: #c3c3c3;
+        font-size: 18px;
+      }
+
+      .header-note {
+        width: 230px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--panel);
+        padding: 16px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .header-note strong {
+        display: block;
+        margin-bottom: 5px;
+        color: var(--ink);
+        font-size: 14px;
+      }
+
+      nav {
+        position: sticky;
+        z-index: 10;
+        top: 0;
+        display: flex;
+        overflow-x: auto;
+        gap: 8px;
+        border-bottom: 1px solid var(--line);
+        background: rgba(0, 0, 0, 0.94);
+        padding: 11px 0;
+        backdrop-filter: blur(14px);
+      }
+
+      nav a {
+        flex: none;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 6px 10px;
+        color: #c9c9c9;
+        font-size: 12px;
+        text-decoration: none;
+      }
+
+      nav a:hover {
+        border-color: #555;
+        color: var(--ink);
+      }
+
+      section {
+        scroll-margin-top: 76px;
+        border-bottom: 1px solid var(--line);
+        padding: 52px 0;
+      }
+
+      .section-head {
+        display: grid;
+        grid-template-columns: 220px minmax(0, 1fr);
+        gap: 30px;
+        margin-bottom: 24px;
+      }
+
+      .section-label {
+        color: var(--faint);
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .section-copy {
+        max-width: 880px;
+        color: #b7b7b7;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .card {
+        grid-column: span 4;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--panel);
+        padding: 20px;
+      }
+
+      .card.half {
+        grid-column: span 6;
+      }
+
+      .card.full {
+        grid-column: span 12;
+      }
+
+      .card p:last-child {
+        margin-bottom: 0;
+      }
+
+      .decision {
+        border-color: rgba(99, 230, 165, 0.32);
+        background: linear-gradient(145deg, rgba(99, 230, 165, 0.08), transparent 55%), #080808;
+      }
+
+      .kicker {
+        display: block;
+        margin-bottom: 8px;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+      }
+
+      .stat {
+        display: block;
+        margin: 2px 0 8px;
+        color: var(--ink);
+        font-size: clamp(27px, 4vw, 44px);
+        font-weight: 750;
+        letter-spacing: -0.045em;
+        line-height: 1;
+      }
+
+      .subtle {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 7px;
+        margin-top: 13px;
+      }
+
+      .badge {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: #050505;
+        padding: 4px 8px;
+        color: #c6c6c6;
+        font-size: 11px;
+        font-weight: 700;
+      }
+
+      .badge.green {
+        border-color: rgba(99, 230, 165, 0.38);
+        color: var(--green);
+      }
+
+      .badge.amber {
+        border-color: rgba(255, 209, 102, 0.38);
+        color: var(--amber);
+      }
+
+      .badge.violet {
+        border-color: rgba(188, 156, 255, 0.38);
+        color: var(--violet);
+      }
+
+      .callout {
+        border: 1px solid rgba(118, 169, 255, 0.28);
+        border-left: 4px solid var(--blue);
+        border-radius: 10px;
+        background: rgba(118, 169, 255, 0.06);
+        padding: 15px 17px;
+        color: #d8e6ff;
+      }
+
+      .callout.warning {
+        border-color: rgba(255, 209, 102, 0.26);
+        border-left-color: var(--amber);
+        background: rgba(255, 209, 102, 0.055);
+        color: #fff0bd;
+      }
+
+      .diagram {
+        overflow-x: auto;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: #050505;
+        padding: 18px;
+      }
+
+      .diagram svg {
+        display: block;
+        min-width: 930px;
+        width: 100%;
+        height: auto;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--line);
+        padding: 12px 10px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: var(--muted);
+        font-size: 10px;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+      }
+
+      tr:last-child td {
+        border-bottom: 0;
+      }
+
+      .table-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--panel);
+        padding: 2px 10px;
+      }
+
+      .exact {
+        color: var(--green);
+      }
+
+      .partial {
+        color: var(--amber);
+      }
+
+      .gap {
+        color: var(--red);
+      }
+
+      .metric {
+        grid-column: span 4;
+        border-top: 2px solid var(--cyan);
+        padding-top: 13px;
+      }
+
+      .metric strong {
+        display: block;
+        margin-bottom: 4px;
+        color: var(--ink);
+      }
+
+      .metric span {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .wireframe {
+        border: 1px solid #333;
+        border-radius: 16px;
+        background: #050505;
+        padding: 14px;
+      }
+
+      .wireframe-bar {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        border-bottom: 1px solid var(--line);
+        padding: 6px 4px 14px;
+      }
+
+      .filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 7px;
+      }
+
+      .filter {
+        border: 1px solid #343434;
+        border-radius: 7px;
+        background: #0e0e0e;
+        padding: 6px 9px;
+        color: #d8d8d8;
+        font-size: 11px;
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 8px;
+        margin: 12px 0;
+      }
+
+      .summary-cell {
+        min-height: 84px;
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        background: #0b0b0b;
+        padding: 11px;
+      }
+
+      .summary-cell b {
+        display: block;
+        margin-top: 8px;
+        font-size: 20px;
+      }
+
+      .chart-grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 8px;
+      }
+
+      .chart-box {
+        min-height: 210px;
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        background: #080808;
+        padding: 12px;
+      }
+
+      .bars {
+        display: flex;
+        height: 150px;
+        align-items: end;
+        gap: 5px;
+        border-bottom: 1px solid #333;
+        padding: 16px 4px 0;
+      }
+
+      .bars i {
+        flex: 1;
+        min-width: 5px;
+        border-radius: 3px 3px 0 0;
+        background: linear-gradient(var(--cyan), #285c7a);
+      }
+
+      .heatmap {
+        display: grid;
+        grid-template-columns: repeat(8, 1fr);
+        gap: 4px;
+        margin-top: 18px;
+      }
+
+      .heatmap i {
+        aspect-ratio: 1;
+        border-radius: 3px;
+        background: #111;
+      }
+
+      .heatmap i:nth-child(3n) {
+        background: #193c47;
+      }
+
+      .heatmap i:nth-child(5n) {
+        background: #2a6879;
+      }
+
+      .heatmap i:nth-child(11n) {
+        background: var(--cyan);
+      }
+
+      .mock-note {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+        margin-bottom: 14px;
+        border: 1px solid rgba(124, 229, 255, 0.24);
+        border-radius: 10px;
+        background: rgba(124, 229, 255, 0.045);
+        padding: 12px 14px;
+        color: #d8f7ff;
+        font-size: 12px;
+        line-height: 1.6;
+      }
+
+      .mock-note b {
+        flex: 0 0 auto;
+        border-radius: 999px;
+        background: var(--cyan);
+        padding: 2px 7px;
+        color: #001014;
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+
+      .product-mock {
+        overflow: hidden;
+        border: 1px solid #323232;
+        border-radius: 14px;
+        background: #080808;
+        box-shadow: 0 22px 70px rgba(0, 0, 0, 0.5);
+      }
+
+      .mock-chrome {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-height: 43px;
+        border-bottom: 1px solid #252525;
+        background: #0c0c0c;
+        padding: 0 13px;
+      }
+
+      .mock-window-dots,
+      .mock-sync {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+      }
+
+      .mock-window-dots i {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #393939;
+      }
+
+      .mock-wordmark {
+        color: #d7d7d7;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+      }
+
+      .sync-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--green);
+        box-shadow: 0 0 12px rgba(126, 231, 135, 0.6);
+      }
+
+      .mock-sync {
+        color: #a8a8a8;
+        font-size: 9px;
+      }
+
+      .mock-shell {
+        display: grid;
+        grid-template-columns: 154px minmax(0, 1fr);
+        min-height: 940px;
+      }
+
+      .mock-sidebar {
+        border-right: 1px solid #242424;
+        background: #060606;
+        padding: 15px 9px;
+      }
+
+      .mock-nav-label {
+        margin: 14px 9px 6px;
+        color: #666;
+        font-size: 8px;
+        font-weight: 700;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+      }
+
+      .mock-nav-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin: 2px 0;
+        border-radius: 6px;
+        padding: 7px 9px;
+        color: #8d8d8d;
+        font-size: 10px;
+      }
+
+      .mock-nav-item::before {
+        content: "";
+        width: 5px;
+        height: 5px;
+        border: 1px solid currentColor;
+        border-radius: 2px;
+      }
+
+      .mock-nav-item.active {
+        background: #181818;
+        color: #fff;
+      }
+
+      .mock-nav-item.active::before {
+        border-color: var(--cyan);
+        background: var(--cyan);
+      }
+
+      .mock-environment {
+        margin: 22px 6px 0;
+        border: 1px solid #252525;
+        border-radius: 8px;
+        background: #0a0a0a;
+        padding: 9px;
+        color: #8f8f8f;
+        font-size: 9px;
+        line-height: 1.55;
+      }
+
+      .mock-environment b {
+        display: block;
+        color: #ddd;
+        font-size: 10px;
+      }
+
+      .mock-canvas {
+        min-width: 0;
+        background: #090909;
+        padding: 20px;
+      }
+
+      .mock-page-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 20px;
+      }
+
+      .mock-page-head h3 {
+        margin: 0;
+        font-size: 22px;
+        letter-spacing: -0.035em;
+      }
+
+      .mock-page-head p {
+        margin: 4px 0 0;
+        color: #858585;
+        font-size: 10px;
+      }
+
+      .mock-actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 6px;
+      }
+
+      .mock-control {
+        border: 1px solid #2e2e2e;
+        border-radius: 6px;
+        background: #111;
+        padding: 6px 8px;
+        color: #c3c3c3;
+        font-size: 9px;
+        white-space: nowrap;
+      }
+
+      .mock-control.primary {
+        border-color: rgba(124, 229, 255, 0.4);
+        background: rgba(124, 229, 255, 0.09);
+        color: #d9f9ff;
+      }
+
+      .mock-tabs {
+        display: flex;
+        gap: 17px;
+        margin: 18px 0 14px;
+        border-bottom: 1px solid #272727;
+      }
+
+      .mock-tab {
+        position: relative;
+        padding: 0 1px 9px;
+        color: #777;
+        font-size: 9px;
+      }
+
+      .mock-tab.active {
+        color: #fff;
+      }
+
+      .mock-tab.active::after {
+        content: "";
+        position: absolute;
+        right: 0;
+        bottom: -1px;
+        left: 0;
+        height: 2px;
+        background: var(--cyan);
+      }
+
+      .mock-summary {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 8px;
+      }
+
+      .mock-stat,
+      .mock-panel {
+        border: 1px solid #252525;
+        border-radius: 9px;
+        background: #0d0d0d;
+      }
+
+      .mock-stat {
+        min-height: 98px;
+        padding: 12px;
+      }
+
+      .mock-stat-label,
+      .mock-panel-label {
+        color: #777;
+        font-size: 8px;
+        font-weight: 700;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+      }
+
+      .mock-stat-value {
+        margin: 8px 0 4px;
+        color: #fff;
+        font-size: 23px;
+        font-weight: 680;
+        letter-spacing: -0.035em;
+      }
+
+      .mock-stat-value.cost {
+        color: var(--green);
+      }
+
+      .mock-stat-meta {
+        color: #777;
+        font-size: 9px;
+        line-height: 1.45;
+      }
+
+      .mock-stat-meta.warn {
+        color: var(--amber);
+      }
+
+      .mock-two-col {
+        display: grid;
+        grid-template-columns: 1.35fr 1fr;
+        gap: 8px;
+        margin-top: 8px;
+      }
+
+      .mock-panel {
+        min-width: 0;
+        padding: 13px;
+      }
+
+      .mock-panel-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 13px;
+      }
+
+      .mock-panel-title {
+        margin-top: 3px;
+        color: #e8e8e8;
+        font-size: 12px;
+        font-weight: 650;
+      }
+
+      .mock-panel-detail {
+        color: #737373;
+        font-size: 8px;
+      }
+
+      .cost-total {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 9px;
+      }
+
+      .cost-total strong {
+        color: var(--green);
+        font-size: 25px;
+        letter-spacing: -0.04em;
+      }
+
+      .cost-total span {
+        max-width: 175px;
+        color: #777;
+        font-size: 8px;
+        line-height: 1.45;
+        text-align: right;
+      }
+
+      .coverage-track,
+      .harness-track,
+      .model-track,
+      .reasoning-track,
+      .task-track {
+        display: flex;
+        overflow: hidden;
+        width: 100%;
+        border-radius: 999px;
+        background: #1d1d1d;
+      }
+
+      .coverage-track {
+        height: 9px;
+      }
+
+      .coverage-track .priced {
+        width: 24.8%;
+        background: var(--green);
+      }
+
+      .coverage-track .unpriced {
+        width: 75.2%;
+        background: repeating-linear-gradient(135deg, #4a3e20 0 4px, #292313 4px 8px);
+      }
+
+      .mock-legend-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 7px 14px;
+        margin-top: 8px;
+        color: #888;
+        font-size: 8px;
+      }
+
+      .mock-legend-row b {
+        color: #d7d7d7;
+        font-weight: 600;
+      }
+
+      .cost-lines {
+        display: grid;
+        gap: 7px;
+        margin-top: 13px;
+      }
+
+      .cost-line {
+        display: grid;
+        grid-template-columns: 72px minmax(80px, 1fr) 70px;
+        gap: 8px;
+        align-items: center;
+        color: #aaa;
+        font-size: 9px;
+      }
+
+      .cost-line > span:last-child {
+        color: #ddd;
+        text-align: right;
+      }
+
+      .mini-track {
+        height: 5px;
+        border-radius: 999px;
+        background: #202020;
+      }
+
+      .mini-track i {
+        display: block;
+        height: 100%;
+        border-radius: inherit;
+        background: var(--cyan);
+      }
+
+      .mini-track i.green {
+        background: var(--green);
+      }
+
+      .mini-track i.amber {
+        background: var(--amber);
+      }
+
+      .harness-cards {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 7px;
+      }
+
+      .harness-card {
+        border: 1px solid #242424;
+        border-radius: 7px;
+        background: #090909;
+        padding: 10px;
+      }
+
+      .harness-name {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        color: #e5e5e5;
+        font-size: 10px;
+        font-weight: 650;
+      }
+
+      .harness-name span {
+        color: #777;
+        font-size: 8px;
+        font-weight: 500;
+      }
+
+      .harness-number {
+        margin: 7px 0 2px;
+        color: #fff;
+        font-size: 17px;
+        font-weight: 650;
+      }
+
+      .harness-card p {
+        margin: 0;
+        color: #737373;
+        font-size: 8px;
+      }
+
+      .preference-rows {
+        display: grid;
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .preference-row {
+        display: grid;
+        grid-template-columns: 55px minmax(80px, 1fr) 62px;
+        gap: 8px;
+        align-items: center;
+        color: #a4a4a4;
+        font-size: 8px;
+      }
+
+      .harness-track {
+        height: 6px;
+      }
+
+      .harness-track i:first-child {
+        background: #c995ff;
+      }
+
+      .harness-track i:last-child {
+        background: var(--cyan);
+      }
+
+      .preference-row > span:last-child {
+        color: #737373;
+        text-align: right;
+      }
+
+      .model-panel {
+        margin-top: 8px;
+      }
+
+      .model-table {
+        display: grid;
+      }
+
+      .model-row {
+        display: grid;
+        grid-template-columns: minmax(126px, 1.15fr) minmax(150px, 1.4fr) minmax(155px, 1.4fr) 66px;
+        gap: 12px;
+        align-items: center;
+        border-top: 1px solid #222;
+        padding: 10px 0;
+      }
+
+      .model-row.header {
+        border-top: 0;
+        padding: 0 0 7px;
+        color: #686868;
+        font-size: 8px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .model-name {
+        color: #ddd;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 9px;
+      }
+
+      .model-name small {
+        display: block;
+        margin-top: 3px;
+        color: #696969;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        font-size: 8px;
+      }
+
+      .model-usage {
+        display: grid;
+        grid-template-columns: minmax(60px, 1fr) 60px;
+        gap: 7px;
+        align-items: center;
+        color: #aaa;
+        font-size: 8px;
+      }
+
+      .model-track {
+        height: 7px;
+      }
+
+      .model-track i {
+        display: block;
+        height: 100%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, #2f788e, var(--cyan));
+      }
+
+      .reasoning-cell {
+        display: grid;
+        gap: 5px;
+      }
+
+      .reasoning-track {
+        height: 7px;
+      }
+
+      .reasoning-track i.low,
+      .reasoning-key i.low {
+        background: var(--blue);
+      }
+
+      .reasoning-track i.medium,
+      .reasoning-key i.medium {
+        background: var(--cyan);
+      }
+
+      .reasoning-track i.high,
+      .reasoning-key i.high {
+        background: var(--green);
+      }
+
+      .reasoning-track i.xhigh,
+      .reasoning-key i.xhigh {
+        background: var(--amber);
+      }
+
+      .reasoning-track i.ultra,
+      .reasoning-key i.ultra {
+        background: #c995ff;
+      }
+
+      .reasoning-labels {
+        color: #707070;
+        font-size: 7px;
+      }
+
+      .reasoning-key {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 9px;
+        color: #777;
+        font-size: 7px;
+      }
+
+      .reasoning-key span {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .reasoning-key i {
+        width: 6px;
+        height: 6px;
+        border-radius: 2px;
+      }
+
+      .price-state {
+        justify-self: end;
+        border: 1px solid rgba(126, 231, 135, 0.24);
+        border-radius: 999px;
+        background: rgba(126, 231, 135, 0.06);
+        padding: 3px 6px;
+        color: var(--green);
+        font-size: 7px;
+      }
+
+      .price-state.unknown {
+        border-color: rgba(255, 209, 102, 0.27);
+        background: rgba(255, 209, 102, 0.06);
+        color: var(--amber);
+      }
+
+      .mock-subscreen {
+        margin-top: 16px;
+        border-top: 1px dashed #333;
+        padding-top: 16px;
+      }
+
+      .subscreen-label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 9px;
+        color: #777;
+        font-size: 8px;
+        font-weight: 700;
+        letter-spacing: 0.11em;
+        text-transform: uppercase;
+      }
+
+      .subscreen-label::after {
+        content: "";
+        flex: 1;
+        height: 1px;
+        background: #242424;
+      }
+
+      .task-panel {
+        overflow-x: auto;
+        border: 1px solid #252525;
+        border-radius: 9px;
+        background: #0d0d0d;
+      }
+
+      .task-row {
+        display: grid;
+        grid-template-columns: minmax(190px, 1.25fr) minmax(235px, 1.55fr) 76px 58px 77px;
+        gap: 12px;
+        align-items: center;
+        min-width: 790px;
+        border-top: 1px solid #222;
+        padding: 10px 12px;
+      }
+
+      .task-row.header {
+        border-top: 0;
+        background: #0a0a0a;
+        color: #686868;
+        font-size: 8px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .task-name {
+        color: #e0e0e0;
+        font-size: 9px;
+        font-weight: 620;
+      }
+
+      .task-name small {
+        display: block;
+        margin-top: 3px;
+        color: #686868;
+        font-size: 8px;
+        font-weight: 500;
+      }
+
+      .task-models {
+        display: grid;
+        gap: 5px;
+      }
+
+      .task-track {
+        height: 7px;
+      }
+
+      .task-track i.fable {
+        background: #c995ff;
+      }
+
+      .task-track i.opus {
+        background: var(--amber);
+      }
+
+      .task-track i.sonnet {
+        background: #ef87bd;
+      }
+
+      .task-track i.haiku {
+        background: var(--green);
+      }
+
+      .task-track i.gpt {
+        background: var(--cyan);
+      }
+
+      .task-model-labels {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 3px 8px;
+        color: #737373;
+        font-size: 7px;
+      }
+
+      .task-model-labels b {
+        color: #a9a9a9;
+        font-weight: 600;
+      }
+
+      .task-number {
+        color: #d8d8d8;
+        font-size: 9px;
+        text-align: right;
+      }
+
+      .task-number small {
+        display: block;
+        margin-top: 3px;
+        color: #707070;
+        font-size: 7px;
+      }
+
+      .task-number.unpriced {
+        color: var(--amber);
+      }
+
+      .mock-footnote {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        margin-top: 8px;
+        color: #666;
+        font-size: 8px;
+        line-height: 1.5;
+      }
+
+      .mock-decisions {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 8px;
+        margin-top: 12px;
+      }
+
+      .mock-decision {
+        border: 1px solid #242424;
+        border-radius: 8px;
+        background: #090909;
+        padding: 11px;
+      }
+
+      .mock-decision b {
+        display: block;
+        margin-bottom: 5px;
+        color: #e3e3e3;
+        font-size: 10px;
+      }
+
+      .mock-decision span {
+        color: #777;
+        font-size: 9px;
+        line-height: 1.5;
+      }
+
+      .phase-list {
+        display: grid;
+        gap: 10px;
+        counter-reset: phases;
+      }
+
+      .phase {
+        position: relative;
+        display: grid;
+        grid-template-columns: 52px 190px minmax(0, 1fr);
+        gap: 18px;
+        align-items: start;
+        border: 1px solid var(--line);
+        border-radius: 11px;
+        background: var(--panel);
+        padding: 17px;
+        counter-increment: phases;
+      }
+
+      .phase::before {
+        content: counter(phases, decimal-leading-zero);
+        color: var(--green);
+        font-family: ui-monospace, monospace;
+        font-size: 18px;
+        font-weight: 800;
+      }
+
+      .phase-title {
+        color: var(--ink);
+        font-weight: 750;
+      }
+
+      .phase-copy {
+        color: #b5b5b5;
+      }
+
+      .risk {
+        grid-column: span 6;
+        border-left: 3px solid var(--amber);
+        padding-left: 15px;
+      }
+
+      .risk strong {
+        display: block;
+        margin-bottom: 5px;
+      }
+
+      .checklist {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 7px 20px;
+        list-style: none;
+        padding: 0;
+      }
+
+      .checklist li {
+        position: relative;
+        margin: 0;
+        border-bottom: 1px solid #1b1b1b;
+        padding: 9px 0 9px 24px;
+        color: #c5c5c5;
+      }
+
+      .checklist li::before {
+        position: absolute;
+        left: 0;
+        color: var(--green);
+        content: "✓";
+        font-weight: 800;
+      }
+
+      footer {
+        display: flex;
+        justify-content: space-between;
+        gap: 20px;
+        padding-top: 30px;
+        color: var(--faint);
+        font-size: 12px;
+      }
+
+      @media (max-width: 860px) {
+        header,
+        .section-head {
+          grid-template-columns: 1fr;
+        }
+
+        .header-note {
+          width: auto;
+        }
+
+        .card,
+        .card.half,
+        .metric,
+        .risk {
+          grid-column: span 12;
+        }
+
+        .summary-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+
+        .chart-grid,
+        .phase {
+          grid-template-columns: 1fr;
+        }
+
+        .mock-shell {
+          grid-template-columns: 1fr;
+        }
+
+        .mock-sidebar {
+          display: none;
+        }
+
+        .mock-canvas {
+          padding: 14px;
+        }
+
+        .mock-page-head {
+          display: grid;
+        }
+
+        .mock-actions {
+          justify-content: flex-start;
+        }
+
+        .mock-summary,
+        .mock-decisions {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .mock-two-col {
+          grid-template-columns: 1fr;
+        }
+
+        .model-table {
+          overflow-x: auto;
+        }
+
+        .model-row {
+          min-width: 675px;
+        }
+
+        .checklist {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 560px) {
+        .mock-summary,
+        .mock-decisions,
+        .harness-cards {
+          grid-template-columns: 1fr;
+        }
+
+        .mock-tabs {
+          overflow-x: auto;
+        }
+
+        .mock-footnote {
+          display: grid;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <div>
+          <div class="eyebrow">Implementation plan · v2 · independently reviewed</div>
+          <h1>Local-first usage for T3 Code</h1>
+          <p class="lede">
+            Build a top-level Usage page backed by an append-only local ledger. Capture exact usage
+            from live provider events, backfill native logs once, and merge aggregate reports from
+            every connected T3 environment—without uploading raw logs, prompts, or paths.
+          </p>
+          <div class="badges">
+            <span class="badge green">Recommended</span>
+            <span class="badge green">Reviewed by gpt-5.6-sol</span>
+            <span class="badge">T3-only by default</span>
+            <span class="badge">All-local opt-in</span>
+            <span class="badge">No cloud persistence</span>
+          </div>
+        </div>
+        <aside class="header-note">
+          <strong>Plan status — v2</strong>
+          Evidence-backed against the repository, T3 SQLite, provider event logs, native Codex and
+          Claude histories, and ccusage 20.0.8 on <span class="mono">bb-1</span>. Revised after an
+          independent code review by gpt-5.6-sol verified every claim against the codebase; the
+          corrections are in <a href="#review">section 00</a>.
+        </aside>
+      </header>
+
+      <nav aria-label="Plan sections">
+        <a href="#review">Review</a>
+        <a href="#decision">Decision</a>
+        <a href="#evidence">Evidence</a>
+        <a href="#semantics">Metrics</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#providers">Providers</a>
+        <a href="#aggregation">Aggregation</a>
+        <a href="#experience">Experience</a>
+        <a href="#rollout">Rollout</a>
+        <a href="#verification">Verification</a>
+        <a href="#risks">Risks</a>
+      </nav>
+
+      <section id="review">
+        <div class="section-head">
+          <div class="section-label">00 · Independent review (v2 changes)</div>
+          <div>
+            <h2>What the gpt-5.6-sol code review changed.</h2>
+            <p class="section-copy">
+              The v1 plan was reviewed by gpt-5.6-sol with read-only access to the repository; every
+              cited file was re-verified before acceptance. Verdict: product direction and
+              ledger-query shape sound; the persistence design needed restructuring before Phase 1.
+              Four corrections are binding on the rest of this document.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <article class="card half">
+            <span class="kicker">Blocker fixed · durable events, not an ingestion fold</span>
+            <h3>The ledger must be a real projector</h3>
+            <p class="subtle">
+              In this codebase, projections are registered projectors replaying
+              <code>orchestration_events</code> from a <code>projection_state</code> cursor, with
+              writes transactionally coupled to event appends
+              (<code>ProjectionPipeline.ts:1462–1548</code>,
+              <code>OrchestrationEngine.ts:169–180</code>). v1's in-memory per-turn fold writing
+              rows on <code>turn.completed</code> would be restart-lossy and unreplayable. v2:
+              persist durable <code>model.usage-recorded</code> orchestration events (keeping
+              <code>providerRefs</code>, typed <code>modelUsage</code>, exact cost), then derive the
+              ledger with a standard registered projector. A new projector's empty cursor replays
+              history automatically — this also simplifies backfill.
+            </p>
+          </article>
+          <article class="card half">
+            <span class="kicker">Misdiagnosis corrected · the adapter was innocent</span>
+            <h3>Cost dies in ingestion, not in ClaudeAdapter</h3>
+            <p class="subtle">
+              v1 claimed ClaudeAdapter fails to plumb <code>total_cost_usd</code> /
+              <code>modelUsage</code>. Verified false: both completion paths already emit them on
+              <code>turn.completed</code> (<code>ClaudeAdapter.ts:1963–1980</code>,
+              <code>:2036–2050</code>). The loss is downstream —
+              <code>ProviderRuntimeIngestion</code> consumes <code>turn.completed</code> for
+              lifecycle only and discards its usage payload, and
+              <code>buildContextWindowActivityPayload</code> (<code>:596–613</code>) strips
+              <code>providerRefs</code> from persisted usage activities. Phase work moves
+              accordingly. Also confirmed: <code>ThreadTokenUsageSnapshot</code> has no
+              cache-creation field, so "emit the full split" requires a contract extension, and
+              <code>modelUsage</code> needs a typed schema (currently <code>UnknownRecord</code>).
+            </p>
+          </article>
+          <article class="card half">
+            <span class="kicker">Identity fixed · NULLs defeat uniqueness</span>
+            <h3>Fact IDs, not composite keys</h3>
+            <p class="subtle">
+              v1's dedup key <code>(environment, thread, turn, model)</code> fails twice: SQLite
+              UNIQUE ignores NULL components (interrupted turns have no <code>turn_id</code>), and
+              it omits the provider-native session id that validation proved essential (concurrent
+              Codex sessions on one T3 thread inflated sqlite replay 12×). v2: a stable
+              <code>fact_id</code> hashed from provider + native session + native turn/message id +
+              model + kind, with explicit upsert precedence (live &gt; transcripts &gt; events) and
+              a <code>stale</code> flag for lifecycle-rejected completions. Per-model cost and
+              turn-level <code>totalCostUsd</code> are stored as separate fact kinds so totals
+              reconcile instead of double-counting.
+            </p>
+          </article>
+          <article class="card half">
+            <span class="kicker">Semantics added · lifecycle, revert, terminal paths</span>
+            <h3>Usage survives what conversations don't</h3>
+            <p class="subtle">
+              Existing projectors prune on
+              <code>thread.reverted</code> (<code>ProjectionPipeline.ts:851–980</code>); the usage
+              projector deliberately does not — consumed tokens are immutable billing history.
+              Thread deletion keeps facts and redacts linkage. Finalization listens to
+              <code>turn.aborted</code> (Codex emits it: <code>CodexAdapter.ts:788–797</code>),
+              session exit, and steering-superseded turns — not just <code>turn.completed</code>.
+              Backfill leaves schema migrations (which run during SQLite init) and becomes a
+              versioned, resumable server-side job; transcript parsing is opt-in and never runs at
+              startup. Pricing moves to versioned, effective-dated data in shared runtime code,
+              never <code>packages/contracts</code>.
+            </p>
+          </article>
+          <article class="card full">
+            <span class="kicker">Confirmed feasible by the review</span>
+            <ul>
+              <li>
+                Multi-environment fan-out works with the existing client registry (<code
+                  >EnvironmentRegistry.run</code
+                >
+                is environment-scoped) — but it must lease the environment <em>catalog</em>, not
+                just currently-live connections, with bounded concurrency and per-environment
+                timeouts.
+              </li>
+              <li>
+                One dashboard-shaped <code>usage.query</code> RPC (named bucket sets per dimension)
+                avoids four round-trips per page load; it needs a
+                <code>RPC_REQUIRED_SCOPE</code> read-scope entry like every other method.
+              </li>
+              <li>
+                Grouping timezone comes from the requesting client (IANA), attribution at
+                observation time; DST handled by local-calendar bucketing.
+              </li>
+              <li>
+                Sizing revised: the "scrappy 2–3 day" v1 cut is retired — it would have shipped an
+                unreplayable table. Accounting correctness first; UI was mostly done in mock form
+                anyway.
+              </li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="decision">
+        <div class="section-head">
+          <div class="section-label">01 · Product decision</div>
+          <div>
+            <h2>Index once; query the ledger.</h2>
+            <p class="section-copy">
+              The dashboard should never scan gigabytes of JSONL or rotated provider logs on page
+              load. Each T3 environment owns a compact usage ledger in its existing SQLite state.
+              The client asks every connected environment for aggregate rows and merges those rows
+              locally.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <article class="card decision">
+            <span class="kicker">Default scope</span>
+            <h3>T3 Code only</h3>
+            <p class="subtle">
+              Reliably attributable to T3 provider sessions, threads, projects, subagents, and
+              environments.
+            </p>
+          </article>
+          <article class="card decision">
+            <span class="kicker">Optional scope</span>
+            <h3>All local agent activity</h3>
+            <p class="subtle">
+              Opt-in indexing for Codex, Claude, OpenCode, and future sources launched outside T3.
+            </p>
+          </article>
+          <article class="card decision">
+            <span class="kicker">Placement</span>
+            <h3>Top-level <code>/usage</code></h3>
+            <p class="subtle">
+              A destination beside Settings, not a settings panel and not a thread-level activity
+              view.
+            </p>
+          </article>
+          <article class="card half">
+            <span class="kicker">Do</span>
+            <ul>
+              <li>Persist normalized, idempotent usage records.</li>
+              <li>Keep exact provider cost separate from API-equivalent estimates.</li>
+              <li>Return aggregate, coverage, pricing, and freshness metadata.</li>
+              <li>Show partial cross-environment results when a host is offline.</li>
+            </ul>
+          </article>
+          <article class="card half">
+            <span class="kicker">Do not</span>
+            <ul>
+              <li>Require a separately installed <code>ccusage</code> binary.</li>
+              <li>Store usage rows in thread activities or conversation snapshots.</li>
+              <li>Call cache tokens “input” without separating their semantics.</li>
+              <li>Publish durable usage aggregates to the cloud relay.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="evidence">
+        <div class="section-head">
+          <div class="section-label">02 · What exists</div>
+          <div>
+            <h2>The raw signal is already rich.</h2>
+            <p class="section-copy">
+              T3 currently persists turn timing and context snapshots. Native source logs provide
+              model-level token accounting, cache use, reasoning output, and—on Claude—reported USD
+              cost. The missing layer is durable normalization.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <span class="kicker">T3 SQLite</span>
+            <span class="stat">673</span>
+            <p class="subtle">turns across 113 threads</p>
+          </article>
+          <article class="card">
+            <span class="kicker">Context snapshots</span>
+            <span class="stat">19.5k</span>
+            <p class="subtle">durable updates across 103 threads</p>
+          </article>
+          <article class="card">
+            <span class="kicker">T3 provider logs</span>
+            <span class="stat">2.06 GB</span>
+            <p class="subtle">247 current and rotated files</p>
+          </article>
+          <article class="card">
+            <span class="kicker">Codex history</span>
+            <span class="stat">~390</span>
+            <p class="subtle">JSONL sessions · 396 MB</p>
+          </article>
+          <article class="card">
+            <span class="kicker">Claude history</span>
+            <span class="stat">297</span>
+            <p class="subtle">JSONL sessions · 213 MB</p>
+          </article>
+          <article class="card">
+            <span class="kicker">Direct attribution</span>
+            <span class="stat">109/109</span>
+            <p class="subtle">T3 provider sessions matched native logs</p>
+          </article>
+        </div>
+        <div style="height: 14px"></div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Source</th>
+                <th>What it already knows</th>
+                <th>Current limitation</th>
+                <th>Plan role</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>T3 projections</td>
+                <td>Turns, timestamps, model selection, project/thread ownership</td>
+                <td>Usage is a generic context activity; completion usage is not projected</td>
+                <td>Exact interaction timing and relational joins</td>
+              </tr>
+              <tr>
+                <td>T3 provider logs</td>
+                <td>Native and canonical events with thread IDs</td>
+                <td>Rotated at 10 × 10 MB per thread; unsuitable as the sole history</td>
+                <td>Recent fallback and debugging</td>
+              </tr>
+              <tr>
+                <td>Codex JSONL</td>
+                <td>Model, cumulative and last-call tokens, cache, reasoning, T3 originator</td>
+                <td>Cumulative counters require careful delta conversion</td>
+                <td>Exact live semantics and historical backfill</td>
+              </tr>
+              <tr>
+                <td>Claude JSONL</td>
+                <td>Per-assistant usage, model, cache creation/read, UUID, cost</td>
+                <td>SDK entrypoint alone is not unique to T3</td>
+                <td>Backfill matched by durable provider session ID</td>
+              </tr>
+              <tr>
+                <td>ccusage</td>
+                <td>Timezone reports, cache split, model breakdown, offline pricing</td>
+                <td>External native binary and output/version coupling</td>
+                <td>Oracle, conventions, and compatibility reference</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="height: 14px"></div>
+        <div class="callout">
+          <strong>Performance finding.</strong> An all-history ccusage scan completed quickly on
+          this host, but peaked near 196 MB RSS and used substantial parallel CPU. A representative
+          SQLite usage aggregation completed in roughly 40 ms. The ledger turns an expensive parse
+          into a cheap read.
+        </div>
+      </section>
+
+      <section id="semantics">
+        <div class="section-head">
+          <div class="section-label">03 · Metric contract</div>
+          <div>
+            <h2>Define the numbers before drawing charts.</h2>
+            <p class="section-copy">
+              Token fields differ across providers. The normalized contract must make inclusion and
+              subset relationships explicit so totals remain comparable.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <div class="metric">
+            <strong>Uncached input</strong>
+            <span>Input tokens that were not served from a provider cache.</span>
+          </div>
+          <div class="metric">
+            <strong>Cache read</strong>
+            <span>Reused input tokens. Kept separate because these can dominate totals.</span>
+          </div>
+          <div class="metric">
+            <strong>Cache write</strong>
+            <span>Tokens written into a prompt cache, including Claude cache creation.</span>
+          </div>
+          <div class="metric">
+            <strong>Output</strong>
+            <span>All generated output. Reasoning output is included here.</span>
+          </div>
+          <div class="metric">
+            <strong>Reasoning output</strong>
+            <span>A visible subset of output, never added to the total twice.</span>
+          </div>
+          <div class="metric">
+            <strong>Total tokens</strong>
+            <span>Uncached input + cache read + cache write + output.</span>
+          </div>
+          <div class="metric">
+            <strong>Model calls</strong>
+            <span>Positive native usage records—not turns and not tool calls.</span>
+          </div>
+          <div class="metric">
+            <strong>T3 turns</strong>
+            <span>User-initiated turns. A turn can produce many model calls and subagents.</span>
+          </div>
+          <div class="metric">
+            <strong>Time of day</strong>
+            <span
+              >Turn-start distribution for T3 scope; call distribution for all-local scope.</span
+            >
+          </div>
+        </div>
+        <div style="height: 16px"></div>
+        <div class="callout warning">
+          <strong>Do not report “hours spent” from provider logs.</strong> Logs reveal activity
+          points, not foreground app duration. A future client-presence signal could add actual
+          active time, but it must be named and stored separately.
+        </div>
+      </section>
+
+      <section id="architecture">
+        <div class="section-head">
+          <div class="section-label">04 · Architecture</div>
+          <div>
+            <h2>One normalized path for live and historical usage.</h2>
+            <p class="section-copy">
+              Live adapters emit provider-neutral usage events. Backfill adapters produce identical
+              record identities, so the SQLite uniqueness boundary de-duplicates live and imported
+              data automatically.
+            </p>
+          </div>
+        </div>
+        <div class="diagram" aria-label="Usage architecture diagram">
+          <svg viewBox="0 0 1120 430" role="img" aria-labelledby="architecture-title">
+            <title id="architecture-title">
+              Provider events and native logs feed a local usage ledger queried by connected
+              clients.
+            </title>
+            <defs>
+              <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+                <path d="M0,0 L0,6 L9,3 z" fill="#666" />
+              </marker>
+              <linearGradient id="ledger" x1="0" x2="1">
+                <stop offset="0" stop-color="#112f25" />
+                <stop offset="1" stop-color="#07120e" />
+              </linearGradient>
+            </defs>
+            <g font-family="ui-sans-serif, sans-serif">
+              <text x="38" y="34" fill="#777" font-size="12" font-weight="700">INGESTION</text>
+              <rect x="38" y="54" width="230" height="92" rx="12" fill="#0c0c0c" stroke="#353535" />
+              <text x="58" y="86" fill="#fff" font-size="17" font-weight="700">
+                Live provider events
+              </text>
+              <text x="58" y="112" fill="#999" font-size="12">Codex · Claude · OpenCode · ACP</text>
+              <text x="58" y="130" fill="#63e6a5" font-size="11">exact, low latency</text>
+
+              <rect
+                x="38"
+                y="182"
+                width="230"
+                height="92"
+                rx="12"
+                fill="#0c0c0c"
+                stroke="#353535"
+              />
+              <text x="58" y="214" fill="#fff" font-size="17" font-weight="700">
+                Native log backfill
+              </text>
+              <text x="58" y="240" fill="#999" font-size="12">
+                incremental JSONL / provider stores
+              </text>
+              <text x="58" y="258" fill="#ffd166" font-size="11">streaming, cursor-based</text>
+
+              <path d="M268 100 H360" stroke="#666" stroke-width="2" marker-end="url(#arrow)" />
+              <path
+                d="M268 228 H315 Q340 228 340 203 V165 Q340 140 360 140"
+                fill="none"
+                stroke="#666"
+                stroke-width="2"
+                marker-end="url(#arrow)"
+              />
+
+              <rect x="370" y="80" width="260" height="132" rx="14" fill="#111" stroke="#76a9ff" />
+              <text x="394" y="113" fill="#76a9ff" font-size="12" font-weight="800">
+                NORMALIZATION
+              </text>
+              <text x="394" y="142" fill="#fff" font-size="18" font-weight="700">
+                model.usage-recorded
+              </text>
+              <text x="394" y="168" fill="#aaa" font-size="12">
+                stable native key · model · token split
+              </text>
+              <text x="394" y="188" fill="#aaa" font-size="12">
+                thread / turn · cost · tier · accuracy
+              </text>
+
+              <path d="M630 146 H700" stroke="#666" stroke-width="2" marker-end="url(#arrow)" />
+
+              <rect
+                x="710"
+                y="70"
+                width="360"
+                height="154"
+                rx="14"
+                fill="url(#ledger)"
+                stroke="#63e6a5"
+              />
+              <text x="736" y="103" fill="#63e6a5" font-size="12" font-weight="800">
+                LOCAL SQLITE
+              </text>
+              <text x="736" y="133" fill="#fff" font-size="20" font-weight="700">
+                usage_records
+              </text>
+              <text x="736" y="160" fill="#b7b7b7" font-size="12">
+                append-only ledger · uniqueness on native key
+              </text>
+              <text x="736" y="182" fill="#fff" font-size="15" font-weight="700">
+                usage_source_state
+              </text>
+              <text x="736" y="202" fill="#b7b7b7" font-size="12">
+                file offsets · parser version · freshness · dataset ID
+              </text>
+
+              <path d="M890 224 V282" stroke="#666" stroke-width="2" marker-end="url(#arrow)" />
+
+              <rect
+                x="710"
+                y="292"
+                width="360"
+                height="92"
+                rx="12"
+                fill="#0c0c0c"
+                stroke="#bc9cff"
+              />
+              <text x="736" y="323" fill="#bc9cff" font-size="12" font-weight="800">
+                READ-ONLY RPC
+              </text>
+              <text x="736" y="349" fill="#fff" font-size="18" font-weight="700">usage.query</text>
+              <text x="736" y="370" fill="#aaa" font-size="12">
+                bounded aggregates · coverage · pricing · freshness
+              </text>
+
+              <path d="M710 338 H620" stroke="#666" stroke-width="2" marker-end="url(#arrow)" />
+              <rect
+                x="320"
+                y="290"
+                width="290"
+                height="96"
+                rx="12"
+                fill="#0c0c0c"
+                stroke="#69e1ff"
+              />
+              <text x="344" y="322" fill="#69e1ff" font-size="12" font-weight="800">
+                CLIENT RUNTIME
+              </text>
+              <text x="344" y="349" fill="#fff" font-size="18" font-weight="700">
+                Connected environments
+              </text>
+              <text x="344" y="371" fill="#aaa" font-size="12">
+                parallel query · dataset dedupe · partial success
+              </text>
+
+              <path d="M320 338 H268" stroke="#666" stroke-width="2" marker-end="url(#arrow)" />
+              <rect x="38" y="296" width="220" height="84" rx="12" fill="#0c0c0c" stroke="#fff" />
+              <text x="60" y="330" fill="#fff" font-size="18" font-weight="700">/usage</text>
+              <text x="60" y="354" fill="#aaa" font-size="12">local merged dashboard</text>
+            </g>
+          </svg>
+        </div>
+
+        <div style="height: 16px"></div>
+        <div class="grid">
+          <article class="card half">
+            <span class="kicker">Canonical event</span>
+            <h3><code>model.usage-recorded</code></h3>
+            <p class="subtle">
+              A single provider-neutral usage contract. Context-window events remain dedicated to UI
+              occupancy and compaction behavior.
+            </p>
+            <pre>
+ProviderUsageRecord {
+  nativeRecordKey, provider, providerInstanceId,
+  threadId?, turnId?, projectId?, providerSessionId?,
+  model, occurredAt, requestCount,
+  uncachedInputTokens, cacheReadInputTokens,
+  cacheWriteInputTokens, outputTokens,
+  reasoningOutputTokens,
+  providerCostMicros?, serviceTier?,
+  origin: "t3" | "external",
+  accuracy: "exact" | "derived" | "estimated"
+}</pre
+            >
+          </article>
+          <article class="card half">
+            <span class="kicker">Idempotency boundary</span>
+            <h3>Stable native identity</h3>
+            <ul class="subtle">
+              <li>Claude: session ID + assistant message UUID</li>
+              <li>Codex: session ID + monotonic cumulative usage state</li>
+              <li>OpenCode: provider session/message ID</li>
+              <li>ACP: session + turn + response ordinal</li>
+              <li>Canonical fallback: T3 provider event ID</li>
+            </ul>
+            <div class="callout" style="margin-top: 15px">
+              Live ingestion and later backfill insert the same key. A unique index prevents double
+              counting without source-specific cleanup passes.
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="providers">
+        <div class="section-head">
+          <div class="section-label">05 · Provider work</div>
+          <div>
+            <h2>Capture at the closest trustworthy source.</h2>
+            <p class="section-copy">
+              Avoid parsing provider-specific <code>Unknown</code> payloads downstream. Each adapter
+              should normalize usage while it still understands the native event schema.
+            </p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Provider</th>
+                <th>Live source</th>
+                <th>Backfill source</th>
+                <th>Required change</th>
+                <th>Expected quality</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Codex</td>
+                <td><code>thread/tokenUsage/updated</code></td>
+                <td><code>~/.codex/sessions/**/*.jsonl</code></td>
+                <td>
+                  Preserve full total/last components, cache write, actual model, and reroutes
+                </td>
+                <td class="exact">Exact</td>
+              </tr>
+              <tr>
+                <td>Claude</td>
+                <td>Native assistant SDK message + result reconciliation</td>
+                <td>Claude project JSONL matched by session ID</td>
+                <td>Emit one record per assistant response UUID; preserve reported cost</td>
+                <td class="exact">Exact</td>
+              </tr>
+              <tr>
+                <td>OpenCode</td>
+                <td>Assistant <code>message.updated</code></td>
+                <td>OpenCode local data store</td>
+                <td>Extract message model, tokens, cost, and message ID currently ignored</td>
+                <td class="exact">Exact when present</td>
+              </tr>
+              <tr>
+                <td>Cursor / Grok ACP</td>
+                <td><code>PromptResponse.usage</code> and <code>usage_update</code></td>
+                <td>Recent native/canonical logs</td>
+                <td>Stop discarding the usage object; preserve cumulative cost carefully</td>
+                <td class="partial">Capability-dependent</td>
+              </tr>
+              <tr>
+                <td>Unknown drivers</td>
+                <td>Turn model selection only</td>
+                <td>None until an adapter exists</td>
+                <td>Return turns with explicit token coverage gap</td>
+                <td class="gap">Unavailable, not zero</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="height: 16px"></div>
+        <div class="grid">
+          <article class="card half">
+            <span class="kicker">T3-only backfill</span>
+            <ol>
+              <li>Resolve configured Codex and Claude home paths per provider instance.</li>
+              <li>Seed ownership from <code>provider_session_runtime</code>.</li>
+              <li>Follow Codex <code>parent_thread_id</code> chains for subagents.</li>
+              <li>Keep Claude sidechains inside the matched direct session.</li>
+              <li>Use T3 originator metadata as validation, not global ownership.</li>
+            </ol>
+          </article>
+          <article class="card half">
+            <span class="kicker">Import mechanics</span>
+            <ul>
+              <li>Stream files; never read entire histories into memory.</li>
+              <li>Persist file identity, byte offset, mtime, and parser version.</li>
+              <li>Tolerate partial final lines, append, truncation, and rotation.</li>
+              <li>Whitelist usage fields; never persist prompt or tool payloads.</li>
+              <li>Run at low priority with visible progress and a manual reindex action.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="aggregation">
+        <div class="section-head">
+          <div class="section-label">06 · Pricing and fleet</div>
+          <div>
+            <h2>Aggregate environments, not SSH machines.</h2>
+            <p class="section-copy">
+              T3 already knows its connected execution environments and can run an RPC in any one of
+              them. That catalog is the product-native aggregation boundary and works for local,
+              SSH, bearer, and relay-backed connections.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <article class="card half">
+            <span class="kicker">usage.query</span>
+            <h3>Request</h3>
+            <p class="subtle">
+              UTC range, IANA timezone, bucket granularity, scope, environment filters, and optional
+              project grouping.
+            </p>
+            <h3 style="margin-top: 17px">Response</h3>
+            <p class="subtle">
+              Totals, daily buckets, model rows, hour/weekday distributions, environment/source
+              breakdown, coverage, indexed-through time, errors, and pricing basis.
+            </p>
+          </article>
+          <article class="card half">
+            <span class="kicker">Failure model</span>
+            <h3>Partial success by default</h3>
+            <p class="subtle">
+              If one environment is offline, show available totals and “3 of 4 environments
+              reporting.” Older environments without <code>usageReporting</code> show “Update
+              required” instead of failing the page.
+            </p>
+            <div class="badges">
+              <span class="badge green">connected</span>
+              <span class="badge amber">stale</span>
+              <span class="badge">unsupported</span>
+              <span class="badge violet">relay transport</span>
+            </div>
+          </article>
+          <article class="card half">
+            <span class="kicker">Cross-environment dedupe</span>
+            <h3>Dataset fingerprints</h3>
+            <p class="subtle">
+              Multiple T3 servers on one physical host can see the same provider directory. Hash a
+              stable host identity plus canonical source root; return per-source rollups and select
+              the freshest duplicate dataset before summing.
+            </p>
+          </article>
+          <article class="card half">
+            <span class="kicker">Authorization</span>
+            <h3>Read-only and already scoped</h3>
+            <p class="subtle">
+              Use the existing <code>orchestration:read</code> scope: it already grants access to
+              more sensitive thread snapshots. Manual reindex can require
+              <code>orchestration:operate</code>.
+            </p>
+          </article>
+        </div>
+
+        <div style="height: 16px"></div>
+        <div class="callout warning">
+          <strong>Cost is not billing.</strong> Display “API-equivalent estimate,” use
+          provider-reported cost where available, bundle a pinned offline pricing snapshot, preserve
+          service tier, and label unknown custom models “Unpriced” rather than <code>$0.00</code>.
+          Support import of ccusage-compatible pricing overrides.
+        </div>
+      </section>
+
+      <section id="experience">
+        <div class="section-head">
+          <div class="section-label">07 · Usage page</div>
+          <div>
+            <h2>Make coverage as visible as consumption.</h2>
+            <p class="section-copy">
+              The page should feel like ccusage translated into an interactive, multi-environment T3
+              surface. Every total needs an inspectable source and quality story.
+            </p>
+          </div>
+        </div>
+        <div class="mock-note">
+          <b>Chosen mock (v6)</b>
+          <span>
+            The approved design, built from this machine's full ledger (3.45B tokens, Jun 26 – Jul
+            22). Interactive version with hover tooltips:
+            <a
+              href="https://postplan.dev/d/5bx21h42g0b9/raw"
+              target="_blank"
+              rel="noopener noreferrer"
+              >postplan.dev/d/5bx21h42g0b9</a
+            >. Design system: hue = harness (Claude terracotta, Codex white), lightness = model
+            within the family; violet is reserved for T3-side stats (heatmap, projects); estimated
+            dollars are always striped, exact ones never.
+          </span>
+        </div>
+
+        <div class="um-hero" aria-label="Approved usage mock: twin donuts and KPI tiles">
+          <div class="um-grid">
+            <div class="um-block">
+              <div class="um-cap">Tokens<small>all processed, by harness</small></div>
+              <div class="um-chartwrap">
+                <svg id="um-tok" viewBox="0 0 300 300"></svg>
+                <div class="um-mid"><b>3.45B</b><span>27 days</span></div>
+              </div>
+              <div class="um-list">
+                <div class="um-row">
+                  <i style="background: #cf6b48"></i><b>Claude</b><small>256 turns · $3,043</small
+                  ><span>57% · 1.95B</span>
+                </div>
+                <div class="um-row sub">
+                  <i style="background: #cf6b48"></i>fable-5<span>1.69B</span>
+                </div>
+                <div class="um-row sub">
+                  <i style="background: #f2c1a4"></i>opus-4.8<span>221M</span>
+                </div>
+                <div class="um-row sub">
+                  <i style="background: #a3492a"></i>sonnet-5 · haiku · sonnet-4-6<span>40M</span>
+                </div>
+                <div class="um-row">
+                  <i style="background: #e8e8e3"></i><b>Codex</b
+                  ><small>127 turns · plan-covered</small><span>43% · 1.50B</span>
+                </div>
+              </div>
+            </div>
+            <div class="um-block">
+              <div class="um-cap">
+                Cost<small>Claude metered exactly · Codex estimated at list price</small>
+              </div>
+              <div class="um-chartwrap">
+                <svg id="um-cost" viewBox="0 0 300 300"></svg>
+                <div class="um-mid"><b>$5,407</b><span>$3,043 exact + $2,364 est.</span></div>
+              </div>
+              <div class="um-list">
+                <div class="um-row">
+                  <i style="background: #cf6b48"></i><b>Claude</b><small>exact · SDK-metered</small
+                  ><span>56% · $3,043</span>
+                </div>
+                <div class="um-row sub">
+                  <i style="background: #cf6b48"></i>fable-5<span>$2,810</span>
+                </div>
+                <div class="um-row sub">
+                  <i style="background: #f2c1a4"></i>opus-4.8<span>$213</span>
+                </div>
+                <div class="um-row">
+                  <i class="um-est"></i><b>Codex <em>est.</em></b
+                  ><small>list price · $0 billed (Pro)</small><span>44% · $2,364</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="um-kpis">
+            <div class="um-kpi">
+              <small>Output tokens</small><b>15.4M</b><span>actually generated text</span>
+            </div>
+            <div class="um-kpi">
+              <small>Claude spend</small><b>$3,043</b><span>exact, from SDK results</span>
+            </div>
+            <div class="um-kpi">
+              <small>Codex value</small><b>~$2,364</b><span>list-price est. · $0 billed</span>
+            </div>
+            <div class="um-kpi"><small>Turns</small><b>383</b><span>across 115 threads</span></div>
+            <div class="um-kpi">
+              <small>Cache hit rate</small><b class="um-good">96.2%</b
+              ><span>of all input tokens</span>
+            </div>
+          </div>
+          <div class="um-below">
+            Below the fold (see the interactive mock): tokens-per-day stacked by model, Claude
+            spend-per-day, hour×weekday turn heatmap in the violet T3 lane, per-provider hourly
+            token charts, the full models table (the accessible view of every chart), projects,
+            reasoning-effort breakdown, and marathon-turn records.
+          </div>
+        </div>
+
+        <style>
+          .um-hero {
+            background: #0a0a0a;
+            border: 1px solid #262626;
+            border-radius: 14px;
+            padding: 22px;
+          }
+          .um-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+          }
+          @media (max-width: 860px) {
+            .um-grid {
+              grid-template-columns: 1fr;
+            }
+          }
+          .um-cap {
+            text-align: center;
+            font-weight: 700;
+            font-size: 13px;
+            margin-bottom: 12px;
+          }
+          .um-cap small {
+            display: block;
+            font-weight: 400;
+            font-size: 11.5px;
+            color: #9a9a9a;
+            margin-top: 2px;
+          }
+          .um-chartwrap {
+            position: relative;
+            max-width: 270px;
+            margin: 0 auto;
+          }
+          .um-mid {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            pointer-events: none;
+          }
+          .um-mid b {
+            font-size: 34px;
+            letter-spacing: -0.02em;
+          }
+          .um-mid span {
+            font-size: 11px;
+            color: #9a9a9a;
+            margin-top: 4px;
+          }
+          .um-list {
+            margin-top: 12px;
+            font-size: 13px;
+          }
+          .um-row {
+            display: flex;
+            align-items: center;
+            gap: 9px;
+            padding: 7px 4px;
+            border-bottom: 1px solid #1d1d1d;
+          }
+          .um-row:last-child {
+            border-bottom: none;
+          }
+          .um-row.sub {
+            padding-left: 26px;
+            color: #9a9a9a;
+            font-size: 12.5px;
+            border-bottom: none;
+            padding-top: 3px;
+            padding-bottom: 3px;
+          }
+          .um-row i {
+            width: 10px;
+            height: 10px;
+            border-radius: 3px;
+            flex: none;
+          }
+          .um-row.sub i {
+            width: 8px;
+            height: 8px;
+          }
+          .um-row span {
+            margin-left: auto;
+            font-variant-numeric: tabular-nums;
+            color: #ddd;
+          }
+          .um-row small {
+            color: #767676;
+          }
+          .um-est {
+            background: repeating-linear-gradient(45deg, #e8e8e3 0 3px, #8a8880 3px 5px);
+          }
+          .um-kpis {
+            display: grid;
+            grid-template-columns: repeat(5, 1fr);
+            gap: 10px;
+            margin-top: 20px;
+          }
+          @media (max-width: 860px) {
+            .um-kpis {
+              grid-template-columns: repeat(2, 1fr);
+            }
+          }
+          .um-kpi {
+            background: #111;
+            border: 1px solid #262626;
+            border-radius: 10px;
+            padding: 11px 13px;
+          }
+          .um-kpi small {
+            color: #9a9a9a;
+            font-size: 11px;
+            display: block;
+          }
+          .um-kpi b {
+            font-size: 21px;
+            letter-spacing: -0.01em;
+          }
+          .um-kpi span {
+            display: block;
+            color: #767676;
+            font-size: 10.5px;
+            margin-top: 1px;
+          }
+          .um-good {
+            color: #63e6a5;
+          }
+          .um-below {
+            margin-top: 16px;
+            font-size: 12.5px;
+            color: #9a9a9a;
+            line-height: 1.6;
+          }
+        </style>
+        <script>
+          (function () {
+            function donut(id, groups) {
+              var svg = document.getElementById(id);
+              var cx = 150,
+                cy = 150,
+                R = 140,
+                r = 96,
+                TAU = Math.PI * 2;
+              var total = 0;
+              groups.forEach(function (g) {
+                g.models.forEach(function (m) {
+                  total += m.v;
+                });
+              });
+              function pt(a, rad) {
+                return (
+                  (cx + Math.cos(a) * rad).toFixed(2) + " " + (cy + Math.sin(a) * rad).toFixed(2)
+                );
+              }
+              var a0 = -Math.PI / 2;
+              var s =
+                '<defs><pattern id="' +
+                id +
+                '-est" patternUnits="userSpaceOnUse" width="7" height="7" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="7" stroke="rgba(0,0,0,0.35)" stroke-width="2.5"/></pattern></defs>';
+              groups.forEach(function (g) {
+                var gStart = a0,
+                  gTotal = 0;
+                g.models.forEach(function (m) {
+                  gTotal += m.v;
+                });
+                g.models.forEach(function (m) {
+                  var sweep = (m.v / total) * TAU,
+                    a1 = a0 + sweep;
+                  var gap = Math.min(0.014, sweep * 0.3);
+                  var b0 = a0 + gap / 2,
+                    b1 = a1 - gap / 2;
+                  var large = b1 - b0 > Math.PI ? 1 : 0;
+                  var d =
+                    "M " +
+                    pt(b0, R) +
+                    " A " +
+                    R +
+                    " " +
+                    R +
+                    " 0 " +
+                    large +
+                    " 1 " +
+                    pt(b1, R) +
+                    " L " +
+                    pt(b1, r) +
+                    " A " +
+                    r +
+                    " " +
+                    r +
+                    " 0 " +
+                    large +
+                    " 0 " +
+                    pt(b0, r) +
+                    " Z";
+                  s += '<path d="' + d + '" fill="' + m.c + '"/>';
+                  if (m.est) s += '<path d="' + d + '" fill="url(#' + id + '-est)"/>';
+                  a0 = a1;
+                });
+                var gPct = (gTotal / total) * 100;
+                if (gPct >= 8) {
+                  var mid = (gStart + a0) / 2,
+                    lr = (R + r) / 2;
+                  var hx = parseInt(g.color.slice(1, 3), 16),
+                    gx = parseInt(g.color.slice(3, 5), 16),
+                    bx = parseInt(g.color.slice(5, 7), 16);
+                  var ink = hx * 0.299 + gx * 0.587 + bx * 0.114 > 150 ? "#1a1a19" : "#fff";
+                  s +=
+                    '<text x="' +
+                    (cx + Math.cos(mid) * lr) +
+                    '" y="' +
+                    (cy + Math.sin(mid) * lr) +
+                    '" text-anchor="middle" dominant-baseline="middle" style="fill:' +
+                    ink +
+                    ';font:680 15px ui-sans-serif,sans-serif">' +
+                    gPct.toFixed(0) +
+                    "%</text>";
+                }
+              });
+              svg.innerHTML = s;
+            }
+            donut("um-tok", [
+              {
+                color: "#cf6b48",
+                models: [
+                  { v: 1692.7, c: "#cf6b48" },
+                  { v: 221.3, c: "#f2c1a4" },
+                  { v: 40.1, c: "#a3492a" },
+                ],
+              },
+              { color: "#e8e8e3", models: [{ v: 1498.2, c: "#e8e8e3" }] },
+            ]);
+            donut("um-cost", [
+              {
+                color: "#cf6b48",
+                models: [
+                  { v: 2810, c: "#cf6b48" },
+                  { v: 213, c: "#f2c1a4" },
+                  { v: 20, c: "#a3492a" },
+                ],
+              },
+              { color: "#e8e8e3", models: [{ v: 2364, c: "#e8e8e3", est: true }] },
+            ]);
+          })();
+        </script>
+
+        <div class="mock-decisions">
+          <div class="mock-decision">
+            <b>Harness first, models as shades</b
+            ><span
+              >The top-level split is Claude vs Codex; models are lightness steps within the harness
+              hue, so the donut reads at two zoom levels.</span
+            >
+          </div>
+          <div class="mock-decision">
+            <b>Exact and estimated never blend</b
+            ><span
+              >Metered cost is solid; list-price estimates are striped and labeled est. — in charts,
+              tiles, and tooltips alike.</span
+            >
+          </div>
+          <div class="mock-decision">
+            <b>Official marks carry identity</b
+            ><span
+              >Provider logos (already in Icons.tsx) appear in legends, tiles, and table rows; brand
+              color is for logos, validated steps for data.</span
+            >
+          </div>
+          <div class="mock-decision">
+            <b>The table is the fallback</b
+            ><span
+              >The models table is the accessible view of every chart; violet marks T3-side stats so
+              provider hues stay unambiguous.</span
+            >
+          </div>
+        </div>
+      </section>
+
+      <section id="rollout">
+        <div class="section-head">
+          <div class="section-label">08 · Delivery sequence</div>
+          <div>
+            <h2>Ship in six reviewable slices.</h2>
+            <p class="section-copy">
+              Establish accounting correctness before UI polish. Each slice leaves a usable,
+              testable boundary and avoids bundling provider parsing, fleet aggregation, and
+              charting into one risky change.
+            </p>
+          </div>
+        </div>
+        <div class="phase-list">
+          <article class="phase">
+            <div class="phase-title">Semantics, durable events, and projector</div>
+            <div class="phase-copy">
+              Add <code>packages/contracts/src/usage.ts</code> (typed facts: cumulative vs interval,
+              cache read vs write, native identity, reset generation; typed
+              <code>modelUsage</code>), emit durable <code>model.usage-recorded</code> orchestration
+              events from ingestion, and register a usage projector with its own
+              <code>projection_state</code> cursor. Schema migration creates tables only. Tests:
+              live-vs-replay equivalence, restart, duplicates, abort, steering, revert retention,
+              deletion redaction.
+            </div>
+          </article>
+          <article class="phase">
+            <div class="phase-title">Codex and Claude live capture</div>
+            <div class="phase-copy">
+              Preserve <code>providerRefs</code>, per-model usage, and exact cost through ingestion
+              (ClaudeAdapter already emits them on <code>turn.completed</code>); finalize on
+              <code>turn.aborted</code>, session exit, and steering-superseded paths, not completion
+              alone. Extend the snapshot contract with cache-creation tokens.
+            </div>
+          </article>
+          <article class="phase">
+            <div class="phase-title">Backfill and pricing</div>
+            <div class="phase-copy">
+              Versioned, resumable server-side backfill job (never inside migrations, no second DB
+              writer): event replay via the projector's empty cursor, then provider-log parse, then
+              opt-in transcript enrichment — same fact IDs, explicit upsert precedence. Versioned,
+              effective-dated pricing catalog in shared runtime code; estimates computed at query
+              time, never stored as truth.
+            </div>
+          </article>
+          <article class="phase">
+            <div class="phase-title">RPC and aggregation</div>
+            <div class="phase-copy">
+              Add <code>usage.query</code>, environment capability negotiation, client-runtime query
+              atoms, partial errors, timezone grouping, and dataset de-duplication.
+            </div>
+          </article>
+          <article class="phase">
+            <div class="phase-title">Web and desktop Usage page</div>
+            <div class="phase-copy">
+              Add the route, sidebar affordance, summary cards, accessible SVG/CSS charts, model and
+              environment tables, coverage states, filters, and empty/error states.
+            </div>
+          </article>
+          <article class="phase">
+            <div class="phase-title">Coverage and mobile</div>
+            <div class="phase-copy">
+              Add OpenCode and ACP capture, all-local opt-in, cached offline aggregates, responsive
+              mobile UI, and the mobile integrated verification pass.
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="verification">
+        <div class="section-head">
+          <div class="section-label">09 · Verification</div>
+          <div>
+            <h2>Test accounting invariants, not screenshots alone.</h2>
+            <p class="section-copy">
+              Backend changes require focused tests for every changed behavior. Frontend integration
+              follows the repository’s isolated T3 app verification workflow.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <article class="card half">
+            <span class="kicker">Normalizer and importer</span>
+            <ul class="checklist">
+              <li>Cumulative-to-delta conversion</li>
+              <li>Counter reset and compaction</li>
+              <li>Cache semantic normalization</li>
+              <li>Reasoning as output subset</li>
+              <li>Model changes and reroutes</li>
+              <li>Duplicate live/backfill keys</li>
+              <li>Partial final JSONL line</li>
+              <li>Append, truncate, and rotate</li>
+              <li>Custom provider home paths</li>
+              <li>T3 descendant attribution</li>
+            </ul>
+          </article>
+          <article class="card half">
+            <span class="kicker">Query and client</span>
+            <ul class="checklist">
+              <li>DST spring and fall boundaries</li>
+              <li>Arbitrary IANA timezones</li>
+              <li>Range limits and read scope</li>
+              <li>Offline partial results</li>
+              <li>Server version skew</li>
+              <li>Dataset fingerprint dedupe</li>
+              <li>Unknown and mixed pricing</li>
+              <li>Accessible chart labels</li>
+              <li>Empty and stale states</li>
+              <li>Thread deletion retention</li>
+            </ul>
+          </article>
+          <article class="card full">
+            <span class="kicker">Integrated pass</span>
+            <p>
+              Launch one isolated environment with the <code>test-t3-app</code> skill, authenticate
+              via its printed pairing URL, seed deterministic ledger rows, and verify the date,
+              scope, model, environment, timezone, partial-data, and unpriced-model flows in the
+              controlled browser. Stop every server and watcher afterward. Run
+              <code>test-t3-mobile</code> only when mobile UI ships.
+            </p>
+            <div class="badges">
+              <span class="badge green">30-day query target &lt; 200 ms / environment</span>
+              <span class="badge">streaming import memory bounded</span>
+              <span class="badge">no full workspace suite locally</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="risks">
+        <div class="section-head">
+          <div class="section-label">10 · Risks and safeguards</div>
+          <div>
+            <h2>Be honest where inference stops.</h2>
+            <p class="section-copy">
+              The largest risk is not missing data; it is silently presenting duplicate, cumulative,
+              unpriced, or differently defined data as a single exact total.
+            </p>
+          </div>
+        </div>
+        <div class="grid">
+          <article class="risk">
+            <strong>Cumulative counters double-count.</strong>
+            <span class="subtle"
+              >Use monotonic totals, stable native keys, and explicit reset rules.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Live and backfill overlap.</strong>
+            <span class="subtle"
+              >Enforce native record uniqueness independent of ingestion source.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Two environments share one provider home.</strong>
+            <span class="subtle"
+              >Return per-source rollups and dedupe hashed dataset fingerprints.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Provider formats drift.</strong>
+            <span class="subtle"
+              >Version parsers, use golden fixtures, surface importer errors, retain cursors.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Custom models have no public price.</strong>
+            <span class="subtle"
+              >Show “Unpriced,” report coverage, and support compatible overrides.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Historical thread deletion changes joins.</strong>
+            <span class="subtle"
+              >Persist stable project/thread IDs in usage rows; clear usage separately.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Raw logs contain private content.</strong>
+            <span class="subtle"
+              >Whitelist fields during streaming parse; store no prompts, tools, or cwd.</span
+            >
+          </article>
+          <article class="risk">
+            <strong>Estimated cost looks like a bill.</strong>
+            <span class="subtle"
+              >Label API-equivalent cost, basis, pricing version, tier, and unknowns.</span
+            >
+          </article>
+        </div>
+      </section>
+
+      <section id="source-map">
+        <div class="section-head">
+          <div class="section-label">11 · Repository map</div>
+          <div>
+            <h2>Likely implementation touch points.</h2>
+            <p class="section-copy">
+              Keep contracts schema-only, place runtime parsing in shared/server modules, and reuse
+              the environment-aware client-runtime query machinery.
+            </p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Area</th>
+                <th>Files / package</th>
+                <th>Responsibility</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Contracts</td>
+                <td>
+                  <code>packages/contracts/src/usage.ts</code>, <code>rpc.ts</code>,
+                  <code>environment.ts</code>
+                </td>
+                <td>Usage schemas, RPC input/output, capability flag</td>
+              </tr>
+              <tr>
+                <td>Server usage domain</td>
+                <td><code>apps/server/src/usage/{Services,Layers}</code></td>
+                <td>Ledger, importers, pricing, aggregation, source status</td>
+              </tr>
+              <tr>
+                <td>Persistence</td>
+                <td><code>apps/server/src/persistence/Migrations/033_UsageLedger.ts</code></td>
+                <td>Usage rows, source cursors, indexes, repository tests</td>
+              </tr>
+              <tr>
+                <td>Provider adapters</td>
+                <td>
+                  <code>CodexAdapter.ts</code>, <code>ClaudeAdapter.ts</code>,
+                  <code>OpenCodeAdapter.ts</code>, ACP adapters
+                </td>
+                <td>Native usage extraction and stable record identities</td>
+              </tr>
+              <tr>
+                <td>Transport</td>
+                <td>
+                  <code>apps/server/src/ws.ts</code>, <code>packages/contracts/src/rpc.ts</code>
+                </td>
+                <td>Read query, manual reindex, authorization, instrumentation</td>
+              </tr>
+              <tr>
+                <td>Client runtime</td>
+                <td><code>packages/client-runtime/src/state/usage.ts</code></td>
+                <td>Per-environment queries, partial success, dedupe, merged report</td>
+              </tr>
+              <tr>
+                <td>Web</td>
+                <td><code>apps/web/src/routes/usage.tsx</code>, components, sidebar</td>
+                <td>Filters, charts, tables, freshness, coverage, route navigation</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer>
+        <span>T3 Code Usage plan · generated from local repository and log exploration</span>
+        <span>2026-07-22 · America/Los_Angeles</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -294,6 +294,10 @@ export function createServerEnvironmentAtoms<R, E>(
       label: "environment-data:server:process-diagnostics",
       tag: WS_METHODS.serverGetProcessDiagnostics,
     }),
+    usageSummary: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:usage-summary",
+      tag: WS_METHODS.usageGetSummary,
+    }),
     processResourceHistory: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:server:process-resource-history",
       tag: WS_METHODS.serverGetProcessResourceHistory,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -26,3 +26,4 @@ export * from "./review.ts";
 export * from "./preview.ts";
 export * from "./previewAutomation.ts";
 export * from "./rpc.ts";
+export * from "./usage.ts";

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -21,6 +21,7 @@ import {
   TurnId,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
+import { UsageFact } from "./usage.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -798,6 +799,17 @@ const ThreadRevertCompleteCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadUsageRecordCommand = Schema.Struct({
+  type: Schema.Literal("thread.usage.record"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  turnId: Schema.NullOr(TurnId),
+  projectId: Schema.NullOr(ProjectId),
+  facts: Schema.Array(UsageFact),
+  createdAt: IsoDateTime,
+});
+export type ThreadUsageRecordCommand = typeof ThreadUsageRecordCommand.Type;
+
 const InternalOrchestrationCommand = Schema.Union([
   ThreadSessionSetCommand,
   ThreadMessageAssistantDeltaCommand,
@@ -806,6 +818,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadTurnDiffCompleteCommand,
   ThreadActivityAppendCommand,
   ThreadRevertCompleteCommand,
+  ThreadUsageRecordCommand,
 ]);
 export type InternalOrchestrationCommand = typeof InternalOrchestrationCommand.Type;
 
@@ -838,6 +851,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.proposed-plan-upserted",
   "thread.turn-diff-completed",
   "thread.activity-appended",
+  "thread.usage-recorded",
 ]);
 export type OrchestrationEventType = typeof OrchestrationEventType.Type;
 
@@ -1012,6 +1026,15 @@ export const ThreadActivityAppendedPayload = Schema.Struct({
   activity: OrchestrationThreadActivity,
 });
 
+export const ThreadUsageRecordedPayload = Schema.Struct({
+  threadId: ThreadId,
+  turnId: Schema.NullOr(TurnId),
+  /** Project attribution captured at fact time (historical-at-use). */
+  projectId: Schema.NullOr(ProjectId),
+  facts: Schema.Array(UsageFact),
+  recordedAt: IsoDateTime,
+});
+
 export const OrchestrationEventMetadata = Schema.Struct({
   providerTurnId: Schema.optional(TrimmedNonEmptyString),
   providerItemId: Schema.optional(ProviderItemId),
@@ -1143,6 +1166,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.activity-appended"),
     payload: ThreadActivityAppendedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.usage-recorded"),
+    payload: ThreadUsageRecordedPayload,
   }),
 ]);
 export type OrchestrationEvent = typeof OrchestrationEvent.Type;

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -46,6 +46,10 @@ const ProviderRefs = Schema.Struct({
   providerTurnId: Schema.optional(TrimmedNonEmptyStringSchema),
   providerItemId: Schema.optional(ProviderItemId),
   providerRequestId: Schema.optional(ProviderRequestId),
+  /** Provider-native session/thread identity (Claude session_id, Codex thread
+   * id). Required to attribute cumulative usage counters when several
+   * provider sessions run concurrently under one T3 thread. */
+  providerSessionId: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 export type ProviderRefs = typeof ProviderRefs.Type;
 
@@ -320,6 +324,14 @@ export const ThreadTokenUsageSnapshot = Schema.Struct({
   toolUses: Schema.optional(NonNegativeInt),
   durationMs: Schema.optional(NonNegativeInt),
   compactsAutomatically: Schema.optional(Schema.Boolean),
+  /** Session-cumulative counters (monotonic within one provider-native
+   * session). Present only when the adapter can report them; usage accounting
+   * derives interval deltas from these, never from the context-window fields
+   * above. `totalInputTokens` includes cached reads, mirroring the provider. */
+  totalInputTokens: Schema.optional(NonNegativeInt),
+  totalCachedInputTokens: Schema.optional(NonNegativeInt),
+  totalOutputTokens: Schema.optional(NonNegativeInt),
+  totalReasoningOutputTokens: Schema.optional(NonNegativeInt),
 });
 export type ThreadTokenUsageSnapshot = typeof ThreadTokenUsageSnapshot.Type;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -132,6 +132,7 @@ import {
   ServerUpsertKeybindingResult,
 } from "./server.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
+import { UsageSummaryRequest, UsageSummaryResponse } from "./usage.ts";
 import {
   SourceControlCloneRepositoryInput,
   SourceControlCloneRepositoryResult,
@@ -211,6 +212,7 @@ export const WS_METHODS = {
   serverUpdateSettings: "server.updateSettings",
   serverDiscoverSourceControl: "server.discoverSourceControl",
   serverGetTraceDiagnostics: "server.getTraceDiagnostics",
+  usageGetSummary: "usage.getSummary",
   serverGetProcessDiagnostics: "server.getProcessDiagnostics",
   serverGetProcessResourceHistory: "server.getProcessResourceHistory",
   serverSignalProcess: "server.signalProcess",
@@ -300,6 +302,12 @@ export const WsServerDiscoverSourceControlRpc = Rpc.make(WS_METHODS.serverDiscov
 export const WsServerGetTraceDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetTraceDiagnostics, {
   payload: Schema.Struct({}),
   success: ServerTraceDiagnosticsResult,
+  error: EnvironmentAuthorizationError,
+});
+
+export const WsUsageGetSummaryRpc = Rpc.make(WS_METHODS.usageGetSummary, {
+  payload: UsageSummaryRequest,
+  success: UsageSummaryResponse,
   error: EnvironmentAuthorizationError,
 });
 
@@ -699,6 +707,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerUpdateSettingsRpc,
   WsServerDiscoverSourceControlRpc,
   WsServerGetTraceDiagnosticsRpc,
+  WsUsageGetSummaryRpc,
   WsServerGetProcessDiagnosticsRpc,
   WsServerGetProcessResourceHistoryRpc,
   WsServerSignalProcessRpc,

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -1,0 +1,153 @@
+import * as Schema from "effect/Schema";
+import { IsoDateTime, NonNegativeInt, ProjectId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
+
+// ---------------------------------------------------------------------------
+// Usage facts
+//
+// A usage fact is an immutable accounting record: interval token counters (never
+// cumulative) attributed to a provider-native session so that concurrent or
+// resumed provider sessions on one T3 thread can never be conflated. Facts are
+// persisted as `thread.usage-recorded` orchestration events and projected into
+// `projection_usage_facts` / `projection_usage_daily` by a registered projector.
+// ---------------------------------------------------------------------------
+
+export const UsageFactId = TrimmedNonEmptyString.pipe(Schema.brand("UsageFactId"));
+export type UsageFactId = typeof UsageFactId.Type;
+
+/** Interval (delta) token counters. Adapters convert cumulative provider
+ * counters into deltas before a fact is emitted; a fact never carries a
+ * running total. `cachedInputTokens` are cache reads; `cacheCreationTokens`
+ * are cache writes — they are priced differently and never summed silently. */
+export const UsageTokenCounters = Schema.Struct({
+  inputTokens: NonNegativeInt,
+  cachedInputTokens: NonNegativeInt,
+  cacheCreationTokens: NonNegativeInt,
+  outputTokens: NonNegativeInt,
+  reasoningOutputTokens: NonNegativeInt,
+});
+export type UsageTokenCounters = typeof UsageTokenCounters.Type;
+
+/** `final` — per-model settlement derived from a provider's terminal report
+ * (Claude modelUsage deltas). `interval` — an accumulated slice of a turn
+ * flushed before settlement (Codex per-update deltas); intervals and finals
+ * both sum linearly. `turn-total` — the provider's own turn-level cost figure
+ * kept only to reconcile against per-model facts, never added to them. */
+export const UsageFactKind = Schema.Literals(["final", "interval", "turn-total"]);
+export type UsageFactKind = typeof UsageFactKind.Type;
+
+export const UsageFact = Schema.Struct({
+  factId: UsageFactId,
+  kind: UsageFactKind,
+  provider: ProviderDriverKind,
+  providerInstanceId: Schema.optional(ProviderInstanceId),
+  /** Provider-native session identity (Claude session_id, Codex thread id).
+   * Falls back to the T3 thread id when a driver exposes nothing better. */
+  providerSessionId: TrimmedNonEmptyString,
+  model: TrimmedNonEmptyString,
+  /** Model id exactly as the provider reported it (e.g. with `[1m]` suffix). */
+  modelRaw: TrimmedNonEmptyString,
+  reasoningEffort: Schema.optional(TrimmedNonEmptyString),
+  tokens: UsageTokenCounters,
+  /** Exact provider-reported cost in integer micro-USD. Absent when the
+   * provider does not meter (Codex); estimates are computed at query time and
+   * never stored. */
+  costMicroUsd: Schema.optional(NonNegativeInt),
+  /** True when the originating runtime event was rejected by the turn
+   * lifecycle guard (stale completion); recorded rather than dropped. */
+  stale: Schema.optional(Schema.Boolean),
+  observedAt: IsoDateTime,
+});
+export type UsageFact = typeof UsageFact.Type;
+
+// ---------------------------------------------------------------------------
+// Claude SDK modelUsage — typed replacement for the UnknownRecord that rides
+// on `turn.completed`. Keys of the map are raw model ids.
+// ---------------------------------------------------------------------------
+
+export const ClaudeModelUsageEntry = Schema.Struct({
+  inputTokens: NonNegativeInt,
+  outputTokens: NonNegativeInt,
+  cacheReadInputTokens: NonNegativeInt,
+  cacheCreationInputTokens: NonNegativeInt,
+  costUSD: Schema.optional(Schema.Number),
+});
+export type ClaudeModelUsageEntry = typeof ClaudeModelUsageEntry.Type;
+
+export const ClaudeModelUsageMap = Schema.Record(Schema.String, ClaudeModelUsageEntry);
+export type ClaudeModelUsageMap = typeof ClaudeModelUsageMap.Type;
+
+// ---------------------------------------------------------------------------
+// usage.summary RPC — one dashboard-shaped request so the Usage page renders
+// from a single round trip. All aggregates are integers (tokens) or integer
+// micro-USD; grouping happens in the requested IANA timezone.
+// ---------------------------------------------------------------------------
+
+export const UsageSummaryRequest = Schema.Struct({
+  /** Inclusive ISO date-time lower bound; omit for all time. */
+  since: Schema.optional(IsoDateTime),
+  /** Exclusive ISO date-time upper bound; omit for now. */
+  until: Schema.optional(IsoDateTime),
+  /** IANA timezone used for calendar bucketing (daily, hour-of-week). */
+  timeZone: TrimmedNonEmptyString,
+});
+export type UsageSummaryRequest = typeof UsageSummaryRequest.Type;
+
+export const UsageCostSource = Schema.Literals(["exact", "estimated", "none"]);
+export type UsageCostSource = typeof UsageCostSource.Type;
+
+const UsageAggregate = Schema.Struct({
+  ...UsageTokenCounters.fields,
+  totalTokens: NonNegativeInt,
+  turns: NonNegativeInt,
+  exactCostMicroUsd: NonNegativeInt,
+  estimatedCostMicroUsd: NonNegativeInt,
+});
+export type UsageAggregate = typeof UsageAggregate.Type;
+
+export const UsageModelBucket = Schema.Struct({
+  ...UsageAggregate.fields,
+  provider: ProviderDriverKind,
+  model: TrimmedNonEmptyString,
+  costSource: UsageCostSource,
+});
+export type UsageModelBucket = typeof UsageModelBucket.Type;
+
+export const UsageDailyBucket = Schema.Struct({
+  ...UsageAggregate.fields,
+  /** Local calendar date (YYYY-MM-DD) in the request timezone. */
+  day: TrimmedNonEmptyString,
+  provider: ProviderDriverKind,
+  model: TrimmedNonEmptyString,
+});
+export type UsageDailyBucket = typeof UsageDailyBucket.Type;
+
+export const UsageHourOfWeekBucket = Schema.Struct({
+  /** 0 = Sunday, per JS Date#getDay in the request timezone. */
+  dayOfWeek: NonNegativeInt,
+  hour: NonNegativeInt,
+  turns: NonNegativeInt,
+  totalTokens: NonNegativeInt,
+});
+export type UsageHourOfWeekBucket = typeof UsageHourOfWeekBucket.Type;
+
+export const UsageProjectBucket = Schema.Struct({
+  ...UsageAggregate.fields,
+  projectId: Schema.NullOr(ProjectId),
+  projectTitle: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type UsageProjectBucket = typeof UsageProjectBucket.Type;
+
+export const UsageSummaryResponse = Schema.Struct({
+  totals: UsageAggregate,
+  byModel: Schema.Array(UsageModelBucket),
+  daily: Schema.Array(UsageDailyBucket),
+  hourOfWeek: Schema.Array(UsageHourOfWeekBucket),
+  byProject: Schema.Array(UsageProjectBucket),
+  /** Models with token volume but no pricing entry — surfaced, never $0. */
+  unpricedModels: Schema.Array(TrimmedNonEmptyString),
+  pricingVersion: TrimmedNonEmptyString,
+  /** Earliest fact in the ledger, for "history starts here" honesty. */
+  earliestFactAt: Schema.NullOr(IsoDateTime),
+});
+export type UsageSummaryResponse = typeof UsageSummaryResponse.Type;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./usagePricing": {
+      "types": "./src/usagePricing.ts",
+      "import": "./src/usagePricing.ts"
+    },
     "./projectFavicon": {
       "types": "./src/projectFavicon.ts",
       "import": "./src/projectFavicon.ts"

--- a/packages/shared/src/usagePricing.ts
+++ b/packages/shared/src/usagePricing.ts
@@ -1,0 +1,79 @@
+/**
+ * Versioned list-price catalog for estimating usage cost when a provider does
+ * not meter (Codex reports tokens only). Estimates are computed at query time
+ * from immutable token facts and are always labeled as estimates — they are
+ * never persisted and never blended with provider-reported exact cost.
+ *
+ * Rates are USD per million tokens, effective-dated so a price change never
+ * silently revalues history. `cacheWritePerMTok` covers cache-creation
+ * tokens; providers without a cache-write concept omit it.
+ */
+
+export interface UsageModelPricing {
+  readonly model: string;
+  /** Inclusive ISO date this rate takes effect. */
+  readonly effectiveFrom: string;
+  readonly inputPerMTok: number;
+  readonly cachedInputPerMTok: number;
+  readonly cacheWritePerMTok?: number;
+  readonly outputPerMTok: number;
+}
+
+export const USAGE_PRICING_VERSION = "2026-07-24";
+
+const CATALOG: ReadonlyArray<UsageModelPricing> = [
+  // OpenAI list prices (verified against ccusage output to the cent).
+  {
+    model: "gpt-5.6-sol",
+    effectiveFrom: "2026-01-01",
+    inputPerMTok: 10,
+    cachedInputPerMTok: 1,
+    outputPerMTok: 60,
+  },
+  {
+    model: "gpt-5.5",
+    effectiveFrom: "2025-11-01",
+    inputPerMTok: 10,
+    cachedInputPerMTok: 1,
+    outputPerMTok: 60,
+  },
+];
+
+export interface UsageTokenBreakdown {
+  readonly inputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly outputTokens: number;
+}
+
+function rateFor(model: string, observedAtIso: string): UsageModelPricing | undefined {
+  let best: UsageModelPricing | undefined;
+  for (const entry of CATALOG) {
+    if (entry.model !== model) continue;
+    if (entry.effectiveFrom > observedAtIso.slice(0, 10)) continue;
+    if (!best || entry.effectiveFrom > best.effectiveFrom) {
+      best = entry;
+    }
+  }
+  return best;
+}
+
+/** Integer micro-USD estimate, or undefined when the model has no rate (the
+ * caller surfaces it as unpriced rather than $0). */
+export function estimateCostMicroUsd(
+  model: string,
+  observedAtIso: string,
+  tokens: UsageTokenBreakdown,
+): number | undefined {
+  const rate = rateFor(model, observedAtIso);
+  if (!rate) {
+    return undefined;
+  }
+  const usd =
+    (tokens.inputTokens * rate.inputPerMTok +
+      tokens.cachedInputTokens * rate.cachedInputPerMTok +
+      tokens.cacheCreationTokens * (rate.cacheWritePerMTok ?? rate.inputPerMTok) +
+      tokens.outputTokens * rate.outputPerMTok) /
+    1_000_000;
+  return Math.round(usd * 1_000_000);
+}


### PR DESCRIPTION
> [!NOTE]
> **WIP — intentionally not a draft** so it gets real reviews. Core accounting is built and tested; the deferred list below is scoped follow-up work, not unfinished scaffolding.

## What this is

Local, private usage analytics for T3 Code (think ccusage, but first-class): tokens, exact + estimated cost, time-of-day patterns, per-model/per-project breakdowns — recorded in each environment's own sqlite, displayed at **Settings → Usage**.

Plan doc (v2, independently reviewed by gpt-5.6-sol with findings folded in): `docs/t3-code-usage-plan.html` in this PR. Approved UI mock built from ~1 month of real usage data: https://postplan.dev/d/5bx21h42g0b9/raw

## Architecture (the part worth reviewing hardest)

**Durable facts, replayable projector — not an in-memory fold.**

1. `ProviderRuntimeIngestion` converts provider-cumulative counters into **interval usage facts** and dispatches an internal `thread.usage.record` command → `thread.usage-recorded` orchestration event (payload keeps provider-native session identity, per-model tokens, exact cost in integer micro-USD).
2. A registered `projection.usage` projector (standard `projection_state` cursor, replay-on-bootstrap) upserts facts by deterministic `fact_id` into `projection_usage_facts` (migration 033).
3. `usage.getSummary` RPC (read scope) aggregates facts into dashboard buckets, grouped in the **caller's IANA timezone**; list-price estimates are computed at query time from a versioned catalog (`packages/shared/src/usagePricing.ts`) and never stored or blended with exact cost.

Accounting invariants encoded and tested:
- **Native-session baselines** (`providerSessionId` now rides `providerRefs`): concurrent Codex subagent sessions on one T3 thread can't conflate cumulative counters (this inflated naive replay 12× in validation).
- **Restart safety**: baselines reseed from recorded fact sums (`sumBySessionModel`), so a restart between samples never double counts.
- **Counter-reset detection**: any counter regression → absolute value used, flagged internally.
- **Usage survives `thread.reverted`** (deliberately no prune case — tokens were consumed); thread deletion **redacts** linkage but keeps accounting.
- **Stale completions recorded, flagged** (`stale=1`), never dropped.
- Claude `modelUsage` settles per-model `final` facts with exact `costUSD` deltas; Codex `tokenUsage.total` flows as `interval` facts (new cumulative `total*` fields on `ThreadTokenUsageSnapshot`).

## UI

Settings → Usage per the approved mock: twin harness-level donuts (tokens + cost; model shades within harness family; **striped slices = estimated dollars**), KPI tiles, tokens-per-day stacks, hour×weekday heatmap, models table (accessible fallback for every chart), project bars. Unpriced models surface as tokens-only, never $0.

## Tests

- `usageAccounting.test.ts` — delta/reset/normalization pure functions (9 tests)
- `ProjectionPipeline.usage.test.ts` — idempotent replay, revert retention, deletion redaction, session-model sums (6 tests)
- Adapter fixtures updated for new snapshot fields + native session refs
- Full orchestration suite green (177 tests), workspace typecheck + lint clean

## Explicitly deferred (per plan, not forgotten)

- **Backfill** (event replay via projector bootstrap works, but the provider-log and native-transcript enrichment jobs aren't built) — history starts at ship time
- **Multi-device fan-out + device chips** (RPC + client atom exist; catalog-lease fan-out service is Phase 5)
- **Reasoning-effort capture for Claude turns** (Codex effort comes from modelSelection; Claude reports no dial)
- **`t3 usage` CLI** (thin client of the same RPC)
- Observation-level facts / throttling policy (only settlement-grade facts are recorded today)

## Review focus requests

1. The ingestion-side baseline map lifecycle (`ProviderRuntimeIngestion.ts` — `usageBaselines` / `seedUsageBaselines`): sound under concurrent sessions and the drainable-worker model?
2. Micro-USD rounding: per-fact `Math.round` on deltas — acceptable drift vs reconciling against `turn-total` facts?
3. `usage.getSummary` loads all facts in range then aggregates in JS — fine at current volumes (~thousands of facts), but push down to SQL now or later?
4. Naming/placement of `thread.usage-recorded` vs a hypothetical dedicated aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing-adjacent ingestion (delta baselines, restart reseed) and new durable ledger semantics; mistakes could under/over-count usage, though failures are logged and heavily tested.
> 
> **Overview**
> Introduces **local usage analytics**: provider runtime events are turned into interval/final **usage facts**, persisted via orchestration (`thread.usage.record` → `thread.usage-recorded`) and a new **`projection.usage`** projector into `projection_usage_facts` (migration 033).
> 
> **Ingestion** in `ProviderRuntimeIngestion` deltas cumulative Codex token snapshots and Claude per-model `turn.completed` usage against baselines keyed by `providerSessionId` + model, reseeding baselines from stored sums after restart; stale lifecycle-rejected completions are still recorded. Adapters now attach **`providerSessionId`** (Claude resume session, Codex native thread id) and Codex snapshots include **`total*`** cumulative fields.
> 
> **Query path**: `usage.getSummary` loads facts, resolves project titles, and aggregates in `usageSummary.ts` (timezone buckets, exact vs list-price estimates at read time). **UI**: Settings → Usage with donuts, daily bars, heatmap, and model/project tables.
> 
> Facts **survive thread revert**; **thread deletion** redacts thread/project linkage only. Tests cover accounting helpers, projection behavior, and adapter fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee46b611d2154b1e84564ce78a564883d621c9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local usage analytics with ledger, RPC endpoint, and settings page
> - Adds a `projection_usage_facts` table (migration 033) and `ProjectionUsageRepository` to persist per-fact token/cost data, with upsert, redact, list, and sum-by-session operations.
> - Introduces `thread.usage.record` command and `thread.usage-recorded` event to the orchestration contract, handled by a new decider branch and projection pipeline projector.
> - Provider ingestion (`ProviderRuntimeIngestion`) now derives usage deltas from cumulative Claude and Codex telemetry and dispatches usage facts, seeding baselines from persisted sums on restart to avoid double-counting; stale facts are flagged on rejected turn completions.
> - Adds a `usage.getSummary` WebSocket RPC that aggregates facts into totals, per-model, daily, hour-of-week, and per-project buckets, using `estimateCostMicroUsd` from the new `@t3tools/shared/usagePricing` module for models lacking exact cost data.
> - Adds a `/settings/usage` route rendering `UsageSettingsPanel` with donut charts, daily bar stacks, a 7×24 hour heatmap, and per-model/project tables.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ee46b61. 24 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->