### PR TITLE
Recover draft thread IDs after failed bootstrap cleanup

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7272,6 +7272,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assertTrue(result._tag === "Failure");
       assertTrue(result.failure._tag === "OrchestrationDispatchCommandError");
       assert.include(result.failure.message, "worktree exploded");
+      assertTrue(result.failure.retryWithNewThreadId === true);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
         ["thread.create", "thread.delete"],

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -861,7 +861,7 @@ const makeWsRpcLayer = (
           let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
           let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
 
-          const cleanupCreatedThread = () =>
+          const cleanupCreatedThread = (): Effect.Effect<boolean> =>
             createdThread
               ? serverCommandId("bootstrap-thread-delete").pipe(
                   Effect.flatMap((commandId) =>
@@ -871,9 +871,18 @@ const makeWsRpcLayer = (
                       threadId: command.threadId,
                     }),
                   ),
-                  Effect.ignoreCause({ log: true }),
+                  Effect.as(true),
+                  Effect.catchCause((cause) =>
+                    Effect.logWarning("Failed to clean up bootstrap thread").pipe(
+                      Effect.annotateLogs({
+                        threadId: command.threadId,
+                        cause: Cause.pretty(cause),
+                      }),
+                      Effect.as(false),
+                    ),
+                  ),
                 )
-              : Effect.void;
+              : Effect.succeed(false);
 
           const recordSetupScriptLaunchFailure = (input: {
             readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
@@ -1051,7 +1060,19 @@ const makeWsRpcLayer = (
               if (Cause.hasInterruptsOnly(cause)) {
                 return Effect.fail(dispatchError);
               }
-              return cleanupCreatedThread().pipe(Effect.flatMap(() => Effect.fail(dispatchError)));
+              return cleanupCreatedThread().pipe(
+                Effect.flatMap((cleanedUp) =>
+                  Effect.fail(
+                    cleanedUp
+                      ? new OrchestrationDispatchCommandError({
+                          message: dispatchError.message,
+                          cause: dispatchError.cause,
+                          retryWithNewThreadId: true,
+                        })
+                      : dispatchError,
+                  ),
+                ),
+              );
             }),
           );
         });

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,6 +1,7 @@
 import {
   EnvironmentId,
   MessageId,
+  OrchestrationDispatchCommandError,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
@@ -26,6 +27,7 @@ import {
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   startNewThreadForProject,
+  shouldRenewDraftThreadIdAfterFailure,
   shouldShowBranchMismatchBanner,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
@@ -64,6 +66,25 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     ...overrides,
   };
 }
+
+describe("shouldRenewDraftThreadIdAfterFailure", () => {
+  it("only renews identities explicitly retired by bootstrap cleanup", () => {
+    expect(
+      shouldRenewDraftThreadIdAfterFailure(
+        new OrchestrationDispatchCommandError({
+          message: "bootstrap failed",
+          retryWithNewThreadId: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRenewDraftThreadIdAfterFailure(
+        new OrchestrationDispatchCommandError({ message: "transport failed" }),
+      ),
+    ).toBe(false);
+    expect(shouldRenewDraftThreadIdAfterFailure(new Error("unrelated"))).toBe(false);
+  });
+});
 
 const completedTurn = {
   turnId: TurnId.make("turn-1"),

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,6 +1,7 @@
 import {
   type EnvironmentId,
   isProviderDriverKind,
+  OrchestrationDispatchCommandError,
   ProjectId,
   type ModelSelection,
   type ProviderDriverKind,
@@ -27,6 +28,11 @@ export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
+const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+
+export function shouldRenewDraftThreadIdAfterFailure(error: unknown): boolean {
+  return isOrchestrationDispatchCommandError(error) && error.retryWithNewThreadId === true;
+}
 
 export function startNewThreadForProject(
   projectRef: ScopedProjectRef | null,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -273,6 +273,7 @@ import {
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   startNewThreadForProject,
+  shouldRenewDraftThreadIdAfterFailure,
   waitForStartedServerThread,
 } from "./ChatView.logic";
 import { useLocalStorage } from "~/hooks/useLocalStorage";
@@ -4843,6 +4844,16 @@ function ChatViewContent(props: ChatViewProps) {
       }
       if (!isAtomCommandInterrupted(failure)) {
         const error = squashAtomCommandFailure(failure);
+        if (isLocalDraftThread && shouldRenewDraftThreadIdAfterFailure(error)) {
+          useComposerDraftStore
+            .getState()
+            .renewDraftThreadId(
+              composerDraftTarget,
+              threadIdForSend,
+              newThreadId(),
+              new Date().toISOString(),
+            );
+        }
         setThreadError(
           threadIdForSend,
           error instanceof Error ? error.message : "Failed to send message.",

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -789,6 +789,50 @@ describe("composerDraftStore project draft thread mapping", () => {
     expect(next.getComposerDraft(draftId)?.prompt).toBe("preserve me");
   });
 
+  it("renews a draft marked promoting by a bootstrap thread deleted during cleanup", () => {
+    const store = useComposerDraftStore.getState();
+    const nextThreadId = ThreadId.make("thread-reminted");
+    const renewedAt = "2026-01-03T00:00:00.000Z";
+    const bootstrapThreadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.setPrompt(draftId, "retry me");
+    // Bootstrap creates the server thread before preparing the worktree, so
+    // the client marks the draft as promoting just before the bootstrap fails
+    // and deletes that thread again.
+    markPromotedDraftThreadByRef(bootstrapThreadRef);
+    expect(store.getDraftThread(draftId)?.promotedTo).toEqual(bootstrapThreadRef);
+
+    expect(store.renewDraftThreadId(draftId, threadId, nextThreadId, renewedAt)).toBe(true);
+
+    const next = useComposerDraftStore.getState();
+    expect(next.getDraftThread(draftId)).toMatchObject({
+      threadId: nextThreadId,
+      createdAt: renewedAt,
+      promotedTo: null,
+    });
+    // Clearing the stale promotion marker makes the draft the project's active
+    // draft session again, so the retry reuses it instead of stranding it.
+    expect(next.getDraftThreadByProjectRef(projectRef)?.draftId).toBe(draftId);
+    expect(next.getComposerDraft(draftId)?.prompt).toBe("retry me");
+  });
+
+  it("does not renew a draft that was promoted to a different server thread", () => {
+    const store = useComposerDraftStore.getState();
+    const nextThreadId = ThreadId.make("thread-should-not-win");
+    const promotedRef = scopeThreadRef(OTHER_TEST_ENVIRONMENT_ID, otherThreadId);
+
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.markDraftThreadPromoting(draftId, promotedRef);
+
+    expect(
+      store.renewDraftThreadId(draftId, threadId, nextThreadId, "2026-01-03T00:00:00.000Z"),
+    ).toBe(false);
+    const next = useComposerDraftStore.getState();
+    expect(next.getDraftThread(draftId)?.threadId).toBe(threadId);
+    expect(next.getDraftThread(draftId)?.promotedTo).toEqual(promotedRef);
+  });
+
   it("does not renew a draft whose reserved identity changed concurrently", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, { threadId });

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -767,6 +767,43 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
+  it("renews a failed bootstrap identity without losing draft content or project mapping", () => {
+    const store = useComposerDraftStore.getState();
+    const nextThreadId = ThreadId.make("thread-renewed");
+    const nextCreatedAt = "2026-01-02T00:00:00.000Z";
+    const previousThreadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.setPrompt(draftId, "preserve me");
+
+    expect(store.renewDraftThreadId(draftId, threadId, nextThreadId, nextCreatedAt)).toBe(true);
+
+    const next = useComposerDraftStore.getState();
+    expect(next.getDraftThread(draftId)).toMatchObject({
+      threadId: nextThreadId,
+      createdAt: nextCreatedAt,
+      promotedTo: null,
+    });
+    expect(next.getDraftThreadByProjectRef(projectRef)?.threadId).toBe(nextThreadId);
+    expect(next.getDraftThreadByRef(previousThreadRef)).toBeNull();
+    expect(next.getComposerDraft(draftId)?.prompt).toBe("preserve me");
+  });
+
+  it("does not renew a draft whose reserved identity changed concurrently", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+
+    expect(
+      store.renewDraftThreadId(
+        draftId,
+        otherThreadId,
+        ThreadId.make("thread-should-not-win"),
+        "2026-01-02T00:00:00.000Z",
+      ),
+    ).toBe(false);
+    expect(useComposerDraftStore.getState().getDraftThread(draftId)?.threadId).toBe(threadId);
+  });
+
   it("clears only matching project draft mapping entries", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, { threadId });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -399,6 +399,16 @@ interface ComposerDraftStoreState {
   markDraftThreadPromoting: (threadRef: ComposerThreadTarget, promotedTo?: ScopedThreadRef) => void;
   /** Removes draft-session metadata after promotion is complete. */
   finalizePromotedDraftThread: (threadRef: ComposerThreadTarget) => void;
+  /**
+   * Replaces the reserved server thread identity after a failed bootstrap
+   * conclusively cleaned up the previous identity.
+   */
+  renewDraftThreadId: (
+    threadRef: ComposerThreadTarget,
+    expectedThreadId: ThreadId,
+    nextThreadId: ThreadId,
+    createdAt: string,
+  ) => boolean;
   clearDraftThread: (threadRef: ComposerThreadTarget) => void;
   setStickyModelSelection: (modelSelection: ModelSelection | null | undefined) => void;
   setPrompt: (threadRef: ComposerThreadTarget, prompt: string) => void;
@@ -2478,6 +2488,35 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             }
             return removeDraftThreadReferences(state, threadKey);
           });
+        },
+        renewDraftThreadId: (threadRef, expectedThreadId, nextThreadId, createdAt) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0) {
+            return false;
+          }
+          let renewed = false;
+          set((state) => {
+            const existing = state.draftThreadsByThreadKey[threadKey];
+            if (
+              existing === undefined ||
+              existing.promotedTo !== null ||
+              existing.threadId !== expectedThreadId
+            ) {
+              return state;
+            }
+            renewed = true;
+            return {
+              draftThreadsByThreadKey: {
+                ...state.draftThreadsByThreadKey,
+                [threadKey]: {
+                  ...existing,
+                  threadId: nextThreadId,
+                  createdAt,
+                },
+              },
+            };
+          });
+          return renewed;
         },
         clearDraftThread: (threadRef) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -401,7 +401,8 @@ interface ComposerDraftStoreState {
   finalizePromotedDraftThread: (threadRef: ComposerThreadTarget) => void;
   /**
    * Replaces the reserved server thread identity after a failed bootstrap
-   * conclusively cleaned up the previous identity.
+   * conclusively cleaned up the previous identity. Any promotion marker left
+   * behind for that now-deleted identity is cleared with it.
    */
   renewDraftThreadId: (
     threadRef: ComposerThreadTarget,
@@ -2497,10 +2498,21 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
           let renewed = false;
           set((state) => {
             const existing = state.draftThreadsByThreadKey[threadKey];
+            if (existing === undefined || existing.threadId !== expectedThreadId) {
+              return state;
+            }
+            // Bootstrap materializes the server thread before it prepares the
+            // worktree, so the client can observe `thread.created` and mark the
+            // draft as promoting moments before bootstrap fails and deletes
+            // that same thread again. A promotion marker pointing at the
+            // identity we are replacing is therefore stale, and clearing it is
+            // exactly the recovery this renewal performs. A marker pointing at
+            // any *other* server thread means the draft really was promoted,
+            // and its identity must not be reminted.
+            const stalePromotedTo = scopeThreadRef(existing.environmentId, expectedThreadId);
             if (
-              existing === undefined ||
-              existing.promotedTo !== null ||
-              existing.threadId !== expectedThreadId
+              existing.promotedTo != null &&
+              !scopedThreadRefsEqual(existing.promotedTo, stalePromotedTo)
             ) {
               return state;
             }
@@ -2512,6 +2524,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                   ...existing,
                   threadId: nextThreadId,
                   createdAt,
+                  promotedTo: null,
                 },
               },
             };

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1415,6 +1415,7 @@ export class OrchestrationDispatchCommandError extends Schema.TaggedErrorClass<O
   {
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),
+    retryWithNewThreadId: Schema.optional(Schema.Boolean),
   },
 ) {}
 


### PR DESCRIPTION
## What Changed

- Mark bootstrap dispatch failures as safe to retry with a fresh thread ID only after provisional-thread cleanup succeeds.
- Atomically remint the local draft identity while preserving its prompt, attachments, project mapping, and settings.
- Guard the remint against concurrent promotion or identity changes.
- Add focused server, classifier, and draft-store regression coverage.

## Why

A failed new-thread bootstrap can create and then delete its provisional thread before returning an error. The event-sourced aggregate permanently consumes that thread ID, while the retained local draft retries the same ID and repeatedly hits `Thread already exists and cannot be created twice`.

The server is the only side that knows cleanup completed conclusively, so it now sends an explicit retry signal. The client rotates the ID only for that signal, avoiding unsafe rotation after ambiguous transport failures.

## UI Changes

No visual UI changes. The existing failed-send state and draft content remain visible; the recovery only changes the reserved identity used by the next retry.

## Validation

- `vp check` — passes in a clean worktree (11 existing warnings)
- `vp test run apps/server/src/server.test.ts -t "cleans up created bootstrap threads when worktree creation defects" --exclude ".worktrees/**" --exclude ".claude/worktrees/**"` — 1 passed
- `vp test run apps/web/src/composerDraftStore.test.ts apps/web/src/components/ChatView.logic.test.ts --exclude ".worktrees/**" --exclude ".claude/worktrees/**"` — 108 passed
- `vp run typecheck` — currently fails in unchanged baseline web files and prompts for the undeclared `@astrojs/check`; no reported failure is in this patch

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable because there is no visual UI change
- [x] Video is not applicable because there is no animation change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration bootstrap failure handling and draft thread identity lifecycle; guards limit reminting to explicit server signals and matching draft state.
> 
> **Overview**
> Fixes retries after a failed new-thread bootstrap that created and then deleted a provisional server thread, which left the client reusing a consumed thread ID and hitting "Thread already exists" on every retry.
> 
> **Server:** Bootstrap `thread.turn.start` failures now set optional `retryWithNewThreadId` on `OrchestrationDispatchCommandError` only when provisional-thread cleanup (delete) succeeds; failed cleanup is logged instead of being swallowed silently.
> 
> **Client:** On send failure for a local draft, `shouldRenewDraftThreadIdAfterFailure` gates a call to `renewDraftThreadId`, which mints a new reserved thread ID while keeping prompt, attachments, and project mapping, and clears stale `promotedTo` markers for the deleted identity. Renewal is refused when the draft was promoted elsewhere or the expected thread ID no longer matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2385d73e0bfae205b090ef44cfdbde35f5ed655e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover draft thread IDs after failed bootstrap cleanup
> - When a bootstrap `thread.turn.start` fails after creating a thread and cleanup (deletion) succeeds, the server now sets `retryWithNewThreadId: true` on `OrchestrationDispatchCommandError` in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/4484/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af).
> - The web client detects this flag via `shouldRenewDraftThreadIdAfterFailure` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/4484/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) and calls `renewDraftThreadId` on the composer draft store to replace the stale server thread identity while preserving draft content.
> - `renewDraftThreadId` in [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/4484/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) validates the expected thread ID matches current state and clears any stale promotion marker for the deleted thread before minting the new ID.
> - Failed cleanup now logs a warning with the thread ID and cause instead of silently ignoring errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2385d73.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->