### PR TITLE
feat(web): add transcript presentation settings

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -304,7 +304,7 @@ export const BranchToolbar = memo(function BranchToolbar({
   if (!hasActiveThread || !activeProject) return null;
 
   return (
-    <div className="chat-composer-context-strip -mt-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(48rem-2.75rem)] items-center gap-2 px-1 pt-5 pb-1">
+    <div className="chat-composer-context-strip -mt-4 mx-auto flex w-[calc(100%-2.75rem)] max-w-[calc(var(--chat-content-max-width,48rem)-2.75rem)] items-center gap-2 px-1 pt-5 pb-1">
       {isMobile ? (
         <MobileRunContextSelector
           envLocked={envLocked}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1543,10 +1543,7 @@ function ChatMarkdown({
 
   return (
     <div
-      className={cn(
-        "chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80",
-        className,
-      )}
+      className={cn("chat-markdown w-full min-w-0 leading-relaxed text-foreground/80", className)}
       onCopy={handleCopy}
     >
       <ReactMarkdown

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5606,11 +5606,7 @@ function ChatViewContent(props: ChatViewProps) {
   ) : null;
 
   return (
-    <div
-      className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
-      data-transcript-text-size={settings.transcriptTextSize}
-      data-transcript-width={settings.transcriptWidth}
-    >
+    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
       {rightPanelOpen && !shouldUsePlanSidebarSheet ? panelLayoutControls : null}
       <div
         className={cn(
@@ -5618,6 +5614,8 @@ function ChatViewContent(props: ChatViewProps) {
           rightPanelMaximized ? "w-0 flex-none" : "flex-1",
         )}
         data-chat-column-maximized-away={rightPanelMaximized ? "true" : "false"}
+        data-transcript-text-size={settings.transcriptTextSize}
+        data-transcript-width={settings.transcriptWidth}
       >
         {/* Top bar */}
         <header
@@ -5711,6 +5709,7 @@ function ChatViewContent(props: ChatViewProps) {
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState}
                 topFadeEnabled={!hasTimelineTopBanner}
+                transcriptWidth={settings.transcriptWidth}
               />
 
               {/* scroll to end pill — shown when user has scrolled away from the live edge */}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5606,7 +5606,11 @@ function ChatViewContent(props: ChatViewProps) {
   ) : null;
 
   return (
-    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+    <div
+      className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
+      data-transcript-text-size={settings.transcriptTextSize}
+      data-transcript-width={settings.transcriptWidth}
+    >
       {rightPanelOpen && !shouldUsePlanSidebarSheet ? panelLayoutControls : null}
       <div
         className={cn(
@@ -5776,7 +5780,7 @@ function ChatViewContent(props: ChatViewProps) {
                   >
                     <div
                       className={cn(
-                        "chat-composer-glass-shell relative mx-auto w-full max-w-3xl",
+                        "chat-composer-glass-shell relative mx-auto w-full max-w-[var(--chat-content-max-width,48rem)]",
                         showComposerContextStrip && "chat-composer-glass-shell-with-context",
                       )}
                     >

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2197,7 +2197,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     <form
       ref={composerFormRef}
       onSubmit={submitComposer}
-      className="mx-auto w-full min-w-0 max-w-3xl"
+      className="mx-auto w-full min-w-0 max-w-[var(--chat-content-max-width,48rem)]"
       data-chat-composer-form="true"
     >
       <div

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -83,7 +83,12 @@ export function ComposerBannerStack({ className, items }: ComposerBannerStackPro
   };
 
   return (
-    <div className={cn("group/banner-stack mx-auto mb-2 max-w-3xl", className)}>
+    <div
+      className={cn(
+        "group/banner-stack mx-auto mb-2 max-w-[var(--chat-content-max-width,48rem)]",
+        className,
+      )}
+    >
       <div
         className={cn(
           "relative flex flex-col-reverse",

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -13,7 +13,6 @@ export const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
 export const TIMELINE_MINIMAP_ITEM_SPACING = 8;
 export const TIMELINE_MINIMAP_MIN_ITEMS = 2;
 export const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
-export const TIMELINE_CONTENT_MAX_WIDTH = 768;
 export const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
 
 export interface TimelineEndState {
@@ -54,13 +53,24 @@ export function resolveTimelineMinimapIndexFromPointer(input: {
   return Math.max(0, Math.min(input.itemCount - 1, Math.round(progress * (input.itemCount - 1))));
 }
 
-export function resolveTimelineMinimapHasPersistentGutter(viewportWidth: number): boolean {
-  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
-    return false;
+function resolveTimelineContentSideGutter(viewportWidth: number, contentWidth: number): number {
+  if (
+    !Number.isFinite(viewportWidth) ||
+    viewportWidth <= 0 ||
+    !Number.isFinite(contentWidth) ||
+    contentWidth <= 0
+  ) {
+    return 0;
   }
 
-  const contentWidth = Math.min(viewportWidth, TIMELINE_CONTENT_MAX_WIDTH);
-  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
+  return Math.max(0, (viewportWidth - Math.min(viewportWidth, contentWidth)) / 2);
+}
+
+export function resolveTimelineMinimapHasPersistentGutter(
+  viewportWidth: number,
+  contentWidth: number,
+): boolean {
+  const sideGutter = resolveTimelineContentSideGutter(viewportWidth, contentWidth);
   return sideGutter >= TIMELINE_MINIMAP_PERSISTENT_GUTTER;
 }
 
@@ -75,13 +85,11 @@ export const TIMELINE_MINIMAP_EXPANDED_HIT_STRIP_WIDTH = "22rem";
  * text and swallow its pointer events. Cap the strip's width so it never
  * extends past the gutter into the content column; 0 disables the strip.
  */
-export function resolveTimelineMinimapHitStripWidth(viewportWidth: number): number {
-  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) {
-    return 0;
-  }
-
-  const contentWidth = Math.min(viewportWidth, TIMELINE_CONTENT_MAX_WIDTH);
-  const sideGutter = Math.max(0, (viewportWidth - contentWidth) / 2);
+export function resolveTimelineMinimapHitStripWidth(
+  viewportWidth: number,
+  contentWidth: number,
+): number {
+  const sideGutter = resolveTimelineContentSideGutter(viewportWidth, contentWidth);
   return Math.max(
     0,
     Math.min(

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -53,24 +53,10 @@ export function resolveTimelineMinimapIndexFromPointer(input: {
   return Math.max(0, Math.min(input.itemCount - 1, Math.round(progress * (input.itemCount - 1))));
 }
 
-function resolveTimelineContentSideGutter(viewportWidth: number, contentWidth: number): number {
-  if (
-    !Number.isFinite(viewportWidth) ||
-    viewportWidth <= 0 ||
-    !Number.isFinite(contentWidth) ||
-    contentWidth <= 0
-  ) {
-    return 0;
+export function resolveTimelineMinimapHasPersistentGutter(sideGutter: number): boolean {
+  if (!Number.isFinite(sideGutter) || sideGutter <= 0) {
+    return false;
   }
-
-  return Math.max(0, (viewportWidth - Math.min(viewportWidth, contentWidth)) / 2);
-}
-
-export function resolveTimelineMinimapHasPersistentGutter(
-  viewportWidth: number,
-  contentWidth: number,
-): boolean {
-  const sideGutter = resolveTimelineContentSideGutter(viewportWidth, contentWidth);
   return sideGutter >= TIMELINE_MINIMAP_PERSISTENT_GUTTER;
 }
 
@@ -85,11 +71,10 @@ export const TIMELINE_MINIMAP_EXPANDED_HIT_STRIP_WIDTH = "22rem";
  * text and swallow its pointer events. Cap the strip's width so it never
  * extends past the gutter into the content column; 0 disables the strip.
  */
-export function resolveTimelineMinimapHitStripWidth(
-  viewportWidth: number,
-  contentWidth: number,
-): number {
-  const sideGutter = resolveTimelineContentSideGutter(viewportWidth, contentWidth);
+export function resolveTimelineMinimapHitStripWidth(sideGutter: number): number {
+  if (!Number.isFinite(sideGutter) || sideGutter <= 0) {
+    return 0;
+  }
   return Math.max(
     0,
     Math.min(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -196,6 +196,7 @@ function buildProps() {
     contentInsetEndAdjustment: 0,
     onIsAtEndChange: () => {},
     onManualNavigation: () => {},
+    transcriptWidth: "medium" as const,
   };
 }
 
@@ -330,27 +331,22 @@ describe("MessagesTimeline", () => {
         pointerY: 999,
       }),
     ).toBe(100);
-    expect(resolveTimelineMinimapHasPersistentGutter(832, 768)).toBe(false);
-    expect(resolveTimelineMinimapHasPersistentGutter(863, 768)).toBe(false);
-    expect(resolveTimelineMinimapHasPersistentGutter(864, 768)).toBe(true);
-    // A wide transcript can consume almost all of a narrower viewport, so its
-    // actual rendered width must win over the former fixed 768px assumption.
-    expect(resolveTimelineMinimapHasPersistentGutter(900, 860)).toBe(false);
+    expect(resolveTimelineMinimapHasPersistentGutter(32)).toBe(false);
+    expect(resolveTimelineMinimapHasPersistentGutter(47.5)).toBe(false);
+    expect(resolveTimelineMinimapHasPersistentGutter(48)).toBe(true);
 
     // No usable gutter (zoomed in / narrow pane): the strip must go inert
     // instead of overlaying the centered content column.
-    expect(resolveTimelineMinimapHitStripWidth(768, 768)).toBe(0);
-    expect(resolveTimelineMinimapHitStripWidth(792, 768)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(0)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(12)).toBe(0);
     // Partial gutter: strip shrinks to what fits between the viewport edge
     // and the content column.
-    expect(resolveTimelineMinimapHitStripWidth(820, 768)).toBe(14);
-    expect(resolveTimelineMinimapHitStripWidth(900, 860)).toBe(8);
+    expect(resolveTimelineMinimapHitStripWidth(26)).toBe(14);
+    expect(resolveTimelineMinimapHitStripWidth(20)).toBe(8);
     // Full gutter: unchanged 40px-wide strip.
-    expect(resolveTimelineMinimapHitStripWidth(872, 768)).toBe(40);
-    expect(resolveTimelineMinimapHitStripWidth(1400, 768)).toBe(40);
-    expect(resolveTimelineMinimapHitStripWidth(0, 768)).toBe(0);
-    expect(resolveTimelineMinimapHitStripWidth(Number.NaN, 768)).toBe(0);
-    expect(resolveTimelineMinimapHitStripWidth(900, 0)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(52)).toBe(40);
+    expect(resolveTimelineMinimapHitStripWidth(316)).toBe(40);
+    expect(resolveTimelineMinimapHitStripWidth(Number.NaN)).toBe(0);
 
     // The collapsed target stays narrow, but an open preview keeps its full
     // 20rem width plus the 2rem offset from the minimap rail interactive.

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -330,22 +330,27 @@ describe("MessagesTimeline", () => {
         pointerY: 999,
       }),
     ).toBe(100);
-    expect(resolveTimelineMinimapHasPersistentGutter(832)).toBe(false);
-    expect(resolveTimelineMinimapHasPersistentGutter(863)).toBe(false);
-    expect(resolveTimelineMinimapHasPersistentGutter(864)).toBe(true);
+    expect(resolveTimelineMinimapHasPersistentGutter(832, 768)).toBe(false);
+    expect(resolveTimelineMinimapHasPersistentGutter(863, 768)).toBe(false);
+    expect(resolveTimelineMinimapHasPersistentGutter(864, 768)).toBe(true);
+    // A wide transcript can consume almost all of a narrower viewport, so its
+    // actual rendered width must win over the former fixed 768px assumption.
+    expect(resolveTimelineMinimapHasPersistentGutter(900, 860)).toBe(false);
 
     // No usable gutter (zoomed in / narrow pane): the strip must go inert
     // instead of overlaying the centered content column.
-    expect(resolveTimelineMinimapHitStripWidth(768)).toBe(0);
-    expect(resolveTimelineMinimapHitStripWidth(792)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(768, 768)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(792, 768)).toBe(0);
     // Partial gutter: strip shrinks to what fits between the viewport edge
     // and the content column.
-    expect(resolveTimelineMinimapHitStripWidth(820)).toBe(14);
+    expect(resolveTimelineMinimapHitStripWidth(820, 768)).toBe(14);
+    expect(resolveTimelineMinimapHitStripWidth(900, 860)).toBe(8);
     // Full gutter: unchanged 40px-wide strip.
-    expect(resolveTimelineMinimapHitStripWidth(872)).toBe(40);
-    expect(resolveTimelineMinimapHitStripWidth(1400)).toBe(40);
-    expect(resolveTimelineMinimapHitStripWidth(0)).toBe(0);
-    expect(resolveTimelineMinimapHitStripWidth(Number.NaN)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(872, 768)).toBe(40);
+    expect(resolveTimelineMinimapHitStripWidth(1400, 768)).toBe(40);
+    expect(resolveTimelineMinimapHitStripWidth(0, 768)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(Number.NaN, 768)).toBe(0);
+    expect(resolveTimelineMinimapHitStripWidth(900, 0)).toBe(0);
 
     // The collapsed target stays narrow, but an open preview keeps its full
     // 20rem width plus the 2rem offset from the minimap rail interactive.

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -97,7 +97,7 @@ import {
 } from "~/lib/previewAnnotation";
 import { cn } from "~/lib/utils";
 import { useUiStateStore } from "~/uiStateStore";
-import { type TimestampFormat } from "@t3tools/contracts/settings";
+import { type TimestampFormat, type TranscriptWidth } from "@t3tools/contracts/settings";
 import { formatChatTimestampTooltip, formatShortTimestamp } from "../../timestampFormat";
 
 import {
@@ -184,6 +184,7 @@ interface MessagesTimelineProps {
   onManualNavigation: () => void;
   hideEmptyPlaceholder?: boolean;
   topFadeEnabled?: boolean;
+  transcriptWidth: TranscriptWidth;
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +220,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onManualNavigation,
   hideEmptyPlaceholder = false,
   topFadeEnabled = false,
+  transcriptWidth,
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
@@ -396,37 +398,30 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     }
 
     const measure = () => {
-      const viewportWidth = timelineViewportElement.getBoundingClientRect().width;
+      const viewportLeft = timelineViewportElement.getBoundingClientRect().left;
       const contentElement = timelineViewportElement.querySelector<HTMLElement>(
         '[data-timeline-root="true"]',
       );
-      const contentWidth = contentElement?.getBoundingClientRect().width ?? viewportWidth;
-      const nextHasPersistentGutter = resolveTimelineMinimapHasPersistentGutter(
-        viewportWidth,
-        contentWidth,
-      );
+      const sideGutter = contentElement
+        ? Math.max(0, contentElement.getBoundingClientRect().left - viewportLeft)
+        : 0;
+      const nextHasPersistentGutter = resolveTimelineMinimapHasPersistentGutter(sideGutter);
       setMinimapHasPersistentGutter((current) =>
         current === nextHasPersistentGutter ? current : nextHasPersistentGutter,
       );
-      setMinimapHitStripWidth(resolveTimelineMinimapHitStripWidth(viewportWidth, contentWidth));
+      setMinimapHitStripWidth(resolveTimelineMinimapHitStripWidth(sideGutter));
     };
 
     const frame = requestAnimationFrame(measure);
 
     const observer = new ResizeObserver(measure);
     observer.observe(timelineViewportElement);
-    const contentElement = timelineViewportElement.querySelector<HTMLElement>(
-      '[data-timeline-root="true"]',
-    );
-    if (contentElement) {
-      observer.observe(contentElement);
-    }
 
     return () => {
       cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [timelineViewportElement, rows.length]);
+  }, [timelineViewportElement, rows.length, transcriptWidth]);
 
   const sharedState = useMemo<TimelineRowSharedState>(
     () => ({

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -460,7 +460,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   // from TimelineRowCtx, which propagates through LegendList's memo.
   const renderItem = useCallback(
     ({ item }: { item: MessagesTimelineRow }) => (
-      <div className="mx-auto w-full min-w-0 max-w-3xl overflow-x-clip" data-timeline-root="true">
+      <div
+        className="mx-auto w-full min-w-0 max-w-[var(--chat-content-max-width,48rem)] overflow-x-clip"
+        data-timeline-root="true"
+      >
         <TimelineRowContent row={item} />
       </div>
     ),
@@ -1585,7 +1588,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
         }
 
         return (
-          <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+          <div className="whitespace-pre-wrap wrap-break-word text-[length:var(--transcript-text-size,0.875rem)] leading-relaxed text-foreground">
             {inlineNodes}
           </div>
         );
@@ -1623,7 +1626,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     }
 
     return (
-      <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+      <div className="whitespace-pre-wrap wrap-break-word text-[length:var(--transcript-text-size,0.875rem)] leading-relaxed text-foreground">
         {inlineNodes}
       </div>
     );
@@ -1664,7 +1667,7 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
         </div>
       </div>
       {comment.text.length > 0 && (
-        <div className="whitespace-pre-wrap wrap-break-word text-sm">
+        <div className="whitespace-pre-wrap wrap-break-word text-[length:var(--transcript-text-size,0.875rem)]">
           <SkillInlineText text={comment.text} skills={ctx.skills} />
         </div>
       )}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -397,17 +397,30 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
     const measure = () => {
       const viewportWidth = timelineViewportElement.getBoundingClientRect().width;
-      const nextHasPersistentGutter = resolveTimelineMinimapHasPersistentGutter(viewportWidth);
+      const contentElement = timelineViewportElement.querySelector<HTMLElement>(
+        '[data-timeline-root="true"]',
+      );
+      const contentWidth = contentElement?.getBoundingClientRect().width ?? viewportWidth;
+      const nextHasPersistentGutter = resolveTimelineMinimapHasPersistentGutter(
+        viewportWidth,
+        contentWidth,
+      );
       setMinimapHasPersistentGutter((current) =>
         current === nextHasPersistentGutter ? current : nextHasPersistentGutter,
       );
-      setMinimapHitStripWidth(resolveTimelineMinimapHitStripWidth(viewportWidth));
+      setMinimapHitStripWidth(resolveTimelineMinimapHitStripWidth(viewportWidth, contentWidth));
     };
 
     const frame = requestAnimationFrame(measure);
 
     const observer = new ResizeObserver(measure);
     observer.observe(timelineViewportElement);
+    const contentElement = timelineViewportElement.querySelector<HTMLElement>(
+      '[data-timeline-root="true"]',
+    );
+    if (contentElement) {
+      observer.observe(contentElement);
+    }
 
     return () => {
       cancelAnimationFrame(frame);

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -69,6 +69,7 @@ import { Button } from "../ui/button";
 import { DraftInput } from "../ui/draft-input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
+import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
@@ -112,6 +113,18 @@ const THEME_OPTIONS = [
     value: "dark",
     label: "Dark",
   },
+] as const;
+
+const TRANSCRIPT_TEXT_SIZE_OPTIONS = [
+  { value: "small", label: "Small" },
+  { value: "medium", label: "Medium" },
+  { value: "large", label: "Large" },
+] as const;
+
+const TRANSCRIPT_WIDTH_OPTIONS = [
+  { value: "narrow", label: "Narrow" },
+  { value: "medium", label: "Medium" },
+  { value: "wide", label: "Wide" },
 ] as const;
 
 const TIMESTAMP_FORMAT_LABELS = {
@@ -404,6 +417,12 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
+      ...(settings.transcriptTextSize !== DEFAULT_UNIFIED_SETTINGS.transcriptTextSize
+        ? ["Transcript text size"]
+        : []),
+      ...(settings.transcriptWidth !== DEFAULT_UNIFIED_SETTINGS.transcriptWidth
+        ? ["Transcript width"]
+        : []),
       ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
@@ -463,6 +482,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
       settings.timestampFormat,
+      settings.transcriptTextSize,
+      settings.transcriptWidth,
       settings.wordWrap,
       theme,
     ],
@@ -481,6 +502,8 @@ export function useSettingsRestore(onRestored?: () => void) {
     setTheme("system");
     updateSettings({
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+      transcriptTextSize: DEFAULT_UNIFIED_SETTINGS.transcriptTextSize,
+      transcriptWidth: DEFAULT_UNIFIED_SETTINGS.transcriptWidth,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
@@ -585,6 +608,78 @@ export function GeneralSettingsPanel() {
                 ))}
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Transcript text size"
+          description="Size of the conversation transcript text."
+          resetAction={
+            settings.transcriptTextSize !== DEFAULT_UNIFIED_SETTINGS.transcriptTextSize ? (
+              <SettingResetButton
+                label="transcript text size"
+                onClick={() =>
+                  updateSettings({
+                    transcriptTextSize: DEFAULT_UNIFIED_SETTINGS.transcriptTextSize,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <ToggleGroup
+              variant="outline"
+              size="sm"
+              value={[settings.transcriptTextSize]}
+              onValueChange={(value) => {
+                const nextValue = value[0];
+                if (nextValue === "small" || nextValue === "medium" || nextValue === "large") {
+                  updateSettings({ transcriptTextSize: nextValue });
+                }
+              }}
+              aria-label="Transcript text size"
+            >
+              {TRANSCRIPT_TEXT_SIZE_OPTIONS.map((option) => (
+                <Toggle key={option.value} value={option.value} className="min-w-16 px-2">
+                  {option.label}
+                </Toggle>
+              ))}
+            </ToggleGroup>
+          }
+        />
+
+        <SettingsRow
+          title="Transcript width"
+          description="Maximum width of the transcript and composer columns."
+          resetAction={
+            settings.transcriptWidth !== DEFAULT_UNIFIED_SETTINGS.transcriptWidth ? (
+              <SettingResetButton
+                label="transcript width"
+                onClick={() =>
+                  updateSettings({ transcriptWidth: DEFAULT_UNIFIED_SETTINGS.transcriptWidth })
+                }
+              />
+            ) : null
+          }
+          control={
+            <ToggleGroup
+              variant="outline"
+              size="sm"
+              value={[settings.transcriptWidth]}
+              onValueChange={(value) => {
+                const nextValue = value[0];
+                if (nextValue === "narrow" || nextValue === "medium" || nextValue === "wide") {
+                  updateSettings({ transcriptWidth: nextValue });
+                }
+              }}
+              aria-label="Transcript width"
+            >
+              {TRANSCRIPT_WIDTH_OPTIONS.map((option) => (
+                <Toggle key={option.value} value={option.value} className="min-w-16 px-2">
+                  {option.label}
+                </Toggle>
+              ))}
+            </ToggleGroup>
           }
         />
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1089,10 +1089,38 @@ label:has(> select#reasoning-effort) select {
 }
 
 /* Chat markdown rendering */
+[data-transcript-width="narrow"] {
+  --chat-content-max-width: 40rem;
+}
+
+[data-transcript-width="medium"] {
+  --chat-content-max-width: 48rem;
+}
+
+[data-transcript-width="wide"] {
+  --chat-content-max-width: 64rem;
+}
+
+[data-transcript-text-size="small"] {
+  --transcript-text-size: 0.8125rem;
+  --transcript-compact-text-size: 0.6875rem;
+}
+
+[data-transcript-text-size="medium"] {
+  --transcript-text-size: 0.875rem;
+  --transcript-compact-text-size: 0.75rem;
+}
+
+[data-transcript-text-size="large"] {
+  --transcript-text-size: 1rem;
+  --transcript-compact-text-size: 0.875rem;
+}
+
 .chat-markdown {
   min-width: 0;
   overflow-wrap: anywhere;
   word-break: break-word;
+  font-size: var(--transcript-text-size, 0.875rem);
 }
 
 .chat-markdown > :first-child {
@@ -1125,21 +1153,21 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown h1 {
-  font-size: 1.25rem;
+  font-size: 1.4286em;
 }
 
 .chat-markdown h2 {
-  font-size: 1.125rem;
+  font-size: 1.2857em;
 }
 
 .chat-markdown h3 {
-  font-size: 1rem;
+  font-size: 1.1429em;
 }
 
 .chat-markdown h4,
 .chat-markdown h5,
 .chat-markdown h6 {
-  font-size: 0.875rem;
+  font-size: 1em;
 }
 
 .chat-markdown h6 {
@@ -1222,7 +1250,7 @@ label:has(> select#reasoning-effort) select {
   border-top: 1px solid var(--border);
   padding-top: 0.75rem;
   color: var(--muted-foreground);
-  font-size: 0.75rem;
+  font-size: var(--transcript-compact-text-size, 0.75rem);
 }
 
 .chat-markdown section[data-footnotes] ol {
@@ -1252,7 +1280,7 @@ label:has(> select#reasoning-effort) select {
   background: var(--muted);
   padding: 0.1rem 0.35rem;
   color: var(--foreground);
-  font-size: 0.75rem;
+  font-size: var(--transcript-compact-text-size, 0.75rem);
 }
 
 .chat-markdown a.chat-markdown-file-link {
@@ -1283,7 +1311,7 @@ label:has(> select#reasoning-effort) select {
   border: none;
   background: transparent;
   padding: 0;
-  font-size: 0.75rem;
+  font-size: var(--transcript-compact-text-size, 0.75rem);
 }
 
 .chat-markdown pre {
@@ -1390,7 +1418,7 @@ label:has(> select#reasoning-effort) select {
   border-collapse: collapse;
   overflow-wrap: normal;
   word-break: normal;
-  font-size: 0.75rem;
+  font-size: var(--transcript-compact-text-size, 0.75rem);
 }
 
 .chat-markdown th,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -49,6 +49,29 @@ describe("ClientSettings glass opacity", () => {
   });
 });
 
+describe("ClientSettings transcript presentation", () => {
+  it("defaults to the existing medium transcript presentation", () => {
+    const settings = decodeClientSettings({});
+    expect(settings.transcriptTextSize).toBe("medium");
+    expect(settings.transcriptWidth).toBe("medium");
+  });
+
+  it.each(["small", "medium", "large"] as const)("accepts transcript text size: %s", (value) => {
+    expect(decodeClientSettings({ transcriptTextSize: value }).transcriptTextSize).toBe(value);
+    expect(decodeClientSettingsPatch({ transcriptTextSize: value }).transcriptTextSize).toBe(value);
+  });
+
+  it.each(["narrow", "medium", "wide"] as const)("accepts transcript width: %s", (value) => {
+    expect(decodeClientSettings({ transcriptWidth: value }).transcriptWidth).toBe(value);
+    expect(decodeClientSettingsPatch({ transcriptWidth: value }).transcriptWidth).toBe(value);
+  });
+
+  it("rejects unsupported transcript presentation values", () => {
+    expect(() => decodeClientSettings({ transcriptTextSize: "extra-large" })).toThrow();
+    expect(() => decodeClientSettingsPatch({ transcriptWidth: "full" })).toThrow();
+  });
+});
+
 describe("ClientSettings sidebar v2", () => {
   it("defaults the beta off with a three-day auto-settle threshold", () => {
     const settings = decodeClientSettings({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -59,6 +59,14 @@ export const GlassOpacity = Schema.Int.check(
 export type GlassOpacity = typeof GlassOpacity.Type;
 export const DEFAULT_GLASS_OPACITY: GlassOpacity = 80;
 
+export const TranscriptTextSize = Schema.Literals(["small", "medium", "large"]);
+export type TranscriptTextSize = typeof TranscriptTextSize.Type;
+export const DEFAULT_TRANSCRIPT_TEXT_SIZE: TranscriptTextSize = "medium";
+
+export const TranscriptWidth = Schema.Literals(["narrow", "medium", "wide"]);
+export type TranscriptWidth = typeof TranscriptWidth.Type;
+export const DEFAULT_TRANSCRIPT_WIDTH: TranscriptWidth = "medium";
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -117,6 +125,12 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarV2Enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
+  ),
+  transcriptTextSize: TranscriptTextSize.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TRANSCRIPT_TEXT_SIZE)),
+  ),
+  transcriptWidth: TranscriptWidth.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TRANSCRIPT_WIDTH)),
   ),
   wordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 });
@@ -605,6 +619,8 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   sidebarV2Enabled: Schema.optionalKey(Schema.Boolean),
   timestampFormat: Schema.optionalKey(TimestampFormat),
+  transcriptTextSize: Schema.optionalKey(TranscriptTextSize),
+  transcriptWidth: Schema.optionalKey(TranscriptWidth),
   wordWrap: Schema.optionalKey(Schema.Boolean),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
Claude Code Desktop already exposes transcript text-size and width controls. This PR brings the same presentation model to T3 Code without changing the existing default.

<img width="752" alt="Claude Code Desktop transcript text size and width settings" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/claude-code-reference.png" />

## What Changed

- Add Small, Medium, and Large transcript text sizes.
- Add Narrow, Medium, and Wide transcript widths.
- Apply the selected width consistently to the transcript, composer, banners, and context strip.
- Keep Medium/Medium as the default, matching the previous fixed presentation.

## Why

The fixed transcript column can feel too narrow on large displays, while different readers may prefer smaller or larger conversation text. These settings make both adjustable without changing the existing experience for anyone who leaves the defaults alone.

## UI Changes

The old fixed presentation corresponds to **Medium text / Medium width**.

<table>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  <tr>
    <td><img alt="Settings before transcript presentation controls" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/settings-before.png" /></td>
    <td><img alt="Settings after adding transcript text size and width controls" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/settings-after.png" /></td>
  </tr>
</table>

<details>
<summary><strong>All nine transcript combinations</strong></summary>
<br />

| Text size | Narrow | Medium | Wide |
| :---: | :---: | :---: | :---: |
| **Small** | <img alt="Small text and narrow transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-small-narrow.png" /> | <img alt="Small text and medium transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-small-medium.png" /> | <img alt="Small text and wide transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-small-wide.png" /> |
| **Medium** | <img alt="Medium text and narrow transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-medium-narrow.png" /> | <img alt="Medium text and medium transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-medium-medium.png" /> | <img alt="Medium text and wide transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-medium-wide.png" /> |
| **Large** | <img alt="Large text and narrow transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-large-narrow.png" /> | <img alt="Large text and medium transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-large-medium.png" /> | <img alt="Large text and wide transcript" src="https://raw.githubusercontent.com/charlielockyer-rice/t3code/pr-assets-transcript-presentation-settings/transcript-large-wide.png" /> |

</details>

## Validation

- Focused formatting and lint checks for the changed files.
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/web typecheck`
- Schema decoding smoke coverage for defaults, supported values, and invalid values.
- Verified all nine combinations in the web client and restored Medium/Medium afterward.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] No animation or interaction change requires a video


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add transcript text size and width presentation settings
> - Adds `transcriptTextSize` and `transcriptWidth` settings (each with small/medium/large or narrow/medium/wide options) to `ClientSettingsSchema` and the General Settings panel UI.
> - The chat column sets `data-transcript-text-size` and `data-transcript-width` data attributes, which drive CSS variables (`--transcript-text-size`, `--chat-content-max-width`) defined in [index.css](https://github.com/pingdotgg/t3code/pull/4481/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to scale typography and max-width dynamically.
> - Minimap helpers in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/4481/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) now accept a caller-measured `sideGutter` instead of computing it from viewport width internally.
> - Behavioral Change: `text-sm` is replaced by a CSS variable in several timeline components, so font size now follows the user's transcript text size setting rather than a fixed value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 807c96e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only client settings with schema validation and unchanged medium defaults; minimap measurement change is localized to layout math.
> 
> **Overview**
> Adds **transcript text size** (small / medium / large) and **transcript width** (narrow / medium / wide) to client settings, with toggle controls in General settings and reset/restore-defaults support. Defaults stay **medium / medium**, matching the old fixed layout.
> 
> The chat column exposes `data-transcript-text-size` and `data-transcript-width`, which drive CSS variables for `--transcript-text-size`, `--transcript-compact-text-size`, and `--chat-content-max-width`. Transcript markdown, user-message text, and related UI now scale via those variables instead of hard-coded `text-sm` / `max-w-3xl`. The same max-width variable is applied to the composer, banners, and branch context strip so the column stays aligned.
> 
> Timeline minimap gutter/hit-strip logic no longer infers gutter from viewport width and a fixed 768px cap; it measures the real side gutter from the timeline content column and re-measures when width changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807c96e82edeb4b9098df8e30fe8c224e5487c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->