### PR TITLE
fix: clean up the remote server update reconnect flow

### DIFF
--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -771,7 +771,9 @@ export function ReviewSheet(props: ReviewSheetProps) {
                 environment.presentation?.connection ?? {
                   phase: "available",
                   error: null,
+                  reason: null,
                   traceId: null,
+                  retryAt: null,
                 }
               }
               resourceName="review"

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -1209,7 +1209,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
               environment.presentation?.connection ?? {
                 phase: "available",
                 error: null,
+                reason: null,
                 traceId: null,
+                retryAt: null,
               }
             }
             resourceName="terminal"

--- a/apps/mobile/src/state/workspaceModel.test.ts
+++ b/apps/mobile/src/state/workspaceModel.test.ts
@@ -40,7 +40,9 @@ function environment(
     connection: {
       phase,
       error: phase === "error" ? "Connection failed." : null,
+      reason: phase === "error" ? "authentication" : null,
       traceId: phase === "error" ? "trace-1" : null,
+      retryAt: null,
     },
     serverConfig: null,
   };

--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -26,6 +26,30 @@ import * as SelfUpdate from "./selfUpdate.ts";
 
 const NODE_PATH = "/usr/local/bin/node";
 
+/**
+ * The deferred restart runs on a detached fiber, so its rollback performs
+ * real filesystem I/O that advancing the TestClock does not await. Poll on
+ * real time until the expected content lands.
+ */
+const eventuallyFileString = Effect.fn("test.eventuallyFileString")(function* (
+  filePath: string,
+  expected: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  let last = "";
+  for (let iteration = 0; iteration < 1_000; iteration += 1) {
+    last = yield* fs.readFileString(filePath);
+    if (last === expected) {
+      return last;
+    }
+    // Yielding (rather than sleeping) keeps this on the real event loop:
+    // TestClock would only advance virtual time and never let the
+    // detached fiber's filesystem writes land.
+    yield* Effect.yieldNow;
+  }
+  return yield* Effect.die(new Error(`Expected file contents were not observed at ${filePath}.`));
+});
+
 interface RecordedCommand {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
@@ -490,7 +514,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("rewrites the systemd unit and restarts the boot service", () =>
+  it.effect("rewrites the systemd unit and defers the boot-service restart", () =>
     Effect.gen(function* () {
       const context = yield* makeContext({ bootService: true });
       const result = yield* context.service.update({ targetVersion: "0.0.29" });
@@ -504,12 +528,15 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
         context.path.join(context.home, ".config", "systemd", "user", "t3code.service"),
       );
       assert.include(unit, `ExecStart=${NODE_PATH} ${pinnedEntry} serve`);
+      // The restart is deferred so the RPC acknowledgement flushes before
+      // systemd stops this process.
       assert.deepEqual(
         context.commands.map((entry) => entry.command),
-        ["npm", NODE_PATH, "systemctl", "systemctl"],
+        ["npm", NODE_PATH, "systemctl"],
       );
       assert.deepEqual(context.commands[2]?.args, ["--user", "daemon-reload"]);
 
+      yield* TestClock.adjust(Duration.seconds(10));
       assert.deepEqual(context.commands[3], {
         command: "systemctl",
         args: ["--user", "restart", "t3code.service"],
@@ -520,7 +547,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("restores the previous unit and permits a retry when systemd restart fails", () =>
+  it.effect("restores the previous unit and permits a retry when the deferred restart fails", () =>
     Effect.gen(function* () {
       let failRestart = true;
       const context = yield* makeContext({
@@ -542,9 +569,12 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
       );
       const previousUnit = yield* context.fs.readFileString(unitPath);
 
-      const first = yield* context.service.update({ targetVersion: "0.0.29" }).pipe(Effect.flip);
-      assert.include(first.reason, "Restarting the systemd boot service failed");
-      assert.equal(yield* context.fs.readFileString(unitPath), previousUnit);
+      // The RPC acknowledges before the restart runs, so a rejected
+      // restart can only roll back and log — never fail the request.
+      const first = yield* context.service.update({ targetVersion: "0.0.29" });
+      assert.deepEqual(first, { targetVersion: "0.0.29", method: "boot-service" });
+      yield* TestClock.adjust(Duration.seconds(10));
+      yield* eventuallyFileString(unitPath, previousUnit);
       assert.deepEqual(
         context.commands.slice(-2).map((entry) => entry.args),
         [

--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -62,6 +62,8 @@ const makeRecordingRunnerLayer = (
     readonly stdoutFor?:
       | ((command: string, args: ReadonlyArray<string>) => string | undefined)
       | undefined;
+    /** Raises a defect (not a typed failure) to exercise unexpected-error paths. */
+    readonly dieWhen?: ((command: string, args: ReadonlyArray<string>) => boolean) | undefined;
   },
 ) =>
   Layer.succeed(
@@ -70,6 +72,9 @@ const makeRecordingRunnerLayer = (
       run: (input) =>
         Effect.sync(() => {
           commands.push({ command: input.command, args: input.args });
+          if (options?.dieWhen?.(input.command, input.args) === true) {
+            throw new Error(`${input.command} died unexpectedly`);
+          }
           const failed = options?.failWhen?.(input.command, input.args) === true;
           const versionFromPath =
             input.command === NODE_PATH && input.args[1] === "--version"
@@ -281,6 +286,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
     readonly failWhen?: (command: string, args: ReadonlyArray<string>) => boolean;
     readonly stdoutFor?: (command: string, args: ReadonlyArray<string>) => string | undefined;
     readonly failSpawn?: boolean;
+    readonly dieWhen?: (command: string, args: ReadonlyArray<string>) => boolean;
   }) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -353,6 +359,7 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
           makeRecordingRunnerLayer(commands, {
             failWhen: options?.failWhen,
             stdoutFor: options?.stdoutFor,
+            dieWhen: options?.dieWhen,
           }),
           configLayer,
         ),
@@ -583,6 +590,32 @@ it.layer(NodeServices.layer)("ServerSelfUpdate.update", (it) => {
         ],
       );
 
+      const retry = yield* context.service.update({ targetVersion: "0.0.30" });
+      assert.deepEqual(retry, { targetVersion: "0.0.30", method: "boot-service" });
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("permits a retry when the deferred restart dies unexpectedly", () =>
+    Effect.gen(function* () {
+      let dieOnRestart = true;
+      const context = yield* makeContext({
+        bootService: true,
+        dieWhen: (command, args) => {
+          if (command !== "systemctl" || args[1] !== "restart" || !dieOnRestart) {
+            return false;
+          }
+          dieOnRestart = false;
+          return true;
+        },
+      });
+
+      const first = yield* context.service.update({ targetVersion: "0.0.29" });
+      assert.deepEqual(first, { targetVersion: "0.0.29", method: "boot-service" });
+      yield* TestClock.adjust(Duration.seconds(10));
+
+      // A defect bypasses the typed rollback handler, so the in-flight guard
+      // has to be released outside it — otherwise this live process would
+      // reject every further update until restarted by other means.
       const retry = yield* context.service.update({ targetVersion: "0.0.30" });
       assert.deepEqual(retry, { targetVersion: "0.0.30", method: "boot-service" });
     }).pipe(Effect.provide(TestClock.layer())),

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -3,6 +3,7 @@
 // detached fire-and-forget child that outlives this process, while Effect's
 // ChildProcessSpawner ties every child to a scope that kills it.
 import {
+  SERVER_SELF_UPDATE_ALREADY_RUNNING_REASON,
   ServerSelfUpdateError,
   type ServerSelfUpdateCapability,
   type ServerSelfUpdateInput,
@@ -18,6 +19,7 @@ import * as NodeChildProcess from "node:child_process";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
@@ -246,7 +248,7 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
 
     const alreadyRunning = yield* Ref.getAndSet(inFlight, true);
     if (alreadyRunning) {
-      return yield* failWith("A server update is already in progress.");
+      return yield* failWith(SERVER_SELF_UPDATE_ALREADY_RUNNING_REASON);
     }
 
     return yield* Effect.gen(function* () {
@@ -387,8 +389,23 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
                     "Server self-update could not restore the previous systemd unit after a rejected restart.",
                   ).pipe(Effect.annotateLogs({ targetVersion, error: String(rollbackError) })),
                 ),
+                // The process survived a rejected restart, so it must stay
+                // updatable — leaving the guard set would reject every retry
+                // until the server was restarted by other means.
                 Effect.ensuring(Ref.set(inFlight, false)),
               ),
+            ),
+            // The typed catch above cannot see defects or interrupts, which
+            // would otherwise strand the guard on a live process. A success
+            // deliberately leaves it set: systemd is about to stop this
+            // process and a second update would race the handoff.
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit)
+                ? Effect.void
+                : Effect.logError("Server self-update restart fiber ended unexpectedly.").pipe(
+                    Effect.annotateLogs({ targetVersion, exit: String(exit) }),
+                    Effect.ensuring(Ref.set(inFlight, false)),
+                  ),
             ),
           ),
         );

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -349,37 +349,46 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* (option
         yield* Effect.logInfo("Server self-update installed; restarting boot service.", {
           targetVersion,
         });
-        // A successful systemd restart stops this process, so the RPC is
-        // interrupted and the reconnecting client observes the new version.
-        // A rejected restart returns while the old process is still alive;
-        // restore the previous unit and report that failure through the RPC.
-        yield* Effect.gen(function* () {
-          const restart = yield* runner
-            .run({
-              command: "systemctl",
-              args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
-            })
-            .pipe(
-              Effect.mapError((cause) =>
-                failWith("Could not restart the systemd boot service.", cause),
+        // Deferred like the respawn path: a synchronous systemctl restart
+        // stops this process mid-RPC, so every successful update used to
+        // surface to the client as an interrupted call indistinguishable
+        // from a dropped connection. Deferring lets the acknowledgement
+        // flush first. The trade: a rejected restart can no longer be
+        // reported through this RPC — it rolls back, logs, and clears the
+        // in-flight guard so a retry works.
+        yield* scheduleRestart(
+          Effect.gen(function* () {
+            const restart = yield* runner
+              .run({
+                command: "systemctl",
+                args: ["--user", "restart", BOOT_SERVICE_UNIT_FILE],
+              })
+              .pipe(
+                Effect.mapError((cause) =>
+                  failWith("Could not restart the systemd boot service.", cause),
+                ),
+              );
+            if (restart.code !== 0) {
+              return yield* failWith(
+                `Restarting the systemd boot service failed (exit code ${String(restart.code)}).`,
+              );
+            }
+          }).pipe(
+            Effect.catch((restartError) =>
+              Effect.logError(
+                "Server self-update restart was rejected; restoring the previous systemd unit.",
+              ).pipe(
+                Effect.annotateLogs({ targetVersion, error: restartError.reason }),
+                Effect.andThen(
+                  writeUnitAtomically(unitPath, previousUnit).pipe(Effect.andThen(reloadSystemd())),
+                ),
+                Effect.catch((rollbackError) =>
+                  Effect.logError(
+                    "Server self-update could not restore the previous systemd unit after a rejected restart.",
+                  ).pipe(Effect.annotateLogs({ targetVersion, error: String(rollbackError) })),
+                ),
+                Effect.ensuring(Ref.set(inFlight, false)),
               ),
-            );
-          if (restart.code !== 0) {
-            return yield* failWith(
-              `Restarting the systemd boot service failed (exit code ${String(restart.code)}).`,
-            );
-          }
-        }).pipe(
-          Effect.catch((restartError) =>
-            writeUnitAtomically(unitPath, previousUnit).pipe(
-              Effect.andThen(reloadSystemd()),
-              Effect.mapError((rollbackError) =>
-                failWith("Could not restore the previous systemd unit.", {
-                  restartError,
-                  rollbackError,
-                }),
-              ),
-              Effect.andThen(Effect.fail(restartError)),
             ),
           ),
         );

--- a/apps/web/src/AppRoot.test.tsx
+++ b/apps/web/src/AppRoot.test.tsx
@@ -6,7 +6,7 @@ import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
 import type { AppRouter } from "./router";
-import { AppRoot } from "./AppRoot";
+import { AppRoot, ServerRestartReconnectHost } from "./AppRoot";
 
 describe("AppRoot", () => {
   it("shares the application atom registry with routed UI and renderer-wide desktop hosts", () => {
@@ -16,9 +16,13 @@ describe("AppRoot", () => {
     const children = Children.toArray(
       (root as ReactElement<{ readonly children: ReactNode }>).props.children,
     );
-    expect(children).toHaveLength(3);
-    expect(isValidElement(children[0]) && children[0].type).toBe(RouterProvider);
-    expect(isValidElement(children[1]) && children[1].type).toBe(PreviewAutomationHosts);
-    expect(isValidElement(children[2]) && children[2].type).toBe(ElectronBrowserHost);
+    expect(children).toHaveLength(4);
+    // The restart-reconnect host is inside the registry provider (it reads
+    // environment atoms) and outside the router, because a server restart
+    // outlives the route the update was triggered from.
+    expect(isValidElement(children[0]) && children[0].type).toBe(ServerRestartReconnectHost);
+    expect(isValidElement(children[1]) && children[1].type).toBe(RouterProvider);
+    expect(isValidElement(children[2]) && children[2].type).toBe(PreviewAutomationHosts);
+    expect(isValidElement(children[3]) && children[3].type).toBe(ElectronBrowserHost);
   });
 });

--- a/apps/web/src/AppRoot.tsx
+++ b/apps/web/src/AppRoot.tsx
@@ -4,6 +4,18 @@ import { ElectronBrowserHost } from "./browser/ElectronBrowserHost";
 import { PreviewAutomationHosts } from "./components/preview/PreviewAutomationHosts";
 import { AppAtomRegistryProvider } from "./rpc/atomRegistry";
 import type { AppRouter } from "./router";
+import { useServerRestartReconnect } from "./useServerRestartReconnect";
+
+/**
+ * Reconnects environments through an expected server restart. Mounted here
+ * because a restart outlives the view it was triggered from — the update
+ * action appears both in the chat composer's skew banner and in
+ * Settings → Connections.
+ */
+export function ServerRestartReconnectHost() {
+  useServerRestartReconnect();
+  return null;
+}
 
 /**
  * Owns renderer-wide providers. The Electron browser host intentionally sits
@@ -13,6 +25,7 @@ import type { AppRouter } from "./router";
 export function AppRoot({ router }: { readonly router: AppRouter }) {
   return (
     <AppAtomRegistryProvider>
+      <ServerRestartReconnectHost />
       <RouterProvider router={router} />
       <PreviewAutomationHosts />
       <ElectronBrowserHost />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -25,12 +25,7 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
-import {
-  clearExpectedServerRestart,
-  isServerRestarting,
-  markServerRestartDisconnected,
-  useServerRestartExpectation,
-} from "~/serverRestartStore";
+import { isServerRestarting, useServerRestartExpected } from "~/serverRestartStore";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
 import {
   parseScopedThreadKey,
@@ -1630,28 +1625,25 @@ function ChatViewContent(props: ChatViewProps) {
   // present them calmly and retry fast instead of letting exponential
   // backoff strand the client asleep when the server comes back.
   const activeEnvironmentId = activeEnvironment?.environmentId ?? null;
-  const activeEnvironmentRestartExpectation = useServerRestartExpectation(activeEnvironmentId);
-  const activeEnvironmentRestartExpected = activeEnvironmentRestartExpectation.expected;
-  const activeEnvironmentRestartSawDisconnect = activeEnvironmentRestartExpectation.sawDisconnect;
+  const activeEnvironmentRestartExpected = useServerRestartExpected(activeEnvironmentId);
   const activeEnvironmentRestarting = isServerRestarting({
-    expectation: activeEnvironmentRestartExpectation,
+    restartExpected: activeEnvironmentRestartExpected,
     environmentUnavailable: activeEnvironmentUnavailable,
   });
+  // While the restart is expected, poke the supervisor on a flat cadence so a
+  // 16-second backoff sleep cannot outlast the server's return. The window is
+  // never cleared here: it is armed while the old server is still connected,
+  // so nothing observed on the connection distinguishes "before the restart"
+  // from "after it". Presentation already gates on the environment being
+  // away, which makes a lingering window inert once the replacement is back.
   useEffect(() => {
-    if (activeEnvironmentId === null || !activeEnvironmentRestartExpected) {
+    if (
+      activeEnvironmentId === null ||
+      !activeEnvironmentRestartExpected ||
+      activeEnvironmentConnectionPhase === "connected"
+    ) {
       return;
     }
-    if (activeEnvironmentConnectionPhase === "connected") {
-      // The window is armed while the old server is still connected, so a
-      // healthy connection only ends it once the restart's disconnect has
-      // actually been seen. Clearing on any connected render would destroy
-      // the window before the restart it exists to cover.
-      if (activeEnvironmentRestartSawDisconnect) {
-        clearExpectedServerRestart(activeEnvironmentId);
-      }
-      return;
-    }
-    markServerRestartDisconnected(activeEnvironmentId);
     // Only wake the supervisor out of a backoff sleep; while an attempt is
     // live, retryNow would interrupt and restart it.
     if (activeEnvironment?.connection.retryAt == null) {
@@ -1666,7 +1658,6 @@ function ChatViewContent(props: ChatViewProps) {
     activeEnvironmentConnectionPhase,
     activeEnvironmentId,
     activeEnvironmentRestartExpected,
-    activeEnvironmentRestartSawDisconnect,
     retryEnvironment,
   ]);
   const handleReconnectActiveEnvironment = useCallback(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -25,7 +25,11 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
-import { isServerRestarting, useServerRestartExpected } from "~/serverRestartStore";
+import {
+  clearExpectedServerRestart,
+  isServerRestarting,
+  useServerRestartExpected,
+} from "~/serverRestartStore";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
 import {
   parseScopedThreadKey,
@@ -1631,19 +1635,28 @@ function ChatViewContent(props: ChatViewProps) {
     environmentUnavailable: activeEnvironmentUnavailable,
   });
   // While the restart is expected, poke the supervisor on a flat cadence so a
-  // 16-second backoff sleep cannot outlast the server's return. The window is
-  // never cleared here: it is armed while the old server is still connected,
-  // so nothing observed on the connection distinguishes "before the restart"
-  // from "after it". Presentation already gates on the environment being
-  // away, which makes a lingering window inert once the replacement is back.
+  // 16-second backoff sleep cannot outlast the server's return.
+  //
+  // The window also has to end at the right moment. Ending it on any healthy
+  // connection is wrong — it is armed while the old server is still connected,
+  // so that clears it before the restart it exists to cover. Never ending it
+  // is also wrong — an unrelated outage later in the window would be dressed
+  // up as an intentional restart. So it ends once this environment has gone
+  // away and come back: the restart it was armed for has been seen through.
+  const restartSawDisconnectRef = useRef(false);
   useEffect(() => {
-    if (
-      activeEnvironmentId === null ||
-      !activeEnvironmentRestartExpected ||
-      activeEnvironmentConnectionPhase === "connected"
-    ) {
+    if (activeEnvironmentId === null || !activeEnvironmentRestartExpected) {
+      restartSawDisconnectRef.current = false;
       return;
     }
+    if (activeEnvironmentConnectionPhase === "connected") {
+      if (restartSawDisconnectRef.current) {
+        restartSawDisconnectRef.current = false;
+        clearExpectedServerRestart(activeEnvironmentId);
+      }
+      return;
+    }
+    restartSawDisconnectRef.current = true;
     // Only wake the supervisor out of a backoff sleep; while an attempt is
     // live, retryNow would interrupt and restart it.
     if (activeEnvironment?.connection.retryAt == null) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -25,11 +25,7 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
-import {
-  clearExpectedServerRestart,
-  isServerRestarting,
-  useServerRestartExpected,
-} from "~/serverRestartStore";
+import { isServerRestarting, useServerRestartExpected } from "~/serverRestartStore";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
 import {
   parseScopedThreadKey,
@@ -1634,45 +1630,10 @@ function ChatViewContent(props: ChatViewProps) {
     restartExpected: activeEnvironmentRestartExpected,
     environmentUnavailable: activeEnvironmentUnavailable,
   });
-  // While the restart is expected, poke the supervisor on a flat cadence so a
-  // 16-second backoff sleep cannot outlast the server's return.
-  //
-  // The window also has to end at the right moment. Ending it on any healthy
-  // connection is wrong — it is armed while the old server is still connected,
-  // so that clears it before the restart it exists to cover. Never ending it
-  // is also wrong — an unrelated outage later in the window would be dressed
-  // up as an intentional restart. So it ends once this environment has gone
-  // away and come back: the restart it was armed for has been seen through.
-  const restartSawDisconnectRef = useRef(false);
-  useEffect(() => {
-    if (activeEnvironmentId === null || !activeEnvironmentRestartExpected) {
-      restartSawDisconnectRef.current = false;
-      return;
-    }
-    if (activeEnvironmentConnectionPhase === "connected") {
-      if (restartSawDisconnectRef.current) {
-        restartSawDisconnectRef.current = false;
-        clearExpectedServerRestart(activeEnvironmentId);
-      }
-      return;
-    }
-    restartSawDisconnectRef.current = true;
-    // Only wake the supervisor out of a backoff sleep; while an attempt is
-    // live, retryNow would interrupt and restart it.
-    if (activeEnvironment?.connection.retryAt == null) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      void retryEnvironment(activeEnvironmentId);
-    }, 2_000);
-    return () => clearTimeout(timer);
-  }, [
-    activeEnvironment?.connection.retryAt,
-    activeEnvironmentConnectionPhase,
-    activeEnvironmentId,
-    activeEnvironmentRestartExpected,
-    retryEnvironment,
-  ]);
+  // Reconnecting through the restart (and ending the window once its restart
+  // has been seen through) is owned by useServerRestartReconnect at the app
+  // level, since an update can be triggered from Settings → Connections too.
+  // This view only presents the result.
   const handleReconnectActiveEnvironment = useCallback(
     async (environmentId: EnvironmentId) => {
       const result = await retryEnvironment(environmentId);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -25,6 +25,7 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
+import { clearExpectedServerRestart, useServerRestartExpected } from "~/serverRestartStore";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
 import {
   parseScopedThreadKey,
@@ -275,6 +276,7 @@ import { RightPanelSheet } from "./RightPanelSheet";
 import { previewEnvironment } from "../state/preview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { Button } from "./ui/button";
+import { Spinner } from "./ui/spinner";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -1619,6 +1621,37 @@ function ChatViewContent(props: ChatViewProps) {
       connection: activeEnvironment.connection,
     };
   }, [activeEnvironment, activeEnvironmentUnavailable, activeEnvironmentUnavailableLabel]);
+  // While a server self-update restart is expected, disconnects are routine:
+  // present them calmly and retry fast instead of letting exponential
+  // backoff strand the client asleep when the server comes back.
+  const activeEnvironmentId = activeEnvironment?.environmentId ?? null;
+  const activeEnvironmentRestartExpected = useServerRestartExpected(activeEnvironmentId);
+  const activeEnvironmentRestarting =
+    activeEnvironmentRestartExpected && activeEnvironmentUnavailable;
+  useEffect(() => {
+    if (activeEnvironmentId === null || !activeEnvironmentRestartExpected) {
+      return;
+    }
+    if (activeEnvironmentConnectionPhase === "connected") {
+      clearExpectedServerRestart(activeEnvironmentId);
+      return;
+    }
+    // Only wake the supervisor out of a backoff sleep; while an attempt is
+    // live, retryNow would interrupt and restart it.
+    if (activeEnvironment?.connection.retryAt == null) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      void retryEnvironment(activeEnvironmentId);
+    }, 2_000);
+    return () => clearTimeout(timer);
+  }, [
+    activeEnvironment?.connection.retryAt,
+    activeEnvironmentConnectionPhase,
+    activeEnvironmentId,
+    activeEnvironmentRestartExpected,
+    retryEnvironment,
+  ]);
   const handleReconnectActiveEnvironment = useCallback(
     async (environmentId: EnvironmentId) => {
       const result = await retryEnvironment(environmentId);
@@ -1832,7 +1865,19 @@ function ChatViewContent(props: ChatViewProps) {
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
   const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
-    if (activeEnvironmentUnavailableState) {
+    if (activeEnvironmentUnavailableState && activeEnvironmentRestarting) {
+      // An expected self-update restart: the disconnect and the transient
+      // connection errors behind it are routine, so keep the tone neutral
+      // and let the fast auto-retry loop do the work instead of asking the
+      // user to reconnect by hand.
+      items.push({
+        id: `environment-restarting:${activeEnvironmentUnavailableState.environmentId}`,
+        variant: "info",
+        icon: <Spinner className="size-4" />,
+        title: `${activeEnvironmentUnavailableState.label} is restarting`,
+        description: "Finishing the server update — reconnecting automatically.",
+      });
+    } else if (activeEnvironmentUnavailableState) {
       const connection = activeEnvironmentUnavailableState.connection;
       const isReconnecting =
         connection.phase === "connecting" || connection.phase === "reconnecting";
@@ -1872,7 +1917,10 @@ function ChatViewContent(props: ChatViewProps) {
       showVersionMismatchBanner &&
       versionMismatch &&
       versionMismatchDismissKey &&
-      versionMismatchEnvironmentId
+      versionMismatchEnvironmentId &&
+      // The mismatch data predates the disconnect; during an expected
+      // restart it is stale and its update action would double-trigger.
+      !activeEnvironmentRestarting
     ) {
       items.push({
         id: `version-mismatch:${versionMismatchDismissKey}`,
@@ -1906,6 +1954,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return items;
   }, [
+    activeEnvironmentRestarting,
     activeEnvironmentUnavailableState,
     handleReconnectActiveEnvironment,
     navigate,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -25,7 +25,12 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
-import { clearExpectedServerRestart, useServerRestartExpected } from "~/serverRestartStore";
+import {
+  clearExpectedServerRestart,
+  isServerRestarting,
+  markServerRestartDisconnected,
+  useServerRestartExpectation,
+} from "~/serverRestartStore";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
 import {
   parseScopedThreadKey,
@@ -1625,17 +1630,28 @@ function ChatViewContent(props: ChatViewProps) {
   // present them calmly and retry fast instead of letting exponential
   // backoff strand the client asleep when the server comes back.
   const activeEnvironmentId = activeEnvironment?.environmentId ?? null;
-  const activeEnvironmentRestartExpected = useServerRestartExpected(activeEnvironmentId);
-  const activeEnvironmentRestarting =
-    activeEnvironmentRestartExpected && activeEnvironmentUnavailable;
+  const activeEnvironmentRestartExpectation = useServerRestartExpectation(activeEnvironmentId);
+  const activeEnvironmentRestartExpected = activeEnvironmentRestartExpectation.expected;
+  const activeEnvironmentRestartSawDisconnect = activeEnvironmentRestartExpectation.sawDisconnect;
+  const activeEnvironmentRestarting = isServerRestarting({
+    expectation: activeEnvironmentRestartExpectation,
+    environmentUnavailable: activeEnvironmentUnavailable,
+  });
   useEffect(() => {
     if (activeEnvironmentId === null || !activeEnvironmentRestartExpected) {
       return;
     }
     if (activeEnvironmentConnectionPhase === "connected") {
-      clearExpectedServerRestart(activeEnvironmentId);
+      // The window is armed while the old server is still connected, so a
+      // healthy connection only ends it once the restart's disconnect has
+      // actually been seen. Clearing on any connected render would destroy
+      // the window before the restart it exists to cover.
+      if (activeEnvironmentRestartSawDisconnect) {
+        clearExpectedServerRestart(activeEnvironmentId);
+      }
       return;
     }
+    markServerRestartDisconnected(activeEnvironmentId);
     // Only wake the supervisor out of a backoff sleep; while an attempt is
     // live, retryNow would interrupt and restart it.
     if (activeEnvironment?.connection.retryAt == null) {
@@ -1650,6 +1666,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeEnvironmentConnectionPhase,
     activeEnvironmentId,
     activeEnvironmentRestartExpected,
+    activeEnvironmentRestartSawDisconnect,
     retryEnvironment,
   ]);
   const handleReconnectActiveEnvironment = useCallback(

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -16,6 +16,7 @@ const testState = vi.hoisted(() => ({
 const restartStore = vi.hoisted(() => ({
   expect: vi.fn(),
   clear: vi.fn(),
+  expectation: vi.fn(() => ({ expected: false, sawDisconnect: false })),
 }));
 
 const hooks = vi.hoisted(() => {
@@ -87,10 +88,15 @@ vi.mock("~/state/use-atom-command", () => ({
 vi.mock("./ui/toast", () => ({
   toastManager: { add: testState.toast },
 }));
-vi.mock("~/serverRestartStore", () => ({
-  expectServerRestart: restartStore.expect,
-  clearExpectedServerRestart: restartStore.clear,
-}));
+vi.mock("~/serverRestartStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/serverRestartStore")>();
+  return {
+    ...actual,
+    expectServerRestart: restartStore.expect,
+    clearExpectedServerRestart: restartStore.clear,
+    useServerRestartExpectation: restartStore.expectation,
+  };
+});
 
 import { ServerUpdateAction } from "./ServerUpdateAction";
 
@@ -133,6 +139,8 @@ describe("ServerUpdateAction", () => {
     testState.toast.mockReset();
     restartStore.expect.mockReset();
     restartStore.clear.mockReset();
+    restartStore.expectation.mockReset();
+    restartStore.expectation.mockReturnValue({ expected: false, sawDisconnect: false });
   });
 
   afterEach(() => {

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -2,11 +2,20 @@ import type { Dispatch, ReactElement, SetStateAction } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
-import type { EnvironmentId } from "@t3tools/contracts";
+import {
+  SERVER_SELF_UPDATE_ALREADY_RUNNING_REASON,
+  ServerSelfUpdateError,
+  type EnvironmentId,
+} from "@t3tools/contracts";
 
 const testState = vi.hoisted(() => ({
   updateServer: vi.fn(),
   toast: vi.fn(),
+}));
+
+const restartStore = vi.hoisted(() => ({
+  expect: vi.fn(),
+  clear: vi.fn(),
 }));
 
 const hooks = vi.hoisted(() => {
@@ -78,6 +87,10 @@ vi.mock("~/state/use-atom-command", () => ({
 vi.mock("./ui/toast", () => ({
   toastManager: { add: testState.toast },
 }));
+vi.mock("~/serverRestartStore", () => ({
+  expectServerRestart: restartStore.expect,
+  clearExpectedServerRestart: restartStore.clear,
+}));
 
 import { ServerUpdateAction } from "./ServerUpdateAction";
 
@@ -118,6 +131,8 @@ describe("ServerUpdateAction", () => {
     hooks.reset();
     testState.updateServer.mockReset();
     testState.toast.mockReset();
+    restartStore.expect.mockReset();
+    restartStore.clear.mockReset();
   });
 
   afterEach(() => {
@@ -194,5 +209,72 @@ describe("ServerUpdateAction", () => {
     expect(testState.toast).not.toHaveBeenCalledWith(
       expect.objectContaining({ title: "Server update failed" }),
     );
+  });
+
+  it("re-arms the restart window when a slow install finally succeeds", async () => {
+    const update =
+      deferred<
+        ReturnType<typeof AsyncResult.success<{ targetVersion: string; method: "boot-service" }>>
+      >();
+    testState.updateServer.mockReturnValue(update.promise);
+
+    renderAction().props.onClick?.();
+    expect(restartStore.expect).toHaveBeenCalledTimes(1);
+
+    // An install can outlast the 90s restart window armed at click time, so
+    // the acknowledgement must restart the clock or the ensuing disconnect
+    // would be presented as an outage.
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    update.resolve(AsyncResult.success({ targetVersion: "0.0.29", method: "boot-service" }));
+    await flushPromises();
+
+    expect(restartStore.expect).toHaveBeenCalledTimes(2);
+    expect(restartStore.clear).not.toHaveBeenCalled();
+  });
+
+  it("re-arms the restart window on an interrupted restart RPC", async () => {
+    testState.updateServer.mockResolvedValue(AsyncResult.failure(Cause.interrupt()));
+
+    renderAction().props.onClick?.();
+    await flushPromises();
+
+    expect(restartStore.expect).toHaveBeenCalledTimes(2);
+    expect(restartStore.clear).not.toHaveBeenCalled();
+  });
+
+  it("withdraws the restart expectation when the server reports a real failure", async () => {
+    testState.updateServer.mockResolvedValue(
+      AsyncResult.failure(
+        Cause.fail(
+          new ServerSelfUpdateError({ reason: "Could not install the requested t3 version." }),
+        ),
+      ),
+    );
+
+    renderAction().props.onClick?.();
+    await flushPromises();
+
+    // The server answered, so it is still alive and no restart is coming.
+    expect(restartStore.clear).toHaveBeenCalledTimes(1);
+    expect(testState.toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Server update failed" }),
+    );
+  });
+
+  it("keeps the restart expectation when an update is already in progress", async () => {
+    testState.updateServer.mockResolvedValue(
+      AsyncResult.failure(
+        Cause.fail(
+          new ServerSelfUpdateError({ reason: SERVER_SELF_UPDATE_ALREADY_RUNNING_REASON }),
+        ),
+      ),
+    );
+
+    renderAction().props.onClick?.();
+    await flushPromises();
+
+    // An earlier request is still installing, so a restart really is pending
+    // — clearing here would restore the harsh reconnect UI mid-restart.
+    expect(restartStore.clear).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/ServerUpdateAction.test.tsx
+++ b/apps/web/src/components/ServerUpdateAction.test.tsx
@@ -16,7 +16,11 @@ const testState = vi.hoisted(() => ({
 const restartStore = vi.hoisted(() => ({
   expect: vi.fn(),
   clear: vi.fn(),
-  expectation: vi.fn(() => ({ expected: false, sawDisconnect: false })),
+  expected: vi.fn(() => false),
+}));
+
+const environmentState = vi.hoisted(() => ({
+  useEnvironment: vi.fn(() => ({ connection: { phase: "connected" } })),
 }));
 
 const hooks = vi.hoisted(() => {
@@ -94,9 +98,12 @@ vi.mock("~/serverRestartStore", async (importOriginal) => {
     ...actual,
     expectServerRestart: restartStore.expect,
     clearExpectedServerRestart: restartStore.clear,
-    useServerRestartExpectation: restartStore.expectation,
+    useServerRestartExpected: restartStore.expected,
   };
 });
+vi.mock("~/state/environments", () => ({
+  useEnvironment: environmentState.useEnvironment,
+}));
 
 import { ServerUpdateAction } from "./ServerUpdateAction";
 
@@ -139,8 +146,10 @@ describe("ServerUpdateAction", () => {
     testState.toast.mockReset();
     restartStore.expect.mockReset();
     restartStore.clear.mockReset();
-    restartStore.expectation.mockReset();
-    restartStore.expectation.mockReturnValue({ expected: false, sawDisconnect: false });
+    restartStore.expected.mockReset();
+    restartStore.expected.mockReturnValue(false);
+    environmentState.useEnvironment.mockReset();
+    environmentState.useEnvironment.mockReturnValue({ connection: { phase: "connected" } });
   });
 
   afterEach(() => {

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import type { EnvironmentId, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import {
+  ServerSelfUpdateError,
+  type EnvironmentId,
+  type ServerSelfUpdateCapability,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -23,6 +28,18 @@ const UPDATE_PENDING_EXPIRY_MS = 12 * 60_000;
 
 function updateFailureMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Server update failed.";
+}
+
+/**
+ * The server rejects a second update while one is already installing. That
+ * failure means a restart is still pending from the earlier request, so the
+ * restart expectation must survive it — unlike every other failure, which
+ * proves nothing is coming.
+ */
+const isServerSelfUpdateError = Schema.is(ServerSelfUpdateError);
+
+function isUpdateAlreadyRunning(error: unknown): boolean {
+  return isServerSelfUpdateError(error) && error.isAlreadyRunning;
 }
 
 /**
@@ -116,13 +133,17 @@ export function ServerUpdateAction({
         clearTimeout(expiry);
         expiry = armExpiry();
       }
+      // The install can consume most of the request window, so the window
+      // armed at click time may already have lapsed by the time the restart
+      // actually begins. Re-arm from the handoff, not from the click.
+      expectServerRestart(environmentId);
     };
     // Armed before dispatch: the boot-service path acknowledges and then
     // drops every connection, and even the respawn acknowledgement can lose
     // the race against the disconnect. An explicit RPC failure proves the
     // server stayed alive, so the expectation is withdrawn there; on
-    // success or interrupt it stays armed and expires on its own if the
-    // server never returns.
+    // success or interrupt it is re-armed from that point and expires on its
+    // own if the server never returns.
     expectServerRestart(environmentId);
     void Promise.resolve()
       .then(() =>
@@ -137,15 +158,21 @@ export function ServerUpdateAction({
           // An interrupt may be the expected boot-service disconnect, but it
           // can also be client-side cancellation before restart was accepted.
           // Release the action quietly; version sync will remove it when a
-          // successful replacement reconnects.
+          // successful replacement reconnects. Re-arm from here for the same
+          // reason as the success path: a long install may have outlasted the
+          // window armed at click time.
           if (isAtomCommandInterrupted(result)) {
+            expectServerRestart(environmentId);
             return;
           }
-          clearExpectedServerRestart(environmentId);
+          const failure = squashAtomCommandFailure(result);
+          if (!isUpdateAlreadyRunning(failure)) {
+            clearExpectedServerRestart(environmentId);
+          }
           toastManager.add({
             type: "error",
             title: "Server update failed",
-            description: updateFailureMessage(squashAtomCommandFailure(result)),
+            description: updateFailureMessage(failure),
           });
           return;
         }
@@ -161,7 +188,9 @@ export function ServerUpdateAction({
       })
       .catch((error: unknown) => {
         if (!ownsAttempt()) return;
-        clearExpectedServerRestart(environmentId);
+        if (!isUpdateAlreadyRunning(error)) {
+          clearExpectedServerRestart(environmentId);
+        }
         toastManager.add({
           type: "error",
           title: "Server update failed",

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -6,6 +6,7 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { clearExpectedServerRestart, expectServerRestart } from "~/serverRestartStore";
 import { serverEnvironment } from "~/state/server";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
@@ -116,6 +117,13 @@ export function ServerUpdateAction({
         expiry = armExpiry();
       }
     };
+    // Armed before dispatch: the boot-service path acknowledges and then
+    // drops every connection, and even the respawn acknowledgement can lose
+    // the race against the disconnect. An explicit RPC failure proves the
+    // server stayed alive, so the expectation is withdrawn there; on
+    // success or interrupt it stays armed and expires on its own if the
+    // server never returns.
+    expectServerRestart(environmentId);
     void Promise.resolve()
       .then(() =>
         updateServer({
@@ -133,6 +141,7 @@ export function ServerUpdateAction({
           if (isAtomCommandInterrupted(result)) {
             return;
           }
+          clearExpectedServerRestart(environmentId);
           toastManager.add({
             type: "error",
             title: "Server update failed",
@@ -152,6 +161,7 @@ export function ServerUpdateAction({
       })
       .catch((error: unknown) => {
         if (!ownsAttempt()) return;
+        clearExpectedServerRestart(environmentId);
         toastManager.add({
           type: "error",
           title: "Server update failed",

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -14,9 +14,10 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import {
   clearExpectedServerRestart,
   expectServerRestart,
-  isServerRestartSettled,
-  useServerRestartExpectation,
+  isExpectedRestartResolved,
+  useServerRestartExpected,
 } from "~/serverRestartStore";
+import { useEnvironment } from "~/state/environments";
 import { serverEnvironment } from "~/state/server";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
@@ -104,17 +105,46 @@ export function ServerUpdateAction({
   );
 
   // The restart is scheduled after the RPC is acknowledged, so a rejected
-  // restart (or a replacement that comes back on the old version) can no
-  // longer be reported through the call. Without this, the mismatch banner
-  // would keep its only action disabled for the full safety window. Once the
-  // restart window has closed and this component is still mounted — meaning
-  // the skew is unresolved and the server is answering again — release the
-  // action so the user can retry immediately.
-  const restartSettled = isServerRestartSettled(useServerRestartExpectation(environmentId));
+  // restart — or a replacement that comes back on the old version — can no
+  // longer be reported through the call. Without a release path the mismatch
+  // banner would keep its only action disabled for the full safety window.
+  //
+  // The signal is the environment going away and then answering again while
+  // this component is still mounted: still mounted means the skew is
+  // unresolved, so whatever restarted did not deliver the new version.
+  // Deliberately independent of the restart window, which is UI presentation
+  // state and can lapse or be re-armed for unrelated reasons.
+  // Two ways that resolves, because a rejected restart may or may not have
+  // taken the connection down with it:
+  //   - the environment went away and came back, so something restarted but
+  //     did not deliver the new version; or
+  //   - the restart window lapsed with the connection never dropping, so no
+  //     restart ever happened (systemd refused it and rolled back).
+  const connectionPhase = useEnvironment(environmentId)?.connection.phase ?? null;
+  const connectionUnavailable = connectionPhase !== null && connectionPhase !== "connected";
+  const restartExpected = useServerRestartExpected(environmentId);
+  const wentAwayRef = useRef(false);
+  const sawWindowRef = useRef(false);
+  if (connectionUnavailable) {
+    wentAwayRef.current = true;
+  }
+  if (restartExpected) {
+    // Guards against reading a not-yet-rendered window as "already lapsed"
+    // in the render between the click and the store update landing.
+    sawWindowRef.current = true;
+  }
+  const restartResolved = isExpectedRestartResolved({
+    sawRestartWindow: sawWindowRef.current,
+    restartExpected,
+    wentAway: wentAwayRef.current,
+    environmentUnavailable: connectionUnavailable,
+  });
   useEffect(() => {
-    if (!restartSettled || !inFlightRef.current) {
+    if (!restartResolved || !inFlightRef.current) {
       return;
     }
+    wentAwayRef.current = false;
+    sawWindowRef.current = false;
     if (expiryRef.current !== null) {
       clearTimeout(expiryRef.current);
       expiryRef.current = null;
@@ -122,7 +152,7 @@ export function ServerUpdateAction({
     attemptRef.current += 1;
     inFlightRef.current = false;
     setPending(false);
-  }, [restartSettled]);
+  }, [restartResolved]);
 
   const handleUpdate = () => {
     // Synchronous re-entry guard: setPending is async, so a rapid

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -161,6 +161,11 @@ export function ServerUpdateAction({
       return;
     }
     inFlightRef.current = true;
+    // Only outages observed during this attempt may resolve it. An earlier
+    // unrelated blip would otherwise satisfy the resolve predicate on the
+    // very next render and re-enable the button mid-update.
+    wentAwayRef.current = false;
+    sawWindowRef.current = false;
     const attempt = attemptRef.current + 1;
     attemptRef.current = attempt;
     const ownsAttempt = () => attemptRef.current === attempt;

--- a/apps/web/src/components/ServerUpdateAction.tsx
+++ b/apps/web/src/components/ServerUpdateAction.tsx
@@ -11,7 +11,12 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
-import { clearExpectedServerRestart, expectServerRestart } from "~/serverRestartStore";
+import {
+  clearExpectedServerRestart,
+  expectServerRestart,
+  isServerRestartSettled,
+  useServerRestartExpectation,
+} from "~/serverRestartStore";
 import { serverEnvironment } from "~/state/server";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { manualServerUpdateCommand } from "~/versionSkew";
@@ -97,6 +102,27 @@ export function ServerUpdateAction({
     },
     [],
   );
+
+  // The restart is scheduled after the RPC is acknowledged, so a rejected
+  // restart (or a replacement that comes back on the old version) can no
+  // longer be reported through the call. Without this, the mismatch banner
+  // would keep its only action disabled for the full safety window. Once the
+  // restart window has closed and this component is still mounted — meaning
+  // the skew is unresolved and the server is answering again — release the
+  // action so the user can retry immediately.
+  const restartSettled = isServerRestartSettled(useServerRestartExpectation(environmentId));
+  useEffect(() => {
+    if (!restartSettled || !inFlightRef.current) {
+      return;
+    }
+    if (expiryRef.current !== null) {
+      clearTimeout(expiryRef.current);
+      expiryRef.current = null;
+    }
+    attemptRef.current += 1;
+    inFlightRef.current = false;
+    setPending(false);
+  }, [restartSettled]);
 
   const handleUpdate = () => {
     // Synchronous re-entry guard: setPending is async, so a rapid

--- a/apps/web/src/components/cloud/cloudEnvironmentConnectionPresentation.test.ts
+++ b/apps/web/src/components/cloud/cloudEnvironmentConnectionPresentation.test.ts
@@ -7,7 +7,7 @@ function connection(
   phase: EnvironmentConnectionPresentation["phase"],
   error: string | null = null,
 ): EnvironmentConnectionPresentation {
-  return { phase, error, traceId: null };
+  return { phase, error, reason: null, traceId: null, retryAt: null };
 }
 
 describe("saved cloud environment connection presentation", () => {

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -130,6 +130,7 @@ import {
   useEnvironments,
   usePrimaryEnvironment,
 } from "~/state/environments";
+import { isServerRestarting, useServerRestartExpected } from "~/serverRestartStore";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { ConnectionStatusDot } from "../ConnectionStatusDot";
 import { ServerUpdateAction } from "../ServerUpdateAction";
@@ -1353,15 +1354,24 @@ function SavedBackendListRow({
   const connectionState = environment.connection.phase;
   const isConnected = connectionState === "connected";
   const isConnecting = connectionState === "connecting" || connectionState === "reconnecting";
+  // An update started from this row restarts the server, so present that
+  // disconnect as the expected restart rather than as a connection failure —
+  // the same treatment the chat composer's skew banner gives it.
+  const isRestarting = isServerRestarting({
+    restartExpected: useServerRestartExpected(environmentId),
+    environmentUnavailable: !isConnected,
+  });
   const stateDotClassName =
     connectionState === "connected"
       ? "bg-success"
-      : connectionState === "connecting" || connectionState === "reconnecting"
+      : isRestarting || connectionState === "connecting" || connectionState === "reconnecting"
         ? "bg-warning"
         : connectionState === "error"
           ? "bg-destructive"
           : "bg-muted-foreground/40";
-  const statusTooltip = connectionStatusText(environment.connection);
+  const statusTooltip = isRestarting
+    ? "Restarting to finish the server update..."
+    : connectionStatusText(environment.connection);
   const errorTraceId = environment.connection.traceId;
   const { copyToClipboard: copyTraceIdToClipboard } = useCopyToClipboard<{ traceId: string }>({
     target: "trace ID",
@@ -1440,7 +1450,13 @@ function SavedBackendListRow({
               />
             </div>
           ) : null}
-          {environment.connection.error ? (
+          {isRestarting ? (
+            <p className="flex min-w-0 items-center gap-2 text-muted-foreground text-xs">
+              <span className="truncate">
+                Restarting to finish the server update — reconnecting automatically.
+              </span>
+            </p>
+          ) : environment.connection.error ? (
             <p className="flex min-w-0 items-center gap-2 text-destructive text-xs">
               <span className="truncate">{connectionStatusText(environment.connection)}</span>
               {errorTraceId ? (

--- a/apps/web/src/serverRestartStore.test.ts
+++ b/apps/web/src/serverRestartStore.test.ts
@@ -5,58 +5,40 @@ import {
   SERVER_RESTART_EXPECTED_WINDOW_MS,
   clearExpectedServerRestart,
   expectServerRestart,
-  isServerRestartSettled,
+  isExpectedRestartResolved,
   isServerRestarting,
-  markServerRestartDisconnected,
   useServerRestartStore,
 } from "./serverRestartStore";
 
 const ENVIRONMENT_ID = "env-test" as EnvironmentId;
 
-function windowFor(environmentId: EnvironmentId) {
-  return useServerRestartStore.getState().windowByEnvironmentId[environmentId] ?? null;
+function expiresAtFor(environmentId: EnvironmentId) {
+  return useServerRestartStore.getState().expiresAtByEnvironmentId[environmentId] ?? null;
 }
 
 describe("serverRestartStore", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    useServerRestartStore.setState({ windowByEnvironmentId: {} });
+    useServerRestartStore.setState({ expiresAtByEnvironmentId: {} });
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("arms a window that has not yet seen the restart's disconnect", () => {
+  it("arms a window that expires on its own", () => {
     expectServerRestart(ENVIRONMENT_ID);
-
-    // The window is armed while the old server is still connected, so the
-    // consumer must be able to tell "waiting for the restart" apart from
-    // "the restart already happened".
-    expect(windowFor(ENVIRONMENT_ID)?.sawDisconnect).toBe(false);
-    expect(windowFor(ENVIRONMENT_ID)?.expiresAt).toBe(
-      Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
-    );
+    expect(expiresAtFor(ENVIRONMENT_ID)).toBe(Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS);
   });
 
-  it("remembers an observed disconnect across a re-arm", () => {
+  it("extends the window when a slow install acknowledges late", () => {
     expectServerRestart(ENVIRONMENT_ID);
-    markServerRestartDisconnected(ENVIRONMENT_ID);
-
-    // A slow install acknowledging late re-arms the window; forgetting the
-    // disconnect here would strand the restarting UI until the window lapsed.
-    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(60_000);
     expectServerRestart(ENVIRONMENT_ID);
 
-    expect(windowFor(ENVIRONMENT_ID)?.sawDisconnect).toBe(true);
-    expect(windowFor(ENVIRONMENT_ID)?.expiresAt).toBe(
-      Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
-    );
-  });
-
-  it("ignores a disconnect for an environment with no armed window", () => {
-    markServerRestartDisconnected(ENVIRONMENT_ID);
-    expect(windowFor(ENVIRONMENT_ID)).toBeNull();
+    // Re-arming from the acknowledgement is what keeps a restart that begins
+    // minutes after the click from being presented as an outage.
+    expect(expiresAtFor(ENVIRONMENT_ID)).toBe(Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS);
   });
 
   it("clears only the requested environment", () => {
@@ -66,58 +48,71 @@ describe("serverRestartStore", () => {
 
     clearExpectedServerRestart(ENVIRONMENT_ID);
 
-    expect(windowFor(ENVIRONMENT_ID)).toBeNull();
-    expect(windowFor(other)).not.toBeNull();
+    expect(expiresAtFor(ENVIRONMENT_ID)).toBeNull();
+    expect(expiresAtFor(other)).not.toBeNull();
   });
 
   describe("isServerRestarting", () => {
     it("does not claim a still-connected environment is restarting", () => {
       // The window is armed before dispatch, while the old server is still
-      // connected. Presenting that as "restarting" would fire the moment the
-      // user clicks, before anything has actually gone away.
-      expect(
-        isServerRestarting({
-          expectation: { expected: true, sawDisconnect: false },
-          environmentUnavailable: false,
-        }),
-      ).toBe(false);
+      // connected. Gating on availability is what keeps that from showing the
+      // restarting banner the instant the user clicks — and what makes a
+      // window outliving its restart harmless.
+      expect(isServerRestarting({ restartExpected: true, environmentUnavailable: false })).toBe(
+        false,
+      );
     });
 
     it("presents an armed window with an away environment as restarting", () => {
-      expect(
-        isServerRestarting({
-          expectation: { expected: true, sawDisconnect: true },
-          environmentUnavailable: true,
-        }),
-      ).toBe(true);
+      expect(isServerRestarting({ restartExpected: true, environmentUnavailable: true })).toBe(
+        true,
+      );
     });
 
     it("falls back to the outage UI once the window lapses", () => {
       // The server never came back; the calm banner must give way.
-      expect(
-        isServerRestarting({
-          expectation: { expected: false, sawDisconnect: true },
-          environmentUnavailable: true,
-        }),
-      ).toBe(false);
+      expect(isServerRestarting({ restartExpected: false, environmentUnavailable: true })).toBe(
+        false,
+      );
     });
   });
 
-  describe("isServerRestartSettled", () => {
-    it("does not treat a live window as settled", () => {
-      expect(isServerRestartSettled({ expected: true, sawDisconnect: true })).toBe(false);
+  describe("isExpectedRestartResolved", () => {
+    const base = {
+      sawRestartWindow: true,
+      restartExpected: true,
+      wentAway: false,
+      environmentUnavailable: false,
+    };
+
+    it("does not resolve while the environment is still away", () => {
+      expect(
+        isExpectedRestartResolved({ ...base, wentAway: true, environmentUnavailable: true }),
+      ).toBe(false);
     });
 
-    it("treats an observed restart whose window has closed as settled", () => {
-      // Covers a rejected systemd restart: the RPC already acknowledged, so
-      // nothing else can tell the update action to release itself.
-      expect(isServerRestartSettled({ expected: false, sawDisconnect: true })).toBe(true);
+    it("resolves once the environment comes back after going away", () => {
+      // Something restarted but the skew is still here, so whatever came back
+      // did not carry the new version.
+      expect(isExpectedRestartResolved({ ...base, wentAway: true })).toBe(true);
     });
 
-    it("does not settle a window that never saw a disconnect", () => {
-      // The restart simply never happened; the explicit-failure path owns
-      // that case, and settling here would release the action early.
-      expect(isServerRestartSettled({ expected: false, sawDisconnect: false })).toBe(false);
+    it("resolves when the window lapses without the connection ever dropping", () => {
+      // systemd refused the restart and rolled back: the RPC already returned
+      // success, so nothing else can release the action.
+      expect(isExpectedRestartResolved({ ...base, restartExpected: false })).toBe(true);
+    });
+
+    it("does not resolve while the restart is still expected", () => {
+      expect(isExpectedRestartResolved(base)).toBe(false);
+    });
+
+    it("does not resolve before a window has been observed", () => {
+      // Guards the render between the click and the store update landing,
+      // which would otherwise look like an already-lapsed window.
+      expect(
+        isExpectedRestartResolved({ ...base, sawRestartWindow: false, restartExpected: false }),
+      ).toBe(false);
     });
   });
 });

--- a/apps/web/src/serverRestartStore.test.ts
+++ b/apps/web/src/serverRestartStore.test.ts
@@ -75,6 +75,22 @@ describe("serverRestartStore", () => {
         false,
       );
     });
+
+    it("does not dress up an unrelated outage as a restart once cleared", () => {
+      // The consumer clears the window after seeing the restart through, so a
+      // later ordinary outage inside the original 90s must read as an outage.
+      expectServerRestart(ENVIRONMENT_ID);
+      clearExpectedServerRestart(ENVIRONMENT_ID);
+      vi.advanceTimersByTime(10_000);
+
+      expect(expiresAtFor(ENVIRONMENT_ID)).toBeNull();
+      expect(
+        isServerRestarting({
+          restartExpected: expiresAtFor(ENVIRONMENT_ID) !== null,
+          environmentUnavailable: true,
+        }),
+      ).toBe(false);
+    });
   });
 
   describe("isExpectedRestartResolved", () => {

--- a/apps/web/src/serverRestartStore.test.ts
+++ b/apps/web/src/serverRestartStore.test.ts
@@ -1,0 +1,123 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  SERVER_RESTART_EXPECTED_WINDOW_MS,
+  clearExpectedServerRestart,
+  expectServerRestart,
+  isServerRestartSettled,
+  isServerRestarting,
+  markServerRestartDisconnected,
+  useServerRestartStore,
+} from "./serverRestartStore";
+
+const ENVIRONMENT_ID = "env-test" as EnvironmentId;
+
+function windowFor(environmentId: EnvironmentId) {
+  return useServerRestartStore.getState().windowByEnvironmentId[environmentId] ?? null;
+}
+
+describe("serverRestartStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useServerRestartStore.setState({ windowByEnvironmentId: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("arms a window that has not yet seen the restart's disconnect", () => {
+    expectServerRestart(ENVIRONMENT_ID);
+
+    // The window is armed while the old server is still connected, so the
+    // consumer must be able to tell "waiting for the restart" apart from
+    // "the restart already happened".
+    expect(windowFor(ENVIRONMENT_ID)?.sawDisconnect).toBe(false);
+    expect(windowFor(ENVIRONMENT_ID)?.expiresAt).toBe(
+      Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
+    );
+  });
+
+  it("remembers an observed disconnect across a re-arm", () => {
+    expectServerRestart(ENVIRONMENT_ID);
+    markServerRestartDisconnected(ENVIRONMENT_ID);
+
+    // A slow install acknowledging late re-arms the window; forgetting the
+    // disconnect here would strand the restarting UI until the window lapsed.
+    vi.advanceTimersByTime(30_000);
+    expectServerRestart(ENVIRONMENT_ID);
+
+    expect(windowFor(ENVIRONMENT_ID)?.sawDisconnect).toBe(true);
+    expect(windowFor(ENVIRONMENT_ID)?.expiresAt).toBe(
+      Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
+    );
+  });
+
+  it("ignores a disconnect for an environment with no armed window", () => {
+    markServerRestartDisconnected(ENVIRONMENT_ID);
+    expect(windowFor(ENVIRONMENT_ID)).toBeNull();
+  });
+
+  it("clears only the requested environment", () => {
+    const other = "env-other" as EnvironmentId;
+    expectServerRestart(ENVIRONMENT_ID);
+    expectServerRestart(other);
+
+    clearExpectedServerRestart(ENVIRONMENT_ID);
+
+    expect(windowFor(ENVIRONMENT_ID)).toBeNull();
+    expect(windowFor(other)).not.toBeNull();
+  });
+
+  describe("isServerRestarting", () => {
+    it("does not claim a still-connected environment is restarting", () => {
+      // The window is armed before dispatch, while the old server is still
+      // connected. Presenting that as "restarting" would fire the moment the
+      // user clicks, before anything has actually gone away.
+      expect(
+        isServerRestarting({
+          expectation: { expected: true, sawDisconnect: false },
+          environmentUnavailable: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("presents an armed window with an away environment as restarting", () => {
+      expect(
+        isServerRestarting({
+          expectation: { expected: true, sawDisconnect: true },
+          environmentUnavailable: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("falls back to the outage UI once the window lapses", () => {
+      // The server never came back; the calm banner must give way.
+      expect(
+        isServerRestarting({
+          expectation: { expected: false, sawDisconnect: true },
+          environmentUnavailable: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("isServerRestartSettled", () => {
+    it("does not treat a live window as settled", () => {
+      expect(isServerRestartSettled({ expected: true, sawDisconnect: true })).toBe(false);
+    });
+
+    it("treats an observed restart whose window has closed as settled", () => {
+      // Covers a rejected systemd restart: the RPC already acknowledged, so
+      // nothing else can tell the update action to release itself.
+      expect(isServerRestartSettled({ expected: false, sawDisconnect: true })).toBe(true);
+    });
+
+    it("does not settle a window that never saw a disconnect", () => {
+      // The restart simply never happened; the explicit-failure path owns
+      // that case, and settling here would release the action early.
+      expect(isServerRestartSettled({ expected: false, sawDisconnect: false })).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/serverRestartStore.ts
+++ b/apps/web/src/serverRestartStore.ts
@@ -9,11 +9,21 @@
  * machine stays transport-only, and this store is UI-side intent that
  * expires on its own if the server never comes back.
  *
- * The window is intentionally write-once-and-expire: it is armed while the
- * old server is still connected (the acknowledgement races its own
- * disconnect), and nothing observed on the connection can reliably end it
- * early. Presentation gates on the environment actually being unavailable,
- * so a lingering window is inert once the replacement is back.
+ * Ending the window is the subtle part. It is armed while the old server is
+ * still connected (the acknowledgement races its own disconnect), so a
+ * connected environment cannot by itself mean the restart is over — that is
+ * how an earlier revision made the whole feature inert. But never ending it
+ * is also wrong: an unrelated outage later in the window would be dressed up
+ * as an intentional restart. So the window ends when the environment has
+ * gone away and come back, i.e. the restart it was armed for has been seen.
+ *
+ * A blip during a long install can consume the window early; the
+ * acknowledgement re-arms it, which is what covers that case.
+ *
+ * Note this observation is only used for presentation. The update action's
+ * own release path deliberately does not depend on it — coupling the two is
+ * what produced a family of bugs where each consumer invalidated the other's
+ * evidence.
  */
 import type { EnvironmentId } from "@t3tools/contracts";
 import { useEffect, useReducer } from "react";

--- a/apps/web/src/serverRestartStore.ts
+++ b/apps/web/src/serverRestartStore.ts
@@ -1,0 +1,80 @@
+/**
+ * Environment-scoped "a server restart is expected" overlay.
+ *
+ * Set around a server self-update so the connection UI can tell an
+ * intentional restart apart from a genuine outage: while the window is
+ * active, disconnects present as a calm "restarting" notice and the client
+ * retries on a fast flat cadence instead of escalating backoff. This is
+ * deliberately not a connection-supervisor phase — the supervisor state
+ * machine stays transport-only, and this store is UI-side intent that
+ * expires on its own if the server never comes back.
+ */
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useEffect, useReducer } from "react";
+import { create } from "zustand";
+
+/**
+ * How long after the last update signal (dispatch, RPC acknowledgement, or
+ * interrupted RPC) a disconnect is still attributed to the restart. Covers
+ * the respawn shim (~3s), boot-service systemd swap, server boot, and relay
+ * re-registration with generous margin; after it lapses the normal error
+ * presentation returns.
+ */
+export const SERVER_RESTART_EXPECTED_WINDOW_MS = 90_000;
+
+interface ServerRestartState {
+  readonly expectedUntilByEnvironmentId: Readonly<Record<string, number>>;
+  readonly expect: (environmentId: EnvironmentId) => void;
+  readonly clear: (environmentId: EnvironmentId) => void;
+}
+
+export const useServerRestartStore = create<ServerRestartState>()((set) => ({
+  expectedUntilByEnvironmentId: {},
+  expect: (environmentId) =>
+    set((state) => ({
+      expectedUntilByEnvironmentId: {
+        ...state.expectedUntilByEnvironmentId,
+        [environmentId]: Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
+      },
+    })),
+  clear: (environmentId) =>
+    set((state) => {
+      if (!(environmentId in state.expectedUntilByEnvironmentId)) {
+        return state;
+      }
+      const next = { ...state.expectedUntilByEnvironmentId };
+      delete next[environmentId];
+      return { expectedUntilByEnvironmentId: next };
+    }),
+}));
+
+export function expectServerRestart(environmentId: EnvironmentId): void {
+  useServerRestartStore.getState().expect(environmentId);
+}
+
+export function clearExpectedServerRestart(environmentId: EnvironmentId): void {
+  useServerRestartStore.getState().clear(environmentId);
+}
+
+/**
+ * Whether a restart window is currently active for the environment.
+ * Re-renders when the window is set, cleared, or lapses.
+ */
+export function useServerRestartExpected(environmentId: EnvironmentId | null): boolean {
+  const expiresAt = useServerRestartStore((state) =>
+    environmentId === null ? null : (state.expectedUntilByEnvironmentId[environmentId] ?? null),
+  );
+  const [, tick] = useReducer((count: number) => count + 1, 0);
+  useEffect(() => {
+    if (expiresAt === null) {
+      return;
+    }
+    const remaining = expiresAt - Date.now();
+    if (remaining <= 0) {
+      return;
+    }
+    const timer = setTimeout(tick, remaining + 50);
+    return () => clearTimeout(timer);
+  }, [expiresAt]);
+  return expiresAt !== null && expiresAt > Date.now();
+}

--- a/apps/web/src/serverRestartStore.ts
+++ b/apps/web/src/serverRestartStore.ts
@@ -8,6 +8,12 @@
  * deliberately not a connection-supervisor phase — the supervisor state
  * machine stays transport-only, and this store is UI-side intent that
  * expires on its own if the server never comes back.
+ *
+ * The window is intentionally write-once-and-expire: it is armed while the
+ * old server is still connected (the acknowledgement races its own
+ * disconnect), and nothing observed on the connection can reliably end it
+ * early. Presentation gates on the environment actually being unavailable,
+ * so a lingering window is inert once the replacement is back.
  */
 import type { EnvironmentId } from "@t3tools/contracts";
 import { useEffect, useReducer } from "react";
@@ -22,60 +28,29 @@ import { create } from "zustand";
  */
 export const SERVER_RESTART_EXPECTED_WINDOW_MS = 90_000;
 
-interface ServerRestartWindow {
-  readonly expiresAt: number;
-  /**
-   * Whether the environment has actually gone away since the window was
-   * armed. The window is armed while the old server is still connected — that
-   * is the point, since the acknowledgement races its own disconnect — so a
-   * connected environment must not end the window until the restart it is
-   * waiting for has been observed.
-   */
-  readonly sawDisconnect: boolean;
-}
-
 interface ServerRestartState {
-  readonly windowByEnvironmentId: Readonly<Record<string, ServerRestartWindow>>;
+  readonly expiresAtByEnvironmentId: Readonly<Record<string, number>>;
   readonly expect: (environmentId: EnvironmentId) => void;
-  readonly markDisconnected: (environmentId: EnvironmentId) => void;
   readonly clear: (environmentId: EnvironmentId) => void;
 }
 
 export const useServerRestartStore = create<ServerRestartState>()((set) => ({
-  windowByEnvironmentId: {},
+  expiresAtByEnvironmentId: {},
   expect: (environmentId) =>
     set((state) => ({
-      windowByEnvironmentId: {
-        ...state.windowByEnvironmentId,
-        [environmentId]: {
-          expiresAt: Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
-          // Re-arming (a slow install acknowledging late) must not forget a
-          // disconnect that was already observed.
-          sawDisconnect: state.windowByEnvironmentId[environmentId]?.sawDisconnect ?? false,
-        },
+      expiresAtByEnvironmentId: {
+        ...state.expiresAtByEnvironmentId,
+        [environmentId]: Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
       },
     })),
-  markDisconnected: (environmentId) =>
-    set((state) => {
-      const current = state.windowByEnvironmentId[environmentId];
-      if (current === undefined || current.sawDisconnect) {
-        return state;
-      }
-      return {
-        windowByEnvironmentId: {
-          ...state.windowByEnvironmentId,
-          [environmentId]: { ...current, sawDisconnect: true },
-        },
-      };
-    }),
   clear: (environmentId) =>
     set((state) => {
-      if (!(environmentId in state.windowByEnvironmentId)) {
+      if (!(environmentId in state.expiresAtByEnvironmentId)) {
         return state;
       }
-      const next = { ...state.windowByEnvironmentId };
+      const next = { ...state.expiresAtByEnvironmentId };
       delete next[environmentId];
-      return { windowByEnvironmentId: next };
+      return { expiresAtByEnvironmentId: next };
     }),
 }));
 
@@ -83,58 +58,18 @@ export function expectServerRestart(environmentId: EnvironmentId): void {
   useServerRestartStore.getState().expect(environmentId);
 }
 
-/** Records that the expected restart's disconnect has now been observed. */
-export function markServerRestartDisconnected(environmentId: EnvironmentId): void {
-  useServerRestartStore.getState().markDisconnected(environmentId);
-}
-
 export function clearExpectedServerRestart(environmentId: EnvironmentId): void {
   useServerRestartStore.getState().clear(environmentId);
 }
 
-export interface ServerRestartExpectation {
-  /** An unexpired restart window is armed for this environment. */
-  readonly expected: boolean;
-  /** The restart's disconnect has been observed, so a reconnect ends it. */
-  readonly sawDisconnect: boolean;
-}
-
 /**
- * Whether an armed restart window has run its course: the disconnect was
- * observed and the window has since closed. Callers use this to recover UI
- * that was held for the restart — the update RPC is acknowledged before the
- * restart runs, so a rejected restart cannot report itself through the call.
- *
- * Note that a window which never saw a disconnect is not "settled": the
- * restart simply never happened, and other paths (an explicit RPC failure)
- * own that case.
+ * Whether an unexpired restart window is armed for the environment.
+ * Re-renders when the window is armed, cleared, or lapses.
  */
-export function isServerRestartSettled(expectation: ServerRestartExpectation): boolean {
-  return expectation.sawDisconnect && !expectation.expected;
-}
-
-/**
- * Whether the environment should currently be presented as restarting rather
- * than as an outage: a live window plus an environment that is actually away.
- */
-export function isServerRestarting(input: {
-  readonly expectation: ServerRestartExpectation;
-  readonly environmentUnavailable: boolean;
-}): boolean {
-  return input.expectation.expected && input.environmentUnavailable;
-}
-
-/**
- * The restart window state for an environment. Re-renders when the window is
- * armed, observes its disconnect, is cleared, or lapses.
- */
-export function useServerRestartExpectation(
-  environmentId: EnvironmentId | null,
-): ServerRestartExpectation {
-  const window = useServerRestartStore((state) =>
-    environmentId === null ? null : (state.windowByEnvironmentId[environmentId] ?? null),
+export function useServerRestartExpected(environmentId: EnvironmentId | null): boolean {
+  const expiresAt = useServerRestartStore((state) =>
+    environmentId === null ? null : (state.expiresAtByEnvironmentId[environmentId] ?? null),
   );
-  const expiresAt = window?.expiresAt ?? null;
   const [, tick] = useReducer((count: number) => count + 1, 0);
   useEffect(() => {
     if (expiresAt === null) {
@@ -147,8 +82,47 @@ export function useServerRestartExpectation(
     const timer = setTimeout(tick, remaining + 50);
     return () => clearTimeout(timer);
   }, [expiresAt]);
-  return {
-    expected: expiresAt !== null && expiresAt > Date.now(),
-    sawDisconnect: window?.sawDisconnect === true,
-  };
+  return expiresAt !== null && expiresAt > Date.now();
+}
+
+/**
+ * Whether the environment should be presented as restarting rather than as an
+ * outage. Requires the environment to actually be away, which is why a window
+ * that outlives its restart is harmless: a reconnected environment reports
+ * false regardless of the window.
+ */
+export function isServerRestarting(input: {
+  readonly restartExpected: boolean;
+  readonly environmentUnavailable: boolean;
+}): boolean {
+  return input.restartExpected && input.environmentUnavailable;
+}
+
+/**
+ * Whether an expected restart has resolved without delivering a new version,
+ * so UI held for it should be released.
+ *
+ * The update RPC is acknowledged before the restart runs, so a rejected
+ * restart cannot report itself through the call. Two shapes resolve it,
+ * because a rejected restart may or may not have dropped the connection:
+ * the environment went away and came back (something restarted, but the skew
+ * is still here), or the window lapsed while the connection never dropped
+ * (no restart ever happened).
+ */
+export function isExpectedRestartResolved(input: {
+  /** A restart window was observed as armed at some point. */
+  readonly sawRestartWindow: boolean;
+  /** A restart window is armed right now. */
+  readonly restartExpected: boolean;
+  /** The environment has been unavailable at some point since arming. */
+  readonly wentAway: boolean;
+  readonly environmentUnavailable: boolean;
+}): boolean {
+  if (input.environmentUnavailable) {
+    return false;
+  }
+  if (input.wentAway) {
+    return true;
+  }
+  return input.sawRestartWindow && !input.restartExpected;
 }

--- a/apps/web/src/serverRestartStore.ts
+++ b/apps/web/src/serverRestartStore.ts
@@ -22,29 +22,60 @@ import { create } from "zustand";
  */
 export const SERVER_RESTART_EXPECTED_WINDOW_MS = 90_000;
 
+interface ServerRestartWindow {
+  readonly expiresAt: number;
+  /**
+   * Whether the environment has actually gone away since the window was
+   * armed. The window is armed while the old server is still connected — that
+   * is the point, since the acknowledgement races its own disconnect — so a
+   * connected environment must not end the window until the restart it is
+   * waiting for has been observed.
+   */
+  readonly sawDisconnect: boolean;
+}
+
 interface ServerRestartState {
-  readonly expectedUntilByEnvironmentId: Readonly<Record<string, number>>;
+  readonly windowByEnvironmentId: Readonly<Record<string, ServerRestartWindow>>;
   readonly expect: (environmentId: EnvironmentId) => void;
+  readonly markDisconnected: (environmentId: EnvironmentId) => void;
   readonly clear: (environmentId: EnvironmentId) => void;
 }
 
 export const useServerRestartStore = create<ServerRestartState>()((set) => ({
-  expectedUntilByEnvironmentId: {},
+  windowByEnvironmentId: {},
   expect: (environmentId) =>
     set((state) => ({
-      expectedUntilByEnvironmentId: {
-        ...state.expectedUntilByEnvironmentId,
-        [environmentId]: Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
+      windowByEnvironmentId: {
+        ...state.windowByEnvironmentId,
+        [environmentId]: {
+          expiresAt: Date.now() + SERVER_RESTART_EXPECTED_WINDOW_MS,
+          // Re-arming (a slow install acknowledging late) must not forget a
+          // disconnect that was already observed.
+          sawDisconnect: state.windowByEnvironmentId[environmentId]?.sawDisconnect ?? false,
+        },
       },
     })),
-  clear: (environmentId) =>
+  markDisconnected: (environmentId) =>
     set((state) => {
-      if (!(environmentId in state.expectedUntilByEnvironmentId)) {
+      const current = state.windowByEnvironmentId[environmentId];
+      if (current === undefined || current.sawDisconnect) {
         return state;
       }
-      const next = { ...state.expectedUntilByEnvironmentId };
+      return {
+        windowByEnvironmentId: {
+          ...state.windowByEnvironmentId,
+          [environmentId]: { ...current, sawDisconnect: true },
+        },
+      };
+    }),
+  clear: (environmentId) =>
+    set((state) => {
+      if (!(environmentId in state.windowByEnvironmentId)) {
+        return state;
+      }
+      const next = { ...state.windowByEnvironmentId };
       delete next[environmentId];
-      return { expectedUntilByEnvironmentId: next };
+      return { windowByEnvironmentId: next };
     }),
 }));
 
@@ -52,18 +83,58 @@ export function expectServerRestart(environmentId: EnvironmentId): void {
   useServerRestartStore.getState().expect(environmentId);
 }
 
+/** Records that the expected restart's disconnect has now been observed. */
+export function markServerRestartDisconnected(environmentId: EnvironmentId): void {
+  useServerRestartStore.getState().markDisconnected(environmentId);
+}
+
 export function clearExpectedServerRestart(environmentId: EnvironmentId): void {
   useServerRestartStore.getState().clear(environmentId);
 }
 
+export interface ServerRestartExpectation {
+  /** An unexpired restart window is armed for this environment. */
+  readonly expected: boolean;
+  /** The restart's disconnect has been observed, so a reconnect ends it. */
+  readonly sawDisconnect: boolean;
+}
+
 /**
- * Whether a restart window is currently active for the environment.
- * Re-renders when the window is set, cleared, or lapses.
+ * Whether an armed restart window has run its course: the disconnect was
+ * observed and the window has since closed. Callers use this to recover UI
+ * that was held for the restart — the update RPC is acknowledged before the
+ * restart runs, so a rejected restart cannot report itself through the call.
+ *
+ * Note that a window which never saw a disconnect is not "settled": the
+ * restart simply never happened, and other paths (an explicit RPC failure)
+ * own that case.
  */
-export function useServerRestartExpected(environmentId: EnvironmentId | null): boolean {
-  const expiresAt = useServerRestartStore((state) =>
-    environmentId === null ? null : (state.expectedUntilByEnvironmentId[environmentId] ?? null),
+export function isServerRestartSettled(expectation: ServerRestartExpectation): boolean {
+  return expectation.sawDisconnect && !expectation.expected;
+}
+
+/**
+ * Whether the environment should currently be presented as restarting rather
+ * than as an outage: a live window plus an environment that is actually away.
+ */
+export function isServerRestarting(input: {
+  readonly expectation: ServerRestartExpectation;
+  readonly environmentUnavailable: boolean;
+}): boolean {
+  return input.expectation.expected && input.environmentUnavailable;
+}
+
+/**
+ * The restart window state for an environment. Re-renders when the window is
+ * armed, observes its disconnect, is cleared, or lapses.
+ */
+export function useServerRestartExpectation(
+  environmentId: EnvironmentId | null,
+): ServerRestartExpectation {
+  const window = useServerRestartStore((state) =>
+    environmentId === null ? null : (state.windowByEnvironmentId[environmentId] ?? null),
   );
+  const expiresAt = window?.expiresAt ?? null;
   const [, tick] = useReducer((count: number) => count + 1, 0);
   useEffect(() => {
     if (expiresAt === null) {
@@ -76,5 +147,8 @@ export function useServerRestartExpected(environmentId: EnvironmentId | null): b
     const timer = setTimeout(tick, remaining + 50);
     return () => clearTimeout(timer);
   }, [expiresAt]);
-  return expiresAt !== null && expiresAt > Date.now();
+  return {
+    expected: expiresAt !== null && expiresAt > Date.now(),
+    sawDisconnect: window?.sawDisconnect === true,
+  };
 }

--- a/apps/web/src/useServerRestartReconnect.test.ts
+++ b/apps/web/src/useServerRestartReconnect.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  MAX_RETRIES_PER_WINDOW,
+  restartRetryDelayMs,
+  shouldPokeRestartRetry,
+} from "./useServerRestartReconnect";
+
+describe("restart reconnect pacing", () => {
+  it("starts fast so a backoff sleep cannot outlast the server's return", () => {
+    expect(restartRetryDelayMs(0)).toBe(2_000);
+    expect(restartRetryDelayMs(1)).toBe(2_000);
+  });
+
+  it("eases off rather than polling at a fixed rate for the whole window", () => {
+    const delays = [0, 1, 2, 3, 4, 5, 20].map(restartRetryDelayMs);
+    // Monotonic, and flat once it reaches the ceiling.
+    for (let index = 1; index < delays.length; index++) {
+      expect(delays[index]).toBeGreaterThanOrEqual(delays[index - 1] ?? 0);
+    }
+    expect(restartRetryDelayMs(20)).toBe(8_000);
+  });
+
+  describe("shouldPokeRestartRetry", () => {
+    const base = { connected: false, retryAt: 1, attempts: 0 };
+
+    it("pokes a supervisor asleep in backoff", () => {
+      expect(shouldPokeRestartRetry(base)).toBe(true);
+    });
+
+    it("does not poke a connected environment", () => {
+      expect(shouldPokeRestartRetry({ ...base, connected: true })).toBe(false);
+    });
+
+    it("does not interrupt a live connection attempt", () => {
+      // retryAt is null while an attempt is in flight; waking it would tear
+      // the attempt down and restart it, making reconnection slower.
+      expect(shouldPokeRestartRetry({ ...base, retryAt: null })).toBe(false);
+    });
+
+    it("stops once the retry budget is spent", () => {
+      // The window is a duration, not a budget. Without the cap a server that
+      // never returns would be retried for the window's full length, and each
+      // poke rebuilds a connection attempt.
+      expect(shouldPokeRestartRetry({ ...base, attempts: MAX_RETRIES_PER_WINDOW - 1 })).toBe(true);
+      expect(shouldPokeRestartRetry({ ...base, attempts: MAX_RETRIES_PER_WINDOW })).toBe(false);
+      expect(shouldPokeRestartRetry({ ...base, attempts: MAX_RETRIES_PER_WINDOW + 5 })).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/useServerRestartReconnect.ts
+++ b/apps/web/src/useServerRestartReconnect.ts
@@ -1,0 +1,151 @@
+/**
+ * Drives expected-restart reconnection for every environment with an armed
+ * restart window, wherever the update was triggered from.
+ *
+ * This is mounted once at the app level rather than in a route: the update
+ * action appears in the chat composer's version-mismatch banner *and* in
+ * Settings → Connections, and the restart it schedules outlives whatever view
+ * the user happens to be on. Scoping this to one view meant an update started
+ * from Settings got no fast reconnect and left its window uncleared.
+ */
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useEffect, useRef } from "react";
+
+import { environmentCatalog } from "./connection/catalog";
+import { clearExpectedServerRestart, useServerRestartStore } from "./serverRestartStore";
+import { useEnvironments } from "./state/environments";
+import { useAtomCommand } from "./state/use-atom-command";
+
+/**
+ * Retry cadence while a restart is expected. Starts fast — a restart is back
+ * in seconds, and the supervisor's own 1s→16s escalation is what strands the
+ * client — then eases off so a server that never returns is not polled at a
+ * fixed 2s for the whole window.
+ */
+const RETRY_DELAYS_MS = [2_000, 2_000, 3_000, 5_000, 8_000] as const;
+
+/**
+ * Upper bound on pokes per restart window. The window is a duration, not a
+ * budget, so without a cap a slow-starting server would be retried for its
+ * full length; each poke tears down and rebuilds a connection attempt, so a
+ * runaway loop is real work. Reaching the cap leaves normal supervisor
+ * backoff in charge, which is the correct end state for a server that is not
+ * coming back.
+ */
+export const MAX_RETRIES_PER_WINDOW = 12;
+
+export function restartRetryDelayMs(attempt: number): number {
+  return RETRY_DELAYS_MS[Math.min(attempt, RETRY_DELAYS_MS.length - 1)] ?? 8_000;
+}
+
+/**
+ * Whether to poke the supervisor for an environment inside a restart window.
+ * Requires a supervisor asleep in backoff (waking a live attempt restarts it,
+ * making reconnection slower) and an unspent retry budget.
+ */
+export function shouldPokeRestartRetry(input: {
+  readonly connected: boolean;
+  readonly retryAt: number | null;
+  readonly attempts: number;
+}): boolean {
+  if (input.connected || input.retryAt == null) {
+    return false;
+  }
+  return input.attempts < MAX_RETRIES_PER_WINDOW;
+}
+
+interface RestartProgress {
+  /** Pokes issued for the current window. */
+  attempts: number;
+  /** The restart's disconnect has been observed for this window. */
+  sawDisconnect: boolean;
+  /** Window identity, so a re-armed window restarts the budget. */
+  expiresAt: number;
+}
+
+export function useServerRestartReconnect(): void {
+  const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
+  const expiresAtByEnvironmentId = useServerRestartStore((state) => state.expiresAtByEnvironmentId);
+  const { environments } = useEnvironments();
+  const progressRef = useRef(new Map<string, RestartProgress>());
+
+  // Effects key off primitives so an unstable environment array identity
+  // cannot restart the timer on every unrelated render.
+  const armed = environments
+    .filter((environment) => expiresAtByEnvironmentId[environment.environmentId] !== undefined)
+    .map((environment) => ({
+      environmentId: environment.environmentId,
+      expiresAt: expiresAtByEnvironmentId[environment.environmentId] ?? 0,
+      connected: environment.connection.phase === "connected",
+      // Only wake a supervisor that is asleep in backoff; interrupting a live
+      // attempt would restart it and make things slower, not faster.
+      retryAt: environment.connection.retryAt,
+    }));
+  const armedKey = armed
+    .map(
+      (entry) =>
+        `${entry.environmentId}:${entry.expiresAt}:${String(entry.connected)}:${String(entry.retryAt ?? 0)}`,
+    )
+    .join("|");
+
+  useEffect(() => {
+    const progress = progressRef.current;
+    for (const key of Array.from(progress.keys())) {
+      if (!armed.some((entry) => entry.environmentId === key)) {
+        progress.delete(key);
+      }
+    }
+
+    const timers: Array<ReturnType<typeof setTimeout>> = [];
+    for (const entry of armed) {
+      const current = progress.get(entry.environmentId);
+      const state: RestartProgress =
+        current === undefined || current.expiresAt !== entry.expiresAt
+          ? {
+              attempts: 0,
+              sawDisconnect: current?.sawDisconnect ?? false,
+              expiresAt: entry.expiresAt,
+            }
+          : current;
+      progress.set(entry.environmentId, state);
+
+      if (entry.connected) {
+        // Ending the window needs the disconnect to have been seen first: it
+        // is armed while the old server is still connected, so "connected"
+        // alone would clear it before the restart it exists to cover. Never
+        // clearing is equally wrong — a later unrelated outage would then be
+        // dressed up as an intentional restart.
+        if (state.sawDisconnect) {
+          progress.delete(entry.environmentId);
+          clearExpectedServerRestart(entry.environmentId as EnvironmentId);
+        }
+        continue;
+      }
+
+      state.sawDisconnect = true;
+      if (
+        !shouldPokeRestartRetry({
+          connected: entry.connected,
+          retryAt: entry.retryAt,
+          attempts: state.attempts,
+        })
+      ) {
+        continue;
+      }
+      const delay = restartRetryDelayMs(state.attempts);
+      timers.push(
+        setTimeout(() => {
+          state.attempts += 1;
+          void retryEnvironment(entry.environmentId as EnvironmentId);
+        }, delay),
+      );
+    }
+    return () => {
+      for (const timer of timers) {
+        clearTimeout(timer);
+      }
+    };
+    // armedKey is the stable serialization of `armed`; depending on the array
+    // itself would re-run this on every render.
+  }, [armedKey, retryEnvironment]);
+}

--- a/packages/client-runtime/src/authorization/layer.test.ts
+++ b/packages/client-runtime/src/authorization/layer.test.ts
@@ -316,6 +316,42 @@ describe("RemoteEnvironmentAuthorization", () => {
     }),
   );
 
+  it.effect("keeps a cached token when the endpoint is merely unreachable", () =>
+    Effect.gen(function* () {
+      const cached = new TokenStore.RemoteDpopAccessToken({
+        environmentId: ENVIRONMENT_ID,
+        label: DESCRIPTOR.label,
+        endpoint: ENDPOINT,
+        accessToken: "cached-access-token",
+        expiresAtEpochMs: Number.MAX_SAFE_INTEGER,
+        dpopThumbprint: "thumbprint-1",
+      });
+      // A restarting server refuses connections outright rather than
+      // answering; re-bootstrapping would not produce a better endpoint, so
+      // the token must survive to keep reconnects to a single request.
+      const harness = yield* makeHarness({
+        initialToken: cached,
+        responses: [],
+      });
+
+      yield* Effect.gen(function* () {
+        const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const failure = yield* remote
+            .authorizeDpop({
+              expectedEnvironmentId: ENVIRONMENT_ID,
+              obtainBootstrap: harness.obtainBootstrap,
+            })
+            .pipe(Effect.flip);
+          expect(failure._tag).toBe("ConnectionTransientError");
+        }
+      }).pipe(Effect.provide(harness.layer));
+
+      expect((yield* Ref.get(harness.tokens)).get(ENVIRONMENT_ID)).toBe(cached);
+      expect(yield* Ref.get(harness.bootstrapCalls)).toBe(0);
+    }),
+  );
+
   it.effect("does not persist a refreshed token until its websocket ticket succeeds", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -60,6 +60,24 @@ export class RemoteEnvironmentAuthorization extends Context.Service<
 const TOKEN_EXPIRY_SAFETY_MARGIN_MS = 60_000;
 const CACHED_ENDPOINT_FAILURE_THRESHOLD = 2;
 
+/**
+ * Transient reasons that suggest the *cached endpoint itself* is stale —
+ * something answered and rejected or could not route the request — so
+ * re-bootstrapping may hand back a different endpoint.
+ *
+ * `network` and `timeout` are excluded on purpose: they only prove the
+ * endpoint was unreachable right now, which is the normal shape of a server
+ * restart or a brief outage. Evicting on those threw away a perfectly good
+ * token and forced a full relay bootstrap + token exchange on every
+ * reconnect, adding latency exactly when the server was coming back.
+ */
+const CACHED_ENDPOINT_STALE_REASONS: ReadonlySet<string> = new Set([
+  "endpoint-unavailable",
+  "remote-unavailable",
+  "relay-unavailable",
+  "transport",
+]);
+
 function mapDpopSocketError(error: RemoteEnvironmentAuthError | ConnectionAttemptError) {
   return error._tag === "ConnectionTransientError" || error._tag === "ConnectionBlockedError"
     ? error
@@ -215,6 +233,11 @@ export const make = Effect.gen(function* () {
         }
         const mappedFailure = mapDpopSocketError(cachedSocket.failure);
         if (mappedFailure._tag === "ConnectionTransientError") {
+          if (!CACHED_ENDPOINT_STALE_REASONS.has(mappedFailure.reason)) {
+            // Pure unreachability: keep the cached token so the next attempt
+            // is a single ticket request rather than a full re-bootstrap.
+            return yield* mappedFailure;
+          }
           const failureCount = yield* recordCachedEndpointFailure(input.expectedEnvironmentId);
           if (failureCount < CACHED_ENDPOINT_FAILURE_THRESHOLD) {
             return yield* mappedFailure;

--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -5,6 +5,7 @@ import * as Option from "effect/Option";
 import { BearerConnectionProfile, type ConnectionCatalogEntry } from "./catalog.ts";
 import {
   BearerConnectionTarget,
+  ConnectionBlockedError,
   ConnectionTransientError,
   type SupervisorConnectionState,
 } from "./model.ts";
@@ -59,7 +60,9 @@ describe("connection presentation", () => {
     expect(presentConnectionState(supervisorState({ phase: "connecting", attempt: 1 }))).toEqual({
       phase: "connecting",
       error: null,
+      reason: null,
       traceId: null,
+      retryAt: null,
     });
     expect(
       presentConnectionState(
@@ -75,8 +78,10 @@ describe("connection presentation", () => {
       ),
     ).toEqual({
       phase: "reconnecting",
-      error: "Socket closed.",
+      error: "The connection to the environment was interrupted.",
+      reason: "transport",
       traceId: "trace-previous",
+      retryAt: null,
     });
     expect(
       presentConnectionState(
@@ -93,8 +98,48 @@ describe("connection presentation", () => {
       ),
     ).toEqual({
       phase: "reconnecting",
-      error: "Disconnected.",
+      error: "The connection to the environment was interrupted.",
+      reason: "transport",
       traceId: "trace-1",
+      retryAt: 1,
+    });
+  });
+
+  it("summarizes transport failures without exposing endpoint internals", () => {
+    const presented = presentConnectionState(
+      supervisorState({
+        phase: "backoff",
+        attempt: 2,
+        retryAt: 5,
+        lastFailure: new ConnectionTransientError({
+          reason: "network",
+          detail:
+            "Failed to fetch remote environment endpoint https://prod-6e7fc14fddd8f0fb.t3coderelay.com/api/auth/websocket-ticket (HttpClientError: Transport error).",
+        }),
+      }),
+    );
+    expect(presented.error).toBe("The environment could not be reached.");
+    expect(presented.error).not.toContain("t3coderelay.com");
+    expect(presented.reason).toBe("network");
+  });
+
+  it("keeps authored blocked-failure messages, which are already actionable", () => {
+    expect(
+      presentConnectionState(
+        supervisorState({
+          phase: "blocked",
+          lastFailure: new ConnectionBlockedError({
+            reason: "authentication",
+            detail: "The environment credential is invalid.",
+          }),
+        }),
+      ),
+    ).toEqual({
+      phase: "error",
+      error: "The environment credential is invalid.",
+      reason: "authentication",
+      traceId: null,
+      retryAt: null,
     });
   });
 
@@ -106,7 +151,7 @@ describe("connection presentation", () => {
           stage: "opening",
           attempt: 2,
           lastFailure: new ConnectionTransientError({
-            reason: "transport",
+            reason: "timeout",
             detail: "Relay connection timed out.",
             traceId: "trace-retry",
           }),
@@ -114,8 +159,10 @@ describe("connection presentation", () => {
       ),
     ).toEqual({
       phase: "reconnecting",
-      error: "Relay connection timed out.",
+      error: "The environment did not respond in time.",
+      reason: "timeout",
       traceId: "trace-retry",
+      retryAt: null,
     });
   });
 
@@ -127,7 +174,9 @@ describe("connection presentation", () => {
     const connection = {
       phase: "reconnecting",
       error: "Relay request timed out.",
+      reason: "timeout",
       traceId: "trace-retry",
+      retryAt: null,
     } as const;
     expect(connectionStatusText(connection)).toBe(
       "Failed to connect. Reconnecting... Reason: Relay request timed out.",
@@ -147,7 +196,9 @@ describe("connection presentation", () => {
     ).toEqual({
       phase: "offline",
       error: null,
+      reason: null,
       traceId: null,
+      retryAt: null,
     });
   });
 
@@ -163,7 +214,9 @@ describe("connection presentation", () => {
     ).toEqual({
       phase: "connected",
       error: null,
+      reason: null,
       traceId: null,
+      retryAt: null,
     });
   });
 
@@ -181,7 +234,9 @@ describe("connection presentation", () => {
     ).toEqual({
       phase: "available",
       error: null,
+      reason: null,
       traceId: null,
+      retryAt: null,
     });
   });
 });

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -2,7 +2,7 @@ import type { ServerConfig } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 
 import type { ConnectionCatalogEntry } from "./catalog.ts";
-import type { NetworkStatus, SupervisorConnectionState } from "./model.ts";
+import type { ConnectionAttemptError, NetworkStatus, SupervisorConnectionState } from "./model.ts";
 
 export type EnvironmentConnectionPhase =
   | "available"
@@ -12,10 +12,18 @@ export type EnvironmentConnectionPhase =
   | "connected"
   | "error";
 
+export type EnvironmentConnectionFailureReason = ConnectionAttemptError["reason"];
+
 export interface EnvironmentConnectionPresentation {
   readonly phase: EnvironmentConnectionPhase;
   readonly error: string | null;
+  readonly reason: EnvironmentConnectionFailureReason | null;
   readonly traceId: string | null;
+  /** Epoch ms of the next scheduled attempt while the supervisor sleeps in
+      backoff; null while an attempt is live. Callers that want to retry
+      early (retryNow) should only do so while this is set — waking an
+      in-flight attempt cancels and restarts it. */
+  readonly retryAt: number | null;
 }
 
 export interface EnvironmentPresentation {
@@ -24,38 +32,91 @@ export interface EnvironmentPresentation {
   readonly serverConfig: ServerConfig | null;
 }
 
+/**
+ * Transport errors carry internal endpoint URLs and raw causes (see
+ * rpc/http.ts) that belong in diagnostics, not user-facing banners. Present
+ * a stable per-reason summary instead; the raw message stays available on
+ * the supervisor state for connection diagnostics.
+ */
+export function connectionFailureSummary(failure: ConnectionAttemptError): string {
+  switch (failure.reason) {
+    case "network":
+      return "The environment could not be reached.";
+    case "transport":
+      return "The connection to the environment was interrupted.";
+    case "timeout":
+      return "The environment did not respond in time.";
+    case "endpoint-unavailable":
+    case "remote-unavailable":
+      return "The environment is not accepting connections yet.";
+    case "relay-unavailable":
+      return "The relay is temporarily unavailable.";
+    // Blocked reasons are actionable, and their details are authored
+    // messages (errors.ts) rather than raw transport dumps.
+    case "authentication":
+    case "permission":
+    case "configuration":
+    case "unsupported":
+      return failure.message;
+  }
+}
+
+function presentFailure(failure: ConnectionAttemptError | null): {
+  readonly error: string | null;
+  readonly reason: EnvironmentConnectionFailureReason | null;
+  readonly traceId: string | null;
+} {
+  if (failure === null) {
+    return { error: null, reason: null, traceId: null };
+  }
+  return {
+    error: connectionFailureSummary(failure),
+    reason: failure.reason,
+    traceId: failure.traceId ?? null,
+  };
+}
+
 export function presentConnectionState(
   state: SupervisorConnectionState,
 ): EnvironmentConnectionPresentation {
   switch (state.phase) {
     case "available":
-      return { phase: "available", error: null, traceId: null };
+      return { phase: "available", ...presentFailure(null), retryAt: null };
     case "offline":
-      return { phase: "offline", error: null, traceId: null };
+      return { phase: "offline", ...presentFailure(null), retryAt: null };
     case "connecting":
       return {
         phase: state.attempt <= 1 && state.lastFailure === null ? "connecting" : "reconnecting",
-        error: state.lastFailure?.message ?? null,
-        traceId: state.lastFailure?.traceId ?? null,
+        ...presentFailure(state.lastFailure),
+        retryAt: null,
       };
     case "connected":
-      return { phase: "connected", error: null, traceId: null };
+      return { phase: "connected", ...presentFailure(null), retryAt: null };
     case "backoff":
       return {
         phase: "reconnecting",
-        error: state.lastFailure?.message ?? null,
-        traceId: state.lastFailure?.traceId ?? null,
+        ...presentFailure(state.lastFailure),
+        retryAt: state.retryAt,
       };
     case "blocked":
       return {
         phase: "error",
-        error: state.lastFailure?.message ?? null,
-        traceId: state.lastFailure?.traceId ?? null,
+        ...presentFailure(state.lastFailure),
+        retryAt: null,
       };
   }
 }
 
-export function connectionStatusText(connection: EnvironmentConnectionPresentation): string {
+/** The status helpers only read phase and error, so callers holding a phase
+    and a message do not have to synthesize a whole presentation. traceId is
+    accepted (and ignored) because callers commonly carry it alongside. */
+export interface ConnectionStatusTextInput {
+  readonly phase: EnvironmentConnectionPhase;
+  readonly error: string | null;
+  readonly traceId?: string | null;
+}
+
+export function connectionStatusText(connection: ConnectionStatusTextInput): string {
   switch (connection.phase) {
     case "available":
       return "Available";
@@ -76,7 +137,7 @@ export function connectionStatusText(connection: EnvironmentConnectionPresentati
   }
 }
 
-export function connectionStatusTitle(connection: EnvironmentConnectionPresentation): string {
+export function connectionStatusTitle(connection: ConnectionStatusTextInput): string {
   if (connection.phase === "reconnecting" && connection.error) {
     return "Failed to connect. Reconnecting...";
   }

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -590,6 +590,12 @@ export const ServerSelfUpdateResult = Schema.Struct({
 });
 export type ServerSelfUpdateResult = typeof ServerSelfUpdateResult.Type;
 
+/** Rejection reason when an update is dispatched while one is already
+    installing. Shared so clients can tell "nothing is happening" apart from
+    "a restart is already pending from an earlier request", which the update
+    UI must not treat as the end of the flow. */
+export const SERVER_SELF_UPDATE_ALREADY_RUNNING_REASON = "A server update is already in progress.";
+
 export class ServerSelfUpdateError extends Schema.TaggedErrorClass<ServerSelfUpdateError>()(
   "ServerSelfUpdateError",
   {
@@ -599,5 +605,10 @@ export class ServerSelfUpdateError extends Schema.TaggedErrorClass<ServerSelfUpd
 ) {
   override get message(): string {
     return `Server update failed: ${this.reason}`;
+  }
+
+  /** True when this rejection means an earlier update is still in flight. */
+  get isAlreadyRunning(): boolean {
+    return this.reason === SERVER_SELF_UPDATE_ALREADY_RUNNING_REASON;
   }
 }


### PR DESCRIPTION
Clicking **Update server** on a relay-connected server showed a spinner, then a disconnected banner with a raw transport error, then hung until the page was refreshed.


Three separate causes, fixed independently — the last two improve every reconnect, not just updates.

### 1. The update RPC never acknowledged on the systemd path

`selfUpdate.ts` ran `systemctl --user restart` synchronously inside the RPC handler, so the process died before the acknowledgement flushed. Every *successful* update reached the client as an interrupt, which `ServerUpdateAction` released quietly — no success toast, and nothing told the connection layer a restart was coming. (The respawn path already deferred its exit by 2s, so it usually won that race.)

The restart is now deferred the same way. The trade-off: a rejected restart can no longer be reported through the already-acknowledged RPC, so rollback and the in-flight reset move onto the detached fiber and log instead. Rollback behavior itself is unchanged and still covered by tests.

### 2. Backoff left the client asleep when the server returned

Reconnect backoff escalates 1s → 2s → 4s → 8s → 16s, and only resets after 30s of *stable* connection — so a restart could even inherit backoff debt from earlier flakiness. The client was frequently asleep in a 16s delay exactly when the server came back. Refreshing reset the failure count, which is why refreshing "fixed" it.

A restart-expected overlay (`serverRestartStore.ts`) is armed **before dispatch** and retries on a flat 2s cadence while active. It's deliberately *not* a new supervisor phase — the transport state machine stays transport-only and this is UI-side intent that expires on its own after 90s. Two safeguards worth noting:

- It only pokes `retryNow` while `retryAt` is set (supervisor sleeping in backoff); waking a live attempt would cancel and restart it.
- Arming before dispatch, rather than treating an interrupt as proof of acceptance, avoids showing "restarting" for a request the server never accepted. An explicit RPC failure withdraws it, since that proves the server stayed up.

### 3. Reconnect threw away the cached DPoP token

Two consecutive websocket-ticket failures evicted the cached token, forcing a full relay bootstrap + token exchange during reconnect. Eviction now only happens for failures that suggest a *stale endpoint*; plain unreachability (`network`/`timeout`) — the exact shape of a restart — keeps the token, so reconnect is a single request.

### Also: raw transport errors no longer reach the banner

`Failed to fetch remote environment endpoint https://prod-…t3coderelay.com/api/auth/websocket-ticket (HttpClientError: …)` was flowing verbatim from `rpc/http.ts` into the composer. Presentation now maps each failure reason to a stable summary and carries `reason` for callers; the raw message stays on the supervisor state for connection diagnostics. Authored blocked-failure messages (auth/permission/config) pass through unchanged since they're already actionable.

## Result

Click Update → button stays "Updating…" → one calm "bb-1 is restarting" banner → reconnects the moment the server is back, typically 10–20s, no refresh. The error UI still appears if the server genuinely never returns.

## Testing

- Full suite green: 4,218 passing, 0 failures. Typecheck and lint clean across all 15 projects.
- New coverage: deferred boot-service restart + rollback-after-deferred-failure, transport-message sanitization, blocked-message passthrough, and cached-token retention under pure unreachability.
- Not verified by running the flow end-to-end against a live relay server — the behavior above is reasoned from the code and covered by unit tests. Worth a manual update against a real remote before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches self-update restart timing, in-flight guards, and reconnect/auth token eviction—behavior changes during server restarts and remote updates, though heavily test-covered.
> 
> **Overview**
> Fixes the remote **Update server** flow so clients get a successful RPC before the process dies, then reconnect calmly instead of showing raw transport errors and sleeping in backoff.
> 
> **Server:** Boot-service self-update now **defers** `systemctl restart` (like respawn) so the update RPC can acknowledge first. Failed or defective deferred restarts roll back the unit, log, and **release the in-flight guard** so another update can be tried; success no longer surfaces as an RPC interrupt.
> 
> **Client:** Adds a per-environment **restart-expectation window** (`serverRestartStore`) plus app-level **`useServerRestartReconnect`** (mounted in `AppRoot`) that pokes fast retries while the supervisor is in backoff (`retryAt` set), without waking in-flight attempts. **`ServerUpdateAction`** arms/re-arms the window around dispatch and success/interrupt, clears it on real failures (but not on “already in progress”), and releases the pending button when restart resolves without a new version. **Chat** and **Connections** show a neutral “restarting” state and hide the version-mismatch update action during an expected restart.
> 
> **Reconnect/auth:** Cached DPoP tokens are **not** evicted on pure `network`/`timeout` unreachability—only on reasons that imply a stale endpoint. Connection presentation adds **`reason`** and **`retryAt`**, and maps transport failures to **stable user-facing summaries** (URLs stay in diagnostics). Mobile/tests pick up the expanded connection shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83faf56b65cf7973045312a0d1d79993c0275143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up the server self-update reconnect flow with expected-restart tracking and proactive reconnection
> - Adds [serverRestartStore.ts](https://github.com/pingdotgg/t3code/pull/4485/files#diff-88749cff4b4dbc4467fa04322a43c2daeabf439d43b5ca3cf96d233fcdf2e354) — a zustand store tracking per-environment restart expectation windows (90s), distinguishing expected restarts from unrelated outages
> - Adds [useServerRestartReconnect.ts](https://github.com/pingdotgg/t3code/pull/4485/files#diff-f74312c7d30f72824ad41ad774ceba2686612d4619496943864ac72209b3b1d7) — a global hook that pokes reconnection on a fast-then-easing cadence while supervisors are in backoff, and clears the window once the environment reconnects
> - Mounts `ServerRestartReconnectHost` app-wide in [AppRoot.tsx](https://github.com/pingdotgg/t3code/pull/4485/files#diff-21926ebb90f26239608d00b3283a87aac57ccce9e94d529a524ce198d179567b) to drive reconnection during expected restarts
> - `ServerUpdateAction` arms the restart window before dispatch, re-arms on RPC success or interrupt, and only clears on real failures (not `already running` rejections)
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4485/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) shows a spinner banner during expected restarts and suppresses the version-mismatch update prompt to avoid double-triggering
> - Server-side [selfUpdate.ts](https://github.com/pingdotgg/t3code/pull/4485/files#diff-ec2e07779fe6544111c93dbc73b0783e8d6f7a09caa236f543bd500d08c4617b) defers the `systemctl restart` asynchronously, rolls back the systemd unit on failure, and releases the in-flight guard to allow retries
> - Authorization layer retains cached tokens on pure network/timeout transients, avoiding unnecessary re-bootstrap during restarts
> - Connection presentation now exposes `reason` and `retryAt` fields to consumers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83faf56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->