### PR TITLE
feat(web): add collapse-all toggle to diff panel

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -11,6 +11,8 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
   Columns2Icon,
   PilcrowIcon,
   Rows3Icon,
@@ -32,6 +34,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../lib/diffRendering";
+import { areAllDiffFilesCollapsed, toggleAllDiffFiles } from "../lib/diffCollapse";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { useProject, useThread } from "../state/entities";
 import { resolveThreadRouteRef } from "../threadRoutes";
@@ -39,6 +42,7 @@ import { useClientSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
 import { AnnotatableCodeView, type AnnotatableCodeViewHandle } from "./diffs/AnnotatableCodeView";
+import { Button } from "./ui/button";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 import { Switch } from "./ui/switch";
 import {
@@ -446,6 +450,8 @@ export default function DiffPanel({
       }),
     [collapsedDiffFileKeys, renderableFiles],
   );
+  const diffFileKeys = useMemo(() => codeViewFiles.map((file) => file.fileKey), [codeViewFiles]);
+  const allDiffFilesCollapsed = areAllDiffFilesCollapsed(diffFileKeys, collapsedDiffFileKeys);
 
   useEffect(() => {
     if (!selectedFilePath) return;
@@ -495,6 +501,18 @@ export default function DiffPanel({
     },
     [collapseScopeKey],
   );
+
+  const toggleDiffFileCollapse = useCallback(() => {
+    setCollapsedDiffFiles((current) => {
+      const currentKeys =
+        current.scopeKey === collapseScopeKey ? current.fileKeys : EMPTY_COLLAPSED_DIFF_FILE_KEYS;
+
+      return {
+        scopeKey: collapseScopeKey,
+        fileKeys: toggleAllDiffFiles(diffFileKeys, currentKeys),
+      };
+    });
+  }, [collapseScopeKey, diffFileKeys]);
 
   const selectTurn = (turnId: TurnId) => {
     if (!routeThreadRef) return;
@@ -695,6 +713,30 @@ export default function DiffPanel({
         )}
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        {codeViewFiles.length > 0 && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="outline"
+                  aria-label={allDiffFilesCollapsed ? "Expand all files" : "Collapse all files"}
+                  onClick={toggleDiffFileCollapse}
+                />
+              }
+            >
+              {allDiffFilesCollapsed ? (
+                <ChevronsUpDownIcon className="size-3" />
+              ) : (
+                <ChevronsDownUpIcon className="size-3" />
+              )}
+            </TooltipTrigger>
+            <TooltipPopup side="top">
+              {allDiffFilesCollapsed ? "Expand all files" : "Collapse all files"}
+            </TooltipPopup>
+          </Tooltip>
+        )}
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -824,7 +866,7 @@ export default function DiffPanel({
                 <AnnotatableCodeView
                   viewerRef={codeViewRef}
                   key={collapseScopeKey ?? reviewSectionId}
-                  className="diff-render-surface h-full min-h-0 overflow-auto"
+                  className="diff-render-surface h-full min-h-0 overflow-auto [&>div>div:last-child]:top-0! [&>div>div:last-child]:bottom-auto!"
                   files={codeViewFiles}
                   sectionId={reviewSectionId}
                   sectionTitle={reviewSectionTitle}

--- a/apps/web/src/lib/diffCollapse.test.ts
+++ b/apps/web/src/lib/diffCollapse.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { areAllDiffFilesCollapsed, toggleAllDiffFiles } from "./diffCollapse";
+
+const FILE_KEYS = ["src/app.ts", "src/index.ts"];
+const FIRST_FILE_KEY = FILE_KEYS[0]!;
+
+describe("diff collapse controls", () => {
+  it("reports whether every rendered file is collapsed", () => {
+    expect(areAllDiffFilesCollapsed(FILE_KEYS, new Set(FILE_KEYS))).toBe(true);
+    expect(areAllDiffFilesCollapsed(FILE_KEYS, new Set([FIRST_FILE_KEY]))).toBe(false);
+    expect(areAllDiffFilesCollapsed([], new Set())).toBe(false);
+  });
+
+  it("collapses all files when any rendered file is expanded", () => {
+    expect(toggleAllDiffFiles(FILE_KEYS, new Set([FIRST_FILE_KEY]))).toEqual(new Set(FILE_KEYS));
+  });
+
+  it("expands all files when every rendered file is collapsed", () => {
+    expect(toggleAllDiffFiles(FILE_KEYS, new Set(FILE_KEYS))).toEqual(new Set());
+  });
+});

--- a/apps/web/src/lib/diffCollapse.ts
+++ b/apps/web/src/lib/diffCollapse.ts
@@ -1,0 +1,13 @@
+export function areAllDiffFilesCollapsed(
+  fileKeys: ReadonlyArray<string>,
+  collapsedFileKeys: ReadonlySet<string>,
+): boolean {
+  return fileKeys.length > 0 && fileKeys.every((fileKey) => collapsedFileKeys.has(fileKey));
+}
+
+export function toggleAllDiffFiles(
+  fileKeys: ReadonlyArray<string>,
+  collapsedFileKeys: ReadonlySet<string>,
+): ReadonlySet<string> {
+  return areAllDiffFilesCollapsed(fileKeys, collapsedFileKeys) ? new Set() : new Set(fileKeys);
+}


### PR DESCRIPTION
## What Changed

Added a button to the Diff panel toolbar that toggles all file diffs between collapsed and expanded states.

The button displays “Collapse all files” when any file is expanded and “Expand all files” when every file is collapsed. Existing per-file collapse controls continue to work independently.

## Why

Large changesets can be difficult to navigate when every file diff is expanded. This toggle makes it easier to collapse the entire list for a quick overview and reopen all files without toggling each one individually.

## UI Changes

Added a collapse/expand-all button to the right-side Diff panel toolbar.

**Before:**

<img width="630" height="403" alt="before" src="https://github.com/user-attachments/assets/83482e3c-b1a5-4117-b457-6e14286fa65b" />


**After:**

<img width="540" height="415" alt="after" src="https://github.com/user-attachments/assets/3279d8a8-5c52-40e3-928a-06573a5860ef" />

**Interaction video:**

https://github.com/user-attachments/assets/1c1278be-9197-4806-9b26-5b51680a47ac


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only diff panel behavior with isolated pure helpers and tests; no auth, data, or API changes.
> 
> **Overview**
> Adds a **collapse/expand all** control to the diff panel toolbar when at least one file is shown. One click collapses every rendered file if any are expanded, or clears collapse state when all are already collapsed; icon and tooltip follow that state.
> 
> Collapse behavior is driven by new helpers in `diffCollapse.ts` (`areAllDiffFilesCollapsed`, `toggleAllDiffFiles`) wired into the existing per-scope `collapsedDiffFileKeys` state, with unit tests for the toggle rules.
> 
> Also adjusts `AnnotatableCodeView` layout classes so sticky diff headers align correctly with the new toolbar control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042ab5b6a04a088b185d2d0235584dc713f839b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapse-all toggle button to diff panel header
> Adds a button to the `DiffPanel` header that collapses all rendered diff files if any are expanded, or expands all if all are collapsed. The button icon and tooltip update to reflect the current state.
>
> - Adds two pure helpers in [`diffCollapse.ts`](https://github.com/pingdotgg/t3code/pull/4475/files#diff-76c67f26ed57963a31ee957bfe8134e12147d7fc5b59503708925ad500a860dd): `areAllDiffFilesCollapsed` and `toggleAllDiffFiles`, with unit tests covering both.
> - The toggle button is only shown when there is at least one diff file rendered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4874e5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->