### PR TITLE
Keep the server alive when a response write hits a dead socket

### DIFF
--- a/apps/server/src/httpResponseErrorGuard.test.ts
+++ b/apps/server/src/httpResponseErrorGuard.test.ts
@@ -1,0 +1,104 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeHttp from "node:http";
+import * as NodeNet from "node:net";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { guardHttpResponseWriteErrors } from "./httpResponseErrorGuard.ts";
+
+const servers: NodeHttp.Server[] = [];
+
+function listen(server: NodeHttp.Server): Promise<number> {
+  servers.push(server);
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as NodeNet.AddressInfo).port);
+    });
+  });
+}
+
+function fetchStatus(port: number, path: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const request = NodeHttp.get({ host: "127.0.0.1", port, path }, (response) => {
+      response.resume();
+      resolve(response.statusCode ?? 0);
+    });
+    request.on("error", reject);
+    request.setTimeout(5_000, () => reject(new Error("request timed out")));
+  });
+}
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+describe("guardHttpResponseWriteErrors", () => {
+  it("contains an upgrade socket write failure instead of crashing the process", async () => {
+    const writeErrors: unknown[] = [];
+    const failureObserved = Promise.withResolvers<void>();
+    const server = guardHttpResponseWriteErrors(NodeHttp.createServer(), (error) => {
+      writeErrors.push(error);
+      failureObserved.resolve();
+    });
+
+    server.on("upgrade", (_request, socket) => {
+      // Simulate the client vanishing while the auth rejection response is
+      // written to the upgrade socket: the write failure surfaces as an
+      // "error" event on a socket Node's http server no longer listens to.
+      socket.destroy(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+    });
+
+    const port = await listen(server);
+
+    const client = NodeNet.connect(port, "127.0.0.1", () => {
+      client.write(
+        [
+          "GET /rpc HTTP/1.1",
+          "Host: 127.0.0.1",
+          "Connection: Upgrade",
+          "Upgrade: websocket",
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          "Sec-WebSocket-Version: 13",
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+    client.on("error", () => {});
+
+    await failureObserved.promise;
+    client.destroy();
+
+    expect(writeErrors).toHaveLength(1);
+    expect(writeErrors[0]).toBeInstanceOf(Error);
+    expect((writeErrors[0] as NodeJS.ErrnoException).code).toBe("EPIPE");
+
+    // The process survived the failed write and the server keeps serving.
+    server.on("request", (_request, response) => {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok");
+    });
+    await expect(fetchStatus(port, "/")).resolves.toBe(200);
+  });
+
+  it("arms every response with an error listener without disturbing normal traffic", async () => {
+    const writeErrors: unknown[] = [];
+    let responseErrorListeners = -1;
+    const server = guardHttpResponseWriteErrors(NodeHttp.createServer(), (error) => {
+      writeErrors.push(error);
+    });
+
+    server.on("request", (_request, response) => {
+      responseErrorListeners = response.listenerCount("error");
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok");
+    });
+
+    const port = await listen(server);
+
+    await expect(fetchStatus(port, "/")).resolves.toBe(200);
+    expect(responseErrorListeners).toBeGreaterThan(0);
+    expect(writeErrors).toEqual([]);
+  });
+});

--- a/apps/server/src/httpResponseErrorGuard.ts
+++ b/apps/server/src/httpResponseErrorGuard.ts
@@ -1,0 +1,39 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import type * as NodeHttp from "node:http";
+
+/**
+ * Node surfaces late socket write failures (EPIPE, ECONNRESET,
+ * ERR_STREAM_DESTROYED) as "error" events. An "error" event without a
+ * listener escalates into an uncaught exception and terminates the whole
+ * server process, taking every other client and all in-flight provider
+ * work with it.
+ *
+ * Two emitters need coverage:
+ *
+ * - Upgrade sockets. Once a connection upgrades (the websocket RPC path,
+ *   including its auth rejection responses), Node's http server detaches
+ *   its own socket error handling, so the raw socket has no listener at
+ *   all until the websocket server adopts it.
+ * - Server responses. Response streams have no default error listener
+ *   either.
+ *
+ * A disconnected client only affects its own request: the request fiber is
+ * already interrupted through the response "close" event, so the write
+ * failure needs no handling beyond being observed.
+ */
+export function guardHttpResponseWriteErrors<T extends NodeHttp.Server>(
+  server: T,
+  onError?: (error: unknown) => void,
+): T {
+  server.on("request", (_request, response) => {
+    response.on("error", (error) => {
+      onError?.(error);
+    });
+  });
+  server.on("upgrade", (_request, socket) => {
+    socket.on("error", (error) => {
+      onError?.(error);
+    });
+  });
+  return server;
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,6 +18,7 @@ import {
   browserApiCorsLayer,
   httpCompressionLayer,
 } from "./http.ts";
+import { guardHttpResponseWriteErrors } from "./httpResponseErrorGuard.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -209,7 +210,7 @@ const HttpServerLive = Layer.unwrap(
         Effect.promise(() => import("@effect/platform-node/NodeHttpServer")),
         Effect.promise(() => import("node:http")),
       ]);
-      return NodeHttpServer.layer(NodeHttp.createServer, {
+      return NodeHttpServer.layer(() => guardHttpResponseWriteErrors(NodeHttp.createServer()), {
         host: config.host ?? "127.0.0.1",
         port: config.port,
         gracefulShutdownTimeout: HTTP_PREEMPTIVE_SHUTDOWN_GRACE_MS,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -12,6 +12,7 @@ import {
   staticAndDevRouteLayer,
   browserApiCorsLayer,
 } from "./http.ts";
+import { guardHttpResponseWriteErrors } from "./httpResponseErrorGuard.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
@@ -137,7 +138,7 @@ const HttpServerLive = Layer.unwrap(
         Effect.promise(() => import("@effect/platform-node/NodeHttpServer")),
         Effect.promise(() => import("node:http")),
       ]);
-      return NodeHttpServer.layer(NodeHttp.createServer, {
+      return NodeHttpServer.layer(() => guardHttpResponseWriteErrors(NodeHttp.createServer()), {
         host: config.host ?? "127.0.0.1",
         port: config.port,
         gracefulShutdownTimeout: HTTP_PREEMPTIVE_SHUTDOWN_GRACE_MS,


### PR DESCRIPTION
## What Changed

The Node HTTP server is created through a small guard that attaches an "error" listener to every server response and every upgrade socket. The listener only observes the failure; a new test reproduces the incident shape and proves the process survives and keeps serving.

## Why

A client that disconnects while an error response is being written crashes the whole server with an unhandled EPIPE, disconnecting every other client and abandoning in-flight provider work.

Upgrade sockets are the worst case and match the reported incident: once a connection upgrades for websocket RPC, Node's http server detaches its own socket error handling, so an auth rejection written to a vanished client emits an "error" event with no listener anywhere, which escalates to an uncaught exception and terminates the process. Plain response streams have no default error listener either.

The failed request needs no recovery logic: its fiber is already interrupted through the response "close" event. The write failure only needs a listener so it stays contained to the request that died.

Fixes #4410

## Testing

- `vp test run apps/server/src/httpResponseErrorGuard.test.ts` passes (2/2): an EPIPE on an upgrade socket is contained and the server still answers a follow-up request; normal traffic is untouched and every response carries an error listener
- `vp test run apps/server/src/server.test.ts` passes (112/112)
- `pnpm typecheck` in apps/server clean
- `vp lint` on changed files clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Node HTTP server creation; behavior change is limited to swallowing late write errors on dead connections, which is the intended fix for #4410.
> 
> **Overview**
> Fixes a **whole-process crash** when a client disconnects during an HTTP write (e.g. **EPIPE** on websocket upgrade / auth rejection paths). Node emits unhandled `error` on response streams and post-upgrade sockets with no default listener.
> 
> Adds **`guardHttpResponseWriteErrors`**, which registers `error` handlers on every **`request` response** and **`upgrade` socket** so failures are observed instead of becoming uncaught exceptions. The Node **`HttpServerLive`** path wraps `NodeHttp.createServer()` with this guard (no callback in production—errors are contained only).
> 
> Integration tests cover upgrade-socket **EPIPE** survival plus normal requests still succeeding with listeners armed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f10a9ea423a154690fe12497615636fccb27ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent uncaught exceptions when writing to dead sockets in the Node HTTP server
> Introduces `guardHttpResponseWriteErrors` in [httpResponseErrorGuard.ts](https://github.com/pingdotgg/t3code/pull/4470/files#diff-70fb1cf3fcd859127bfd9df34b6fd6d99f88902cb216ab132153d64888687d8f), which attaches `error` listeners to HTTP response objects and upgrade sockets, routing write errors (e.g. `EPIPE`) to an optional callback instead of letting them propagate as uncaught exceptions.
>
> - The Node branch of `HttpServerLive` in [server.ts](https://github.com/pingdotgg/t3code/pull/4470/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) wraps `NodeHttp.createServer()` with this guard so all response and upgrade socket errors are captured automatically.
> - Behavioral Change: write errors on dead sockets that previously crashed the process are now silently swallowed unless a callback is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f10a9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->