### PR TITLE
Restore model picker layout and retain iterative test state

### DIFF
--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-t3-app
-description: Launch and test the T3 Code web app in isolated development environments, including first-try browser authentication with one-time pairing URLs, pairing-token recovery, worktree-safe state directories, dev server lifecycle, and direct SQLite inspection or fixture seeding. Use when an agent needs to run T3 locally, test UI behavior in a browser, recover from an expired or consumed pairing token, isolate dev state, or prepare test data in state.sqlite.
+description: Launch, retain, and test the T3 Code web app in isolated development environments, including first-try browser authentication with one-time pairing URLs, pairing-token recovery, worktree-safe state directories, cross-turn dev server lifecycle, and direct SQLite inspection or fixture seeding. Use when an agent needs to run T3 locally, iteratively test UI behavior with a human, recover from an expired or consumed pairing token, isolate dev state, or prepare test data in state.sqlite.
 ---
 
 # Test T3 App
@@ -19,6 +19,16 @@ Use this skill for the web client. For iOS Simulator, Android Emulator, or physi
 Treat a base directory as disposable only when it was created or deliberately selected for the current test. Never delete or directly seed the shared `~/.t3` directory. Prefer starting with a new temporary base directory over clearing state of uncertain ownership.
 
 The dev runner disables browser auto-open by default. Do not pass `--browser` during automated testing: an automatically opened page can consume the one-time bootstrap token before the controlled browser uses it.
+
+## Preserve the environment while iterating
+
+Treat the overall testing or implementation loop—not an assistant turn or one verification pass—as the environment lifecycle boundary.
+
+- Keep the dev process, base directory, selected ports, authenticated browser tab, registered projects, and seeded fixtures alive while the user may inspect the result or request follow-up changes.
+- Do not stop the server merely because one verification pass completed or because you are yielding a response to the user.
+- Before starting another environment, check whether the existing process and browser tab still serve the task. Reuse them when healthy instead of discarding useful state.
+- On a later turn, verify that the existing process is alive and reuse its printed ports and base directory. If it exited, restart with the same base directory; create a new pairing token only when the browser session is no longer valid.
+- Tell the user when a test environment remains available, including its non-secret web URL when useful. Never include a pairing token.
 
 ## Authenticate the browser on the first navigation
 
@@ -58,9 +68,17 @@ Read [references/sqlite-fixtures.md](references/sqlite-fixtures.md) before chang
 
 The helper refuses to write to the shared `~/.t3` directory by default and creates a database backup before each mutation.
 
-## Finish the test
+## Tear down only when the testing loop is finished
 
-Stop the dev process with its terminal interrupt. Preserve the isolated base directory when it contains useful reproduction evidence; otherwise remove only a path that was created for this test after resolving and verifying the exact target. A fresh isolated base directory is the safest reset when authentication, migrations, or fixture state becomes ambiguous.
+Tear down when the user explicitly asks, confirms the iteration is finished, or the overall task is genuinely complete with no pending human review. Do not infer completion from the end of an assistant turn.
+
+When teardown is appropriate:
+
+1. Stop the dev process with its terminal interrupt.
+2. Preserve the isolated base directory when it contains useful reproduction evidence or state for a likely follow-up.
+3. Otherwise remove only a path created for this test after resolving and verifying the exact target.
+
+If completion is uncertain, keep the environment alive and mention that it is retained for further iteration. A fresh isolated base directory remains the safest reset when authentication, migrations, or fixture state becomes ambiguous.
 
 ## Troubleshoot predictably
 

--- a/.agents/skills/test-t3-app/agents/openai.yaml
+++ b/.agents/skills/test-t3-app/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "T3 App Testing"
-  short_description: "Launch and seed isolated T3 test environments"
-  default_prompt: "Use $test-t3-app to launch an isolated T3 development environment and test it in the browser."
+  short_description: "Launch and retain isolated T3 test environments"
+  default_prompt: "Use $test-t3-app to launch an isolated T3 environment and iteratively test it in the browser while preserving state."

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -521,7 +521,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   return (
     <TooltipProvider delay={0}>
       <div
-        className="dropdown-glass model-picker-surface relative flex h-screen max-h-96 w-screen max-w-100 flex-row overflow-hidden rounded-xl text-popover-foreground"
+        className="dropdown-glass model-picker-surface relative flex h-screen max-h-96 w-screen max-w-100 flex-row overflow-hidden rounded-lg text-popover-foreground"
         data-model-picker-content="true"
       >
         {/* Sidebar */}
@@ -568,18 +568,23 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             handleModelSelect(slug, instanceId);
           }}
         >
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col overflow-hidden bg-muted/40",
+              showSidebar && "border-l",
+            )}
+          >
             {/* Search bar */}
             <div className="px-4 pt-2.5">
-              <div className="-translate-y-px rounded-lg bg-accent px-2 py-1">
+              <div className="-translate-y-px border-b border-border/70 pb-2.5 transition-colors focus-within:border-ring">
                 <ComboboxInput
                   ref={searchInputRef}
                   className="[&_input]:h-6.5 [&_input]:font-sans [&_input]:leading-6.5"
-                  inputClassName="rounded-none bg-transparent text-sm placeholder:text-muted-foreground/80"
+                  inputClassName="rounded-none bg-transparent text-sm"
                   placeholder="Search models..."
                   showTrigger={false}
                   startAddon={
-                    <SearchIcon className="-translate-x-0.5 size-4 shrink-0 text-muted-foreground/80" />
+                    <SearchIcon className="-translate-x-0.5 size-4 shrink-0 text-muted-foreground/55" />
                   }
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -97,7 +97,10 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
   }, [props.instanceEntries, props.selectedInstanceId, showFavorites]);
 
   return (
-    <div className="w-12 shrink-0 overflow-hidden bg-muted/60" data-model-picker-sidebar="true">
+    <div
+      className="w-12 shrink-0 overflow-hidden border-r bg-muted/30"
+      data-model-picker-sidebar="true"
+    >
       <div className="h-full overflow-y-auto overscroll-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div
           ref={sidebarContentRef}
@@ -115,7 +118,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
           ) : null}
           {/* Favorites section */}
           {showFavorites ? (
-            <div className="mb-1 pb-1">
+            <div className="mb-1 border-b pb-1">
               <div className="relative w-full">
                 <Tooltip>
                   <TooltipTrigger

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -188,7 +188,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
       <PopoverPopup
         align="start"
         className="border-0 bg-transparent p-0 shadow-none before:hidden [--viewport-inline-padding:0]"
-        viewportClassName="!overflow-hidden p-0"
+        viewportClassName="rounded-lg !overflow-hidden p-0 [clip-path:inset(0_round_var(--radius-lg))]"
       >
         <ModelPickerContent
           activeInstanceId={activeInstanceId}


### PR DESCRIPTION
## What changed

- Restores the model picker’s previous visual hierarchy: sidebar dividers, muted list surface, and underlined search field.
- Clips the Base UI popover viewport to the picker’s rounded boundary so scrolled content cannot expose sharp bottom corners.
- Preserves the glass tint and backdrop blur instead of making the picker opaque or see-through.
- Updates `test-t3-app` guidance to retain authenticated dev environments across human iteration and tear them down only when review is actually finished.

## Why

The picker restyle changed more than the intended glass surface, and its rectangular popover viewport clipped the rounded inner surface at the bottom. During follow-up testing, eagerly tearing down the dev environment also discarded useful browser and application state between review turns.

## User impact

The model picker again matches the prior layout while keeping the glass treatment, its lower corners render correctly in light mode, and iterative UI verification can retain server and browser state until explicitly completed.

## Validation

- `vp fmt --check .agents/skills/test-t3-app/SKILL.md .agents/skills/test-t3-app/agents/openai.yaml apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ModelPickerSidebar.tsx apps/web/src/components/chat/ProviderModelPicker.tsx`
- `vp lint apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ModelPickerSidebar.tsx apps/web/src/components/chat/ProviderModelPicker.tsx`
- `vp run --filter @t3tools/web typecheck`
- `vp test run src/components/chat/modelPickerSearch.test.ts --project unit` (7 tests)
- React Doctor: 91/100; only existing maintainability warnings
- Integrated light-mode browser verification: search, model selection, restored composer layout, glass blur, and rounded lower corners


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore model picker layout and retain iterative test state across turns
> - Restores model picker popup styling: rounded corners (`lg` radius), left border on main content when sidebar is visible, and search bar underline focus state in [`ModelPickerContent.tsx`](https://github.com/pingdotgg/t3code/pull/4450/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c)
> - Updates [`ModelPickerSidebar.tsx`](https://github.com/pingdotgg/t3code/pull/4450/files#diff-fa2e087b7dc1c16a9d152200a1f1e1aa32e1a66a8d3ffdcdc4439765c3d0b15b) to show a right border and section divider under favorites with a lighter background tint
> - Clips the popover viewport to `lg` radius in [`ProviderModelPicker.tsx`](https://github.com/pingdotgg/t3code/pull/4450/files#diff-01e915fe10bb55b513fb511c18383cd09199ea82c807cdf1fa405ba3261b0a40)
> - Updates the T3 app testing skill in [SKILL.md](https://github.com/pingdotgg/t3code/pull/4450/files#diff-dff7b690a4370926371a9cb5f33e69be07ecad8d0466ee84cef7e17aa8ba69a4) to preserve dev server, ports, and browser sessions across turns rather than tearing down between each turn
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02f531b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic chat UI class changes and agent documentation only; no runtime logic, auth, or data paths.
> 
> **Overview**
> **Model picker** styling is adjusted to bring back the prior hierarchy while keeping the glass surface: sidebar **right border** and lighter tint, **muted list panel** with a left divider when the rail is visible, and an **underlined search field** (replacing the accent search block) with subtler icon contrast. Corner radius moves to **`rounded-lg`**, and the popover **viewport is clipped** to that radius so scrolled list content no longer shows sharp bottom corners.
> 
> The **`test-t3-app`** skill now tells agents to **keep dev servers, ports, auth, and fixtures alive across review turns**, reuse healthy environments on follow-ups, and **tear down only** when the user confirms the loop is done—not after each assistant response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f531b7a681dcc25f96a0f98e257b71680b4fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->