### PR TITLE
feat(web): show fast mode as a bolt instead of a "Normal" label

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -81,6 +81,22 @@ describe("buildTraitsTriggerDisplay", () => {
     });
   });
 
+  it("stays blank when descriptors resolve to no label and there is no fast mode", () => {
+    // A select with neither a currentValue nor an isDefault option yields no
+    // label. Without a fastMode descriptor present that must stay blank rather
+    // than falling through to a bogus "Normal".
+    const unresolved: Extract<ProviderOptionDescriptor, { type: "select" }> = {
+      id: "effort",
+      label: "effort",
+      type: "select",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High" },
+      ],
+    };
+    expect(display([unresolved], false)).toEqual({ label: "", showFastModeIcon: false });
+  });
+
   it("still renders the prompt-controlled ultrathink label alongside the bolt", () => {
     expect(
       buildTraitsTriggerDisplay({

--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ProviderOptionDescriptor } from "@t3tools/contracts";
+import { buildTraitsTriggerDisplay } from "./TraitsPicker";
+
+function selectDescriptor(
+  id: string,
+  options: ReadonlyArray<{ id: string; label: string }>,
+  currentValue: string,
+): Extract<ProviderOptionDescriptor, { type: "select" }> {
+  return { id, label: id, type: "select", options: [...options], currentValue };
+}
+
+function fastModeDescriptor(
+  currentValue: boolean,
+): Extract<ProviderOptionDescriptor, { type: "boolean" }> {
+  return { id: "fastMode", label: "Fast Mode", type: "boolean", currentValue };
+}
+
+const EFFORT = selectDescriptor(
+  "effort",
+  [
+    { id: "high", label: "High" },
+    { id: "max", label: "Max" },
+  ],
+  "high",
+);
+const CONTEXT_WINDOW = selectDescriptor(
+  "contextWindow",
+  [
+    { id: "200k", label: "200k" },
+    { id: "1m", label: "1M" },
+  ],
+  "1m",
+);
+
+function display(descriptors: ReadonlyArray<ProviderOptionDescriptor>, fastModeEnabled: boolean) {
+  return buildTraitsTriggerDisplay({
+    descriptors,
+    primarySelectDescriptorId: "effort",
+    ultrathinkPromptControlled: false,
+    fastModeEnabled,
+  });
+}
+
+describe("buildTraitsTriggerDisplay", () => {
+  it("omits fast mode from the label entirely when it is off", () => {
+    expect(display([EFFORT, fastModeDescriptor(false), CONTEXT_WINDOW], false)).toEqual({
+      label: "High · 1M",
+      showFastModeIcon: false,
+    });
+  });
+
+  it("shows the bolt instead of a text label when fast mode is on", () => {
+    expect(display([EFFORT, fastModeDescriptor(true), CONTEXT_WINDOW], true)).toEqual({
+      label: "High · 1M",
+      showFastModeIcon: true,
+    });
+  });
+
+  it("keeps non-fastMode booleans as text labels", () => {
+    const thinking: Extract<ProviderOptionDescriptor, { type: "boolean" }> = {
+      id: "thinking",
+      label: "Thinking",
+      type: "boolean",
+      currentValue: true,
+    };
+    expect(display([EFFORT, thinking], false)).toEqual({
+      label: "High · Thinking On",
+      showFastModeIcon: false,
+    });
+  });
+
+  it("falls back to a text label when fast mode is the only trait", () => {
+    expect(display([fastModeDescriptor(true)], true)).toEqual({
+      label: "Fast",
+      showFastModeIcon: false,
+    });
+    expect(display([fastModeDescriptor(false)], false)).toEqual({
+      label: "Normal",
+      showFastModeIcon: false,
+    });
+  });
+
+  it("still renders the prompt-controlled ultrathink label alongside the bolt", () => {
+    expect(
+      buildTraitsTriggerDisplay({
+        descriptors: [EFFORT, fastModeDescriptor(true)],
+        primarySelectDescriptorId: "effort",
+        ultrathinkPromptControlled: true,
+        fastModeEnabled: true,
+      }),
+    ).toEqual({ label: "Ultrathink", showFastModeIcon: true });
+  });
+});

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -16,7 +16,7 @@ import {
 } from "@t3tools/shared/model";
 import { memo, useCallback, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
-import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, ZapIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
 import {
   Menu,
@@ -379,6 +379,41 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   );
 });
 
+/**
+ * Build the traits trigger's text label plus whether the fast-mode bolt should
+ * render. Fast mode is a lightning bolt when on and nothing at all when off —
+ * "Normal" is the near-universal case and isn't worth the horizontal space. The
+ * one exception is when fast mode is the only trait, where a bare bolt (or bare
+ * chevron) would leave the trigger unreadable.
+ */
+export function buildTraitsTriggerDisplay(input: {
+  descriptors: ReadonlyArray<ProviderOptionDescriptor>;
+  primarySelectDescriptorId: string | null;
+  ultrathinkPromptControlled: boolean;
+  fastModeEnabled: boolean;
+}): { label: string; showFastModeIcon: boolean } {
+  const labels: Array<string> = [];
+  for (const descriptor of input.descriptors) {
+    if (descriptor.id === "fastMode" && descriptor.type === "boolean") {
+      continue;
+    }
+    const label =
+      input.ultrathinkPromptControlled && descriptor.id === input.primarySelectDescriptorId
+        ? "Ultrathink"
+        : descriptor.type === "boolean"
+          ? `${descriptor.label} ${descriptor.currentValue === true ? "On" : "Off"}`
+          : getProviderOptionCurrentLabel(descriptor);
+    if (typeof label === "string" && label.length > 0) {
+      labels.push(label);
+    }
+  }
+
+  if (labels.length === 0) {
+    return { label: input.fastModeEnabled ? "Fast" : "Normal", showFastModeIcon: false };
+  }
+  return { label: labels.join(" · "), showFastModeIcon: input.fastModeEnabled };
+}
+
 export const TraitsPicker = memo(function TraitsPicker({
   provider,
   instanceId,
@@ -393,7 +428,7 @@ export const TraitsPicker = memo(function TraitsPicker({
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
+  const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled, fastModeEnabled } =
     getTraitsSectionVisibility({
       provider,
       models,
@@ -415,23 +450,18 @@ export const TraitsPicker = memo(function TraitsPicker({
     return null;
   }
 
-  const triggerLabels: Array<string> = [];
-  for (const descriptor of descriptors) {
-    const label =
-      ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
-        ? "Ultrathink"
-        : descriptor.type === "boolean"
-          ? descriptor.id === "fastMode"
-            ? descriptor.currentValue === true
-              ? "Fast"
-              : "Normal"
-            : `${descriptor.label} ${descriptor.currentValue === true ? "On" : "Off"}`
-          : getProviderOptionCurrentLabel(descriptor);
-    if (typeof label === "string" && label.length > 0) {
-      triggerLabels.push(label);
-    }
-  }
-  const triggerLabel = triggerLabels.join(" · ");
+  const { label: triggerLabel, showFastModeIcon } = buildTraitsTriggerDisplay({
+    descriptors,
+    primarySelectDescriptorId: primarySelectDescriptor?.id ?? null,
+    ultrathinkPromptControlled,
+    fastModeEnabled,
+  });
+  const fastModeIcon = showFastModeIcon ? (
+    <>
+      <ZapIcon aria-hidden="true" className="size-3 shrink-0 text-foreground/80 opacity-100" />
+      <span className="sr-only">Fast mode on</span>
+    </>
+  ) : null;
 
   const isCodexStyle = provider === "codex";
 
@@ -457,12 +487,14 @@ export const TraitsPicker = memo(function TraitsPicker({
         }
       >
         {isCodexStyle ? (
-          <span className="flex min-w-0 w-full items-center gap-2 overflow-hidden">
-            {triggerLabel}
+          <span className="flex min-w-0 w-full items-center gap-1.5 overflow-hidden">
+            {fastModeIcon}
+            <span className="min-w-0 truncate">{triggerLabel}</span>
             <ChevronDownIcon aria-hidden="true" className="size-3 shrink-0 opacity-60" />
           </span>
         ) : (
           <>
+            {fastModeIcon}
             <span>{triggerLabel}</span>
             <ChevronDownIcon aria-hidden="true" className="size-3 opacity-60" />
           </>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -392,9 +392,11 @@ export function buildTraitsTriggerDisplay(input: {
   ultrathinkPromptControlled: boolean;
   fastModeEnabled: boolean;
 }): { label: string; showFastModeIcon: boolean } {
+  let hasFastMode = false;
   const labels: Array<string> = [];
   for (const descriptor of input.descriptors) {
     if (descriptor.id === "fastMode" && descriptor.type === "boolean") {
+      hasFastMode = true;
       continue;
     }
     const label =
@@ -408,7 +410,10 @@ export function buildTraitsTriggerDisplay(input: {
     }
   }
 
-  if (labels.length === 0) {
+  // Only fall back to text when fast mode is genuinely the sole trait. Keying
+  // off an empty label list alone would also catch descriptors that resolved to
+  // no label at all, printing a bogus "Normal" for a model without fast mode.
+  if (labels.length === 0 && hasFastMode) {
     return { label: input.fastModeEnabled ? "Fast" : "Normal", showFastModeIcon: false };
   }
   return { label: labels.join(" · "), showFastModeIcon: input.fastModeEnabled };


### PR DESCRIPTION
The composer's traits trigger spelled out the fast-mode state as text, so the near-universal off case burned horizontal space on the word "Normal": `High · Normal · 1M`.

Now it works the way Codex does it — a lightning bolt when fast mode is on, and nothing at all when it's off.

| before | after (fast off) | after (fast on) |
|---|---|---|
| `High · Normal · 1M` | `High · 1M` | ⚡ `High · 1M` |

<img width="399" height="230" alt="image" src="https://github.com/user-attachments/assets/95952958-7267-423c-be31-c37f388abab5" />


### Changes

- `fastMode` no longer contributes to the trigger's text label.
- When fast mode is on, a `ZapIcon` renders at the start of the trigger, with an `sr-only` "Fast mode on" — the icon is now the only signal, so screen readers need the text.
- Label-building moved into an exported pure function `buildTraitsTriggerDisplay` so it's testable without mounting the menu.

### Edge case

For models where fast mode is the *only* trait, dropping the text would leave a bare bolt or bare chevron with nothing to read. That case falls back to the old `Fast`/`Normal` text and skips the icon. Every model currently in the providers pairs fast mode with at least an effort select, so in practice you always get the icon path — the fallback just keeps the component from degrading if a provider ever exposes fast mode alone.

Mobile is untouched: `providerOptionsConfigurationLabel` already drops boolean traits when they're off, so it never showed "Normal".

### Testing

- `pnpm --filter @t3tools/web typecheck` — clean
- `pnpm -w run lint` — clean, no new warnings on this file
- 15 tests pass across the new `TraitsPicker.test.ts` and existing `composerProviderState.test.tsx`

Not visually confirmed in a running browser — if the gap next to the label looks off, it's a one-line tweak to the `gap-1.5` on the Codex-style span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer UI and display logic only; behavior is covered by new unit tests with no auth or data changes.
> 
> **Overview**
> The composer **traits trigger** no longer shows **Fast**/**Normal** in the joined label when fast mode sits alongside other traits. Off is silent; on adds a **`ZapIcon`** bolt (plus **`sr-only` “Fast mode on”**) ahead of labels like `High · 1M`.
> 
> Label logic moves into exported **`buildTraitsTriggerDisplay`**, with unit tests covering off/on, other booleans, ultrathink, fast-mode-only fallback text, and empty labels without bogus **Normal**. Codex-style triggers use slightly tighter gap and a truncating label span.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 364966ca242a5973e382183ae87ab74b5629a578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show a bolt icon instead of 'Fast'/'Normal' text for fast mode in the chat traits picker
> - Introduces `buildTraitsTriggerDisplay` in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/4488/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45), a pure function that builds the trigger label and a `showFastModeIcon` flag from provider option descriptors.
> - When fast mode is on, the trigger renders a `ZapIcon` (bolt) with an sr-only 'Fast mode on' label instead of the word 'Normal' or 'Fast'.
> - 'Fast'/'Normal' text is only used as a fallback when fast mode is the sole active trait; 'Ultrathink' is used when `ultrathinkPromptControlled` matches the primary select.
> - Behavioral Change: triggers that previously showed 'Fast' or 'Normal' text alongside other traits will now show only the bolt icon; triggers with no other traits and no fast mode will be blank.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 364966c. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->