### PR TITLE
Fix sidebar resize limit after window growth

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -19,6 +19,7 @@ import ThreadSidebar from "./Sidebar";
 import ThreadSidebarV2 from "./SidebarV2";
 import { useSidebarStageBackdropVariant } from "./SidebarStageBackdrop";
 import {
+  resolveThreadSidebarCssWidth,
   resolveThreadSidebarMaximumWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
   THREAD_SIDEBAR_DEFAULT_WIDTH,
@@ -117,6 +118,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
   const sidebarResizable = useMemo(
     () => ({
+      getCssWidth: resolveThreadSidebarCssWidth,
       maxWidth: () => resolveThreadSidebarMaximumWidth(window.innerWidth),
       minWidth: THREAD_SIDEBAR_MIN_WIDTH,
       shouldAcceptWidth: ({
@@ -143,7 +145,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       : false;
   });
   const sidebarProviderStyle = {
-    "--sidebar-width": `min(${sidebarWidth}px, max(${THREAD_SIDEBAR_MIN_WIDTH}px, calc(100vw - ${THREAD_MAIN_CONTENT_MIN_WIDTH}px)))`,
+    "--sidebar-width": resolveThreadSidebarCssWidth(sidebarWidth),
     ...(isMacosDesktop && !isWindowFullscreen
       ? { "--workspace-controls-left": MACOS_TRAFFIC_LIGHTS_LEFT_INSET }
       : {}),

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -2,8 +2,8 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   useEffect,
+  useMemo,
   useState,
-  useSyncExternalStore,
   type CSSProperties,
   type ReactNode,
 } from "react";
@@ -19,9 +19,9 @@ import ThreadSidebar from "./Sidebar";
 import ThreadSidebarV2 from "./SidebarV2";
 import { useSidebarStageBackdropVariant } from "./SidebarStageBackdrop";
 import {
-  resolveInitialThreadSidebarWidth,
   resolveThreadSidebarMaximumWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
+  THREAD_SIDEBAR_DEFAULT_WIDTH,
   THREAD_SIDEBAR_MIN_WIDTH,
   THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
 } from "./threadSidebarWidth";
@@ -37,24 +37,15 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
 
-function subscribeToViewportWidth(onChange: () => void): () => void {
-  window.addEventListener("resize", onChange);
-  return () => window.removeEventListener("resize", onChange);
-}
-
-function readViewportWidth(): number {
-  return window.innerWidth;
-}
-
 function readInitialThreadSidebarWidth(): number {
   try {
-    return resolveInitialThreadSidebarWidth(
-      getLocalStorageItem(THREAD_SIDEBAR_WIDTH_STORAGE_KEY, Schema.Finite),
-      window.innerWidth,
-    );
+    const storedWidth = getLocalStorageItem(THREAD_SIDEBAR_WIDTH_STORAGE_KEY, Schema.Finite);
+    return storedWidth === null
+      ? THREAD_SIDEBAR_DEFAULT_WIDTH
+      : Math.max(THREAD_SIDEBAR_MIN_WIDTH, storedWidth);
   } catch (error) {
     console.error("Could not read persisted thread sidebar width.", error);
-    return resolveInitialThreadSidebarWidth(null, window.innerWidth);
+    return THREAD_SIDEBAR_DEFAULT_WIDTH;
   }
 }
 
@@ -124,11 +115,27 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const useSidebarV2Theme = useSidebarV2 || isOnSettings;
   const isMacosDesktop = isElectron && isMacPlatform(navigator.platform);
   const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
-  // Subscribed rather than read once: the clamp must track live window size,
-  // and a clamped drag ends with an unchanged width, which skips the re-render
-  // that would otherwise refresh a render-time snapshot.
-  const viewportWidth = useSyncExternalStore(subscribeToViewportWidth, readViewportWidth);
-  const sidebarMaximumWidth = resolveThreadSidebarMaximumWidth(viewportWidth);
+  const sidebarResizable = useMemo(
+    () => ({
+      maxWidth: () => resolveThreadSidebarMaximumWidth(window.innerWidth),
+      minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+      shouldAcceptWidth: ({
+        currentWidth,
+        nextWidth,
+        wrapper,
+      }: {
+        currentWidth: number;
+        nextWidth: number;
+        wrapper: HTMLElement;
+      }) =>
+        nextWidth <= currentWidth ||
+        wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
+      storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
+      hydrateStoredWidth: false,
+      onResize: setSidebarWidth,
+    }),
+    [],
+  );
   const [isWindowFullscreen, setIsWindowFullscreen] = useState(() => {
     const getWindowFullscreenState = window.desktopBridge?.getWindowFullscreenState;
     return isMacosDesktop && typeof getWindowFullscreenState === "function"
@@ -136,7 +143,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       : false;
   });
   const sidebarProviderStyle = {
-    "--sidebar-width": `${sidebarWidth}px`,
+    "--sidebar-width": `min(${sidebarWidth}px, max(${THREAD_SIDEBAR_MIN_WIDTH}px, calc(100vw - ${THREAD_MAIN_CONTENT_MIN_WIDTH}px)))`,
     ...(isMacosDesktop && !isWindowFullscreen
       ? { "--workspace-controls-left": MACOS_TRAFFIC_LIGHTS_LEFT_INSET }
       : {}),
@@ -187,15 +194,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         data-app-sidebar=""
         data-sidebar-version={useSidebarV2Theme ? "v2" : "v1"}
         className="border-r border-sidebar-border bg-sidebar text-sidebar-foreground"
-        resizable={{
-          maxWidth: sidebarMaximumWidth,
-          minWidth: THREAD_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
-            nextWidth <= currentWidth ||
-            wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
-          storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
-          onResize: setSidebarWidth,
-        }}
+        resizable={sidebarResizable}
       >
         {useSidebarV2 ? <ThreadSidebarV2 /> : <ThreadSidebar />}
         <SidebarRail />

--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   resolveInitialThreadSidebarWidth,
+  resolveThreadSidebarMaximumWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
   THREAD_SIDEBAR_DEFAULT_WIDTH,
   THREAD_SIDEBAR_MIN_WIDTH,
@@ -26,6 +27,11 @@ describe("thread sidebar width", () => {
     expect(resolveInitialThreadSidebarWidth(900, viewportWidth)).toBe(
       viewportWidth - THREAD_MAIN_CONTENT_MIN_WIDTH,
     );
+  });
+
+  it("raises the maximum when the viewport grows", () => {
+    expect(resolveThreadSidebarMaximumWidth(1000)).toBe(1000 - THREAD_MAIN_CONTENT_MIN_WIDTH);
+    expect(resolveThreadSidebarMaximumWidth(1800)).toBe(1800 - THREAD_MAIN_CONTENT_MIN_WIDTH);
   });
 
   it("keeps the sidebar minimum when the whole layout is narrower than its minimums", () => {

--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   resolveInitialThreadSidebarWidth,
+  resolveThreadSidebarCssWidth,
   resolveThreadSidebarMaximumWidth,
   THREAD_MAIN_CONTENT_MIN_WIDTH,
   THREAD_SIDEBAR_DEFAULT_WIDTH,
@@ -32,6 +33,12 @@ describe("thread sidebar width", () => {
   it("raises the maximum when the viewport grows", () => {
     expect(resolveThreadSidebarMaximumWidth(1000)).toBe(1000 - THREAD_MAIN_CONTENT_MIN_WIDTH);
     expect(resolveThreadSidebarMaximumWidth(1800)).toBe(1800 - THREAD_MAIN_CONTENT_MIN_WIDTH);
+  });
+
+  it("expresses the preferred width with a live viewport clamp", () => {
+    expect(resolveThreadSidebarCssWidth(400)).toBe(
+      `min(400px, max(${THREAD_SIDEBAR_MIN_WIDTH}px, calc(100vw - ${THREAD_MAIN_CONTENT_MIN_WIDTH}px)))`,
+    );
   });
 
   it("keeps the sidebar minimum when the whole layout is narrower than its minimums", () => {

--- a/apps/web/src/components/threadSidebarWidth.ts
+++ b/apps/web/src/components/threadSidebarWidth.ts
@@ -10,6 +10,10 @@ export function resolveThreadSidebarMaximumWidth(viewportWidth: number): number 
   );
 }
 
+export function resolveThreadSidebarCssWidth(width: number): string {
+  return `min(${width}px, max(${THREAD_SIDEBAR_MIN_WIDTH}px, calc(100vw - ${THREAD_MAIN_CONTENT_MIN_WIDTH}px)))`;
+}
+
 export function resolveInitialThreadSidebarWidth(
   storedWidth: number | null,
   viewportWidth: number,

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -2,6 +2,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  clampSidebarWidthValue,
+  resolveSidebarMaximumWidth,
   SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuSubButton,
@@ -19,6 +21,18 @@ function renderSidebarButton(className?: string) {
 }
 
 describe("sidebar interactive cursors", () => {
+  it("resolves and clamps against a live maximum width", () => {
+    let maximumWidth = 360;
+    const liveMaximumWidth = () => maximumWidth;
+
+    expect(resolveSidebarMaximumWidth(liveMaximumWidth)).toBe(360);
+    expect(clampSidebarWidthValue(340, 208, liveMaximumWidth)).toBe(340);
+
+    maximumWidth = 208;
+    expect(resolveSidebarMaximumWidth(liveMaximumWidth)).toBe(208);
+    expect(clampSidebarWidthValue(340, 208, liveMaximumWidth)).toBe(208);
+  });
+
   it("uses mobile sheet visibility for the shared responsive state", () => {
     expect(resolveSidebarState({ isMobile: true, open: true, openMobile: false })).toBe(
       "collapsed",

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   clampSidebarWidthValue,
+  resolveSidebarCssWidth,
   resolveSidebarMaximumWidth,
   SidebarMenuAction,
   SidebarMenuButton,
@@ -31,6 +32,13 @@ describe("sidebar interactive cursors", () => {
     maximumWidth = 208;
     expect(resolveSidebarMaximumWidth(liveMaximumWidth)).toBe(208);
     expect(clampSidebarWidthValue(340, 208, liveMaximumWidth)).toBe(208);
+  });
+
+  it("preserves a dynamic CSS width when committing a rail resize", () => {
+    const getCssWidth = (width: number) => `min(${width}px, calc(100vw - 640px))`;
+
+    expect(resolveSidebarCssWidth(340, getCssWidth)).toBe("min(340px, calc(100vw - 640px))");
+    expect(resolveSidebarCssWidth(340)).toBe("340px");
   });
 
   it("uses mobile sheet visibility for the shared responsive state", () => {

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -40,7 +40,8 @@ type SidebarContextProps = {
 };
 
 type SidebarResizableOptions = {
-  maxWidth?: number;
+  hydrateStoredWidth?: boolean;
+  maxWidth?: number | (() => number);
   minWidth?: number;
   onResize?: (width: number) => void;
   shouldAcceptWidth?: (context: {
@@ -55,7 +56,8 @@ type SidebarResizableOptions = {
 };
 
 type SidebarResolvedResizableOptions = {
-  maxWidth: number;
+  hydrateStoredWidth: boolean;
+  maxWidth: number | (() => number);
   minWidth: number;
   onResize?: (width: number) => void;
   shouldAcceptWidth?: (context: {
@@ -199,6 +201,7 @@ function Sidebar({
 
     const options = typeof resizable === "boolean" ? {} : resizable;
     return {
+      hydrateStoredWidth: options.hydrateStoredWidth ?? true,
       maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
       minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
       storageKey: options.storageKey ?? null,
@@ -343,8 +346,20 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
   );
 }
 
+export function resolveSidebarMaximumWidth(maxWidth: number | (() => number)): number {
+  return typeof maxWidth === "function" ? maxWidth() : maxWidth;
+}
+
+export function clampSidebarWidthValue(
+  width: number,
+  minWidth: number,
+  maxWidth: number | (() => number),
+): number {
+  return Math.max(minWidth, Math.min(width, resolveSidebarMaximumWidth(maxWidth)));
+}
+
 function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptions): number {
-  return Math.max(options.minWidth, Math.min(width, options.maxWidth));
+  return clampSidebarWidthValue(width, options.minWidth, options.maxWidth);
 }
 
 function SidebarRail({
@@ -388,13 +403,17 @@ function SidebarRail({
       if (resizeState.rafId !== null) {
         window.cancelAnimationFrame(resizeState.rafId);
       }
+      const width = resolvedResizable
+        ? clampSidebarWidth(resizeState.width, resolvedResizable)
+        : resizeState.width;
+      resizeState.wrapper.style.setProperty("--sidebar-width", `${width}px`);
+      if (resolvedResizable?.storageKey && typeof window !== "undefined") {
+        setLocalStorageItem(resolvedResizable.storageKey, width, Schema.Finite);
+      }
+      resolvedResizable?.onResize?.(width);
       resizeState.transitionTargets.forEach((element) => {
         element.style.removeProperty("transition-duration");
       });
-      if (resolvedResizable?.storageKey && typeof window !== "undefined") {
-        setLocalStorageItem(resolvedResizable.storageKey, resizeState.width, Schema.Finite);
-      }
-      resolvedResizable?.onResize?.(resizeState.width);
       resizeStateRef.current = null;
       if (resizeState.rail.hasPointerCapture(pointerId)) {
         resizeState.rail.releasePointerCapture(pointerId);
@@ -556,7 +575,13 @@ function SidebarRail({
   );
 
   React.useLayoutEffect(() => {
-    if (!resolvedResizable?.storageKey || typeof window === "undefined") return;
+    if (
+      !resolvedResizable?.storageKey ||
+      !resolvedResizable.hydrateStoredWidth ||
+      typeof window === "undefined"
+    ) {
+      return;
+    }
     const rail = railRef.current;
     if (!rail) return;
     const wrapper = rail.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
@@ -574,7 +599,40 @@ function SidebarRail({
     // Hydrate the CSS variable before the browser paints so a restored sidebar
     // never flashes at the default width first.
     wrapper.style.setProperty("--sidebar-width", `${clampedWidth}px`);
-    resolvedResizable.onResize?.(clampedWidth);
+    // Preserve the user's stored preference even when the current viewport
+    // temporarily applies a smaller maximum width.
+    resolvedResizable.onResize?.(storedWidth);
+  }, [resolvedResizable]);
+
+  React.useEffect(() => {
+    if (!resolvedResizable || typeof window === "undefined") return;
+
+    const suppressViewportResizeTransition = () => {
+      // Pointer moves resolve the live maximum. Do not interrupt their
+      // imperative width; stopResize clamps once more before persisting.
+      if (resizeStateRef.current) return;
+
+      const rail = railRef.current;
+      const wrapper = rail?.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
+      const sidebarRoot = rail?.closest<HTMLElement>("[data-slot='sidebar']");
+      if (!wrapper || !sidebarRoot) return;
+
+      const transitionTargets = [
+        sidebarRoot.querySelector<HTMLElement>("[data-slot='sidebar-gap']"),
+        sidebarRoot.querySelector<HTMLElement>("[data-slot='sidebar-container']"),
+      ].filter((element): element is HTMLElement => element !== null);
+      transitionTargets.forEach((element) => {
+        element.style.setProperty("transition-duration", "0ms");
+      });
+      window.requestAnimationFrame(() => {
+        transitionTargets.forEach((element) => {
+          element.style.removeProperty("transition-duration");
+        });
+      });
+    };
+
+    window.addEventListener("resize", suppressViewportResizeTransition);
+    return () => window.removeEventListener("resize", suppressViewportResizeTransition);
   }, [resolvedResizable]);
 
   React.useEffect(() => {

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -40,6 +40,7 @@ type SidebarContextProps = {
 };
 
 type SidebarResizableOptions = {
+  getCssWidth?: (width: number) => string;
   hydrateStoredWidth?: boolean;
   maxWidth?: number | (() => number);
   minWidth?: number;
@@ -56,6 +57,7 @@ type SidebarResizableOptions = {
 };
 
 type SidebarResolvedResizableOptions = {
+  getCssWidth?: (width: number) => string;
   hydrateStoredWidth: boolean;
   maxWidth: number | (() => number);
   minWidth: number;
@@ -205,6 +207,7 @@ function Sidebar({
       maxWidth: options.maxWidth ?? Number.POSITIVE_INFINITY,
       minWidth: options.minWidth ?? SIDEBAR_RESIZE_DEFAULT_MIN_WIDTH,
       storageKey: options.storageKey ?? null,
+      ...(options.getCssWidth ? { getCssWidth: options.getCssWidth } : {}),
       ...(options.onResize ? { onResize: options.onResize } : {}),
       ...(options.shouldAcceptWidth ? { shouldAcceptWidth: options.shouldAcceptWidth } : {}),
     };
@@ -358,6 +361,13 @@ export function clampSidebarWidthValue(
   return Math.max(minWidth, Math.min(width, resolveSidebarMaximumWidth(maxWidth)));
 }
 
+export function resolveSidebarCssWidth(
+  width: number,
+  getCssWidth?: (width: number) => string,
+): string {
+  return getCssWidth?.(width) ?? `${width}px`;
+}
+
 function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptions): number {
   return clampSidebarWidthValue(width, options.minWidth, options.maxWidth);
 }
@@ -406,7 +416,11 @@ function SidebarRail({
       const width = resolvedResizable
         ? clampSidebarWidth(resizeState.width, resolvedResizable)
         : resizeState.width;
-      resizeState.wrapper.style.setProperty("--sidebar-width", `${width}px`);
+      // Keep caller-owned viewport clamps even when onResize does not trigger a render.
+      resizeState.wrapper.style.setProperty(
+        "--sidebar-width",
+        resolveSidebarCssWidth(width, resolvedResizable?.getCssWidth),
+      );
       if (resolvedResizable?.storageKey && typeof window !== "undefined") {
         setLocalStorageItem(resolvedResizable.storageKey, width, Schema.Finite);
       }


### PR DESCRIPTION
## What Changed

- Recompute the thread sidebar maximum width when the browser or Electron window resizes.
- Add focused coverage showing that the allowed sidebar width grows with the viewport.

## Why

The sidebar maximum was calculated only during render from the initial window width. If a restored or resized window became wider without another relevant render, the resize rail retained the old cap and could not use the newly available space.

## UI Changes

Behavioral only; there are no visual styling changes. In a controlled browser, a stored 900px sidebar correctly clamped to 360px at a 1000px viewport, then returned to 900px when the viewport grew to 1600px, leaving 700px for main content. The collaborative preview screenshot and recording endpoints timed out, so no media is attached.

## Validation

- `vp test run --project unit src/components/threadSidebarWidth.test.ts` (from apps/web)
- `vp fmt --check apps/web/src/components/AppSidebarLayout.tsx apps/web/src/components/threadSidebarWidth.test.ts`
- `vp lint apps/web/src/components/AppSidebarLayout.tsx apps/web/src/components/threadSidebarWidth.test.ts`
- `git diff --check`
- Web package typecheck attempted; it is currently blocked by unrelated existing errors in BranchToolbarBranchSelector, ModelPickerContent, PreviewAutomationHosts, and state atom hooks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (preview capture timed out)
- [ ] I included a video for animation/interaction changes (preview recording failed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and resize behavior only in the web app sidebar; no auth, data, or API changes. Risk is localized UI edge cases around persistence vs viewport clamping.
> 
> **Overview**
> Fixes the thread sidebar staying capped at the **initial** window width after the viewport grows, so drag-resize can use newly available space.
> 
> **`AppSidebarLayout`** drops `useSyncExternalStore` viewport tracking and passes a resizable config with a **live** `maxWidth` (`window.innerWidth`), `getCssWidth` via `resolveThreadSidebarCssWidth`, and `hydrateStoredWidth: false` so initial width stays parent-owned. `--sidebar-width` is set to a CSS `min()` / `max()` / `calc(100vw - …)` expression instead of a fixed pixel value.
> 
> **Shared `Sidebar` / `SidebarRail`** now accept `maxWidth` as a number or getter, optional `getCssWidth`, and `hydrateStoredWidth`. On resize end, width is clamped with the live max, `--sidebar-width` is written through `getCssWidth`, and persistence runs after clamping. Stored-width hydration calls `onResize` with the **unclamped** stored value so a narrow viewport does not overwrite the user’s preference. A window `resize` listener briefly disables width transitions (skipped during active drags) to avoid glitches when the CSS clamp updates.
> 
> Unit tests cover live max clamping, CSS width helpers, and rail commit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bd69e9f8abeb9037136635c4e02464ac60c63a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar resize limit to respect viewport width after window growth
> - The sidebar resize limit was not updating when the browser window grew larger, leaving the maximum width stale. This PR fixes that by making `maxWidth` a live function evaluated at commit time (`window.innerWidth`) rather than a fixed value.
> - `SidebarRail` now clamps and persists the correct width on stop-resize, and sets `--sidebar-width` using a dynamic CSS `min()` expression via the new `resolveThreadSidebarCssWidth` util.
> - A new viewport resize listener in `SidebarRail` suppresses CSS transitions during viewport-driven width adjustments to avoid visual glitches.
> - `hydrateStoredWidth=false` is set for the thread sidebar so the rail doesn't auto-apply stored width; the parent component handles initial width independently.
> - Behavioral Change: stored width hydration now passes the original (unclamped) value to `onResize` so user preference is preserved even when the viewport temporarily reduces the allowed maximum.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81bd69e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->