### PR TITLE
fix(server): drop non-interactive Codex models from the model picker

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,26 @@
 import { assert, it } from "@effect/vitest";
+import type * as CodexSchema from "effect-codex-app-server/schema";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  parseCodexModelListResponse,
+} from "./CodexProvider.ts";
+
+const catalogModel = (
+  overrides: Partial<CodexSchema.V2ModelListResponse__Model> &
+    Pick<CodexSchema.V2ModelListResponse__Model, "model">,
+): CodexSchema.V2ModelListResponse__Model => ({
+  additionalSpeedTiers: [],
+  defaultReasoningEffort: "medium",
+  description: "Test model",
+  displayName: overrides.model,
+  hidden: false,
+  id: overrides.model,
+  isDefault: false,
+  supportedReasoningEfforts: [],
+  ...overrides,
+});
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -134,6 +154,53 @@ it("keeps Codex's own default when no preferred model is available", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("keeps selectable models from the catalog", () => {
+  const models = parseCodexModelListResponse({
+    data: [
+      catalogModel({ model: "gpt-5.6-sol", displayName: "gpt-5.6-sol", isDefault: true }),
+      catalogModel({ model: "gpt-5.6-luna", displayName: "gpt-5.6-luna" }),
+    ],
+  });
+
+  assert.deepStrictEqual(
+    models.map((model) => ({ slug: model.slug, name: model.name, isDefault: model.isDefault })),
+    [
+      { slug: "gpt-5.6-sol", name: "GPT-5.6-Sol", isDefault: true },
+      { slug: "gpt-5.6-luna", name: "GPT-5.6-Luna", isDefault: undefined },
+    ],
+  );
+});
+
+it("drops catalog models the app server marks as hidden", () => {
+  const models = parseCodexModelListResponse({
+    data: [
+      catalogModel({ model: "gpt-5.6-sol" }),
+      catalogModel({ model: "gpt-5.6-internal", hidden: true }),
+    ],
+  });
+
+  assert.deepStrictEqual(
+    models.map((model) => model.slug),
+    ["gpt-5.6-sol"],
+  );
+});
+
+it("drops non-interactive Codex models even when they are not marked hidden", () => {
+  // codex-cli 0.145.0 reports codex-auto-review with hidden: false and the
+  // display name of another model, so it appears as a duplicate picker row.
+  const models = parseCodexModelListResponse({
+    data: [
+      catalogModel({ model: "codex-auto-review", displayName: "gpt-5.6-luna" }),
+      catalogModel({ model: "gpt-5.6-luna", displayName: "gpt-5.6-luna" }),
+    ],
+  });
+
+  assert.deepStrictEqual(
+    models.map((model) => ({ slug: model.slug, name: model.name })),
+    [{ slug: "gpt-5.6-luna", name: "GPT-5.6-Luna" }],
+  );
 });
 
 it("ignores custom models that shadow a preferred slug", () => {

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -182,10 +182,24 @@ const toDisplayName = (model: CodexSchema.V2ModelListResponse__Model): string =>
     .replace(/-([a-z])/g, (_, c) => "-" + c.toUpperCase());
 };
 
-function parseCodexModelListResponse(
+// Codex models that exist for internal Codex machinery rather than interactive
+// use, and that `model/list` does not mark as hidden. As of codex-cli 0.145.0
+// `codex-auto-review` (the automatic approval-review model) is returned with
+// `hidden: false` and the display name of another catalog entry
+// ("GPT-5.6-Luna"), so it renders as a duplicate picker row. Selecting it
+// produces a session where every tool call fails locally with "unsupported
+// custom tool call" and every follow-up turn is rejected by the API.
+const NON_INTERACTIVE_CODEX_MODEL_SLUGS = new Set(["codex-auto-review"]);
+
+function isSelectableCodexModel(model: CodexSchema.V2ModelListResponse__Model): boolean {
+  return !model.hidden && !NON_INTERACTIVE_CODEX_MODEL_SLUGS.has(model.model);
+}
+
+/** @internal */
+export function parseCodexModelListResponse(
   response: CodexSchema.V2ModelListResponse,
 ): ReadonlyArray<ServerProviderModel> {
-  return response.data.map((model) => ({
+  return response.data.filter(isSelectableCodexModel).map((model) => ({
     slug: model.model,
     name: toDisplayName(model),
     isCustom: false,


### PR DESCRIPTION
## What Changed

`parseCodexModelListResponse` now filters the Codex `model/list` catalog before
building picker entries:

- entries the app server marks `hidden: true` are dropped (the flag was
  previously read off the schema and discarded)
- entries whose slug is a known non-interactive Codex model are dropped
  (currently just `codex-auto-review`)

## Why

codex-cli 0.145.0 returns `codex-auto-review` — Codex's internal *"Automatic
approval review model"* — in the ordinary catalog, with `hidden: false` **and**
the display name of a different entry. Probing the app server directly:

```
$ codex app-server   # model/list
gpt-5.6-sol         hidden=false  GPT-5.6-Sol
gpt-5.6-terra       hidden=false  GPT-5.6-Terra
codex-auto-review   hidden=false  GPT-5.6-Luna     <-- internal model, name of another entry
gpt-5.6-luna        hidden=false  GPT-5.6-Luna
gpt-5.5             hidden=false  GPT-5.5
...
```

So the picker shows two identical `GPT-5.6-Luna` rows and one of them silently
routes to a model that cannot do any work. A thread started on it fails in two
stages:

1. Every tool call is rejected locally. The model emits a code-mode
   `custom_tool_call` (`name: "exec"`, `namespace: "exec"`) and codex answers
   `custom_tool_call_output: "unsupported custom tool call: execexec"`. No tool
   row ever renders — the model just narrates that "the shell tool is currently
   failing on invocation" and gives up.
2. Every subsequent turn dies before it starts, because the retained call items
   carry `namespace`, which is not a valid Responses API input field:

   ```
   invalid_request_error: [ObjectParam] [input[5].namespace]
   [unknown_parameter] Unknown parameter: 'input[5].namespace'.   (willRetry: false)
   ```

   That surfaces as `thread/status/changed → systemError` about half a second
   after each send, and the thread is unrecoverable since the offending item is
   permanently in history.

Filtering the catalog is the narrow fix: honoring `hidden` is simply respecting
a field the protocol already provides, and the slug list covers the case where
Codex itself mislabels an internal model as selectable. There is precedent for
both shapes in the tree — `OpenCodeProvider` filters `agent.hidden`, and
`opencodeRuntime` keeps a `KNOWN_HIDDEN_AGENTS` set for entries the CLI does not
flag.

## UI Changes

No visual changes. The only user-visible effect is that the duplicate
`GPT-5.6-Luna` row disappears from the Codex model picker; the remaining rows
and their ordering are unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a — a row is removed, no visual redesign)
- [x] I included a video for animation/interaction changes (n/a)

---

Validation (scoped per `AGENTS.md`, which asks that repo-wide suites be left to CI):

```
vp test run apps/server/src/provider/Layers/CodexProvider.test.ts   # 9 passed
vp run --filter t3 typecheck                                       # exit 0
vp lint apps/server/src/provider/Layers/CodexProvider{,.test}.ts    # clean
vp fmt --check apps/server/src/provider/Layers/CodexProvider{,.test}.ts
```

The three new tests were confirmed to fail against the unfiltered parser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow server-side catalog filtering for the Codex model picker only; no auth, persistence, or session runtime logic changes beyond which slugs are offered.
> 
> **Overview**
> **Codex model picker** now filters the `model/list` catalog before building rows: entries with `hidden: true` are omitted, and slugs in `NON_INTERACTIVE_CODEX_MODEL_SLUGS` (currently `codex-auto-review`) are omitted even when the app server leaves them visible.
> 
> This removes duplicate picker labels (e.g. two **GPT-5.6-Luna** rows from codex-cli 0.145.0) and blocks selection of internal models that break tool calls and follow-up turns. `parseCodexModelListResponse` is exported for unit tests covering normal catalog mapping, hidden filtering, and the `codex-auto-review` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75d35701081c09d2308fb0da96f2a13eca9faf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop non-interactive Codex models from the model picker
> Filters out models that should not appear in the interactive model picker by updating `parseCodexModelListResponse` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/4487/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53). Models marked as hidden or whose slug appears in `NON_INTERACTIVE_CODEX_MODEL_SLUGS` (initially `codex-auto-review`) are excluded. The function is also now exported to support direct testing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c75d357.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->