### PR TITLE
Limit physical key fallback to non-Latin layout output

### DIFF
--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -712,6 +712,35 @@ describe("resolveShortcutCommand", () => {
       "rightPanel.toggle",
     );
   });
+
+  it("matches non-Latin layout letters using the physical key code", () => {
+    const keybindings = compile([{ shortcut: modShortcut("d"), command: "diff.toggle" }]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "в", code: "KeyD", metaKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+      "diff.toggle",
+    );
+  });
+
+  it("ignores the physical key code when the layout types a different Latin letter", () => {
+    const keybindings = compile([{ shortcut: modShortcut("d"), command: "diff.toggle" }]);
+
+    // On a remapped layout the physical D key types "a"; only the physical
+    // key whose layout output is "d" may trigger the shortcut.
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "a", code: "KeyD", metaKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "d", code: "KeyL", metaKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+      "diff.toggle",
+    );
+  });
 });
 
 describe("formatShortcutLabel", () => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -637,6 +637,35 @@ describe("resolveShortcutCommand", () => {
       "rightPanel.toggle",
     );
   });
+
+  it("matches non-Latin layout letters using the physical key code", () => {
+    const keybindings = compile([{ shortcut: modShortcut("d"), command: "diff.toggle" }]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "в", code: "KeyD", metaKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+      "diff.toggle",
+    );
+  });
+
+  it("ignores the physical key code when the layout types a different Latin letter", () => {
+    const keybindings = compile([{ shortcut: modShortcut("d"), command: "diff.toggle" }]);
+
+    // On a remapped layout the physical D key types "a"; only the physical
+    // key whose layout output is "d" may trigger the shortcut.
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "a", code: "KeyD", metaKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "d", code: "KeyL", metaKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+      "diff.toggle",
+    );
+  });
 });
 
 describe("formatShortcutLabel", () => {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -71,9 +71,15 @@ function normalizeEventKey(key: string): string {
 }
 
 function resolveEventKeys(event: ShortcutEventLike): Set<string> {
-  const keys = new Set([normalizeEventKey(event.key)]);
+  const layoutKey = normalizeEventKey(event.key);
+  const keys = new Set([layoutKey]);
+  // The physical-position fallback exists for layouts that type non-Latin
+  // letters (Cyrillic, Greek) and for Option-modified symbols on macOS.
+  // When the layout already produces a Latin letter, match on it alone;
+  // otherwise a remapped physical key triggers shortcuts for two different
+  // letters at once and shadows system shortcuts on non-QWERTY layouts.
   const letterCode = event.code?.match(/^Key([A-Z])$/)?.[1];
-  if (letterCode) {
+  if (letterCode && !/^[a-z]$/.test(layoutKey)) {
     keys.add(letterCode.toLowerCase());
   }
   const aliases = event.code ? EVENT_CODE_KEY_ALIASES[event.code] : undefined;


### PR DESCRIPTION
## What Changed

Shortcut matching only falls back to the physical `KeyA`-`KeyZ` position when the layout-derived key is not itself a Latin letter. Two regression tests cover a non-Latin layout (still matched by position) and a remapped Latin layout (matched by layout output only).

## Why

`resolveEventKeys` accepted both the layout key and the physical code for every keypress. On a remapped Latin layout one physical key then triggered shortcuts for two different letters at once: with a layout where physical D types "a", a `mod+D` binding fires on `mod+A` and the user can no longer select all text.

The physical fallback exists for a real reason (Cyrillic and other non-Latin layouts, plus Option-modified symbols on macOS, produce keys that ASCII-defined shortcuts can never match), so it stays for exactly those cases: when `event.key` is not a Latin letter. When the layout already types Latin letters it speaks the shortcut vocabulary and is trusted alone.

Fixes #4434

## Testing

- `vp test run apps/web/src/keybindings.test.ts` passes (43/43), including the existing Option-modified `KeyB` case and the two new layout tests
- Related suites (shortcutModifierState, KeybindingsSettings.logic, projectScriptKeybindings) pass (17/17)
- `pnpm typecheck` in apps/web clean
- `vp lint` on changed files clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to shortcut resolution with targeted tests; behavior shift only affects remapped Latin layouts where layout and physical labels disagreed.
> 
> **Overview**
> **Keyboard shortcuts** no longer treat physical `KeyA`–`KeyZ` position as an extra match when the layout already types a Latin letter.
> 
> `resolveEventKeys` still falls back to `event.code` for non-Latin output (e.g. Cyrillic) and macOS Option symbols, but remapped Latin layouts (physical D typing `a`) only match on the layout character—so `mod+D` no longer fires on `mod+A` and system shortcuts like select-all are not shadowed.
> 
> Two tests cover Cyrillic-on-physical-D still resolving `diff.toggle`, and remapped Latin keys matching by layout output only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85645a8b62f7f2666617aae80448168e4ce8ae6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit physical key code fallback in `resolveEventKeys` to non-Latin layout output
> Previously, `resolveEventKeys` always added the physical letter derived from `event.code` as a fallback candidate, which caused shortcuts to fire incorrectly when the keyboard layout produced a different Latin letter than the physical key label (e.g. key `'a'` on a key with code `KeyD` would match a binding for `'d'`).
>
> - The fallback to the physical key letter is now only applied when the layout key is not a Latin a–z character, so non-Latin layouts (e.g. Cyrillic) still resolve shortcuts correctly via physical key.
> - Latin layouts that remap keys (e.g. Dvorak-style remapping) no longer trigger shortcuts for the wrong key.
> - Behavioral Change: events where the layout produces a Latin letter but on a physically different key will no longer match bindings for the physical key's label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85645a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->