### PR TITLE
Add Claude Opus 5 model

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -530,6 +530,29 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("preserves xhigh effort for Claude Opus 5", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-5",
+          [{ id: "effort", value: "xhigh" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, "xhigh");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("falls back to default effort when unsupported max is requested for Sonnet 4.6", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -340,6 +340,7 @@ function selectedClaudeContextWindow(
   modelSelection: ModelSelection | undefined,
 ): number | undefined {
   switch (modelSelection?.model) {
+    case "claude-opus-5":
     case "claude-opus-4-8":
     case "claude-opus-4-7":
       // Always 1M at the API; these models expose no contextWindow option.

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -51,6 +51,7 @@ const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
 } as const;
+const MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219";
 const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
@@ -83,6 +84,33 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
             { value: "200k", label: "200k" },
             { value: "1m", label: "1M", isDefault: true },
           ],
+        }),
+      ],
+    }),
+  },
+  {
+    slug: "claude-opus-5",
+    name: "Claude Opus 5",
+    isCustom: false,
+    capabilities: createModelCapabilities({
+      optionDescriptors: [
+        buildSelectOptionDescriptor({
+          id: "effort",
+          label: "Reasoning",
+          options: [
+            { value: "low", label: "Low" },
+            { value: "medium", label: "Medium" },
+            { value: "high", label: "High", isDefault: true },
+            { value: "xhigh", label: "Extra High" },
+            { value: "max", label: "Max" },
+            { value: "ultracode", label: "Ultracode" },
+            { value: "ultrathink", label: "Ultrathink" },
+          ],
+          promptInjectedValues: ["ultrathink"],
+        }),
+        buildBooleanOptionDescriptor({
+          id: "fastMode",
+          label: "Fast Mode",
         }),
       ],
     }),
@@ -272,6 +300,10 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   },
 ];
 
+function supportsClaudeOpus5(version: string | null | undefined): boolean {
+  return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;
+}
+
 function supportsClaudeFable5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_FABLE_5_VERSION) >= 0 : false;
 }
@@ -288,6 +320,9 @@ function getBuiltInClaudeModelsForVersion(
   version: string | null | undefined,
 ): ReadonlyArray<ServerProviderModel> {
   return BUILT_IN_MODELS.filter((model) => {
+    if (model.slug === "claude-opus-5") {
+      return supportsClaudeOpus5(version);
+    }
     if (model.slug === "claude-fable-5") {
       return supportsClaudeFable5(version);
     }
@@ -299,6 +334,11 @@ function getBuiltInClaudeModelsForVersion(
     }
     return true;
   });
+}
+
+function formatClaudeOpus5UpgradeMessage(version: string | null): string {
+  const versionLabel = version ? `v${version}` : "the installed version";
+  return `Claude Code ${versionLabel} is too old for Claude Opus 5. Upgrade to v${MINIMUM_CLAUDE_OPUS_5_VERSION} or newer to access it.`;
 }
 
 function formatClaudeFable5UpgradeMessage(version: string | null): string {
@@ -360,6 +400,7 @@ export function normalizeClaudeCliEffort(
   if (
     effort === "xhigh" &&
     model !== "claude-fable-5" &&
+    model !== "claude-opus-5" &&
     model !== "claude-opus-4-8" &&
     model !== "claude-sonnet-5"
   ) {
@@ -837,13 +878,15 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
   );
-  const versionUpgradeMessage = supportsClaudeFable5(parsedVersion)
+  const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
     ? undefined
-    : supportsClaudeOpus48(parsedVersion)
-      ? formatClaudeFable5UpgradeMessage(parsedVersion)
-      : supportsClaudeOpus47(parsedVersion)
-        ? formatClaudeOpus48UpgradeMessage(parsedVersion)
-        : formatClaudeOpus47UpgradeMessage(parsedVersion);
+    : supportsClaudeFable5(parsedVersion)
+      ? formatClaudeOpus5UpgradeMessage(parsedVersion)
+      : supportsClaudeOpus48(parsedVersion)
+        ? formatClaudeFable5UpgradeMessage(parsedVersion)
+        : supportsClaudeOpus47(parsedVersion)
+          ? formatClaudeOpus48UpgradeMessage(parsedVersion)
+          : formatClaudeOpus47UpgradeMessage(parsedVersion);
 
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1842,6 +1842,62 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect("includes Claude Opus 5 on supported Claude Code versions", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities(),
+          );
+          const opus5 = status.models.find((model) => model.slug === "claude-opus-5");
+          assert.strictEqual(opus5?.name, "Claude Opus 5");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.219\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("hides Claude Opus 5 on older Claude Code versions", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities(),
+          );
+          assert.strictEqual(
+            status.models.some((model) => model.slug === "claude-opus-5"),
+            false,
+          );
+          assert.strictEqual(
+            status.message,
+            "Claude Code v2.1.218 is too old for Claude Opus 5. Upgrade to v2.1.219 or newer to access it.",
+          );
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.218\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("includes Claude Fable 5 on supported Claude Code versions", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -176,7 +176,10 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   [CLAUDE_DRIVER_KIND]: {
-    opus: "claude-opus-4-8",
+    opus: "claude-opus-5",
+    "opus-5": "claude-opus-5",
+    "claude-opus-5.0": "claude-opus-5",
+    "claude-opus-5-0": "claude-opus-5",
     "opus-4.8": "claude-opus-4-8",
     "claude-opus-4.8": "claude-opus-4-8",
     "opus-4.7": "claude-opus-4-7",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -151,7 +151,7 @@ describe("model slug normalization", () => {
   it("preserves exact custom slugs instead of expanding provider aliases", () => {
     const claude = ProviderDriverKind.make("claudeAgent");
 
-    expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-4-8");
+    expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
   });
 });


### PR DESCRIPTION
## What Changed

Adds `claude-opus-5` to the built-in Claude model list, following the same shape as the existing Opus 4.8 entry.

- **Model entry** in `BUILT_IN_MODELS`, placed after Fable 5 and ahead of Opus 4.8.
- **Effort**: full ladder (`low`/`medium`/`high`/`xhigh`/`max`) with `high` as the default, matching Claude Code's own `default_effort` for the model, plus the `ultracode` and prompt-injected `ultrathink` options — identical to Opus 4.8. Also added to the `xhigh` passthrough list in `normalizeClaudeCliEffort` so it isn't downgraded to `max`.
- **Fast Mode**: `fastMode` boolean descriptor. Its presence is the whole gate — `ClaudeAdapter` derives `fastModeSupported` from the descriptor list, so no other wiring was needed.
- **1M context**: 1M is both the default and the maximum for Opus 5, so it gets no `contextWindow` selector and instead joins Opus 4.8/4.7 in `selectedClaudeContextWindow`, which always reports 1M.
- **Version gate**: hidden below Claude Code v2.1.219, with the usual upgrade message slotted into the existing version chain.
- **Aliases**: `opus` now resolves to `claude-opus-5`, matching Claude Code's own `opus` alias default, with `opus-5` / `claude-opus-5.0` / `claude-opus-5-0` added. Existing `opus-4.8` / `4.7` / `4.6` aliases are untouched.
- **Tests**: version-gating pair in `ProviderRegistry.test.ts`, an `xhigh` passthrough case in `ClaudeAdapter.test.ts`, and the updated `opus` alias expectation in `packages/shared/src/model.test.ts`.

## Why

Opus 5 shipped in Claude Code v2.1.219 and is the current default Opus there, but T3 doesn't offer it — users on a current CLI can only pick Opus 4.8 or older from the model picker.

Sources for the specifics:

- 1M as default *and* maximum: [What's new in Claude Opus 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5) — this is why it gets no 200k/1M selector, unlike Fable 5 and Sonnet 5.
- Fast mode support and the v2.1.219 gate: [Speed up responses with fast mode](https://code.claude.com/docs/en/fast-mode) — "Fast mode is supported on Opus 5, Opus 4.8, and Opus 4.7" and "Opus 5 is the fast mode default in Claude Code v2.1.219 and later".
- Default effort and the `opus` alias target: the model table in the Claude Code 2.1.219 bundle (`default_effort: "high"`, `aliases.opus.default: "claude-opus-5"`).

## UI Changes

No layout or visual change — the model picker gains one row from the existing built-in model list, rendered by the existing code path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — n/a, no visual change
- [x] I included a video for animation/interaction changes — n/a

---

Noting the caveat in CONTRIBUTING.md: happy for this to be closed or reimplemented directly if you'd rather land model additions yourselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model catalog and alias mapping changes with no auth or data-path changes; behavior follows existing Opus 4.8 patterns.
> 
> **Overview**
> Adds **`claude-opus-5`** as a built-in Claude model so users on current Claude Code can pick it in the model list.
> 
> The provider registers Opus 5 with the same **reasoning effort** ladder and **fast mode** options as recent Opus models, treats it as a fixed **1M** context window (no context selector), and only exposes it when Claude Code is **v2.1.219+**, with an upgrade message in the existing version chain. **`xhigh`** effort is passed through to the SDK for Opus 5 instead of being downgraded to **`max`**.
> 
> **`opus`** and related aliases now normalize to **`claude-opus-5`** instead of Opus 4.8. Tests cover version gating, **`xhigh`** passthrough, and the updated alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f63267812fe94fcf5ecb358dcde93724f841f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Opus 5 model to the Claude provider
> - Adds `claude-opus-5` as a built-in model with `Reasoning` and `fastMode` options, gated behind Claude Code version `2.1.219` (constant `MINIMUM_CLAUDE_OPUS_5_VERSION`).
> - Updates `selectedClaudeContextWindow` to return a 1M token context window for `claude-opus-5`.
> - Keeps `xhigh` effort unnormalized for `claude-opus-5` (no remapping to `max`), consistent with Opus 4.8 and Sonnet 5.
> - Updates `MODEL_SLUG_ALIASES_BY_PROVIDER` so the generic `opus` alias now resolves to `claude-opus-5` instead of `claude-opus-4-8`.
> - Behavioral Change: `normalizeModelSlug('opus', claude)` now returns `claude-opus-5`; any code relying on `opus` resolving to `claude-opus-4-8` will be affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f63267.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Opus 5 model.
  * Added model aliases including `opus`, `opus-5`, and Claude Opus 5 naming variants.
  * Added Reasoning and Fast Mode capabilities for Claude Opus 5.
  * Claude Opus 5 is available only with the required Claude Code CLI version.

* **Bug Fixes**
  * Preserved maximum effort settings for Claude Opus 5.
  * Applied the correct 1M-token context window for Claude Opus 5.
  * Added clearer upgrade messaging when the required CLI version is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->