### PR TITLE
Carry a redacted stderr excerpt on git command failures

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -775,6 +775,21 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         );
         assert.notInclude(redacted.stderrExcerpt ?? "", "token-value");
         assert.include(redacted.stderrExcerpt ?? "", "could not read from");
+
+        // Option values below the whole-argument length floor are still
+        // redacted: a short secret must not survive the filter.
+        const shortValue = attachGitStderrExcerpt(
+          new GitCommandError({
+            operation: "GitVcsDriver.test.shortValue",
+            command: "git",
+            cwd: "/tmp/repo",
+            detail: "Git command exited with a non-zero status.",
+          }),
+          "fatal: authentication failed for abc",
+          ["fetch", "--token=abc"],
+        );
+        assert.notInclude(shortValue.stderrExcerpt ?? "", "abc");
+        assert.include(shortValue.stderrExcerpt ?? "", "authentication failed");
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -8,6 +8,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -16,8 +17,14 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, type ReviewDiffFileContentsInput } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
-import { makeGitVcsDriverCore, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import {
+  attachGitStderrExcerpt,
+  makeGitVcsDriverCore,
+  splitNullSeparatedGitStdoutPaths,
+} from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
+
+const encodeGitCommandError = Schema.encodeSync(GitCommandError);
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-git-vcs-driver-test-",
@@ -710,8 +717,64 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.isAbove(error.stderrLength ?? 0, 0);
         assert.notInclude(error.detail, secret);
         assert.notInclude(error.message, secret);
+        assert.notInclude(error.stderrExcerpt ?? "", secret);
         assert.notProperty(error, "args");
         assert.notProperty(error, "stderr");
+
+        const encoded = encodeGitCommandError(error);
+        assert.notProperty(encoded, "stderrExcerpt");
+      }),
+    );
+
+    it.effect("carries a bounded stderr excerpt for in-process consumers", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        const error = yield* driver
+          .execute({
+            operation: "GitVcsDriver.test.stderrExcerpt",
+            cwd,
+            args: ["log", "-1"],
+          })
+          .pipe(Effect.flip);
+
+        assert.equal(error._tag, "GitCommandError");
+        assert.include(error.stderrExcerpt ?? "", "not a git repository");
+        // Stderr must stay out of the message so client-facing events and
+        // telemetry keep their existing redaction guarantees.
+        assert.notInclude(error.message, "not a git repository");
+      }),
+    );
+
+    it.effect("redacts argument values and caps the stderr excerpt", () =>
+      Effect.sync(() => {
+        const longStderr = `fatal: ${"x".repeat(600)}`;
+        const capped = attachGitStderrExcerpt(
+          new GitCommandError({
+            operation: "GitVcsDriver.test.cap",
+            command: "git",
+            cwd: "/tmp/repo",
+            detail: "Git command exited with a non-zero status.",
+          }),
+          longStderr,
+          [],
+        );
+        assert.isAtMost(capped.stderrExcerpt?.length ?? 0, 403);
+        assert.equal(capped.stderrExcerpt?.endsWith("..."), true);
+
+        const redacted = attachGitStderrExcerpt(
+          new GitCommandError({
+            operation: "GitVcsDriver.test.redact",
+            command: "git",
+            cwd: "/tmp/repo",
+            detail: "Git command exited with a non-zero status.",
+          }),
+          "fatal: could not read from 'https://token-value@example.com/repo.git'",
+          ["fetch", "--depth=1", "https://token-value@example.com/repo.git"],
+        );
+        assert.notInclude(redacted.stderrExcerpt ?? "", "token-value");
+        assert.include(redacted.stderrExcerpt ?? "", "could not read from");
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -5,6 +5,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -12,8 +13,10 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
-import { splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import { attachGitStderrExcerpt, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
+
+const encodeGitCommandError = Schema.encodeSync(GitCommandError);
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-git-vcs-driver-test-",
@@ -209,8 +212,64 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.isAbove(error.stderrLength ?? 0, 0);
         assert.notInclude(error.detail, secret);
         assert.notInclude(error.message, secret);
+        assert.notInclude(error.stderrExcerpt ?? "", secret);
         assert.notProperty(error, "args");
         assert.notProperty(error, "stderr");
+
+        const encoded = encodeGitCommandError(error);
+        assert.notProperty(encoded, "stderrExcerpt");
+      }),
+    );
+
+    it.effect("carries a bounded stderr excerpt for in-process consumers", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        const error = yield* driver
+          .execute({
+            operation: "GitVcsDriver.test.stderrExcerpt",
+            cwd,
+            args: ["log", "-1"],
+          })
+          .pipe(Effect.flip);
+
+        assert.equal(error._tag, "GitCommandError");
+        assert.include(error.stderrExcerpt ?? "", "not a git repository");
+        // Stderr must stay out of the message so client-facing events and
+        // telemetry keep their existing redaction guarantees.
+        assert.notInclude(error.message, "not a git repository");
+      }),
+    );
+
+    it.effect("redacts argument values and caps the stderr excerpt", () =>
+      Effect.sync(() => {
+        const longStderr = `fatal: ${"x".repeat(600)}`;
+        const capped = attachGitStderrExcerpt(
+          new GitCommandError({
+            operation: "GitVcsDriver.test.cap",
+            command: "git",
+            cwd: "/tmp/repo",
+            detail: "Git command exited with a non-zero status.",
+          }),
+          longStderr,
+          [],
+        );
+        assert.isAtMost(capped.stderrExcerpt?.length ?? 0, 403);
+        assert.equal(capped.stderrExcerpt?.endsWith("..."), true);
+
+        const redacted = attachGitStderrExcerpt(
+          new GitCommandError({
+            operation: "GitVcsDriver.test.redact",
+            command: "git",
+            cwd: "/tmp/repo",
+            detail: "Git command exited with a non-zero status.",
+          }),
+          "fatal: could not read from 'https://token-value@example.com/repo.git'",
+          ["fetch", "--depth=1", "https://token-value@example.com/repo.git"],
+        );
+        assert.notInclude(redacted.stderrExcerpt ?? "", "token-value");
+        assert.include(redacted.stderrExcerpt ?? "", "could not read from");
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -270,6 +270,21 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         );
         assert.notInclude(redacted.stderrExcerpt ?? "", "token-value");
         assert.include(redacted.stderrExcerpt ?? "", "could not read from");
+
+        // Option values below the whole-argument length floor are still
+        // redacted: a short secret must not survive the filter.
+        const shortValue = attachGitStderrExcerpt(
+          new GitCommandError({
+            operation: "GitVcsDriver.test.shortValue",
+            command: "git",
+            cwd: "/tmp/repo",
+            detail: "Git command exited with a non-zero status.",
+          }),
+          "fatal: authentication failed for abc",
+          ["fetch", "--token=abc"],
+        );
+        assert.notInclude(shortValue.stderrExcerpt ?? "", "abc");
+        assert.include(shortValue.stderrExcerpt ?? "", "authentication failed");
       }),
     );
 

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -403,10 +403,18 @@ export function attachGitStderrExcerpt(
 ): GitCommandError {
   const redactionCandidates = args
     .flatMap((arg) => {
+      // The length floor only applies to whole arguments, where it prevents
+      // mangling ordinary words like subcommand names. Extracted option
+      // values are redacted regardless of length so a short secret in
+      // `--option=value` form cannot slip through.
+      const candidates = arg.length >= STDERR_REDACTION_MIN_LENGTH ? [arg] : [];
       const separatorIndex = arg.indexOf("=");
-      return separatorIndex >= 0 ? [arg, arg.slice(separatorIndex + 1)] : [arg];
+      const value = separatorIndex >= 0 ? arg.slice(separatorIndex + 1) : "";
+      if (value.length > 0) {
+        candidates.push(value);
+      }
+      return candidates;
     })
-    .filter((candidate) => candidate.length >= STDERR_REDACTION_MIN_LENGTH)
     .sort((left, right) => right.length - left.length);
 
   let excerpt = stderr;

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -386,6 +386,45 @@ function gitCommandContext(
   } as const;
 }
 
+const STDERR_EXCERPT_MAX_LENGTH = 400;
+const STDERR_REDACTION_MIN_LENGTH = 4;
+
+/**
+ * Attach a bounded stderr excerpt to a command failure for in-process
+ * consumers. Command arguments (and `--option=value` values) are redacted
+ * first so tokens embedded in URLs or options keep the same redaction
+ * guarantees as the structured error fields. The excerpt lives outside the
+ * error schema, so it never leaves the process.
+ */
+export function attachGitStderrExcerpt(
+  error: GitCommandError,
+  stderr: string,
+  args: readonly string[],
+): GitCommandError {
+  const redactionCandidates = args
+    .flatMap((arg) => {
+      const separatorIndex = arg.indexOf("=");
+      return separatorIndex >= 0 ? [arg, arg.slice(separatorIndex + 1)] : [arg];
+    })
+    .filter((candidate) => candidate.length >= STDERR_REDACTION_MIN_LENGTH)
+    .sort((left, right) => right.length - left.length);
+
+  let excerpt = stderr;
+  for (const candidate of redactionCandidates) {
+    excerpt = excerpt.split(candidate).join("<redacted>");
+  }
+  excerpt = excerpt.replace(/\s+/g, " ").trim();
+  if (excerpt.length === 0) {
+    return error;
+  }
+
+  error.stderrExcerpt =
+    excerpt.length > STDERR_EXCERPT_MAX_LENGTH
+      ? `${excerpt.slice(0, STDERR_EXCERPT_MAX_LENGTH)}...`
+      : excerpt;
+  return error;
+}
+
 function parseDefaultBranchFromRemoteHeadRef(value: string, remoteName: string): string | null {
   const trimmed = value.trim();
   const prefix = `refs/remotes/${remoteName}/`;
@@ -795,13 +834,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         yield* trace2Monitor.flush;
 
         if (!input.allowNonZeroExit && exitCode !== 0) {
-          return yield* new GitCommandError({
-            ...gitCommandContext(commandInput),
-            detail: "Git command exited with a non-zero status.",
-            exitCode,
-            stdoutLength: stdout.text.length,
-            stderrLength: stderr.text.length,
-          });
+          return yield* attachGitStderrExcerpt(
+            new GitCommandError({
+              ...gitCommandContext(commandInput),
+              detail: "Git command exited with a non-zero status.",
+              exitCode,
+              stdoutLength: stdout.text.length,
+              stderrLength: stderr.text.length,
+            }),
+            stderr.text,
+            commandInput.args,
+          );
         }
 
         return {
@@ -876,13 +919,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           return Effect.succeed(result);
         }
         return Effect.fail(
-          new GitCommandError({
-            ...gitCommandContext({ operation, cwd, args }),
-            detail: options.fallbackErrorDetail ?? "Git command exited with a non-zero status.",
-            ...(result.exitCode === null ? {} : { exitCode: result.exitCode }),
-            stdoutLength: result.stdout.length,
-            stderrLength: result.stderr.length,
-          }),
+          attachGitStderrExcerpt(
+            new GitCommandError({
+              ...gitCommandContext({ operation, cwd, args }),
+              detail: options.fallbackErrorDetail ?? "Git command exited with a non-zero status.",
+              ...(result.exitCode === null ? {} : { exitCode: result.exitCode }),
+              stdoutLength: result.stdout.length,
+              stderrLength: result.stderr.length,
+            }),
+            result.stderr,
+            args,
+          ),
         );
       }),
     );

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -345,10 +345,18 @@ export function attachGitStderrExcerpt(
 ): GitCommandError {
   const redactionCandidates = args
     .flatMap((arg) => {
+      // The length floor only applies to whole arguments, where it prevents
+      // mangling ordinary words like subcommand names. Extracted option
+      // values are redacted regardless of length so a short secret in
+      // `--option=value` form cannot slip through.
+      const candidates = arg.length >= STDERR_REDACTION_MIN_LENGTH ? [arg] : [];
       const separatorIndex = arg.indexOf("=");
-      return separatorIndex >= 0 ? [arg, arg.slice(separatorIndex + 1)] : [arg];
+      const value = separatorIndex >= 0 ? arg.slice(separatorIndex + 1) : "";
+      if (value.length > 0) {
+        candidates.push(value);
+      }
+      return candidates;
     })
-    .filter((candidate) => candidate.length >= STDERR_REDACTION_MIN_LENGTH)
     .sort((left, right) => right.length - left.length);
 
   let excerpt = stderr;

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -328,6 +328,45 @@ function gitCommandContext(
   } as const;
 }
 
+const STDERR_EXCERPT_MAX_LENGTH = 400;
+const STDERR_REDACTION_MIN_LENGTH = 4;
+
+/**
+ * Attach a bounded stderr excerpt to a command failure for in-process
+ * consumers. Command arguments (and `--option=value` values) are redacted
+ * first so tokens embedded in URLs or options keep the same redaction
+ * guarantees as the structured error fields. The excerpt lives outside the
+ * error schema, so it never leaves the process.
+ */
+export function attachGitStderrExcerpt(
+  error: GitCommandError,
+  stderr: string,
+  args: readonly string[],
+): GitCommandError {
+  const redactionCandidates = args
+    .flatMap((arg) => {
+      const separatorIndex = arg.indexOf("=");
+      return separatorIndex >= 0 ? [arg, arg.slice(separatorIndex + 1)] : [arg];
+    })
+    .filter((candidate) => candidate.length >= STDERR_REDACTION_MIN_LENGTH)
+    .sort((left, right) => right.length - left.length);
+
+  let excerpt = stderr;
+  for (const candidate of redactionCandidates) {
+    excerpt = excerpt.split(candidate).join("<redacted>");
+  }
+  excerpt = excerpt.replace(/\s+/g, " ").trim();
+  if (excerpt.length === 0) {
+    return error;
+  }
+
+  error.stderrExcerpt =
+    excerpt.length > STDERR_EXCERPT_MAX_LENGTH
+      ? `${excerpt.slice(0, STDERR_EXCERPT_MAX_LENGTH)}...`
+      : excerpt;
+  return error;
+}
+
 function parseDefaultBranchFromRemoteHeadRef(value: string, remoteName: string): string | null {
   const trimmed = value.trim();
   const prefix = `refs/remotes/${remoteName}/`;
@@ -730,13 +769,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         yield* trace2Monitor.flush;
 
         if (!input.allowNonZeroExit && exitCode !== 0) {
-          return yield* new GitCommandError({
-            ...gitCommandContext(commandInput),
-            detail: "Git command exited with a non-zero status.",
-            exitCode,
-            stdoutLength: stdout.text.length,
-            stderrLength: stderr.text.length,
-          });
+          return yield* attachGitStderrExcerpt(
+            new GitCommandError({
+              ...gitCommandContext(commandInput),
+              detail: "Git command exited with a non-zero status.",
+              exitCode,
+              stdoutLength: stdout.text.length,
+              stderrLength: stderr.text.length,
+            }),
+            stderr.text,
+            commandInput.args,
+          );
         }
 
         return {
@@ -811,13 +854,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           return Effect.succeed(result);
         }
         return Effect.fail(
-          new GitCommandError({
-            ...gitCommandContext({ operation, cwd, args }),
-            detail: options.fallbackErrorDetail ?? "Git command exited with a non-zero status.",
-            ...(result.exitCode === null ? {} : { exitCode: result.exitCode }),
-            stdoutLength: result.stdout.length,
-            stderrLength: result.stderr.length,
-          }),
+          attachGitStderrExcerpt(
+            new GitCommandError({
+              ...gitCommandContext({ operation, cwd, args }),
+              detail: options.fallbackErrorDetail ?? "Git command exited with a non-zero status.",
+              ...(result.exitCode === null ? {} : { exitCode: result.exitCode }),
+              stdoutLength: result.stdout.length,
+              stderrLength: result.stderr.length,
+            }),
+            result.stderr,
+            args,
+          ),
         );
       }),
     );

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -339,6 +339,13 @@ export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()(
   detail: Schema.String,
   cause: Schema.optional(Schema.Defect()),
 }) {
+  /**
+   * Bounded, argument-redacted git stderr excerpt for in-process consumers.
+   * Deliberately not part of the schema and not part of `message`, so it
+   * never crosses RPC, client event, or telemetry serialization boundaries.
+   */
+  stderrExcerpt?: string;
+
   override get message(): string {
     return `Git command failed in ${this.operation} (${this.cwd}): ${this.detail}`;
   }

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -332,6 +332,13 @@ export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()(
   detail: Schema.String,
   cause: Schema.optional(Schema.Defect()),
 }) {
+  /**
+   * Bounded, argument-redacted git stderr excerpt for in-process consumers.
+   * Deliberately not part of the schema and not part of `message`, so it
+   * never crosses RPC, client event, or telemetry serialization boundaries.
+   */
+  stderrExcerpt?: string;
+
   override get message(): string {
     return `Git command failed in ${this.operation} (${this.cwd}): ${this.detail}`;
   }


### PR DESCRIPTION
## What Changed

`GitCommandError` gains an optional `stderrExcerpt` carrying up to 400 characters of git's stderr, with command arguments and `--option=value` values redacted out first. The excerpt lives outside the error schema and outside `message`, so it is only visible to in-process consumers.

## Why

Failed git commands recorded only `stderrLength`, so every precondition failure (branch already exists, stale worktree metadata, permissions, missing ref) collapsed into the same opaque "Git command exited with a non-zero status." and diagnosing meant rerunning the command by hand.

Dropping stderr from messages is clearly deliberate here: existing tests forbid stderr and argument content in `message` and in client-facing events. This change keeps all of those guarantees (the redaction test now also covers the excerpt, and a new test proves schema encoding excludes it) while giving server-side code a bounded signal to log or inspect. This is the fallback design suggested in the issue.

Fixes #4380

## Testing

- `vp test run` on GitVcsDriverCore, GitVcsDriver, and GitManager suites passes (105/105), including three new tests: excerpt present on a real failure, excerpt capped and argument-redacted, excerpt absent from schema encoding and from `message`
- `pnpm typecheck` in apps/server and packages/contracts clean
- `vp lint` on changed files clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only change on git failure paths with explicit redaction and schema exclusion; no change to serialized errors or auth flows.
> 
> **Overview**
> **Git command failures** now carry an optional in-process `stderrExcerpt` on `GitCommandError`, so server code can see *why* git failed without rerunning commands. The field is **not** in the Effect schema, **not** in `message`, and schema encoding still drops it—same boundary as existing “no stderr on the wire” guarantees.
> 
> `attachGitStderrExcerpt` builds the excerpt from captured stderr: redacts whole args (≥4 chars) and `--option=value` values (any length), normalizes whitespace, caps at 400 characters. Non-zero exits from `runGitCommand` and `executeGit` attach it automatically.
> 
> Tests cover real failures, length cap, token/URL redaction, and that `message` and encoded errors stay clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540835c4626bb2bc79d76990cdeadf8ecef6d3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attach a redacted stderr excerpt to `GitCommandError` on git command failures
> - Adds an optional `stderrExcerpt` field to `GitCommandError` in [git.ts](https://github.com/pingdotgg/t3code/pull/4467/files#diff-2282301d92a7a9ddc7e8d88b986c9628fdf70497dc6a09fe80eb8d46d6a769e7) for in-process use only — it is excluded from serialization and the error message.
> - Introduces `attachGitStderrExcerpt` in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/4467/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8), which redacts secret-looking args (whole args ≥4 chars, or values after `=`), collapses whitespace, and caps the excerpt at 400 characters with an ellipsis.
> - Hooks `attachGitStderrExcerpt` into both non-zero exit failure paths in `makeGitVcsDriverCore` so all thrown `GitCommandError` instances carry the excerpt when stderr is non-empty after redaction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 540835c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->