### PR TITLE
Skip user hooks during Claude capability probes

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -46,6 +46,7 @@ it("isolates Claude capability probes without dropping workspace setting sources
   assert.equal(options.strictMcpConfig, true);
   assert.equal(options.cwd, "/workspace/project");
   assert.deepEqual(options.settingSources, [...CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES]);
+  assert.deepEqual(options.settings, { disableAllHooks: true });
   assert.deepEqual(options.allowedTools, []);
   assert.equal(options.persistSession, false);
   assert.equal(options.pathToClaudeCodeExecutable, "/usr/bin/claude");
@@ -149,6 +150,14 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       assert.equal(invocation.mcpConfig, undefined);
 
       assert.equal(invocation.args.includes("--setting-sources=user,project,local"), true);
+
+      const settingsFlagIndex = invocation.args.indexOf("--settings");
+      assert.notEqual(settingsFlagIndex, -1);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const flagSettings = JSON.parse(invocation.args[settingsFlagIndex + 1] ?? "{}") as {
+        readonly disableAllHooks?: boolean;
+      };
+      assert.equal(flagSettings.disableAllHooks, true);
     }).pipe(Effect.scoped),
   );
 });

--- a/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts
@@ -30,6 +30,7 @@ it("isolates Claude capability probes without dropping workspace setting sources
   assert.equal(options.strictMcpConfig, true);
   assert.equal(options.cwd, "/workspace/project");
   assert.deepEqual(options.settingSources, [...CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES]);
+  assert.deepEqual(options.settings, { disableAllHooks: true });
   assert.deepEqual(options.allowedTools, []);
   assert.equal(options.persistSession, false);
   assert.equal(options.pathToClaudeCodeExecutable, "/usr/bin/claude");
@@ -133,6 +134,14 @@ it.layer(NodeServices.layer)("Claude capability probe SDK boundary", (it) => {
       assert.equal(invocation.mcpConfig, undefined);
 
       assert.equal(invocation.args.includes("--setting-sources=user,project,local"), true);
+
+      const settingsFlagIndex = invocation.args.indexOf("--settings");
+      assert.notEqual(settingsFlagIndex, -1);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const flagSettings = JSON.parse(invocation.args[settingsFlagIndex + 1] ?? "{}") as {
+        readonly disableAllHooks?: boolean;
+      };
+      assert.equal(flagSettings.disableAllHooks, true);
     }).pipe(Effect.scoped),
   );
 });

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -594,6 +594,10 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
     pathToClaudeCodeExecutable: input.executablePath,
     abortController: input.abortController,
     settingSources: [...CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES],
+    // The probe keeps filesystem setting sources for slash-command discovery,
+    // but must not run the user's hooks: it fires every few minutes, so
+    // SessionStart hooks would run on every health check.
+    settings: { disableAllHooks: true },
     allowedTools: [],
     // Ignore MCP definitions from every filesystem setting source above. The
     // SDK combines this empty explicit map with --strict-mcp-config.

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -534,6 +534,10 @@ export function buildClaudeCapabilitiesProbeQueryOptions(input: {
     pathToClaudeCodeExecutable: input.executablePath,
     abortController: input.abortController,
     settingSources: [...CLAUDE_CAPABILITIES_PROBE_SETTING_SOURCES],
+    // The probe keeps filesystem setting sources for slash-command discovery,
+    // but must not run the user's hooks: it fires every few minutes, so
+    // SessionStart hooks would run on every health check.
+    settings: { disableAllHooks: true },
     allowedTools: [],
     // Ignore MCP definitions from every filesystem setting source above. The
     // SDK combines this empty explicit map with --strict-mcp-config.


### PR DESCRIPTION
## What Changed

Pass `settings: { disableAllHooks: true }` to the periodic Claude capability probe, with regression assertions in both probe tests.

## Why

The probe keeps user, project, and local setting sources so slash command discovery works, but loading those sources also runs the user's SessionStart hooks every few minutes. Hooks that log or send telemetry fire on every health check and pollute their data with probe sessions. Disabling hooks through the flag settings layer keeps command discovery intact while making the probe silent.

Fixes #3050

## Testing

- `vp test run apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts` passes (2/2), including a new assertion on the built query options and one on the serialized `--settings` flag at the SDK boundary
- `pnpm typecheck` in apps/server clean
- `vp lint` on changed files clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to probe-only SDK options with regression tests; no impact on normal Claude sessions.
> 
> **Overview**
> Periodic Claude capability probes now pass **`settings: { disableAllHooks: true }`** in `buildClaudeCapabilitiesProbeQueryOptions`, so user/project/local setting sources still load for slash-command discovery but **SessionStart and other hooks do not run** on every few-minute health check.
> 
> Tests assert the built options include `disableAllHooks: true` and that the SDK invocation serializes the same value on the `--settings` CLI flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b7ba2cb869ea4c18ccdd15f485ce6c1debe668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip user hooks during Claude capability probes by passing `disableAllHooks: true`
> Adds `settings: { disableAllHooks: true }` to the options returned by `buildClaudeCapabilitiesProbeQueryOptions` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/4466/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3), ensuring user-defined hooks do not run during capability detection. Tests in [ClaudeCapabilitiesProbe.test.ts](https://github.com/pingdotgg/t3code/pull/4466/files#diff-8fac0899603d26e4f699ec16a2b9040897f2340bcd5e025e0edf3ac34e91752c) verify the `--settings` flag is present and that `disableAllHooks` is set to `true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60b7ba2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->