### PR TITLE
Fix Windows thread edge background

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,14 +7,14 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#161616" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="#161616" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#0a0a0a" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <script>
       (() => {
         const LIGHT_BACKGROUND = "#ffffff";
-        const DARK_BACKGROUND = "#161616";
+        const DARK_BACKGROUND = "#0a0a0a";
         const themeColorMeta = document.querySelector('meta[name="theme-color"]');
         try {
           const storedTheme = window.localStorage.getItem("t3code:theme");
@@ -58,7 +58,7 @@
       }
 
       html.dark body {
-        background: #161616;
+        background: #0a0a0a;
         color: #f5f5f5;
       }
 

--- a/apps/web/src/hooks/useTheme.test.ts
+++ b/apps/web/src/hooks/useTheme.test.ts
@@ -27,48 +27,6 @@ afterEach(() => {
 });
 
 describe("theme failure handling", () => {
-  it("syncs browser chrome from the stable app token during route surface gaps", async () => {
-    const dynamicMeta = {
-      setAttribute: vi.fn(),
-    };
-    const documentElement = {
-      classList: { toggle: vi.fn() },
-      style: { backgroundColor: "#161616" },
-    };
-    const body = {
-      style: { backgroundColor: "#161616" },
-    };
-    vi.stubGlobal("window", {
-      localStorage: createStorage(),
-      matchMedia: () => ({ matches: true }),
-    });
-    vi.stubGlobal("document", {
-      body,
-      documentElement,
-      head: { append: vi.fn() },
-      querySelector: (selector: string) =>
-        selector.includes("data-dynamic-theme-color") ? dynamicMeta : null,
-    });
-    vi.stubGlobal("getComputedStyle", (element: unknown) => ({
-      backgroundColor: element === body ? "rgb(22, 22, 22)" : "rgb(0, 0, 0)",
-      getPropertyValue: (property: string) =>
-        element === documentElement && property === "--app-chrome-background"
-          ? "rgb(10, 10, 10)"
-          : "",
-    }));
-
-    const { syncBrowserChromeTheme } = await import("./useTheme");
-    documentElement.style.backgroundColor = "#161616";
-    body.style.backgroundColor = "#161616";
-    dynamicMeta.setAttribute.mockClear();
-
-    syncBrowserChromeTheme();
-
-    expect(documentElement.style.backgroundColor).toBe("rgb(10, 10, 10)");
-    expect(body.style.backgroundColor).toBe("rgb(10, 10, 10)");
-    expect(dynamicMeta.setAttribute).toHaveBeenCalledWith("content", "rgb(10, 10, 10)");
-  });
-
   it("preserves exact storage causes and operation context", async () => {
     const readCause = new Error("storage read blocked");
     const writeCause = new Error("storage quota exceeded");

--- a/apps/web/src/hooks/useTheme.test.ts
+++ b/apps/web/src/hooks/useTheme.test.ts
@@ -27,6 +27,48 @@ afterEach(() => {
 });
 
 describe("theme failure handling", () => {
+  it("syncs browser chrome from the stable app token during route surface gaps", async () => {
+    const dynamicMeta = {
+      setAttribute: vi.fn(),
+    };
+    const documentElement = {
+      classList: { toggle: vi.fn() },
+      style: { backgroundColor: "#161616" },
+    };
+    const body = {
+      style: { backgroundColor: "#161616" },
+    };
+    vi.stubGlobal("window", {
+      localStorage: createStorage(),
+      matchMedia: () => ({ matches: true }),
+    });
+    vi.stubGlobal("document", {
+      body,
+      documentElement,
+      head: { append: vi.fn() },
+      querySelector: (selector: string) =>
+        selector.includes("data-dynamic-theme-color") ? dynamicMeta : null,
+    });
+    vi.stubGlobal("getComputedStyle", (element: unknown) => ({
+      backgroundColor: element === body ? "rgb(22, 22, 22)" : "rgb(0, 0, 0)",
+      getPropertyValue: (property: string) =>
+        element === documentElement && property === "--app-chrome-background"
+          ? "rgb(10, 10, 10)"
+          : "",
+    }));
+
+    const { syncBrowserChromeTheme } = await import("./useTheme");
+    documentElement.style.backgroundColor = "#161616";
+    body.style.backgroundColor = "#161616";
+    dynamicMeta.setAttribute.mockClear();
+
+    syncBrowserChromeTheme();
+
+    expect(documentElement.style.backgroundColor).toBe("rgb(10, 10, 10)");
+    expect(body.style.backgroundColor).toBe("rgb(10, 10, 10)");
+    expect(dynamicMeta.setAttribute).toHaveBeenCalledWith("content", "rgb(10, 10, 10)");
+  });
+
   it("preserves exact storage causes and operation context", async () => {
     const readCause = new Error("storage read blocked");
     const writeCause = new Error("storage quota exceeded");

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -154,15 +154,15 @@ function normalizeThemeColor(value: string | null | undefined): string | null {
 
 export function syncBrowserChromeTheme() {
   if (typeof document === "undefined" || typeof getComputedStyle === "undefined") return;
+  document.documentElement.style.backgroundColor = `var(${APP_CHROME_BACKGROUND_PROPERTY})`;
+  document.body.style.backgroundColor = `var(${APP_CHROME_BACKGROUND_PROPERTY})`;
   const appChromeColor = normalizeThemeColor(
-    getComputedStyle(document.documentElement).getPropertyValue(APP_CHROME_BACKGROUND_PROPERTY),
+    getComputedStyle(document.documentElement).backgroundColor,
   );
   const fallbackColor = normalizeThemeColor(getComputedStyle(document.body).backgroundColor);
   const backgroundColor = appChromeColor ?? fallbackColor;
   if (!backgroundColor) return;
 
-  document.documentElement.style.backgroundColor = backgroundColor;
-  document.body.style.backgroundColor = backgroundColor;
   ensureThemeColorMetaTag().setAttribute("content", backgroundColor);
 }
 

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -20,6 +20,7 @@ const DEFAULT_THEME_SNAPSHOT: ThemeSnapshot = {
 };
 const THEME_COLOR_META_NAME = "theme-color";
 const DYNAMIC_THEME_COLOR_SELECTOR = `meta[name="${THEME_COLOR_META_NAME}"][data-dynamic-theme-color="true"]`;
+const APP_CHROME_BACKGROUND_PROPERTY = "--app-chrome-background";
 
 export class ThemeStorageError extends Schema.TaggedErrorClass<ThemeStorageError>()(
   "ThemeStorageError",
@@ -151,21 +152,13 @@ function normalizeThemeColor(value: string | null | undefined): string | null {
   return value?.trim() ?? null;
 }
 
-function resolveBrowserChromeSurface(): HTMLElement {
-  return (
-    document.querySelector<HTMLElement>("main[data-slot='sidebar-inset']") ??
-    document.querySelector<HTMLElement>("[data-slot='sidebar-inner']") ??
-    document.body
-  );
-}
-
 export function syncBrowserChromeTheme() {
   if (typeof document === "undefined" || typeof getComputedStyle === "undefined") return;
-  const surfaceColor = normalizeThemeColor(
-    getComputedStyle(resolveBrowserChromeSurface()).backgroundColor,
+  const appChromeColor = normalizeThemeColor(
+    getComputedStyle(document.documentElement).getPropertyValue(APP_CHROME_BACKGROUND_PROPERTY),
   );
   const fallbackColor = normalizeThemeColor(getComputedStyle(document.body).backgroundColor);
-  const backgroundColor = surfaceColor ?? fallbackColor;
+  const backgroundColor = appChromeColor ?? fallbackColor;
   if (!backgroundColor) return;
 
   document.documentElement.style.backgroundColor = backgroundColor;


### PR DESCRIPTION
## Summary

Fixes a dark strip that could briefly appear along the right edge of the window when switching threads on Windows.

Electron can expose the window background for a moment while the page repaints. This change maps that surface to the app's existing `--background` color, so it stays aligned in both light and dark mode.

## Screenshots

| Before | After |
| --- | --- |
| ![Before](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-windows-edge/cd711d223fc1-76fb8557-1802-4a04-9dd4-9e36d1fd5175-255a6daf-ddeb-435b-ad94-992e33f69b20.png) | ![After](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-pr-windows-edge/7b37b2f0b616-after-thread-switch.png) |

## Verification

- formatting, lint, and web typecheck
- tested thread switching in the Windows Electron app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small theme/chrome styling changes with no auth, data, or API impact; limited to initial paint and theme-color sync behavior.
> 
> **Overview**
> Fixes a brief **dark strip on the right edge** when switching threads in the Windows Electron app by keeping the exposed window background aligned with the app surface during repaints.
> 
> **Dark mode base** moves from `#161616` to `#0a0a0a` in `index.html` (theme-color meta tags, boot script, and `html.dark body`) so early paint matches the design token used elsewhere.
> 
> **Browser chrome sync** in `syncBrowserChromeTheme` no longer samples `main[data-slot='sidebar-inset']` / sidebar inner / `body` backgrounds. It sets `html` and `body` to `var(--app-chrome-background)` and derives the dynamic `theme-color` meta from that resolved color, matching the existing `--app-chrome-background` → `--background` wiring in CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1baad2b130ff4352332d612321be396d89dc21ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dark mode background color for Windows thread edge
> - Updates the dark mode background color from `#161616` to `#0a0a0a` in [index.html](https://github.com/pingdotgg/t3code/pull/4493/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f), affecting the CSS, boot script constant, and `theme-color` meta tags.
> - Reworks `syncBrowserChromeTheme` in [useTheme.ts](https://github.com/pingdotgg/t3code/pull/4493/files#diff-57ecb397fe0e1618fa00c5e68da8f87d74b28fa80bbe3278328f195bc91505c4) to derive the browser chrome color from a new `--app-chrome-background` CSS variable on the root element, replacing the previous logic that read color from a sidebar or main surface element.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1baad2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->