### PR TITLE
Color settled PR labels on hover

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -117,7 +117,11 @@ import {
   sortThreadsForSidebarV2,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
-import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
+import {
+  prStatusIndicator,
+  resolveThreadPr,
+  settledPrHoverColorClass,
+} from "./ThreadStatusIndicators";
 import {
   resolveSnoozePresets,
   snoozeWakeDescription,
@@ -498,6 +502,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     hasDedicatedWorktree: thread.worktreePath !== null,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
   // Report the PR state up: the parent partitions rows with effectiveSettled,
   // and a merged/closed PR auto-settles a thread — data only rows have.
   const prState = pr?.state ?? null;
@@ -714,7 +719,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
           variant === "slim" && variantAction === "unsettle"
             ? props.isActive
               ? "text-muted-foreground/70"
-              : "text-muted-foreground/35 transition-colors group-hover/v2-row:text-muted-foreground/65"
+              : cn("text-muted-foreground/35 transition-colors", settledPrHoverClass)
             : prStatus.colorClass,
         )}
         aria-label={prStatus.tooltip}

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,7 +1,11 @@
 import type { VcsStatusResult } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
+import {
+  prStatusIndicator,
+  resolveThreadPr,
+  settledPrHoverColorClass,
+} from "./ThreadStatusIndicators";
 
 function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
   return {
@@ -69,5 +73,24 @@ describe("prStatusIndicator", () => {
       tooltipLead: "PR #42 - Open",
       tooltipTitle: "PR branch",
     });
+  });
+
+  it("uses red for closed pull requests", () => {
+    const closedPr = status().pr;
+    if (!closedPr) throw new Error("Expected pull request fixture");
+
+    expect(prStatusIndicator({ ...closedPr, state: "closed" }, undefined)?.colorClass).toContain(
+      "text-red-600",
+    );
+  });
+});
+
+describe("settledPrHoverColorClass", () => {
+  it.each([
+    ["open", "text-emerald-600"],
+    ["merged", "text-violet-600"],
+    ["closed", "text-red-600"],
+  ] as const)("restores the %s pull request color on row hover", (state, colorClass) => {
+    expect(settledPrHoverColorClass(state)).toContain(`group-hover/v2-row:${colorClass}`);
   });
 });

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -35,6 +35,17 @@ export interface TerminalStatusIndicator {
 
 export type ThreadPr = VcsStatusResult["pr"];
 
+export function settledPrHoverColorClass(state: NonNullable<ThreadPr>["state"]): string {
+  switch (state) {
+    case "open":
+      return "group-hover/v2-row:text-emerald-600 dark:group-hover/v2-row:text-emerald-300/90";
+    case "merged":
+      return "group-hover/v2-row:text-violet-600 dark:group-hover/v2-row:text-violet-300/90";
+    case "closed":
+      return "group-hover/v2-row:text-red-600 dark:group-hover/v2-row:text-red-300/90";
+  }
+}
+
 export function prStatusIndicator(
   pr: ThreadPr,
   provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
@@ -65,7 +76,7 @@ export function prStatusIndicator(
   if (pr.state === "closed") {
     return {
       label: `${presentation.shortName} closed`,
-      colorClass: "text-zinc-500 dark:text-zinc-400/80",
+      colorClass: "text-red-600 dark:text-red-300/90",
       tooltip,
       tooltipLead,
       tooltipTitle: pr.title,


### PR DESCRIPTION
## Summary

- restore pull request state colors when hovering settled sidebar rows
- use green for open, purple for merged, and red for closed pull requests
- keep settled PR labels subdued when the row is idle
- add focused coverage for each supported PR state

## Why

Settled thread rows muted their PR number with a fixed gray class. On hover, the project favicon regained its color but the PR label did not, making state harder to scan.

## Validation

- `vp test run apps/web/src/components/ThreadStatusIndicators.test.ts`
- `vp lint --report-unused-disable-directives apps/web/src/components/SidebarV2.tsx apps/web/src/components/ThreadStatusIndicators.tsx apps/web/src/components/ThreadStatusIndicators.test.ts`
- `vp run --filter @t3tools/web typecheck`
- `npx -y react-doctor@latest . --verbose --diff`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar presentation and Tailwind class changes only; no auth, data, or API behavior.
> 
> **Overview**
> **Settled slim sidebar rows** keep subdued PR `#` labels at rest but apply **state-colored hover** (green open, violet merged, red closed) via new `settledPrHoverColorClass`, matching how the favicon regains color on `group-hover/v2-row`.
> 
> **Closed pull requests** now use the same **red** styling as other PR indicators (`prStatusIndicator`), replacing the previous neutral zinc treatment.
> 
> Tests cover closed PR coloring and each hover class mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f60911ba2f3c3471fee31aa463522b2aebde01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Color settled PR badge labels by state on hover in sidebar
> - PR badge buttons on slim sidebar rows now show state-specific colors on hover (emerald for open, violet for merged, red for closed) instead of a muted foreground color.
> - Adds `settledPrHoverColorClass` in [ThreadStatusIndicators.tsx](https://github.com/pingdotgg/t3code/pull/4451/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189) to map PR state to `group-hover/v2-row` Tailwind classes with dark-mode variants.
> - Also changes the closed PR indicator color from muted zinc to red in `prStatusIndicator`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9f6091.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->