### PR TITLE
Fix Sidebar V2 narrow-width issues: hover-action overlap and disappearing logo

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -879,10 +879,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               ) : (
                 <span className="flex-1" />
               )}
-              <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
+              <span className="ml-auto grid h-5 min-w-8 shrink-0 grid-cols-1 grid-rows-1 items-center justify-items-end pl-1 text-xs">
                 <span
                   className={cn(
-                    "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
+                    "col-start-1 row-start-1 tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
                     snoozeMenuOpen && "opacity-0",
                   )}
                 >
@@ -917,7 +917,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 {props.settlementSupported || showSnoozeButton ? (
                   <span
                     className={cn(
-                      "absolute inset-y-0 right-0 flex items-stretch gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
+                      "col-start-1 row-start-1 flex items-stretch gap-0.5 self-stretch opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
                       snoozeMenuOpen && "opacity-100",
                     )}
                   >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -251,7 +251,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 
   @media (min-width: 48rem) {
-    @container sidebar-header (min-width: 13.5rem) {
+    @container sidebar-header (min-width: 12.75rem) {
       .sidebar-brand {
         display: flex;
       }


### PR DESCRIPTION
## What changed

Two small fixes for Sidebar V2 (beta) at narrow sidebar widths:

1. **Hover actions no longer overlap the project title** (`apps/web/src/components/SidebarV2.tsx`). In the card row header, the snooze/settle hover actions were absolutely positioned over a slot sized only by the small time label, so at narrow sidebar widths the buttons painted on top of the project title. The time label and the hover actions now share a single CSS grid cell: the slot is always as wide as the wider of the two, the title truncates with an ellipsis instead of being overlapped, and hover still just cross-fades the label and actions with no layout shift. Keyboard access (`focus-within` reveal) is unchanged.

2. **The T3 Code logo no longer disappears at narrow widths** (`apps/web/src/index.css`). `.sidebar-brand` is shown by a `sidebar-header` container query with a `13.5rem` (216px) threshold, but the sidebar can be resized down to `THREAD_SIDEBAR_MIN_WIDTH` = `13rem` (208px). In that 208-215px band the logo vanished despite having ~100px of free space (the brand needs ~110px including the titlebar-control inset). Lowered the threshold to `12.75rem` so the logo survives the sidebar's full resize range; the value stays just under the sidebar minimum to absorb the 1px border on the container's content box.

## Why

Both are visible polish bugs in the Sidebar V2 beta that only reproduce when the sidebar is dragged near its minimum width.

## Before / After

Sidebar at its 208px minimum width, first row hovered:

| Before | After |
| --- | --- |
| <img width="430" height="800" alt="before-narrow-sidebar" src="https://github.com/user-attachments/assets/bf663a9a-5d65-484e-a23f-5cea737a4f91" />| <img width="430" height="800" alt="after-narrow-sidebar" src="https://github.com/user-attachments/assets/28911fd4-5c1c-4094-8237-f79a2003c541" /> |

Before: no logo in the header, and the clock + Settle buttons paint over the project title. After: logo visible, title truncates, actions sit cleanly to the right. Verified live in an isolated dev environment (measured 0px overlap between the actions and the title across both rows; previously 52px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout and container-query tweaks in Sidebar V2; no auth, data, or API changes.
> 
> **Overview**
> Fixes two **Sidebar V2** polish issues when the sidebar is dragged near its minimum width.
> 
> **Card row header:** The status/time label and snooze/settle hover actions now share a single **CSS grid** cell instead of absolutely stacking actions on a slot sized only by the label. The right column grows to fit the wider layer, the project title keeps truncating, and hover still cross-fades label vs actions without layout shift.
> 
> **Header logo:** The `sidebar-header` container query that shows `.sidebar-brand` is lowered from **13.5rem** to **12.75rem** so the T3 logo stays visible across the full resizable range down to `THREAD_SIDEBAR_MIN_WIDTH` (13rem / 208px).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9888136468276b64a8a5d8918f53ee3e1b17b294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hover-action overlap and disappearing logo in narrow-width SidebarV2
> - Replaces the absolute-positioned control overlay in `SidebarV2Row` with a single-cell CSS grid, so the time/status label and hover/focus controls occupy the same cell without overlap.
> - Lowers the container query threshold for `.sidebar-brand` visibility from `13.5rem` to `12.75rem` in [index.css](https://github.com/pingdotgg/t3code/pull/4464/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd), preventing the logo from disappearing at narrow sidebar widths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9888136.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->