### PR TITLE
fix(web): render provider status banner using alert

### DIFF
--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -172,11 +172,7 @@ function ComposerBannerStackAlert({
   const dismissOnly = item.onDismiss && !item.actions;
 
   return (
-    <Alert
-      variant={item.variant}
-      className={cn("alert-glass", item.className)}
-      data-variant={item.variant}
-    >
+    <Alert variant={item.variant} className={cn("alert-glass", item.className)}>
       {item.icon}
       <AlertTitle>{item.title}</AlertTitle>
       {item.description ? <AlertDescription>{item.description}</AlertDescription> : null}

--- a/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.test.tsx
@@ -41,7 +41,15 @@ describe("ProviderStatusBanner", () => {
 
     expect(markup).toContain('role="alert"');
     expect(markup).toContain('aria-label="Dismiss Codex provider warning"');
-    expect(markup).toContain("absolute top-2 right-2");
+  });
+
+  it("renders an opaque surface so the timeline behind it cannot read through", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderStatusBanner status={warningProvider()} onDismiss={() => {}} />,
+    );
+
+    expect(markup).toContain("alert-glass");
+    expect(markup).toContain('data-variant="warning"');
   });
 
   it("labels error dismiss controls with the correct severity", () => {

--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -65,8 +65,6 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
             aria-label={`Dismiss ${providerName} provider ${status.status}`}
             onClick={onDismiss}
           >
-            {/* Ghost buttons force svgs to muted-foreground unless the icon
-                sets its own text colour, which would drop the alert's tint. */}
             <XIcon
               aria-hidden
               className={cn(

--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -1,6 +1,7 @@
 import { type ServerProvider } from "@t3tools/contracts";
 import { memo } from "react";
 import { InfoIcon, XIcon } from "lucide-react";
+import { cn } from "~/lib/utils";
 import { formatProviderDriverKindLabel } from "../../providerModels";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "../ui/alert";
 import { Button } from "../ui/button";
@@ -32,6 +33,7 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
   }
 
   const providerName = status.displayName?.trim() || formatProviderDriverKindLabel(status.driver);
+  const variant = status.status === "warning" ? "warning" : "error";
   const isUnauthenticated = status.status === "error" && status.auth.status === "unauthenticated";
   const title = isUnauthenticated
     ? `${providerName} is unauthenticated`
@@ -45,12 +47,7 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
 
   return (
     <div className="pointer-events-auto mx-auto w-fit max-w-[calc(100%-2rem)] pt-3">
-      {/*
-       * This banner is an overlay painted on top of the message timeline, so it
-       * needs `alert-glass` — the alert variants alone are a 4% tint with no
-       * surface behind them, which lets the transcript read through the copy.
-       */}
-      <Alert variant={status.status === "warning" ? "warning" : "error"} className="alert-glass">
+      <Alert variant={variant} className="alert-glass">
         <InfoIcon aria-hidden />
         <AlertTitle>{title}</AlertTitle>
         <AlertDescription>
@@ -68,7 +65,15 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
             aria-label={`Dismiss ${providerName} provider ${status.status}`}
             onClick={onDismiss}
           >
-            <XIcon aria-hidden className="size-3.5" />
+            {/* Ghost buttons force svgs to muted-foreground unless the icon
+                sets its own text colour, which would drop the alert's tint. */}
+            <XIcon
+              aria-hidden
+              className={cn(
+                "size-3.5",
+                variant === "warning" ? "text-warning" : "text-destructive",
+              )}
+            />
           </Button>
         </AlertAction>
       </Alert>

--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -1,8 +1,9 @@
 import { type ServerProvider } from "@t3tools/contracts";
 import { memo } from "react";
 import { InfoIcon, XIcon } from "lucide-react";
-import { cn } from "~/lib/utils";
 import { formatProviderDriverKindLabel } from "../../providerModels";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "../ui/alert";
+import { Button } from "../ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 export function getProviderStatusBannerKey(status: ServerProvider | null): string | null {
@@ -44,36 +45,33 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
 
   return (
     <div className="pointer-events-auto mx-auto w-fit max-w-[calc(100%-2rem)] pt-3">
-      <div
-        className={cn(
-          "relative inline-flex items-center gap-3 rounded-xl border py-3 ps-3.5 pe-10 text-card-foreground text-sm",
-          status.status === "warning"
-            ? "border-warning/32 bg-warning/4 [&_svg]:text-warning"
-            : "border-destructive/32 bg-destructive/4 text-destructive-foreground [&_svg]:text-destructive",
-        )}
-        role="alert"
-      >
-        <InfoIcon className="size-4 shrink-0" aria-hidden />
-        <div className="flex min-w-0 flex-col gap-1">
-          <div className="font-medium">{title}</div>
+      {/*
+       * This banner is an overlay painted on top of the message timeline, so it
+       * needs `alert-glass` — the alert variants alone are a 4% tint with no
+       * surface behind them, which lets the transcript read through the copy.
+       */}
+      <Alert variant={status.status === "warning" ? "warning" : "error"} className="alert-glass">
+        <InfoIcon aria-hidden />
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>
           <Tooltip>
-            <TooltipTrigger
-              render={<div className="line-clamp-3 text-muted-foreground">{message}</div>}
-            />
+            <TooltipTrigger render={<div className="line-clamp-3">{message}</div>} />
             <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
               {message}
             </TooltipPopup>
           </Tooltip>
-        </div>
-        <button
-          type="button"
-          aria-label={`Dismiss ${providerName} provider ${status.status}`}
-          className="absolute top-2 right-2 inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-foreground/8 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={onDismiss}
-        >
-          <XIcon aria-hidden className="size-3.5" />
-        </button>
-      </div>
+        </AlertDescription>
+        <AlertAction>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label={`Dismiss ${providerName} provider ${status.status}`}
+            onClick={onDismiss}
+          >
+            <XIcon aria-hidden className="size-3.5" />
+          </Button>
+        </AlertAction>
+      </Alert>
     </div>
   );
 });

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -68,6 +68,9 @@ function Alert({
     <div
       className={cn(alertVariants({ variant }), className)}
       data-slot="alert"
+      // `.alert-glass` keys its tint off the variant, so surfaces that opt into
+      // the opaque alert background don't have to restate it at the call site.
+      data-variant={variant ?? "default"}
       role="alert"
       {...props}
     >

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -68,8 +68,6 @@ function Alert({
     <div
       className={cn(alertVariants({ variant }), className)}
       data-slot="alert"
-      // `.alert-glass` keys its tint off the variant, so surfaces that opt into
-      // the opaque alert background don't have to restate it at the call site.
       data-variant={variant ?? "default"}
       role="alert"
       {...props}


### PR DESCRIPTION
## Summary

- render `ProviderStatusBanner` with the shared `<Alert>` component instead of a hand-rolled copy of it
- opt it into `alert-glass`, the surface the composer banners already use
- have `Alert` emit `data-variant` itself so call sites stop restating it

No CSS changes.

## The bug

When Codex has connection issues, the provider status toast is unreadable — the chat transcript shows straight through it.

`ChatView` renders the banner as an overlay on top of the virtualised timeline:

```tsx
<div className="pointer-events-none absolute inset-x-0 top-0 z-20">
  <ProviderStatusBanner … />
```

Its only surface was `bg-destructive/4` / `bg-warning/4`. Measured on the live element:

```
background-color: oklab(0.655 0.203 0.088 / 0.04)   ← 4% alpha
background-image: none
backdrop-filter:  none
overlay z-index:  20                                 ← correctly on top
```

It paints *above* the timeline — you are seeing **through** it, not behind it. This is not a stacking-order bug.

Before:
<img width="2560" height="1720" alt="before-full" src="https://github.com/user-attachments/assets/135c85ed-e544-42f6-aa30-73680e41bcc5" />
After:
<img width="2560" height="1720" alt="after-full" src="https://github.com/user-attachments/assets/3b539fdc-1138-4e14-9cb8-69e2d48782c8" />


## Why it looked fine in other places

`ThreadErrorBanner` uses the identical `Alert variant="error"` with the same `bg-destructive/4`, but renders in normal document flow. Nothing paints behind it, so 4% over `--background` reads as solid. Same CSS, different situation — the discriminator is whether anything is painted behind the alert, not where it sits in the tree.

## Root cause

`ProviderStatusBanner` was a hand-rolled `<div>` that duplicated `alertVariants`' class strings plus its own dismiss button and layout. It never used `<Alert>`, and never picked up `alert-glass` — the class `ComposerBannerStack` adds to give an alert a real surface. Because it had opted out of the shared component, every improvement to the shared alert surface skipped it.

The fix is to delete the duplication: the banner is now `<Alert variant={…} className="alert-glass">` with `AlertTitle` / `AlertDescription` / `AlertAction`, matching `ThreadErrorBanner` and `ComposerBannerStack`.

## Does this affect the other variants?

The transparency lives in `alertVariants` — `error`, `info`, `success` and `warning` are all `bg-<color>/4`, so any alert painted over content bleeds. After this change:

| surface | variants | status |
| --- | --- | --- |
| `ComposerBannerStack` | error / info / success / warning | already had `alert-glass` — unaffected |
| `ProviderStatusBanner` | error / warning | fixed here |
| `ThreadErrorBanner` | error | no `alert-glass`, but it renders in normal flow so it does not bleed today |

## Validation

Reproduced in the real app against a real provider failure: Codex's `binaryPath` pointed at a binary that never answers, so the app-server probe hits its 10s timeout and reports the exact message from the bug report — `Timed out while checking Codex app-server provider status.` — with a seeded multi-message transcript scrolled behind the banner.

Measured on the live element in each run:

| | `alert-glass` | `data-variant` | background | backdrop-filter |
| --- | --- | --- | --- | --- |
| before | `false` | `null` | `oklab(… / 0.04)` | `none` |
| after | `true` | `error` | `srgb(… / 0.8)` | `blur(16px) saturate(1.08)` |

`alert-glass` resolves against `--glass-opacity`, which is a **user setting** (40–100, default 80), so legibility must not depend on where that slider sits. Checked the worst case — glass opacity dragged to its 40% minimum, in both dark and light themes — and the banner stays fully legible; the backdrop blur does the work.

- `vp test` — `ProviderStatusBanner` + `ComposerBannerStack`, 7 passed
- `vp lint`, `vp fmt --check`, `vp run typecheck` — clean

## Notes for review

- **Visual delta:** adopting `Alert`'s error variant also picks up `[&_[data-slot=alert-description]]:text-destructive-foreground/80`, so the error message body is now red-tinted rather than grey. It matches how error alerts read elsewhere in the app, but it is a change from the old styling.
- **Test change:** the existing test asserted `"absolute top-2 right-2"`, an implementation detail of the hand-rolled dismiss button. Replaced with an assertion that the banner renders on the shared opaque surface, matching how `ComposerBannerStack.test.tsx` checks it.
- **Superseded commits:** earlier revisions of this branch made `.alert-glass` opaque in CSS. Those could not fix the reported bug — `ProviderStatusBanner` never carried the class, so the selector never matched the broken element. They have been dropped in favour of the component fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor of chat overlay banner and a small Alert attribute; no auth, data, or API changes.
> 
> **Overview**
> Fixes **unreadable provider status toasts** when they overlay the chat timeline by replacing the hand-rolled banner markup with the shared **`Alert`** stack and **`alert-glass`**, matching composer banners.
> 
> **`ProviderStatusBanner`** now uses `Alert` / `AlertTitle` / `AlertDescription` / `AlertAction` with a ghost icon dismiss button instead of duplicated variant classes and an absolutely positioned control. Error copy picks up the shared error description styling (red-tinted body vs grey).
> 
> **`Alert`** sets **`data-variant`** on the root so call sites (including **`ComposerBannerStack`**) no longer duplicate it.
> 
> Tests assert **`alert-glass`** and **`data-variant`** instead of dismiss-button positioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b516c99ab7afc3da7a44b35c7e63d07e94c430de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render `ProviderStatusBanner` using shared `Alert` component
> - Refactors [`ProviderStatusBanner`](https://github.com/pingdotgg/t3code/pull/4492/files#diff-d53076993b72ce28ed4241d2451251fe23b3d13a1fbc6effc6cc4a65c525e981) to use `Alert`, `AlertTitle`, `AlertDescription`, `AlertAction`, and `Button` instead of custom divs, applying the `alert-glass` class and a computed `warning`/`error` variant.
> - Adds a `data-variant` attribute to the root element of [`Alert`](https://github.com/pingdotgg/t3code/pull/4492/files#diff-55ced12b2438f63fb67a53bf532aa32f1bbc13e493218e907f1566ef473ac255), defaulting to `'default'`, so all rendered alerts now expose their variant in the DOM.
> - Replaces the custom dismiss button with a ghost icon-xs `Button` inside `AlertAction`, with conditional icon color based on variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b516c99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->