### PR TITLE
Keep block code plain when copying from rendered markdown

### DIFF
--- a/apps/web/src/markdown-clipboard.test.ts
+++ b/apps/web/src/markdown-clipboard.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { serializeRenderedMarkdownFragment } from "./markdown-clipboard";
+
+const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+class FakeText {
+  readonly nodeType = TEXT_NODE;
+  readonly childNodes: ReadonlyArray<never> = [];
+
+  constructor(readonly textContent: string) {}
+}
+
+class FakeElement {
+  readonly nodeType = ELEMENT_NODE;
+  readonly childNodes: Array<FakeElement | FakeText> = [];
+  readonly classList = {
+    contains: (name: string) => this.classNames.includes(name),
+  };
+
+  constructor(
+    readonly tagName: string,
+    private readonly classNames: ReadonlyArray<string> = [],
+  ) {}
+
+  get localName(): string {
+    return this.tagName.toLowerCase();
+  }
+
+  get textContent(): string {
+    return this.childNodes.map((child) => child.textContent).join("");
+  }
+
+  append(...children: Array<FakeElement | FakeText>): this {
+    this.childNodes.push(...children);
+    return this;
+  }
+
+  getAttribute(): string | null {
+    return null;
+  }
+
+  hasAttribute(): boolean {
+    return false;
+  }
+}
+
+function asNode(element: FakeElement): Node {
+  return element as unknown as Node;
+}
+
+function shikiCodeLine(text: string): FakeElement {
+  const token = new FakeElement("SPAN").append(new FakeText(text));
+  return new FakeElement("SPAN", ["line"]).append(token);
+}
+
+describe("serializeRenderedMarkdownFragment", () => {
+  beforeEach(() => {
+    vi.stubGlobal("Node", { TEXT_NODE, ELEMENT_NODE });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("wraps inline code in backticks", () => {
+    const paragraph = new FakeElement("P").append(
+      new FakeText("run "),
+      new FakeElement("CODE").append(new FakeText("git status")),
+      new FakeText(" first"),
+    );
+    const container = new FakeElement("DIV").append(paragraph);
+
+    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("run `git status` first");
+  });
+
+  it("keeps a highlighted block code selection plain when its pre wrapper is outside the range", () => {
+    const code = new FakeElement("CODE").append(
+      shikiCodeLine("git show-ref --verify refs/remotes/origin/opt/deploy/dev"),
+    );
+    const container = new FakeElement("DIV").append(code);
+
+    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe(
+      "git show-ref --verify refs/remotes/origin/opt/deploy/dev",
+    );
+  });
+
+  it("keeps a multi-line code selection plain instead of inline-wrapping it", () => {
+    const code = new FakeElement("CODE").append(new FakeText("first line\nsecond line"));
+    const container = new FakeElement("DIV").append(code);
+
+    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("first line\nsecond line");
+  });
+});

--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -37,6 +37,22 @@ function wrapInlineMarker(content: string, marker: string): string {
   return `${match?.[1] ?? ""}${marker}${core}${marker}${match?.[3] ?? ""}`;
 }
 
+/**
+ * A code element whose pre wrapper fell outside the copied range is still
+ * block code, recognizable by its highlighter line spans or embedded
+ * newlines. Wrapping it like inline code produces backtick-surrounded
+ * shell commands on paste.
+ */
+function isBlockCodeElement(element: Element, content: string): boolean {
+  if (content.includes("\n")) return true;
+  for (const child of element.childNodes) {
+    if (child.nodeType === Node.ELEMENT_NODE && (child as Element).classList.contains("line")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function wrapInlineCode(code: string): string {
   const longestRun = [...(code.match(/`+/g) ?? [])].reduce(
     (max, run) => Math.max(max, run.length),
@@ -201,8 +217,10 @@ function serializeNode(node: Node): string {
       return `${serializeChildren(element).trim()}\n\n`;
     case "PRE":
       return serializeCodeBlock(element);
-    case "CODE":
-      return wrapInlineCode(element.textContent ?? "");
+    case "CODE": {
+      const content = element.textContent ?? "";
+      return isBlockCodeElement(element, content) ? content : wrapInlineCode(content);
+    }
     case "STRONG":
     case "B":
       return wrapInlineMarker(serializeChildren(element), "**");


### PR DESCRIPTION
## What Changed

The markdown clipboard serializer now recognizes block code that arrives without its `pre` wrapper (highlighter line spans or embedded newlines) and copies it verbatim instead of wrapping it like inline code. Real inline code keeps its backticks.

## Why

Selecting the contents of a rendered code block can produce a copy fragment holding the `code` element but not its `pre` parent, most visibly on Firefox. The serializer fell into the inline-code branch and wrapped the copied text in single backticks. Pasting that into a shell runs the command inside command substitution:

```
λ `git show-ref --verify refs/remotes/origin/opt/deploy/dev`
zsh: 97649d91...: command not found
```

Copies that legitimately span prose plus a whole code block still include the `pre` element and keep their fenced form, so the markdown-preserving copy feature is unchanged.

Fixes #4368

## Testing

- `vp test run apps/web/src/markdown-clipboard.test.ts` passes (3/3): inline code still wrapped, highlighted block selection stays plain, multi-line selection stays plain
- `pnpm typecheck` in apps/web clean
- `vp lint` on changed files clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to markdown copy serialization with new unit tests; no auth, data, or API impact.
> 
> **Overview**
> Copying from rendered chat markdown no longer wraps **block** code in single backticks when the selection only includes the inner `code` node (common in Firefox) instead of the surrounding `pre`.
> 
> `serializeRenderedMarkdownFragment` now uses **`isBlockCodeElement`** to treat `CODE` as block when the text has newlines or Shiki-style `.line` child spans, and returns plain text in those cases. True inline `code` still gets backtick wrapping.
> 
> Unit tests cover inline code, highlighted block fragments without `pre`, and multi-line selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7588ac26331262efae7acaff65ee75ac0140dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep block code plain when copying from rendered markdown
> When copying from rendered markdown, `CODE` elements that represent block code were incorrectly wrapped in backticks. The fix introduces `isBlockCodeElement` in [markdown-clipboard.ts](https://github.com/pingdotgg/t3code/pull/4468/files#diff-4584df63e01a8b69a0505a0836c9272794c0385577c79484ce7e43b50c06adaa), which checks for newlines in content or child elements with class `line` (used by syntax-highlighted blocks). Block code is now returned as plain text; only inline code gets backtick wrapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f7588a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->