### PR TITLE
fix(codex): wait for plugin sync before loading skills

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,53 @@
 import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  refreshCodexSkillsAfterPluginSync,
+} from "./CodexProvider.ts";
+
+it.effect("waits for plugin inventory before force-reloading skills", () =>
+  Effect.gen(function* () {
+    const calls: Array<{ method: string; payload: unknown }> = [];
+    const skillsResponse = {
+      data: [{ cwd: "/tmp/project", errors: [], skills: [] }],
+    };
+    const client = {
+      request: (method: string, payload: unknown) => {
+        calls.push({ method, payload });
+        switch (method) {
+          case "plugin/installed":
+            return Effect.succeed({ marketplaces: [] });
+          case "skills/list":
+            return Effect.succeed(skillsResponse);
+          default:
+            return Effect.die(new Error(`Unexpected request: ${method}`));
+        }
+      },
+    } as unknown as Parameters<typeof refreshCodexSkillsAfterPluginSync>[0]["client"];
+
+    const response = yield* refreshCodexSkillsAfterPluginSync({
+      client,
+      cwd: "/tmp/project",
+    });
+
+    assert.strictEqual(response, skillsResponse);
+    assert.deepStrictEqual(calls, [
+      {
+        method: "plugin/installed",
+        payload: { cwds: ["/tmp/project"] },
+      },
+      {
+        method: "skills/list",
+        payload: {
+          cwds: ["/tmp/project"],
+          forceReload: true,
+        },
+      },
+    ]);
+  }),
+);
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -50,6 +50,34 @@ export interface CodexAppServerProviderSnapshot {
   readonly skills: ReadonlyArray<ServerProviderSkill>;
 }
 
+export interface CodexSkillDiscoveryClient {
+  readonly request: {
+    (
+      method: "plugin/installed",
+      payload: CodexSchema.V2PluginInstalledParams,
+    ): Effect.Effect<CodexSchema.V2PluginInstalledResponse, CodexErrors.CodexAppServerError>;
+    (
+      method: "skills/list",
+      payload: CodexSchema.V2SkillsListParams,
+    ): Effect.Effect<CodexSchema.V2SkillsListResponse, CodexErrors.CodexAppServerError>;
+  };
+}
+
+export const refreshCodexSkillsAfterPluginSync = Effect.fn("refreshCodexSkillsAfterPluginSync")(
+  function* (input: { readonly client: CodexSkillDiscoveryClient; readonly cwd: string }) {
+    // Codex materializes remote plugins asynchronously after initialization.
+    // Reading the installed-plugin inventory is the readiness barrier for the
+    // subsequent forced disk scan; that transition emits no `skills/changed`.
+    yield* input.client.request("plugin/installed", {
+      cwds: [input.cwd],
+    });
+    return yield* input.client.request("skills/list", {
+      cwds: [input.cwd],
+      forceReload: true,
+    });
+  },
+);
+
 const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
   none: "None",
   minimal: "Minimal",
@@ -391,8 +419,9 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
 
   const [skillsResponse, models] = yield* Effect.all(
     [
-      client.request("skills/list", {
-        cwds: [input.cwd],
+      refreshCodexSkillsAfterPluginSync({
+        client,
+        cwd: input.cwd,
       }),
       requestAllCodexModels(client),
     ],

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -393,27 +393,79 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
-  it.effect("falls back to thread/start when resume fails recoverably", () =>
+  it.effect("refreshes skills after plugin sync before starting a thread", () =>
     Effect.gen(function* () {
-      const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
+      const calls: Array<{ method: string; payload: unknown }> = [];
       const started = makeThreadOpenResponse("fresh-thread");
       const client = {
-        request: <M extends "thread/start" | "thread/resume">(
-          method: M,
-          payload: CodexRpc.ClientRequestParamsByMethod[M],
-        ) => {
+        request: (method: string, payload: unknown) => {
           calls.push({ method, payload });
-          if (method === "thread/resume") {
-            return Effect.fail(
-              new CodexErrors.CodexAppServerRequestError({
-                code: -32603,
-                errorMessage: "thread not found",
-              }),
-            );
+          switch (method) {
+            case "plugin/installed":
+              return Effect.succeed({ marketplaces: [] });
+            case "skills/list":
+              return Effect.succeed({
+                data: [{ cwd: "/tmp/project", errors: [], skills: [] }],
+              });
+            case "thread/start":
+              return Effect.succeed(started);
+            default:
+              return Effect.die(new Error(`Unexpected request: ${method}`));
           }
-          return Effect.succeed(started as CodexRpc.ClientRequestResponsesByMethod[M]);
         },
-      };
+      } as unknown as Parameters<typeof openCodexThread>[0]["client"];
+
+      const opened = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: undefined,
+      });
+
+      NodeAssert.equal(opened.thread.id, "fresh-thread");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["plugin/installed", "skills/list", "thread/start"],
+      );
+      NodeAssert.deepStrictEqual(calls[0]?.payload, { cwds: ["/tmp/project"] });
+      NodeAssert.deepStrictEqual(calls[1]?.payload, {
+        cwds: ["/tmp/project"],
+        forceReload: true,
+      });
+    }),
+  );
+
+  it.effect("falls back to thread/start when resume fails recoverably", () =>
+    Effect.gen(function* () {
+      const calls: Array<{ method: string; payload: unknown }> = [];
+      const started = makeThreadOpenResponse("fresh-thread");
+      const client = {
+        request: (method: string, payload: unknown) => {
+          calls.push({ method, payload });
+          switch (method) {
+            case "plugin/installed":
+              return Effect.succeed({ marketplaces: [] });
+            case "skills/list":
+              return Effect.succeed({
+                data: [{ cwd: "/tmp/project", errors: [], skills: [] }],
+              });
+            case "thread/resume":
+              return Effect.fail(
+                new CodexErrors.CodexAppServerRequestError({
+                  code: -32603,
+                  errorMessage: "thread not found",
+                }),
+              );
+            case "thread/start":
+              return Effect.succeed(started);
+            default:
+              return Effect.die(new Error(`Unexpected request: ${method}`));
+          }
+        },
+      } as unknown as Parameters<typeof openCodexThread>[0]["client"];
 
       const opened = yield* openCodexThread({
         client,
@@ -428,7 +480,7 @@ describe("openCodexThread", () => {
       NodeAssert.equal(opened.thread.id, "fresh-thread");
       NodeAssert.deepStrictEqual(
         calls.map((call) => call.method),
-        ["thread/resume", "thread/start"],
+        ["plugin/installed", "skills/list", "thread/resume", "thread/start"],
       );
     }),
   );
@@ -436,23 +488,28 @@ describe("openCodexThread", () => {
   it.effect("propagates non-recoverable resume failures", () =>
     Effect.gen(function* () {
       const client = {
-        request: <M extends "thread/start" | "thread/resume">(
-          method: M,
-          _payload: CodexRpc.ClientRequestParamsByMethod[M],
-        ) => {
-          if (method === "thread/resume") {
-            return Effect.fail(
-              new CodexErrors.CodexAppServerRequestError({
-                code: -32603,
-                errorMessage: "timed out waiting for server",
-              }),
-            );
+        request: (method: string) => {
+          switch (method) {
+            case "plugin/installed":
+              return Effect.succeed({ marketplaces: [] });
+            case "skills/list":
+              return Effect.succeed({
+                data: [{ cwd: "/tmp/project", errors: [], skills: [] }],
+              });
+            case "thread/resume":
+              return Effect.fail(
+                new CodexErrors.CodexAppServerRequestError({
+                  code: -32603,
+                  errorMessage: "timed out waiting for server",
+                }),
+              );
+            case "thread/start":
+              return Effect.succeed(makeThreadOpenResponse("fresh-thread"));
+            default:
+              return Effect.die(new Error(`Unexpected request: ${method}`));
           }
-          return Effect.succeed(
-            makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
-          );
         },
-      };
+      } as unknown as Parameters<typeof openCodexThread>[0]["client"];
 
       const error = yield* openCodexThread({
         client,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -35,7 +35,11 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
-import { buildCodexInitializeParams } from "./CodexProvider.ts";
+import {
+  buildCodexInitializeParams,
+  refreshCodexSkillsAfterPluginSync,
+  type CodexSkillDiscoveryClient,
+} from "./CodexProvider.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
@@ -447,14 +451,14 @@ type CodexThreadOpenResponse =
 
 type CodexThreadOpenMethod = "thread/start" | "thread/resume";
 
-interface CodexThreadOpenClient {
+interface CodexThreadOpenClient extends CodexSkillDiscoveryClient {
   readonly request: <M extends CodexThreadOpenMethod>(
     method: M,
     payload: CodexRpc.ClientRequestParamsByMethod[M],
   ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexErrors.CodexAppServerError>;
 }
 
-export const openCodexThread = (input: {
+export const openCodexThread = Effect.fn("openCodexThread")(function* (input: {
   readonly client: CodexThreadOpenClient;
   readonly threadId: ThreadId;
   readonly runtimeMode: RuntimeMode;
@@ -462,7 +466,12 @@ export const openCodexThread = (input: {
   readonly requestedModel: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
-}): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
+}): Effect.fn.Return<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> {
+  yield* refreshCodexSkillsAfterPluginSync({
+    client: input.client,
+    cwd: input.cwd,
+  });
+
   const resumeThreadId = input.resumeThreadId;
   const startParams = buildThreadStartParams({
     cwd: input.cwd,
@@ -472,10 +481,10 @@ export const openCodexThread = (input: {
   });
 
   if (resumeThreadId === undefined) {
-    return input.client.request("thread/start", startParams);
+    return yield* input.client.request("thread/start", startParams);
   }
 
-  return input.client
+  return yield* input.client
     .request("thread/resume", {
       threadId: resumeThreadId,
       ...startParams,
@@ -491,7 +500,7 @@ export const openCodexThread = (input: {
         }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
       ),
     );
-};
+});
 
 function readNotificationThreadId(notification: CodexServerNotification): string | undefined {
   switch (notification.method) {


### PR DESCRIPTION
## What

- wait for Codex remote-plugin materialisation before provider skill discovery
- force a fresh skill scan before starting or resuming a Codex thread
- cover the request order in provider and session-runtime tests

## Why

Codex app-server materialises enabled remote plugins asynchronously after initialisation. T3 read `skills/list` immediately and cached that incomplete snapshot for both the skill picker and new threads. Remote-plugin materialisation does not emit `skills/changed`, so affected sessions remained incomplete.

`plugin/installed` provides a readiness barrier. After it resolves, `skills/list` with `forceReload: true` returns the complete installed skill set.

## Verification

- focused provider tests: 3 files, 53 tests passed
- formatting check passed
- lint passed with pre-existing unrelated warnings only
- server typecheck passed with pre-existing suggestions only
- production build passed
- isolated macOS app: full quit/reopen, 14/14 Superpowers 6.1.1 skills visible in the `$` picker
- fresh thread injected the complete bodies and exact installed paths for:
  - `superpowers:systematic-debugging`
  - `superpowers:test-driven-development`
  - `superpowers:writing-plans`
  - `superpowers:verification-before-completion`

The `/` picker remains the built-in command picker; skills are intentionally discovered through `$`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wait for plugin sync before loading skills in Codex provider and session runtime
> - Adds `refreshCodexSkillsAfterPluginSync` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/4461/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53), which first awaits `plugin/installed` and then requests `skills/list` with `forceReload=true`.
> - Updates `probeCodexAppServerProvider` to use this utility instead of calling `skills/list` directly.
> - Updates `openCodexThread` in [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/4461/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) to run the plugin sync + skills reload step before starting or resuming a thread.
> - Behavioral Change: skills are now always fetched after plugin inventory is confirmed, adding two sequential RPCs (`plugin/installed` then `skills/list`) to both the probe and thread-open paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6364b63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->