### PR TITLE
Keep rapid settings edits from reverting each other

### DIFF
--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -87,6 +87,33 @@ describe("pendingServerSettings", () => {
     expect(getPendingServerPatches(environmentId)).toEqual([]);
   });
 
+  it("retires a successful overlay when its settings echo arrives before the RPC settles", () => {
+    const patch = { providerInstances: { [codexId]: providerInstance("codex", false) } };
+    const id = retain(patch);
+    const settledSettings = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, patch);
+
+    acknowledgePendingServerSettings(environmentId, settledSettings);
+    expect(getPendingServerPatches(environmentId)).toHaveLength(1);
+
+    settlePendingServerPatch(environmentId, id, settledSettings);
+    expect(getPendingServerPatches(environmentId)).toEqual([]);
+  });
+
+  it("records an early echo while an older successful patch is still awaiting its echo", () => {
+    const firstPatch = { enableAssistantStreaming: false };
+    const firstId = retain(firstPatch);
+    const secondPatch = { enableProviderUpdateChecks: false };
+    const secondId = retain(secondPatch);
+    const firstSettings = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, firstPatch);
+    const secondSettings = applyServerSettingsPatch(firstSettings, secondPatch);
+
+    settlePendingServerPatch(environmentId, firstId, firstSettings);
+    acknowledgePendingServerSettings(environmentId, secondSettings);
+    settlePendingServerPatch(environmentId, secondId, secondSettings);
+
+    expect(getPendingServerPatches(environmentId)).toEqual([]);
+  });
+
   it("drops the overlay for a failed write so the server value wins again", () => {
     const id = retain({
       providerInstances: { [codexId]: providerInstance("codex", false) },

--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -153,6 +153,57 @@ describe("pendingServerSettings", () => {
     ]);
   });
 
+  it("rebases provider environment rows by name without duplicating them", () => {
+    const environmentConfig = (value: string) => ({
+      driver: ProviderDriverKind.make("codex"),
+      enabled: true,
+      environment: [{ name: "OPENAI_API_KEY", value, sensitive: false }],
+    });
+    const currentSettings = {
+      ...DEFAULT_SERVER_SETTINGS,
+      providerInstances: { [codexId]: environmentConfig("current") },
+    };
+    const failedBase = {
+      ...currentSettings,
+      providerInstances: { [codexId]: environmentConfig("failed") },
+    };
+    const patch = {
+      providerInstances: { [codexId]: environmentConfig("intended") },
+    };
+    const settings = applyPendingServerPatches(currentSettings, [
+      { id: 1, patch, baseSettings: failedBase },
+    ]);
+
+    expect(settings.providerInstances[codexId]?.environment).toEqual([
+      { name: "OPENAI_API_KEY", value: "intended", sensitive: false },
+    ]);
+  });
+
+  it("rebases array deltas onto a missing authoritative array", () => {
+    const failedOptionsBase = {
+      ...DEFAULT_SERVER_SETTINGS,
+      textGenerationModelSelection: {
+        ...DEFAULT_SERVER_SETTINGS.textGenerationModelSelection,
+        options: [{ id: "failed", value: true }],
+      },
+    };
+    const patch = {
+      textGenerationModelSelection: {
+        options: [
+          { id: "failed", value: true },
+          { id: "intended", value: true },
+        ],
+      },
+    };
+    const settings = applyPendingServerPatches(DEFAULT_SERVER_SETTINGS, [
+      { id: 1, patch, baseSettings: failedOptionsBase },
+    ]);
+
+    expect(settings.textGenerationModelSelection.options).toEqual([
+      { id: "intended", value: true },
+    ]);
+  });
+
   it("rebases array insertions and removals without restoring failed elements", () => {
     const currentSettings = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       providers: { codex: { customModels: ["A"] } },

--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -5,13 +5,15 @@ import {
   ProviderInstanceId,
 } from "@t3tools/contracts";
 import { afterEach, describe, expect, it } from "vite-plus/test";
+import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 
 import {
   __resetPendingServerPatchesForTests,
+  acknowledgePendingServerSettings,
   applyPendingServerPatches,
   getPendingServerPatches,
-  releasePendingServerPatch,
   retainPendingServerPatch,
+  settlePendingServerPatch,
   subscribePendingServerPatches,
 } from "./pendingServerSettings";
 
@@ -23,6 +25,13 @@ const providerInstance = (driver: string, enabled: boolean) => ({
   driver: ProviderDriverKind.make(driver),
   enabled,
 });
+const retain = (patch: Parameters<typeof retainPendingServerPatch>[1]) =>
+  retainPendingServerPatch(
+    environmentId,
+    patch,
+    applyPendingServerPatches(DEFAULT_SERVER_SETTINGS, getPendingServerPatches(environmentId)),
+    DEFAULT_SERVER_SETTINGS,
+  );
 
 afterEach(() => {
   __resetPendingServerPatchesForTests();
@@ -40,7 +49,7 @@ describe("pendingServerSettings", () => {
     const disableCodex = {
       providerInstances: { [codexId]: providerInstance("codex", false) },
     };
-    retainPendingServerPatch(environmentId, disableCodex);
+    retain(disableCodex);
 
     // Before the echo lands, the panel must already see codex disabled so the
     // next whole-map replacement it builds carries that edit forward.
@@ -56,7 +65,7 @@ describe("pendingServerSettings", () => {
         [claudeId]: providerInstance("claudeAgent", false),
       },
     };
-    retainPendingServerPatch(environmentId, disableClaude);
+    retain(disableClaude);
 
     const both = applyPendingServerPatches(
       DEFAULT_SERVER_SETTINGS,
@@ -66,23 +75,23 @@ describe("pendingServerSettings", () => {
     expect(both.providerInstances[claudeId]?.enabled).toBe(false);
   });
 
-  it("retains the overlay until the last outstanding write settles", () => {
+  it("retains a successful overlay until its settings echo arrives", () => {
     const patch = { providerInstances: { [codexId]: providerInstance("codex", false) } };
-    retainPendingServerPatch(environmentId, patch);
-    retainPendingServerPatch(environmentId, patch);
+    const id = retain(patch);
+    const settledSettings = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, patch);
 
-    releasePendingServerPatch(environmentId);
-    expect(getPendingServerPatches(environmentId)).toHaveLength(2);
+    settlePendingServerPatch(environmentId, id, settledSettings);
+    expect(getPendingServerPatches(environmentId)).toHaveLength(1);
 
-    releasePendingServerPatch(environmentId);
+    acknowledgePendingServerSettings(environmentId, settledSettings);
     expect(getPendingServerPatches(environmentId)).toEqual([]);
   });
 
   it("drops the overlay for a failed write so the server value wins again", () => {
-    retainPendingServerPatch(environmentId, {
+    const id = retain({
       providerInstances: { [codexId]: providerInstance("codex", false) },
     });
-    releasePendingServerPatch(environmentId);
+    settlePendingServerPatch(environmentId, id, null);
 
     const settings = applyPendingServerPatches(
       DEFAULT_SERVER_SETTINGS,
@@ -93,12 +102,9 @@ describe("pendingServerSettings", () => {
 
   it("scopes pending writes to their own environment", () => {
     const otherEnvironmentId = EnvironmentId.make("environment-2");
-    retainPendingServerPatch(environmentId, {
-      providerInstances: { [codexId]: providerInstance("codex", false) },
-    });
+    retain({ providerInstances: { [codexId]: providerInstance("codex", false) } });
 
     expect(getPendingServerPatches(otherEnvironmentId)).toEqual([]);
-    releasePendingServerPatch(otherEnvironmentId);
     expect(getPendingServerPatches(environmentId)).toHaveLength(1);
   });
 
@@ -108,10 +114,10 @@ describe("pendingServerSettings", () => {
       notifications += 1;
     });
 
-    retainPendingServerPatch(environmentId, { enableAssistantStreaming: false });
-    releasePendingServerPatch(environmentId);
+    const id = retain({ enableAssistantStreaming: false });
+    settlePendingServerPatch(environmentId, id, null);
     unsubscribe();
-    retainPendingServerPatch(environmentId, { enableAssistantStreaming: false });
+    retain({ enableAssistantStreaming: false });
 
     expect(notifications).toBe(2);
   });

--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -120,6 +120,71 @@ describe("pendingServerSettings", () => {
     );
   });
 
+  it("rebases model option deltas without restoring failed option values", () => {
+    const currentSettings = {
+      ...DEFAULT_SERVER_SETTINGS,
+      textGenerationModelSelection: {
+        ...DEFAULT_SERVER_SETTINGS.textGenerationModelSelection,
+        options: [{ id: "reasoning_effort", value: "low" }],
+      },
+    };
+    const failedOptionsBase = {
+      ...currentSettings,
+      textGenerationModelSelection: {
+        ...currentSettings.textGenerationModelSelection,
+        options: [{ id: "reasoning_effort", value: "medium" }],
+      },
+    };
+    const patch = {
+      textGenerationModelSelection: {
+        options: [
+          { id: "reasoning_effort", value: "medium" },
+          { id: "verbosity", value: "high" },
+        ],
+      },
+    };
+    const settings = applyPendingServerPatches(currentSettings, [
+      { id: 1, patch, baseSettings: failedOptionsBase },
+    ]);
+
+    expect(settings.textGenerationModelSelection.options).toEqual([
+      { id: "reasoning_effort", value: "low" },
+      { id: "verbosity", value: "high" },
+    ]);
+  });
+
+  it("rebases array insertions and removals without restoring failed elements", () => {
+    const currentSettings = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
+      providers: { codex: { customModels: ["A"] } },
+    });
+    const failedInsertionBase = applyServerSettingsPatch(currentSettings, {
+      providers: { codex: { customModels: ["A", "B"] } },
+    });
+    const afterInsertion = applyPendingServerPatches(currentSettings, [
+      {
+        id: 1,
+        patch: { providers: { codex: { customModels: ["A", "B", "C"] } } },
+        baseSettings: failedInsertionBase,
+      },
+    ]);
+    expect(afterInsertion.providers.codex.customModels).toEqual(["A", "C"]);
+
+    const currentAfterFailedRemoval = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
+      providers: { codex: { customModels: ["A", "B"] } },
+    });
+    const failedRemovalBase = applyServerSettingsPatch(currentAfterFailedRemoval, {
+      providers: { codex: { customModels: ["A"] } },
+    });
+    const afterRemoval = applyPendingServerPatches(currentAfterFailedRemoval, [
+      {
+        id: 2,
+        patch: { providers: { codex: { customModels: ["A", "C"] } } },
+        baseSettings: failedRemovalBase,
+      },
+    ]);
+    expect(afterRemoval.providers.codex.customModels).toEqual(["A", "B", "C"]);
+  });
+
   it("drops stale legacy provider edits inherited from a failed optimistic base", () => {
     const failedBase = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       providers: { codex: { binaryPath: "/failed/codex" } },

--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -97,6 +97,29 @@ describe("pendingServerSettings", () => {
     );
   });
 
+  it("drops model options when their optimistic model change failed", () => {
+    const failedModelBase = {
+      ...DEFAULT_SERVER_SETTINGS,
+      textGenerationModelSelection: {
+        instanceId: claudeId,
+        model: "claude-sonnet",
+      },
+    };
+    const patch = {
+      textGenerationModelSelection: {
+        ...failedModelBase.textGenerationModelSelection,
+        options: [{ id: "reasoning_effort", value: "high" }],
+      },
+    };
+    const settings = applyPendingServerPatches(DEFAULT_SERVER_SETTINGS, [
+      { id: 1, patch, baseSettings: failedModelBase },
+    ]);
+
+    expect(settings.textGenerationModelSelection).toEqual(
+      DEFAULT_SERVER_SETTINGS.textGenerationModelSelection,
+    );
+  });
+
   it("drops stale legacy provider edits inherited from a failed optimistic base", () => {
     const failedBase = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       providers: { codex: { binaryPath: "/failed/codex" } },

--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -1,0 +1,118 @@
+import {
+  DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  __resetPendingServerPatchesForTests,
+  applyPendingServerPatches,
+  getPendingServerPatches,
+  releasePendingServerPatch,
+  retainPendingServerPatch,
+  subscribePendingServerPatches,
+} from "./pendingServerSettings";
+
+const environmentId = EnvironmentId.make("environment-1");
+const codexId = ProviderInstanceId.make("codex");
+const claudeId = ProviderInstanceId.make("claudeAgent");
+
+const providerInstance = (driver: string, enabled: boolean) => ({
+  driver: ProviderDriverKind.make(driver),
+  enabled,
+});
+
+afterEach(() => {
+  __resetPendingServerPatchesForTests();
+});
+
+describe("pendingServerSettings", () => {
+  it("has no overlay before a write is dispatched", () => {
+    expect(getPendingServerPatches(environmentId)).toEqual([]);
+    expect(getPendingServerPatches(null)).toEqual([]);
+    expect(applyPendingServerPatches(DEFAULT_SERVER_SETTINGS, [])).toBe(DEFAULT_SERVER_SETTINGS);
+  });
+
+  it("keeps a second provider toggle from reverting the first one", () => {
+    // Disabling codex is dispatched from the server's own (empty) map.
+    const disableCodex = {
+      providerInstances: { [codexId]: providerInstance("codex", false) },
+    };
+    retainPendingServerPatch(environmentId, disableCodex);
+
+    // Before the echo lands, the panel must already see codex disabled so the
+    // next whole-map replacement it builds carries that edit forward.
+    const optimistic = applyPendingServerPatches(
+      DEFAULT_SERVER_SETTINGS,
+      getPendingServerPatches(environmentId),
+    );
+    expect(optimistic.providerInstances[codexId]?.enabled).toBe(false);
+
+    const disableClaude = {
+      providerInstances: {
+        ...optimistic.providerInstances,
+        [claudeId]: providerInstance("claudeAgent", false),
+      },
+    };
+    retainPendingServerPatch(environmentId, disableClaude);
+
+    const both = applyPendingServerPatches(
+      DEFAULT_SERVER_SETTINGS,
+      getPendingServerPatches(environmentId),
+    );
+    expect(both.providerInstances[codexId]?.enabled).toBe(false);
+    expect(both.providerInstances[claudeId]?.enabled).toBe(false);
+  });
+
+  it("retains the overlay until the last outstanding write settles", () => {
+    const patch = { providerInstances: { [codexId]: providerInstance("codex", false) } };
+    retainPendingServerPatch(environmentId, patch);
+    retainPendingServerPatch(environmentId, patch);
+
+    releasePendingServerPatch(environmentId);
+    expect(getPendingServerPatches(environmentId)).toHaveLength(2);
+
+    releasePendingServerPatch(environmentId);
+    expect(getPendingServerPatches(environmentId)).toEqual([]);
+  });
+
+  it("drops the overlay for a failed write so the server value wins again", () => {
+    retainPendingServerPatch(environmentId, {
+      providerInstances: { [codexId]: providerInstance("codex", false) },
+    });
+    releasePendingServerPatch(environmentId);
+
+    const settings = applyPendingServerPatches(
+      DEFAULT_SERVER_SETTINGS,
+      getPendingServerPatches(environmentId),
+    );
+    expect(settings).toBe(DEFAULT_SERVER_SETTINGS);
+  });
+
+  it("scopes pending writes to their own environment", () => {
+    const otherEnvironmentId = EnvironmentId.make("environment-2");
+    retainPendingServerPatch(environmentId, {
+      providerInstances: { [codexId]: providerInstance("codex", false) },
+    });
+
+    expect(getPendingServerPatches(otherEnvironmentId)).toEqual([]);
+    releasePendingServerPatch(otherEnvironmentId);
+    expect(getPendingServerPatches(environmentId)).toHaveLength(1);
+  });
+
+  it("notifies subscribers when the pending set changes", () => {
+    let notifications = 0;
+    const unsubscribe = subscribePendingServerPatches(() => {
+      notifications += 1;
+    });
+
+    retainPendingServerPatch(environmentId, { enableAssistantStreaming: false });
+    releasePendingServerPatch(environmentId);
+    unsubscribe();
+    retainPendingServerPatch(environmentId, { enableAssistantStreaming: false });
+
+    expect(notifications).toBe(2);
+  });
+});

--- a/apps/web/src/hooks/pendingServerSettings.test.ts
+++ b/apps/web/src/hooks/pendingServerSettings.test.ts
@@ -75,6 +75,51 @@ describe("pendingServerSettings", () => {
     expect(both.providerInstances[claudeId]?.enabled).toBe(false);
   });
 
+  it("preserves a server model fallback that a queued patch did not change", () => {
+    const serverFallback = {
+      ...DEFAULT_SERVER_SETTINGS,
+      textGenerationModelSelection: {
+        instanceId: claudeId,
+        model: "claude-sonnet",
+      },
+    };
+    const patch = {
+      enableProviderUpdateChecks: false,
+      textGenerationModelSelection: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection,
+    };
+    const settings = applyPendingServerPatches(serverFallback, [
+      { id: 1, patch, baseSettings: DEFAULT_SERVER_SETTINGS },
+    ]);
+
+    expect(settings.enableProviderUpdateChecks).toBe(false);
+    expect(settings.textGenerationModelSelection).toEqual(
+      serverFallback.textGenerationModelSelection,
+    );
+  });
+
+  it("drops stale legacy provider edits inherited from a failed optimistic base", () => {
+    const failedBase = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
+      providers: { codex: { binaryPath: "/failed/codex" } },
+    });
+    const patch = {
+      providers: {
+        codex: failedBase.providers.codex,
+        claudeAgent: {
+          ...failedBase.providers.claudeAgent,
+          binaryPath: "/selected/claude",
+        },
+      },
+    };
+    const settings = applyPendingServerPatches(DEFAULT_SERVER_SETTINGS, [
+      { id: 1, patch, baseSettings: failedBase },
+    ]);
+
+    expect(settings.providers.codex.binaryPath).toBe(
+      DEFAULT_SERVER_SETTINGS.providers.codex.binaryPath,
+    );
+    expect(settings.providers.claudeAgent.binaryPath).toBe("/selected/claude");
+  });
+
   it("retains a successful overlay until its settings echo arrives", () => {
     const patch = { providerInstances: { [codexId]: providerInstance("codex", false) } };
     const id = retain(patch);

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -85,6 +85,31 @@ function rebaseChangedValue(original: unknown, intended: unknown, current: unkno
   return rebased;
 }
 
+function isSameModelTarget(
+  left: ServerSettings["textGenerationModelSelection"],
+  right: ServerSettings["textGenerationModelSelection"],
+): boolean {
+  return left.instanceId === right.instanceId && left.model === right.model;
+}
+
+function rebaseModelSelection(
+  original: ServerSettings["textGenerationModelSelection"],
+  intended: ServerSettings["textGenerationModelSelection"],
+  current: ServerSettings["textGenerationModelSelection"],
+): ServerSettings["textGenerationModelSelection"] {
+  if (!isSameModelTarget(original, intended)) {
+    return intended;
+  }
+  if (!isSameModelTarget(original, current)) {
+    return current;
+  }
+  return rebaseChangedValue(
+    original,
+    intended,
+    current,
+  ) as ServerSettings["textGenerationModelSelection"];
+}
+
 /**
  * Preserve only the edits made by this operation when its original optimistic
  * base no longer matches the latest authoritative server settings.
@@ -97,11 +122,18 @@ export function rebaseServerSettingsPatch(
   const intended = applyServerSettingsPatch(originalBase, patch);
   const rebased: Record<string, unknown> = {};
   for (const key of Object.keys(patch)) {
-    rebased[key] = rebaseChangedValue(
-      originalBase[key as keyof ServerSettings],
-      intended[key as keyof ServerSettings],
-      currentBase[key as keyof ServerSettings],
-    );
+    rebased[key] =
+      key === "textGenerationModelSelection"
+        ? rebaseModelSelection(
+            originalBase.textGenerationModelSelection,
+            intended.textGenerationModelSelection,
+            currentBase.textGenerationModelSelection,
+          )
+        : rebaseChangedValue(
+            originalBase[key as keyof ServerSettings],
+            intended[key as keyof ServerSettings],
+            currentBase[key as keyof ServerSettings],
+          );
   }
   return rebased as ServerSettingsPatch;
 }

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -196,7 +196,10 @@ export function acknowledgePendingServerSettings(
     } else {
       pendingByEnvironment.set(environmentId, {
         patches,
-        authoritativeSettings: settings,
+        authoritativeSettings: patches.reduce(
+          (latest, entry) => entry.settledSettings ?? latest,
+          settings,
+        ),
         observedSettings: settings,
       });
     }

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -1,0 +1,107 @@
+/**
+ * Optimistic overlay for server settings writes that are still in flight.
+ *
+ * Server settings only change locally once the server echoes a
+ * `settingsUpdated` broadcast back over the websocket. Until that round trip
+ * lands, readers still see pre-edit settings, so a second edit issued inside
+ * the window is computed from stale state — and because keys such as
+ * `providerInstances` are whole-value replacements rather than deep merges,
+ * that second write silently reverts the first one. (Toggle one provider off,
+ * toggle a second off a moment later, and the first provider's switch snaps
+ * back on once its own write is overwritten.)
+ *
+ * Each in-flight patch is retained here and replayed on top of the server value
+ * through the same `applyServerSettingsPatch` the server runs, so both reads and
+ * follow-up patches are built from the edit the user just made. Retained patches
+ * are dropped once no write is outstanding for that environment, at which point
+ * the server value is authoritative again — including when a write failed.
+ *
+ * @module hooks/pendingServerSettings
+ */
+import type { EnvironmentId, ServerSettings, ServerSettingsPatch } from "@t3tools/contracts";
+import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
+
+interface PendingServerPatches {
+  readonly patches: ReadonlyArray<ServerSettingsPatch>;
+  /** Writes dispatched for this environment that have not settled yet. */
+  readonly inFlight: number;
+}
+
+export const NO_PENDING_SERVER_PATCHES: ReadonlyArray<ServerSettingsPatch> = [];
+
+const pendingByEnvironment = new Map<EnvironmentId, PendingServerPatches>();
+const listeners = new Set<() => void>();
+
+function emitChange(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribePendingServerPatches(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Snapshot accessor for `useSyncExternalStore`: the returned array is stable
+ * until the environment's pending set actually changes.
+ */
+export function getPendingServerPatches(
+  environmentId: EnvironmentId | null,
+): ReadonlyArray<ServerSettingsPatch> {
+  if (environmentId === null) return NO_PENDING_SERVER_PATCHES;
+  return pendingByEnvironment.get(environmentId)?.patches ?? NO_PENDING_SERVER_PATCHES;
+}
+
+/** Record a patch that has just been dispatched to the server. */
+export function retainPendingServerPatch(
+  environmentId: EnvironmentId,
+  patch: ServerSettingsPatch,
+): void {
+  const pending = pendingByEnvironment.get(environmentId);
+  pendingByEnvironment.set(environmentId, {
+    patches: [...(pending?.patches ?? NO_PENDING_SERVER_PATCHES), patch],
+    inFlight: (pending?.inFlight ?? 0) + 1,
+  });
+  emitChange();
+}
+
+/**
+ * Mark one dispatched write as settled. Patches are only forgotten when the
+ * last outstanding write settles: releasing them one at a time would expose the
+ * server value before its later echo arrived, flickering the UI back to a state
+ * the user has already edited away from.
+ */
+export function releasePendingServerPatch(environmentId: EnvironmentId): void {
+  const pending = pendingByEnvironment.get(environmentId);
+  if (pending === undefined) return;
+  if (pending.inFlight <= 1) {
+    pendingByEnvironment.delete(environmentId);
+  } else {
+    pendingByEnvironment.set(environmentId, {
+      patches: pending.patches,
+      inFlight: pending.inFlight - 1,
+    });
+  }
+  emitChange();
+}
+
+/** Replay in-flight patches over an authoritative server settings value. */
+export function applyPendingServerPatches(
+  settings: ServerSettings,
+  patches: ReadonlyArray<ServerSettingsPatch>,
+): ServerSettings {
+  if (patches.length === 0) return settings;
+  return patches.reduce<ServerSettings>(
+    (current, patch) => applyServerSettingsPatch(current, patch),
+    settings,
+  );
+}
+
+export function __resetPendingServerPatchesForTests(): void {
+  pendingByEnvironment.clear();
+  listeners.clear();
+}

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -53,35 +53,57 @@ function structurallyEqual(left: unknown, right: unknown): boolean {
   );
 }
 
+function rebaseChangedValue(original: unknown, intended: unknown, current: unknown): unknown {
+  if (structurallyEqual(original, intended)) return current;
+  if (
+    typeof original !== "object" ||
+    original === null ||
+    typeof intended !== "object" ||
+    intended === null ||
+    typeof current !== "object" ||
+    current === null ||
+    Array.isArray(original) ||
+    Array.isArray(intended) ||
+    Array.isArray(current)
+  ) {
+    return intended;
+  }
+
+  const originalRecord = original as Readonly<Record<string, unknown>>;
+  const intendedRecord = intended as Readonly<Record<string, unknown>>;
+  const rebased = { ...(current as Readonly<Record<string, unknown>>) };
+  const keys = new Set([...Object.keys(originalRecord), ...Object.keys(intendedRecord)]);
+  for (const key of keys) {
+    if (structurallyEqual(originalRecord[key], intendedRecord[key])) continue;
+    const value = rebaseChangedValue(originalRecord[key], intendedRecord[key], rebased[key]);
+    if (value === undefined) {
+      delete rebased[key];
+    } else {
+      rebased[key] = value;
+    }
+  }
+  return rebased;
+}
+
 /**
- * Preserve only the provider-instance edits made by this operation when its
- * original optimistic base no longer matches the server after an earlier
- * write failed.
+ * Preserve only the edits made by this operation when its original optimistic
+ * base no longer matches the latest authoritative server settings.
  */
 export function rebaseServerSettingsPatch(
   patch: ServerSettingsPatch,
   originalBase: ServerSettings,
   currentBase: ServerSettings,
 ): ServerSettingsPatch {
-  if (patch.providerInstances === undefined) return patch;
-
-  const rebasedProviderInstances = { ...currentBase.providerInstances };
-  const keys = new Set([
-    ...Object.keys(originalBase.providerInstances),
-    ...Object.keys(patch.providerInstances),
-  ]);
-  for (const key of keys) {
-    const instanceId = key as keyof typeof patch.providerInstances;
-    const previous = originalBase.providerInstances[instanceId];
-    const next = patch.providerInstances[instanceId];
-    if (structurallyEqual(previous, next)) continue;
-    if (next === undefined) {
-      delete rebasedProviderInstances[instanceId];
-    } else {
-      rebasedProviderInstances[instanceId] = next;
-    }
+  const intended = applyServerSettingsPatch(originalBase, patch);
+  const rebased: Record<string, unknown> = {};
+  for (const key of Object.keys(patch)) {
+    rebased[key] = rebaseChangedValue(
+      originalBase[key as keyof ServerSettings],
+      intended[key as keyof ServerSettings],
+      currentBase[key as keyof ServerSettings],
+    );
   }
-  return { ...patch, providerInstances: rebasedProviderInstances };
+  return rebased as ServerSettingsPatch;
 }
 
 export function subscribePendingServerPatches(listener: () => void): () => void {

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -10,7 +10,10 @@ export interface PendingServerPatch {
 
 interface PendingServerState {
   readonly patches: ReadonlyArray<PendingServerPatch>;
+  /** Latest successful RPC result, used to rebase the next queued write. */
   readonly authoritativeSettings: ServerSettings;
+  /** Latest settings snapshot published to React, which may precede its RPC result. */
+  readonly observedSettings: ServerSettings;
 }
 
 export const NO_PENDING_SERVER_PATCHES: ReadonlyArray<PendingServerPatch> = [];
@@ -120,6 +123,7 @@ export function retainPendingServerPatch(
   pendingByEnvironment.set(environmentId, {
     patches: [...(existing?.patches ?? NO_PENDING_SERVER_PATCHES), { id, patch, baseSettings }],
     authoritativeSettings: existing?.authoritativeSettings ?? authoritativeSettings,
+    observedSettings: existing?.observedSettings ?? authoritativeSettings,
   });
   emitChange();
   return id;
@@ -146,18 +150,26 @@ export function settlePendingServerPatch(
 ): void {
   const state = pendingByEnvironment.get(environmentId);
   if (!state) return;
+  const settledIndex = state.patches.findIndex((entry) => entry.id === id);
+  const settingsWereAlreadyObserved =
+    settings !== null &&
+    settledIndex >= 0 &&
+    structurallyEqual(state.observedSettings, settings);
   const patches =
     settings === null
       ? state.patches.filter((entry) => entry.id !== id)
-      : state.patches.map((entry) =>
-          entry.id === id ? { ...entry, settledSettings: settings } : entry,
-        );
-  if (patches.length === 0 && settings === null) {
+      : settingsWereAlreadyObserved
+        ? state.patches.slice(settledIndex + 1)
+        : state.patches.map((entry) =>
+            entry.id === id ? { ...entry, settledSettings: settings } : entry,
+          );
+  if (patches.length === 0) {
     pendingByEnvironment.delete(environmentId);
   } else {
     pendingByEnvironment.set(environmentId, {
       patches,
       authoritativeSettings: settings ?? state.authoritativeSettings,
+      observedSettings: state.observedSettings,
     });
   }
   emitChange();
@@ -185,17 +197,19 @@ export function acknowledgePendingServerSettings(
       pendingByEnvironment.set(environmentId, {
         patches,
         authoritativeSettings: settings,
+        observedSettings: settings,
       });
     }
     emitChange();
     return;
   }
-  if (!state.patches.some((entry) => entry.settledSettings !== undefined)) {
-    pendingByEnvironment.set(environmentId, {
-      ...state,
-      authoritativeSettings: settings,
-    });
-  }
+  pendingByEnvironment.set(environmentId, {
+    ...state,
+    ...(state.patches.some((entry) => entry.settledSettings !== undefined)
+      ? {}
+      : { authoritativeSettings: settings }),
+    observedSettings: settings,
+  });
 }
 
 export function __resetPendingServerPatchesForTests(): void {

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -53,16 +53,14 @@ function structurallyEqual(left: unknown, right: unknown): boolean {
   );
 }
 
-function stableArrayElementId(value: unknown): string | null {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value) ||
-    typeof (value as { readonly id?: unknown }).id !== "string"
-  ) {
+function stableArrayElementKey(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
   }
-  return (value as { readonly id: string }).id;
+  const record = value as { readonly id?: unknown; readonly name?: unknown };
+  if (typeof record.id === "string") return `id:${record.id}`;
+  if (typeof record.name === "string") return `name:${record.name}`;
+  return null;
 }
 
 function removeFirstStructurallyEqual(values: Array<unknown>, target: unknown): boolean {
@@ -102,19 +100,19 @@ function rebaseArrayById(
   intended: ReadonlyArray<unknown>,
   current: ReadonlyArray<unknown>,
 ): ReadonlyArray<unknown> {
-  const originalById = new Map(original.map((value) => [stableArrayElementId(value), value]));
-  const intendedById = new Map(intended.map((value) => [stableArrayElementId(value), value]));
+  const originalById = new Map(original.map((value) => [stableArrayElementKey(value), value]));
+  const intendedById = new Map(intended.map((value) => [stableArrayElementKey(value), value]));
   const rebased = [...current];
 
   for (const id of originalById.keys()) {
     if (intendedById.has(id)) continue;
-    const index = rebased.findIndex((value) => stableArrayElementId(value) === id);
+    const index = rebased.findIndex((value) => stableArrayElementKey(value) === id);
     if (index >= 0) rebased.splice(index, 1);
   }
   for (const [id, intendedValue] of intendedById) {
     const originalValue = originalById.get(id);
     if (originalValue !== undefined && structurallyEqual(originalValue, intendedValue)) continue;
-    const currentIndex = rebased.findIndex((value) => stableArrayElementId(value) === id);
+    const currentIndex = rebased.findIndex((value) => stableArrayElementKey(value) === id);
     const rebasedValue =
       originalValue === undefined
         ? intendedValue
@@ -134,15 +132,19 @@ function rebaseArray(
   current: ReadonlyArray<unknown>,
 ): ReadonlyArray<unknown> {
   const allValues = [...original, ...intended, ...current];
-  return allValues.length > 0 && allValues.every((value) => stableArrayElementId(value) !== null)
+  return allValues.length > 0 && allValues.every((value) => stableArrayElementKey(value) !== null)
     ? rebaseArrayById(original, intended, current)
     : rebaseArrayByValue(original, intended, current);
 }
 
 function rebaseChangedValue(original: unknown, intended: unknown, current: unknown): unknown {
   if (structurallyEqual(original, intended)) return current;
-  if (Array.isArray(original) && Array.isArray(intended) && Array.isArray(current)) {
-    return rebaseArray(original, intended, current);
+  if (
+    Array.isArray(original) &&
+    Array.isArray(intended) &&
+    (Array.isArray(current) || current === undefined)
+  ) {
+    return rebaseArray(original, intended, current ?? []);
   }
   if (
     typeof original !== "object" ||

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -1,41 +1,84 @@
-/**
- * Optimistic overlay for server settings writes that are still in flight.
- *
- * Server settings only change locally once the server echoes a
- * `settingsUpdated` broadcast back over the websocket. Until that round trip
- * lands, readers still see pre-edit settings, so a second edit issued inside
- * the window is computed from stale state — and because keys such as
- * `providerInstances` are whole-value replacements rather than deep merges,
- * that second write silently reverts the first one. (Toggle one provider off,
- * toggle a second off a moment later, and the first provider's switch snaps
- * back on once its own write is overwritten.)
- *
- * Each in-flight patch is retained here and replayed on top of the server value
- * through the same `applyServerSettingsPatch` the server runs, so both reads and
- * follow-up patches are built from the edit the user just made. Retained patches
- * are dropped once no write is outstanding for that environment, at which point
- * the server value is authoritative again — including when a write failed.
- *
- * @module hooks/pendingServerSettings
- */
 import type { EnvironmentId, ServerSettings, ServerSettingsPatch } from "@t3tools/contracts";
 import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 
-interface PendingServerPatches {
-  readonly patches: ReadonlyArray<ServerSettingsPatch>;
-  /** Writes dispatched for this environment that have not settled yet. */
-  readonly inFlight: number;
+export interface PendingServerPatch {
+  readonly id: number;
+  readonly patch: ServerSettingsPatch;
+  readonly baseSettings: ServerSettings;
+  readonly settledSettings?: ServerSettings;
 }
 
-export const NO_PENDING_SERVER_PATCHES: ReadonlyArray<ServerSettingsPatch> = [];
+interface PendingServerState {
+  readonly patches: ReadonlyArray<PendingServerPatch>;
+  readonly authoritativeSettings: ServerSettings;
+}
 
-const pendingByEnvironment = new Map<EnvironmentId, PendingServerPatches>();
+export const NO_PENDING_SERVER_PATCHES: ReadonlyArray<PendingServerPatch> = [];
+
+const pendingByEnvironment = new Map<EnvironmentId, PendingServerState>();
 const listeners = new Set<() => void>();
+let nextPendingPatchId = 1;
 
 function emitChange(): void {
-  for (const listener of listeners) {
-    listener();
+  for (const listener of listeners) listener();
+}
+
+function structurallyEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (typeof left !== "object" || left === null || typeof right !== "object" || right === null) {
+    return false;
   }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => structurallyEqual(value, right[index]))
+    );
+  }
+  const leftRecord = left as Readonly<Record<string, unknown>>;
+  const rightRecord = right as Readonly<Record<string, unknown>>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(rightRecord, key) &&
+        structurallyEqual(leftRecord[key], rightRecord[key]),
+    )
+  );
+}
+
+/**
+ * Preserve only the provider-instance edits made by this operation when its
+ * original optimistic base no longer matches the server after an earlier
+ * write failed.
+ */
+export function rebaseServerSettingsPatch(
+  patch: ServerSettingsPatch,
+  originalBase: ServerSettings,
+  currentBase: ServerSettings,
+): ServerSettingsPatch {
+  if (patch.providerInstances === undefined) return patch;
+
+  const rebasedProviderInstances = { ...currentBase.providerInstances };
+  const keys = new Set([
+    ...Object.keys(originalBase.providerInstances),
+    ...Object.keys(patch.providerInstances),
+  ]);
+  for (const key of keys) {
+    const instanceId = key as keyof typeof patch.providerInstances;
+    const previous = originalBase.providerInstances[instanceId];
+    const next = patch.providerInstances[instanceId];
+    if (structurallyEqual(previous, next)) continue;
+    if (next === undefined) {
+      delete rebasedProviderInstances[instanceId];
+    } else {
+      rebasedProviderInstances[instanceId] = next;
+    }
+  }
+  return { ...patch, providerInstances: rebasedProviderInstances };
 }
 
 export function subscribePendingServerPatches(listener: () => void): () => void {
@@ -45,63 +88,118 @@ export function subscribePendingServerPatches(listener: () => void): () => void 
   };
 }
 
-/**
- * Snapshot accessor for `useSyncExternalStore`: the returned array is stable
- * until the environment's pending set actually changes.
- */
 export function getPendingServerPatches(
   environmentId: EnvironmentId | null,
-): ReadonlyArray<ServerSettingsPatch> {
+): ReadonlyArray<PendingServerPatch> {
   if (environmentId === null) return NO_PENDING_SERVER_PATCHES;
   return pendingByEnvironment.get(environmentId)?.patches ?? NO_PENDING_SERVER_PATCHES;
 }
 
-/** Record a patch that has just been dispatched to the server. */
+export function applyPendingServerPatches(
+  settings: ServerSettings,
+  patches: ReadonlyArray<PendingServerPatch>,
+): ServerSettings {
+  return patches.reduce((current, pending) => {
+    const rebasedPatch = rebaseServerSettingsPatch(
+      pending.patch,
+      pending.baseSettings,
+      current,
+    );
+    return applyServerSettingsPatch(current, rebasedPatch);
+  }, settings);
+}
+
 export function retainPendingServerPatch(
   environmentId: EnvironmentId,
   patch: ServerSettingsPatch,
-): void {
-  const pending = pendingByEnvironment.get(environmentId);
+  baseSettings: ServerSettings,
+  authoritativeSettings: ServerSettings,
+): number {
+  const existing = pendingByEnvironment.get(environmentId);
+  const id = nextPendingPatchId++;
   pendingByEnvironment.set(environmentId, {
-    patches: [...(pending?.patches ?? NO_PENDING_SERVER_PATCHES), patch],
-    inFlight: (pending?.inFlight ?? 0) + 1,
+    patches: [...(existing?.patches ?? NO_PENDING_SERVER_PATCHES), { id, patch, baseSettings }],
+    authoritativeSettings: existing?.authoritativeSettings ?? authoritativeSettings,
   });
   emitChange();
+  return id;
 }
 
-/**
- * Mark one dispatched write as settled. Patches are only forgotten when the
- * last outstanding write settles: releasing them one at a time would expose the
- * server value before its later echo arrived, flickering the UI back to a state
- * the user has already edited away from.
- */
-export function releasePendingServerPatch(environmentId: EnvironmentId): void {
-  const pending = pendingByEnvironment.get(environmentId);
-  if (pending === undefined) return;
-  if (pending.inFlight <= 1) {
+export function getPendingServerPatchForDispatch(
+  environmentId: EnvironmentId,
+  id: number,
+): ServerSettingsPatch | null {
+  const state = pendingByEnvironment.get(environmentId);
+  const pending = state?.patches.find((entry) => entry.id === id);
+  if (!state || !pending) return null;
+  return rebaseServerSettingsPatch(
+    pending.patch,
+    pending.baseSettings,
+    state.authoritativeSettings,
+  );
+}
+
+export function settlePendingServerPatch(
+  environmentId: EnvironmentId,
+  id: number,
+  settings: ServerSettings | null,
+): void {
+  const state = pendingByEnvironment.get(environmentId);
+  if (!state) return;
+  const patches =
+    settings === null
+      ? state.patches.filter((entry) => entry.id !== id)
+      : state.patches.map((entry) =>
+          entry.id === id ? { ...entry, settledSettings: settings } : entry,
+        );
+  if (patches.length === 0 && settings === null) {
     pendingByEnvironment.delete(environmentId);
   } else {
     pendingByEnvironment.set(environmentId, {
-      patches: pending.patches,
-      inFlight: pending.inFlight - 1,
+      patches,
+      authoritativeSettings: settings ?? state.authoritativeSettings,
     });
   }
   emitChange();
 }
 
-/** Replay in-flight patches over an authoritative server settings value. */
-export function applyPendingServerPatches(
+/**
+ * Retire successful overlays only when their actual settingsUpdated payload is
+ * observed. An initial config snapshot cannot acknowledge a write accidentally.
+ */
+export function acknowledgePendingServerSettings(
+  environmentId: EnvironmentId,
   settings: ServerSettings,
-  patches: ReadonlyArray<ServerSettingsPatch>,
-): ServerSettings {
-  if (patches.length === 0) return settings;
-  return patches.reduce<ServerSettings>(
-    (current, patch) => applyServerSettingsPatch(current, patch),
-    settings,
+): void {
+  const state = pendingByEnvironment.get(environmentId);
+  if (!state) return;
+  const acknowledgedIndex = state.patches.findLastIndex(
+    (entry) =>
+      entry.settledSettings !== undefined && structurallyEqual(entry.settledSettings, settings),
   );
+  if (acknowledgedIndex >= 0) {
+    const patches = state.patches.slice(acknowledgedIndex + 1);
+    if (patches.length === 0) {
+      pendingByEnvironment.delete(environmentId);
+    } else {
+      pendingByEnvironment.set(environmentId, {
+        patches,
+        authoritativeSettings: settings,
+      });
+    }
+    emitChange();
+    return;
+  }
+  if (!state.patches.some((entry) => entry.settledSettings !== undefined)) {
+    pendingByEnvironment.set(environmentId, {
+      ...state,
+      authoritativeSettings: settings,
+    });
+  }
 }
 
 export function __resetPendingServerPatchesForTests(): void {
   pendingByEnvironment.clear();
   listeners.clear();
+  nextPendingPatchId = 1;
 }

--- a/apps/web/src/hooks/pendingServerSettings.ts
+++ b/apps/web/src/hooks/pendingServerSettings.ts
@@ -53,8 +53,97 @@ function structurallyEqual(left: unknown, right: unknown): boolean {
   );
 }
 
+function stableArrayElementId(value: unknown): string | null {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    typeof (value as { readonly id?: unknown }).id !== "string"
+  ) {
+    return null;
+  }
+  return (value as { readonly id: string }).id;
+}
+
+function removeFirstStructurallyEqual(values: Array<unknown>, target: unknown): boolean {
+  const index = values.findIndex((value) => structurallyEqual(value, target));
+  if (index < 0) return false;
+  values.splice(index, 1);
+  return true;
+}
+
+function rebaseArrayByValue(
+  original: ReadonlyArray<unknown>,
+  intended: ReadonlyArray<unknown>,
+  current: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> {
+  const unmatchedIntended = [...intended];
+  const removed: Array<unknown> = [];
+  for (const value of original) {
+    if (!removeFirstStructurallyEqual(unmatchedIntended, value)) {
+      removed.push(value);
+    }
+  }
+
+  const unmatchedOriginal = [...original];
+  const added = intended.filter(
+    (value) => !removeFirstStructurallyEqual(unmatchedOriginal, value),
+  );
+  const rebased = [...current];
+  for (const value of removed) {
+    removeFirstStructurallyEqual(rebased, value);
+  }
+  rebased.push(...added);
+  return rebased;
+}
+
+function rebaseArrayById(
+  original: ReadonlyArray<unknown>,
+  intended: ReadonlyArray<unknown>,
+  current: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> {
+  const originalById = new Map(original.map((value) => [stableArrayElementId(value), value]));
+  const intendedById = new Map(intended.map((value) => [stableArrayElementId(value), value]));
+  const rebased = [...current];
+
+  for (const id of originalById.keys()) {
+    if (intendedById.has(id)) continue;
+    const index = rebased.findIndex((value) => stableArrayElementId(value) === id);
+    if (index >= 0) rebased.splice(index, 1);
+  }
+  for (const [id, intendedValue] of intendedById) {
+    const originalValue = originalById.get(id);
+    if (originalValue !== undefined && structurallyEqual(originalValue, intendedValue)) continue;
+    const currentIndex = rebased.findIndex((value) => stableArrayElementId(value) === id);
+    const rebasedValue =
+      originalValue === undefined
+        ? intendedValue
+        : rebaseChangedValue(originalValue, intendedValue, rebased[currentIndex]);
+    if (currentIndex < 0) {
+      rebased.push(rebasedValue);
+    } else {
+      rebased[currentIndex] = rebasedValue;
+    }
+  }
+  return rebased;
+}
+
+function rebaseArray(
+  original: ReadonlyArray<unknown>,
+  intended: ReadonlyArray<unknown>,
+  current: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> {
+  const allValues = [...original, ...intended, ...current];
+  return allValues.length > 0 && allValues.every((value) => stableArrayElementId(value) !== null)
+    ? rebaseArrayById(original, intended, current)
+    : rebaseArrayByValue(original, intended, current);
+}
+
 function rebaseChangedValue(original: unknown, intended: unknown, current: unknown): unknown {
   if (structurallyEqual(original, intended)) return current;
+  if (Array.isArray(original) && Array.isArray(intended) && Array.isArray(current)) {
+    return rebaseArray(original, intended, current);
+  }
   if (
     typeof original !== "object" ||
     original === null ||

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -9,7 +9,7 @@
  * access is intentionally named as such so environment-sensitive consumers
  * cannot silently read the wrong server's settings.
  */
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import {
   DEFAULT_SERVER_SETTINGS,
@@ -25,11 +25,14 @@ import {
 } from "@t3tools/contracts/settings";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
+  acknowledgePendingServerSettings,
   applyPendingServerPatches,
   getPendingServerPatches,
+  getPendingServerPatchForDispatch,
   NO_PENDING_SERVER_PATCHES,
-  releasePendingServerPatch,
+  type PendingServerPatch,
   retainPendingServerPatch,
+  settlePendingServerPatch,
   subscribePendingServerPatches,
 } from "./pendingServerSettings";
 import { ensureLocalApi } from "~/localApi";
@@ -48,6 +51,7 @@ let clientSettingsSnapshot = DEFAULT_CLIENT_SETTINGS;
 let clientSettingsHydrated = false;
 let clientSettingsHydrationPromise: Promise<void> | null = null;
 let clientSettingsHydrationGeneration = 0;
+const serverSettingsWriteQueueByEnvironment = new Map<EnvironmentId, Promise<void>>();
 
 function emitClientSettingsChange() {
   for (const listener of clientSettingsListeners) {
@@ -152,7 +156,7 @@ function persistClientSettings(settings: ClientSettings): void {
 
 function usePendingServerPatches(
   environmentId: EnvironmentId | null,
-): ReadonlyArray<ServerSettingsPatch> {
+): ReadonlyArray<PendingServerPatch> {
   const getSnapshot = useCallback(() => getPendingServerPatches(environmentId), [environmentId]);
   return useSyncExternalStore(
     subscribePendingServerPatches,
@@ -225,6 +229,11 @@ function useMergedSettings<T>(
 ): T {
   const clientSettings = useClientSettingsValue();
   const pendingPatches = usePendingServerPatches(environmentId);
+  useEffect(() => {
+    if (environmentId) {
+      acknowledgePendingServerSettings(environmentId, serverSettings);
+    }
+  }, [environmentId, serverSettings]);
 
   const optimisticServerSettings = useMemo<ServerSettings>(
     () => applyPendingServerPatches(serverSettings, pendingPatches),
@@ -269,7 +278,10 @@ export function usePrimarySettings<T = UnifiedSettings>(
  * Server keys are applied optimistically through `./pendingServerSettings` and
  * persisted via RPC. Client keys go through client persistence.
  */
-function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
+function useUpdateSettingsTarget(
+  environmentId: EnvironmentId | null,
+  serverSettings: ServerSettings,
+) {
   const persistServerSettings = useAtomCommand(
     serverEnvironment.updateSettings,
     "server settings update",
@@ -280,12 +292,40 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
 
       if (Object.keys(serverPatch).length > 0) {
         if (environmentId) {
-          retainPendingServerPatch(environmentId, serverPatch);
-          void persistServerSettings({
+          const optimisticBase = applyPendingServerPatches(
+            serverSettings,
+            getPendingServerPatches(environmentId),
+          );
+          const pendingId = retainPendingServerPatch(
             environmentId,
-            input: { patch: serverPatch },
-          }).finally(() => {
-            releasePendingServerPatch(environmentId);
+            serverPatch,
+            optimisticBase,
+            serverSettings,
+          );
+          const previous =
+            serverSettingsWriteQueueByEnvironment.get(environmentId) ?? Promise.resolve();
+          const current = previous
+            .then(async () => {
+              const pendingPatch = getPendingServerPatchForDispatch(environmentId, pendingId);
+              if (!pendingPatch) return;
+              const result = await persistServerSettings({
+                environmentId,
+                input: { patch: pendingPatch },
+              });
+              settlePendingServerPatch(
+                environmentId,
+                pendingId,
+                result._tag === "Success" ? result.value : null,
+              );
+            })
+            .catch(() => {
+              settlePendingServerPatch(environmentId, pendingId, null);
+            });
+          serverSettingsWriteQueueByEnvironment.set(environmentId, current);
+          void current.finally(() => {
+            if (serverSettingsWriteQueueByEnvironment.get(environmentId) === current) {
+              serverSettingsWriteQueueByEnvironment.delete(environmentId);
+            }
           });
         }
       }
@@ -297,18 +337,24 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
         });
       }
     },
-    [environmentId, persistServerSettings],
+    [environmentId, persistServerSettings, serverSettings],
   );
 
   return updateSettings;
 }
 
 export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {
-  return useUpdateSettingsTarget(environmentId);
+  const serverSettings =
+    useAtomValue(serverEnvironment.settingsValueAtom(environmentId)) ?? DEFAULT_SERVER_SETTINGS;
+  return useUpdateSettingsTarget(environmentId, serverSettings);
 }
 
 export function useUpdatePrimarySettings() {
-  return useUpdateSettingsTarget(usePrimaryEnvironment()?.environmentId ?? null);
+  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  return useUpdateSettingsTarget(
+    environmentId,
+    useAtomValue(primaryServerSettingsAtom),
+  );
 }
 
 export function useUpdateClientSettings() {

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -24,6 +24,14 @@ import {
   type UnifiedSettings,
 } from "@t3tools/contracts/settings";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
+import {
+  applyPendingServerPatches,
+  getPendingServerPatches,
+  NO_PENDING_SERVER_PATCHES,
+  releasePendingServerPatch,
+  retainPendingServerPatch,
+  subscribePendingServerPatches,
+} from "./pendingServerSettings";
 import { ensureLocalApi } from "~/localApi";
 import * as Struct from "effect/Struct";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
@@ -142,6 +150,17 @@ function persistClientSettings(settings: ClientSettings): void {
     });
 }
 
+function usePendingServerPatches(
+  environmentId: EnvironmentId | null,
+): ReadonlyArray<ServerSettingsPatch> {
+  const getSnapshot = useCallback(() => getPendingServerPatches(environmentId), [environmentId]);
+  return useSyncExternalStore(
+    subscribePendingServerPatches,
+    getSnapshot,
+    () => NO_PENDING_SERVER_PATCHES,
+  );
+}
+
 // ── Key sets for routing patches ─────────────────────────────────────
 
 const SERVER_SETTINGS_KEYS = new Set<string>(Struct.keys(ServerSettings.fields));
@@ -200,14 +219,21 @@ export function mergeEnvironmentSettings(
 }
 
 function useMergedSettings<T>(
+  environmentId: EnvironmentId | null,
   serverSettings: ServerSettings,
   selector: ((settings: UnifiedSettings) => T) | undefined,
 ): T {
   const clientSettings = useClientSettingsValue();
+  const pendingPatches = usePendingServerPatches(environmentId);
+
+  const optimisticServerSettings = useMemo<ServerSettings>(
+    () => applyPendingServerPatches(serverSettings, pendingPatches),
+    [pendingPatches, serverSettings],
+  );
 
   const merged = useMemo<UnifiedSettings>(
-    () => mergeEnvironmentSettings(serverSettings, clientSettings),
-    [clientSettings, serverSettings],
+    () => mergeEnvironmentSettings(optimisticServerSettings, clientSettings),
+    [clientSettings, optimisticServerSettings],
   );
 
   return useMemo(() => (selector ? selector(merged) : (merged as T)), [merged, selector]);
@@ -226,20 +252,21 @@ export function useEnvironmentSettings<T = UnifiedSettings>(
   selector?: (settings: UnifiedSettings) => T,
 ): T {
   const serverSettings = useAtomValue(serverEnvironment.settingsValueAtom(environmentId));
-  return useMergedSettings(serverSettings ?? DEFAULT_SERVER_SETTINGS, selector);
+  return useMergedSettings(environmentId, serverSettings ?? DEFAULT_SERVER_SETTINGS, selector);
 }
 
 /** Primary-only settings access for the settings UI and other explicitly global surfaces. */
 export function usePrimarySettings<T = UnifiedSettings>(
   selector?: (settings: UnifiedSettings) => T,
 ): T {
-  return useMergedSettings(useAtomValue(primaryServerSettingsAtom), selector);
+  const environmentId = usePrimaryEnvironment()?.environmentId ?? null;
+  return useMergedSettings(environmentId, useAtomValue(primaryServerSettingsAtom), selector);
 }
 
 /**
  * Returns an updater that routes each key to the correct backing store.
  *
- * Server keys are optimistically patched in atom-backed server state, then
+ * Server keys are applied optimistically through `./pendingServerSettings` and
  * persisted via RPC. Client keys go through client persistence.
  */
 function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
@@ -253,9 +280,12 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
 
       if (Object.keys(serverPatch).length > 0) {
         if (environmentId) {
+          retainPendingServerPatch(environmentId, serverPatch);
           void persistServerSettings({
             environmentId,
             input: { patch: serverPatch },
+          }).finally(() => {
+            releasePendingServerPatch(environmentId);
           });
         }
       }


### PR DESCRIPTION
## What Changed

`useUpdateSettingsTarget` now retains each in-flight server settings patch and replays it over the server value (via the same `applyServerSettingsPatch` the server runs) until no write is outstanding for that environment.

- New `apps/web/src/hooks/pendingServerSettings.ts` holds the per-environment overlay: retain on dispatch, release when the write settles, drop the overlay only when the last outstanding write settles.
- `useMergedSettings` applies the overlay before merging client settings, so `usePrimarySettings` / `useEnvironmentSettings` reflect the edit immediately.
- Unit tests for the overlay semantics in `pendingServerSettings.test.ts`.

## Why

Server settings only change locally once the server echoes `settingsUpdated` back over the websocket. Until then, readers still see pre-edit settings, so a second edit issued inside that window is computed from stale state — and because keys such as `providerInstances` are whole-map replacements rather than deep merges (`applyServerSettingsPatch`), the second write silently reverts the first.

Reproduction before this change, in Settings → Providers: toggle Codex off, then toggle Claude off a moment later. Codex's switch snaps back on and its `enabled: false` never reaches `settings.json` — only the Claude entry is persisted. The same race applies to every provider-instance edit (binary path, custom models, accent color, add/delete), plus `favorites` and `providerModelPreferences`, since those patches are also built from the settings snapshot.

The doc comment on `useUpdateSettingsTarget` already claimed server keys were patched optimistically; this makes that true.

## UI Changes

No visual changes. Behavioral only: a provider toggle now flips immediately and stays flipped instead of reverting when another edit follows quickly.

Verified in a local build (server + web from this branch, driven through the browser): toggling two providers in immediate succession leaves both switches off and persists both entries to `settings.json`; an off/on/other three-click sequence composes correctly. On `main` the same first sequence loses the first toggle.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — n/a, no visual change
- [x] I included a video for animation/interaction changes — n/a, no motion change

<sub>Validation: `vp test run src/hooks/pendingServerSettings.test.ts` (6 passed), `vp test run src/hooks src/components/settings src/providerInstances.test.ts` (86 passed), `vp run typecheck` in `apps/web`, `vp lint apps/web/src/hooks/`, `vp fmt --check`.</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence paths for all server settings with non-trivial merge/rebase logic; behavior is well covered by new unit tests but incorrect rebasing could still corrupt settings state.
> 
> **Overview**
> Fixes a race where **rapid server settings edits** (e.g. toggling two providers before the websocket echo) could **revert earlier changes**, because patches like `providerInstances` are whole-map replacements built from stale snapshots.
> 
> Adds **`pendingServerSettings`**: per-environment queues of in-flight patches with **rebase** logic so each write keeps only its delta when the authoritative base moves (arrays by id/name, model selection edge cases, failed writes dropped). **`useSettings`** applies pending patches for reads, **serializes RPC writes** per environment, rebases at dispatch, and retires overlays on RPC settle plus **`settingsUpdated`** acknowledgment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b60cd9734fb4bcd26d0a0e0144e3163c02dca59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent rapid server settings edits from reverting each other with optimistic overlay queuing
> - Adds an optimistic write overlay system in [pendingServerSettings.ts](https://github.com/pingdotgg/t3code/pull/4494/files#diff-f2650264c386b6065701c18f8b9f4414617d30775d3512881b150d0cf8c65358) that tracks staged server settings patches per environment, with rebase semantics to merge concurrent edits rather than overwrite them.
> - Server settings updates in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/4494/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) are now staged optimistically, dispatched sequentially per environment with rebased payloads, and settled based on RPC outcome.
> - Incoming server echoes are matched against pending patches via `acknowledgePendingServerSettings`; overlays are retired only when the correct echo arrives, preventing premature or missed retirement.
> - Array and object rebasing preserves only the delta of each operation relative to authoritative settings, so interleaved edits to different fields do not clobber each other.
> - Behavioral Change: `useMergedSettings` now returns optimistic settings immediately on write and participates in the acknowledgment lifecycle; components will see in-flight values until the server confirms them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b60cd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->