### PR TITLE
feat(web): select diagnostics environment

### DIFF
--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -1,0 +1,81 @@
+import { assert, describe, it } from "@effect/vitest";
+import { EnvironmentId } from "@t3tools/contracts";
+
+import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+
+const PRIMARY = EnvironmentId.make("primary");
+const ACTIVE = EnvironmentId.make("active");
+const SELECTED = EnvironmentId.make("selected");
+
+describe("resolveDiagnosticsEnvironmentId", () => {
+  it("preserves an explicit available selection", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [PRIMARY, ACTIVE, SELECTED],
+      }),
+      SELECTED,
+    );
+  });
+
+  it("defaults to the primary environment when one is available", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [ACTIVE, PRIMARY],
+      }),
+      PRIMARY,
+    );
+  });
+
+  it("uses the active environment when there is no primary environment", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [SELECTED, ACTIVE],
+      }),
+      ACTIVE,
+    );
+  });
+
+  it("falls back to the first available environment", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+        availableEnvironmentIds: [SELECTED, ACTIVE],
+      }),
+      SELECTED,
+    );
+  });
+
+  it("recovers when the explicit selection is no longer available", () => {
+    assert.equal(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [PRIMARY, ACTIVE],
+      }),
+      PRIMARY,
+    );
+  });
+
+  it("returns null when no environments are available", () => {
+    assert.isNull(
+      resolveDiagnosticsEnvironmentId({
+        selectedEnvironmentId: SELECTED,
+        primaryEnvironmentId: PRIMARY,
+        activeEnvironmentId: ACTIVE,
+        availableEnvironmentIds: [],
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts
@@ -1,7 +1,14 @@
 import { assert, describe, it } from "@effect/vitest";
 import { EnvironmentId } from "@t3tools/contracts";
 
-import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+import {
+  addPendingProcessSignal,
+  diagnosticsConnectionNotice,
+  pendingProcessSignalPids,
+  removePendingProcessSignal,
+  resolveDiagnosticsEnvironmentId,
+  type PendingProcessSignal,
+} from "./DiagnosticsSettings.logic";
 
 const PRIMARY = EnvironmentId.make("primary");
 const ACTIVE = EnvironmentId.make("active");
@@ -76,6 +83,107 @@ describe("resolveDiagnosticsEnvironmentId", () => {
         activeEnvironmentId: ACTIVE,
         availableEnvironmentIds: [],
       }),
+    );
+  });
+});
+
+describe("diagnosticsConnectionNotice", () => {
+  it("returns null while the environment is connected", () => {
+    assert.isNull(
+      diagnosticsConnectionNotice({ phase: "connected", label: "Laptop", error: null }),
+    );
+  });
+
+  it("explains that an offline environment cannot report diagnostics", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "offline", label: "Laptop", error: null }),
+      "Laptop is offline. Diagnostics load once it reconnects.",
+    );
+  });
+
+  it("explains that a never-connected environment cannot report diagnostics", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "available", label: "Laptop", error: null }),
+      "Laptop is not connected. Diagnostics load once it connects.",
+    );
+  });
+
+  it("includes the failure reason while reconnecting", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({
+        phase: "reconnecting",
+        label: "Laptop",
+        error: "socket hang up",
+      }),
+      "Reconnecting to Laptop... Reason: socket hang up",
+    );
+  });
+
+  it("reports a blocked connection", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "error", label: "Laptop", error: "unauthorized" }),
+      "Could not connect to Laptop. Reason: unauthorized",
+    );
+  });
+
+  it("reports an initial connection attempt", () => {
+    assert.equal(
+      diagnosticsConnectionNotice({ phase: "connecting", label: "Laptop", error: null }),
+      "Connecting to Laptop...",
+    );
+  });
+});
+
+describe("pending process signals", () => {
+  it("tracks pending signals per environment and pid", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 200 },
+    );
+
+    assert.deepEqual([...pendingProcessSignalPids(pending, PRIMARY)], [100]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, ACTIVE)], [200]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, SELECTED)], []);
+    assert.deepEqual([...pendingProcessSignalPids(pending, null)], []);
+  });
+
+  it("does not duplicate a signal that is already pending", () => {
+    const pending = addPendingProcessSignal([{ environmentId: PRIMARY, pid: 100 }], {
+      environmentId: PRIMARY,
+      pid: 100,
+    });
+
+    assert.equal(pending.length, 1);
+  });
+
+  it("keeps the same pid pending in another environment", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 100 },
+    );
+
+    assert.deepEqual([...pendingProcessSignalPids(pending, PRIMARY)], [100]);
+    assert.deepEqual([...pendingProcessSignalPids(pending, ACTIVE)], [100]);
+  });
+
+  it("only clears the completed request, leaving other environments pending", () => {
+    const pending = addPendingProcessSignal(
+      addPendingProcessSignal([], { environmentId: PRIMARY, pid: 100 }),
+      { environmentId: ACTIVE, pid: 200 },
+    );
+
+    const remaining = removePendingProcessSignal(pending, { environmentId: PRIMARY, pid: 100 });
+
+    assert.deepEqual([...pendingProcessSignalPids(remaining, PRIMARY)], []);
+    assert.deepEqual([...pendingProcessSignalPids(remaining, ACTIVE)], [200]);
+  });
+
+  it("ignores completions for signals that are no longer pending", () => {
+    const pending: ReadonlyArray<PendingProcessSignal> = [{ environmentId: PRIMARY, pid: 100 }];
+
+    assert.strictEqual(
+      removePendingProcessSignal(pending, { environmentId: ACTIVE, pid: 100 }),
+      pending,
     );
   });
 });

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,0 +1,30 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export function resolveDiagnosticsEnvironmentId(input: {
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+}): EnvironmentId | null {
+  const availableEnvironmentIds = new Set(input.availableEnvironmentIds);
+
+  if (
+    input.selectedEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.selectedEnvironmentId)
+  ) {
+    return input.selectedEnvironmentId;
+  }
+  if (
+    input.primaryEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.primaryEnvironmentId)
+  ) {
+    return input.primaryEnvironmentId;
+  }
+  if (
+    input.activeEnvironmentId !== null &&
+    availableEnvironmentIds.has(input.activeEnvironmentId)
+  ) {
+    return input.activeEnvironmentId;
+  }
+  return input.availableEnvironmentIds[0] ?? null;
+}

--- a/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
+++ b/apps/web/src/components/settings/DiagnosticsSettings.logic.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 export function resolveDiagnosticsEnvironmentId(input: {
@@ -27,4 +28,77 @@ export function resolveDiagnosticsEnvironmentId(input: {
     return input.activeEnvironmentId;
   }
   return input.availableEnvironmentIds[0] ?? null;
+}
+
+/**
+ * Diagnostics queries only run while the selected environment has a connected
+ * supervisor generation; otherwise they stay pending forever. Returns the
+ * message to show instead of a loading state, or `null` when diagnostics can
+ * actually be collected.
+ */
+export function diagnosticsConnectionNotice(input: {
+  readonly phase: EnvironmentConnectionPhase;
+  readonly label: string;
+  readonly error: string | null;
+}): string | null {
+  switch (input.phase) {
+    case "connected":
+      return null;
+    case "connecting":
+      return `Connecting to ${input.label}...`;
+    case "reconnecting":
+      return input.error
+        ? `Reconnecting to ${input.label}... Reason: ${input.error}`
+        : `Reconnecting to ${input.label}...`;
+    case "offline":
+      return `${input.label} is offline. Diagnostics load once it reconnects.`;
+    case "available":
+      return `${input.label} is not connected. Diagnostics load once it connects.`;
+    case "error":
+      return input.error
+        ? `Could not connect to ${input.label}. Reason: ${input.error}`
+        : `Could not connect to ${input.label}.`;
+  }
+}
+
+/**
+ * An in-flight process signal. Signals are identified by environment as well as
+ * pid so that a completion in one environment cannot clear pending state that
+ * belongs to another one.
+ */
+export interface PendingProcessSignal {
+  readonly environmentId: EnvironmentId;
+  readonly pid: number;
+}
+
+function isSamePendingProcessSignal(left: PendingProcessSignal, right: PendingProcessSignal) {
+  return left.environmentId === right.environmentId && left.pid === right.pid;
+}
+
+export function addPendingProcessSignal(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  signal: PendingProcessSignal,
+): ReadonlyArray<PendingProcessSignal> {
+  return pending.some((entry) => isSamePendingProcessSignal(entry, signal))
+    ? pending
+    : [...pending, signal];
+}
+
+export function removePendingProcessSignal(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  signal: PendingProcessSignal,
+): ReadonlyArray<PendingProcessSignal> {
+  const next = pending.filter((entry) => !isSamePendingProcessSignal(entry, signal));
+  return next.length === pending.length ? pending : next;
+}
+
+export function pendingProcessSignalPids(
+  pending: ReadonlyArray<PendingProcessSignal>,
+  environmentId: EnvironmentId | null,
+): ReadonlySet<number> {
+  return new Set(
+    pending
+      .filter((entry) => environmentId !== null && entry.environmentId === environmentId)
+      .map((entry) => entry.pid),
+  );
 }

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -775,9 +775,19 @@ function ProcessResourceHistoryTable({
   );
 }
 
-function DiagnosticsLastChecked({ checkedAt }: { checkedAt: DateTime.Utc | null }) {
+function DiagnosticsLastChecked({
+  checkedAt,
+  isConnected,
+}: {
+  checkedAt: DateTime.Utc | null;
+  isConnected: boolean;
+}) {
   useRelativeTimeTick();
   const relative = getRelativeTimeState(checkedAt ? DateTime.formatIso(checkedAt) : null);
+
+  if (!isConnected) {
+    return null;
+  }
 
   if (relative.status === "missing") {
     return <span className="text-[11px] text-muted-foreground/50">Checking</span>;
@@ -1141,7 +1151,10 @@ export function DiagnosticsSettingsPanel() {
         title="Live Processes"
         headerAction={
           <div className="flex items-center gap-1.5">
-            <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
+            <DiagnosticsLastChecked
+              checkedAt={processData?.readAt ?? null}
+              isConnected={isConnected}
+            />
             <DiagnosticsRefreshButton
               isPending={isProcessPending && isConnected}
               isDisabled={!isConnected}
@@ -1209,7 +1222,10 @@ export function DiagnosticsSettingsPanel() {
               selectedWindowMs={resourceWindowMs}
               onSelect={setResourceWindowMs}
             />
-            <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
+            <DiagnosticsLastChecked
+              checkedAt={resourceData?.readAt ?? null}
+              isConnected={isConnected}
+            />
             <DiagnosticsRefreshButton
               isPending={isResourcePending && isConnected}
               isDisabled={!isConnected}
@@ -1273,7 +1289,7 @@ export function DiagnosticsSettingsPanel() {
         title="Trace Diagnostics"
         headerAction={
           <div className="flex items-center gap-1.5">
-            <DiagnosticsLastChecked checkedAt={data?.readAt ?? null} />
+            <DiagnosticsLastChecked checkedAt={data?.readAt ?? null} isConnected={isConnected} />
             <Tooltip>
               <TooltipTrigger
                 render={

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -851,6 +851,15 @@ export function DiagnosticsSettingsPanel() {
   });
   const diagnosticsEnvironment =
     environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  // Query atoms retain their last successful value while an environment is
+  // disconnected. Derive connectivity before subscribing so cached diagnostics
+  // can never render as current data or leave process actions available.
+  const connectionNotice = diagnosticsConnectionNotice({
+    phase: diagnosticsEnvironment?.connection.phase ?? "available",
+    label: diagnosticsEnvironment?.label ?? "This environment",
+    error: diagnosticsEnvironment?.connection.error ?? null,
+  });
+  const isConnected = connectionNotice === null;
   const observability = diagnosticsEnvironment?.serverConfig?.observability ?? null;
   const availableEditors = diagnosticsEnvironment?.serverConfig?.availableEditors ?? [];
   const environmentItems = useMemo(
@@ -871,28 +880,33 @@ export function DiagnosticsSettingsPanel() {
   const selectedResourceWindow =
     RESOURCE_HISTORY_WINDOWS.find((option) => option.windowMs === resourceWindowMs) ??
     RESOURCE_HISTORY_WINDOWS[1];
-  const { data, error, isPending, refresh } = useEnvironmentQuery(
-    environmentId === null
+  const {
+    data: cachedData,
+    error: cachedError,
+    isPending: isTracePending,
+    refresh,
+  } = useEnvironmentQuery(
+    environmentId === null || !isConnected
       ? null
       : serverEnvironment.traceDiagnostics({ environmentId, input: {} }),
   );
   const {
-    data: processData,
-    error: processError,
-    isPending: isProcessPending,
+    data: cachedProcessData,
+    error: cachedProcessError,
+    isPending: isProcessQueryPending,
     refresh: refreshProcesses,
   } = useEnvironmentQuery(
-    environmentId === null
+    environmentId === null || !isConnected
       ? null
       : serverEnvironment.processDiagnostics({ environmentId, input: {} }),
   );
   const {
-    data: resourceData,
-    error: resourceError,
-    isPending: isResourcePending,
+    data: cachedResourceData,
+    error: cachedResourceError,
+    isPending: isResourceQueryPending,
     refresh: refreshResources,
   } = useEnvironmentQuery(
-    environmentId === null
+    environmentId === null || !isConnected
       ? null
       : serverEnvironment.processResourceHistory({
           environmentId,
@@ -902,6 +916,15 @@ export function DiagnosticsSettingsPanel() {
           },
         }),
   );
+  const data = isConnected ? cachedData : null;
+  const error = isConnected ? cachedError : null;
+  const isPending = isConnected && isTracePending;
+  const processData = isConnected ? cachedProcessData : null;
+  const processError = isConnected ? cachedProcessError : null;
+  const isProcessPending = isConnected && isProcessQueryPending;
+  const resourceData = isConnected ? cachedResourceData : null;
+  const resourceError = isConnected ? cachedResourceError : null;
+  const isResourcePending = isConnected && isResourceQueryPending;
   // Panel-local state is keyed by environment so that a result produced for one
   // environment is never shown for (or applied to) another one.
   const [logsDirectoryState, setLogsDirectoryState] = useState<LogsDirectoryState | null>(null);
@@ -977,7 +1000,7 @@ export function DiagnosticsSettingsPanel() {
       ) {
         return;
       }
-      if (environmentId === null) {
+      if (environmentId === null || !isConnected) {
         return;
       }
 
@@ -1023,17 +1046,9 @@ export function DiagnosticsSettingsPanel() {
         refreshProcesses();
       })();
     },
-    [environmentId, refreshProcesses, signalServerProcess],
+    [environmentId, isConnected, refreshProcesses, signalServerProcess],
   );
 
-  // Diagnostics RPCs only run while the environment's supervisor is connected,
-  // so anything else has to surface as a state instead of an endless spinner.
-  const connectionNotice = diagnosticsConnectionNotice({
-    phase: diagnosticsEnvironment?.connection.phase ?? "available",
-    label: diagnosticsEnvironment?.label ?? "This environment",
-    error: diagnosticsEnvironment?.connection.error ?? null,
-  });
-  const isConnected = connectionNotice === null;
   const statPlaceholder = isConnected ? "..." : "—";
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
@@ -1173,6 +1188,7 @@ export function DiagnosticsSettingsPanel() {
           </div>
         ) : null}
         <ProcessDiagnosticsTable
+          key={environmentId}
           processes={processData?.processes ?? []}
           signalingPids={signalingPids}
           onSignal={signalProcess}

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -15,7 +15,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import type {
   EnvironmentId,
   ServerProcessDiagnosticsEntry,
@@ -849,10 +849,19 @@ interface LogsDirectoryState {
 }
 
 export function DiagnosticsSettingsPanel() {
-  const { environments } = useEnvironments();
+  const { environments, isReady: isEnvironmentCatalogReady } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
   const activeEnvironmentId = useActiveEnvironmentId();
   const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  useEffect(() => {
+    if (
+      isEnvironmentCatalogReady &&
+      selectedEnvironmentId !== null &&
+      !environments.some((environment) => environment.environmentId === selectedEnvironmentId)
+    ) {
+      setSelectedEnvironmentId(null);
+    }
+  }, [environments, isEnvironmentCatalogReady, selectedEnvironmentId]);
   const environmentId = resolveDiagnosticsEnvironmentId({
     selectedEnvironmentId,
     primaryEnvironmentId: primaryEnvironment?.environmentId ?? null,

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -2,18 +2,22 @@ import {
   AlertTriangleIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  CloudIcon,
   CopyIcon,
   FolderOpenIcon,
   InfoIcon,
+  MonitorIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { useAtomValue } from "@effect/atom-react";
+import { Link } from "@tanstack/react-router";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type {
+  EnvironmentId,
   ServerProcessDiagnosticsEntry,
   ServerProcessResourceHistorySummary,
   ServerProcessSignal,
@@ -25,19 +29,31 @@ import { cn } from "../../lib/utils";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { useEnvironmentQuery } from "../../state/query";
-import {
-  primaryServerAvailableEditorsAtom,
-  primaryServerObservabilityAtom,
-  serverEnvironment,
-} from "../../state/server";
+import { serverEnvironment } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
-import { usePrimaryEnvironment } from "../../state/environments";
+import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
+import { useActiveEnvironmentId } from "../../state/entities";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
-import { SettingsPageContainer, SettingsSection, useRelativeTimeTick } from "./settingsLayout";
+import {
+  SettingsPageContainer,
+  SettingsRow,
+  SettingsSection,
+  useRelativeTimeTick,
+} from "./settingsLayout";
+import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -808,10 +824,28 @@ function DiagnosticsRefreshButton({
 }
 
 export function DiagnosticsSettingsPanel() {
-  const observability = useAtomValue(primaryServerObservabilityAtom);
-  const availableEditors = useAtomValue(primaryServerAvailableEditorsAtom);
+  const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
-  const environmentId = primaryEnvironment?.environmentId ?? null;
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  const environmentId = resolveDiagnosticsEnvironmentId({
+    selectedEnvironmentId,
+    primaryEnvironmentId: primaryEnvironment?.environmentId ?? null,
+    activeEnvironmentId,
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+  });
+  const diagnosticsEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const observability = diagnosticsEnvironment?.serverConfig?.observability ?? null;
+  const availableEditors = diagnosticsEnvironment?.serverConfig?.availableEditors ?? [];
+  const environmentItems = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
   const signalServerProcess = useAtomCommand(serverEnvironment.signalProcess, {
     reportFailure: false,
   });
@@ -956,8 +990,85 @@ export function DiagnosticsSettingsPanel() {
     ? Option.getOrElse(data.partialFailure, () => false)
     : false;
 
+  if (environmentId === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Environment">
+          <SettingsRow
+            title="Diagnostics source"
+            description="Process, resource, and trace diagnostics are collected by a specific backend."
+            status="Connect an environment to view diagnostics."
+            control={
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Manage connections
+              </Button>
+            }
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
+
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Environment">
+        <SettingsRow
+          title="Diagnostics source"
+          description="Process, resource, and trace diagnostics are collected by a specific backend. Choose the machine you want to inspect."
+          status={
+            diagnosticsEnvironment ? (
+              <>
+                {connectionStatusText(diagnosticsEnvironment.connection)}
+                {diagnosticsEnvironment.displayUrl
+                  ? ` · ${diagnosticsEnvironment.displayUrl}`
+                  : null}
+              </>
+            ) : (
+              "Connect an environment to view diagnostics."
+            )
+          }
+          control={
+            diagnosticsEnvironment ? (
+              <Select
+                value={diagnosticsEnvironment.environmentId}
+                onValueChange={(value) => setSelectedEnvironmentId(value as EnvironmentId)}
+                items={environmentItems}
+              >
+                <SelectTrigger className="w-full sm:w-64" aria-label="Diagnostics environment">
+                  {diagnosticsEnvironment.entry.target._tag === "PrimaryConnectionTarget" ? (
+                    <MonitorIcon className="size-4" />
+                  ) : (
+                    <CloudIcon className="size-4" />
+                  )}
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectGroup>
+                    <SelectGroupLabel>Machine</SelectGroupLabel>
+                    {environments.map((environment) => (
+                      <SelectItem key={environment.environmentId} value={environment.environmentId}>
+                        <span className="inline-flex items-center gap-1.5">
+                          {environment.entry.target._tag === "PrimaryConnectionTarget" ? (
+                            <MonitorIcon className="size-3" />
+                          ) : (
+                            <CloudIcon className="size-3" />
+                          )}
+                          {environment.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectPopup>
+              </Select>
+            ) : (
+              <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                Manage connections
+              </Button>
+            )
+          }
+        />
+      </SettingsSection>
+
       <SettingsSection
         title="Live Processes"
         headerAction={

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -53,7 +53,14 @@ import {
   SettingsSection,
   useRelativeTimeTick,
 } from "./settingsLayout";
-import { resolveDiagnosticsEnvironmentId } from "./DiagnosticsSettings.logic";
+import {
+  addPendingProcessSignal,
+  diagnosticsConnectionNotice,
+  pendingProcessSignalPids,
+  removePendingProcessSignal,
+  resolveDiagnosticsEnvironmentId,
+  type PendingProcessSignal,
+} from "./DiagnosticsSettings.logic";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const NUMBER_FORMAT = new Intl.NumberFormat();
@@ -410,12 +417,12 @@ function ProcessSignalActions({
 
 function ProcessDiagnosticsTable({
   processes,
-  signalingPid,
+  signalingPids,
   onSignal,
   emptyLabel,
 }: {
   processes: ReadonlyArray<ServerProcessDiagnosticsEntry>;
-  signalingPid: number | null;
+  signalingPids: ReadonlySet<number>;
   onSignal: (pid: number, signal: ServerProcessSignal) => void;
   emptyLabel?: string;
 }) {
@@ -524,7 +531,7 @@ function ProcessDiagnosticsTable({
               <td className="p-2 align-middle sm:pr-4">
                 <ProcessSignalActions
                   process={process}
-                  isSignaling={signalingPid === process.pid}
+                  isSignaling={signalingPids.has(process.pid)}
                   onSignal={onSignal}
                 />
               </td>
@@ -823,6 +830,12 @@ function DiagnosticsRefreshButton({
   );
 }
 
+interface LogsDirectoryState {
+  readonly environmentId: EnvironmentId | null;
+  readonly isOpening: boolean;
+  readonly error: string | null;
+}
+
 export function DiagnosticsSettingsPanel() {
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
@@ -887,9 +900,20 @@ export function DiagnosticsSettingsPanel() {
           },
         }),
   );
-  const [isOpeningLogsDirectory, setIsOpeningLogsDirectory] = useState(false);
-  const [openLogsDirectoryError, setOpenLogsDirectoryError] = useState<string | null>(null);
-  const [signalingPid, setSignalingPid] = useState<number | null>(null);
+  // Panel-local state is keyed by environment so that a result produced for one
+  // environment is never shown for (or applied to) another one.
+  const [logsDirectoryState, setLogsDirectoryState] = useState<LogsDirectoryState | null>(null);
+  const [pendingSignals, setPendingSignals] = useState<ReadonlyArray<PendingProcessSignal>>([]);
+  const logsDirectory =
+    logsDirectoryState !== null && logsDirectoryState.environmentId === environmentId
+      ? logsDirectoryState
+      : null;
+  const isOpeningLogsDirectory = logsDirectory?.isOpening ?? false;
+  const openLogsDirectoryError = logsDirectory?.error ?? null;
+  const signalingPids = useMemo(
+    () => pendingProcessSignalPids(pendingSignals, environmentId),
+    [environmentId, pendingSignals],
+  );
 
   const openLogsDirectory = useCallback(() => {
     const logsDirectoryPath = observability?.logsDirectoryPath ?? null;
@@ -897,16 +921,23 @@ export function DiagnosticsSettingsPanel() {
 
     const editor = resolveAndPersistPreferredEditor(availableEditors ?? []);
     if (!editor) {
-      setOpenLogsDirectoryError("No available editors found.");
+      setLogsDirectoryState({
+        environmentId,
+        isOpening: false,
+        error: "No available editors found.",
+      });
       return;
     }
     if (environmentId === null) {
-      setOpenLogsDirectoryError("No environment is selected.");
+      setLogsDirectoryState({
+        environmentId,
+        isOpening: false,
+        error: "No environment is selected.",
+      });
       return;
     }
 
-    setIsOpeningLogsDirectory(true);
-    setOpenLogsDirectoryError(null);
+    setLogsDirectoryState({ environmentId, isOpening: true, error: null });
     void (async () => {
       const result = await openInEditor({
         environmentId,
@@ -915,13 +946,22 @@ export function DiagnosticsSettingsPanel() {
           editor,
         },
       });
-      setIsOpeningLogsDirectory(false);
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        setOpenLogsDirectoryError(
-          error instanceof Error ? error.message : "Unable to open logs folder.",
-        );
-      }
+      const failure =
+        result._tag === "Failure" && !isAtomCommandInterrupted(result)
+          ? squashAtomCommandFailure(result)
+          : null;
+      const error =
+        failure === null
+          ? null
+          : failure instanceof Error
+            ? failure.message
+            : "Unable to open logs folder.";
+      // Only the request that owns the current pending state may clear it.
+      setLogsDirectoryState((current) =>
+        current !== null && current.environmentId === environmentId
+          ? { environmentId, isOpening: false, error }
+          : current,
+      );
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
 
@@ -939,13 +979,14 @@ export function DiagnosticsSettingsPanel() {
         return;
       }
 
-      setSignalingPid(pid);
+      const pendingSignal: PendingProcessSignal = { environmentId, pid };
+      setPendingSignals((current) => addPendingProcessSignal(current, pendingSignal));
       void (async () => {
         const result = await signalServerProcess({
           environmentId,
           input: { pid, signal },
         });
-        setSignalingPid(null);
+        setPendingSignals((current) => removePendingProcessSignal(current, pendingSignal));
         if (result._tag === "Failure") {
           if (!isAtomCommandInterrupted(result)) {
             const error = squashAtomCommandFailure(result);
@@ -982,6 +1023,16 @@ export function DiagnosticsSettingsPanel() {
     },
     [environmentId, refreshProcesses, signalServerProcess],
   );
+
+  // Diagnostics RPCs only run while the environment's supervisor is connected,
+  // so anything else has to surface as a state instead of an endless spinner.
+  const connectionNotice = diagnosticsConnectionNotice({
+    phase: diagnosticsEnvironment?.connection.phase ?? "available",
+    label: diagnosticsEnvironment?.label ?? "This environment",
+    error: diagnosticsEnvironment?.connection.error ?? null,
+  });
+  const isConnected = connectionNotice === null;
+  const statPlaceholder = isConnected ? "..." : "—";
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
   const processResourceError = resourceData ? Option.getOrNull(resourceData.error) : null;
@@ -1075,7 +1126,7 @@ export function DiagnosticsSettingsPanel() {
           <div className="flex items-center gap-1.5">
             <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
             <DiagnosticsRefreshButton
-              isPending={isProcessPending}
+              isPending={isProcessPending && isConnected}
               label="Refresh process diagnostics"
               onClick={refreshProcesses}
             />
@@ -1085,21 +1136,21 @@ export function DiagnosticsSettingsPanel() {
         <StatsGrid>
           <StatBlock
             label="Child Processes"
-            value={processData ? formatCount(processData.processCount) : "..."}
+            value={processData ? formatCount(processData.processCount) : statPlaceholder}
           />
           <StatBlock
             label="CPU"
-            value={processData ? `${processData.totalCpuPercent.toFixed(1)}%` : "..."}
+            value={processData ? `${processData.totalCpuPercent.toFixed(1)}%` : statPlaceholder}
             tooltip="Total CPU across live child processes of the current server process. The desktop shell and other parent processes are not included."
           />
           <StatBlock
             label="Memory"
-            value={processData ? formatBytes(processData.totalRssBytes) : "..."}
+            value={processData ? formatBytes(processData.totalRssBytes) : statPlaceholder}
             tooltip="Total resident memory across live child processes of the current server process. The desktop shell and other parent processes are not included."
           />
           <StatBlock
             label="Server PID"
-            value={processData ? String(processData.serverPid) : "..."}
+            value={processData ? String(processData.serverPid) : statPlaceholder}
           />
         </StatsGrid>
         {processDiagnosticsError || processError ? (
@@ -1120,12 +1171,13 @@ export function DiagnosticsSettingsPanel() {
         ) : null}
         <ProcessDiagnosticsTable
           processes={processData?.processes ?? []}
-          signalingPid={signalingPid}
+          signalingPids={signalingPids}
           onSignal={signalProcess}
           emptyLabel={
-            isProcessInitialLoading
+            connectionNotice ??
+            (isProcessInitialLoading
               ? "Loading live processes..."
-              : "No live descendant processes found."
+              : "No live descendant processes found.")
           }
         />
       </SettingsSection>
@@ -1140,7 +1192,7 @@ export function DiagnosticsSettingsPanel() {
             />
             <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
             <DiagnosticsRefreshButton
-              isPending={isResourcePending}
+              isPending={isResourcePending && isConnected}
               label="Refresh resource history"
               onClick={refreshResources}
             />
@@ -1150,21 +1202,23 @@ export function DiagnosticsSettingsPanel() {
         <StatsGrid>
           <StatBlock
             label="CPU Time"
-            value={resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : "..."}
+            value={
+              resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : statPlaceholder
+            }
             tooltip="Approximate active CPU time for the T3 server root process and its descendants during the selected window. It grows only while sampled processes use CPU and older samples leave as the window moves."
           />
           <StatBlock
             label="Samples"
-            value={resourceData ? formatCount(resourceData.retainedSampleCount) : "..."}
+            value={resourceData ? formatCount(resourceData.retainedSampleCount) : statPlaceholder}
             tooltip="In-memory process samples retained by the server. This resets when the server restarts."
           />
           <StatBlock
             label="Interval"
-            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : "..."}
+            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : statPlaceholder}
           />
           <StatBlock
             label="Processes"
-            value={resourceData ? formatCount(resourceData.topProcesses.length) : "..."}
+            value={resourceData ? formatCount(resourceData.topProcesses.length) : statPlaceholder}
           />
         </StatsGrid>
         {processResourceError || resourceError ? (
@@ -1187,9 +1241,10 @@ export function DiagnosticsSettingsPanel() {
         <ProcessResourceHistoryTable
           processes={resourceData?.topProcesses ?? []}
           emptyLabel={
-            isResourcePending && resourceData === null
+            connectionNotice ??
+            (isResourcePending && resourceData === null
               ? "Collecting process resource samples..."
-              : "No process resource samples found for this window."
+              : "No process resource samples found for this window.")
           }
         />
       </SettingsSection>
@@ -1206,7 +1261,9 @@ export function DiagnosticsSettingsPanel() {
                     size="icon-xs"
                     variant="ghost"
                     className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-                    disabled={!observability?.logsDirectoryPath || isOpeningLogsDirectory}
+                    disabled={
+                      !isConnected || !observability?.logsDirectoryPath || isOpeningLogsDirectory
+                    }
                     onClick={openLogsDirectory}
                     aria-label="Open logs folder"
                   >
@@ -1217,7 +1274,7 @@ export function DiagnosticsSettingsPanel() {
               <TooltipPopup side="top">Open logs folder</TooltipPopup>
             </Tooltip>
             <DiagnosticsRefreshButton
-              isPending={isPending}
+              isPending={isPending && isConnected}
               label="Refresh trace diagnostics"
               onClick={refresh}
             />
@@ -1225,15 +1282,15 @@ export function DiagnosticsSettingsPanel() {
         }
       >
         <StatsGrid>
-          <StatBlock label="Spans" value={data ? formatCount(data.recordCount) : "..."} />
+          <StatBlock label="Spans" value={data ? formatCount(data.recordCount) : statPlaceholder} />
           <StatBlock
             label="Failures"
-            value={data ? formatCount(data.failureCount) : "..."}
+            value={data ? formatCount(data.failureCount) : statPlaceholder}
             tone={data && data.failureCount > 0 ? "danger" : "default"}
           />
           <StatBlock
             label="Slow Spans"
-            value={data ? formatCount(data.slowSpanCount) : "..."}
+            value={data ? formatCount(data.slowSpanCount) : statPlaceholder}
             tooltip={
               data
                 ? `Spans with a duration of ${formatDuration(data.slowSpanThresholdMs)} or longer.`
@@ -1243,7 +1300,7 @@ export function DiagnosticsSettingsPanel() {
           />
           <StatBlock
             label="Parse Errors"
-            value={data ? formatCount(data.parseErrorCount) : "..."}
+            value={data ? formatCount(data.parseErrorCount) : statPlaceholder}
             tone={data && data.parseErrorCount > 0 ? "warning" : "default"}
           />
         </StatsGrid>
@@ -1303,7 +1360,12 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading failures..." : "No failed spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading failures..." : "No failed spans found.")
+            }
+          />
         )}
       </SettingsSection>
 
@@ -1332,7 +1394,10 @@ export function DiagnosticsSettingsPanel() {
           </DiagnosticsTable>
         ) : (
           <EmptyRows
-            label={isInitialLoading ? "Loading failure groups..." : "No repeated failures found."}
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading failure groups..." : "No repeated failures found.")
+            }
           />
         )}
       </SettingsSection>
@@ -1362,7 +1427,11 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading slow spans..." : "No spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ?? (isInitialLoading ? "Loading slow spans..." : "No spans found.")
+            }
+          />
         )}
       </SettingsSection>
 
@@ -1425,7 +1494,10 @@ export function DiagnosticsSettingsPanel() {
           </ScrollArea>
         ) : (
           <EmptyRows
-            label={isInitialLoading ? "Loading recent logs..." : "No warnings or errors found."}
+            label={
+              connectionNotice ??
+              (isInitialLoading ? "Loading recent logs..." : "No warnings or errors found.")
+            }
           />
         )}
       </SettingsSection>
@@ -1458,7 +1530,11 @@ export function DiagnosticsSettingsPanel() {
             ))}
           </DiagnosticsTable>
         ) : (
-          <EmptyRows label={isInitialLoading ? "Loading span names..." : "No spans found."} />
+          <EmptyRows
+            label={
+              connectionNotice ?? (isInitialLoading ? "Loading span names..." : "No spans found.")
+            }
+          />
         )}
       </SettingsSection>
     </SettingsPageContainer>

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -802,10 +802,12 @@ function DiagnosticsLastChecked({ checkedAt }: { checkedAt: DateTime.Utc | null 
 
 function DiagnosticsRefreshButton({
   isPending,
+  isDisabled = false,
   label,
   onClick,
 }: {
   isPending: boolean;
+  isDisabled?: boolean;
   label: string;
   onClick: () => void;
 }) {
@@ -817,7 +819,7 @@ function DiagnosticsRefreshButton({
             size="icon-xs"
             variant="ghost"
             className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
-            disabled={isPending}
+            disabled={isPending || isDisabled}
             onClick={onClick}
             aria-label={label}
           >
@@ -937,7 +939,8 @@ export function DiagnosticsSettingsPanel() {
       return;
     }
 
-    setLogsDirectoryState({ environmentId, isOpening: true, error: null });
+    const request: LogsDirectoryState = { environmentId, isOpening: true, error: null };
+    setLogsDirectoryState(request);
     void (async () => {
       const result = await openInEditor({
         environmentId,
@@ -950,17 +953,16 @@ export function DiagnosticsSettingsPanel() {
         result._tag === "Failure" && !isAtomCommandInterrupted(result)
           ? squashAtomCommandFailure(result)
           : null;
-      const error =
+      const failureMessage =
         failure === null
           ? null
           : failure instanceof Error
             ? failure.message
             : "Unable to open logs folder.";
-      // Only the request that owns the current pending state may clear it.
+      // Identity check: only the request that still owns the slot may clear it,
+      // so a later request (in this or another environment) is never disturbed.
       setLogsDirectoryState((current) =>
-        current !== null && current.environmentId === environmentId
-          ? { environmentId, isOpening: false, error }
-          : current,
+        current === request ? { environmentId, isOpening: false, error: failureMessage } : current,
       );
     })();
   }, [availableEditors, environmentId, observability?.logsDirectoryPath, openInEditor]);
@@ -1127,6 +1129,7 @@ export function DiagnosticsSettingsPanel() {
             <DiagnosticsLastChecked checkedAt={processData?.readAt ?? null} />
             <DiagnosticsRefreshButton
               isPending={isProcessPending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh process diagnostics"
               onClick={refreshProcesses}
             />
@@ -1193,6 +1196,7 @@ export function DiagnosticsSettingsPanel() {
             <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
             <DiagnosticsRefreshButton
               isPending={isResourcePending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh resource history"
               onClick={refreshResources}
             />
@@ -1275,6 +1279,7 @@ export function DiagnosticsSettingsPanel() {
             </Tooltip>
             <DiagnosticsRefreshButton
               isPending={isPending && isConnected}
+              isDisabled={!isConnected}
               label="Refresh trace diagnostics"
               onClick={refresh}
             />


### PR DESCRIPTION
## What Changed

Adds an explicit diagnostics-source picker and routes every diagnostics request through the selected backend.

## Why

Client-only mode has no primary local environment, so the diagnostics page previously had no backend to query. Diagnostics are backend-specific, not client-specific.

## Behavior

- Defaults to primary, then active, then first available environment.
- Keeps an explicit machine selection while it remains connected.
- Gives a clear Connections call to action when no environments are available.
- Replaces indefinite loading states with an explanatory notice when the selected environment is not connected, and disables refresh / "Open logs folder" while it is unreachable.
- Keys logs-folder errors and in-flight process signals by environment, so one machine's state never leaks into another's.

## UI evidence

All shots come from the same build, light theme, and one 1800px-wide window. Two environments are configured: `dev-workstation` (this machine, connected) and `demo-box` (a saved remote backend that was deliberately shut down).

"Before" is `acccd0e9f` (this branch's pre-review-fix head); "after" is `eb272e4f6`. The branch has since been rebased onto upstream main as `0db411ea1815`; that rebase changed no file content, so these captures still reflect the current head exactly.

### 1. Selecting an environment that is not connected

Diagnostics RPCs only resolve while the environment's supervisor is connected, so before this fix the page waited forever.

**Before — `acccd0e9f`:** every stat reads `...`, every table sits on "Loading live processes…" / "Collecting process resource samples…" / "Loading failures…" / "Loading span names…" indefinitely, and all three refresh icons spin forever. "Open logs folder" is still enabled even though it cannot work.

![Before: diagnostics for a disconnected environment load forever](https://raw.githubusercontent.com/colonelpanic8/t3code/evidence/diagnostics-environment-selector-eb272e4f6/docs/evidence/diagnostics-environment-selector/before-disconnected.png)

**After — `eb272e4f6` (content-identical to current head `0db411ea1815`):** every stat reads `—`, and every table explains the actual state ("Reconnecting to demo-box… Reason: …") instead of pretending to load. The refresh icons are static and disabled, and "Open logs folder" is disabled too.

![After: diagnostics for a disconnected environment explain the connection state](https://raw.githubusercontent.com/colonelpanic8/t3code/evidence/diagnostics-environment-selector-eb272e4f6/docs/evidence/diagnostics-environment-selector/after-disconnected.png)

The notice wording follows the connection phase, so a backend that is `offline`, `available`, `connecting`, or `error` gets its own message rather than the reconnecting one shown here.

### 2. The new "Diagnostics source" picker

This is what the PR adds; there is no equivalent on `main`, where the page always queried the primary backend.

Diagnostics collected from the selected backend, with its connection status and URL under the heading:

![After: diagnostics page with the Diagnostics source row and live data](https://raw.githubusercontent.com/colonelpanic8/t3code/evidence/diagnostics-environment-selector-eb272e4f6/docs/evidence/diagnostics-environment-selector/after-connected.png)

Picker open — machine choice is explicit, and local vs remote backends are distinguished by icon:

![After: the environment picker open, listing both machines](https://raw.githubusercontent.com/colonelpanic8/t3code/evidence/diagnostics-environment-selector-eb272e4f6/docs/evidence/diagnostics-environment-selector/after-picker-open.png)

## Verification

- `vp test run apps/web/src/components/settings/DiagnosticsSettings.logic.test.ts`
- `vp check` (passes; existing repo warnings only)
- Web integration: paired two isolated servers as separate environments, opened `/settings/diagnostics`, confirmed diagnostics are collected from whichever machine is selected, then killed the remote backend and re-checked the page on both the pre-fix and current commits to produce the before/after images above.
- `vp run typecheck` is blocked by an incomplete local dependency tree (`apps/marketing` cannot find `astro`); focused web typecheck also reports 10 pre-existing errors outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live process signaling and multi-environment diagnostics routing; mistakes could show wrong-machine data or leave actions enabled when disconnected, though the PR explicitly gates on connectivity and keys state by environment.
> 
> **Overview**
> Adds a **Diagnostics source** row with an environment picker so process, resource, and trace diagnostics run against a chosen backend instead of always using the primary server.
> 
> Resolution follows **selected → primary → active → first available**, with recovery when a saved machine drops off the catalog and a **Manage connections** path when none exist. Diagnostics RPCs and UI actions only run when that environment is **connected**; cached query data is not shown while disconnected, so stats show `—` instead of stale values and refresh, logs folder, and process signals are disabled. Empty tables show **connection-phase notices** (offline, reconnecting, error, etc.) instead of indefinite loading spinners.
> 
> Panel state is scoped per environment: in-flight process signals and logs-folder open/errors are keyed by `environmentId`, and the process table resets on switch via `key={environmentId}`. Pure helpers in `DiagnosticsSettings.logic` cover resolution, notices, and pending-signal tracking, with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2628089aeb368203cba7ce108f8c839aa7d59132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add environment selection to the diagnostics settings panel
> - Adds an environment selector to `DiagnosticsSettingsPanel` so users can target any available environment for diagnostics, not just the primary one.
> - Introduces `resolveDiagnosticsEnvironmentId` to determine the active diagnostics environment with a defined fallback precedence (selected → primary → active → first available → null).
> - Suppresses data queries and disables action buttons when the selected environment is not connected; shows a `diagnosticsConnectionNotice` string instead of stale data.
> - Replaces the single `signalingPid` with a per-environment `pendingSignals` set so multiple in-flight process signals can be tracked and displayed concurrently.
> - Scopes the async 'Open logs folder' result to the environment that initiated it via a new `LogsDirectoryState` interface keyed by `environmentId`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2628089.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

