### PR TITLE
feat(claude): add Claude Opus 5

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ProviderInstanceId } from "@t3tools/contracts";
+import { createModelSelection } from "@t3tools/shared/model";
+
+import {
+  getClaudeModelCapabilities,
+  normalizeClaudeCliEffort,
+  resolveClaudeApiModelId,
+  resolveClaudeContextWindow,
+} from "./ClaudeProvider.ts";
+
+const CLAUDE_INSTANCE = ProviderInstanceId.make("claudeAgent");
+
+function descriptorIds(model: string): ReadonlyArray<string> {
+  const descriptors = getClaudeModelCapabilities(model).optionDescriptors ?? [];
+  return descriptors.map((descriptor) => descriptor.id);
+}
+
+describe("ClaudeProvider Opus 5", () => {
+  it("exposes reasoning, fast mode, and context window on a single model entry", () => {
+    expect(descriptorIds("claude-opus-5")).toEqual(["effort", "fastMode", "contextWindow"]);
+  });
+
+  it("keeps xhigh as xhigh instead of widening it to max", () => {
+    expect(normalizeClaudeCliEffort("xhigh", "claude-opus-5")).toBe("xhigh");
+  });
+
+  it("still widens xhigh to max for models that do not support it", () => {
+    expect(normalizeClaudeCliEffort("xhigh", "claude-opus-4-6")).toBe("max");
+  });
+
+  it("maps ultracode to xhigh and drops the prompt-prefix ultrathink mode", () => {
+    expect(normalizeClaudeCliEffort("ultracode", "claude-opus-5")).toBe("xhigh");
+    expect(normalizeClaudeCliEffort("ultrathink", "claude-opus-5")).toBeUndefined();
+  });
+
+  it("defaults to the 1M context window", () => {
+    const selection = createModelSelection(CLAUDE_INSTANCE, "claude-opus-5");
+    expect(resolveClaudeContextWindow(selection)).toBe("1m");
+    expect(resolveClaudeApiModelId(selection)).toBe("claude-opus-5[1m]");
+  });
+
+  it("drops the 1M suffix when the 200k context window is selected", () => {
+    const selection = createModelSelection(CLAUDE_INSTANCE, "claude-opus-5", [
+      { id: "contextWindow", value: "200k" },
+    ]);
+    expect(resolveClaudeContextWindow(selection)).toBe("200k");
+    expect(resolveClaudeApiModelId(selection)).toBe("claude-opus-5");
+  });
+});

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -51,6 +51,7 @@ const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
 } as const;
+const MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219";
 const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
@@ -75,6 +76,41 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
             { value: "ultrathink", label: "Ultrathink" },
           ],
           promptInjectedValues: ["ultrathink"],
+        }),
+        buildSelectOptionDescriptor({
+          id: "contextWindow",
+          label: "Context Window",
+          options: [
+            { value: "200k", label: "200k" },
+            { value: "1m", label: "1M", isDefault: true },
+          ],
+        }),
+      ],
+    }),
+  },
+  {
+    slug: "claude-opus-5",
+    name: "Claude Opus 5",
+    isCustom: false,
+    capabilities: createModelCapabilities({
+      optionDescriptors: [
+        buildSelectOptionDescriptor({
+          id: "effort",
+          label: "Reasoning",
+          options: [
+            { value: "low", label: "Low" },
+            { value: "medium", label: "Medium" },
+            { value: "high", label: "High", isDefault: true },
+            { value: "xhigh", label: "Extra High" },
+            { value: "max", label: "Max" },
+            { value: "ultracode", label: "Ultracode" },
+            { value: "ultrathink", label: "Ultrathink" },
+          ],
+          promptInjectedValues: ["ultrathink"],
+        }),
+        buildBooleanOptionDescriptor({
+          id: "fastMode",
+          label: "Fast Mode",
         }),
         buildSelectOptionDescriptor({
           id: "contextWindow",
@@ -272,6 +308,10 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   },
 ];
 
+function supportsClaudeOpus5(version: string | null | undefined): boolean {
+  return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;
+}
+
 function supportsClaudeFable5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_FABLE_5_VERSION) >= 0 : false;
 }
@@ -288,6 +328,9 @@ function getBuiltInClaudeModelsForVersion(
   version: string | null | undefined,
 ): ReadonlyArray<ServerProviderModel> {
   return BUILT_IN_MODELS.filter((model) => {
+    if (model.slug === "claude-opus-5") {
+      return supportsClaudeOpus5(version);
+    }
     if (model.slug === "claude-fable-5") {
       return supportsClaudeFable5(version);
     }
@@ -299,6 +342,11 @@ function getBuiltInClaudeModelsForVersion(
     }
     return true;
   });
+}
+
+function formatClaudeOpus5UpgradeMessage(version: string | null): string {
+  const versionLabel = version ? `v${version}` : "the installed version";
+  return `Claude Code ${versionLabel} is too old for Claude Opus 5. Upgrade to v${MINIMUM_CLAUDE_OPUS_5_VERSION} or newer to access it.`;
 }
 
 function formatClaudeFable5UpgradeMessage(version: string | null): string {
@@ -359,6 +407,7 @@ export function normalizeClaudeCliEffort(
   }
   if (
     effort === "xhigh" &&
+    model !== "claude-opus-5" &&
     model !== "claude-fable-5" &&
     model !== "claude-opus-4-8" &&
     model !== "claude-sonnet-5"
@@ -837,13 +886,15 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
   );
-  const versionUpgradeMessage = supportsClaudeFable5(parsedVersion)
+  const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
     ? undefined
-    : supportsClaudeOpus48(parsedVersion)
-      ? formatClaudeFable5UpgradeMessage(parsedVersion)
-      : supportsClaudeOpus47(parsedVersion)
-        ? formatClaudeOpus48UpgradeMessage(parsedVersion)
-        : formatClaudeOpus47UpgradeMessage(parsedVersion);
+    : supportsClaudeFable5(parsedVersion)
+      ? formatClaudeOpus5UpgradeMessage(parsedVersion)
+      : supportsClaudeOpus48(parsedVersion)
+        ? formatClaudeFable5UpgradeMessage(parsedVersion)
+        : supportsClaudeOpus47(parsedVersion)
+          ? formatClaudeOpus48UpgradeMessage(parsedVersion)
+          : formatClaudeOpus47UpgradeMessage(parsedVersion);
 
   const capabilities = resolveCapabilities
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -176,7 +176,10 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   [CLAUDE_DRIVER_KIND]: {
-    opus: "claude-opus-4-8",
+    opus: "claude-opus-5",
+    "opus-5": "claude-opus-5",
+    "claude-opus-5.0": "claude-opus-5",
+    "claude-opus-5-0": "claude-opus-5",
     "opus-4.8": "claude-opus-4-8",
     "claude-opus-4.8": "claude-opus-4-8",
     "opus-4.7": "claude-opus-4-7",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -151,7 +151,7 @@ describe("model slug normalization", () => {
   it("preserves exact custom slugs instead of expanding provider aliases", () => {
     const claude = ProviderDriverKind.make("claudeAgent");
 
-    expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-4-8");
+    expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
   });
 });


### PR DESCRIPTION
## What Changed

Adds `claude-opus-5` to the Claude provider's built-in model list, gated on Claude Code `>= 2.1.219`.

- New `BUILT_IN_MODELS` entry carrying the three option descriptors Opus 5 supports: `effort`, `fastMode`, and `contextWindow` (200k / 1M, defaulting to 1M).
- `MINIMUM_CLAUDE_OPUS_5_VERSION`, `supportsClaudeOpus5`, a `getBuiltInClaudeModelsForVersion` branch, and `formatClaudeOpus5UpgradeMessage`, following the existing Fable 5 / Opus 4.8 / Opus 4.7 pattern. Opus 5 becomes the newest gate in the `versionUpgradeMessage` cascade.
- `normalizeClaudeCliEffort` passes `xhigh` through for `claude-opus-5` instead of widening it to `max`.
- Alias map: bare `opus` resolves to `claude-opus-5`, plus `opus-5` / `claude-opus-5.0` / `claude-opus-5-0`, mirroring the existing Sonnet 5 alias shape.
- Focused tests in a new `ClaudeProvider.test.ts`.

## Why

Claude Code 2.1.219 shipped Opus 5:

> Added Claude Opus 5 (`claude-opus-5`), now the default Opus model — 1M context, fast mode at $10/$50 per Mtok

Without a built-in entry it is only reachable as a custom model slug, and custom models resolve to `DEFAULT_CLAUDE_MODEL_CAPABILITIES`, which has no option descriptors. That means no reasoning selector, no fast-mode toggle, and no way to pick a context window. Reaching 1M requires hand-writing `claude-opus-5[1m]` into `customModels`, which lands each context window in the picker as a separate row.

The three descriptors come from that same 2.1.219 changelog: 1M context and fast mode are named in the entry above, and fast-mode support is confirmed again by "Removed Opus 4.7 from fast mode; `/fast` now applies to Opus 5 and Opus 4.8". Bare `opus` is repointed because the entry calls Opus 5 "the default Opus model".

The `normalizeClaudeCliEffort` change is load-bearing rather than cosmetic: that function widens `xhigh` to `max` for every model outside its allowlist, so adding the model entry alone would let the picker offer Extra High while silently sending `max`.

Opus 5 is deliberately kept out of the always-1M branch of `selectedClaudeContextWindow` in `ClaudeAdapter.ts`. That branch exists for models exposing no `contextWindow` option; Opus 5 falls through to `resolveClaudeContextWindow` so the context meter tracks the actual selection.

One open question for maintainers: 1M-default is certain from the changelog, but I could not confirm whether 200k remains selectable for Opus 5. The 200k option is included to match the Fable 5 / Opus 4.6 shape, and selecting it yields a bare `claude-opus-5`, which is still a valid id. Happy to drop it if you know otherwise.

Not included, to keep this focused: `claude-opus-4-7` still declares a `fastMode` descriptor, which 2.1.219 removed ("Removed Opus 4.7 from fast mode"). Separate fix — say the word and I'll open it.

## UI Changes

The model picker gains one "Claude Opus 5" row at ⌘2. No layout, styling, or interaction changes — the row renders through the existing descriptor-driven picker.

**Before** (`main`)

![Model picker before](https://raw.githubusercontent.com/SI-RUI-ZHANG/t3code/pr-assets/claude-opus-5/before-model-picker.png)

**After**

![Model picker after](https://raw.githubusercontent.com/SI-RUI-ZHANG/t3code/pr-assets/claude-opus-5/after-model-picker.png)

Option controls on the new row — one model, with the context window as a selector rather than a second entry:

![Opus 5 option controls](https://raw.githubusercontent.com/SI-RUI-ZHANG/t3code/pr-assets/claude-opus-5/opus5-options-open.png)

Both captured from `vp run dev` against Claude Code 2.1.219, same viewport and disposable home directory.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — not applicable, no motion or interaction change

## Verification

- New `apps/server/src/provider/Layers/ClaudeProvider.test.ts` — 6 focused tests covering the descriptor set, the `xhigh` passthrough, `ultracode`/`ultrathink` handling, and both context-window branches.
- `vp test run` across the affected suites (`ClaudeProvider`, `ClaudeAdapter`, `providerSnapshot`, `modelSelection`, `modelOrdering`, `shared/model`) — 88 passing.
- `vp run --filter t3 --filter @t3tools/contracts --filter @t3tools/shared typecheck` — clean.
- `vp fmt` / `vp lint` — clean.

`packages/shared/src/model.test.ts` needed one expectation updated for the `opus` alias repoint. That test asserts custom slugs are preserved rather than alias-expanded; the alias target is only its contrast case, so its subject is unchanged.
