### PR TITLE
Preserve Opus fallback on older Claude Code

### DIFF
--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { deriveProviderInstanceEntries } from "./providerInstances";
 import {
   getAppModelOptionsForInstance,
+  resolveAppModelSelection,
   resolveAppModelSelectionForInstance,
   resolveAppModelSelectionState,
 } from "./modelSelection";
@@ -301,5 +302,30 @@ describe("instance-scoped model selection", () => {
       instanceId: ProviderInstanceId.make("claude_openrouter"),
       model: "openai/gpt-5.5",
     });
+  });
+});
+
+describe("provider-scoped model selection", () => {
+  it("keeps the bare Opus alias in the Opus family when Opus 5 is gated out", () => {
+    // Mirrors Claude Code 2.1.169-2.1.218, where Opus 5 is filtered out of the
+    // served catalog. The provider default is the first built-in that survives
+    // filtering (Fable 5), so without the family fallback `opus` resolves to a
+    // different model family while Opus 4.8 is still available.
+    const providers = [
+      provider({
+        provider: ProviderDriverKind.make("claudeAgent"),
+        instanceId: "claudeAgent",
+        models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5"],
+      }),
+    ];
+
+    expect(
+      resolveAppModelSelection(
+        ProviderDriverKind.make("claudeAgent"),
+        settingsWithProviderInstances(),
+        providers,
+        "opus",
+      ),
+    ).toBe("claude-opus-4-8");
   });
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -12,6 +12,7 @@ import {
   getProviderOptionStringSelectionValue,
   normalizeCustomModelSlug,
   normalizeModelSlug,
+  resolveSelectableModel,
 } from "./model.ts";
 
 const codexCaps: ModelCapabilities = createModelCapabilities({
@@ -153,5 +154,25 @@ describe("model slug normalization", () => {
 
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
+  });
+
+  it("resolves the bare Opus alias to the newest available Claude model", () => {
+    const claude = ProviderDriverKind.make("claudeAgent");
+    const currentModels = [
+      { slug: "claude-opus-5", name: "Claude Opus 5" },
+      { slug: "claude-opus-4-8", name: "Claude Opus 4.8" },
+    ];
+    const olderModels = [
+      { slug: "claude-opus-custom", name: "Custom Opus" },
+      { slug: "claude-opus-4-6", name: "Claude Opus 4.6" },
+      { slug: "claude-sonnet-5", name: "Claude Sonnet 5" },
+      { slug: "claude-opus-4-8", name: "Claude Opus 4.8" },
+    ];
+    const customModels = [{ slug: "claude-opus-custom", name: "Custom Opus" }];
+
+    expect(resolveSelectableModel(claude, "opus", currentModels)).toBe("claude-opus-5");
+    expect(resolveSelectableModel(claude, "opus", olderModels)).toBe("claude-opus-4-8");
+    expect(resolveSelectableModel(claude, "opus-5", olderModels)).toBeNull();
+    expect(resolveSelectableModel(claude, "opus", customModels)).toBeNull();
   });
 });

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -12,6 +12,14 @@ import {
 
 const DEFAULT_PROVIDER_DRIVER_KIND = ProviderDriverKind.make("codex");
 
+const CLAUDE_OPUS_FALLBACK_MODELS = [
+  "claude-opus-5",
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-opus-4-5",
+] as const;
+
 export interface SelectableModelOption {
   slug: string;
   name: string;
@@ -287,7 +295,22 @@ export function resolveSelectableModel(
   }
 
   const resolved = options.find((option) => option.slug === normalized);
-  return resolved ? resolved.slug : null;
+  if (resolved) {
+    return resolved.slug;
+  }
+
+  // The bare Claude `opus` alias tracks the newest Opus model, but newer
+  // models can be omitted from the live catalog when the installed Claude
+  // Code version is too old. In that case, preserve the model family instead
+  // of falling through to the provider's unrelated default model. Use a fixed
+  // built-in priority so user-defined picker ordering and custom model slugs
+  // cannot change which fallback is selected.
+  if (provider === ProviderDriverKind.make("claudeAgent") && trimmed === "opus") {
+    const availableSlugs = new Set(options.map((option) => option.slug));
+    return CLAUDE_OPUS_FALLBACK_MODELS.find((slug) => availableSlugs.has(slug)) ?? null;
+  }
+
+  return null;
 }
 
 function resolveModelSlug(model: string | null | undefined, provider: ProviderDriverKind): string {


### PR DESCRIPTION
## What Changed

The bare `opus` alias now resolves to the newest Opus model the installed Claude Code actually supports, instead of falling through to the provider default when Opus 5 is absent from the catalog.

Two files in `packages/shared`. No SDK bump, no change to the version gate.

## Why

#4472 repointed `opus` to `claude-opus-5`. That slug is gated behind `MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219"` in `getBuiltInClaudeModelsForVersion()`, so on older clients it never reaches the served catalog. `resolveSelectableModel()` returns `null`, and selection falls through to `getDefaultServerModel()` — which takes the first non-custom model surviving version filtering, `claude-fable-5` from 2.1.169 up.

In practice: on Claude Code 2.1.169–2.1.218, picking `opus` gives you Claude Fable 5 while Opus 4.8 is sitting available in the same catalog.

| Claude Code | before | after |
| --- | --- | --- |
| >= 2.1.219 | Opus 5 | Opus 5 — direct match, fallback never runs |
| 2.1.169 – 2.1.218 | Fable 5 | Opus 4.8 |
| 2.1.154 – 2.1.168 | Opus 4.8 | unchanged |
| < 2.1.154 / unknown | Opus 4.7 / 4.6 | unchanged |

Only the second row moves. Below 2.1.169 the default already lands on the newest available Opus, so the fallback is a no-op there.

Falling through to the newest supported model is the right behaviour when nothing was asked for. `opus` is a family request though, so it now resolves inside the Opus family first. The default policy itself is untouched.

The fallback walks a fixed list of built-in slugs, so `modelOrder` cannot shift which Opus is picked and `claude-opus-custom` is never selected. It reads the visible option list, so a model hidden via `hiddenModels` stays unselected. Explicit `opus-5` still resolves to nothing when Opus 5 is absent, rather than quietly downgrading to a different model.

Resolves the open finding on #4472: https://github.com/pingdotgg/t3code/pull/4472#discussion_r3647506358

`apps/web/src/modelSelection.test.ts` pins this end to end: with `claude-fable-5` present and `claude-opus-5` filtered out, `resolveAppModelSelection` returns `claude-opus-4-8`. Reverting `packages/shared/src/model.ts` to 41a430a8 fails that case with `claude-fable-5`.

Tests: `vp test run packages/shared/src/model.test.ts apps/web/src/modelSelection.test.ts` — 17 passed. Typecheck on `@t3tools/shared` and `@t3tools/web`, targeted lint and format, and `git diff --check` — all clean. Claude adapter suite — 62 passed.

Verified live on Claude Code 2.1.219 (Windows): `claude -p --model claude-opus-5` responds across all five efforts, `claude-opus-5[1m]` is accepted, and the bare `opus` alias resolves.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — n/a, no UI changes
- [ ] I included a video for animation/interaction changes — n/a


> [!NOTE]
> ### Preserve Opus model fallback in `resolveSelectableModel` for older Claude Code
> When the provider is `claudeAgent` and the requested value is `'opus'`, `resolveSelectableModel` now iterates a fixed priority list (`CLAUDE_OPUS_FALLBACK_MODELS`) and returns the newest available Claude Opus model slug instead of returning null. This ensures older Claude Code clients that send the bare `'opus'` alias still resolve to a valid model when the normalized target slug is not present in the available options.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29a898e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Claude `opus` alias resolution when the normalized slug is missing; no auth, persistence, or version-gate changes.
> 
> **Overview**
> Fixes a regression where the bare **`opus`** alias could resolve to an unrelated default (e.g. **Fable 5**) when **Opus 5** is missing from the live catalog on Claude Code **2.1.169–2.1.218**.
> 
> **`resolveSelectableModel`** in `@t3tools/shared` now, for **`claudeAgent`** and input **`opus`**, walks a fixed **`CLAUDE_OPUS_FALLBACK_MODELS`** priority list and picks the first slug present in the caller’s option list. Direct normalization still wins when **Opus 5** is available; explicit **`opus-5`** still returns nothing if that slug isn’t offered. Custom Opus slugs are not used as fallbacks.
> 
> Tests cover shared resolution behavior and **`resolveAppModelSelection`** end-to-end when the served catalog omits Opus 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4da06b92b3165cbcc6a748fb8de07fd9715541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


