### PR TITLE
Add Antigravity (agy) provider via an ACP compatibility bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ Known constraints, all inherent to print mode:
   answers — a `deny` decision genuinely stops it and is reported back to the model. Controlled
   by the `requireToolApproval` setting, on by default; it fails closed on timeout, a lost
   bridge, or any hook failure. Turn it off to let tools run unattended.
+- **What the approval gate does and does not defend against.** Decisions travel as files in a
+  per-turn temp directory, signed with an HMAC over the hook, the verdict, and a digest of the
+  hook's own payload; the key is generated per turn and reaches the hook through the
+  environment `agy` passes down. That stops an unrelated process forging a decision, stops a
+  decision being replayed onto a different request, and stops a tool approved in one turn
+  signing for any later turn.
+  It does **not** contain a tool within the turn that approved it: that tool inherits the same
+  environment, so it can sign decisions for other tools in that turn. Closing that needs an
+  OS-level boundary — a broker socket or sandbox whose credentials are not inheritable — which
+  is outside what this provider can do while `agy` runs unsandboxed. The gate's purpose is to
+  stop the model acting unilaterally, not to contain code the user has already approved.
 - Attachments are passed by path, not inline: the adapter sends `resource_link` blocks for
   files the attachment store already wrote to disk, and the bridge names those paths in the
   prompt and adds their directory to the workspace. `agy` has no attachment flag, so inline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,19 @@ Known constraints, all inherent to print mode:
   a force-killed bridge can leave one `agy` behind until its `--print-timeout` elapses.
 - Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
   server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
+- Runtime events are buffered without a cap, so a subscriber that stops consuming grows memory
+  until it resumes. This is the shape every adapter uses — Claude, Codex, Cursor, Grok and
+  OpenCode all publish through an unbounded queue or pub/sub, as does `ProviderService` itself —
+  so this provider follows it rather than diverging. Bounding it is a decision for the shared
+  runtime, not for one provider. What the bridge does bound is its own side: `writeMessage`
+  honours stdout backpressure and pauses polling while the pipe is behind, so a slow reader
+  cannot inflate the bridge process.
+- A transcript record carrying no `step_index` is ordered by where it was read, inheriting the
+  preceding entry's key. Every record observed in practice carries one. If a planner response
+  without an index were read in the same poll as the `PreToolUse` hook of the step after it, the
+  tool call would be announced first. Hooks have to be ingested before transcript records — a
+  record has nothing to attach to otherwise — so ordering the two exactly would need a shared
+  sequence number Antigravity does not emit.
 
 ## Reference Repos
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ Known constraints, all inherent to print mode:
   boundary the approval gate draws: code the user has already approved can do as it likes,
   including backgrounding itself. Reaping those would need a supervisor process that stays
   in the group, or a Windows Job Object — neither reachable in plain Node.
+  The bridge also kills its child group on SIGTERM, SIGINT and normal exit, but a SIGKILL of
+  the bridge itself runs no handler, and `agy` is then reparented to init. POSIX offers no
+  portable parent-death signal (`PR_SET_PDEATHSIG` is Linux-only and not exposed by Node), so
+  a force-killed bridge can leave one `agy` behind until its `--print-timeout` elapses.
 - Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
   server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,14 +40,19 @@ step index (`stepIdx` in a hook == `step_index` in the transcript):
 
 Known constraints, all inherent to print mode:
 
-- Tools are auto-approved (`--dangerously-skip-permissions`); no approval flow is possible.
+- `agy` always runs with `--dangerously-skip-permissions` because print mode cannot prompt.
+  Approvals instead come from the `PreToolUse` hook, which blocks the tool until T3 Code
+  answers — a `deny` decision genuinely stops it and is reported back to the model. Enable
+  with the `requireToolApproval` setting; it is off by default because each approval blocks
+  the turn on a human, and it fails closed on timeout or a lost bridge.
 - Attachments are passed by path, not inline: the adapter sends `resource_link` blocks for
   files the attachment store already wrote to disk, and the bridge names those paths in the
   prompt and adds their directory to the workspace. `agy` has no attachment flag, so inline
   image capability stays off.
 - No session modes, and no provider-side rollback — a resumed conversation keeps its full
   trajectory, so `rollbackThread` fails rather than silently truncating local state only.
-- The model binds when the bridge spawns `agy`, so `sessionModelSwitch` is `"unsupported"`.
+- `--model` is a per-spawn flag that composes with `--conversation`, so a model switch keeps
+  the trajectory and applies from the next turn (`sessionModelSwitch: "in-session"`).
 - Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
   server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,9 @@ Known constraints, all inherent to print mode:
 
 - `agy` always runs with `--dangerously-skip-permissions` because print mode cannot prompt.
   Approvals instead come from the `PreToolUse` hook, which blocks the tool until T3 Code
-  answers — a `deny` decision genuinely stops it and is reported back to the model. Enable
-  with the `requireToolApproval` setting; it is off by default because each approval blocks
-  the turn on a human, and it fails closed on timeout or a lost bridge.
+  answers — a `deny` decision genuinely stops it and is reported back to the model. Controlled
+  by the `requireToolApproval` setting, on by default; it fails closed on timeout, a lost
+  bridge, or any hook failure. Turn it off to let tools run unattended.
 - Attachments are passed by path, not inline: the adapter sends `resource_link` blocks for
   files the attachment store already wrote to disk, and the bridge names those paths in the
   prompt and adds their directory to the workspace. `agy` has no attachment flag, so inline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,13 @@ Known constraints, all inherent to print mode:
   trajectory, so `rollbackThread` fails rather than silently truncating local state only.
 - `--model` is a per-spawn flag that composes with `--conversation`, so a model switch keeps
   the trajectory and applies from the next turn (`sessionModelSwitch: "in-session"`).
+- Cancelling a turn kills `agy`'s whole process group, not just `agy`: tools it started
+  otherwise keep writing to the workspace after Stop. The group is owned from spawn and
+  reaped when the leader exits, which is the last moment the group id is certainly still
+  ours — a delayed signal to a bare group id can land on whatever the OS recycled it onto.
+  On Windows there are no process groups; `taskkill /T` covers the tree while the leader
+  lives, but a tool that outlives its leader there cannot be reaped without a Job Object,
+  which needs a native addon.
 - Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
   server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,31 @@
 - `packages/shared`: Shared runtime utilities consumed by both server and client applications. Uses explicit subpath exports (e.g. `@t3tools/shared/git`) — no barrel index.
 - `packages/client-runtime`: Shared runtime package for sharing client code across web and mobile.
 
+## Antigravity provider
+
+The `antigravity` driver wraps the Antigravity CLI (`agy`), which has **no native agent
+protocol**. `apps/server/src/provider/acp/antigravity/agyBridge.ts` presents the ACP surface
+`AcpSessionRuntime` needs and runs each turn through `agy --print`, shipping as hidden
+subcommands of the server binary (`t3 agy-acp`, `t3 agy-hook`).
+
+A live event stream is reconstructed from two documented Antigravity sources that correlate on
+step index (`stepIdx` in a hook == `step_index` in the transcript):
+
+- **Hooks** (`PreToolUse`/`PostToolUse`/`Stop`) give tool name, arguments, and status. The bridge
+  registers them via a throwaway `--add-dir` workspace so nothing is written into the user's repo.
+  Both the session cwd and that hook workspace must be passed — `--add-dir` replaces the workspace
+  rather than adding to cwd, so passing only the hook dir hides the project from the agent.
+- **The trajectory transcript** (`transcript.jsonl`) gives assistant text and real tool output as
+  the turn runs. Its record format is undocumented, so parsing degrades to emitting nothing.
+
+Known constraints, all inherent to print mode:
+
+- Tools are auto-approved (`--dangerously-skip-permissions`); no approval flow is possible.
+- No image attachments, and no session modes.
+- The model binds when the bridge spawns `agy`, so `sessionModelSwitch` is `"unsupported"`.
+- Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
+  server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
+
 ## Reference Repos
 
 - Open-source Codex repo: https://github.com/openai/codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,12 +65,14 @@ Known constraints, all inherent to print mode:
 - `--model` is a per-spawn flag that composes with `--conversation`, so a model switch keeps
   the trajectory and applies from the next turn (`sessionModelSwitch: "in-session"`).
 - Cancelling a turn kills `agy`'s whole process group, not just `agy`: tools it started
-  otherwise keep writing to the workspace after Stop. The group is owned from spawn and
-  reaped when the leader exits, which is the last moment the group id is certainly still
-  ours — a delayed signal to a bare group id can land on whatever the OS recycled it onto.
-  On Windows there are no process groups; `taskkill /T` covers the tree while the leader
-  lives, but a tool that outlives its leader there cannot be reaped without a Job Object,
-  which needs a native addon.
+  otherwise keep writing to the workspace after Stop. Every signal is guarded on the leader
+  still being alive, because a group id belongs to us only while it holds one — once the
+  leader is reaped the number is free, and a signal sent afterwards can land on whatever
+  inherited it. Nothing signals a group after its `exit`.
+  The cost is that a tool which deliberately outlives `agy` is not reaped. That is the same
+  boundary the approval gate draws: code the user has already approved can do as it likes,
+  including backgrounding itself. Reaping those would need a supervisor process that stays
+  in the group, or a Windows Job Object — neither reachable in plain Node.
 - Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
   server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,12 @@ step index (`stepIdx` in a hook == `step_index` in the transcript):
 Known constraints, all inherent to print mode:
 
 - Tools are auto-approved (`--dangerously-skip-permissions`); no approval flow is possible.
-- No image attachments, and no session modes.
+- Attachments are passed by path, not inline: the adapter sends `resource_link` blocks for
+  files the attachment store already wrote to disk, and the bridge names those paths in the
+  prompt and adds their directory to the workspace. `agy` has no attachment flag, so inline
+  image capability stays off.
+- No session modes, and no provider-side rollback — a resumed conversation keeps its full
+  trajectory, so `rollbackThread` fails rather than silently truncating local state only.
 - The model binds when the bridge spawns `agy`, so `sessionModelSwitch` is `"unsupported"`.
 - Any `agy` subcommand spawned for a probe must set `stdin: "ignore"`. `agy` starts a language
   server and will not emit output while stdin stays open, so the default `"pipe"` hangs it.

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -1,5 +1,6 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeCrypto from "node:crypto";
+import * as NodeURL from "node:url";
 import * as NodeFS from "node:fs";
 
 import type { ChatAttachment } from "@t3tools/contracts";
@@ -74,6 +75,19 @@ export function resolveAttachmentPath(input: {
     attachmentsDir: input.attachmentsDir,
     relativePath: attachmentRelativePath(input.attachment),
   });
+}
+
+/**
+ * `file:` URL for a resolved attachment path.
+ *
+ * Providers that hand attachments to an external agent by reference need a URI
+ * rather than a bare path. `pathToFileURL` is used rather than string
+ * concatenation because it escapes `#` and `?` — which would otherwise
+ * truncate the path on the way back through `fileURLToPath` — and handles
+ * Windows drive letters.
+ */
+export function attachmentFileUrl(attachmentPath: string): string {
+  return NodeURL.pathToFileURL(attachmentPath).href;
 }
 
 export function resolveAttachmentPathById(input: {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -7,6 +7,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 
 import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
+import { agyAcpCommand, agyHookCommand } from "./cli/agy.ts";
 import { authCommand } from "./cli/auth.ts";
 import { connectCommand } from "./cli/connect.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
@@ -49,6 +50,8 @@ export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
       authCommand,
       projectCommand,
       serviceCommand,
+      agyAcpCommand,
+      agyHookCommand,
       cloudEnabled ? connectCommand : connectUnavailableCommand,
     ]),
   );

--- a/apps/server/src/cli/agy.ts
+++ b/apps/server/src/cli/agy.ts
@@ -1,0 +1,31 @@
+/**
+ * Hidden CLI entry points for the Antigravity ACP bridge.
+ *
+ * Both are internal plumbing rather than user-facing commands: the provider
+ * spawns `t3 agy-acp` as an ACP agent, and that bridge registers `t3 agy-hook
+ * <event>` as Antigravity's tool-lifecycle hook. Shipping them as subcommands
+ * of the server binary keeps the bridge inside the same bundle.
+ *
+ * @module cli/agy
+ */
+import * as Effect from "effect/Effect";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { runAgyBridge, runAgyHook } from "../provider/acp/antigravity/agyBridge.ts";
+
+export const agyAcpCommand = Command.make("agy-acp").pipe(
+  Command.withDescription("Run the Antigravity ACP compatibility bridge over stdio."),
+  Command.withHidden,
+  Command.withHandler(() => Effect.promise(() => runAgyBridge())),
+);
+
+export const agyHookCommand = Command.make("agy-hook", {
+  event: Flag.string("event").pipe(
+    Flag.withDescription("Antigravity hook event name."),
+    Flag.withDefault("unknown"),
+  ),
+}).pipe(
+  Command.withDescription("Handle one Antigravity tool-lifecycle hook event."),
+  Command.withHidden,
+  Command.withHandler(({ event }) => Effect.promise(() => runAgyHook(event))),
+);

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -1,0 +1,177 @@
+/**
+ * AntigravityDriver — built-in driver for the Antigravity CLI (`agy`).
+ *
+ * Sessions run through T3 Code's bundled ACP bridge rather than a native agent
+ * protocol; see `provider/acp/antigravity/agyBridge.ts`.
+ *
+ * @module Drivers/AntigravityDriver
+ */
+import { AntigravitySettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeAntigravityTextGeneration } from "../../textGeneration/AntigravityTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeAntigravityAdapter } from "../Layers/AntigravityAdapter.ts";
+import {
+  buildInitialAntigravityProviderSnapshot,
+  checkAntigravityProviderStatus,
+  enrichAntigravitySnapshot,
+} from "../Layers/AntigravityProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("antigravity");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+// Antigravity ships its own installer and updater (`agy update`), so T3 Code
+// never manages the binary itself.
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+  }),
+);
+
+export type AntigravityDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Antigravity",
+    supportsMultipleInstances: true,
+  },
+  configSchema: AntigravitySettings,
+  defaultConfig: (): AntigravitySettings => decodeAntigravitySettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies AntigravitySettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeAntigravityAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeAntigravityTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkAntigravityProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<
+        ProviderSnapshotSettings<AntigravitySettings>
+      >({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialAntigravityProviderSnapshot(settings.provider).pipe(
+            Effect.map(stampIdentity),
+          ),
+        checkProvider,
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichAntigravitySnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            httpClient,
+          }),
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Antigravity snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -657,22 +657,28 @@ export function makeAntigravityAdapter(
                   pendingApprovals.delete(requestId);
                   return { outcome: { outcome: "cancelled" } as const };
                 }
-                yield* offerRuntimeEvent(
-                  makeAcpRequestOpenedEvent({
-                    stamp: yield* makeEventStamp(),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId: approvalTurnId,
-                    requestId: RuntimeRequestId.make(requestId),
-                    permissionRequest,
-                    detail: permissionRequest.detail ?? "Antigravity tool call",
-                    args: params,
-                    source: "acp.jsonrpc",
-                    method: "session/request_permission",
-                    rawPayload: params,
+                // Built first, then published and recorded in one uninterruptible
+                // step. An interrupt between the two would leave the UI showing
+                // a request the finalizer does not know to close.
+                const openedEvent = makeAcpRequestOpenedEvent({
+                  stamp: yield* makeEventStamp(),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: approvalTurnId,
+                  requestId: RuntimeRequestId.make(requestId),
+                  permissionRequest,
+                  detail: permissionRequest.detail ?? "Antigravity tool call",
+                  args: params,
+                  source: "acp.jsonrpc",
+                  method: "session/request_permission",
+                  rawPayload: params,
+                });
+                yield* Effect.uninterruptible(
+                  Effect.gen(function* () {
+                    yield* offerRuntimeEvent(openedEvent);
+                    opened = { requestId, permissionRequest, turnId: approvalTurnId };
                   }),
                 );
-                opened = { requestId, permissionRequest, turnId: approvalTurnId };
                 // Raced against a deadline and cleaned up unconditionally: the
                 // bridge forgets its side of a timed-out request, so without
                 // this the handler would stay blocked and the entry retained.
@@ -684,18 +690,24 @@ export function makeAntigravityAdapter(
                 const resolved: ProviderApprovalDecision = Option.isSome(answered)
                   ? answered.value
                   : "cancel";
-                yield* offerRuntimeEvent(
-                  makeAcpRequestResolvedEvent({
-                    stamp: yield* makeEventStamp(),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId: approvalTurnId,
-                    requestId: RuntimeRequestId.make(requestId),
-                    permissionRequest,
-                    decision: resolved,
+                // Same pairing on the way out: an interrupt between publishing
+                // this and recording it would have the finalizer publish a
+                // second, contradictory resolution.
+                const resolvedEvent = makeAcpRequestResolvedEvent({
+                  stamp: yield* makeEventStamp(),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: approvalTurnId,
+                  requestId: RuntimeRequestId.make(requestId),
+                  permissionRequest,
+                  decision: resolved,
+                });
+                yield* Effect.uninterruptible(
+                  Effect.gen(function* () {
+                    yield* offerRuntimeEvent(resolvedEvent);
+                    resolutionPublished = true;
                   }),
                 );
-                resolutionPublished = true;
                 // Re-checked at the moment of answering: an approval decided
                 // while Stop was landing must not come back as an allow.
                 const stillLive =

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -183,7 +183,16 @@ interface AntigravitySessionContext {
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
-  promptsInFlight: number;
+  /**
+   * Prompts still in flight, counted per turn rather than per session.
+   *
+   * A shared counter breaks as soon as two turns overlap, which epoch-scoped
+   * steering makes possible: a prompt sent after a Stop opens its own turn
+   * while the cancelled one is still settling. Whichever finished first would
+   * see the other's prompt in the count, decide it was not the last, and skip
+   * its terminal event — orphaning that turn.
+   */
+  readonly promptsInFlightByTurn: Map<TurnId, number>;
   stopped: boolean;
 }
 
@@ -430,6 +439,9 @@ export function makeAntigravityAdapter(
             const claimed = [...ctx.publishedTurnIds];
             ctx.publishedTurnIds.clear();
             ctx.reservedTurnIds.clear();
+            // Counts go with the turns they belonged to; a finalizer waking
+            // later finds nothing outstanding and settles nothing.
+            ctx.promptsInFlightByTurn.clear();
             ctx.activeTurnId = undefined;
             return claimed;
           }),
@@ -696,7 +708,7 @@ export function makeAntigravityAdapter(
             approvals: pendingApprovals,
             acpSessionId: started.sessionId,
             activeTurnEpoch: -1,
-            promptsInFlight: 0,
+            promptsInFlightByTurn: new Map(),
             stopped: false,
           };
 
@@ -901,7 +913,8 @@ export function makeAntigravityAdapter(
         // folds into the ongoing work, so the active turn id is reused.
         //
         // The id is minted first, before anything is read, so that reading
-        // `promptsInFlight` and claiming it are one synchronous step. Yielding
+        // the turn's prompt count and claiming it are one synchronous step.
+        // Yielding
         // between the two — which generating the id here used to do — let two
         // concurrent calls both observe zero and open rival turns over the
         // same thread.
@@ -909,15 +922,16 @@ export function makeAntigravityAdapter(
         // Same epoch only: a prompt accepted after a Stop must not fold into the
         // turn that Stop cancelled, or it would inherit its id and publish a
         // completion for it while the cancelled one is still settling.
+        const activeTurnBusy =
+          ctx.activeTurnId !== undefined &&
+          (ctx.promptsInFlightByTurn.get(ctx.activeTurnId) ?? 0) > 0;
         const steeringTurnId =
-          ctx.promptsInFlight > 0 && ctx.activeTurnEpoch === acceptedEpoch
-            ? ctx.activeTurnId
-            : undefined;
+          activeTurnBusy && ctx.activeTurnEpoch === acceptedEpoch ? ctx.activeTurnId : undefined;
         const turnId = steeringTurnId ?? freshTurnId;
         // Claimed together, without an intervening yield: assigning the active
-        // turn id later let a concurrent call see `promptsInFlight > 0` with no
+        // turn id later let a concurrent call see a busy turn with no
         // id yet and open a rival turn.
-        ctx.promptsInFlight += 1;
+        ctx.promptsInFlightByTurn.set(turnId, (ctx.promptsInFlightByTurn.get(turnId) ?? 0) + 1);
         ctx.activeTurnId = turnId;
         ctx.activeTurnEpoch = acceptedEpoch;
         // Terminal-event bookkeeping. Publication happens in exactly one place
@@ -1100,8 +1114,14 @@ export function makeAntigravityAdapter(
               // Decrement and the last-prompt test are one synchronous step, so
               // a steer arriving mid-settlement cannot make two prompts both
               // believe they own the turn and publish a terminal event each.
-              const remaining = Math.max(0, ctx.promptsInFlight - 1);
-              ctx.promptsInFlight = remaining;
+              // Scoped to this turn: another turn's prompts must not keep this
+              // one from settling, nor settle it on their behalf.
+              const remaining = Math.max(0, (ctx.promptsInFlightByTurn.get(turnId) ?? 1) - 1);
+              if (remaining > 0) {
+                ctx.promptsInFlightByTurn.set(turnId, remaining);
+              } else {
+                ctx.promptsInFlightByTurn.delete(turnId);
+              }
               if (remaining > 0) {
                 return;
               }
@@ -1142,8 +1162,8 @@ export function makeAntigravityAdapter(
                 payload: { state, stopReason },
               });
               // `catchCause` rather than `catch`: a defect while stamping or
-              // publishing would otherwise escape after `promptsInFlight` was
-              // already decremented, stranding the turn as running.
+              // publishing would otherwise escape after the turn's prompt count
+              // was already decremented, stranding the turn as running.
             }).pipe(Effect.catchCause(() => Effect.void)),
           ),
         );

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1403,11 +1403,16 @@ export function makeAntigravityAdapter(
                       // minute deadline, unanswerable, with the turn already
                       // reported complete.
                       //
-                      // Done before `activeTurnId` is cleared so the handlers see
-                      // the state they were opened against, and awaited — with a
-                      // bound, because a handler that never finishes must not
-                      // strand the turn — so `request.resolved` is published
-                      // before the completion below.
+                      // `activeTurnId` is also the approval handler's liveness
+                      // check. Clear the internal claim before releasing any
+                      // decisions so an accept racing this settlement is
+                      // reported as cancelled, matching the bridge token that
+                      // has already been retired. The public session claim is
+                      // kept until the terminal bookkeeping below; nothing in
+                      // the approval wait depends on the internal claim.
+                      if (ctx.activeTurnId === turnId) {
+                        ctx.activeTurnId = undefined;
+                      }
                       const orphanedApprovals = [...ctx.approvals.values()].filter(
                         (approval) => approval.turnId === turnId,
                       );
@@ -1429,14 +1434,6 @@ export function makeAntigravityAdapter(
                             { concurrency: "unbounded" },
                           ).pipe(Effect.timeoutOption(APPROVAL_SETTLE_TIMEOUT_MS)),
                         );
-                      }
-                      // One prompt per turn, so this settles unconditionally.
-                      // Cleared even when the turn never started — a model switch can
-                      // fail after `activeTurnId` is installed, and leaving it set
-                      // advertises a turn to `listSessions` and the reaper that no
-                      // longer exists. Only the event below depends on having started.
-                      if (ctx.activeTurnId === turnId) {
-                        ctx.activeTurnId = undefined;
                       }
                       // Read from shared state rather than this call's local flag: the
                       // prompt that published `turn.started` may not be the one that

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -402,8 +402,10 @@ export function makeAntigravityAdapter(
           // With approvals enabled the bridge blocks each tool on this callback,
           // so it must be registered before `start()` — the first tool call can
           // arrive as soon as the first turn begins.
-          const pendingApprovals = approvalsByThread.get(input.threadId) ?? new Map();
-          approvalsByThread.set(input.threadId, pendingApprovals);
+          // Not published to `approvalsByThread` yet: if startup fails there is
+          // no session context for teardown to clean up, and repeated failures
+          // across thread ids would grow the map. Registered after `start()`.
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
           yield* acp.handleRequestPermission((params) =>
             mapAcpCallbackFailure(
               Effect.gen(function* () {
@@ -494,6 +496,8 @@ export function makeAntigravityAdapter(
             promptsInFlight: 0,
             stopped: false,
           };
+
+          approvalsByThread.set(input.threadId, pendingApprovals);
 
           const nf = yield* Stream.runDrain(
             Stream.mapEffect(acp.getEvents(), (event) =>
@@ -751,9 +755,13 @@ export function makeAntigravityAdapter(
               // believe they own the turn and publish a terminal event each.
               const remaining = Math.max(0, ctx.promptsInFlight - 1);
               ctx.promptsInFlight = remaining;
-              if (remaining > 0 || !turnStarted) {
+              if (remaining > 0) {
                 return;
               }
+              // Cleared even when the turn never started — a model switch can
+              // fail after `activeTurnId` is installed, and leaving it set
+              // advertises a turn to `listSessions` and the reaper that no
+              // longer exists. Only the event below depends on having started.
               if (ctx.activeTurnId === turnId) {
                 ctx.activeTurnId = undefined;
               }
@@ -767,6 +775,9 @@ export function makeAntigravityAdapter(
               // still owes consumers a terminal event; without one the turn
               // renders as running forever even though sendTurn already
               // returned an error.
+              if (!turnStarted) {
+                return;
+              }
               const state = !promptSucceeded
                 ? "failed"
                 : stopReason === "cancelled"
@@ -788,6 +799,17 @@ export function makeAntigravityAdapter(
     const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
+        // Settled before the cancel goes out, as ACP requires: an outstanding
+        // permission request has a hook process blocked behind it, and the
+        // bridge turns "cancel" into a denial. Leaving it pending would hold
+        // that tool until the hook's own timeout.
+        const pending = approvalsByThread.get(threadId);
+        if (pending) {
+          for (const [, approval] of pending) {
+            yield* Deferred.succeed(approval.decision, "cancel");
+          }
+          pending.clear();
+        }
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(
             Effect.mapError((error) =>

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -176,14 +176,9 @@ interface AntigravitySessionContext {
   readonly approvals: Map<ApprovalRequestId, PendingApproval>;
   /** Bridge-side session id, needed to address provider-specific notifications. */
   readonly acpSessionId: string;
-  /**
-   * Ids of prompts accepted but not yet answered by the bridge. An interrupt
-   * fences exactly these, so a cancel can never stop a prompt submitted after
-   * it — which every session-scoped variant of this did.
-   */
-  readonly outstandingPromptIds: Set<string>;
-  /** Counter behind `outstandingPromptIds`; unique within this session. */
-  nextPromptSeq: number;
+
+  /** Cancel epoch the active turn belongs to; steering is scoped to it. */
+  activeTurnEpoch: number;
   /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
@@ -700,8 +695,7 @@ export function makeAntigravityAdapter(
             teardownSignal: yield* Deferred.make<void>(),
             approvals: pendingApprovals,
             acpSessionId: started.sessionId,
-            outstandingPromptIds: new Set(),
-            nextPromptSeq: 0,
+            activeTurnEpoch: -1,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -847,21 +841,14 @@ export function makeAntigravityAdapter(
         }).pipe(Effect.scoped),
       );
 
-    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) => {
-      // Captured outside the workflow so the finalizer can retire the id no
-      // matter where inside it things stopped.
-      let registered: { ctx: AntigravitySessionContext; promptId: string } | undefined;
-      return Effect.gen(function* () {
+    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
-        // Claimed before any yielding preparation. Attachment resolution and id
-        // generation both yield, and a Stop landing in that window would
-        // otherwise find nothing outstanding to fence — the prompt would then
-        // reach `agy` carrying the post-cancel state and pass every check.
-        ctx.nextPromptSeq += 1;
-        const promptId = `${ctx.acpSessionId}-${ctx.nextPromptSeq}`;
+        // Read before any yielding preparation. Attachment resolution and id
+        // generation both yield, and a Stop landing in that window raises the
+        // cancelled mark past this value — so the prompt is still covered by
+        // the fence even though it had not been submitted yet.
         const acceptedEpoch = ctx.cancelEpoch;
-        ctx.outstandingPromptIds.add(promptId);
-        registered = { ctx, promptId };
 
         // `agy --print` takes a single text prompt, so attachments travel as
         // `resource_link` blocks (ACP baseline, no capability needed) pointing
@@ -919,13 +906,20 @@ export function makeAntigravityAdapter(
         // concurrent calls both observe zero and open rival turns over the
         // same thread.
         const freshTurnId = TurnId.make(yield* randomUUIDv4);
-        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+        // Same epoch only: a prompt accepted after a Stop must not fold into the
+        // turn that Stop cancelled, or it would inherit its id and publish a
+        // completion for it while the cancelled one is still settling.
+        const steeringTurnId =
+          ctx.promptsInFlight > 0 && ctx.activeTurnEpoch === acceptedEpoch
+            ? ctx.activeTurnId
+            : undefined;
         const turnId = steeringTurnId ?? freshTurnId;
         // Claimed together, without an intervening yield: assigning the active
         // turn id later let a concurrent call see `promptsInFlight > 0` with no
         // id yet and open a rival turn.
         ctx.promptsInFlight += 1;
         ctx.activeTurnId = turnId;
+        ctx.activeTurnEpoch = acceptedEpoch;
         // Terminal-event bookkeeping. Publication happens in exactly one place
         // (the teardown below) so that the decision cannot race a steer.
         let stopReason: string | null = null;
@@ -1059,7 +1053,7 @@ export function makeAntigravityAdapter(
                   Effect.raceFirst(ctx.acp.drainEvents, Deferred.await(ctx.teardownSignal)),
                 );
                 return yield* ctx.acp
-                  .prompt({ prompt: promptParts, _meta: { t3: { promptId } } })
+                  .prompt({ prompt: promptParts, _meta: { t3: { epoch: acceptedEpoch } } })
                   .pipe(
                     Effect.tapCause(() => drain),
                     Effect.tap(() => drain),
@@ -1153,30 +1147,17 @@ export function makeAntigravityAdapter(
             }).pipe(Effect.catchCause(() => Effect.void)),
           ),
         );
-      }).pipe(
-        // Registered before validation and attachment work so a Stop landing
-        // during those can still fence this prompt — which means its removal
-        // has to cover them failing too. An id left behind would be re-fenced
-        // by every later Stop.
-        Effect.ensuring(
-          Effect.sync(() => {
-            registered?.ctx.outstandingPromptIds.delete(registered.promptId);
-          }),
-        ),
-      );
-    };
+      });
 
     const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
         // Recorded before anything else: prompts already accepted but still
         // queued upstream compare against this and refuse to submit.
+        // Read and bumped in one synchronous step: everything accepted up to
+        // and including this value is what the fence below covers.
+        const cancelledThrough = ctx.cancelEpoch;
         ctx.cancelEpoch += 1;
-        // Snapshotted in the same synchronous step as the bump. A live Set
-        // iterator yields entries added during iteration, so a prompt accepted
-        // after this cancel would be fenced by it and wrongly reported
-        // cancelled.
-        const fencedPromptIds = [...ctx.outstandingPromptIds];
         // Settled before the cancel goes out, as ACP requires: an outstanding
         // permission request has a hook process blocked behind it, and the
         // bridge turns "cancel" into a denial. Leaving it pending would hold
@@ -1194,9 +1175,13 @@ export function makeAntigravityAdapter(
         // lets the bridge recognise and stop that one. Sending it
         // unconditionally would instead fence a cancel that arrived after its
         // own turn ended, killing the next unrelated prompt.
-        for (const outstanding of fencedPromptIds) {
-          yield* Effect.ignore(ctx.acp.notify("t3/fence", { promptId: outstanding }));
-        }
+        // One notification names the epoch being cancelled through, rather than
+        // one per outstanding prompt. Everything accepted at or below it is
+        // cancelled; anything accepted afterwards carries a higher epoch and is
+        // untouched, so nothing has to be tracked per prompt or evicted.
+        yield* Effect.ignore(
+          ctx.acp.notify("t3/fence", { sessionId: ctx.acpSessionId, epoch: cancelledThrough }),
+        );
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(
             Effect.mapError((error) =>

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -332,6 +332,23 @@ export function makeAntigravityAdapter(
           }
           approvalsByThread.delete(ctx.threadId);
         }
+        // Claimed here, so a `sendTurn` finalizer waking later finds nothing
+        // left to settle and stays silent. Otherwise closing the scope wakes
+        // `acp.prompt` on another fiber and its completion lands after
+        // `session.exited` — or on whatever session replaced this one.
+        const orphanedTurnIds = [...ctx.startedTurnIds];
+        ctx.startedTurnIds.clear();
+        for (const orphanedTurnId of orphanedTurnIds) {
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: orphanedTurnId,
+            payload: { state: "cancelled", stopReason: null },
+          });
+        }
+        ctx.activeTurnId = undefined;
         if (ctx.notificationFiber) {
           yield* Fiber.interrupt(ctx.notificationFiber);
         }
@@ -804,13 +821,19 @@ export function makeAntigravityAdapter(
             ctx.startedTurnIds.add(turnId);
           }
           if (announcing) {
-            yield* offerRuntimeEvent({
-              type: "turn.started",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: { model: ctx.session.model },
+            // Stamp generation sits inside the guarded region: it can fail or
+            // be interrupted too, and a claim left behind without its event
+            // would make a steer skip the start and let settlement publish an
+            // orphan completion.
+            yield* Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "turn.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: { model: ctx.session.model },
+              });
             }).pipe(
               Effect.onExit((exit) =>
                 Exit.isSuccess(exit)
@@ -829,7 +852,15 @@ export function makeAntigravityAdapter(
                 if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
                   return undefined;
                 }
-                return yield* ctx.acp.prompt({ prompt: promptParts });
+                const response = yield* ctx.acp.prompt({ prompt: promptParts });
+                // The bridge writes its `session/update` notifications before
+                // the prompt response, but the runtime only queues them.
+                // Draining inside the gate keeps the turn from settling — and
+                // its id from being cleared — while content, tool and item
+                // events are still pending, which would leave them
+                // unattributed or attributed to the next turn.
+                yield* ctx.acp.drainEvents;
+                return response;
               }),
             )
             .pipe(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1209,14 +1209,25 @@ export function makeAntigravityAdapter(
         // Fallback: if the bridge never answers — wedged, or already gone — the
         // interrupt still happens, just late enough not to truncate a healthy
         // drain. Forked into the session scope so it dies with the session.
-        yield* Effect.forkIn(
-          Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(
-            Effect.flatMap(() =>
-              ctx.activeTurnId === undefined ? Effect.void : Effect.ignore(ctx.acp.cancel),
+        //
+        // Scoped to the turn being cancelled by identity, not to "some turn is
+        // active". This cancel can settle normally and a fresh turn start
+        // inside the timeout; `acp.cancel` interrupts whatever prompt the
+        // runtime currently holds, so a laxer check would interrupt that new
+        // turn — and the bridge would ignore the accompanying cancel, its
+        // epoch being newer than this fence, leaving `agy` running while T3
+        // believed the turn was cancelled.
+        const cancelledTurnId = ctx.activeTurnId;
+        if (cancelledTurnId !== undefined) {
+          yield* Effect.forkIn(
+            Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(
+              Effect.flatMap(() =>
+                ctx.activeTurnId === cancelledTurnId ? Effect.ignore(ctx.acp.cancel) : Effect.void,
+              ),
             ),
-          ),
-          ctx.scope,
-        );
+            ctx.scope,
+          );
+        }
       });
 
     // `agy` itself always runs with permissions skipped — print mode cannot

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -174,6 +174,8 @@ interface AntigravitySessionContext {
    * session's before clearing the registry entry.
    */
   readonly approvals: Map<ApprovalRequestId, PendingApproval>;
+  /** Bridge-side session id, needed to address provider-specific notifications. */
+  readonly acpSessionId: string;
   /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
@@ -208,6 +210,12 @@ function resolveEffortSelection(
   const raw = options?.find((option) => option.id === "effort")?.value;
   const effort = typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
   return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
+}
+
+/** A thread's lock plus how many callers currently want it. */
+interface ThreadLock {
+  readonly semaphore: Semaphore.Semaphore;
+  holders: number;
 }
 
 interface PendingApproval {
@@ -262,7 +270,7 @@ export function makeAntigravityAdapter(
      * exists, and `respondToRequest` resolves entries from a different call.
      */
     const approvalsByThread = new Map<ThreadId, Map<ApprovalRequestId, PendingApproval>>();
-    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, ThreadLock>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
 
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
@@ -293,26 +301,51 @@ export function makeAntigravityAdapter(
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
 
+    /**
+     * Acquire this thread's lock, counting holders so the entry can be dropped
+     * once the last one leaves. Threads come and go for the life of the
+     * adapter — and a `stopSession` for an id that never existed still mints a
+     * lock — so an unreleased entry per id would grow without bound.
+     */
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
-        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
-          current.get(threadId),
-        );
+        const existing: Option.Option<ThreadLock> = Option.fromNullishOr(current.get(threadId));
         return Option.match(existing, {
           onNone: () =>
             Semaphore.make(1).pipe(
               Effect.map((semaphore) => {
+                const lock: ThreadLock = { semaphore, holders: 1 };
                 const next = new Map(current);
-                next.set(threadId, semaphore);
-                return [semaphore, next] as const;
+                next.set(threadId, lock);
+                return [lock, next] as const;
               }),
             ),
-          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+          onSome: (lock) => {
+            lock.holders += 1;
+            return Effect.succeed([lock, current] as const);
+          },
         });
       });
 
+    const releaseThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.update(threadLocksRef, (current) => {
+        const lock = current.get(threadId);
+        if (!lock) {
+          return current;
+        }
+        lock.holders -= 1;
+        if (lock.holders > 0) {
+          return current;
+        }
+        const next = new Map(current);
+        next.delete(threadId);
+        return next;
+      });
+
     const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
-      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+      Effect.flatMap(getThreadSemaphore(threadId), (lock) =>
+        lock.semaphore.withPermit(effect).pipe(Effect.ensuring(releaseThreadSemaphore(threadId))),
+      );
 
     const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
       Effect.gen(function* () {
@@ -653,6 +686,7 @@ export function makeAntigravityAdapter(
             lifecycleGate: yield* Semaphore.make(1),
             teardownSignal: yield* Deferred.make<void>(),
             approvals: pendingApprovals,
+            acpSessionId: started.sessionId,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -740,6 +774,12 @@ export function makeAntigravityAdapter(
             Effect.catch((cause) =>
               Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
             ),
+            // However this consumer ends — teardown, a defect while stamping,
+            // an interrupt — it fires the same signal drains wait on. Without
+            // it a consumer that died on its own would leave every later drain
+            // queuing a barrier nobody can acknowledge, hanging `sendTurn`
+            // while it holds the prompt gate.
+            Effect.onExit(() => Effect.ignore(Deferred.succeed(ctx.teardownSignal, undefined))),
             Effect.forkChild,
           );
 
@@ -1098,6 +1138,15 @@ export function makeAntigravityAdapter(
             yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
           }
           pending.clear();
+        }
+        // Fenced before cancelling, and only with a prompt outstanding. The
+        // runtime forks its cancel notification, so a prompt written just
+        // before this can still reach the bridge afterwards; the fence is what
+        // lets the bridge recognise and stop that one. Sending it
+        // unconditionally would instead fence a cancel that arrived after its
+        // own turn ended, killing the next unrelated prompt.
+        if (ctx.promptsInFlight > 0) {
+          yield* Effect.ignore(ctx.acp.notify("t3/fence", { sessionId: ctx.acpSessionId }));
         }
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1123,17 +1123,26 @@ export function makeAntigravityAdapter(
                       if (ctx.stopped) {
                         return;
                       }
-                      yield* offerRuntimeEvent({
-                        type: "turn.started",
+                      const startedEvent = {
+                        type: "turn.started" as const,
                         ...(yield* makeEventStamp()),
                         provider: PROVIDER,
                         threadId: input.threadId,
                         turnId,
                         payload: { model: ctx.session.model },
-                      });
-                      // Marked published only once the event is genuinely out, so
-                      // teardown never completes a turn that was merely reserved.
-                      ctx.publishedTurnIds.add(turnId);
+                      };
+                      // Published and recorded together. Marking only after the
+                      // event is out keeps teardown from completing a turn that
+                      // was merely reserved — but an interrupt between the two
+                      // would drop the reservation with the start already on
+                      // the wire, and settlement would owe a completion it did
+                      // not know about.
+                      yield* Effect.uninterruptible(
+                        Effect.gen(function* () {
+                          yield* offerRuntimeEvent(startedEvent);
+                          ctx.publishedTurnIds.add(turnId);
+                        }),
+                      );
                     }),
                   )
                   .pipe(
@@ -1211,52 +1220,66 @@ export function makeAntigravityAdapter(
               };
             }).pipe(
               Effect.ensuring(
-                Effect.gen(function* () {
-                  // One prompt per turn, so this settles unconditionally.
-                  // Cleared even when the turn never started — a model switch can
-                  // fail after `activeTurnId` is installed, and leaving it set
-                  // advertises a turn to `listSessions` and the reaper that no
-                  // longer exists. Only the event below depends on having started.
-                  if (ctx.activeTurnId === turnId) {
-                    ctx.activeTurnId = undefined;
-                  }
-                  // Read from shared state rather than this call's local flag: the
-                  // prompt that published `turn.started` may not be the one that
-                  // settles the turn, and the settler still owes the completion.
-                  const published = ctx.publishedTurnIds.has(turnId);
-                  ctx.publishedTurnIds.delete(turnId);
-                  ctx.reservedTurnIds.delete(turnId);
-                  // The public session field is what `listSessions` and the reaper
-                  // read, so leaving it set would advertise a turn that has ended.
-                  if (ctx.session.activeTurnId === turnId) {
-                    const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
-                    ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
-                  }
-                  // A prompt that failed or was interrupted after `turn.started`
-                  // still owes consumers a terminal event; without one the turn
-                  // renders as running forever even though sendTurn already
-                  // returned an error.
-                  if (!published) {
-                    return;
-                  }
-                  const state =
-                    stopReason === "cancelled"
-                      ? "cancelled"
-                      : promptSucceeded
-                        ? "completed"
-                        : "failed";
-                  yield* offerRuntimeEvent({
-                    type: "turn.completed",
-                    ...(yield* makeEventStamp()),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId,
-                    payload: { state, stopReason },
-                  });
-                  // `catchCause` rather than `catch`: a defect while stamping or
-                  // publishing would otherwise escape after the turn's prompt count
-                  // was already decremented, stranding the turn as running.
-                }).pipe(Effect.catchCause(() => Effect.void)),
+                // Settlement takes the same gate teardown does. It clears the
+                // published claim and then yields to stamp and publish; without
+                // the gate, a concurrent stop could see an empty set, decide it
+                // owed nothing, emit `session.exited`, and have this completion
+                // arrive after it. Whichever takes the gate first owns the
+                // terminal event, and the other finds nothing to publish.
+                ctx.lifecycleGate
+                  .withPermit(
+                    Effect.gen(function* () {
+                      // One prompt per turn, so this settles unconditionally.
+                      // Cleared even when the turn never started — a model switch can
+                      // fail after `activeTurnId` is installed, and leaving it set
+                      // advertises a turn to `listSessions` and the reaper that no
+                      // longer exists. Only the event below depends on having started.
+                      if (ctx.activeTurnId === turnId) {
+                        ctx.activeTurnId = undefined;
+                      }
+                      // Read from shared state rather than this call's local flag: the
+                      // prompt that published `turn.started` may not be the one that
+                      // settles the turn, and the settler still owes the completion.
+                      const published = ctx.publishedTurnIds.has(turnId);
+                      ctx.publishedTurnIds.delete(turnId);
+                      ctx.reservedTurnIds.delete(turnId);
+                      // The public session field is what `listSessions` and the reaper
+                      // read, so leaving it set would advertise a turn that has ended.
+                      if (ctx.session.activeTurnId === turnId) {
+                        const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
+                        ctx.session = {
+                          ...endedSession,
+                          status: "ready",
+                          updatedAt: yield* nowIso,
+                        };
+                      }
+                      // A prompt that failed or was interrupted after `turn.started`
+                      // still owes consumers a terminal event; without one the turn
+                      // renders as running forever even though sendTurn already
+                      // returned an error.
+                      if (!published) {
+                        return;
+                      }
+                      const state =
+                        stopReason === "cancelled"
+                          ? "cancelled"
+                          : promptSucceeded
+                            ? "completed"
+                            : "failed";
+                      yield* offerRuntimeEvent({
+                        type: "turn.completed",
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: { state, stopReason },
+                      });
+                      // `catchCause` rather than `catch`: a defect while stamping or
+                      // publishing would otherwise escape after the turn's prompt count
+                      // was already decremented, stranding the turn as running.
+                    }),
+                  )
+                  .pipe(Effect.catchCause(() => Effect.void)),
               ),
             );
           }),
@@ -1266,6 +1289,14 @@ export function makeAntigravityAdapter(
     const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
+        // Uninterruptible as a whole. The epoch moves first, so an interrupt
+        // partway would leave prompts refused against a fence the bridge never
+        // received — `agy` running on after Stop with nothing left to tell it.
+        yield* Effect.uninterruptible(cancelSequence(ctx, threadId));
+      });
+
+    const cancelSequence = (ctx: AntigravitySessionContext, threadId: ThreadId) =>
+      Effect.gen(function* () {
         // Recorded before anything else: prompts already accepted but still
         // queued upstream compare against this and refuse to submit.
         // Read and bumped in one synchronous step: everything accepted up to

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -754,9 +754,15 @@ export function makeAntigravityAdapter(
                   ),
                 );
                 const eventStreamDrained = Option.isSome(drained) && drained.value;
+                // Rechecked by turn identity, not only by epoch. A turn that
+                // ends on its own — `agy` exiting, or its print timeout — moves
+                // no epoch, so a request that waited out a slow consumer would
+                // open here against a turn settlement had already completed and
+                // then resolve it immediately afterwards.
                 if (
                   !eventStreamDrained ||
                   ctx.stopped ||
+                  ctx.activeTurnId !== approvalTurnId ||
                   (approvalEpoch !== undefined && approvalEpoch !== ctx.cancelEpoch)
                 ) {
                   pendingApprovals.delete(requestId);

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -282,6 +282,14 @@ export function makeAntigravityAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
     const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
 
+    // Scope for work that must outlive the session it concerns — specifically
+    // the cancel-acknowledgement fallback, whose whole job is to tear that
+    // session down. Forked into the session's own scope it would be closing the
+    // scope it runs in, and a scope waits for its children: the close would
+    // wait on the fiber waiting on the close.
+    const adapterScope = yield* Scope.make("sequential");
+    yield* Effect.addFinalizer(() => Effect.ignore(Scope.close(adapterScope, Exit.void)));
+
     const sessions = new Map<ThreadId, AntigravitySessionContext>();
     /**
      * Approvals awaiting a user decision, per thread. Held outside the session
@@ -928,12 +936,18 @@ export function makeAntigravityAdapter(
                     );
                     return;
                 }
-              }),
+              }).pipe(
+                // Per event, not around the whole stream. Catching outside the
+                // drain meant one unprocessable notification ended the consumer
+                // for good: every later event was lost, and the turn events
+                // that depend on it stopped being attributed even though
+                // prompts kept completing.
+                Effect.catchCause((cause) =>
+                  Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
+                ),
+              ),
             ),
           ).pipe(
-            Effect.catch((cause) =>
-              Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
-            ),
             // However this consumer ends — teardown, a defect while stamping,
             // an interrupt — it fires the same signal drains wait on. Without
             // it a consumer that died on its own would leave every later drain
@@ -1428,7 +1442,7 @@ export function makeAntigravityAdapter(
                 ),
               ),
             ),
-            ctx.scope,
+            adapterScope,
           );
         }
       });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -731,6 +731,25 @@ export function makeAntigravityAdapter(
                   pendingApprovals.delete(requestId);
                   return { outcome: { outcome: "cancelled" } as const };
                 }
+                // The bridge sends the tool update before asking permission,
+                // but the ACP runtime only queues that update. Wait until the
+                // notification consumer has published everything ahead of this
+                // barrier so the request cannot overtake the tool call it
+                // belongs to. Teardown wins the race when that consumer is no
+                // longer available, which keeps a stopped session from holding
+                // the hook callback forever.
+                const eventStreamDrained = yield* Effect.raceFirst(
+                  ctx.acp.drainEvents.pipe(Effect.as(true)),
+                  Deferred.await(ctx.teardownSignal).pipe(Effect.as(false)),
+                );
+                if (
+                  !eventStreamDrained ||
+                  ctx.stopped ||
+                  (approvalEpoch !== undefined && approvalEpoch !== ctx.cancelEpoch)
+                ) {
+                  pendingApprovals.delete(requestId);
+                  return { outcome: { outcome: "cancelled" } as const };
+                }
                 // Built first, then published and recorded in one uninterruptible
                 // step. An interrupt between the two would leave the UI showing
                 // a request the finalizer does not know to close.
@@ -1464,11 +1483,18 @@ export function makeAntigravityAdapter(
         // Uninterruptible as a whole. The epoch moves first, so an interrupt
         // partway would leave prompts refused against a fence the bridge never
         // received — `agy` running on after Stop with nothing left to tell it.
-        yield* Effect.uninterruptible(cancelSequence(ctx, threadId));
+        yield* Effect.uninterruptible(cancelSequence(ctx));
       });
 
-    const cancelSequence = (ctx: AntigravitySessionContext, threadId: ThreadId) =>
+    const cancelSequence = (ctx: AntigravitySessionContext) =>
       Effect.gen(function* () {
+        // `requireSession` yields its context to the caller, so a concurrent
+        // restart can replace it before this effect begins. A stale interrupt
+        // must not cancel either the old process or approvals owned by the new
+        // session now registered for the same thread.
+        if (sessions.get(ctx.threadId) !== ctx) {
+          return;
+        }
         // Recorded before anything else: prompts already accepted but still
         // queued upstream compare against this and refuse to submit.
         // Read and bumped in one synchronous step: everything accepted up to
@@ -1484,11 +1510,8 @@ export function makeAntigravityAdapter(
         // permission request has a hook process blocked behind it, and the
         // bridge turns "cancel" into a denial. Leaving it pending would hold
         // that tool until the hook's own timeout.
-        const pending = approvalsByThread.get(threadId);
-        if (pending) {
-          for (const [, approval] of pending) {
-            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
-          }
+        for (const [, approval] of ctx.approvals) {
+          yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
         }
         // The fence names the epoch being cancelled through, rather than one
         // notification per outstanding prompt. Everything accepted at or below

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -89,6 +89,12 @@ const PROVIDER = ProviderDriverKind.make("antigravity");
  * unanswered request pinning its entry and its UI prompt forever.
  */
 const APPROVAL_WAIT_MS = 11 * 60 * 1000;
+/**
+ * How long to let the bridge answer a cancelled prompt on its own before
+ * interrupting the RPC. Only a backstop against a wedged bridge; the normal
+ * path settles well inside it.
+ */
+const CANCEL_ACK_TIMEOUT_MS = 10_000;
 const ANTIGRAVITY_RESUME_VERSION = 1 as const;
 
 export interface AntigravityAdapterLiveOptions {
@@ -1185,25 +1191,31 @@ export function makeAntigravityAdapter(
           }
           pending.clear();
         }
-        // Fenced before cancelling, and only with a prompt outstanding. The
-        // runtime forks its cancel notification, so a prompt written just
-        // before this can still reach the bridge afterwards; the fence is what
-        // lets the bridge recognise and stop that one. Sending it
-        // unconditionally would instead fence a cancel that arrived after its
-        // own turn ended, killing the next unrelated prompt.
-        // One notification names the epoch being cancelled through, rather than
-        // one per outstanding prompt. Everything accepted at or below it is
-        // cancelled; anything accepted afterwards carries a higher epoch and is
-        // untouched, so nothing has to be tracked per prompt or evicted.
+        // The fence names the epoch being cancelled through, rather than one
+        // notification per outstanding prompt. Everything accepted at or below
+        // it is cancelled; anything accepted afterwards carries a higher epoch
+        // and is untouched, so nothing has to be tracked per prompt.
         yield* Effect.ignore(
           ctx.acp.notify("t3/fence", { sessionId: ctx.acpSessionId, epoch: cancelledThrough }),
         );
-        yield* Effect.ignore(
-          ctx.acp.cancel.pipe(
-            Effect.mapError((error) =>
-              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+        // Sent as a plain notification rather than through `acp.cancel`, which
+        // interrupts the local prompt RPC. That interrupt settles the turn and
+        // releases the gate before the bridge has killed `agy` and run its
+        // final drain, so the transcript and failed-tool updates that drain
+        // produces arrive with no turn to belong to. Delivered this way the
+        // bridge answers the original prompt itself, after its updates are on
+        // the wire, and the turn settles on that response.
+        yield* Effect.ignore(ctx.acp.notify("session/cancel", { sessionId: ctx.acpSessionId }));
+        // Fallback: if the bridge never answers — wedged, or already gone — the
+        // interrupt still happens, just late enough not to truncate a healthy
+        // drain. Forked into the session scope so it dies with the session.
+        yield* Effect.forkIn(
+          Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(
+            Effect.flatMap(() =>
+              ctx.activeTurnId === undefined ? Effect.void : Effect.ignore(ctx.acp.cancel),
             ),
           ),
+          ctx.scope,
         );
       });
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -462,14 +462,21 @@ export function makeAntigravityAdapter(
         yield* cleanupContext(ctx);
 
         for (const orphanedTurnId of orphanedTurnIds) {
+          // The stamp is generated inside the ignored region, not before it.
+          // `makeEventStamp` can fail — it mints a UUID — and evaluating it
+          // outside would abort teardown after `ctx.stopped` was set and the
+          // published set cleared, losing this completion and everything after
+          // it with no later stop able to retry.
           yield* Effect.ignore(
-            offerRuntimeEvent({
-              type: "turn.completed",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: ctx.threadId,
-              turnId: orphanedTurnId,
-              payload: { state: "cancelled", stopReason: null },
+            Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                turnId: orphanedTurnId,
+                payload: { state: "cancelled", stopReason: null },
+              });
             }),
           );
         }
@@ -478,12 +485,14 @@ export function makeAntigravityAdapter(
         // session exiting.
         if (sessions.get(ctx.threadId) === undefined) {
           yield* Effect.ignore(
-            offerRuntimeEvent({
-              type: "session.exited",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: ctx.threadId,
-              payload: { exitKind: "graceful" },
+            Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "session.exited",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                payload: { exitKind: "graceful" },
+              });
             }),
           );
         }
@@ -592,8 +601,11 @@ export function makeAntigravityAdapter(
           // no session context for teardown to clean up, and repeated failures
           // across thread ids would grow the map. Registered after `start()`.
           const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
-          yield* acp.handleRequestPermission((params) =>
-            mapAcpCallbackFailure(
+          yield* acp.handleRequestPermission((params) => {
+            // Held outside the workflow so the finalizer can clear the entry
+            // wherever inside it things stopped.
+            let registeredRequestId: ApprovalRequestId | undefined;
+            return mapAcpCallbackFailure(
               Effect.gen(function* () {
                 // Bound to the turn actually running, with the epoch that turn
                 // was accepted at — not the session's current epoch. A request
@@ -620,6 +632,7 @@ export function makeAntigravityAdapter(
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
                 pendingApprovals.set(requestId, { decision });
+                registeredRequestId = requestId;
                 // Rechecked after registering, not only before: minting the id
                 // and the deferred both yield, and a Stop landing in that gap
                 // would find no entry to cancel — leaving this request open in
@@ -653,7 +666,6 @@ export function makeAntigravityAdapter(
                 // this the handler would stay blocked and the entry retained.
                 const answered = yield* Deferred.await(decision).pipe(
                   Effect.timeoutOption(APPROVAL_WAIT_MS),
-                  Effect.ensuring(Effect.sync(() => pendingApprovals.delete(requestId))),
                 );
                 // An unanswered request denies, matching the bridge's own
                 // timeout: this gate must never resolve to "allow" by default.
@@ -685,9 +697,21 @@ export function makeAntigravityAdapter(
                     ? { outcome: "selected" as const, optionId }
                     : ({ outcome: "cancelled" } as const),
                 };
-              }),
-            ),
-          );
+              }).pipe(
+                // Covers everything after the entry was registered, not just
+                // the wait: a failure while stamping or publishing either event
+                // would otherwise leave the entry in the map for good, and the
+                // request open in the UI with nothing able to answer it.
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    if (registeredRequestId !== undefined) {
+                      pendingApprovals.delete(registeredRequestId);
+                    }
+                  }),
+                ),
+              ),
+            );
+          });
 
           const started = yield* acp
             .start()

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -180,6 +180,15 @@ interface AntigravitySessionContext {
   /** Cancel epoch the active turn belongs to; steering is scoped to it. */
   activeTurnEpoch: number;
   /**
+   * Turn whose prompt currently owns the submission gate.
+   *
+   * Streamed events belong to whichever turn the bridge is actually running,
+   * which is not always the newest: after a Stop a fresh turn can be announced
+   * while the cancelled turn's final updates are still being consumed, and
+   * attributing those to the newcomer files one turn's output under another.
+   */
+  submittingTurnId: TurnId | undefined;
+  /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
@@ -708,6 +717,7 @@ export function makeAntigravityAdapter(
             approvals: pendingApprovals,
             acpSessionId: started.sessionId,
             activeTurnEpoch: -1,
+            submittingTurnId: undefined,
             promptsInFlightByTurn: new Map(),
             stopped: false,
           };
@@ -728,7 +738,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.activeTurnId,
+                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
                         itemId: event.itemId,
                         lifecycle: "item.started",
                       }),
@@ -740,7 +750,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.activeTurnId,
+                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
                         itemId: event.itemId,
                         lifecycle: "item.completed",
                       }),
@@ -753,7 +763,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.activeTurnId,
+                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
                         payload: event.payload,
                         source: "acp.jsonrpc",
                         method: "session/update",
@@ -768,7 +778,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.activeTurnId,
+                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
                         toolCall: event.toolCall,
                         rawPayload: event.rawPayload,
                       }),
@@ -781,7 +791,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.activeTurnId,
+                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
                         ...(event.itemId ? { itemId: event.itemId } : {}),
                         text: event.text,
                         rawPayload: event.rawPayload,
@@ -1046,6 +1056,10 @@ export function makeAntigravityAdapter(
                 if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
                   return undefined;
                 }
+                // Owned from here until after the drain below, so this turn's
+                // streamed events stay attributed to it even once a newer turn
+                // has been announced.
+                ctx.submittingTurnId = turnId;
                 // The bridge writes its `session/update` notifications before
                 // the prompt response, but the runtime only queues them.
                 // Draining inside the gate keeps the turn from settling — and
@@ -1071,6 +1085,15 @@ export function makeAntigravityAdapter(
                   .pipe(
                     Effect.tapCause(() => drain),
                     Effect.tap(() => drain),
+                    // Released only after the drain, so events this turn queued
+                    // are still attributed to it.
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        if (ctx.submittingTurnId === turnId) {
+                          ctx.submittingTurnId = undefined;
+                        }
+                      }),
+                    ),
                   );
               }),
             )

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -5,9 +5,12 @@
  * to is T3 Code's own bridge (`t3 agy-acp`). That shapes three deliberate
  * differences from the CLI-native ACP adapters:
  *
- *   - **No permission requests.** The bridge drives `agy` with
- *     `--dangerously-skip-permissions` because print mode cannot prompt, so
- *     tools are auto-approved and no approval flow can be surfaced.
+ *   - **Approvals come from the hook, not the CLI.** `agy` always runs with
+ *     `--dangerously-skip-permissions` because print mode cannot prompt. When
+ *     `requireToolApproval` is set, the bridge's `PreToolUse` hook becomes the
+ *     gate instead: it blocks the tool until this adapter answers, and a
+ *     denial is reported back to the model. Off by default, since every
+ *     approval stops the turn until a human replies.
  *   - **No session modes.** Print mode has no plan/ask distinction to switch.
  *   - **Attachments travel by reference.** `agy --print` has no attachment
  *     flag, so files are sent as `resource_link` blocks and the bridge stages
@@ -21,11 +24,14 @@
 
 import {
   type AntigravitySettings,
+  ApprovalRequestId,
   EventId,
+  type ProviderApprovalDecision,
   type ProviderRuntimeEvent,
   type ProviderSession,
   ProviderDriverKind,
   ProviderInstanceId,
+  RuntimeRequestId,
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -43,6 +49,7 @@ import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
 import { attachmentFileUrl, resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -60,8 +67,11 @@ import {
   makeAcpAssistantItemEvent,
   makeAcpContentDeltaEvent,
   makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
   makeAcpToolCallEvent,
 } from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   makeAntigravityAcpRuntime,
@@ -136,6 +146,32 @@ function resolveEffortSelection(
   return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
 }
 
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+function selectPermissionOptionId(
+  request: EffectAcpSchema.RequestPermissionRequest,
+  decision: Exclude<ProviderApprovalDecision, "cancel">,
+): string | undefined {
+  const kind =
+    decision === "acceptForSession"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  return request.options.find((entry) => entry.kind === kind)?.optionId.trim() || undefined;
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  return (
+    selectPermissionOptionId(request, "acceptForSession") ??
+    selectPermissionOptionId(request, "accept")
+  );
+}
+
 export function makeAntigravityAdapter(
   antigravitySettings: AntigravitySettings,
   options?: AntigravityAdapterLiveOptions,
@@ -156,6 +192,12 @@ export function makeAntigravityAdapter(
     const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
 
     const sessions = new Map<ThreadId, AntigravitySessionContext>();
+    /**
+     * Approvals awaiting a user decision, per thread. Held outside the session
+     * context because the permission callback is registered before the context
+     * exists, and `respondToRequest` resolves entries from a different call.
+     */
+    const approvalsByThread = new Map<ThreadId, Map<ApprovalRequestId, PendingApproval>>();
     const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
 
@@ -173,6 +215,16 @@ export function makeAntigravityAdapter(
     );
     const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
     const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapAcpCallbackFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Antigravity ACP callback.",
+              cause,
+            }),
+        ),
+      );
 
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
@@ -235,6 +287,16 @@ export function makeAntigravityAdapter(
       Effect.gen(function* () {
         if (ctx.stopped) return;
         ctx.stopped = true;
+        // Anything still waiting on a human is cancelled, which the bridge
+        // turns into a denial. Left pending, the hook would block its tool
+        // until its own timeout with no one able to answer.
+        const pending = approvalsByThread.get(ctx.threadId);
+        if (pending) {
+          for (const [, approval] of pending) {
+            yield* Deferred.succeed(approval.decision, "cancel");
+          }
+          approvalsByThread.delete(ctx.threadId);
+        }
         if (ctx.notificationFiber) {
           yield* Fiber.interrupt(ctx.notificationFiber);
         }
@@ -334,6 +396,64 @@ export function makeAntigravityAdapter(
                   detail: cause.message,
                   cause,
                 }),
+            ),
+          );
+
+          // With approvals enabled the bridge blocks each tool on this callback,
+          // so it must be registered before `start()` — the first tool call can
+          // arrive as soon as the first turn begins.
+          const pendingApprovals = approvalsByThread.get(input.threadId) ?? new Map();
+          approvalsByThread.set(input.threadId, pendingApprovals);
+          yield* acp.handleRequestPermission((params) =>
+            mapAcpCallbackFailure(
+              Effect.gen(function* () {
+                if (input.runtimeMode === "full-access") {
+                  const autoApproved = selectAutoApprovedPermissionOption(params);
+                  if (autoApproved !== undefined) {
+                    return { outcome: { outcome: "selected" as const, optionId: autoApproved } };
+                  }
+                }
+                const permissionRequest = parsePermissionRequest(params);
+                const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                const turnId = sessions.get(input.threadId)?.activeTurnId;
+                pendingApprovals.set(requestId, { decision });
+                yield* offerRuntimeEvent(
+                  makeAcpRequestOpenedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    requestId: RuntimeRequestId.make(requestId),
+                    permissionRequest,
+                    detail: permissionRequest.detail ?? "Antigravity tool call",
+                    args: params,
+                    source: "acp.jsonrpc",
+                    method: "session/request_permission",
+                    rawPayload: params,
+                  }),
+                );
+                const resolved = yield* Deferred.await(decision);
+                pendingApprovals.delete(requestId);
+                yield* offerRuntimeEvent(
+                  makeAcpRequestResolvedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    requestId: RuntimeRequestId.make(requestId),
+                    permissionRequest,
+                    decision: resolved,
+                  }),
+                );
+                const optionId =
+                  resolved === "cancel" ? undefined : selectPermissionOptionId(params, resolved);
+                return {
+                  outcome: optionId
+                    ? { outcome: "selected" as const, optionId }
+                    : ({ outcome: "cancelled" } as const),
+                };
+              }),
             ),
           );
 
@@ -680,18 +800,25 @@ export function makeAntigravityAdapter(
         );
       });
 
-    // Antigravity runs every turn with `--dangerously-skip-permissions`, so
-    // the bridge never opens an approval or question request. Reaching either
-    // responder means the caller is tracking a request this provider cannot
-    // have produced.
-    const respondToRequest: AntigravityAdapterShape["respondToRequest"] = (threadId, requestId) =>
+    // `agy` itself always runs with permissions skipped — print mode cannot
+    // prompt — so when approvals are enabled the bridge's PreToolUse hook is
+    // the gate, and this resolves the decision it is blocked on.
+    const respondToRequest: AntigravityAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
       Effect.gen(function* () {
         yield* requireSession(threadId);
-        return yield* new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "session/request_permission",
-          detail: `Antigravity auto-approves tools and never opens approvals; unknown request: ${requestId}`,
-        });
+        const pending = approvalsByThread.get(threadId)?.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
       });
 
     const respondToUserInput: AntigravityAdapterShape["respondToUserInput"] = (

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -485,6 +485,24 @@ export function makeAntigravityAdapter(
     const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
+
+        // The bridge declares no image capability: `agy --print` takes text
+        // only, so attachments cannot be forwarded. This runs before any
+        // `turn.started` is offered — a rejected prompt that had already
+        // announced a turn would leave the UI with one that never completes.
+        const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
+        if (input.input?.trim()) {
+          promptParts.push({ type: "text", text: input.input.trim() });
+        }
+        if (promptParts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue:
+              "Turn requires non-empty text. Antigravity print mode does not accept attachments.",
+          });
+        }
+
         // A sendTurn while a prompt is in flight is a steer: the new prompt
         // folds into the ongoing work, so the active turn id is reused.
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
@@ -507,21 +525,6 @@ export function makeAntigravityAdapter(
               threadId: input.threadId,
               turnId,
               payload: { model: ctx.session.model },
-            });
-          }
-
-          // The bridge declares no image capability: `agy --print` takes text
-          // only, so attachments cannot be forwarded.
-          const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          if (input.input?.trim()) {
-            promptParts.push({ type: "text", text: input.input.trim() });
-          }
-          if (promptParts.length === 0) {
-            return yield* new ProviderAdapterValidationError({
-              provider: PROVIDER,
-              operation: "sendTurn",
-              issue:
-                "Turn requires non-empty text. Antigravity print mode does not accept attachments.",
             });
           }
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -603,9 +603,19 @@ export function makeAntigravityAdapter(
           yield* acp.handleRequestPermission((params) =>
             mapAcpCallbackFailure(
               Effect.gen(function* () {
-                // A request arriving after teardown has no live turn behind it,
-                // so it must not be auto-approved on the way out.
-                if (ctx?.stopped) {
+                // Bound to the turn actually running, with the epoch that turn
+                // was accepted at — not the session's current epoch. A request
+                // from a cancelled turn can arrive after the epoch moved, and
+                // reading the live value would make it look current.
+                const approvalTurnId = ctx?.submittingTurnId ?? ctx?.activeTurnId;
+                const approvalEpoch = ctx?.activeTurnEpoch;
+                const turnCancelled =
+                  approvalEpoch !== undefined &&
+                  ctx !== undefined &&
+                  approvalEpoch !== ctx.cancelEpoch;
+                // Checked before auto-approval, not after: teardown or a Stop
+                // must not be waved through by full access.
+                if (ctx?.stopped || turnCancelled) {
                   return { outcome: { outcome: "cancelled" } as const };
                 }
                 if (input.runtimeMode === "full-access") {
@@ -615,7 +625,6 @@ export function makeAntigravityAdapter(
                   }
                 }
                 const permissionRequest = parsePermissionRequest(params);
-                const approvalEpoch = ctx?.cancelEpoch;
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
                 const turnId = sessions.get(input.threadId)?.activeTurnId;
@@ -625,7 +634,7 @@ export function makeAntigravityAdapter(
                     stamp: yield* makeEventStamp(),
                     provider: PROVIDER,
                     threadId: input.threadId,
-                    turnId,
+                    turnId: approvalTurnId,
                     requestId: RuntimeRequestId.make(requestId),
                     permissionRequest,
                     detail: permissionRequest.detail ?? "Antigravity tool call",
@@ -660,7 +669,9 @@ export function makeAntigravityAdapter(
                 );
                 // Re-checked at the moment of answering: an approval decided
                 // while Stop was landing must not come back as an allow.
-                const stillLive = !ctx?.stopped && ctx?.cancelEpoch === approvalEpoch;
+                const stillLive =
+                  !ctx?.stopped &&
+                  (approvalEpoch === undefined || ctx?.cancelEpoch === approvalEpoch);
                 const optionId =
                   resolved === "cancel" || !stillLive
                     ? undefined
@@ -929,6 +940,18 @@ export function makeAntigravityAdapter(
         // concurrent calls both observe zero and open rival turns over the
         // same thread.
         const freshTurnId = TurnId.make(yield* randomUUIDv4);
+        // Rechecked here, after the last yield and before any turn state is
+        // touched. A prompt that stalled in preparation can resume once a Stop
+        // has landed and a newer turn has claimed the pointer; claiming here
+        // would overwrite that pointer and then clear it again on the way out,
+        // leaving the newer turn counted but unreachable.
+        if (ctx.stopped || ctx.cancelEpoch !== acceptedEpoch) {
+          return {
+            threadId: input.threadId,
+            turnId: freshTurnId,
+            resumeCursor: ctx.session.resumeCursor,
+          };
+        }
         // Same epoch only: a prompt accepted after a Stop must not fold into the
         // turn that Stop cancelled, or it would inherit its id and publish a
         // completion for it while the cancelled one is still settling.

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -9,8 +9,8 @@
  *     `--dangerously-skip-permissions` because print mode cannot prompt. When
  *     `requireToolApproval` is set, the bridge's `PreToolUse` hook becomes the
  *     gate instead: it blocks the tool until this adapter answers, and a
- *     denial is reported back to the model. Off by default, since every
- *     approval stops the turn until a human replies.
+ *     denial is reported back to the model. On by default: without it nothing
+ *     stands between the model and an auto-approved tool.
  *   - **No session modes.** Print mode has no plan/ask distinction to switch.
  *   - **Attachments travel by reference.** `agy --print` has no attachment
  *     flag, so files are sent as `resource_link` blocks and the bridge stages
@@ -293,7 +293,9 @@ export function makeAntigravityAdapter(
         const pending = approvalsByThread.get(ctx.threadId);
         if (pending) {
           for (const [, approval] of pending) {
-            yield* Deferred.succeed(approval.decision, "cancel");
+            // Ignored: an answer racing session stop may have settled this
+            // already, and that must not abort the rest of teardown.
+            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
           }
           approvalsByThread.delete(ctx.threadId);
         }
@@ -668,8 +670,15 @@ export function makeAntigravityAdapter(
 
         // A sendTurn while a prompt is in flight is a steer: the new prompt
         // folds into the ongoing work, so the active turn id is reused.
+        //
+        // The id is minted first, before anything is read, so that reading
+        // `promptsInFlight` and claiming it are one synchronous step. Yielding
+        // between the two — which generating the id here used to do — let two
+        // concurrent calls both observe zero and open rival turns over the
+        // same thread.
+        const freshTurnId = TurnId.make(yield* randomUUIDv4);
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
-        const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+        const turnId = steeringTurnId ?? freshTurnId;
         ctx.promptsInFlight += 1;
         // Terminal-event bookkeeping. Publication happens in exactly one place
         // (the teardown below) so that the decision cannot race a steer.
@@ -791,7 +800,10 @@ export function makeAntigravityAdapter(
                 turnId,
                 payload: { state, stopReason },
               });
-            }).pipe(Effect.catch(() => Effect.void)),
+              // `catchCause` rather than `catch`: a defect while stamping or
+              // publishing would otherwise escape after `promptsInFlight` was
+              // already decremented, stranding the turn as running.
+            }).pipe(Effect.catchCause(() => Effect.void)),
           ),
         );
       });
@@ -806,7 +818,7 @@ export function makeAntigravityAdapter(
         const pending = approvalsByThread.get(threadId);
         if (pending) {
           for (const [, approval] of pending) {
-            yield* Deferred.succeed(approval.decision, "cancel");
+            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
           }
           pending.clear();
         }

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -35,6 +35,7 @@ import {
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -943,11 +944,23 @@ export function makeAntigravityAdapter(
                 // that depend on it stopped being attributed even though
                 // prompts kept completing.
                 Effect.catchCause((cause) =>
-                  Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
+                  // Interrupts pass through. Swallowing them kept this fiber
+                  // alive through teardown, so `Fiber.interrupt` waited on a
+                  // consumer that had been told to stop and would not —
+                  // stranding the session and its bridge.
+                  Cause.hasInterruptsOnly(cause)
+                    ? Effect.failCause(cause)
+                    : Effect.logError("Failed to process Antigravity runtime notification.", {
+                        cause,
+                      }),
                 ),
               ),
             ),
           ).pipe(
+            // Absorbs a typed failure that escapes the per-event handler while
+            // leaving interruption alone — `Effect.catch` does not catch it —
+            // so teardown can still stop this fiber.
+            Effect.catch(() => Effect.void),
             // However this consumer ends — teardown, a defect while stamping,
             // an interrupt — it fires the same signal drains wait on. Without
             // it a consumer that died on its own would leave every later drain

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -441,6 +441,13 @@ export function makeAntigravityAdapter(
        * in the meantime would take its replacement down with it.
        */
       onlyIfActiveTurn?: TurnId,
+      /**
+       * Additional condition rechecked under the gate. The fallback's reason to
+       * stop — the bridge never acknowledged — can stop being true between it
+       * deciding and this claiming, and the turn stays active while its events
+       * drain, so the turn id alone does not settle it.
+       */
+      onlyIf?: () => boolean,
     ) => {
       // Whether this call is the one that claimed the teardown. The cleanup
       // below must not run otherwise: a call that declined because the turn had
@@ -456,6 +463,9 @@ export function makeAntigravityAdapter(
               return undefined;
             }
             if (onlyIfActiveTurn !== undefined && ctx.activeTurnId !== onlyIfActiveTurn) {
+              return undefined;
+            }
+            if (onlyIf !== undefined && !onlyIf()) {
               return undefined;
             }
             ctx.stopped = true;
@@ -1411,9 +1421,11 @@ export function makeAntigravityAdapter(
                 // ten seconds late, and the check has to happen under the same
                 // gate that claims the stop or a turn that settled meanwhile
                 // takes its replacement down with it.
-                ctx.awaitingBridgeAck.has(cancelledTurnId)
-                  ? Effect.ignore(stopSessionInternal(ctx, cancelledTurnId))
-                  : Effect.void,
+                Effect.ignore(
+                  stopSessionInternal(ctx, cancelledTurnId, () =>
+                    ctx.awaitingBridgeAck.has(cancelledTurnId),
+                  ),
+                ),
               ),
             ),
             ctx.scope,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -793,7 +793,17 @@ export function makeAntigravityAdapter(
           // Claimed from shared state, not from "am I a steer": the prompt this
           // one folded into may have failed before it announced anything, and
           // emitting content for a turn that never started strands the UI.
-          if (!ctx.startedTurnIds.has(turnId)) {
+          //
+          // Test and claim are one synchronous step — publishing first and
+          // marking afterwards let two concurrent steers both find the turn
+          // unannounced and emit `turn.started` twice. The claim is released
+          // again if publication does not happen, so a turn nobody saw start
+          // cannot later be completed.
+          const announcing = !ctx.startedTurnIds.has(turnId);
+          if (announcing) {
+            ctx.startedTurnIds.add(turnId);
+          }
+          if (announcing) {
             yield* offerRuntimeEvent({
               type: "turn.started",
               ...(yield* makeEventStamp()),
@@ -801,11 +811,13 @@ export function makeAntigravityAdapter(
               threadId: input.threadId,
               turnId,
               payload: { model: ctx.session.model },
-            });
-            // Marked only after the event is actually out, so a failed publish
-            // cannot let another prompt emit a completion for a turn nobody
-            // saw start.
-            ctx.startedTurnIds.add(turnId);
+            }).pipe(
+              Effect.onExit((exit) =>
+                Exit.isSuccess(exit)
+                  ? Effect.void
+                  : Effect.sync(() => ctx.startedTurnIds.delete(turnId)),
+              ),
+            );
           }
 
           const result = yield* ctx.promptGate

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -847,8 +847,11 @@ export function makeAntigravityAdapter(
         }).pipe(Effect.scoped),
       );
 
-    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
-      Effect.gen(function* () {
+    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) => {
+      // Captured outside the workflow so the finalizer can retire the id no
+      // matter where inside it things stopped.
+      let registered: { ctx: AntigravitySessionContext; promptId: string } | undefined;
+      return Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
         // Claimed before any yielding preparation. Attachment resolution and id
         // generation both yield, and a Stop landing in that window would
@@ -858,6 +861,7 @@ export function makeAntigravityAdapter(
         const promptId = `${ctx.acpSessionId}-${ctx.nextPromptSeq}`;
         const acceptedEpoch = ctx.cancelEpoch;
         ctx.outstandingPromptIds.add(promptId);
+        registered = { ctx, promptId };
 
         // `agy --print` takes a single text prompt, so attachments travel as
         // `resource_link` blocks (ACP baseline, no capability needed) pointing
@@ -1099,9 +1103,6 @@ export function makeAntigravityAdapter(
         }).pipe(
           Effect.ensuring(
             Effect.gen(function* () {
-              // No longer in transit, whatever happened to it: a fence for this
-              // id would now stop nothing, and keeping it would grow the set.
-              ctx.outstandingPromptIds.delete(promptId);
               // Decrement and the last-prompt test are one synchronous step, so
               // a steer arriving mid-settlement cannot make two prompts both
               // believe they own the turn and publish a terminal event each.
@@ -1152,7 +1153,18 @@ export function makeAntigravityAdapter(
             }).pipe(Effect.catchCause(() => Effect.void)),
           ),
         );
-      });
+      }).pipe(
+        // Registered before validation and attachment work so a Stop landing
+        // during those can still fence this prompt — which means its removal
+        // has to cover them failing too. An id left behind would be re-fenced
+        // by every later Stop.
+        Effect.ensuring(
+          Effect.sync(() => {
+            registered?.ctx.outstandingPromptIds.delete(registered.promptId);
+          }),
+        ),
+      );
+    };
 
     const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
@@ -1160,6 +1172,11 @@ export function makeAntigravityAdapter(
         // Recorded before anything else: prompts already accepted but still
         // queued upstream compare against this and refuse to submit.
         ctx.cancelEpoch += 1;
+        // Snapshotted in the same synchronous step as the bump. A live Set
+        // iterator yields entries added during iteration, so a prompt accepted
+        // after this cancel would be fenced by it and wrongly reported
+        // cancelled.
+        const fencedPromptIds = [...ctx.outstandingPromptIds];
         // Settled before the cancel goes out, as ACP requires: an outstanding
         // permission request has a hook process blocked behind it, and the
         // bridge turns "cancel" into a denial. Leaving it pending would hold
@@ -1177,7 +1194,7 @@ export function makeAntigravityAdapter(
         // lets the bridge recognise and stop that one. Sending it
         // unconditionally would instead fence a cancel that arrived after its
         // own turn ended, killing the next unrelated prompt.
-        for (const outstanding of ctx.outstandingPromptIds) {
+        for (const outstanding of fencedPromptIds) {
           yield* Effect.ignore(ctx.acp.notify("t3/fence", { promptId: outstanding }));
         }
         yield* Effect.ignore(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1,0 +1,690 @@
+/**
+ * AntigravityAdapterLive — Antigravity CLI (`agy`) via the bundled ACP bridge.
+ *
+ * Antigravity has no native agent protocol, so the ACP peer this adapter talks
+ * to is T3 Code's own bridge (`t3 agy-acp`). That shapes three deliberate
+ * differences from the CLI-native ACP adapters:
+ *
+ *   - **No permission requests.** The bridge drives `agy` with
+ *     `--dangerously-skip-permissions` because print mode cannot prompt, so
+ *     tools are auto-approved and no approval flow can be surfaced.
+ *   - **No session modes.** Print mode has no plan/ask distinction to switch.
+ *   - **Model is fixed per session.** The bridge passes `--model` when it
+ *     spawns `agy`, so changing models requires a new session
+ *     (`sessionModelSwitch: "unsupported"`).
+ *
+ * @module AntigravityAdapterLive
+ */
+
+import {
+  type AntigravitySettings,
+  EventId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import {
+  makeAntigravityAcpRuntime,
+  resolveAntigravityBaseModelId,
+} from "../acp/AntigravityAcpSupport.ts";
+import { type AntigravityAdapterShape } from "../Services/AntigravityAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = ProviderDriverKind.make("antigravity");
+const ANTIGRAVITY_RESUME_VERSION = 1 as const;
+
+export interface AntigravityAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  /**
+   * Selections are honored when `modelSelection.instanceId` matches this value.
+   * Defaults to the legacy built-in instance id (`antigravity`).
+   */
+  readonly instanceId?: ProviderInstanceId;
+  /**
+   * Optional per-session settings resolver, used by tests that mutate
+   * `ServerSettingsService` mid-flight. Production leaves this undefined and
+   * relies on the hydration layer rebuilding the adapter on config change.
+   */
+  readonly resolveSettings?: Effect.Effect<AntigravitySettings>;
+}
+
+interface AntigravitySessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  activeTurnId: TurnId | undefined;
+  /**
+   * Number of prompts in flight. >0 means a turn is running, so a new
+   * sendTurn steers the existing turn rather than opening a new one.
+   */
+  promptsInFlight: number;
+  stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAntigravityResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== ANTIGRAVITY_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+/**
+ * Reasoning effort for `agy --effort`, read from the model option selections.
+ * Antigravity accepts only low/medium/high.
+ */
+function resolveEffortSelection(
+  options:
+    | ReadonlyArray<{ readonly id: string; readonly value: string | boolean }>
+    | null
+    | undefined,
+): string | undefined {
+  // Option values are a string/boolean union across providers; only a string
+  // effort is meaningful here.
+  const raw = options?.find((option) => option.id === "effort")?.value;
+  const effort = typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
+  return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
+}
+
+export function makeAntigravityAdapter(
+  antigravitySettings: AntigravitySettings,
+  options?: AntigravityAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("antigravity");
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, AntigravitySessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Antigravity runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<AntigravitySessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: AntigravitySessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: AntigravityAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const modelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          let ctx!: AntigravitySessionContext;
+
+          const resumeSessionId = parseAntigravityResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          const effectiveSettings = options?.resolveSettings
+            ? yield* options.resolveSettings
+            : antigravitySettings;
+
+          // The model and effort are bound when the bridge spawns `agy`, so
+          // they must be resolved before the runtime is constructed rather
+          // than applied afterwards via session config.
+          const boundModel = resolveAntigravityBaseModelId(modelSelection?.model);
+          const boundEffort = resolveEffortSelection(modelSelection?.options);
+
+          const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+          const acp = yield* makeAntigravityAcpRuntime({
+            antigravitySettings: effectiveSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            model: boundModel,
+            ...(boundEffort ? { effort: boundEffort } : {}),
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(mcpSession
+              ? {
+                  mcpServers: [
+                    {
+                      type: "http" as const,
+                      name: "t3-code",
+                      url: mcpSession.endpoint,
+                      headers: [{ name: "Authorization", value: mcpSession.authorizationHeader }],
+                    },
+                  ],
+                }
+              : {}),
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Crypto.Crypto, crypto),
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          const started = yield* acp
+            .start()
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+              ),
+            );
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: boundModel,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: ANTIGRAVITY_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx = {
+            threadId: input.threadId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            turns: [],
+            activeTurnId: undefined,
+            promptsInFlight: 0,
+            stopped: false,
+          };
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "EventStreamBarrier":
+                    yield* Deferred.succeed(event.acknowledge, undefined);
+                    return;
+                  // The bridge never changes modes; print mode has none.
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpPlanUpdatedEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        payload: event.payload,
+                        source: "acp.jsonrpc",
+                        method: "session/update",
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
+            ),
+            Effect.forkChild,
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Antigravity ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        // A sendTurn while a prompt is in flight is a steer: the new prompt
+        // folds into the ongoing work, so the active turn id is reused.
+        const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+        const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+        ctx.promptsInFlight += 1;
+
+        return yield* Effect.gen(function* () {
+          ctx.activeTurnId = turnId;
+          ctx.session = {
+            ...ctx.session,
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+          };
+
+          if (steeringTurnId === undefined) {
+            yield* offerRuntimeEvent({
+              type: "turn.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: { model: ctx.session.model },
+            });
+          }
+
+          // The bridge declares no image capability: `agy --print` takes text
+          // only, so attachments cannot be forwarded.
+          const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
+          if (input.input?.trim()) {
+            promptParts.push({ type: "text", text: input.input.trim() });
+          }
+          if (promptParts.length === 0) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "sendTurn",
+              issue:
+                "Turn requires non-empty text. Antigravity print mode does not accept attachments.",
+            });
+          }
+
+          const result = yield* ctx.acp
+            .prompt({ prompt: promptParts })
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+
+          const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+          if (turnRecord) {
+            turnRecord.items.push({ prompt: promptParts, result });
+          } else {
+            ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+          }
+          ctx.session = {
+            ...ctx.session,
+            activeTurnId: turnId,
+            updatedAt: yield* nowIso,
+          };
+
+          // Only the last remaining prompt settles the turn, so a steer-
+          // superseded prompt resolving does not end the merged turn.
+          if (ctx.promptsInFlight === 1) {
+            yield* offerRuntimeEvent({
+              type: "turn.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: {
+                state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                stopReason: result.stopReason ?? null,
+              },
+            });
+          }
+
+          return {
+            threadId: input.threadId,
+            turnId,
+            resumeCursor: ctx.session.resumeCursor,
+          };
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
+            }),
+          ),
+        );
+      });
+
+    const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+
+    // Antigravity runs every turn with `--dangerously-skip-permissions`, so
+    // the bridge never opens an approval or question request. Reaching either
+    // responder means the caller is tracking a request this provider cannot
+    // have produced.
+    const respondToRequest: AntigravityAdapterShape["respondToRequest"] = (threadId, requestId) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "session/request_permission",
+          detail: `Antigravity auto-approves tools and never opens approvals; unknown request: ${requestId}`,
+        });
+      });
+
+    const respondToUserInput: AntigravityAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+    ) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "session/user_input",
+          detail: `Antigravity print mode cannot ask questions; unknown request: ${requestId}`,
+        });
+      });
+
+    const readThread: AntigravityAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: AntigravityAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        const nextLength = Math.max(0, ctx.turns.length - numTurns);
+        ctx.turns.splice(nextLength);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const stopSession: AntigravityAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: AntigravityAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: AntigravityAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: AntigravityAdapterShape["stopAll"] = () =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to emit Antigravity session shutdown event.", { cause }),
+        ),
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      // `agy --model` is applied when the bridge spawns the CLI, so switching
+      // models mid-session is not possible.
+      capabilities: { sessionModelSwitch: "unsupported" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies AntigravityAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -98,6 +98,13 @@ const APPROVAL_WAIT_MS = 9 * 60 * 1000;
  * path settles well inside it.
  */
 const CANCEL_ACK_TIMEOUT_MS = 10_000;
+/**
+ * How long turn settlement waits for an approval handler it just cancelled to
+ * publish its resolution. Short: the handler is already unblocked, so this only
+ * covers the hop back through the runtime, and a turn must never be held open
+ * by a handler that will not finish.
+ */
+const APPROVAL_SETTLE_TIMEOUT_MS = 5_000;
 const ANTIGRAVITY_RESUME_VERSION = 1 as const;
 
 export interface AntigravityAdapterLiveOptions {
@@ -240,6 +247,14 @@ interface ThreadLock {
 
 interface PendingApproval {
   readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  /**
+   * The turn this request belongs to, so settlement can release exactly the
+   * approvals its own turn opened. Undefined when no turn was active, which
+   * only happens for a request arriving outside a prompt.
+   */
+  readonly turnId: TurnId | undefined;
+  /** Completed once the handler has published this request's resolution. */
+  readonly settled: Deferred.Deferred<void>;
 }
 
 function selectPermissionOptionId(
@@ -694,7 +709,8 @@ export function makeAntigravityAdapter(
                 const permissionRequest = parsePermissionRequest(params);
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
-                pendingApprovals.set(requestId, { decision });
+                const settled = yield* Deferred.make<void>();
+                pendingApprovals.set(requestId, { decision, turnId: approvalTurnId, settled });
                 registeredRequestId = requestId;
                 // Rechecked after registering, not only before: minting the id
                 // and the deferred both yield, and a Stop landing in that gap
@@ -742,6 +758,29 @@ export function makeAntigravityAdapter(
                 const resolved: ProviderApprovalDecision = Option.isSome(answered)
                   ? answered.value
                   : "cancel";
+                // Re-checked at the moment of answering: an approval decided
+                // while Stop was landing must not come back as an allow.
+                //
+                // Turn identity is part of that check, not just the epoch. Two
+                // consecutive turns with no cancel between them share an epoch,
+                // so a request still open when its own turn ended would look
+                // current again once the next one started, and this would
+                // answer "allow" for a tool whose token the bridge has already
+                // retired.
+                const stillLive =
+                  !ctx?.stopped &&
+                  ctx?.activeTurnId === approvalTurnId &&
+                  (approvalEpoch === undefined || ctx?.cancelEpoch === approvalEpoch);
+                const optionId =
+                  resolved === "cancel" || !stillLive
+                    ? undefined
+                    : selectPermissionOptionId(params, resolved);
+                // Decided before the event is built, so what the UI is told and
+                // what the agent is told are the same thing. Publishing the
+                // user's raw answer here reported an approval that the liveness
+                // check had already turned into a cancellation — the tool did
+                // not run, and the transcript claimed it was allowed to.
+                const effective: ProviderApprovalDecision = optionId ? resolved : "cancel";
                 // Same pairing on the way out: an interrupt between publishing
                 // this and recording it would have the finalizer publish a
                 // second, contradictory resolution.
@@ -752,7 +791,7 @@ export function makeAntigravityAdapter(
                   turnId: approvalTurnId,
                   requestId: RuntimeRequestId.make(requestId),
                   permissionRequest,
-                  decision: resolved,
+                  decision: effective,
                 });
                 yield* Effect.uninterruptible(
                   Effect.gen(function* () {
@@ -760,24 +799,6 @@ export function makeAntigravityAdapter(
                     resolutionPublished = true;
                   }),
                 );
-                // Re-checked at the moment of answering: an approval decided
-                // while Stop was landing must not come back as an allow.
-                //
-                // Turn identity is part of that check, not just the epoch. Two
-                // consecutive turns with no cancel between them share an epoch,
-                // so a request still open when its own turn ended would look
-                // current again once the next one started, and this would
-                // answer "allow" for a tool whose token the bridge has already
-                // retired. The bridge denies it either way — the damage is a UI
-                // reporting an approval that was never honoured.
-                const stillLive =
-                  !ctx?.stopped &&
-                  ctx?.activeTurnId === approvalTurnId &&
-                  (approvalEpoch === undefined || ctx?.cancelEpoch === approvalEpoch);
-                const optionId =
-                  resolved === "cancel" || !stillLive
-                    ? undefined
-                    : selectPermissionOptionId(params, resolved);
                 return {
                   outcome: optionId
                     ? { outcome: "selected" as const, optionId }
@@ -813,7 +834,15 @@ export function makeAntigravityAdapter(
                         );
                       }
                       if (registeredRequestId !== undefined) {
+                        const registered = pendingApprovals.get(registeredRequestId);
                         pendingApprovals.delete(registeredRequestId);
+                        // Announces that this handler is done publishing. Turn
+                        // settlement cancels outstanding approvals and waits on
+                        // this, so `request.resolved` precedes `turn.completed`
+                        // instead of racing it.
+                        if (registered !== undefined) {
+                          yield* Effect.ignore(Deferred.succeed(registered.settled, undefined));
+                        }
                       }
                     }),
                   ),
@@ -1316,6 +1345,31 @@ export function makeAntigravityAdapter(
                 ctx.lifecycleGate
                   .withPermit(
                     Effect.gen(function* () {
+                      // Anything this turn opened and never got an answer for is
+                      // released here. `agy` dying with a hook mid-approval used
+                      // to leave the request sitting in the UI for the full nine
+                      // minute deadline, unanswerable, with the turn already
+                      // reported complete.
+                      //
+                      // Done before `activeTurnId` is cleared so the handlers see
+                      // the state they were opened against, and awaited — with a
+                      // bound, because a handler that never finishes must not
+                      // strand the turn — so `request.resolved` is published
+                      // before the completion below.
+                      const orphanedApprovals = [...ctx.approvals.entries()].filter(
+                        ([, approval]) => approval.turnId === turnId,
+                      );
+                      for (const [requestId, approval] of orphanedApprovals) {
+                        yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
+                        ctx.approvals.delete(requestId);
+                      }
+                      for (const [, approval] of orphanedApprovals) {
+                        yield* Effect.ignore(
+                          Deferred.await(approval.settled).pipe(
+                            Effect.timeoutOption(APPROVAL_SETTLE_TIMEOUT_MS),
+                          ),
+                        );
+                      }
                       // One prompt per turn, so this settles unconditionally.
                       // Cleared even when the turn never started — a model switch can
                       // fail after `activeTurnId` is installed, and leaving it set

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -133,6 +133,17 @@ interface AntigravitySessionContext {
    */
   readonly startedTurnIds: Set<TurnId>;
   /**
+   * Serializes prompt submission for this thread.
+   *
+   * `acp.prompt` already queues internally on its own semaphore, but that one
+   * is acquired inside the call where nothing can be rechecked — a steer could
+   * clear the cancel check, wait there, and reach the agent after Stop. Taking
+   * the same serialization here instead makes the wait observable, so the
+   * epoch can be re-read at the point submission actually begins. Deliberately
+   * separate from the thread lock, which teardown needs to stay free.
+   */
+  readonly promptGate: Semaphore.Semaphore;
+  /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
@@ -529,6 +540,7 @@ export function makeAntigravityAdapter(
             currentModelId: boundModel,
             cancelEpoch: 0,
             startedTurnIds: new Set(),
+            promptGate: yield* Semaphore.make(1),
             promptsInFlight: 0,
             stopped: false,
           };
@@ -627,27 +639,37 @@ export function makeAntigravityAdapter(
           approvalsByThread.set(input.threadId, pendingApprovals);
           sessionScopeTransferred = true;
 
-          yield* offerRuntimeEvent({
-            type: "session.started",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { resume: started.initializeResult },
-          });
-          yield* offerRuntimeEvent({
-            type: "session.state.changed",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { state: "ready", reason: "Antigravity ACP session ready" },
-          });
-          yield* offerRuntimeEvent({
-            type: "thread.started",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: input.threadId,
-            payload: { providerThreadId: started.sessionId },
-          });
+          // Past this point the scoped finalizer no longer owns the scope, so
+          // a failure or interrupt while announcing the session would strand
+          // the bridge process, its notification fiber, and both registry
+          // entries with nothing left to close them. Ownership has moved to
+          // the session, so teardown has to move with it.
+          yield* Effect.onError(
+            Effect.gen(function* () {
+              yield* offerRuntimeEvent({
+                type: "session.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { resume: started.initializeResult },
+              });
+              yield* offerRuntimeEvent({
+                type: "session.state.changed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { state: "ready", reason: "Antigravity ACP session ready" },
+              });
+              yield* offerRuntimeEvent({
+                type: "thread.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                payload: { providerThreadId: started.sessionId },
+              });
+            }),
+            () => Effect.ignore(stopSessionInternal(ctx)),
+          );
 
           return session;
         }).pipe(Effect.scoped),
@@ -755,6 +777,19 @@ export function makeAntigravityAdapter(
             ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
           }
 
+          // Rechecked before anything is announced: everything above yields, so
+          // the session can be stopped or the turn interrupted while
+          // attachments resolve and the model is selected. Announcing a turn
+          // on a closed runtime would emit events after `session.exited`.
+          if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
+            stopReason = "cancelled";
+            return {
+              threadId: input.threadId,
+              turnId,
+              resumeCursor: ctx.session.resumeCursor,
+            };
+          }
+
           // Claimed from shared state, not from "am I a steer": the prompt this
           // one folded into may have failed before it announced anything, and
           // emitting content for a turn that never started strands the UI.
@@ -772,10 +807,25 @@ export function makeAntigravityAdapter(
             // saw start.
             ctx.startedTurnIds.add(turnId);
           }
-          // Rechecked here rather than only at accept time: everything above
-          // yields, and an interrupt during any of it means this prompt must
-          // not reach the agent.
-          if (ctx.cancelEpoch !== acceptedEpoch) {
+
+          const result = yield* ctx.promptGate
+            .withPermit(
+              Effect.gen(function* () {
+                // Re-read once submission actually begins. Waiting for the gate
+                // is exactly the window in which Stop can land, and a prompt that
+                // reached the bridge after a cancel would spawn `agy` anyway.
+                if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
+                  return undefined;
+                }
+                return yield* ctx.acp.prompt({ prompt: promptParts });
+              }),
+            )
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+          if (result === undefined) {
             stopReason = "cancelled";
             return {
               threadId: input.threadId,
@@ -783,14 +833,6 @@ export function makeAntigravityAdapter(
               resumeCursor: ctx.session.resumeCursor,
             };
           }
-
-          const result = yield* ctx.acp
-            .prompt({ prompt: promptParts })
-            .pipe(
-              Effect.mapError((error) =>
-                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
-              ),
-            );
 
           const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
           if (turnRecord) {

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -89,11 +89,6 @@ const PROVIDER = ProviderDriverKind.make("antigravity");
  * unanswered request pinning its entry and its UI prompt forever.
  */
 const APPROVAL_WAIT_MS = 11 * 60 * 1000;
-/**
- * Cap on waiting for queued ACP events to be consumed before a turn settles.
- * Only an ordering nicety, so it must never outlive a torn-down consumer.
- */
-const EVENT_DRAIN_TIMEOUT_MS = 5_000;
 const ANTIGRAVITY_RESUME_VERSION = 1 as const;
 
 export interface AntigravityAdapterLiveOptions {
@@ -156,6 +151,29 @@ interface AntigravitySessionContext {
    * separate from the thread lock, which teardown needs to stay free.
    */
   readonly promptGate: Semaphore.Semaphore;
+  /**
+   * Serializes the turn-lifecycle critical sections against teardown.
+   *
+   * Announcing a turn is "check the session is live, reserve the turn, publish
+   * the start" and teardown is "mark stopped, snapshot what was published".
+   * Interleaving those two is what let a start be published after
+   * `session.exited`, or a turn be completed while its start was still being
+   * stamped. Both run under this, and both are short and yield-free apart from
+   * the publications they own.
+   */
+  readonly lifecycleGate: Semaphore.Semaphore;
+  /**
+   * Fired the moment teardown begins. Waiting on the event consumer races
+   * against this rather than a wall clock, so a slow but healthy consumer is
+   * still awaited in full while a torn-down one never blocks anybody.
+   */
+  readonly teardownSignal: Deferred.Deferred<void>;
+  /**
+   * This session's pending approvals. Held on the context as well as in
+   * `approvalsByThread` so teardown can tell its own map from a replacement
+   * session's before clearing the registry entry.
+   */
+  readonly approvals: Map<ApprovalRequestId, PendingApproval>;
   /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
@@ -329,81 +347,101 @@ export function makeAntigravityAdapter(
       return Effect.succeed(ctx);
     };
 
+    /**
+     * Idempotent, uninterruptible teardown of everything a context owns.
+     *
+     * Shared by the normal stop path and its failure path so neither can leave
+     * half of it done: `ctx.stopped` is set before any of this runs, so a stop
+     * that died partway would otherwise make every later attempt return
+     * immediately with the bridge and its `agy` child still alive.
+     */
+    const cleanupContext = (ctx: AntigravitySessionContext) =>
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          if (ctx.notificationFiber) {
+            yield* Effect.ignore(Fiber.interrupt(ctx.notificationFiber));
+            ctx.notificationFiber = undefined;
+          }
+          yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+          // Ownership-checked: a replacement session may already have been
+          // installed while this teardown was closing a slow child, and
+          // clearing its entries would leak that session's process.
+          if (sessions.get(ctx.threadId) === ctx) {
+            sessions.delete(ctx.threadId);
+          }
+          if (approvalsByThread.get(ctx.threadId) === ctx.approvals) {
+            approvalsByThread.delete(ctx.threadId);
+          }
+        }),
+      );
+
     const stopSessionInternal = (ctx: AntigravitySessionContext) =>
       Effect.gen(function* () {
-        if (ctx.stopped) return;
-        ctx.stopped = true;
+        // Claiming the stop, snapshotting what was published, and clearing the
+        // active turn happen under the lifecycle gate so they cannot interleave
+        // with a `sendTurn` that is midway through announcing its turn.
+        const orphanedTurnIds = yield* ctx.lifecycleGate.withPermit(
+          Effect.sync(() => {
+            if (ctx.stopped) {
+              return undefined;
+            }
+            ctx.stopped = true;
+            const claimed = [...ctx.publishedTurnIds];
+            ctx.publishedTurnIds.clear();
+            ctx.reservedTurnIds.clear();
+            ctx.activeTurnId = undefined;
+            return claimed;
+          }),
+        );
+        if (orphanedTurnIds === undefined) {
+          return;
+        }
+        // Releases anything waiting on the event consumer before that consumer
+        // is torn down.
+        yield* Effect.ignore(Deferred.succeed(ctx.teardownSignal, undefined));
+
         // Anything still waiting on a human is cancelled, which the bridge
         // turns into a denial. Left pending, the hook would block its tool
         // until its own timeout with no one able to answer.
-        const pending = approvalsByThread.get(ctx.threadId);
-        if (pending) {
-          for (const [, approval] of pending) {
-            // Ignored: an answer racing session stop may have settled this
-            // already, and that must not abort the rest of teardown.
-            yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
-          }
-          approvalsByThread.delete(ctx.threadId);
+        for (const [, approval] of ctx.approvals) {
+          // Ignored: an answer racing session stop may have settled this
+          // already, and that must not abort the rest of teardown.
+          yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
         }
-        // Claimed here, so a `sendTurn` finalizer waking later finds nothing
-        // left to settle and stays silent. Otherwise closing the scope wakes
-        // `acp.prompt` on another fiber and its completion lands after
-        // `session.exited` — or on whatever session replaced this one.
-        const orphanedTurnIds = [...ctx.publishedTurnIds];
-        ctx.publishedTurnIds.clear();
-        ctx.reservedTurnIds.clear();
+        ctx.approvals.clear();
+
+        // Quiesced before any terminal event is published: updates already
+        // queued for the consumer would otherwise surface after the completion
+        // that is supposed to close them out.
+        yield* cleanupContext(ctx);
+
         for (const orphanedTurnId of orphanedTurnIds) {
-          yield* offerRuntimeEvent({
-            type: "turn.completed",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: ctx.threadId,
-            turnId: orphanedTurnId,
-            payload: { state: "cancelled", stopReason: null },
-          });
-        }
-        ctx.activeTurnId = undefined;
-        // Uninterruptible, and after the events above rather than gated on
-        // them: `ctx.stopped` is already true, so a failure or interrupt while
-        // publishing would make every later stop attempt return immediately
-        // and leave the bridge and its `agy` child running for good.
-        yield* Effect.uninterruptible(
-          Effect.gen(function* () {
-            if (ctx.notificationFiber) {
-              yield* Effect.ignore(Fiber.interrupt(ctx.notificationFiber));
-            }
-            yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
-            // Only if this context still owns the slot: a replacement session
-            // may already have been installed while this teardown was closing
-            // a slow child, and deleting it would leak that one's process.
-            if (sessions.get(ctx.threadId) === ctx) {
-              sessions.delete(ctx.threadId);
-            }
-          }),
-        );
-        yield* Effect.ignore(
-          offerRuntimeEvent({
-            type: "session.exited",
-            ...(yield* makeEventStamp()),
-            provider: PROVIDER,
-            threadId: ctx.threadId,
-            payload: { exitKind: "graceful" },
-          }),
-        );
-      }).pipe(
-        // Publication of the shutdown events above is best effort; the process
-        // and registry cleanup underneath it is not optional.
-        Effect.onExit(() =>
-          Effect.uninterruptible(
-            Effect.gen(function* () {
-              yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
-              if (sessions.get(ctx.threadId) === ctx) {
-                sessions.delete(ctx.threadId);
-              }
+          yield* Effect.ignore(
+            offerRuntimeEvent({
+              type: "turn.completed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: ctx.threadId,
+              turnId: orphanedTurnId,
+              payload: { state: "cancelled", stopReason: null },
             }),
-          ),
-        ),
-      );
+          );
+        }
+        // Suppressed when a replacement already holds this thread: the event
+        // names the thread, not the context, so it would read as the new
+        // session exiting.
+        if (sessions.get(ctx.threadId) === undefined) {
+          yield* Effect.ignore(
+            offerRuntimeEvent({
+              type: "session.exited",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: ctx.threadId,
+              payload: { exitKind: "graceful" },
+            }),
+          );
+        }
+      }).pipe(Effect.onExit(() => cleanupContext(ctx)));
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
       withThreadLock(
@@ -612,6 +650,9 @@ export function makeAntigravityAdapter(
             reservedTurnIds: new Set(),
             publishedTurnIds: new Set(),
             promptGate: yield* Semaphore.make(1),
+            lifecycleGate: yield* Semaphore.make(1),
+            teardownSignal: yield* Deferred.make<void>(),
+            approvals: pendingApprovals,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -870,34 +911,51 @@ export function makeAntigravityAdapter(
           // unannounced and emit `turn.started` twice. The claim is released
           // again if publication does not happen, so a turn nobody saw start
           // cannot later be completed.
-          const announcing = !ctx.reservedTurnIds.has(turnId);
-          if (announcing) {
-            ctx.reservedTurnIds.add(turnId);
-          }
+          // Reservation is taken under the lifecycle gate so teardown cannot
+          // snapshot between the check and the claim.
+          const announcing = yield* ctx.lifecycleGate.withPermit(
+            Effect.sync(() => {
+              if (ctx.stopped || ctx.reservedTurnIds.has(turnId)) {
+                return false;
+              }
+              ctx.reservedTurnIds.add(turnId);
+              return true;
+            }),
+          );
           if (announcing) {
             // Stamp generation sits inside the guarded region: it can fail or
             // be interrupted too, and a claim left behind without its event
             // would make a steer skip the start and let settlement publish an
             // orphan completion.
-            yield* Effect.gen(function* () {
-              yield* offerRuntimeEvent({
-                type: "turn.started",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
-                threadId: input.threadId,
-                turnId,
-                payload: { model: ctx.session.model },
-              });
-              // Marked published only once the event is genuinely out, so
-              // teardown never completes a turn that was merely reserved.
-              ctx.publishedTurnIds.add(turnId);
-            }).pipe(
-              Effect.onExit((exit) =>
-                Exit.isSuccess(exit)
-                  ? Effect.void
-                  : Effect.sync(() => ctx.reservedTurnIds.delete(turnId)),
-              ),
-            );
+            yield* ctx.lifecycleGate
+              .withPermit(
+                Effect.gen(function* () {
+                  // Re-checked inside the gate: teardown may have run while
+                  // this fiber waited for it, and a start published after
+                  // `session.exited` is worse than no start at all.
+                  if (ctx.stopped) {
+                    return;
+                  }
+                  yield* offerRuntimeEvent({
+                    type: "turn.started",
+                    ...(yield* makeEventStamp()),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    payload: { model: ctx.session.model },
+                  });
+                  // Marked published only once the event is genuinely out, so
+                  // teardown never completes a turn that was merely reserved.
+                  ctx.publishedTurnIds.add(turnId);
+                }),
+              )
+              .pipe(
+                Effect.onExit((exit) =>
+                  Exit.isSuccess(exit)
+                    ? Effect.void
+                    : Effect.sync(() => ctx.reservedTurnIds.delete(turnId)),
+                ),
+              );
           }
 
           const result = yield* ctx.promptGate
@@ -922,8 +980,12 @@ export function makeAntigravityAdapter(
                 // Losing the ordering guarantee is recoverable; a permanent
                 // hang is not. The error path drains too — a nonzero `agy`
                 // exit still emits final updates before its response.
+                // Raced against teardown rather than a wall clock: a slow but
+                // healthy consumer is still awaited in full, while a consumer
+                // that stop has interrupted can never strand this fiber
+                // holding the gate.
                 const drain = Effect.ignore(
-                  Effect.timeoutOption(ctx.acp.drainEvents, EVENT_DRAIN_TIMEOUT_MS),
+                  Effect.raceFirst(ctx.acp.drainEvents, Deferred.await(ctx.teardownSignal)),
                 );
                 return yield* ctx.acp.prompt({ prompt: promptParts }).pipe(
                   Effect.tapCause(() => drain),
@@ -1128,11 +1190,16 @@ export function makeAntigravityAdapter(
 
     // Snapshotted, not iterated live: teardown deletes from this map, and a
     // concurrent `startSession` can install a replacement mid-sweep.
+    // Each teardown runs under the thread lock, so a sweep cannot interleave
+    // with a `startSession` installing a replacement for the same thread.
+    const stopSwept = (ctx: AntigravitySessionContext) =>
+      withThreadLock(ctx.threadId, stopSessionInternal(ctx));
+
     const stopAll: AntigravityAdapterShape["stopAll"] = () =>
-      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true });
+      Effect.forEach(Array.from(sessions.values()), stopSwept, { discard: true });
 
     yield* Effect.addFinalizer(() =>
-      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true }).pipe(
+      Effect.forEach(Array.from(sessions.values()), stopSwept, { discard: true }).pipe(
         Effect.catch((cause) =>
           Effect.logError("Failed to emit Antigravity session shutdown event.", { cause }),
         ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -188,6 +188,15 @@ interface AntigravitySessionContext {
   /** Cancel epoch the active turn belongs to; steering is scoped to it. */
   activeTurnEpoch: number;
   /**
+   * Turns whose prompt the bridge has not answered yet.
+   *
+   * The cancel fallback arms on this rather than on "is that turn still
+   * active": a turn stays active while its events drain, and a healthy drain
+   * can outlast the acknowledgement window — which would have the fallback
+   * tear down a session that is working perfectly.
+   */
+  readonly awaitingBridgeAck: Set<TurnId>;
+  /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
@@ -432,8 +441,12 @@ export function makeAntigravityAdapter(
        * in the meantime would take its replacement down with it.
        */
       onlyIfActiveTurn?: TurnId,
-    ) =>
-      Effect.gen(function* () {
+    ) => {
+      // Whether this call is the one that claimed the teardown. The cleanup
+      // below must not run otherwise: a call that declined because the turn had
+      // moved on would close a session that is perfectly alive.
+      let claimedTeardown = false;
+      return Effect.gen(function* () {
         // Claiming the stop, snapshotting what was published, and clearing the
         // active turn happen under the lifecycle gate so they cannot interleave
         // with a `sendTurn` that is midway through announcing its turn.
@@ -446,6 +459,7 @@ export function makeAntigravityAdapter(
               return undefined;
             }
             ctx.stopped = true;
+            claimedTeardown = true;
             const claimed = [...ctx.publishedTurnIds];
             ctx.publishedTurnIds.clear();
             ctx.reservedTurnIds.clear();
@@ -517,8 +531,13 @@ export function makeAntigravityAdapter(
         // while the completions and `session.exited` it owed were never
         // published — and no later stop would retry, the flag already being set.
         Effect.uninterruptible,
-        Effect.onExit(() => cleanupContext(ctx)),
+        // Only for the call that claimed the teardown. Running it regardless
+        // meant a declined call — the fallback finding its turn already gone —
+        // closed and deregistered a live session without so much as a
+        // `session.exited`.
+        Effect.onExit(() => (claimedTeardown ? cleanupContext(ctx) : Effect.void)),
       );
+    };
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
       withThreadLock(
@@ -818,6 +837,7 @@ export function makeAntigravityAdapter(
             approvals: pendingApprovals,
             acpSessionId: started.sessionId,
             activeTurnEpoch: -1,
+            awaitingBridgeAck: new Set(),
             stopped: false,
           };
 
@@ -1192,11 +1212,18 @@ export function makeAntigravityAdapter(
                 const drain = Effect.ignore(
                   Effect.raceFirst(ctx.acp.drainEvents, Deferred.await(ctx.teardownSignal)),
                 );
+                ctx.awaitingBridgeAck.add(turnId);
                 return yield* ctx.acp
                   .prompt({ prompt: promptParts, _meta: { t3: { epoch: acceptedEpoch } } })
                   .pipe(
+                    // Cleared the moment the bridge answers, before draining:
+                    // the drain is the part that can legitimately run long, and
+                    // the fallback must not read that as an unresponsive bridge.
+                    Effect.tapCause(() => Effect.sync(() => ctx.awaitingBridgeAck.delete(turnId))),
+                    Effect.tap(() => Effect.sync(() => ctx.awaitingBridgeAck.delete(turnId))),
                     Effect.tapCause(() => drain),
                     Effect.tap(() => drain),
+                    Effect.ensuring(Effect.sync(() => ctx.awaitingBridgeAck.delete(turnId))),
                   );
               }).pipe(
                 Effect.mapError((error) =>
@@ -1384,7 +1411,9 @@ export function makeAntigravityAdapter(
                 // ten seconds late, and the check has to happen under the same
                 // gate that claims the stop or a turn that settled meanwhile
                 // takes its replacement down with it.
-                Effect.ignore(stopSessionInternal(ctx, cancelledTurnId)),
+                ctx.awaitingBridgeAck.has(cancelledTurnId)
+                  ? Effect.ignore(stopSessionInternal(ctx, cancelledTurnId))
+                  : Effect.void,
               ),
             ),
             ctx.scope,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1408,7 +1408,14 @@ export function makeAntigravityAdapter(
         // produces arrive with no turn to belong to. Delivered this way the
         // bridge answers the original prompt itself, after its updates are on
         // the wire, and the turn settles on that response.
-        yield* Effect.ignore(ctx.acp.notify("session/cancel", { sessionId: ctx.acpSessionId }));
+        // Carries the epoch it cancels, so it is bounded to the same turns the
+        // fence covers even if the fence itself never arrived.
+        yield* Effect.ignore(
+          ctx.acp.notify("session/cancel", {
+            sessionId: ctx.acpSessionId,
+            epoch: cancelledThrough,
+          }),
+        );
         // Fallback: if the bridge never answers — wedged, or already gone — the
         // interrupt still happens, just late enough not to truncate a healthy
         // drain. Forked into the session scope so it dies with the session.

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -89,6 +89,11 @@ const PROVIDER = ProviderDriverKind.make("antigravity");
  * unanswered request pinning its entry and its UI prompt forever.
  */
 const APPROVAL_WAIT_MS = 11 * 60 * 1000;
+/**
+ * Cap on waiting for queued ACP events to be consumed before a turn settles.
+ * Only an ordering nicety, so it must never outlive a torn-down consumer.
+ */
+const EVENT_DRAIN_TIMEOUT_MS = 5_000;
 const ANTIGRAVITY_RESUME_VERSION = 1 as const;
 
 export interface AntigravityAdapterLiveOptions {
@@ -127,11 +132,19 @@ interface AntigravitySessionContext {
    */
   cancelEpoch: number;
   /**
-   * Turns for which `turn.started` has actually been published. Shared rather
-   * than per-call, so a steer cannot assume the prompt it folded into already
-   * announced the turn — that prompt may have failed during preflight.
+   * Turns whose `turn.started` a prompt has reserved the right to publish.
+   * Shared rather than per-call, so a steer cannot assume the prompt it folded
+   * into already announced the turn — that prompt may have failed in preflight.
    */
-  readonly startedTurnIds: Set<TurnId>;
+  readonly reservedTurnIds: Set<TurnId>;
+  /**
+   * Turns whose `turn.started` is actually on the wire.
+   *
+   * Kept apart from the reservation: teardown may run while a start is still
+   * being stamped, and completing a turn nobody has seen start is as wrong as
+   * dropping the completion of one they have.
+   */
+  readonly publishedTurnIds: Set<TurnId>;
   /**
    * Serializes prompt submission for this thread.
    *
@@ -336,8 +349,9 @@ export function makeAntigravityAdapter(
         // left to settle and stays silent. Otherwise closing the scope wakes
         // `acp.prompt` on another fiber and its completion lands after
         // `session.exited` — or on whatever session replaced this one.
-        const orphanedTurnIds = [...ctx.startedTurnIds];
-        ctx.startedTurnIds.clear();
+        const orphanedTurnIds = [...ctx.publishedTurnIds];
+        ctx.publishedTurnIds.clear();
+        ctx.reservedTurnIds.clear();
         for (const orphanedTurnId of orphanedTurnIds) {
           yield* offerRuntimeEvent({
             type: "turn.completed",
@@ -349,19 +363,47 @@ export function makeAntigravityAdapter(
           });
         }
         ctx.activeTurnId = undefined;
-        if (ctx.notificationFiber) {
-          yield* Fiber.interrupt(ctx.notificationFiber);
-        }
-        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
-        sessions.delete(ctx.threadId);
-        yield* offerRuntimeEvent({
-          type: "session.exited",
-          ...(yield* makeEventStamp()),
-          provider: PROVIDER,
-          threadId: ctx.threadId,
-          payload: { exitKind: "graceful" },
-        });
-      });
+        // Uninterruptible, and after the events above rather than gated on
+        // them: `ctx.stopped` is already true, so a failure or interrupt while
+        // publishing would make every later stop attempt return immediately
+        // and leave the bridge and its `agy` child running for good.
+        yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            if (ctx.notificationFiber) {
+              yield* Effect.ignore(Fiber.interrupt(ctx.notificationFiber));
+            }
+            yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+            // Only if this context still owns the slot: a replacement session
+            // may already have been installed while this teardown was closing
+            // a slow child, and deleting it would leak that one's process.
+            if (sessions.get(ctx.threadId) === ctx) {
+              sessions.delete(ctx.threadId);
+            }
+          }),
+        );
+        yield* Effect.ignore(
+          offerRuntimeEvent({
+            type: "session.exited",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            payload: { exitKind: "graceful" },
+          }),
+        );
+      }).pipe(
+        // Publication of the shutdown events above is best effort; the process
+        // and registry cleanup underneath it is not optional.
+        Effect.onExit(() =>
+          Effect.uninterruptible(
+            Effect.gen(function* () {
+              yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+              if (sessions.get(ctx.threadId) === ctx) {
+                sessions.delete(ctx.threadId);
+              }
+            }),
+          ),
+        ),
+      );
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
       withThreadLock(
@@ -461,6 +503,11 @@ export function makeAntigravityAdapter(
           yield* acp.handleRequestPermission((params) =>
             mapAcpCallbackFailure(
               Effect.gen(function* () {
+                // A request arriving after teardown has no live turn behind it,
+                // so it must not be auto-approved on the way out.
+                if (ctx?.stopped) {
+                  return { outcome: { outcome: "cancelled" } as const };
+                }
                 if (input.runtimeMode === "full-access") {
                   const autoApproved = selectAutoApprovedPermissionOption(params);
                   if (autoApproved !== undefined) {
@@ -468,6 +515,7 @@ export function makeAntigravityAdapter(
                   }
                 }
                 const permissionRequest = parsePermissionRequest(params);
+                const approvalEpoch = ctx?.cancelEpoch;
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
                 const turnId = sessions.get(input.threadId)?.activeTurnId;
@@ -510,8 +558,13 @@ export function makeAntigravityAdapter(
                     decision: resolved,
                   }),
                 );
+                // Re-checked at the moment of answering: an approval decided
+                // while Stop was landing must not come back as an allow.
+                const stillLive = !ctx?.stopped && ctx?.cancelEpoch === approvalEpoch;
                 const optionId =
-                  resolved === "cancel" ? undefined : selectPermissionOptionId(params, resolved);
+                  resolved === "cancel" || !stillLive
+                    ? undefined
+                    : selectPermissionOptionId(params, resolved);
                 return {
                   outcome: optionId
                     ? { outcome: "selected" as const, optionId }
@@ -556,7 +609,8 @@ export function makeAntigravityAdapter(
             activeTurnId: undefined,
             currentModelId: boundModel,
             cancelEpoch: 0,
-            startedTurnIds: new Set(),
+            reservedTurnIds: new Set(),
+            publishedTurnIds: new Set(),
             promptGate: yield* Semaphore.make(1),
             promptsInFlight: 0,
             stopped: false,
@@ -816,9 +870,9 @@ export function makeAntigravityAdapter(
           // unannounced and emit `turn.started` twice. The claim is released
           // again if publication does not happen, so a turn nobody saw start
           // cannot later be completed.
-          const announcing = !ctx.startedTurnIds.has(turnId);
+          const announcing = !ctx.reservedTurnIds.has(turnId);
           if (announcing) {
-            ctx.startedTurnIds.add(turnId);
+            ctx.reservedTurnIds.add(turnId);
           }
           if (announcing) {
             // Stamp generation sits inside the guarded region: it can fail or
@@ -834,11 +888,14 @@ export function makeAntigravityAdapter(
                 turnId,
                 payload: { model: ctx.session.model },
               });
+              // Marked published only once the event is genuinely out, so
+              // teardown never completes a turn that was merely reserved.
+              ctx.publishedTurnIds.add(turnId);
             }).pipe(
               Effect.onExit((exit) =>
                 Exit.isSuccess(exit)
                   ? Effect.void
-                  : Effect.sync(() => ctx.startedTurnIds.delete(turnId)),
+                  : Effect.sync(() => ctx.reservedTurnIds.delete(turnId)),
               ),
             );
           }
@@ -852,15 +909,26 @@ export function makeAntigravityAdapter(
                 if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
                   return undefined;
                 }
-                const response = yield* ctx.acp.prompt({ prompt: promptParts });
                 // The bridge writes its `session/update` notifications before
                 // the prompt response, but the runtime only queues them.
                 // Draining inside the gate keeps the turn from settling — and
                 // its id from being cleared — while content, tool and item
                 // events are still pending, which would leave them
                 // unattributed or attributed to the next turn.
-                yield* ctx.acp.drainEvents;
-                return response;
+                //
+                // Bounded and best-effort: the drain waits on the notification
+                // consumer, and stop interrupts that consumer, so an unbounded
+                // wait here would strand this fiber holding the gate forever.
+                // Losing the ordering guarantee is recoverable; a permanent
+                // hang is not. The error path drains too — a nonzero `agy`
+                // exit still emits final updates before its response.
+                const drain = Effect.ignore(
+                  Effect.timeoutOption(ctx.acp.drainEvents, EVENT_DRAIN_TIMEOUT_MS),
+                );
+                return yield* ctx.acp.prompt({ prompt: promptParts }).pipe(
+                  Effect.tapCause(() => drain),
+                  Effect.tap(() => drain),
+                );
               }),
             )
             .pipe(
@@ -918,8 +986,9 @@ export function makeAntigravityAdapter(
               // Read from shared state rather than this call's local flag: the
               // prompt that published `turn.started` may not be the one that
               // settles the turn, and the settler still owes the completion.
-              const published = ctx.startedTurnIds.has(turnId);
-              ctx.startedTurnIds.delete(turnId);
+              const published = ctx.publishedTurnIds.has(turnId);
+              ctx.publishedTurnIds.delete(turnId);
+              ctx.reservedTurnIds.delete(turnId);
               // The public session field is what `listSessions` and the reaper
               // read, so leaving it set would advertise a turn that has ended.
               if (ctx.session.activeTurnId === turnId) {
@@ -1057,11 +1126,13 @@ export function makeAntigravityAdapter(
         return c !== undefined && !c.stopped;
       });
 
+    // Snapshotted, not iterated live: teardown deletes from this map, and a
+    // concurrent `startSession` can install a replacement mid-sweep.
     const stopAll: AntigravityAdapterShape["stopAll"] = () =>
-      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true });
 
     yield* Effect.addFinalizer(() =>
-      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true }).pipe(
         Effect.catch((cause) =>
           Effect.logError("Failed to emit Antigravity session shutdown event.", { cause }),
         ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -672,6 +672,10 @@ export function makeAntigravityAdapter(
             // Held outside the workflow so the finalizer can clear the entry
             // wherever inside it things stopped.
             let registeredRequestId: ApprovalRequestId | undefined;
+            // Held alongside the id so the finalizer can signal completion even
+            // after the entry has been removed from the registry by settlement
+            // or teardown.
+            let registeredApproval: PendingApproval | undefined;
             // Set once the UI has been told a request exists. From then on it
             // is owed a terminal event: the tool is denied either way, but a
             // request left open cannot be answered or dismissed.
@@ -710,8 +714,10 @@ export function makeAntigravityAdapter(
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
                 const settled = yield* Deferred.make<void>();
-                pendingApprovals.set(requestId, { decision, turnId: approvalTurnId, settled });
+                const approval: PendingApproval = { decision, turnId: approvalTurnId, settled };
+                pendingApprovals.set(requestId, approval);
                 registeredRequestId = requestId;
+                registeredApproval = approval;
                 // Rechecked after registering, not only before: minting the id
                 // and the deferred both yield, and a Stop landing in that gap
                 // would find no entry to cancel — leaving this request open in
@@ -767,8 +773,13 @@ export function makeAntigravityAdapter(
                 // current again once the next one started, and this would
                 // answer "allow" for a tool whose token the bridge has already
                 // retired.
+                // A defined turn on both sides is required, not just equality:
+                // a request that arrived with no turn running compared
+                // `undefined === undefined` against a session whose turn had
+                // already been cleared, and passed.
                 const stillLive =
                   !ctx?.stopped &&
+                  approvalTurnId !== undefined &&
                   ctx?.activeTurnId === approvalTurnId &&
                   (approvalEpoch === undefined || ctx?.cancelEpoch === approvalEpoch);
                 const optionId =
@@ -834,15 +845,17 @@ export function makeAntigravityAdapter(
                         );
                       }
                       if (registeredRequestId !== undefined) {
-                        const registered = pendingApprovals.get(registeredRequestId);
                         pendingApprovals.delete(registeredRequestId);
-                        // Announces that this handler is done publishing. Turn
-                        // settlement cancels outstanding approvals and waits on
-                        // this, so `request.resolved` precedes `turn.completed`
-                        // instead of racing it.
-                        if (registered !== undefined) {
-                          yield* Effect.ignore(Deferred.succeed(registered.settled, undefined));
-                        }
+                      }
+                      // Completed from the entry captured at registration, not
+                      // from a fresh map lookup. Settlement and teardown both
+                      // remove entries before this finalizer runs, so looking it
+                      // up here found nothing and left every waiter to time out.
+                      // This handler owns the signal; the map is only a registry.
+                      if (registeredApproval !== undefined) {
+                        yield* Effect.ignore(
+                          Deferred.succeed(registeredApproval.settled, undefined),
+                        );
                       }
                     }),
                   ),
@@ -1356,18 +1369,26 @@ export function makeAntigravityAdapter(
                       // bound, because a handler that never finishes must not
                       // strand the turn — so `request.resolved` is published
                       // before the completion below.
-                      const orphanedApprovals = [...ctx.approvals.entries()].filter(
-                        ([, approval]) => approval.turnId === turnId,
+                      const orphanedApprovals = [...ctx.approvals.values()].filter(
+                        (approval) => approval.turnId === turnId,
                       );
-                      for (const [requestId, approval] of orphanedApprovals) {
+                      for (const approval of orphanedApprovals) {
                         yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
-                        ctx.approvals.delete(requestId);
                       }
-                      for (const [, approval] of orphanedApprovals) {
+                      // Entries are left in place: each handler removes its own
+                      // on the way out. Removing them here left the finalizers
+                      // with nothing to look up, so nothing ever signalled and
+                      // every wait below ran its deadline out in full.
+                      //
+                      // Awaited together under a single budget rather than one
+                      // deadline each, so a turn with several open requests
+                      // cannot hold the lifecycle gate for a multiple of it.
+                      if (orphanedApprovals.length > 0) {
                         yield* Effect.ignore(
-                          Deferred.await(approval.settled).pipe(
-                            Effect.timeoutOption(APPROVAL_SETTLE_TIMEOUT_MS),
-                          ),
+                          Effect.all(
+                            orphanedApprovals.map((approval) => Deferred.await(approval.settled)),
+                            { concurrency: "unbounded" },
+                          ).pipe(Effect.timeoutOption(APPROVAL_SETTLE_TIMEOUT_MS)),
                         );
                       }
                       // One prompt per turn, so this settles unconditionally.

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -605,6 +605,17 @@ export function makeAntigravityAdapter(
             // Held outside the workflow so the finalizer can clear the entry
             // wherever inside it things stopped.
             let registeredRequestId: ApprovalRequestId | undefined;
+            // Set once the UI has been told a request exists. From then on it
+            // is owed a terminal event: the tool is denied either way, but a
+            // request left open cannot be answered or dismissed.
+            let opened:
+              | {
+                  readonly requestId: ApprovalRequestId;
+                  readonly permissionRequest: ReturnType<typeof parsePermissionRequest>;
+                  readonly turnId: TurnId | undefined;
+                }
+              | undefined;
+            let resolutionPublished = false;
             return mapAcpCallbackFailure(
               Effect.gen(function* () {
                 // Bound to the turn actually running, with the epoch that turn
@@ -661,6 +672,7 @@ export function makeAntigravityAdapter(
                     rawPayload: params,
                   }),
                 );
+                opened = { requestId, permissionRequest, turnId: approvalTurnId };
                 // Raced against a deadline and cleaned up unconditionally: the
                 // bridge forgets its side of a timed-out request, so without
                 // this the handler would stay blocked and the entry retained.
@@ -683,6 +695,7 @@ export function makeAntigravityAdapter(
                     decision: resolved,
                   }),
                 );
+                resolutionPublished = true;
                 // Re-checked at the moment of answering: an approval decided
                 // while Stop was landing must not come back as an allow.
                 const stillLive =
@@ -703,11 +716,34 @@ export function makeAntigravityAdapter(
                 // would otherwise leave the entry in the map for good, and the
                 // request open in the UI with nothing able to answer it.
                 Effect.ensuring(
-                  Effect.sync(() => {
-                    if (registeredRequestId !== undefined) {
-                      pendingApprovals.delete(registeredRequestId);
-                    }
-                  }),
+                  Effect.uninterruptible(
+                    Effect.gen(function* () {
+                      // A request the UI has seen but never got a resolution
+                      // for would sit there permanently, unanswerable. The tool
+                      // is denied regardless; this closes the request out.
+                      if (opened !== undefined && !resolutionPublished) {
+                        const closing = opened;
+                        yield* Effect.ignore(
+                          Effect.gen(function* () {
+                            yield* offerRuntimeEvent(
+                              makeAcpRequestResolvedEvent({
+                                stamp: yield* makeEventStamp(),
+                                provider: PROVIDER,
+                                threadId: input.threadId,
+                                turnId: closing.turnId,
+                                requestId: RuntimeRequestId.make(closing.requestId),
+                                permissionRequest: closing.permissionRequest,
+                                decision: "cancel",
+                              }),
+                            );
+                          }),
+                        );
+                      }
+                      if (registeredRequestId !== undefined) {
+                        pendingApprovals.delete(registeredRequestId);
+                      }
+                    }),
+                  ),
                 ),
               ),
             );

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -180,28 +180,9 @@ interface AntigravitySessionContext {
   /** Cancel epoch the active turn belongs to; steering is scoped to it. */
   activeTurnEpoch: number;
   /**
-   * Turn whose prompt currently owns the submission gate.
-   *
-   * Streamed events belong to whichever turn the bridge is actually running,
-   * which is not always the newest: after a Stop a fresh turn can be announced
-   * while the cancelled turn's final updates are still being consumed, and
-   * attributing those to the newcomer files one turn's output under another.
-   */
-  submittingTurnId: TurnId | undefined;
-  /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
-  /**
-   * Prompts still in flight, counted per turn rather than per session.
-   *
-   * A shared counter breaks as soon as two turns overlap, which epoch-scoped
-   * steering makes possible: a prompt sent after a Stop opens its own turn
-   * while the cancelled one is still settling. Whichever finished first would
-   * see the other's prompt in the count, decide it was not the last, and skip
-   * its terminal event — orphaning that turn.
-   */
-  readonly promptsInFlightByTurn: Map<TurnId, number>;
   stopped: boolean;
 }
 
@@ -448,9 +429,6 @@ export function makeAntigravityAdapter(
             const claimed = [...ctx.publishedTurnIds];
             ctx.publishedTurnIds.clear();
             ctx.reservedTurnIds.clear();
-            // Counts go with the turns they belonged to; a finalizer waking
-            // later finds nothing outstanding and settles nothing.
-            ctx.promptsInFlightByTurn.clear();
             ctx.activeTurnId = undefined;
             return claimed;
           }),
@@ -607,7 +585,7 @@ export function makeAntigravityAdapter(
                 // was accepted at — not the session's current epoch. A request
                 // from a cancelled turn can arrive after the epoch moved, and
                 // reading the live value would make it look current.
-                const approvalTurnId = ctx?.submittingTurnId ?? ctx?.activeTurnId;
+                const approvalTurnId = ctx?.activeTurnId;
                 const approvalEpoch = ctx?.activeTurnEpoch;
                 const turnCancelled =
                   approvalEpoch !== undefined &&
@@ -728,8 +706,6 @@ export function makeAntigravityAdapter(
             approvals: pendingApprovals,
             acpSessionId: started.sessionId,
             activeTurnEpoch: -1,
-            submittingTurnId: undefined,
-            promptsInFlightByTurn: new Map(),
             stopped: false,
           };
 
@@ -749,7 +725,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
+                        turnId: ctx.activeTurnId,
                         itemId: event.itemId,
                         lifecycle: "item.started",
                       }),
@@ -761,7 +737,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
+                        turnId: ctx.activeTurnId,
                         itemId: event.itemId,
                         lifecycle: "item.completed",
                       }),
@@ -774,7 +750,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
+                        turnId: ctx.activeTurnId,
                         payload: event.payload,
                         source: "acp.jsonrpc",
                         method: "session/update",
@@ -789,7 +765,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
+                        turnId: ctx.activeTurnId,
                         toolCall: event.toolCall,
                         rawPayload: event.rawPayload,
                       }),
@@ -802,7 +778,7 @@ export function makeAntigravityAdapter(
                         stamp: yield* makeEventStamp(),
                         provider: PROVIDER,
                         threadId: ctx.threadId,
-                        turnId: ctx.submittingTurnId ?? ctx.activeTurnId,
+                        turnId: ctx.activeTurnId,
                         ...(event.itemId ? { itemId: event.itemId } : {}),
                         text: event.text,
                         rawPayload: event.rawPayload,
@@ -930,159 +906,151 @@ export function makeAntigravityAdapter(
           });
         }
 
-        // A sendTurn while a prompt is in flight is a steer: the new prompt
-        // folds into the ongoing work, so the active turn id is reused.
-        //
-        // The id is minted first, before anything is read, so that reading
-        // the turn's prompt count and claiming it are one synchronous step.
-        // Yielding
-        // between the two — which generating the id here used to do — let two
-        // concurrent calls both observe zero and open rival turns over the
-        // same thread.
         const freshTurnId = TurnId.make(yield* randomUUIDv4);
-        // Rechecked here, after the last yield and before any turn state is
-        // touched. A prompt that stalled in preparation can resume once a Stop
-        // has landed and a newer turn has claimed the pointer; claiming here
-        // would overwrite that pointer and then clear it again on the way out,
-        // leaving the newer turn counted but unreachable.
-        if (ctx.stopped || ctx.cancelEpoch !== acceptedEpoch) {
-          return {
-            threadId: input.threadId,
-            turnId: freshTurnId,
-            resumeCursor: ctx.session.resumeCursor,
-          };
-        }
-        // Same epoch only: a prompt accepted after a Stop must not fold into the
-        // turn that Stop cancelled, or it would inherit its id and publish a
-        // completion for it while the cancelled one is still settling.
-        const activeTurnBusy =
-          ctx.activeTurnId !== undefined &&
-          (ctx.promptsInFlightByTurn.get(ctx.activeTurnId) ?? 0) > 0;
-        const steeringTurnId =
-          activeTurnBusy && ctx.activeTurnEpoch === acceptedEpoch ? ctx.activeTurnId : undefined;
-        const turnId = steeringTurnId ?? freshTurnId;
-        // Claimed together, without an intervening yield: assigning the active
-        // turn id later let a concurrent call see a busy turn with no
-        // id yet and open a rival turn.
-        ctx.promptsInFlightByTurn.set(turnId, (ctx.promptsInFlightByTurn.get(turnId) ?? 0) + 1);
-        ctx.activeTurnId = turnId;
-        ctx.activeTurnEpoch = acceptedEpoch;
-        // Terminal-event bookkeeping. Publication happens in exactly one place
-        // (the teardown below) so that the decision cannot race a steer.
-        let stopReason: string | null = null;
-        let promptSucceeded = false;
 
-        return yield* Effect.gen(function* () {
-          ctx.session = {
-            ...ctx.session,
-            activeTurnId: turnId,
-            updatedAt: yield* nowIso,
-          };
+        // The submission gate is taken before the turn is claimed, not after.
+        //
+        // Claiming outside it let two turns exist at once — a prompt sent after
+        // a Stop opened its own while the cancelled one was still settling —
+        // and everything that reads "the current turn" then has to guess which
+        // one it means: streamed events, permission requests, the epoch a
+        // decision is checked against. Guarding each of those in turn produced
+        // a new mismatch every time. Inside the gate there is exactly one live
+        // turn, so there is nothing to disambiguate.
+        //
+        // This costs nothing in practice: `acp.prompt` already serializes on
+        // its own semaphore, so a second prompt could never reach `agy` early
+        // anyway — only its bookkeeping ran ahead.
+        return yield* ctx.promptGate.withPermit(
+          Effect.gen(function* () {
+            // Rechecked with the gate held and before any turn state is
+            // touched. Waiting for the gate is exactly when a Stop can land.
+            if (ctx.stopped || ctx.cancelEpoch !== acceptedEpoch) {
+              return {
+                threadId: input.threadId,
+                turnId: freshTurnId,
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }
+            // Each prompt is its own turn. Steering used to fold a second
+            // prompt into a running turn, but `agy --print` cannot inject into
+            // a running invocation — the second prompt always became its own
+            // `agy` process, and the merge existed only in the bookkeeping.
+            // Holding the gate makes that explicit: by the time this runs, any
+            // earlier prompt has already settled.
+            const turnId = freshTurnId;
+            ctx.activeTurnId = turnId;
+            ctx.activeTurnEpoch = acceptedEpoch;
+            let stopReason: string | null = null;
+            let promptSucceeded = false;
 
-          // `agy` binds the model with a `--model` flag on each spawn, and that
-          // flag composes with `--conversation` — verified against the CLI: a
-          // resumed conversation answers on the new model with its history
-          // intact. Applied before `turn.started` so the announced model is the
-          // one the turn actually runs on.
-          const turnModelSelection =
-            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
-          const requestedModelId = turnModelSelection?.model
-            ? resolveAntigravityBaseModelId(turnModelSelection.model)
-            : undefined;
-          if (requestedModelId !== undefined && requestedModelId !== ctx.currentModelId) {
-            yield* ctx.acp
-              .setSessionModel(requestedModelId)
-              .pipe(
-                Effect.mapError((cause) =>
-                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
-                ),
-              );
-            ctx.currentModelId = requestedModelId;
-            ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
-          }
+            return yield* Effect.gen(function* () {
+              ctx.session = {
+                ...ctx.session,
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+              };
 
-          // Rechecked before anything is announced: everything above yields, so
-          // the session can be stopped or the turn interrupted while
-          // attachments resolve and the model is selected. Announcing a turn
-          // on a closed runtime would emit events after `session.exited`.
-          if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
-            stopReason = "cancelled";
-            return {
-              threadId: input.threadId,
-              turnId,
-              resumeCursor: ctx.session.resumeCursor,
-            };
-          }
-
-          // Claimed from shared state, not from "am I a steer": the prompt this
-          // one folded into may have failed before it announced anything, and
-          // emitting content for a turn that never started strands the UI.
-          //
-          // Test and claim are one synchronous step — publishing first and
-          // marking afterwards let two concurrent steers both find the turn
-          // unannounced and emit `turn.started` twice. The claim is released
-          // again if publication does not happen, so a turn nobody saw start
-          // cannot later be completed.
-          // Reservation is taken under the lifecycle gate so teardown cannot
-          // snapshot between the check and the claim.
-          const announcing = yield* ctx.lifecycleGate.withPermit(
-            Effect.sync(() => {
-              if (ctx.stopped || ctx.reservedTurnIds.has(turnId)) {
-                return false;
+              // `agy` binds the model with a `--model` flag on each spawn, and that
+              // flag composes with `--conversation` — verified against the CLI: a
+              // resumed conversation answers on the new model with its history
+              // intact. Applied before `turn.started` so the announced model is the
+              // one the turn actually runs on.
+              const turnModelSelection =
+                input.modelSelection?.instanceId === boundInstanceId
+                  ? input.modelSelection
+                  : undefined;
+              const requestedModelId = turnModelSelection?.model
+                ? resolveAntigravityBaseModelId(turnModelSelection.model)
+                : undefined;
+              if (requestedModelId !== undefined && requestedModelId !== ctx.currentModelId) {
+                yield* ctx.acp
+                  .setSessionModel(requestedModelId)
+                  .pipe(
+                    Effect.mapError((cause) =>
+                      mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+                    ),
+                  );
+                ctx.currentModelId = requestedModelId;
+                ctx.session = {
+                  ...ctx.session,
+                  model: turnModelSelection?.model ?? ctx.session.model,
+                };
               }
-              ctx.reservedTurnIds.add(turnId);
-              return true;
-            }),
-          );
-          if (announcing) {
-            // Stamp generation sits inside the guarded region: it can fail or
-            // be interrupted too, and a claim left behind without its event
-            // would make a steer skip the start and let settlement publish an
-            // orphan completion.
-            yield* ctx.lifecycleGate
-              .withPermit(
-                Effect.gen(function* () {
-                  // Re-checked inside the gate: teardown may have run while
-                  // this fiber waited for it, and a start published after
-                  // `session.exited` is worse than no start at all.
-                  if (ctx.stopped) {
-                    return;
-                  }
-                  yield* offerRuntimeEvent({
-                    type: "turn.started",
-                    ...(yield* makeEventStamp()),
-                    provider: PROVIDER,
-                    threadId: input.threadId,
-                    turnId,
-                    payload: { model: ctx.session.model },
-                  });
-                  // Marked published only once the event is genuinely out, so
-                  // teardown never completes a turn that was merely reserved.
-                  ctx.publishedTurnIds.add(turnId);
-                }),
-              )
-              .pipe(
-                Effect.onExit((exit) =>
-                  Exit.isSuccess(exit)
-                    ? Effect.void
-                    : Effect.sync(() => ctx.reservedTurnIds.delete(turnId)),
-                ),
-              );
-          }
 
-          const result = yield* ctx.promptGate
-            .withPermit(
-              Effect.gen(function* () {
-                // Re-read once submission actually begins. Waiting for the gate
-                // is exactly the window in which Stop can land, and a prompt that
-                // reached the bridge after a cancel would spawn `agy` anyway.
+              // Rechecked before anything is announced: everything above yields, so
+              // the session can be stopped or the turn interrupted while
+              // attachments resolve and the model is selected. Announcing a turn
+              // on a closed runtime would emit events after `session.exited`.
+              if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
+                stopReason = "cancelled";
+                return {
+                  threadId: input.threadId,
+                  turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
+
+              // Claimed from shared state, not from "am I a steer": the prompt this
+              // one folded into may have failed before it announced anything, and
+              // emitting content for a turn that never started strands the UI.
+              //
+              // Test and claim are one synchronous step — publishing first and
+              // marking afterwards let two concurrent steers both find the turn
+              // unannounced and emit `turn.started` twice. The claim is released
+              // again if publication does not happen, so a turn nobody saw start
+              // cannot later be completed.
+              // Reservation is taken under the lifecycle gate so teardown cannot
+              // snapshot between the check and the claim.
+              const announcing = yield* ctx.lifecycleGate.withPermit(
+                Effect.sync(() => {
+                  if (ctx.stopped || ctx.reservedTurnIds.has(turnId)) {
+                    return false;
+                  }
+                  ctx.reservedTurnIds.add(turnId);
+                  return true;
+                }),
+              );
+              if (announcing) {
+                // Stamp generation sits inside the guarded region: it can fail or
+                // be interrupted too, and a claim left behind without its event
+                // would make a steer skip the start and let settlement publish an
+                // orphan completion.
+                yield* ctx.lifecycleGate
+                  .withPermit(
+                    Effect.gen(function* () {
+                      // Re-checked inside the gate: teardown may have run while
+                      // this fiber waited for it, and a start published after
+                      // `session.exited` is worse than no start at all.
+                      if (ctx.stopped) {
+                        return;
+                      }
+                      yield* offerRuntimeEvent({
+                        type: "turn.started",
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId,
+                        payload: { model: ctx.session.model },
+                      });
+                      // Marked published only once the event is genuinely out, so
+                      // teardown never completes a turn that was merely reserved.
+                      ctx.publishedTurnIds.add(turnId);
+                    }),
+                  )
+                  .pipe(
+                    Effect.onExit((exit) =>
+                      Exit.isSuccess(exit)
+                        ? Effect.void
+                        : Effect.sync(() => ctx.reservedTurnIds.delete(turnId)),
+                    ),
+                  );
+              }
+
+              const result = yield* Effect.gen(function* () {
                 if (ctx.cancelEpoch !== acceptedEpoch || ctx.stopped) {
                   return undefined;
                 }
-                // Owned from here until after the drain below, so this turn's
-                // streamed events stay attributed to it even once a newer turn
-                // has been announced.
-                ctx.submittingTurnId = turnId;
                 // The bridge writes its `session/update` notifications before
                 // the prompt response, but the runtime only queues them.
                 // Draining inside the gate keeps the turn from settling — and
@@ -1108,110 +1076,92 @@ export function makeAntigravityAdapter(
                   .pipe(
                     Effect.tapCause(() => drain),
                     Effect.tap(() => drain),
-                    // Released only after the drain, so events this turn queued
-                    // are still attributed to it.
-                    Effect.ensuring(
-                      Effect.sync(() => {
-                        if (ctx.submittingTurnId === turnId) {
-                          ctx.submittingTurnId = undefined;
-                        }
-                      }),
-                    ),
                   );
-              }),
-            )
-            .pipe(
-              Effect.mapError((error) =>
-                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
-              ),
-            );
-          if (result === undefined) {
-            stopReason = "cancelled";
-            return {
-              threadId: input.threadId,
-              turnId,
-              resumeCursor: ctx.session.resumeCursor,
-            };
-          }
+              }).pipe(
+                Effect.mapError((error) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+                ),
+              );
+              if (result === undefined) {
+                stopReason = "cancelled";
+                return {
+                  threadId: input.threadId,
+                  turnId,
+                  resumeCursor: ctx.session.resumeCursor,
+                };
+              }
 
-          const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
-          if (turnRecord) {
-            turnRecord.items.push({ prompt: promptParts, result });
-          } else {
-            ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
-          }
-          ctx.session = {
-            ...ctx.session,
-            activeTurnId: turnId,
-            updatedAt: yield* nowIso,
-          };
-
-          promptSucceeded = true;
-          stopReason = result.stopReason ?? null;
-
-          return {
-            threadId: input.threadId,
-            turnId,
-            resumeCursor: ctx.session.resumeCursor,
-          };
-        }).pipe(
-          Effect.ensuring(
-            Effect.gen(function* () {
-              // Decrement and the last-prompt test are one synchronous step, so
-              // a steer arriving mid-settlement cannot make two prompts both
-              // believe they own the turn and publish a terminal event each.
-              // Scoped to this turn: another turn's prompts must not keep this
-              // one from settling, nor settle it on their behalf.
-              const remaining = Math.max(0, (ctx.promptsInFlightByTurn.get(turnId) ?? 1) - 1);
-              if (remaining > 0) {
-                ctx.promptsInFlightByTurn.set(turnId, remaining);
+              const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+              if (turnRecord) {
+                turnRecord.items.push({ prompt: promptParts, result });
               } else {
-                ctx.promptsInFlightByTurn.delete(turnId);
+                ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
               }
-              if (remaining > 0) {
-                return;
-              }
-              // Cleared even when the turn never started — a model switch can
-              // fail after `activeTurnId` is installed, and leaving it set
-              // advertises a turn to `listSessions` and the reaper that no
-              // longer exists. Only the event below depends on having started.
-              if (ctx.activeTurnId === turnId) {
-                ctx.activeTurnId = undefined;
-              }
-              // Read from shared state rather than this call's local flag: the
-              // prompt that published `turn.started` may not be the one that
-              // settles the turn, and the settler still owes the completion.
-              const published = ctx.publishedTurnIds.has(turnId);
-              ctx.publishedTurnIds.delete(turnId);
-              ctx.reservedTurnIds.delete(turnId);
-              // The public session field is what `listSessions` and the reaper
-              // read, so leaving it set would advertise a turn that has ended.
-              if (ctx.session.activeTurnId === turnId) {
-                const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
-                ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
-              }
-              // A prompt that failed or was interrupted after `turn.started`
-              // still owes consumers a terminal event; without one the turn
-              // renders as running forever even though sendTurn already
-              // returned an error.
-              if (!published) {
-                return;
-              }
-              const state =
-                stopReason === "cancelled" ? "cancelled" : promptSucceeded ? "completed" : "failed";
-              yield* offerRuntimeEvent({
-                type: "turn.completed",
-                ...(yield* makeEventStamp()),
-                provider: PROVIDER,
+              ctx.session = {
+                ...ctx.session,
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+              };
+
+              promptSucceeded = true;
+              stopReason = result.stopReason ?? null;
+
+              return {
                 threadId: input.threadId,
                 turnId,
-                payload: { state, stopReason },
-              });
-              // `catchCause` rather than `catch`: a defect while stamping or
-              // publishing would otherwise escape after the turn's prompt count
-              // was already decremented, stranding the turn as running.
-            }).pipe(Effect.catchCause(() => Effect.void)),
-          ),
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }).pipe(
+              Effect.ensuring(
+                Effect.gen(function* () {
+                  // One prompt per turn, so this settles unconditionally.
+                  // Cleared even when the turn never started — a model switch can
+                  // fail after `activeTurnId` is installed, and leaving it set
+                  // advertises a turn to `listSessions` and the reaper that no
+                  // longer exists. Only the event below depends on having started.
+                  if (ctx.activeTurnId === turnId) {
+                    ctx.activeTurnId = undefined;
+                  }
+                  // Read from shared state rather than this call's local flag: the
+                  // prompt that published `turn.started` may not be the one that
+                  // settles the turn, and the settler still owes the completion.
+                  const published = ctx.publishedTurnIds.has(turnId);
+                  ctx.publishedTurnIds.delete(turnId);
+                  ctx.reservedTurnIds.delete(turnId);
+                  // The public session field is what `listSessions` and the reaper
+                  // read, so leaving it set would advertise a turn that has ended.
+                  if (ctx.session.activeTurnId === turnId) {
+                    const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
+                    ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
+                  }
+                  // A prompt that failed or was interrupted after `turn.started`
+                  // still owes consumers a terminal event; without one the turn
+                  // renders as running forever even though sendTurn already
+                  // returned an error.
+                  if (!published) {
+                    return;
+                  }
+                  const state =
+                    stopReason === "cancelled"
+                      ? "cancelled"
+                      : promptSucceeded
+                        ? "completed"
+                        : "failed";
+                  yield* offerRuntimeEvent({
+                    type: "turn.completed",
+                    ...(yield* makeEventStamp()),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    payload: { state, stopReason },
+                  });
+                  // `catchCause` rather than `catch`: a defect while stamping or
+                  // publishing would otherwise escape after the turn's prompt count
+                  // was already decremented, stranding the turn as running.
+                }).pipe(Effect.catchCause(() => Effect.void)),
+              ),
+            );
+          }),
         );
       });
 

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -84,11 +84,13 @@ const PROVIDER = ProviderDriverKind.make("antigravity");
 /**
  * How long this side waits for a tool-approval answer.
  *
- * Deliberately longer than the bridge's own wait: the bridge denies first and
- * the blocked hook is released by that, so this only exists to stop an
- * unanswered request pinning its entry and its UI prompt forever.
+ * Deliberately *shorter* than the bridge's own wait, which is shorter again
+ * than the hook's. Each layer must give up before the one behind it: when this
+ * was the longest, the bridge had already denied and released the hook while
+ * the request was still open here, so a user answering in that window got an
+ * acceptance the bridge would ignore.
  */
-const APPROVAL_WAIT_MS = 11 * 60 * 1000;
+const APPROVAL_WAIT_MS = 9 * 60 * 1000;
 /**
  * How long to let the bridge answer a cancelled prompt on its own before
  * interrupting the RPC. Only a backstop against a wedged bridge; the normal
@@ -1241,7 +1243,6 @@ export function makeAntigravityAdapter(
                       // prompt that published `turn.started` may not be the one that
                       // settles the turn, and the settler still owes the completion.
                       const published = ctx.publishedTurnIds.has(turnId);
-                      ctx.publishedTurnIds.delete(turnId);
                       ctx.reservedTurnIds.delete(turnId);
                       // The public session field is what `listSessions` and the reaper
                       // read, so leaving it set would advertise a turn that has ended.
@@ -1258,22 +1259,33 @@ export function makeAntigravityAdapter(
                       // renders as running forever even though sendTurn already
                       // returned an error.
                       if (!published) {
+                        ctx.publishedTurnIds.delete(turnId);
                         return;
                       }
-                      const state =
+                      const state: "cancelled" | "completed" | "failed" =
                         stopReason === "cancelled"
                           ? "cancelled"
                           : promptSucceeded
                             ? "completed"
                             : "failed";
-                      yield* offerRuntimeEvent({
-                        type: "turn.completed",
+                      // The claim is surrendered only once the event is built
+                      // and published. Releasing it first meant a failure while
+                      // stamping — which mints a UUID — left teardown seeing no
+                      // published turn, so nothing ever reported the turn ending.
+                      const completedEvent = {
+                        type: "turn.completed" as const,
                         ...(yield* makeEventStamp()),
                         provider: PROVIDER,
                         threadId: input.threadId,
                         turnId,
                         payload: { state, stopReason },
-                      });
+                      };
+                      yield* Effect.uninterruptible(
+                        Effect.gen(function* () {
+                          yield* offerRuntimeEvent(completedEvent);
+                          ctx.publishedTurnIds.delete(turnId);
+                        }),
+                      );
                       // `catchCause` rather than `catch`: a defect while stamping or
                       // publishing would otherwise escape after the turn's prompt count
                       // was already decremented, stranding the turn as running.
@@ -1349,7 +1361,15 @@ export function makeAntigravityAdapter(
           yield* Effect.forkIn(
             Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(
               Effect.flatMap(() =>
-                ctx.activeTurnId === cancelledTurnId ? Effect.ignore(ctx.acp.cancel) : Effect.void,
+                ctx.activeTurnId !== cancelledTurnId
+                  ? Effect.void
+                  : // Still running this long after a cancel means the bridge is
+                    // not processing notifications. Interrupting the RPC alone
+                    // would settle the turn here while a detached `agy` kept
+                    // running tools, so the session goes instead: closing its
+                    // scope ends the bridge process, whose own exit handler
+                    // kills the `agy` process group.
+                    Effect.ignore(stopSessionInternal(ctx)),
               ),
             ),
             ctx.scope,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -423,7 +423,16 @@ export function makeAntigravityAdapter(
         }),
       );
 
-    const stopSessionInternal = (ctx: AntigravitySessionContext) =>
+    const stopSessionInternal = (
+      ctx: AntigravitySessionContext,
+      /**
+       * Stop only while this turn is still the active one. Used by the
+       * cancel-acknowledgement fallback, whose decision to stop was made ten
+       * seconds earlier: without rechecking under the gate, a turn that settled
+       * in the meantime would take its replacement down with it.
+       */
+      onlyIfActiveTurn?: TurnId,
+    ) =>
       Effect.gen(function* () {
         // Claiming the stop, snapshotting what was published, and clearing the
         // active turn happen under the lifecycle gate so they cannot interleave
@@ -431,6 +440,9 @@ export function makeAntigravityAdapter(
         const orphanedTurnIds = yield* ctx.lifecycleGate.withPermit(
           Effect.sync(() => {
             if (ctx.stopped) {
+              return undefined;
+            }
+            if (onlyIfActiveTurn !== undefined && ctx.activeTurnId !== onlyIfActiveTurn) {
               return undefined;
             }
             ctx.stopped = true;
@@ -1361,15 +1373,18 @@ export function makeAntigravityAdapter(
           yield* Effect.forkIn(
             Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(
               Effect.flatMap(() =>
-                ctx.activeTurnId !== cancelledTurnId
-                  ? Effect.void
-                  : // Still running this long after a cancel means the bridge is
-                    // not processing notifications. Interrupting the RPC alone
-                    // would settle the turn here while a detached `agy` kept
-                    // running tools, so the session goes instead: closing its
-                    // scope ends the bridge process, whose own exit handler
-                    // kills the `agy` process group.
-                    Effect.ignore(stopSessionInternal(ctx)),
+                // Still running this long after a cancel means the bridge is
+                // not processing notifications. Interrupting the RPC alone
+                // would settle the turn here while a detached `agy` kept
+                // running tools, so the session goes instead: closing its scope
+                // ends the bridge process, whose own exit handler kills the
+                // `agy` process group.
+                //
+                // The turn is named rather than checked here: this fiber woke
+                // ten seconds late, and the check has to happen under the same
+                // gate that claims the stop or a turn that settled meanwhile
+                // takes its replacement down with it.
+                Effect.ignore(stopSessionInternal(ctx, cancelledTurnId)),
               ),
             ),
             ctx.scope,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -81,6 +81,14 @@ import { type AntigravityAdapterShape } from "../Services/AntigravityAdapter.ts"
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
 const PROVIDER = ProviderDriverKind.make("antigravity");
+/**
+ * How long this side waits for a tool-approval answer.
+ *
+ * Deliberately longer than the bridge's own wait: the bridge denies first and
+ * the blocked hook is released by that, so this only exists to stop an
+ * unanswered request pinning its entry and its UI prompt forever.
+ */
+const APPROVAL_WAIT_MS = 11 * 60 * 1000;
 const ANTIGRAVITY_RESUME_VERSION = 1 as const;
 
 export interface AntigravityAdapterLiveOptions {
@@ -110,6 +118,20 @@ interface AntigravitySessionContext {
   activeTurnId: TurnId | undefined;
   /** Model the bridge will pass to `agy --model` on the next turn. */
   currentModelId: string | undefined;
+  /**
+   * Bumped by every interrupt. A prompt records this when it is accepted and
+   * rechecks it immediately before submitting: the ACP runtime serializes
+   * prompts behind a semaphore, so a steer can still be waiting there when
+   * Stop is pressed and would otherwise reach the bridge *after* the cancel,
+   * capture the post-cancel state, and run anyway.
+   */
+  cancelEpoch: number;
+  /**
+   * Turns for which `turn.started` has actually been published. Shared rather
+   * than per-call, so a steer cannot assume the prompt it folded into already
+   * announced the turn — that prompt may have failed during preflight.
+   */
+  readonly startedTurnIds: Set<TurnId>;
   /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
@@ -437,8 +459,18 @@ export function makeAntigravityAdapter(
                     rawPayload: params,
                   }),
                 );
-                const resolved = yield* Deferred.await(decision);
-                pendingApprovals.delete(requestId);
+                // Raced against a deadline and cleaned up unconditionally: the
+                // bridge forgets its side of a timed-out request, so without
+                // this the handler would stay blocked and the entry retained.
+                const answered = yield* Deferred.await(decision).pipe(
+                  Effect.timeoutOption(APPROVAL_WAIT_MS),
+                  Effect.ensuring(Effect.sync(() => pendingApprovals.delete(requestId))),
+                );
+                // An unanswered request denies, matching the bridge's own
+                // timeout: this gate must never resolve to "allow" by default.
+                const resolved: ProviderApprovalDecision = Option.isSome(answered)
+                  ? answered.value
+                  : "cancel";
                 yield* offerRuntimeEvent(
                   makeAcpRequestResolvedEvent({
                     stamp: yield* makeEventStamp(),
@@ -495,11 +527,11 @@ export function makeAntigravityAdapter(
             turns: [],
             activeTurnId: undefined,
             currentModelId: boundModel,
+            cancelEpoch: 0,
+            startedTurnIds: new Set(),
             promptsInFlight: 0,
             stopped: false,
           };
-
-          approvalsByThread.set(input.threadId, pendingApprovals);
 
           const nf = yield* Stream.runDrain(
             Stream.mapEffect(acp.getEvents(), (event) =>
@@ -589,6 +621,10 @@ export function makeAntigravityAdapter(
 
           ctx.notificationFiber = nf;
           sessions.set(input.threadId, ctx);
+          // Published only now: teardown finds pending approvals through the
+          // session context, so registering earlier would leak the entry if
+          // startup were interrupted before the session existed.
+          approvalsByThread.set(input.threadId, pendingApprovals);
           sessionScopeTransferred = true;
 
           yield* offerRuntimeEvent({
@@ -679,10 +715,11 @@ export function makeAntigravityAdapter(
         const freshTurnId = TurnId.make(yield* randomUUIDv4);
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
         const turnId = steeringTurnId ?? freshTurnId;
+        const acceptedEpoch = ctx.cancelEpoch;
         ctx.promptsInFlight += 1;
         // Terminal-event bookkeeping. Publication happens in exactly one place
         // (the teardown below) so that the decision cannot race a steer.
-        let turnStarted = steeringTurnId !== undefined;
+        let turnStarted = false;
         let stopReason: string | null = null;
         let promptSucceeded = false;
 
@@ -716,7 +753,11 @@ export function makeAntigravityAdapter(
             ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
           }
 
-          if (steeringTurnId === undefined) {
+          // Claimed from shared state, not from "am I a steer": the prompt this
+          // one folded into may have failed before it announced anything, and
+          // emitting content for a turn that never started strands the UI.
+          if (!ctx.startedTurnIds.has(turnId)) {
+            ctx.startedTurnIds.add(turnId);
             yield* offerRuntimeEvent({
               type: "turn.started",
               ...(yield* makeEventStamp()),
@@ -725,7 +766,19 @@ export function makeAntigravityAdapter(
               turnId,
               payload: { model: ctx.session.model },
             });
-            turnStarted = true;
+          }
+          turnStarted = ctx.startedTurnIds.has(turnId);
+
+          // Rechecked here rather than only at accept time: everything above
+          // yields, and an interrupt during any of it means this prompt must
+          // not reach the agent.
+          if (ctx.cancelEpoch !== acceptedEpoch) {
+            stopReason = "cancelled";
+            return {
+              threadId: input.threadId,
+              turnId,
+              resumeCursor: ctx.session.resumeCursor,
+            };
           }
 
           const result = yield* ctx.acp
@@ -774,6 +827,7 @@ export function makeAntigravityAdapter(
               if (ctx.activeTurnId === turnId) {
                 ctx.activeTurnId = undefined;
               }
+              ctx.startedTurnIds.delete(turnId);
               // The public session field is what `listSessions` and the reaper
               // read, so leaving it set would advertise a turn that has ended.
               if (ctx.session.activeTurnId === turnId) {
@@ -787,11 +841,8 @@ export function makeAntigravityAdapter(
               if (!turnStarted) {
                 return;
               }
-              const state = !promptSucceeded
-                ? "failed"
-                : stopReason === "cancelled"
-                  ? "cancelled"
-                  : "completed";
+              const state =
+                stopReason === "cancelled" ? "cancelled" : promptSucceeded ? "completed" : "failed";
               yield* offerRuntimeEvent({
                 type: "turn.completed",
                 ...(yield* makeEventStamp()),
@@ -811,6 +862,9 @@ export function makeAntigravityAdapter(
     const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
+        // Recorded before anything else: prompts already accepted but still
+        // queued upstream compare against this and refuse to submit.
+        ctx.cancelEpoch += 1;
         // Settled before the cancel goes out, as ACP requires: an outstanding
         // permission request has a hook process blocked behind it, and the
         // bridge turns "cancel" into a denial. Leaving it pending would hold

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -667,9 +667,11 @@ export function makeAntigravityAdapter(
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
         const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
         ctx.promptsInFlight += 1;
-        // Tracks whether a terminal event was published on the success path, so
-        // the teardown below can tell "already reported" from "died silently".
-        let settled = false;
+        // Terminal-event bookkeeping. Publication happens in exactly one place
+        // (the teardown below) so that the decision cannot race a steer.
+        let turnStarted = steeringTurnId !== undefined;
+        let stopReason: string | null = null;
+        let promptSucceeded = false;
 
         return yield* Effect.gen(function* () {
           ctx.activeTurnId = turnId;
@@ -679,22 +681,11 @@ export function makeAntigravityAdapter(
             updatedAt: yield* nowIso,
           };
 
-          if (steeringTurnId === undefined) {
-            yield* offerRuntimeEvent({
-              type: "turn.started",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: { model: ctx.session.model },
-            });
-          }
-
           // `agy` binds the model with a `--model` flag on each spawn, and that
           // flag composes with `--conversation` — verified against the CLI: a
           // resumed conversation answers on the new model with its history
-          // intact. So a switch is applied to the bridge session here and takes
-          // effect on the turn about to run.
+          // intact. Applied before `turn.started` so the announced model is the
+          // one the turn actually runs on.
           const turnModelSelection =
             input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
           const requestedModelId = turnModelSelection?.model
@@ -710,6 +701,18 @@ export function makeAntigravityAdapter(
               );
             ctx.currentModelId = requestedModelId;
             ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
+          }
+
+          if (steeringTurnId === undefined) {
+            yield* offerRuntimeEvent({
+              type: "turn.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: { model: ctx.session.model },
+            });
+            turnStarted = true;
           }
 
           const result = yield* ctx.acp
@@ -732,22 +735,8 @@ export function makeAntigravityAdapter(
             updatedAt: yield* nowIso,
           };
 
-          // Only the last remaining prompt settles the turn, so a steer-
-          // superseded prompt resolving does not end the merged turn.
-          if (ctx.promptsInFlight === 1) {
-            yield* offerRuntimeEvent({
-              type: "turn.completed",
-              ...(yield* makeEventStamp()),
-              provider: PROVIDER,
-              threadId: input.threadId,
-              turnId,
-              payload: {
-                state: result.stopReason === "cancelled" ? "cancelled" : "completed",
-                stopReason: result.stopReason ?? null,
-              },
-            });
-            settled = true;
-          }
+          promptSucceeded = true;
+          stopReason = result.stopReason ?? null;
 
           return {
             threadId: input.threadId,
@@ -757,13 +746,12 @@ export function makeAntigravityAdapter(
         }).pipe(
           Effect.ensuring(
             Effect.gen(function* () {
+              // Decrement and the last-prompt test are one synchronous step, so
+              // a steer arriving mid-settlement cannot make two prompts both
+              // believe they own the turn and publish a terminal event each.
               const remaining = Math.max(0, ctx.promptsInFlight - 1);
               ctx.promptsInFlight = remaining;
-              // A prompt that failed or was interrupted after `turn.started`
-              // was announced still owes consumers a terminal event; without
-              // one the turn renders as running forever even though sendTurn
-              // has already returned an error.
-              if (settled || remaining > 0) {
+              if (remaining > 0 || !turnStarted) {
                 return;
               }
               if (ctx.activeTurnId === turnId) {
@@ -775,13 +763,22 @@ export function makeAntigravityAdapter(
                 const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
                 ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
               }
+              // A prompt that failed or was interrupted after `turn.started`
+              // still owes consumers a terminal event; without one the turn
+              // renders as running forever even though sendTurn already
+              // returned an error.
+              const state = !promptSucceeded
+                ? "failed"
+                : stopReason === "cancelled"
+                  ? "cancelled"
+                  : "completed";
               yield* offerRuntimeEvent({
                 type: "turn.completed",
                 ...(yield* makeEventStamp()),
                 provider: PROVIDER,
                 threadId: input.threadId,
                 turnId,
-                payload: { state: "failed", stopReason: null },
+                payload: { state, stopReason },
               });
             }).pipe(Effect.catch(() => Effect.void)),
           ),

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -177,6 +177,14 @@ interface AntigravitySessionContext {
   /** Bridge-side session id, needed to address provider-specific notifications. */
   readonly acpSessionId: string;
   /**
+   * Ids of prompts accepted but not yet answered by the bridge. An interrupt
+   * fences exactly these, so a cancel can never stop a prompt submitted after
+   * it — which every session-scoped variant of this did.
+   */
+  readonly outstandingPromptIds: Set<string>;
+  /** Counter behind `outstandingPromptIds`; unique within this session. */
+  nextPromptSeq: number;
+  /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
    */
@@ -343,8 +351,13 @@ export function makeAntigravityAdapter(
       });
 
     const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
-      Effect.flatMap(getThreadSemaphore(threadId), (lock) =>
-        lock.semaphore.withPermit(effect).pipe(Effect.ensuring(releaseThreadSemaphore(threadId))),
+      // Bracketed: an interrupt landing between taking the holder count and
+      // registering its release would retain that thread's entry for good,
+      // which is the leak the counting is there to prevent.
+      Effect.acquireUseRelease(
+        getThreadSemaphore(threadId),
+        (lock) => lock.semaphore.withPermit(effect),
+        () => releaseThreadSemaphore(threadId),
       );
 
     const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
@@ -687,6 +700,8 @@ export function makeAntigravityAdapter(
             teardownSignal: yield* Deferred.make<void>(),
             approvals: pendingApprovals,
             acpSessionId: started.sessionId,
+            outstandingPromptIds: new Set(),
+            nextPromptSeq: 0,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -780,7 +795,12 @@ export function makeAntigravityAdapter(
             // queuing a barrier nobody can acknowledge, hanging `sendTurn`
             // while it holds the prompt gate.
             Effect.onExit(() => Effect.ignore(Deferred.succeed(ctx.teardownSignal, undefined))),
-            Effect.forkChild,
+            // Forked into the session's own scope, not the calling fiber's.
+            // `startSession` can run inside a short-lived request fiber, and a
+            // child fork would die with it while the session and its bridge
+            // live on — taking every future event with it, and now also
+            // tripping the signal above so drains stop waiting.
+            Effect.forkIn(sessionScope),
           );
 
           ctx.notificationFiber = nf;
@@ -830,6 +850,14 @@ export function makeAntigravityAdapter(
     const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
+        // Claimed before any yielding preparation. Attachment resolution and id
+        // generation both yield, and a Stop landing in that window would
+        // otherwise find nothing outstanding to fence — the prompt would then
+        // reach `agy` carrying the post-cancel state and pass every check.
+        ctx.nextPromptSeq += 1;
+        const promptId = `${ctx.acpSessionId}-${ctx.nextPromptSeq}`;
+        const acceptedEpoch = ctx.cancelEpoch;
+        ctx.outstandingPromptIds.add(promptId);
 
         // `agy --print` takes a single text prompt, so attachments travel as
         // `resource_link` blocks (ACP baseline, no capability needed) pointing
@@ -889,7 +917,6 @@ export function makeAntigravityAdapter(
         const freshTurnId = TurnId.make(yield* randomUUIDv4);
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
         const turnId = steeringTurnId ?? freshTurnId;
-        const acceptedEpoch = ctx.cancelEpoch;
         // Claimed together, without an intervening yield: assigning the active
         // turn id later let a concurrent call see `promptsInFlight > 0` with no
         // id yet and open a rival turn.
@@ -1027,10 +1054,12 @@ export function makeAntigravityAdapter(
                 const drain = Effect.ignore(
                   Effect.raceFirst(ctx.acp.drainEvents, Deferred.await(ctx.teardownSignal)),
                 );
-                return yield* ctx.acp.prompt({ prompt: promptParts }).pipe(
-                  Effect.tapCause(() => drain),
-                  Effect.tap(() => drain),
-                );
+                return yield* ctx.acp
+                  .prompt({ prompt: promptParts, _meta: { t3: { promptId } } })
+                  .pipe(
+                    Effect.tapCause(() => drain),
+                    Effect.tap(() => drain),
+                  );
               }),
             )
             .pipe(
@@ -1070,6 +1099,9 @@ export function makeAntigravityAdapter(
         }).pipe(
           Effect.ensuring(
             Effect.gen(function* () {
+              // No longer in transit, whatever happened to it: a fence for this
+              // id would now stop nothing, and keeping it would grow the set.
+              ctx.outstandingPromptIds.delete(promptId);
               // Decrement and the last-prompt test are one synchronous step, so
               // a steer arriving mid-settlement cannot make two prompts both
               // believe they own the turn and publish a terminal event each.
@@ -1145,8 +1177,8 @@ export function makeAntigravityAdapter(
         // lets the bridge recognise and stop that one. Sending it
         // unconditionally would instead fence a cancel that arrived after its
         // own turn ended, killing the next unrelated prompt.
-        if (ctx.promptsInFlight > 0) {
-          yield* Effect.ignore(ctx.acp.notify("t3/fence", { sessionId: ctx.acpSessionId }));
+        for (const outstanding of ctx.outstandingPromptIds) {
+          yield* Effect.ignore(ctx.acp.notify("t3/fence", { promptId: outstanding }));
         }
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -9,9 +9,12 @@
  *     `--dangerously-skip-permissions` because print mode cannot prompt, so
  *     tools are auto-approved and no approval flow can be surfaced.
  *   - **No session modes.** Print mode has no plan/ask distinction to switch.
- *   - **Model is fixed per session.** The bridge passes `--model` when it
- *     spawns `agy`, so changing models requires a new session
- *     (`sessionModelSwitch: "unsupported"`).
+ *   - **Attachments travel by reference.** `agy --print` has no attachment
+ *     flag, so files are sent as `resource_link` blocks and the bridge stages
+ *     them into a directory it grants the CLI access to for that turn.
+ *   - **Model changes apply from the next turn.** `--model` is a per-spawn
+ *     flag that composes with `--conversation`, so a switch keeps the
+ *     trajectory rather than needing a new session.
  *
  * @module AntigravityAdapterLive
  */
@@ -42,6 +45,8 @@ import * as SynchronizedRef from "effect/SynchronizedRef";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
+import { attachmentFileUrl, resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import {
   ProviderAdapterProcessError,
@@ -93,6 +98,8 @@ interface AntigravitySessionContext {
   notificationFiber: Fiber.Fiber<void, never> | undefined;
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   activeTurnId: TurnId | undefined;
+  /** Model the bridge will pass to `agy --model` on the next turn. */
+  currentModelId: string | undefined;
   /**
    * Number of prompts in flight. >0 means a turn is running, so a new
    * sendTurn steers the existing turn rather than opening a new one.
@@ -135,6 +142,7 @@ export function makeAntigravityAdapter(
 ) {
   return Effect.gen(function* () {
     const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("antigravity");
+    const serverConfig = yield* Effect.service(ServerConfig);
     const path = yield* Path.Path;
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const crypto = yield* Crypto.Crypto;
@@ -362,6 +370,7 @@ export function makeAntigravityAdapter(
             notificationFiber: undefined,
             turns: [],
             activeTurnId: undefined,
+            currentModelId: boundModel,
             promptsInFlight: 0,
             stopped: false,
           };
@@ -486,20 +495,50 @@ export function makeAntigravityAdapter(
       Effect.gen(function* () {
         const ctx = yield* requireSession(input.threadId);
 
-        // The bridge declares no image capability: `agy --print` takes text
-        // only, so attachments cannot be forwarded. This runs before any
-        // `turn.started` is offered — a rejected prompt that had already
-        // announced a turn would leave the UI with one that never completes.
-        const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-        if (input.input?.trim()) {
-          promptParts.push({ type: "text", text: input.input.trim() });
-        }
+        // `agy --print` takes a single text prompt, so attachments travel as
+        // `resource_link` blocks (ACP baseline, no capability needed) pointing
+        // at the files the attachment store already wrote to disk. The bridge
+        // renders those paths into the prompt and grants `agy` read access to
+        // stages just those files into a per-turn directory it can grant `agy`
+        // access to. Nothing is re-encoded.
+        //
+        // This runs before any `turn.started` is offered — a rejected prompt
+        // that had already announced a turn would leave the UI with one that
+        // never completes.
+        const text = input.input?.trim();
+        const attachmentParts = yield* Effect.forEach(input.attachments ?? [], (attachment) =>
+          Effect.gen(function* () {
+            const attachmentPath = resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            });
+            if (!attachmentPath) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/prompt",
+                detail: `Invalid attachment id '${attachment.id}'.`,
+              });
+            }
+            return {
+              type: "resource_link",
+              // `pathToFileURL` rather than hand-built escaping: it handles
+              // Windows drive letters and escapes `#`/`?`, which would
+              // otherwise truncate the path when the bridge parses it back.
+              uri: attachmentFileUrl(attachmentPath),
+              name: path.basename(attachmentPath),
+              ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {}),
+            } satisfies EffectAcpSchema.ContentBlock;
+          }),
+        );
+        const promptParts: Array<EffectAcpSchema.ContentBlock> = [
+          ...(text ? [{ type: "text" as const, text }] : []),
+          ...attachmentParts,
+        ];
         if (promptParts.length === 0) {
           return yield* new ProviderAdapterValidationError({
             provider: PROVIDER,
             operation: "sendTurn",
-            issue:
-              "Turn requires non-empty text. Antigravity print mode does not accept attachments.",
+            issue: "Turn requires non-empty text or attachments.",
           });
         }
 
@@ -508,6 +547,9 @@ export function makeAntigravityAdapter(
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
         const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
         ctx.promptsInFlight += 1;
+        // Tracks whether a terminal event was published on the success path, so
+        // the teardown below can tell "already reported" from "died silently".
+        let settled = false;
 
         return yield* Effect.gen(function* () {
           ctx.activeTurnId = turnId;
@@ -526,6 +568,28 @@ export function makeAntigravityAdapter(
               turnId,
               payload: { model: ctx.session.model },
             });
+          }
+
+          // `agy` binds the model with a `--model` flag on each spawn, and that
+          // flag composes with `--conversation` — verified against the CLI: a
+          // resumed conversation answers on the new model with its history
+          // intact. So a switch is applied to the bridge session here and takes
+          // effect on the turn about to run.
+          const turnModelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const requestedModelId = turnModelSelection?.model
+            ? resolveAntigravityBaseModelId(turnModelSelection.model)
+            : undefined;
+          if (requestedModelId !== undefined && requestedModelId !== ctx.currentModelId) {
+            yield* ctx.acp
+              .setSessionModel(requestedModelId)
+              .pipe(
+                Effect.mapError((cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+                ),
+              );
+            ctx.currentModelId = requestedModelId;
+            ctx.session = { ...ctx.session, model: turnModelSelection?.model ?? ctx.session.model };
           }
 
           const result = yield* ctx.acp
@@ -562,6 +626,7 @@ export function makeAntigravityAdapter(
                 stopReason: result.stopReason ?? null,
               },
             });
+            settled = true;
           }
 
           return {
@@ -571,9 +636,34 @@ export function makeAntigravityAdapter(
           };
         }).pipe(
           Effect.ensuring(
-            Effect.sync(() => {
-              ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
-            }),
+            Effect.gen(function* () {
+              const remaining = Math.max(0, ctx.promptsInFlight - 1);
+              ctx.promptsInFlight = remaining;
+              // A prompt that failed or was interrupted after `turn.started`
+              // was announced still owes consumers a terminal event; without
+              // one the turn renders as running forever even though sendTurn
+              // has already returned an error.
+              if (settled || remaining > 0) {
+                return;
+              }
+              if (ctx.activeTurnId === turnId) {
+                ctx.activeTurnId = undefined;
+              }
+              // The public session field is what `listSessions` and the reaper
+              // read, so leaving it set would advertise a turn that has ended.
+              if (ctx.session.activeTurnId === turnId) {
+                const { activeTurnId: _endedTurnId, ...endedSession } = ctx.session;
+                ctx.session = { ...endedSession, status: "ready", updatedAt: yield* nowIso };
+              }
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: { state: "failed", stopReason: null },
+              });
+            }).pipe(Effect.catch(() => Effect.void)),
           ),
         );
       });
@@ -625,7 +715,7 @@ export function makeAntigravityAdapter(
 
     const rollbackThread: AntigravityAdapterShape["rollbackThread"] = (threadId, numTurns) =>
       Effect.gen(function* () {
-        const ctx = yield* requireSession(threadId);
+        yield* requireSession(threadId);
         if (!Number.isInteger(numTurns) || numTurns < 1) {
           return yield* new ProviderAdapterValidationError({
             provider: PROVIDER,
@@ -633,9 +723,16 @@ export function makeAntigravityAdapter(
             issue: "numTurns must be an integer >= 1.",
           });
         }
-        const nextLength = Math.max(0, ctx.turns.length - numTurns);
-        ctx.turns.splice(nextLength);
-        return { threadId, turns: ctx.turns };
+        // Truncating the local turn list would report success while leaving the
+        // Antigravity trajectory untouched: the next turn resumes the same
+        // `--conversation` and still sees the rolled-back exchanges, so the
+        // model would answer from history the user believes is gone. Print mode
+        // exposes no rewind primitive, so this fails loudly instead.
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread/rollback",
+          detail: "Antigravity conversations do not support provider-side rollback.",
+        });
       });
 
     const stopSession: AntigravityAdapterShape["stopSession"] = (threadId) =>
@@ -675,7 +772,7 @@ export function makeAntigravityAdapter(
       provider: PROVIDER,
       // `agy --model` is applied when the bridge spawns the CLI, so switching
       // models mid-session is not possible.
-      capabilities: { sessionModelSwitch: "unsupported" },
+      capabilities: { sessionModelSwitch: "in-session" },
       startSession,
       sendTurn,
       interruptTurn,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -36,6 +36,7 @@ import {
   TurnId,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -689,6 +690,12 @@ export function makeAntigravityAdapter(
             let resolutionPublished = false;
             return mapAcpCallbackFailure(
               Effect.gen(function* () {
+                // The bridge's own deadline is already running when this
+                // workflow starts. One absolute cutoff covers both queued event
+                // delivery and the user's decision, so time spent draining
+                // cannot leave a request actionable after the bridge has
+                // stopped accepting it.
+                const approvalDeadline = (yield* Clock.currentTimeMillis) + APPROVAL_WAIT_MS;
                 // Bound to the turn actually running, with the epoch that turn
                 // was accepted at — not the session's current epoch. A request
                 // from a cancelled turn can arrive after the epoch moved, and
@@ -738,10 +745,15 @@ export function makeAntigravityAdapter(
                 // belongs to. Teardown wins the race when that consumer is no
                 // longer available, which keeps a stopped session from holding
                 // the hook callback forever.
-                const eventStreamDrained = yield* Effect.raceFirst(
+                const drained = yield* Effect.raceFirst(
                   ctx.acp.drainEvents.pipe(Effect.as(true)),
                   Deferred.await(ctx.teardownSignal).pipe(Effect.as(false)),
+                ).pipe(
+                  Effect.timeoutOption(
+                    Math.max(0, approvalDeadline - (yield* Clock.currentTimeMillis)),
+                  ),
                 );
+                const eventStreamDrained = Option.isSome(drained) && drained.value;
                 if (
                   !eventStreamDrained ||
                   ctx.stopped ||
@@ -776,7 +788,9 @@ export function makeAntigravityAdapter(
                 // bridge forgets its side of a timed-out request, so without
                 // this the handler would stay blocked and the entry retained.
                 const answered = yield* Deferred.await(decision).pipe(
-                  Effect.timeoutOption(APPROVAL_WAIT_MS),
+                  Effect.timeoutOption(
+                    Math.max(0, approvalDeadline - (yield* Clock.currentTimeMillis)),
+                  ),
                 );
                 // An unanswered request denies, matching the bridge's own
                 // timeout: this gate must never resolve to "allow" by default.

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -762,8 +762,17 @@ export function makeAntigravityAdapter(
                 );
                 // Re-checked at the moment of answering: an approval decided
                 // while Stop was landing must not come back as an allow.
+                //
+                // Turn identity is part of that check, not just the epoch. Two
+                // consecutive turns with no cancel between them share an epoch,
+                // so a request still open when its own turn ended would look
+                // current again once the next one started, and this would
+                // answer "allow" for a tool whose token the bridge has already
+                // retired. The bridge denies it either way — the damage is a UI
+                // reporting an approval that was never honoured.
                 const stillLive =
                   !ctx?.stopped &&
+                  ctx?.activeTurnId === approvalTurnId &&
                   (approvalEpoch === undefined || ctx?.cancelEpoch === approvalEpoch);
                 const optionId =
                   resolved === "cancel" || !stillLive

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1179,6 +1179,11 @@ export function makeAntigravityAdapter(
         // Read and bumped in one synchronous step: everything accepted up to
         // and including this value is what the fence below covers.
         const cancelledThrough = ctx.cancelEpoch;
+        // Captured in the same synchronous step as the epoch, before anything
+        // yields. Reading it later would name whichever turn happened to be
+        // active by then — the cancelled one can finish and a new one acquire
+        // the gate while approvals are settled and notifications are written.
+        const cancelledTurnId = ctx.activeTurnId;
         ctx.cancelEpoch += 1;
         // Settled before the cancel goes out, as ACP requires: an outstanding
         // permission request has a hook process blocked behind it, and the
@@ -1217,7 +1222,6 @@ export function makeAntigravityAdapter(
         // turn — and the bridge would ignore the accompanying cancel, its
         // epoch being newer than this fence, leaving `agy` running while T3
         // believed the turn was cancelled.
-        const cancelledTurnId = ctx.activeTurnId;
         if (cancelledTurnId !== undefined) {
           yield* Effect.forkIn(
             Effect.sleep(CANCEL_ACK_TIMEOUT_MS).pipe(

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -487,7 +487,15 @@ export function makeAntigravityAdapter(
             }),
           );
         }
-      }).pipe(Effect.onExit(() => cleanupContext(ctx)));
+      }).pipe(
+        // The whole sequence is uninterruptible, not just the cleanup inside
+        // it. `ctx.stopped` and the published-turn snapshot are taken first, so
+        // an interrupt partway would have the session torn down by `onExit`
+        // while the completions and `session.exited` it owed were never
+        // published — and no later stop would retry, the flag already being set.
+        Effect.uninterruptible,
+        Effect.onExit(() => cleanupContext(ctx)),
+      );
 
     const startSession: AntigravityAdapterShape["startSession"] = (input) =>
       withThreadLock(
@@ -611,8 +619,20 @@ export function makeAntigravityAdapter(
                 const permissionRequest = parsePermissionRequest(params);
                 const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                 const decision = yield* Deferred.make<ProviderApprovalDecision>();
-                const turnId = sessions.get(input.threadId)?.activeTurnId;
                 pendingApprovals.set(requestId, { decision });
+                // Rechecked after registering, not only before: minting the id
+                // and the deferred both yield, and a Stop landing in that gap
+                // would find no entry to cancel — leaving this request open in
+                // the UI and its deferred held for the full approval timeout.
+                if (
+                  ctx?.stopped ||
+                  (approvalEpoch !== undefined &&
+                    ctx !== undefined &&
+                    approvalEpoch !== ctx.cancelEpoch)
+                ) {
+                  pendingApprovals.delete(requestId);
+                  return { outcome: { outcome: "cancelled" } as const };
+                }
                 yield* offerRuntimeEvent(
                   makeAcpRequestOpenedEvent({
                     stamp: yield* makeEventStamp(),
@@ -645,7 +665,7 @@ export function makeAntigravityAdapter(
                     stamp: yield* makeEventStamp(),
                     provider: PROVIDER,
                     threadId: input.threadId,
-                    turnId,
+                    turnId: approvalTurnId,
                     requestId: RuntimeRequestId.make(requestId),
                     permissionRequest,
                     decision: resolved,

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1489,7 +1489,6 @@ export function makeAntigravityAdapter(
           for (const [, approval] of pending) {
             yield* Effect.ignore(Deferred.succeed(approval.decision, "cancel"));
           }
-          pending.clear();
         }
         // The fence names the epoch being cancelled through, rather than one
         // notification per outstanding prompt. Everything accepted at or below

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -716,15 +716,17 @@ export function makeAntigravityAdapter(
         const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
         const turnId = steeringTurnId ?? freshTurnId;
         const acceptedEpoch = ctx.cancelEpoch;
+        // Claimed together, without an intervening yield: assigning the active
+        // turn id later let a concurrent call see `promptsInFlight > 0` with no
+        // id yet and open a rival turn.
         ctx.promptsInFlight += 1;
+        ctx.activeTurnId = turnId;
         // Terminal-event bookkeeping. Publication happens in exactly one place
         // (the teardown below) so that the decision cannot race a steer.
-        let turnStarted = false;
         let stopReason: string | null = null;
         let promptSucceeded = false;
 
         return yield* Effect.gen(function* () {
-          ctx.activeTurnId = turnId;
           ctx.session = {
             ...ctx.session,
             activeTurnId: turnId,
@@ -757,7 +759,6 @@ export function makeAntigravityAdapter(
           // one folded into may have failed before it announced anything, and
           // emitting content for a turn that never started strands the UI.
           if (!ctx.startedTurnIds.has(turnId)) {
-            ctx.startedTurnIds.add(turnId);
             yield* offerRuntimeEvent({
               type: "turn.started",
               ...(yield* makeEventStamp()),
@@ -766,9 +767,11 @@ export function makeAntigravityAdapter(
               turnId,
               payload: { model: ctx.session.model },
             });
+            // Marked only after the event is actually out, so a failed publish
+            // cannot let another prompt emit a completion for a turn nobody
+            // saw start.
+            ctx.startedTurnIds.add(turnId);
           }
-          turnStarted = ctx.startedTurnIds.has(turnId);
-
           // Rechecked here rather than only at accept time: everything above
           // yields, and an interrupt during any of it means this prompt must
           // not reach the agent.
@@ -827,6 +830,10 @@ export function makeAntigravityAdapter(
               if (ctx.activeTurnId === turnId) {
                 ctx.activeTurnId = undefined;
               }
+              // Read from shared state rather than this call's local flag: the
+              // prompt that published `turn.started` may not be the one that
+              // settles the turn, and the settler still owes the completion.
+              const published = ctx.startedTurnIds.has(turnId);
               ctx.startedTurnIds.delete(turnId);
               // The public session field is what `listSessions` and the reaper
               // read, so leaving it set would advertise a turn that has ended.
@@ -838,7 +845,7 @@ export function makeAntigravityAdapter(
               // still owes consumers a terminal event; without one the turn
               // renders as running forever even though sendTurn already
               // returned an error.
-              if (!turnStarted) {
+              if (!published) {
                 return;
               }
               const state =

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -43,9 +43,9 @@ const ANTIGRAVITY_PRESENTATION = {
   displayName: "Antigravity",
   badgeLabel: "Experimental",
   showInteractionModeToggle: false,
-  // The bridge passes `--model` when it spawns `agy`, so a model change only
-  // takes effect on a new session.
-  requiresNewThreadForModelChange: true,
+  // `--model` is a per-spawn flag that composes with `--conversation`, so the
+  // bridge applies a switch to the next turn without losing the trajectory.
+  requiresNewThreadForModelChange: false,
 } as const;
 
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -1,0 +1,328 @@
+/**
+ * AntigravityProvider — health probe and model discovery for the Antigravity
+ * CLI (`agy`).
+ *
+ * Model discovery calls `agy models` directly rather than starting an ACP
+ * session as the Grok provider does: Antigravity has no agent protocol of its
+ * own, so spinning up the bridge just to enumerate models would spawn a
+ * print-mode process for no reason.
+ *
+ * @module AntigravityProvider
+ */
+import {
+  type AntigravitySettings,
+  type ModelCapabilities,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import { parseAntigravityModelList } from "../acp/AntigravityAcpSupport.ts";
+
+const ANTIGRAVITY_PRESENTATION = {
+  displayName: "Antigravity",
+  badgeLabel: "Experimental",
+  showInteractionModeToggle: false,
+  // The bridge passes `--model` when it spawns `agy`, so a model change only
+  // takes effect on a new session.
+  requiresNewThreadForModelChange: true,
+} as const;
+
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
+
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
+
+/**
+ * Fallback list used before discovery completes or when `agy models` fails.
+ * Discovery replaces this with whatever the installed CLI actually offers.
+ */
+const ANTIGRAVITY_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "gemini-3.1-pro-high",
+    name: "Gemini 3.1 Pro (High)",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+];
+
+/**
+ * Turn an Antigravity model slug into a display name.
+ *
+ * Slugs encode the reasoning tier as a trailing `-high` / `-medium` / `-low`,
+ * which reads better as a parenthetical suffix.
+ */
+export function formatAntigravityModelName(slug: string): string {
+  const tierMatch = /^(.*)-(high|medium|low)$/.exec(slug);
+  const base = tierMatch?.[1] ?? slug;
+  const tier = tierMatch?.[2];
+  // Vendor initialisms read wrong under plain title-casing.
+  const initialisms: Record<string, string> = { gpt: "GPT", oss: "OSS", ai: "AI" };
+  const pretty = base
+    .split("-")
+    .map((word) => {
+      const lower = word.toLowerCase();
+      if (initialisms[lower]) {
+        return initialisms[lower];
+      }
+      // Leave version and size fragments (3.1, 120b) as written.
+      return /^\d/.test(word) ? word : `${word.charAt(0).toUpperCase()}${word.slice(1)}`;
+    })
+    .join(" ");
+  return tier ? `${pretty} (${tier.charAt(0).toUpperCase()}${tier.slice(1)})` : pretty;
+}
+
+function antigravityModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = ANTIGRAVITY_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+}
+
+export function buildInitialAntigravityProviderSnapshot(
+  settings: AntigravitySettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = antigravityModelsFromSettings(settings.customModels);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Antigravity CLI availability...",
+      },
+    });
+  });
+}
+
+const runAgyCommand = (
+  settings: AntigravitySettings,
+  args: ReadonlyArray<string>,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const command = settings.binaryPath || "agy";
+    const spawnCommand = yield* resolveSpawnCommand(command, [...args], { env: environment });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+        // `agy` starts a language server and will not emit `models` output
+        // until stdin closes. The default "pipe" leaves it open forever, so
+        // the probe would hang and time out with an empty list.
+        stdin: "ignore",
+      }),
+    );
+  });
+
+const discoverAntigravityModels = (
+  settings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.map(runAgyCommand(settings, ["models"], environment), (output) =>
+    output.code === 0
+      ? parseAntigravityModelList(output.stdout).map(
+          (slug): ServerProviderModel => ({
+            slug,
+            name: formatAntigravityModelName(slug),
+            isCustom: false,
+            capabilities: EMPTY_CAPABILITIES,
+          }),
+        )
+      : [],
+  );
+
+export const checkAntigravityProviderStatus = Effect.fn("checkAntigravityProviderStatus")(
+  function* (
+    settings: AntigravitySettings,
+    environment: NodeJS.ProcessEnv = process.env,
+  ): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+    const checkedAt = DateTime.formatIso(yield* DateTime.now);
+    const fallbackModels = antigravityModelsFromSettings(settings.customModels);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    const versionResult = yield* runAgyCommand(settings, ["--version"], environment).pipe(
+      Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+      Effect.result,
+    );
+
+    if (Result.isFailure(versionResult)) {
+      const error = versionResult.failure;
+      yield* Effect.logWarning("Antigravity CLI health check failed.", { errorTag: error._tag });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: !isCommandMissingCause(error),
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: isCommandMissingCause(error)
+            ? "Antigravity CLI (`agy`) is not installed or not on PATH."
+            : "Failed to execute Antigravity CLI health check.",
+        },
+      });
+    }
+
+    if (Option.isNone(versionResult.success)) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but timed out while running `agy --version`.",
+        },
+      });
+    }
+
+    const versionOutput = versionResult.success.value;
+    const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+    if (versionOutput.code !== 0) {
+      yield* Effect.logWarning("Antigravity CLI version probe exited with a non-zero status.", {
+        exitCode: versionOutput.code,
+      });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but failed to run.",
+        },
+      });
+    }
+
+    const discoveryResult = yield* discoverAntigravityModels(settings, environment).pipe(
+      Effect.timeoutOption(MODEL_DISCOVERY_TIMEOUT_MS),
+      Effect.result,
+    );
+    const discoveredModels =
+      Result.isSuccess(discoveryResult) && Option.isSome(discoveryResult.success)
+        ? discoveryResult.success.value
+        : [];
+    if (discoveredModels.length === 0) {
+      // A CLI that runs but lists no models is almost always an unfinished
+      // Google sign-in, which `agy models` reports by printing nothing.
+      yield* Effect.logWarning("Antigravity model discovery returned no models.");
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but listed no models. Run `agy` to sign in.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: antigravityModelsFromSettings(settings.customModels, discoveredModels),
+      probe: {
+        installed: true,
+        version,
+        status: "ready",
+        auth: { status: "unknown" },
+      },
+    });
+  },
+);
+
+export const enrichAntigravitySnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Antigravity version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1402,6 +1402,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                   claudeAgent: { enabled: false },
                   cursor: { enabled: false },
                   grok: { enabled: false },
+                  antigravity: { enabled: false },
                   opencode: { enabled: false },
                 },
                 // `providerInstances` keys are branded `ProviderInstanceId`;
@@ -1513,6 +1514,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                   claudeAgent: { enabled: false },
                   cursor: { enabled: false },
                   grok: { enabled: false },
+                  antigravity: { enabled: false },
                   opencode: { enabled: false },
                 },
               }),
@@ -1626,6 +1628,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                   claudeAgent: { enabled: false },
                   cursor: { enabled: false },
                   grok: { enabled: false },
+                  antigravity: { enabled: false },
                   opencode: { enabled: false },
                 },
                 providerInstances: {
@@ -1759,6 +1762,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               );
 
               assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
+                "antigravity",
                 "claudeAgent",
                 "codex",
                 "cursor",

--- a/apps/server/src/provider/Services/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Services/AntigravityAdapter.ts
@@ -1,0 +1,16 @@
+/**
+ * AntigravityAdapter — shape type for the Antigravity provider adapter.
+ *
+ * The driver model ({@link ../Drivers/AntigravityDriver}) bundles one adapter
+ * per instance as a captured closure, so this module only retains the shape
+ * interface as a naming anchor for the driver bundle.
+ *
+ * @module AntigravityAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * AntigravityAdapterShape — per-instance Antigravity adapter contract.
+ */
+export interface AntigravityAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -269,6 +269,52 @@ describe("AcpSessionRuntime", () => {
     ),
   );
 
+  it.effect("cancels prompts that were already waiting for prompt serialization", () =>
+    Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
+      yield* runtime.start();
+
+      const firstPrompt = yield* runtime
+        .prompt({
+          prompt: [{ type: "text", text: "hang forever" }],
+        })
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* TestClock.adjust("500 millis");
+      const queuedPrompt = yield* runtime
+        .prompt({
+          prompt: [{ type: "text", text: "already queued" }],
+        })
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* runtime.cancel;
+
+      expect(yield* Fiber.join(firstPrompt)).toMatchObject({ stopReason: "cancelled" });
+      expect(yield* Fiber.join(queuedPrompt)).toMatchObject({ stopReason: "cancelled" });
+      expect(
+        yield* runtime.prompt({
+          prompt: [{ type: "text", text: "submitted after cancellation" }],
+        }),
+      ).toMatchObject({ stopReason: "end_turn" });
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: {
+            command: mockAgentCommand,
+            args: mockAgentArgs,
+            env: {
+              T3_ACP_HANG_FIRST_PROMPT_FOREVER: "1",
+            },
+          },
+          cwd: process.cwd(),
+          clientInfo: { name: "t3-test", version: "0.0.0" },
+          authMethodId: "test",
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    ),
+  );
+
   it.effect("segments assistant text around ACP tool calls", () =>
     Effect.gen(function* () {
       const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -49,6 +49,12 @@ export type AcpSessionRuntimeEvent = AcpParsedSessionEvent | AcpSessionEventStre
 
 const defaultSessionLoadTimeout = Duration.seconds(90);
 const defaultSessionLoadReplayIdleGap = Duration.seconds(2);
+/**
+ * How long a prompt waits for an in-flight `session/cancel` notification to
+ * reach the agent before sending anyway. Only a backstop against a wedged
+ * transport — the write is a single stdio frame and normally completes at once.
+ */
+const CANCEL_NOTIFICATION_WRITE_TIMEOUT_MS = 5_000;
 
 export interface AcpSpawnInput {
   readonly command: string;
@@ -290,6 +296,18 @@ export const make = (
       ),
     );
     const assistantSegmentRef = yield* Ref.make<AcpAssistantSegmentState>({ nextSegmentIndex: 0 });
+    /**
+     * Set while a `session/cancel` notification is still being written.
+     *
+     * Cancelling interrupts the in-flight prompt, which releases the
+     * serialization semaphore immediately, while the notification itself is
+     * sent on a forked fiber. Without this gate the next queued prompt could
+     * reach the agent first and then be cancelled by a notification meant for
+     * the turn before it.
+     */
+    const cancelNotificationRef = yield* Ref.make<Option.Option<Deferred.Deferred<void>>>(
+      Option.none(),
+    );
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     const promptSerializationSemaphore = yield* Semaphore.make(1);
@@ -720,6 +738,17 @@ export const make = (
         promptSerializationSemaphore.withPermit(
           Effect.gen(function* () {
             const started = yield* getStartedState;
+            // A cancel that landed while this prompt waited for the semaphore is
+            // still on its way to the agent. Sending now would put this prompt
+            // in front of it and have it absorb the cancellation.
+            const pendingCancel = yield* Ref.getAndSet(cancelNotificationRef, Option.none());
+            if (Option.isSome(pendingCancel)) {
+              yield* Effect.ignore(
+                Deferred.await(pendingCancel.value).pipe(
+                  Effect.timeoutOption(CANCEL_NOTIFICATION_WRITE_TIMEOUT_MS),
+                ),
+              );
+            }
             yield* closeActiveAssistantSegment({
               queue: eventQueue,
               assistantSegmentRef,
@@ -767,13 +796,24 @@ export const make = (
       cancel: getStartedState.pipe(
         Effect.flatMap((started) =>
           Effect.gen(function* () {
+            // Published and forked before the interrupt, not after. Interrupting
+            // releases the prompt serialization semaphore at once, so a queued
+            // prompt could otherwise be sent to the agent ahead of this
+            // notification and be cancelled in place of the turn it was meant
+            // for. `prompt` waits on this deferred before sending.
+            const written = yield* Deferred.make<void>();
+            yield* Ref.set(cancelNotificationRef, Option.some(written));
+            yield* acp.agent.cancel({ sessionId: started.sessionId }).pipe(
+              Effect.ignore,
+              // Released however the send ends: a failed notification must not
+              // leave the next prompt waiting out the full timeout.
+              Effect.ensuring(Effect.ignore(Deferred.succeed(written, undefined))),
+              Effect.forkIn(runtimeScope),
+            );
             const activePromptFiber = yield* Ref.get(activePromptFiberRef);
             if (Option.isSome(activePromptFiber)) {
               yield* Fiber.interrupt(activePromptFiber.value).pipe(Effect.ignore);
             }
-            yield* acp.agent
-              .cancel({ sessionId: started.sessionId })
-              .pipe(Effect.ignore, Effect.forkIn(runtimeScope));
           }),
         ),
       ),

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -749,7 +749,13 @@ export const make = (
                   yield* Ref.set(activePromptFiberRef, Option.none());
                 }),
               ),
-              Effect.tap(() =>
+              // Closed however the prompt ends, not only when it succeeds. An
+              // agent that streamed some text and then failed the RPC left its
+              // segment open, and the next prompt closed it on the way in —
+              // after the caller had moved to a new turn, so the `item.completed`
+              // landed on the wrong one. A failed prompt still ends whatever it
+              // was saying.
+              Effect.ensuring(
                 closeActiveAssistantSegment({
                   queue: eventQueue,
                   assistantSegmentRef,

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -297,17 +297,18 @@ export const make = (
     );
     const assistantSegmentRef = yield* Ref.make<AcpAssistantSegmentState>({ nextSegmentIndex: 0 });
     /**
-     * Set while a `session/cancel` notification is still being written.
+     * Serializes writing to the agent against publishing the fiber that owns
+     * that write.
      *
-     * Cancelling interrupts the in-flight prompt, which releases the
-     * serialization semaphore immediately, while the notification itself is
-     * sent on a forked fiber. Without this gate the next queued prompt could
-     * reach the agent first and then be cancelled by a notification meant for
-     * the turn before it.
+     * Held by `prompt` across "send the request, then record its fiber", and by
+     * `cancel` across "send the notification, then interrupt that fiber". The
+     * two operations are indivisible with respect to each other, which is what
+     * makes cancellation land on the turn it was issued for: without it a
+     * cancel could write its notification into the gap between a prompt being
+     * sent and its fiber being registered, cancelling nothing and leaving the
+     * prompt running.
      */
-    const cancelNotificationRef = yield* Ref.make<Option.Option<Deferred.Deferred<void>>>(
-      Option.none(),
-    );
+    const dispatchGate = yield* Semaphore.make(1);
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     const promptSerializationSemaphore = yield* Semaphore.make(1);
@@ -738,17 +739,6 @@ export const make = (
         promptSerializationSemaphore.withPermit(
           Effect.gen(function* () {
             const started = yield* getStartedState;
-            // A cancel that landed while this prompt waited for the semaphore is
-            // still on its way to the agent. Sending now would put this prompt
-            // in front of it and have it absorb the cancellation.
-            const pendingCancel = yield* Ref.getAndSet(cancelNotificationRef, Option.none());
-            if (Option.isSome(pendingCancel)) {
-              yield* Effect.ignore(
-                Deferred.await(pendingCancel.value).pipe(
-                  Effect.timeoutOption(CANCEL_NOTIFICATION_WRITE_TIMEOUT_MS),
-                ),
-              );
-            }
             yield* closeActiveAssistantSegment({
               queue: eventQueue,
               assistantSegmentRef,
@@ -760,12 +750,23 @@ export const make = (
             const cancelledResponse = {
               stopReason: "cancelled",
             } satisfies EffectAcpSchema.PromptResponse;
-            const promptRpcFiber = yield* runLoggedRequest(
-              "session/prompt",
-              requestPayload,
-              acp.agent.prompt(requestPayload),
-            ).pipe(Effect.forkIn(runtimeScope));
-            yield* Ref.set(activePromptFiberRef, Option.some(promptRpcFiber));
+            // Sending and publishing the fiber are one step, so a concurrent
+            // cancel either sees no prompt at all or sees this one and can
+            // interrupt it. Uninterruptible because being interrupted between
+            // the two would leave a live RPC nothing can reach.
+            const promptRpcFiber = yield* dispatchGate.withPermit(
+              Effect.uninterruptible(
+                Effect.gen(function* () {
+                  const fiber = yield* runLoggedRequest(
+                    "session/prompt",
+                    requestPayload,
+                    acp.agent.prompt(requestPayload),
+                  ).pipe(Effect.forkIn(runtimeScope));
+                  yield* Ref.set(activePromptFiberRef, Option.some(fiber));
+                  return fiber;
+                }),
+              ),
+            );
             return yield* Fiber.join(promptRpcFiber).pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterruptsOnly(cause)
@@ -795,26 +796,32 @@ export const make = (
         ),
       cancel: getStartedState.pipe(
         Effect.flatMap((started) =>
-          Effect.gen(function* () {
-            // Published and forked before the interrupt, not after. Interrupting
-            // releases the prompt serialization semaphore at once, so a queued
-            // prompt could otherwise be sent to the agent ahead of this
-            // notification and be cancelled in place of the turn it was meant
-            // for. `prompt` waits on this deferred before sending.
-            const written = yield* Deferred.make<void>();
-            yield* Ref.set(cancelNotificationRef, Option.some(written));
-            yield* acp.agent.cancel({ sessionId: started.sessionId }).pipe(
-              Effect.ignore,
-              // Released however the send ends: a failed notification must not
-              // leave the next prompt waiting out the full timeout.
-              Effect.ensuring(Effect.ignore(Deferred.succeed(written, undefined))),
-              Effect.forkIn(runtimeScope),
-            );
-            const activePromptFiber = yield* Ref.get(activePromptFiberRef);
-            if (Option.isSome(activePromptFiber)) {
-              yield* Fiber.interrupt(activePromptFiber.value).pipe(Effect.ignore);
-            }
-          }),
+          // Taken under the same gate `prompt` publishes its fiber under, so a
+          // cancel never lands in the gap between a prompt being sent and
+          // becoming interruptible. Whichever side takes the gate first wins:
+          // either this reads a fiber and interrupts it, or the prompt has not
+          // been sent yet and starts after the notification is already out.
+          dispatchGate.withPermit(
+            Effect.uninterruptible(
+              Effect.gen(function* () {
+                // Written before the interrupt. Interrupting first releases the
+                // serialization semaphore at once, and the queued prompt behind
+                // it would reach the agent ahead of this notification and absorb
+                // a cancellation meant for its predecessor.
+                //
+                // Bounded rather than forked: forking reintroduces exactly the
+                // ordering this exists to prevent, and a wedged transport must
+                // not hold the gate forever.
+                yield* acp.agent
+                  .cancel({ sessionId: started.sessionId })
+                  .pipe(Effect.ignore, Effect.timeoutOption(CANCEL_NOTIFICATION_WRITE_TIMEOUT_MS));
+                const activePromptFiber = yield* Ref.get(activePromptFiberRef);
+                if (Option.isSome(activePromptFiber)) {
+                  yield* Fiber.interrupt(activePromptFiber.value).pipe(Effect.ignore);
+                }
+              }),
+            ),
+          ),
         ),
       ),
       setMode: (modeId) =>

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -312,6 +312,7 @@ export const make = (
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     const promptSerializationSemaphore = yield* Semaphore.make(1);
+    const cancellationGenerationRef = yield* Ref.make(0);
     const activePromptFiberRef = yield* Ref.make<
       Option.Option<Fiber.Fiber<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>>
     >(Option.none());
@@ -736,64 +737,77 @@ export const make = (
       getModeState: Ref.get(modeStateRef),
       getConfigOptions: Ref.get(configOptionsRef),
       prompt: (payload) =>
-        promptSerializationSemaphore.withPermit(
-          Effect.gen(function* () {
-            const started = yield* getStartedState;
-            yield* closeActiveAssistantSegment({
-              queue: eventQueue,
-              assistantSegmentRef,
-            });
-            const requestPayload = {
-              sessionId: started.sessionId,
-              ...payload,
-            } satisfies EffectAcpSchema.PromptRequest;
-            const cancelledResponse = {
-              stopReason: "cancelled",
-            } satisfies EffectAcpSchema.PromptResponse;
-            // Sending and publishing the fiber are one step, so a concurrent
-            // cancel either sees no prompt at all or sees this one and can
-            // interrupt it. Uninterruptible because being interrupted between
-            // the two would leave a live RPC nothing can reach.
-            const promptRpcFiber = yield* dispatchGate.withPermit(
-              Effect.uninterruptible(
-                Effect.gen(function* () {
-                  const fiber = yield* runLoggedRequest(
-                    "session/prompt",
-                    requestPayload,
-                    acp.agent.prompt(requestPayload),
-                  ).pipe(Effect.forkIn(runtimeScope));
-                  yield* Ref.set(activePromptFiberRef, Option.some(fiber));
-                  return fiber;
-                }),
-              ),
-            );
-            return yield* Fiber.join(promptRpcFiber).pipe(
-              Effect.catchCause((cause) =>
-                Cause.hasInterruptsOnly(cause)
-                  ? Effect.succeed(cancelledResponse)
-                  : Effect.failCause(cause),
-              ),
-              Effect.ensuring(
-                Effect.gen(function* () {
-                  yield* Fiber.interrupt(promptRpcFiber).pipe(Effect.ignore);
-                  yield* Ref.set(activePromptFiberRef, Option.none());
-                }),
-              ),
-              // Closed however the prompt ends, not only when it succeeds. An
-              // agent that streamed some text and then failed the RPC left its
-              // segment open, and the next prompt closed it on the way in —
-              // after the caller had moved to a new turn, so the `item.completed`
-              // landed on the wrong one. A failed prompt still ends whatever it
-              // was saying.
-              Effect.ensuring(
-                closeActiveAssistantSegment({
-                  queue: eventQueue,
-                  assistantSegmentRef,
-                }),
-              ),
-            );
-          }),
-        ),
+        Effect.gen(function* () {
+          // Captured before waiting for prompt serialization. A cancel that
+          // lands while this prompt is queued moves the generation, so the
+          // prompt can decline instead of reaching the agent after Stop.
+          const cancellationGeneration = yield* Ref.get(cancellationGenerationRef);
+          return yield* promptSerializationSemaphore.withPermit(
+            Effect.gen(function* () {
+              const cancelledResponse = {
+                stopReason: "cancelled",
+              } satisfies EffectAcpSchema.PromptResponse;
+              const started = yield* getStartedState;
+              yield* closeActiveAssistantSegment({
+                queue: eventQueue,
+                assistantSegmentRef,
+              });
+              const requestPayload = {
+                sessionId: started.sessionId,
+                ...payload,
+              } satisfies EffectAcpSchema.PromptRequest;
+              // Sending and publishing the fiber are one step, so a concurrent
+              // cancel either sees no prompt at all or sees this one and can
+              // interrupt it. Uninterruptible because being interrupted between
+              // the two would leave a live RPC nothing can reach.
+              const promptRpcFiber = yield* dispatchGate.withPermit(
+                Effect.uninterruptible(
+                  Effect.gen(function* () {
+                    const currentGeneration = yield* Ref.get(cancellationGenerationRef);
+                    if (currentGeneration !== cancellationGeneration) {
+                      return Option.none();
+                    }
+                    const fiber = yield* runLoggedRequest(
+                      "session/prompt",
+                      requestPayload,
+                      acp.agent.prompt(requestPayload),
+                    ).pipe(Effect.forkIn(runtimeScope));
+                    yield* Ref.set(activePromptFiberRef, Option.some(fiber));
+                    return Option.some(fiber);
+                  }),
+                ),
+              );
+              if (Option.isNone(promptRpcFiber)) {
+                return cancelledResponse;
+              }
+              return yield* Fiber.join(promptRpcFiber.value).pipe(
+                Effect.catchCause((cause) =>
+                  Cause.hasInterruptsOnly(cause)
+                    ? Effect.succeed(cancelledResponse)
+                    : Effect.failCause(cause),
+                ),
+                Effect.ensuring(
+                  Effect.gen(function* () {
+                    yield* Fiber.interrupt(promptRpcFiber.value).pipe(Effect.ignore);
+                    yield* Ref.set(activePromptFiberRef, Option.none());
+                  }),
+                ),
+                // Closed however the prompt ends, not only when it succeeds. An
+                // agent that streamed some text and then failed the RPC left its
+                // segment open, and the next prompt closed it on the way in —
+                // after the caller had moved to a new turn, so the `item.completed`
+                // landed on the wrong one. A failed prompt still ends whatever it
+                // was saying.
+                Effect.ensuring(
+                  closeActiveAssistantSegment({
+                    queue: eventQueue,
+                    assistantSegmentRef,
+                  }),
+                ),
+              );
+            }),
+          );
+        }),
       cancel: getStartedState.pipe(
         Effect.flatMap((started) =>
           // Taken under the same gate `prompt` publishes its fiber under, so a
@@ -804,6 +818,7 @@ export const make = (
           dispatchGate.withPermit(
             Effect.uninterruptible(
               Effect.gen(function* () {
+                yield* Ref.update(cancellationGenerationRef, (generation) => generation + 1);
                 // Written before the interrupt. Interrupting first releases the
                 // serialization semaphore at once, and the queued prompt behind
                 // it would reach the agent ahead of this notification and absorb

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildAntigravityAcpSpawnInput,
+  parseAntigravityModelList,
+  resolveAntigravityBaseModelId,
+} from "./AntigravityAcpSupport.ts";
+import { formatAntigravityModelName } from "../Layers/AntigravityProvider.ts";
+
+describe("parseAntigravityModelList", () => {
+  it("parses the one-slug-per-line output of `agy models`", () => {
+    const models = parseAntigravityModelList(
+      "gemini-3.6-flash-high\ngemini-3.1-pro-high\nclaude-sonnet-4-6\n",
+    );
+
+    expect(models).toEqual(["gemini-3.6-flash-high", "gemini-3.1-pro-high", "claude-sonnet-4-6"]);
+  });
+
+  it("drops blank lines, duplicates, and prose", () => {
+    const models = parseAntigravityModelList(
+      "\ngemini-3.1-pro-high\n\ngemini-3.1-pro-high\nAvailable agents:\n  gpt-oss-120b-medium  \n",
+    );
+
+    expect(models).toEqual(["gemini-3.1-pro-high", "gpt-oss-120b-medium"]);
+  });
+});
+
+describe("resolveAntigravityBaseModelId", () => {
+  it("resolves a bare family name to a concrete reasoning tier", () => {
+    expect(resolveAntigravityBaseModelId("gemini-3.1-pro")).toBe("gemini-3.1-pro-high");
+    expect(resolveAntigravityBaseModelId("flash")).toBe("gemini-3.6-flash-medium");
+  });
+
+  it("passes through a slug that already names a tier", () => {
+    expect(resolveAntigravityBaseModelId("gemini-3.6-flash-low")).toBe("gemini-3.6-flash-low");
+  });
+
+  it("falls back to the default when nothing is selected", () => {
+    expect(resolveAntigravityBaseModelId(undefined)).toBe("gemini-3.1-pro-high");
+    expect(resolveAntigravityBaseModelId("  ")).toBe("gemini-3.1-pro-high");
+  });
+});
+
+describe("buildAntigravityAcpSpawnInput", () => {
+  it("spawns this server binary's bridge subcommand rather than agy directly", () => {
+    const spawn = buildAntigravityAcpSpawnInput({
+      antigravitySettings: null,
+      cwd: "/repo",
+    });
+
+    expect(spawn.command).toBe(process.execPath);
+    expect(spawn.args.at(-1)).toBe("agy-acp");
+    expect(spawn.cwd).toBe("/repo");
+  });
+
+  it("passes per-turn configuration to the bridge through the environment", () => {
+    const spawn = buildAntigravityAcpSpawnInput({
+      antigravitySettings: {
+        binaryPath: "/opt/agy",
+        printTimeout: "30m",
+        appDataDir: "/data/agy",
+      } as never,
+      cwd: "/repo",
+      model: "gemini-3.1-pro-high",
+      effort: "high",
+    });
+
+    expect(spawn.env).toMatchObject({
+      T3_AGY_COMMAND: "/opt/agy",
+      T3_AGY_PRINT_TIMEOUT: "30m",
+      T3_AGY_APP_DATA_DIR: "/data/agy",
+      T3_AGY_MODEL: "gemini-3.1-pro-high",
+      T3_AGY_EFFORT: "high",
+    });
+  });
+
+  it("omits unset settings so the bridge keeps its own defaults", () => {
+    const spawn = buildAntigravityAcpSpawnInput({
+      antigravitySettings: { binaryPath: "", printTimeout: "", appDataDir: "" } as never,
+      cwd: "/repo",
+    });
+
+    expect(spawn.env).not.toHaveProperty("T3_AGY_COMMAND");
+    expect(spawn.env).not.toHaveProperty("T3_AGY_PRINT_TIMEOUT");
+    expect(spawn.env).not.toHaveProperty("T3_AGY_MODEL");
+  });
+});
+
+describe("formatAntigravityModelName", () => {
+  it("renders the trailing reasoning tier as a suffix", () => {
+    expect(formatAntigravityModelName("gemini-3.1-pro-high")).toBe("Gemini 3.1 Pro (High)");
+    expect(formatAntigravityModelName("gemini-3.6-flash-low")).toBe("Gemini 3.6 Flash (Low)");
+  });
+
+  it("leaves a slug with no tier suffix alone", () => {
+    expect(formatAntigravityModelName("claude-sonnet-4-6")).toBe("Claude Sonnet 4 6");
+  });
+
+  it("keeps vendor initialisms uppercase", () => {
+    expect(formatAntigravityModelName("gpt-oss-120b-medium")).toBe("GPT OSS 120b (Medium)");
+  });
+});

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -29,7 +29,7 @@ export const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3.1-pro-high";
 
 type AntigravityAcpRuntimeSettings = Pick<
   AntigravitySettings,
-  "binaryPath" | "printTimeout" | "appDataDir"
+  "binaryPath" | "printTimeout" | "appDataDir" | "requireToolApproval"
 >;
 
 interface AntigravityAcpRuntimeInput extends Omit<
@@ -78,6 +78,9 @@ export function buildAntigravityAcpSpawnInput(input: {
   }
   if (settings?.appDataDir?.trim()) {
     env["T3_AGY_APP_DATA_DIR"] = settings.appDataDir.trim();
+  }
+  if (settings?.requireToolApproval) {
+    env["T3_AGY_REQUIRE_APPROVAL"] = "1";
   }
   if (input.model?.trim()) {
     env["T3_AGY_MODEL"] = input.model.trim();

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -1,0 +1,143 @@
+/**
+ * Spawn wiring for the Antigravity provider.
+ *
+ * Unlike Cursor and Grok — whose CLIs speak ACP natively — Antigravity has no
+ * agent protocol, so the "ACP agent" spawned here is T3 Code's own bridge
+ * (`t3 agy-acp`, see `antigravity/agyBridge.ts`). Running it as a subcommand of
+ * this same binary means the bridge always ships and versions with the server.
+ *
+ * @module provider/acp/AntigravityAcpSupport
+ */
+import { type AntigravitySettings, ProviderDriverKind } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
+
+/** Antigravity manages its own Google sign-in, so there is nothing to select. */
+const ANTIGRAVITY_AUTH_METHOD = "none";
+
+export const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3.1-pro-high";
+
+type AntigravityAcpRuntimeSettings = Pick<
+  AntigravitySettings,
+  "binaryPath" | "printTimeout" | "appDataDir"
+>;
+
+interface AntigravityAcpRuntimeInput extends Omit<
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly antigravitySettings: AntigravityAcpRuntimeSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+  /** Model the bridge should pass to `agy --model` for this session. */
+  readonly model?: string | undefined;
+  /** Reasoning effort for `agy --effort`. */
+  readonly effort?: string | undefined;
+}
+
+/**
+ * Resolve how to re-invoke this server binary.
+ *
+ * Under `node src/bin.ts` the entry script must be passed explicitly; a packed
+ * single-file build is itself the executable.
+ */
+export function resolveBridgeCommand(): { command: string; args: ReadonlyArray<string> } {
+  const entry = process.argv[1];
+  return entry
+    ? { command: process.execPath, args: [entry, "agy-acp"] }
+    : { command: process.execPath, args: ["agy-acp"] };
+}
+
+export function buildAntigravityAcpSpawnInput(input: {
+  readonly antigravitySettings: AntigravityAcpRuntimeSettings | null | undefined;
+  readonly cwd: string;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly model?: string | undefined;
+  readonly effort?: string | undefined;
+}): AcpSessionRuntime.AcpSpawnInput {
+  const { command, args } = resolveBridgeCommand();
+  const settings = input.antigravitySettings;
+  // The bridge reads its per-turn configuration from the environment so that
+  // `agy` invocation details stay entirely inside the bridge process.
+  const env: NodeJS.ProcessEnv = { ...input.environment };
+  if (settings?.binaryPath?.trim()) {
+    env["T3_AGY_COMMAND"] = settings.binaryPath.trim();
+  }
+  if (settings?.printTimeout?.trim()) {
+    env["T3_AGY_PRINT_TIMEOUT"] = settings.printTimeout.trim();
+  }
+  if (settings?.appDataDir?.trim()) {
+    env["T3_AGY_APP_DATA_DIR"] = settings.appDataDir.trim();
+  }
+  if (input.model?.trim()) {
+    env["T3_AGY_MODEL"] = input.model.trim();
+  }
+  if (input.effort?.trim()) {
+    env["T3_AGY_EFFORT"] = input.effort.trim();
+  }
+
+  return { command, args: [...args], cwd: input.cwd, env };
+}
+
+export const makeAntigravityAcpRuntime = (
+  input: AntigravityAcpRuntimeInput,
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Crypto.Crypto | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildAntigravityAcpSpawnInput({
+          antigravitySettings: input.antigravitySettings,
+          cwd: input.cwd,
+          ...(input.environment ? { environment: input.environment } : {}),
+          ...(input.model ? { model: input.model } : {}),
+          ...(input.effort ? { effort: input.effort } : {}),
+        }),
+        authMethodId: ANTIGRAVITY_AUTH_METHOD,
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
+  });
+
+export function resolveAntigravityBaseModelId(model: string | null | undefined): string {
+  const trimmed = model?.trim();
+  const base = trimmed && trimmed.length > 0 ? trimmed : DEFAULT_ANTIGRAVITY_MODEL;
+  return normalizeModelSlug(base, ANTIGRAVITY_DRIVER_KIND) ?? DEFAULT_ANTIGRAVITY_MODEL;
+}
+
+/**
+ * Parse `agy models` output.
+ *
+ * The command prints one slug per line with no header or decoration.
+ */
+export function parseAntigravityModelList(output: string): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  for (const line of output.split("\n")) {
+    const slug = line.trim();
+    if (slug.length === 0 || slug.includes(" ")) {
+      continue;
+    }
+    seen.add(slug);
+  }
+  return [...seen];
+}

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -35,9 +35,11 @@ import {
   agyToolTitle,
   hookSessionUpdate,
   makeAgyTurnState,
+  orderAgySessionUpdates,
   type AgyHookDecision,
   type AgyHookEvent,
   type AgyHookPayload,
+  type AgyOrderedSessionUpdate,
   type AgySessionUpdate,
   type AgyTurnState,
 } from "./agyEvents.ts";
@@ -1217,8 +1219,8 @@ let activeTurnToken: TurnToken | undefined;
 /**
  * Drain everything Antigravity has produced so far and emit it as ACP updates.
  *
- * Hooks are read first so a tool call is always announced before the
- * transcript record carrying its output is matched against it.
+ * Hooks are ingested first so transcript records can match tool calls, then
+ * both sources are emitted in Antigravity step order.
  */
 function drain(input: {
   readonly sessionId: string;
@@ -1234,6 +1236,8 @@ function drain(input: {
   /** Defaults to true; set false to run hook and terminal cleanup only. */
   readonly readTranscript?: boolean;
 }): boolean {
+  const bufferedUpdates: Array<AgyOrderedSessionUpdate> = [];
+  const approvals: Array<{ readonly name: string; readonly payload: AgyHookPayload }> = [];
   for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
     // Diffing the file contents each hook captured, rather than the arguments
     // of the edit, keeps this correct across tools whose argument shapes
@@ -1255,7 +1259,11 @@ function drain(input: {
         // since the transcript is read once by byte offset.
         input.state.pendingTerminal.set(stepIdx, update);
       } else {
-        sendSessionUpdate(input.sessionId, update);
+        bufferedUpdates.push({
+          stepIdx,
+          phase: hook.event === "pre-tool-use" ? "pre" : "terminal",
+          update,
+        });
       }
     }
     // The hook process is blocked until a decision file appears, so this has
@@ -1271,13 +1279,7 @@ function drain(input: {
           reason: "Antigravity turn ended before this tool was approved",
         });
       } else {
-        requestToolApproval({
-          sessionId: input.sessionId,
-          hookDir: input.hookDir,
-          hookName: name,
-          payload: hook.payload,
-          turnToken: input.turnToken,
-        });
+        approvals.push({ name, payload: hook.payload });
       }
     }
   }
@@ -1344,6 +1346,7 @@ function drain(input: {
     if (!input.state.transcriptPrimed && allLines.length > 0) {
       const trimmed = dropPriorTurnRecords(allLines);
       const foundBoundary = trimmed.length !== allLines.length;
+      input.state.transcriptBoundarySeen = input.state.transcriptBoundarySeen || foundBoundary;
       if (input.state.resumedConversation && !input.final && moreTranscript) {
         // Still short of the end of the file, so no `USER_INPUT` seen so far can
         // be trusted to be this turn's: the current turn's opening record may
@@ -1355,12 +1358,13 @@ function drain(input: {
         // what keeps the hold bounded to a single turn's output.
         const heldChars =
           input.cursor.carryLength + trimmed.reduce((total, line) => total + line.length + 1, 0);
-        if (!foundBoundary && heldChars > MAX_TRANSCRIPT_LINE_CHARS) {
+        if (!input.state.transcriptBoundarySeen && heldChars > MAX_TRANSCRIPT_LINE_CHARS) {
           // No boundary anywhere in a budget's worth of scanning. Give up on
-          // locating it and drop what was scanned: this turn loses whatever
-          // preceded this point, which is the right way to be wrong. Priming on
-          // it instead would replay another turn's output as this one's.
-          input.state.transcriptPrimed = true;
+          // what was scanned, including the partial record at the read cutoff:
+          // this turn loses whatever preceded this point, which is the right
+          // way to be wrong. Priming while unread bytes remain would replay
+          // another turn's output as this one's.
+          input.cursor.discardThroughNextNewline();
         } else {
           input.cursor.retain(trimmed);
         }
@@ -1434,14 +1438,25 @@ function drain(input: {
             continue;
           }
           for (const update of retried.updates) {
-            sendSessionUpdate(input.sessionId, update);
+            bufferedUpdates.push({
+              stepIdx: candidate.step_index,
+              phase: "transcript",
+              update,
+            });
           }
           if (retried.emittedAssistantText) {
             input.assistantText.emitted = true;
           }
           const retriedStep = candidate.step_index;
           if (typeof retriedStep === "number") {
-            flushTerminal(input.sessionId, input.state, retriedStep);
+            const terminal = takeTerminal(input.state, retriedStep);
+            if (terminal) {
+              bufferedUpdates.push({
+                stepIdx: retriedStep,
+                phase: "terminal",
+                update: terminal,
+              });
+            }
           }
         }
         if (trimmed) {
@@ -1453,7 +1468,11 @@ function drain(input: {
         break;
       }
       for (const update of result.updates) {
-        sendSessionUpdate(input.sessionId, update);
+        bufferedUpdates.push({
+          stepIdx: record.step_index,
+          phase: "transcript",
+          update,
+        });
       }
       if (result.emittedAssistantText) {
         input.assistantText.emitted = true;
@@ -1461,7 +1480,14 @@ function drain(input: {
       // This step's output is out; the call can be completed now.
       const stepIndex = record.step_index;
       if (typeof stepIndex === "number") {
-        flushTerminal(input.sessionId, input.state, stepIndex);
+        const terminal = takeTerminal(input.state, stepIndex);
+        if (terminal) {
+          bufferedUpdates.push({
+            stepIdx: stepIndex,
+            phase: "terminal",
+            update: terminal,
+          });
+        }
       }
     }
   }
@@ -1469,23 +1495,36 @@ function drain(input: {
   // Nothing more will arrive, so anything still waiting on a transcript record
   // that never came is completed without output rather than left spinning.
   if (input.final) {
-    const remaining = [...input.state.pendingTerminal.values()];
+    const remaining = [...input.state.pendingTerminal];
     input.state.pendingTerminal.clear();
-    for (const terminal of remaining) {
-      sendSessionUpdate(input.sessionId, terminal);
+    for (const [stepIdx, terminal] of remaining) {
+      bufferedUpdates.push({ stepIdx, phase: "terminal", update: terminal });
     }
+  }
+
+  for (const update of orderAgySessionUpdates(bufferedUpdates)) {
+    sendSessionUpdate(input.sessionId, update);
+  }
+  for (const approval of approvals) {
+    requestToolApproval({
+      sessionId: input.sessionId,
+      hookDir: input.hookDir,
+      hookName: approval.name,
+      payload: approval.payload,
+      turnToken: input.turnToken,
+    });
   }
 
   return moreTranscript;
 }
 
-function flushTerminal(sessionId: string, state: AgyTurnState, stepIdx: number): void {
+function takeTerminal(state: AgyTurnState, stepIdx: number): AgySessionUpdate | undefined {
   const terminal = state.pendingTerminal.get(stepIdx);
   if (!terminal) {
-    return;
+    return undefined;
   }
   state.pendingTerminal.delete(stepIdx);
-  sendSessionUpdate(sessionId, terminal);
+  return terminal;
 }
 
 /**
@@ -1688,9 +1727,23 @@ async function runTurn(
     });
   }, HOOK_POLL_INTERVAL_MS);
 
+  let childError: Error | undefined;
   const exitCode = await new Promise<number | null>((resolve) => {
-    child.on("error", () => resolve(null));
-    child.on("close", (code) => resolve(code));
+    child.on("error", (error) => {
+      childError = error;
+      // An error can report a failed kill while the process is still alive.
+      // The turn continues to own and poll the child until `close`; arm the
+      // normal escalation rather than releasing its directories underneath it.
+      if (
+        activeChild === child &&
+        child.pid !== undefined &&
+        child.exitCode === null &&
+        child.signalCode === null
+      ) {
+        killActiveChild();
+      }
+    });
+    child.once("close", (code) => resolve(code));
   });
 
   clearInterval(poller);
@@ -1813,8 +1866,10 @@ async function runTurn(
   if (cancelled) {
     return { stopReason: "cancelled" };
   }
-  if (exitCode !== 0) {
-    const captured = stderr.trim() || stdout.trim();
+  if (exitCode !== 0 || childError !== undefined) {
+    const processError = childError?.message.trim() ?? "";
+    const processOutput = stderr.trim() || stdout.trim();
+    const captured = [processError, processOutput].filter((part) => part.length > 0).join("\n");
     const truncated = stderr.trim() ? stderrTruncated : stdoutTruncated;
     const detail = captured
       ? truncated

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -828,6 +828,12 @@ interface TurnOutcome {
 let activeChild: NodeChildProcess.ChildProcess | null = null;
 /** Session whose turn is currently running, if any. Gates `session/cancel`. */
 let activeTurnSessionId: string | null = null;
+/**
+ * Set once stdin closes. Queued prompts decline instead of spawning: killing
+ * only the running child let the queue advance and start another `agy` after
+ * the client had gone, which then ran to the print timeout.
+ */
+let shuttingDown = false;
 const cancelledSessions = new Set<string>();
 /**
  * Highest cancelled epoch per session.
@@ -856,11 +862,16 @@ function cancelledThrough(sessionId: string): number {
   return cancelledThroughEpoch.get(sessionId) ?? -1;
 }
 
-/** Prompts accepted for a session but not yet handled, by session id. */
-const queuedPromptCounts = new Map<string, number>();
+/**
+ * Prompts accepted for a session but not yet handled, counting only those that
+ * carry no epoch. A tagged prompt is already covered by the session's mark and
+ * consumes no marker, so banking a cancel on its account would leave an entry
+ * that only some later untagged prompt could consume.
+ */
+const queuedUntaggedCounts = new Map<string, number>();
 
-function queuedPrompts(sessionId: string): number {
-  return queuedPromptCounts.get(sessionId) ?? 0;
+function queuedUntagged(sessionId: string): number {
+  return queuedUntaggedCounts.get(sessionId) ?? 0;
 }
 
 /** The adapter's cancel epoch for a submission, carried in `_meta.t3.epoch`. */
@@ -1342,6 +1353,12 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "unknown sessionId");
         return;
       }
+      if (shuttingDown) {
+        // The client is gone; starting `agy` now would leave it running with
+        // nobody to read its output.
+        sendResult(id, { stopReason: "cancelled" });
+        return;
+      }
       // Compared against the session's cancelled high-water mark. A cancel
       // that outran this prompt raised that mark, and anything the user sends
       // afterwards carries a higher epoch and is unaffected.
@@ -1407,7 +1424,7 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // would otherwise sit here and stop something sent much later. A prompt
         // carrying an epoch is already covered by the mark and consumes no
         // marker, so this only ever applies to an untagged one.
-        if (queuedPrompts(sessionId) > 0) {
+        if (queuedUntagged(sessionId) > 0) {
           unscopedCancels.add(sessionId);
         }
         return;
@@ -1492,22 +1509,29 @@ export async function runAgyBridge(): Promise<void> {
       const pending = message;
       // Counted from acceptance to handling, so a cancel can tell "a prompt is
       // waiting" from "nothing is outstanding".
-      const queuedSessionId =
+      const queuedParams =
         pending["method"] === "session/prompt"
-          ? (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"]
+          ? (pending["params"] as Record<string, unknown> | undefined)
+          : undefined;
+      const queuedSessionId =
+        queuedParams && promptEpochOf(queuedParams) === undefined
+          ? queuedParams["sessionId"]
           : undefined;
       if (typeof queuedSessionId === "string") {
-        queuedPromptCounts.set(queuedSessionId, queuedPrompts(queuedSessionId) + 1);
+        queuedUntaggedCounts.set(queuedSessionId, queuedUntagged(queuedSessionId) + 1);
       }
       queue = queue
         .then(() => handleRequest(pending))
         .finally(() => {
           if (typeof queuedSessionId === "string") {
-            const remaining = queuedPrompts(queuedSessionId) - 1;
+            const remaining = queuedUntagged(queuedSessionId) - 1;
             if (remaining > 0) {
-              queuedPromptCounts.set(queuedSessionId, remaining);
+              queuedUntaggedCounts.set(queuedSessionId, remaining);
             } else {
-              queuedPromptCounts.delete(queuedSessionId);
+              queuedUntaggedCounts.delete(queuedSessionId);
+              // Nothing untagged is waiting any more, so a marker banked for
+              // one cannot be consumed and must not outlive it.
+              unscopedCancels.delete(queuedSessionId);
             }
           }
         })
@@ -1522,6 +1546,8 @@ export async function runAgyBridge(): Promise<void> {
     }
   }
 
+  // Recorded before anything else so queued prompts see it and decline.
+  shuttingDown = true;
   // stdin closed: no approval can still be answered, so unblock the hooks
   // waiting on them (they fail closed) rather than letting them time out.
   failPendingOutbound("T3 Code disconnected before approving this tool call");

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -854,8 +854,13 @@ function promptEpochOf(params: Record<string, unknown>): number | undefined {
   const epoch = isRecord(t3) ? t3["epoch"] : undefined;
   return typeof epoch === "number" ? epoch : undefined;
 }
-/** Cancel epoch of the turn currently running, so a fence can reach it. */
-let activeTurnEpoch = -1;
+/**
+ * Cancel epoch of the turn currently running, or undefined when its prompt
+ * carried no epoch. An untagged client is not using the extension, so it keeps
+ * plain `session/cancel` semantics rather than being scoped by a mark it never
+ * contributes to.
+ */
+let activeTurnEpoch: number | undefined;
 /** Token of that turn, retired when its epoch is cancelled. */
 let activeTurnToken: TurnToken | undefined;
 
@@ -1055,7 +1060,7 @@ async function runTurn(
   sessionId: string,
   session: BridgeSession,
   prompt: RenderedPrompt,
-  promptEpoch: number,
+  promptEpoch: number | undefined,
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
@@ -1196,7 +1201,7 @@ async function runTurn(
   // now resolves to a denial rather than writing into a vanishing directory or
   // banking a blanket approval for the next turn.
   turnToken.live = false;
-  activeTurnEpoch = -1;
+  activeTurnEpoch = undefined;
   activeTurnToken = undefined;
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
@@ -1324,8 +1329,12 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       // Compared against the session's cancelled high-water mark. A cancel
       // that outran this prompt raised that mark, and anything the user sends
       // afterwards carries a higher epoch and is unaffected.
-      const promptEpoch = promptEpochOf(params) ?? 0;
-      if (promptEpoch <= cancelledThrough(sessionId)) {
+      //
+      // A prompt without an epoch is from a client that does not send fences,
+      // so there is no mark it could be measured against — refusing it would
+      // reject every prompt such a client ever sends once a mark exists.
+      const promptEpoch = promptEpochOf(params);
+      if (promptEpoch !== undefined && promptEpoch <= cancelledThrough(sessionId)) {
         // Cancelled before it could start; never spawn `agy` for it.
         sendResult(id, { stopReason: "cancelled" });
         return;
@@ -1358,7 +1367,11 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       // stop on arrival, so it is stopped here. Retiring the token is what
       // makes an approval still in flight deny, including one the client
       // would auto-approve.
-      if (activeTurnToken?.sessionId === sessionId && activeTurnEpoch <= epoch) {
+      if (
+        activeTurnToken?.sessionId === sessionId &&
+        activeTurnEpoch !== undefined &&
+        activeTurnEpoch <= epoch
+      ) {
         activeTurnToken.live = false;
         cancelledSessions.add(sessionId);
         activeChild?.kill("SIGTERM");
@@ -1372,7 +1385,10 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // has been cancelled. A prompt accepted after the fence carries a
         // higher epoch and must survive this notification, which the runtime
         // forks and can therefore deliver late.
-        if (activeTurnEpoch <= cancelledThrough(sessionId)) {
+        //
+        // An untagged turn has no epoch to scope by, so it is cancelled
+        // outright — that is the plain ACP behaviour its client expects.
+        if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
           cancelledSessions.add(sessionId);
           activeChild?.kill("SIGTERM");
         }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -380,6 +380,22 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
 
 // ── Tool approval ─────────────────────────────────────────────────────
 
+/**
+ * Identity for one `runTurn`, used to bound the lifetime of its approvals.
+ *
+ * A cancel generation alone is not enough: a hook file first read after the
+ * turn ended has no earlier generation to compare against, and a decision
+ * banked from a dead turn must not carry into the next one.
+ */
+interface TurnToken {
+  readonly sessionId: string;
+  live: boolean;
+}
+
+function turnTokenLive(token: TurnToken): boolean {
+  return token.live && !cancelledSessions.has(token.sessionId);
+}
+
 const APPROVE_OPTION = "allow";
 const APPROVE_SESSION_OPTION = "allow-session";
 const REJECT_OPTION = "reject";
@@ -430,7 +446,18 @@ function requestToolApproval(input: {
   readonly hookDir: string;
   readonly hookName: string;
   readonly payload: AgyHookPayload;
+  /** The turn that asked. Approvals are only valid while it is still running. */
+  readonly turnToken: TurnToken;
 }): void {
+  // Checked before the session-wide fast path, not after: a hook first seen
+  // after a cancel would otherwise be waved through by a blanket approval.
+  if (!turnTokenLive(input.turnToken)) {
+    writeDecision(input.hookDir, input.hookName, {
+      decision: "deny",
+      reason: "Cancelled before this tool was approved",
+    });
+    return;
+  }
   // Already approved for the whole session: answer without troubling the user.
   if (sessionWideApprovals.has(input.sessionId)) {
     writeDecision(input.hookDir, input.hookName, { decision: "allow" });
@@ -438,8 +465,7 @@ function requestToolApproval(input: {
   }
   const toolCall = input.payload.toolCall;
   const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
-  // An allow decided while Stop was landing must not be written as an allow.
-  const requestedAtGeneration = cancelGeneration(input.sessionId);
+
   void sendRequest(
     "session/request_permission",
     {
@@ -465,13 +491,16 @@ function requestToolApproval(input: {
     APPROVAL_WAIT_MS,
   )
     .then((result) => {
-      const decision =
-        cancelGeneration(input.sessionId) !== requestedAtGeneration
-          ? ({
-              decision: "deny",
-              reason: "Cancelled before this tool was approved",
-            } satisfies AgyHookDecision)
-          : approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      // Re-checked at the moment of answering: the turn may have ended or been
+      // cancelled while the user was deciding.
+      const decision = !turnTokenLive(input.turnToken)
+        ? ({
+            decision: "deny",
+            reason: "Cancelled before this tool was approved",
+          } satisfies AgyHookDecision)
+        : approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      // Only recorded for a still-live turn. A blanket approval banked from a
+      // turn that has already ended would silently pre-approve the next one.
       if (decision.decision === "allow" && selectedOptionId(result) === APPROVE_SESSION_OPTION) {
         sessionWideApprovals.add(input.sessionId);
       }
@@ -811,6 +840,17 @@ const cancelledSessions = new Set<string>();
  * that lands harmlessly between two turns.
  */
 const cancelGenerations = new Map<string, number>();
+/**
+ * Sessions cancelled while no turn was running.
+ *
+ * The generation check compares a prompt's enqueue-time value against its
+ * run-time value, which cannot see a cancel that landed *before* the prompt
+ * arrived — the prompt simply reads the post-cancel value and matches. The
+ * runtime forks its cancel notification, so that ordering is real. This
+ * one-shot marker is consumed by the next prompt for the session, which then
+ * refuses to start.
+ */
+const pendingCancelMarkers = new Set<string>();
 /** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
 const queuedPromptGenerations = new Map<unknown, number>();
 
@@ -833,6 +873,7 @@ function drain(input: {
   readonly decoder: NodeStringDecoder.StringDecoder;
   readonly transcriptOffset: { value: number };
   readonly assistantText: { emitted: boolean };
+  readonly turnToken: TurnToken;
   readonly final: boolean;
 }): void {
   for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
@@ -877,6 +918,7 @@ function drain(input: {
           hookDir: input.hookDir,
           hookName: name,
           payload: hook.payload,
+          turnToken: input.turnToken,
         });
       }
     }
@@ -1015,6 +1057,9 @@ async function runTurn(
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
+  // This turn was allowed to start, so no in-transit cancel is outstanding for
+  // it; leaving the marker would stop an unrelated later prompt.
+  pendingCancelMarkers.delete(sessionId);
   // Claimed before any setup work: spawning `agy` takes long enough that a
   // cancel can land first, and cancels are only honoured for the session
   // holding this claim. Leaving it unset until after the spawn would silently
@@ -1070,6 +1115,7 @@ async function runTurn(
     state.resolvedTranscriptPath = baseline.path;
   }
   const assistantText = { emitted: false };
+  const turnToken: TurnToken = { sessionId, live: true };
   activeChild = child;
   // A cancel during startup had no process to signal; deliver it now.
   if (cancelledSessions.has(sessionId)) {
@@ -1097,6 +1143,7 @@ async function runTurn(
       decoder,
       transcriptOffset,
       assistantText,
+      turnToken,
       final: false,
     });
   }, HOOK_POLL_INTERVAL_MS);
@@ -1118,6 +1165,7 @@ async function runTurn(
     decoder,
     transcriptOffset,
     assistantText,
+    turnToken,
     final: true,
   });
 
@@ -1140,6 +1188,10 @@ async function runTurn(
     persistConversationId(sessionId, state.conversationId);
   }
 
+  // Retired before the directories are reclaimed: any approval still in flight
+  // now resolves to a denial rather than writing into a vanishing directory or
+  // banking a blanket approval for the next turn.
+  turnToken.live = false;
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
   cleanupDir(attachmentDir);
@@ -1265,7 +1317,13 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       }
       const queuedAt = queuedPromptGenerations.get(id);
       queuedPromptGenerations.delete(id);
-      if (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId)) {
+      // Consumed here, so exactly one prompt is stopped by a cancel that
+      // outran it; anything the user sends afterwards runs normally.
+      const cancelledInTransit = pendingCancelMarkers.delete(sessionId);
+      if (
+        cancelledInTransit ||
+        (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId))
+      ) {
         // Cancelled while it sat in the queue; never spawn `agy` for it.
         sendResult(id, { stopReason: "cancelled" });
         return;
@@ -1289,6 +1347,10 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // Always recorded, so prompts already queued for this session can see
         // that a cancel happened and refuse to start.
         cancelGenerations.set(sessionId, cancelGeneration(sessionId) + 1);
+        if (sessionId !== activeTurnSessionId) {
+          // No turn to interrupt, so this cancel is for one still in transit.
+          pendingCancelMarkers.add(sessionId);
+        }
         // Only a cancel aimed at the turn actually running decides its stop
         // reason. Cancels bypass the request queue, so one arriving after a
         // turn finished — or targeting an idle session — must not sit in the

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -876,9 +876,24 @@ function drain(input: {
           const buffer = Buffer.alloc(length);
           // `readSync` may return fewer bytes than asked for. Decoding the
           // whole buffer would feed the zero-filled tail through as content
-          // and skip the real bytes for good, so only what was actually read
-          // is consumed; the rest is picked up on the next poll.
-          const bytesRead = NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
+          // and skip the real bytes for good. Read until the measured range is
+          // filled rather than relying on the next poll — the final drain has
+          // no next poll, and would lose the tail along with whatever partial
+          // record the cursor is about to flush.
+          let bytesRead = 0;
+          while (bytesRead < length) {
+            const read = NodeFS.readSync(
+              fd,
+              buffer,
+              bytesRead,
+              length - bytesRead,
+              input.transcriptOffset.value + bytesRead,
+            );
+            if (read <= 0) {
+              break;
+            }
+            bytesRead += read;
+          }
           // Decoded through the turn's streaming decoder, not `toString`: a
           // write can land mid-multibyte-character, and decoding each slice
           // independently would replace the partial sequence with U+FFFD and

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -84,6 +84,44 @@ const sessions = new Map<string, BridgeSession>();
 // `session/load` — potentially in a fresh bridge process — can still resume
 // the right conversation.
 
+/**
+ * Where Antigravity keeps a conversation's trajectory.
+ *
+ * Layout confirmed against real conversations:
+ * `<appDataDir>/brain/<conversation-uuid>/.system_generated/logs/`.
+ */
+function transcriptDirFor(conversationId: string): string {
+  const appDataDir =
+    process.env["T3_AGY_APP_DATA_DIR"]?.trim() ||
+    NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
+  return NodePath.join(appDataDir, "brain", conversationId, ".system_generated", "logs");
+}
+
+/**
+ * Bytes already in a resumed conversation's transcript before this turn runs.
+ *
+ * A positive baseline, taken before `agy` is spawned, is what makes "records
+ * from earlier turns" precise. Inferring the boundary from the last
+ * `USER_INPUT` record cannot: the file always contains previous ones, so a
+ * poll landing before the new marker is written would treat an earlier turn's
+ * output as live. Returns 0 when the file cannot be measured, which falls back
+ * to the marker heuristic rather than skipping the turn's own output.
+ */
+function transcriptBaseline(conversationId: string | undefined): number {
+  if (!conversationId) {
+    return 0;
+  }
+  const dir = transcriptDirFor(conversationId);
+  for (const name of ["transcript.jsonl", "transcript_full.jsonl"]) {
+    try {
+      return NodeFS.statSync(NodePath.join(dir, name)).size;
+    } catch {
+      // Try the sibling, then give up.
+    }
+  }
+  return 0;
+}
+
 function stateDirPath(): string {
   const appDataDir =
     process.env["T3_AGY_APP_DATA_DIR"]?.trim() ||
@@ -489,8 +527,16 @@ export async function runAgyHook(event: string): Promise<void> {
       // With approvals on, this process is the gate: block until the bridge
       // reports the user's answer. `deny` here genuinely stops the tool —
       // Antigravity reports the reason back to the model.
-      if (gating && payload?.toolCall) {
-        const decision = await awaitDecision(hookDir, name);
+      if (gating) {
+        // Every gating path answers here. A payload without `toolCall` used to
+        // fall through to the observation-only response, which allows — so a
+        // change in Antigravity's payload shape would have run tools unapproved.
+        const decision = payload?.toolCall
+          ? await awaitDecision(hookDir, name)
+          : ({
+              decision: "deny",
+              reason: "T3 Code could not identify this tool call for approval",
+            } satisfies AgyHookDecision);
         process.stdout.write(JSON.stringify(decision));
         return;
       }
@@ -929,6 +975,9 @@ async function runTurn(
   // holding this claim. Leaving it unset until after the spawn would silently
   // drop those, letting an auto-approving child run on past a cancelled turn.
   activeTurnSessionId = sessionId;
+  // Measured before `agy` starts: whatever the transcript already holds
+  // belongs to earlier turns of the conversation being resumed.
+  const baseline = transcriptBaseline(session.conversationId);
   let hookDir: string | undefined;
   let hookWorkspace: string | undefined;
   let attachmentDir: string | undefined;
@@ -967,7 +1016,12 @@ async function runTurn(
   const seenHooks = new Set<string>();
   const cursor = new AgyTranscriptCursor();
   const decoder = new NodeStringDecoder.StringDecoder("utf8");
-  const transcriptOffset = { value: 0 };
+  const transcriptOffset = { value: baseline };
+  if (baseline > 0) {
+    // Reading starts past every earlier turn, so there is no prior-turn
+    // content left for the `USER_INPUT` heuristic to guess at.
+    state.transcriptPrimed = true;
+  }
   const assistantText = { emitted: false };
   activeChild = child;
   // A cancel during startup had no process to signal; deliver it now.

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -856,6 +856,17 @@ const cancelGenerations = new Map<string, number>();
  * was meant for.
  */
 const fencedPromptIds = new Set<string>();
+/**
+ * Upper bound on remembered fences. A fence whose prompt already arrived is
+ * applied immediately instead of stored, so this only holds ids still in
+ * transit; the cap exists so a client that fences prompts it never sends
+ * cannot grow the set without limit.
+ */
+const MAX_FENCED_PROMPT_IDS = 256;
+/** Prompt id of the turn currently running, so a fence can reach it. */
+let activeTurnPromptId: string | undefined;
+/** Token of the turn currently running, retired when its prompt is fenced. */
+let activeTurnToken: TurnToken | undefined;
 
 /** The adapter's per-submission id, carried in `_meta.t3.promptId`. */
 function promptIdOf(params: Record<string, unknown>): string | undefined {
@@ -1067,6 +1078,7 @@ async function runTurn(
   sessionId: string,
   session: BridgeSession,
   prompt: RenderedPrompt,
+  promptId: string | undefined,
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
@@ -1127,6 +1139,10 @@ async function runTurn(
   }
   const assistantText = { emitted: false };
   const turnToken: TurnToken = { sessionId, live: true };
+  // Published so an out-of-band fence naming this prompt can retire the turn
+  // rather than being stored for an arrival that already happened.
+  activeTurnPromptId = promptId;
+  activeTurnToken = turnToken;
   activeChild = child;
   // A cancel during startup had no process to signal; deliver it now.
   if (cancelledSessions.has(sessionId)) {
@@ -1203,6 +1219,12 @@ async function runTurn(
   // now resolves to a denial rather than writing into a vanishing directory or
   // banking a blanket approval for the next turn.
   turnToken.live = false;
+  activeTurnPromptId = undefined;
+  activeTurnToken = undefined;
+  if (promptId !== undefined) {
+    // Its fence, if any, has been dealt with; nothing may consume it later.
+    fencedPromptIds.delete(promptId);
+  }
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
   cleanupDir(attachmentDir);
@@ -1348,7 +1370,7 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "session/prompt requires at least one text block");
         return;
       }
-      const outcome = await runTurn(sessionId, session, prompt);
+      const outcome = await runTurn(sessionId, session, prompt, promptId);
       if (outcome.failure) {
         sendError(id, -32000, `Antigravity turn failed: ${outcome.failure}`);
         return;
@@ -1360,9 +1382,27 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     // a prompt outstanding. Notifications carry no id, so nothing is replied.
     case "t3/fence": {
       const promptId = typeof params["promptId"] === "string" ? params["promptId"] : undefined;
-      if (promptId) {
-        fencedPromptIds.add(promptId);
+      if (!promptId) {
+        return;
       }
+      if (activeTurnToken && promptId === activeTurnPromptId) {
+        // Already running: there is nothing to stop on arrival, so the fence is
+        // applied to the turn itself. Retiring the token denies any approval
+        // still in flight, including ones the adapter would auto-approve.
+        activeTurnToken.live = false;
+        cancelledSessions.add(activeTurnToken.sessionId);
+        activeChild?.kill("SIGTERM");
+        return;
+      }
+      if (fencedPromptIds.size >= MAX_FENCED_PROMPT_IDS) {
+        // Oldest first: a fence this stale describes a prompt that is never
+        // going to arrive.
+        const oldest = fencedPromptIds.values().next();
+        if (!oldest.done) {
+          fencedPromptIds.delete(oldest.value);
+        }
+      }
+      fencedPromptIds.add(promptId);
       return;
     }
     case "session/cancel": {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -83,50 +83,40 @@ const sessions = new Map<string, BridgeSession>();
 // `session/load` — potentially in a fresh bridge process — can still resume
 // the right conversation.
 
-function stateFilePath(): string {
+function stateDirPath(): string {
   const appDataDir =
     process.env["T3_AGY_APP_DATA_DIR"]?.trim() ||
     NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
-  return NodePath.join(appDataDir, "t3code-acp-sessions.json");
+  return NodePath.join(appDataDir, "t3code-acp-sessions");
 }
 
-function readSessionMap(): Record<string, string> {
-  try {
-    const parsed: unknown = JSON.parse(NodeFS.readFileSync(stateFilePath(), "utf8"));
-    if (typeof parsed !== "object" || parsed === null) {
-      return {};
-    }
-    // The bridge does not exclusively own this file, so entries are validated
-    // rather than cast. A non-string value reaching a caller would throw and
-    // leave the request it came from unanswered.
-    const map: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof value === "string") {
-        map[key] = value;
-      }
-    }
-    return map;
-  } catch {
-    return {};
-  }
+/**
+ * One file per session rather than a shared map.
+ *
+ * Several bridge processes can finish turns at once, and a shared map means a
+ * read-modify-write: two writers would each rebuild it from their own stale
+ * snapshot and the later rename would drop the other's entry, silently losing
+ * a thread's conversation. Independent files never contend.
+ *
+ * Returns undefined for a session id that is not a plain token, since the id
+ * becomes a filename and is supplied by the client.
+ */
+function sessionFilePath(sessionId: string): string | undefined {
+  return /^[A-Za-z0-9_-]{1,128}$/.test(sessionId)
+    ? NodePath.join(stateDirPath(), `${sessionId}.json`)
+    : undefined;
 }
 
 function persistConversationId(sessionId: string, conversationId: string): void {
+  const target = sessionFilePath(sessionId);
+  if (!target) {
+    return;
+  }
   try {
-    const target = stateFilePath();
     NodeFS.mkdirSync(NodePath.dirname(target), { recursive: true });
-    const map = readSessionMap();
-    if (map[sessionId] === conversationId) {
-      return;
-    }
-    map[sessionId] = conversationId;
-    // Written through a uniquely-named temp file and renamed into place. The
-    // map is now the sole resume authority and several bridge processes can
-    // finish turns at once; a partial write would be read back as empty JSON
-    // and silently start a fresh conversation. Rename is atomic within a
-    // filesystem, so a reader sees either the old file or the complete new one.
+    // Written aside and renamed so a reader never sees a partial file.
     const staging = `${target}.${process.pid}.${NodeCrypto.randomUUID()}.tmp`;
-    NodeFS.writeFileSync(staging, JSON.stringify(map, null, 2));
+    NodeFS.writeFileSync(staging, JSON.stringify({ conversationId }));
     NodeFS.renameSync(staging, target);
   } catch {
     // Losing the mapping costs conversation continuity on the next resume,
@@ -137,15 +127,30 @@ function persistConversationId(sessionId: string, conversationId: string): void 
 /**
  * Map a bridge session id to the Antigravity conversation it should resume.
  *
- * The persisted map is the only authority. Bridge session ids are themselves
- * random UUIDs, so an id that merely looks like a conversation id is
+ * The persisted record is the only authority. Bridge session ids are random
+ * UUIDs themselves, so an id that merely looks like a conversation id is
  * indistinguishable from one the bridge minted — falling back to the shape of
  * the string would make `session/load` resume a conversation that never
- * existed whenever the map is missing or unreadable. Returning `undefined`
- * starts a fresh conversation, which is the recoverable outcome.
+ * existed. Returning undefined starts a fresh one, which is recoverable.
  */
 function lookupConversationId(sessionId: string): string | undefined {
-  return readSessionMap()[sessionId]?.trim() || undefined;
+  const target = sessionFilePath(sessionId);
+  if (!target) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(NodeFS.readFileSync(target, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return undefined;
+    }
+    // Validated rather than cast: the bridge does not exclusively own this
+    // file, and a non-string value would throw and leave the request that read
+    // it unanswered.
+    const value = (parsed as { conversationId?: unknown }).conversationId;
+    return typeof value === "string" ? value.trim() || undefined : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // ── JSON-RPC plumbing ─────────────────────────────────────────────────
@@ -520,35 +525,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Only `file:` URIs are taken: a remote URL is left in the prompt text for the
  * agent's own fetch tool, and passing one to `--add-dir` would be meaningless.
  */
-function collectAttachments(promptBlocks: ReadonlyArray<unknown>): ReadonlyArray<PromptAttachment> {
-  const attachments: Array<PromptAttachment> = [];
+function collectAttachments(promptBlocks: ReadonlyArray<unknown>): {
+  readonly files: ReadonlyArray<PromptAttachment>;
+  readonly remoteUris: ReadonlyArray<string>;
+} {
+  const files: Array<PromptAttachment> = [];
+  const remoteUris: Array<string> = [];
   for (const block of promptBlocks) {
     if (!isRecord(block) || block["type"] !== "resource_link") {
       continue;
     }
     const uri = block["uri"];
-    if (typeof uri !== "string" || !uri.startsWith("file://")) {
+    if (typeof uri !== "string" || uri.length === 0) {
+      continue;
+    }
+    if (!uri.startsWith("file://")) {
+      // `resource_link` is baseline ACP, so a remote link has to reach the
+      // agent: it goes into the prompt text for Antigravity's own fetch tool.
+      remoteUris.push(uri);
       continue;
     }
     let filePath: string;
     try {
       filePath = NodeURL.fileURLToPath(uri);
     } catch {
+      remoteUris.push(uri);
       continue;
     }
     const name = typeof block["name"] === "string" ? block["name"] : NodePath.basename(filePath);
-    attachments.push({
+    files.push({
       path: filePath,
       name,
       mimeType: typeof block["mimeType"] === "string" ? block["mimeType"] : undefined,
     });
   }
-  return attachments;
+  return { files, remoteUris };
 }
 
 interface RenderedPrompt {
   readonly baseText: string;
   readonly attachments: ReadonlyArray<PromptAttachment>;
+  readonly remoteUris: ReadonlyArray<string>;
 }
 
 function renderPrompt(session: BridgeSession, promptBlocks: unknown): RenderedPrompt | null {
@@ -564,15 +581,16 @@ function renderPrompt(session: BridgeSession, promptBlocks: unknown): RenderedPr
     .join("\n\n")
     .trim();
 
-  const attachments = collectAttachments(promptBlocks);
-  if (text.length === 0 && attachments.length === 0) {
+  const { files, remoteUris } = collectAttachments(promptBlocks);
+  if (text.length === 0 && files.length === 0 && remoteUris.length === 0) {
     return null;
   }
 
   const systemPrompt = session.systemPrompt?.trim();
   return {
     baseText: systemPrompt ? `System instructions:\n${systemPrompt}\n\nRequest:\n${text}` : text,
-    attachments,
+    attachments: files,
+    remoteUris,
   };
 }
 
@@ -599,24 +617,29 @@ function stageAttachments(attachments: ReadonlyArray<PromptAttachment>): {
     // collide and a crafted name cannot escape the staging directory.
     const safeName = `${index}-${NodePath.basename(attachment.name).replace(/[^\w.-]+/g, "_")}`;
     const target = NodePath.join(dir, safeName);
-    try {
-      NodeFS.copyFileSync(attachment.path, target);
-    } catch {
-      // An unreadable attachment is dropped rather than failing the whole turn.
-      return;
-    }
+    // Not swallowed: silently dropping an attachment would run the turn
+    // against a prompt the user did not write, and an attachment-only request
+    // would become an empty prompt that still reports success.
+    NodeFS.copyFileSync(attachment.path, target);
     staged.push({ path: target, name: safeName, mimeType: attachment.mimeType });
   });
   return { dir, staged };
 }
 
-function composePromptText(baseText: string, staged: ReadonlyArray<PromptAttachment>): string {
-  if (staged.length === 0) {
-    return baseText;
+function composePromptText(
+  baseText: string,
+  staged: ReadonlyArray<PromptAttachment>,
+  remoteUris: ReadonlyArray<string>,
+): string {
+  const blocks: Array<string> = [];
+  if (staged.length > 0) {
+    const list = staged.map((a) => `- ${a.path}${a.mimeType ? ` (${a.mimeType})` : ""}`).join("\n");
+    blocks.push(`Attached files (read them from these paths):\n${list}`);
   }
-  const list = staged.map((a) => `- ${a.path}${a.mimeType ? ` (${a.mimeType})` : ""}`).join("\n");
-  const block = `Attached files (read them from these paths):\n${list}`;
-  return baseText.length > 0 ? `${baseText}\n\n${block}` : block;
+  if (remoteUris.length > 0) {
+    blocks.push(`Attached links (fetch them):\n${remoteUris.map((u) => `- ${u}`).join("\n")}`);
+  }
+  return [baseText, ...blocks].filter((part) => part.length > 0).join("\n\n");
 }
 
 interface TurnOutcome {
@@ -653,7 +676,15 @@ function drain(input: {
     const fileText = hook.capturedFileText ?? undefined;
     const update = hookSessionUpdate(hook, input.state, fileText);
     if (update) {
-      sendSessionUpdate(input.sessionId, update);
+      const stepIdx = hook.payload?.stepIdx;
+      if (hook.event === "post-tool-use" && typeof stepIdx === "number") {
+        // Held back rather than sent: the transcript record carrying this
+        // step's real output is usually read later in this same pass, and a
+        // completed call can no longer take content.
+        input.state.pendingTerminal.set(stepIdx, update);
+      } else {
+        sendSessionUpdate(input.sessionId, update);
+      }
     }
     // The hook process is blocked until a decision file appears, so this has
     // to be started for every announced tool call.
@@ -708,8 +739,32 @@ function drain(input: {
       if (result.emittedAssistantText) {
         input.assistantText.emitted = true;
       }
+      // This step's output is out; the call can be completed now.
+      const stepIndex = record.step_index;
+      if (typeof stepIndex === "number") {
+        flushTerminal(input.sessionId, input.state, stepIndex);
+      }
     }
   }
+
+  // Nothing more will arrive, so anything still waiting on a transcript record
+  // that never came is completed without output rather than left spinning.
+  if (input.final) {
+    const remaining = [...input.state.pendingTerminal.values()];
+    input.state.pendingTerminal.clear();
+    for (const terminal of remaining) {
+      sendSessionUpdate(input.sessionId, terminal);
+    }
+  }
+}
+
+function flushTerminal(sessionId: string, state: AgyTurnState, stepIdx: number): void {
+  const terminal = state.pendingTerminal.get(stepIdx);
+  if (!terminal) {
+    return;
+  }
+  state.pendingTerminal.delete(stepIdx);
+  sendSessionUpdate(sessionId, terminal);
 }
 
 /**
@@ -764,7 +819,7 @@ async function runTurn(
         session,
         hookWorkspace,
         attachmentDir,
-        promptText: composePromptText(prompt.baseText, attachments.staged),
+        promptText: composePromptText(prompt.baseText, attachments.staged, prompt.remoteUris),
       }),
       {
         cwd: session.cwd,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -841,20 +841,29 @@ const cancelledSessions = new Set<string>();
  */
 const cancelGenerations = new Map<string, number>();
 /**
- * Sessions with a prompt the client has cancelled but which has not arrived.
+ * Ids of individual prompts the client cancelled before they arrived.
  *
  * The generation check compares a prompt's enqueue-time value against its
  * run-time value, which cannot see a cancel that landed *before* the prompt
  * arrived — the prompt simply reads the post-cancel value and matches, and the
  * runtime forks its cancel notification, so that ordering is real.
  *
- * Set only by the explicit `t3/fence` notification, which the adapter sends —
- * and awaits — before cancelling, and only when it actually has a prompt
- * outstanding. Inferring it from "no turn is running" instead would fence a
- * cancel that merely arrived after its own turn finished, killing the next
- * unrelated prompt.
+ * Keyed by prompt, not by session: every session-scoped variant of this ends
+ * up cancelling some later, unrelated prompt, because "a cancel happened and
+ * no turn is running" also describes a cancel that merely arrived after its
+ * own turn finished. The adapter stamps each submission with an id and names
+ * that exact id when it fences, so a fence can only ever stop the prompt it
+ * was meant for.
  */
-const pendingCancelMarkers = new Set<string>();
+const fencedPromptIds = new Set<string>();
+
+/** The adapter's per-submission id, carried in `_meta.t3.promptId`. */
+function promptIdOf(params: Record<string, unknown>): string | undefined {
+  const meta = params["_meta"];
+  const t3 = isRecord(meta) ? meta["t3"] : undefined;
+  const promptId = isRecord(t3) ? t3["promptId"] : undefined;
+  return typeof promptId === "string" && promptId.length > 0 ? promptId : undefined;
+}
 /** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
 const queuedPromptGenerations = new Map<unknown, number>();
 
@@ -1061,9 +1070,7 @@ async function runTurn(
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
-  // This turn was allowed to start, so no in-transit cancel is outstanding for
-  // it; leaving the marker would stop an unrelated later prompt.
-  pendingCancelMarkers.delete(sessionId);
+
   // Claimed before any setup work: spawning `agy` takes long enough that a
   // cancel can land first, and cancels are only honoured for the session
   // holding this claim. Leaving it unset until after the spawn would silently
@@ -1324,9 +1331,10 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "unknown sessionId");
         return;
       }
-      // Consumed here, so exactly one prompt is stopped by a cancel that
-      // outran it; anything the user sends afterwards runs normally.
-      const cancelledInTransit = pendingCancelMarkers.delete(sessionId);
+      // Consumed by id, so a fence can only stop the prompt it named; anything
+      // the user sends afterwards runs normally.
+      const promptId = promptIdOf(params);
+      const cancelledInTransit = promptId !== undefined && fencedPromptIds.delete(promptId);
       if (
         cancelledInTransit ||
         (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId))
@@ -1351,9 +1359,9 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     // Sent by the adapter immediately before it cancels, and only while it has
     // a prompt outstanding. Notifications carry no id, so nothing is replied.
     case "t3/fence": {
-      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      if (sessionId && sessions.has(sessionId)) {
-        pendingCancelMarkers.add(sessionId);
+      const promptId = typeof params["promptId"] === "string" ? params["promptId"] : undefined;
+      if (promptId) {
+        fencedPromptIds.add(promptId);
       }
       return;
     }
@@ -1418,6 +1426,14 @@ export async function runAgyBridge(): Promise<void> {
       // id but no method, and must never enter the request queue — the turn
       // holding that queue is exactly what is waiting on the answer.
       if (message["method"] === undefined && resolveOutbound(message)) {
+        continue;
+      }
+
+      // Handled out of band alongside cancel. Queued, it would sit behind the
+      // very prompt it is meant to stop and only be recorded once that prompt
+      // had already run.
+      if (message["method"] === "t3/fence") {
+        void handleRequest(message);
         continue;
       }
 

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -64,6 +64,12 @@ const KILL_ESCALATION_MS = 5_000;
 /** Secret shared with hook processes so a decision cannot be forged. */
 const HOOK_SECRET_ENV = "T3_AGY_HOOK_SECRET";
 const HOOK_POLL_INTERVAL_MS = 50;
+/**
+ * Drains a transcript record waits for the hook that would announce its tool
+ * call. Twenty polls is a second — long enough for a hook that is merely late,
+ * short enough that a step no hook will ever cover does not stall the stream.
+ */
+const MAX_DEFERRED_DRAINS = 20;
 const DEFAULT_PRINT_TIMEOUT = "2h";
 const HOOKS_KEY = "t3code-antigravity-observer";
 
@@ -1278,19 +1284,36 @@ function drain(input: {
     }
     // Records held from an earlier pass go first: their hook may have arrived
     // since, and they are older than anything read just now.
-    const held = input.state.deferredRecords.splice(0, input.state.deferredRecords.length);
+    const carried = input.state.deferredRecords.splice(0, input.state.deferredRecords.length);
     const records = [
-      ...held,
+      ...carried,
       ...allLines.map((line) => parseTranscriptLine(line)).filter((r) => r !== null),
     ];
-    for (const record of records) {
+    if (carried.length === 0) {
+      input.state.deferredDrains = 0;
+    }
+    // A deferral is a barrier, not a skip: everything after it is held too.
+    // Emitting later records while an earlier one waits would put a tool's
+    // output after text that followed it, and replay it out of order next pass.
+    //
+    // Bounded, because Antigravity emits steps for its own internal work that
+    // no hook ever announces. Past the limit the held records are released in
+    // order and any still unmatched are dropped, so an unhookable step costs
+    // its own output rather than stalling everything behind it.
+    const held = input.state.deferredRecords;
+    const releasing = input.final || input.state.deferredDrains >= MAX_DEFERRED_DRAINS;
+    for (let index = 0; index < records.length; index += 1) {
+      const record = records[index];
+      if (record === undefined) {
+        continue;
+      }
       const result = transcriptRecordUpdates(record, input.state);
+      if (result.deferred && !releasing) {
+        held.push(...records.slice(index).filter((entry) => entry !== undefined));
+        input.state.deferredDrains += 1;
+        break;
+      }
       if (result.deferred) {
-        // Its tool call has not been announced yet. On the final pass nothing
-        // more is coming, so holding it would only lose it silently.
-        if (!input.final) {
-          input.state.deferredRecords.push(record);
-        }
         continue;
       }
       for (const update of result.updates) {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -961,25 +961,53 @@ let activeChild: NodeChildProcess.ChildProcess | null = null;
  * output can still arrive against a turn that has been reported cancelled.
  */
 /**
- * Process groups signalled but not yet confirmed dead.
+ * Groups signalled but not yet confirmed dead, keyed by the child that owns
+ * them so a pending escalation can be cancelled and never runs twice.
  *
- * `agy` can exit on SIGTERM while a tool it started ignores the signal, and
- * `runTurn` then clears `activeChild`. Only the pending escalation still knew
- * that group existed — and a shutdown inside that window runs no timers, so the
- * tool survived with nothing left to stop it.
+ * A group id is only safe to signal while a member is alive: once the group is
+ * empty the OS may reuse the number, and a delayed SIGKILL would land on
+ * whatever inherited it.
  */
-const pendingKillGroups = new Set<number>();
+const pendingKills = new Map<
+  NodeChildProcess.ChildProcess,
+  { readonly pid: number; timer?: ReturnType<typeof setTimeout> }
+>();
+
+function signalGroupOf(
+  child: NodeChildProcess.ChildProcess,
+  pid: number,
+  signal: NodeJS.Signals,
+): void {
+  try {
+    // Negative pid targets the group, which `detached: true` gave the child.
+    process.kill(-pid, signal);
+  } catch {
+    // Already gone, or never got a group; fall back to the child alone.
+    try {
+      child.kill(signal);
+    } catch {
+      // Nothing left to signal.
+    }
+  }
+}
+
+function clearPendingKill(child: NodeChildProcess.ChildProcess): void {
+  const pending = pendingKills.get(child);
+  if (pending?.timer) {
+    clearTimeout(pending.timer);
+  }
+  pendingKills.delete(child);
+}
 
 /** SIGKILL every group still awaiting escalation. Used on shutdown. */
 function killPendingGroups(): void {
-  for (const pid of pendingKillGroups) {
-    try {
-      process.kill(-pid, "SIGKILL");
-    } catch {
-      // Already gone.
+  for (const [child, pending] of pendingKills) {
+    signalGroupOf(child, pending.pid, "SIGKILL");
+    if (pending.timer) {
+      clearTimeout(pending.timer);
     }
   }
-  pendingKillGroups.clear();
+  pendingKills.clear();
 }
 
 function killActiveChild(options?: { readonly immediate?: boolean }): void {
@@ -1003,35 +1031,40 @@ function killActiveChild(options?: { readonly immediate?: boolean }): void {
     }
     return;
   }
-  const signalGroup = (signal: NodeJS.Signals) => {
-    try {
-      // Negative pid targets the group, which `detached: true` gave the child.
-      process.kill(-pid, signal);
-    } catch {
-      // Already gone, or never got a group; fall back to the child alone.
-      try {
-        child.kill(signal);
-      } catch {
-        // Nothing left to signal.
-      }
-    }
-  };
   if (options?.immediate) {
-    signalGroup("SIGKILL");
-    pendingKillGroups.delete(pid);
+    signalGroupOf(child, pid, "SIGKILL");
+    clearPendingKill(child);
     return;
   }
-  signalGroup("SIGTERM");
-  pendingKillGroups.add(pid);
-  // Escalation does not depend on the leader still being alive. `agy` can exit
-  // on SIGTERM while a tool it started ignores the signal and keeps the group —
-  // and the workspace — busy; signalling a group that has genuinely gone is
-  // harmless, the error is caught above.
+  if (pendingKills.has(child)) {
+    // Already signalled — a fence and the cancel behind it both land here. A
+    // second timer would be another delayed signal nobody cancels.
+    return;
+  }
+  signalGroupOf(child, pid, "SIGTERM");
+  const pending: { readonly pid: number; timer?: ReturnType<typeof setTimeout> } = { pid };
+  pendingKills.set(child, pending);
+  // `agy` can die on SIGTERM while a tool it started ignores it and keeps the
+  // group busy. Killing at that moment is what makes the group id safe to use:
+  // it belongs to us while any member lives, and this runs the instant the
+  // leader goes rather than seconds later, when the number may have been
+  // recycled onto something unrelated.
+  child.once("exit", () => {
+    if (pendingKills.get(child) === pending) {
+      signalGroupOf(child, pid, "SIGKILL");
+      clearPendingKill(child);
+    }
+  });
+  // Backstop for a leader that ignores SIGTERM outright. Safe to target by
+  // group, because the leader is by definition still alive if this fires.
   const escalation = setTimeout(() => {
-    signalGroup("SIGKILL");
-    pendingKillGroups.delete(pid);
+    if (pendingKills.get(child) === pending && child.exitCode === null) {
+      signalGroupOf(child, pid, "SIGKILL");
+    }
+    clearPendingKill(child);
   }, KILL_ESCALATION_MS);
   escalation.unref?.();
+  pending.timer = escalation;
 }
 /** Session whose turn is currently running, if any. Gates `session/cancel`. */
 let activeTurnSessionId: string | null = null;

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -374,11 +374,28 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
       const raw = NodeFS.readFileSync(NodePath.join(hookDir, name), "utf8");
       const parsed: unknown = JSON.parse(raw);
       if (typeof parsed === "object" && parsed !== null) {
-        // Digested from the bytes on disk, which is what the hook itself
-        // hashed; a file swapped in between changes this and the hook rejects
-        // the decision rather than acting on a request nobody approved.
-        hookPayloadDigests.set(name, digestPayload((parsed as AgyHookEvent).rawPayload ?? ""));
-        events.push({ name, event: parsed as AgyHookEvent });
+        const record = parsed as AgyHookEvent;
+        // The signed digest and the payload shown to the user must come from
+        // the same bytes. Taking the outer `payload` for display while signing
+        // `rawPayload` would let an attacker rewrite only the outer copy: the
+        // user approves harmless-looking arguments, the hook's digest still
+        // matches its untouched stdin, and the original request runs.
+        const raw = record.rawPayload;
+        if (typeof raw !== "string") {
+          continue;
+        }
+        let payload: AgyHookPayload;
+        try {
+          const reparsed: unknown = JSON.parse(raw);
+          if (typeof reparsed !== "object" || reparsed === null) {
+            continue;
+          }
+          payload = reparsed as AgyHookPayload;
+        } catch {
+          continue;
+        }
+        hookPayloadDigests.set(name, digestPayload(raw));
+        events.push({ name, event: { ...record, payload } });
       }
     } catch {
       // A half-written hook file is picked up on the next poll.
@@ -924,7 +941,7 @@ let activeChild: NodeChildProcess.ChildProcess | null = null;
  * mid-write keeps changing the workspace after the user pressed Stop, and its
  * output can still arrive against a turn that has been reported cancelled.
  */
-function killActiveChild(): void {
+function killActiveChild(options?: { readonly immediate?: boolean }): void {
   const child = activeChild;
   if (!child?.pid) {
     return;
@@ -958,6 +975,10 @@ function killActiveChild(): void {
       }
     }
   };
+  if (options?.immediate) {
+    signalGroup("SIGKILL");
+    return;
+  }
   signalGroup("SIGTERM");
   // Escalation does not depend on the leader still being alive. `agy` can exit
   // on SIGTERM while a tool it started ignores the signal and keeps the group —
@@ -1378,6 +1399,9 @@ async function runTurn(
   // now resolves to a denial rather than writing into a vanishing directory or
   // banking a blanket approval for the next turn.
   turnToken.live = false;
+  // Scoped to the turn: every hook of every turn would otherwise stay in here
+  // for the life of the bridge.
+  hookPayloadDigests.clear();
   activeTurnEpoch = undefined;
   activeTurnToken = undefined;
   cleanupDir(hookDir);
@@ -1610,9 +1634,12 @@ export async function runAgyBridge(): Promise<void> {
   // otherwise. Losing the bridge — a signal, a crashing parent — would
   // otherwise leave `agy` and its tools running against the user's workspace
   // with nothing left to stop them.
+  // Shutdown kills outright rather than scheduling an escalation: `process.exit`
+  // runs no timers, so a graceful SIGTERM here would leave a tool that ignores
+  // it alive in its own detached group with the bridge already gone.
   const stopChildOnExit = () => {
     shuttingDown = true;
-    killActiveChild();
+    killActiveChild({ immediate: true });
   };
   process.once("SIGTERM", () => {
     stopChildOnExit();

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -57,6 +57,10 @@ const DECISION_SUFFIX = ".decision";
 const APPROVAL_WAIT_MS = 10 * 60 * 1000;
 const APPROVAL_HOOK_TIMEOUT_SECONDS = 11 * 60;
 const APPROVAL_POLL_INTERVAL_MS = 50;
+/** Grace period before a cancelled process group is killed outright. */
+const KILL_ESCALATION_MS = 5_000;
+/** Secret shared with hook processes so a decision cannot be forged. */
+const HOOK_SECRET_ENV = "T3_AGY_HOOK_SECRET";
 const HOOK_POLL_INTERVAL_MS = 50;
 const DEFAULT_PRINT_TIMEOUT = "2h";
 const HOOKS_KEY = "t3code-antigravity-observer";
@@ -416,11 +420,33 @@ function decisionPath(hookDir: string, hookName: string): string {
   return NodePath.join(hookDir, `${hookName}${DECISION_SUFFIX}`);
 }
 
+/**
+ * Authenticate a decision so only this bridge can issue one.
+ *
+ * The decision is a file in a temp directory, and anything running as the user
+ * — including a tool the user has just approved — could otherwise drop an
+ * `allow` there and have every later tool wave itself through. The secret is
+ * generated per bridge process and reaches the hook through its environment,
+ * so a forged file fails the check and is treated as no decision at all.
+ */
+function signDecision(hookName: string, decision: AgyHookDecision): string {
+  // Both sides resolve the same value: the bridge holds it in memory, and the
+  // hook — a separate process — reads the copy handed to it in its
+  // environment.
+  const secret = process.env[HOOK_SECRET_ENV] || hookSecret;
+  return NodeCrypto.createHmac("sha256", secret)
+    .update(`${hookName}:${decision.decision}`)
+    .digest("hex");
+}
+
 function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecision): void {
   try {
     const target = decisionPath(hookDir, hookName);
     const staging = `${target}.tmp`;
-    NodeFS.writeFileSync(staging, JSON.stringify(decision));
+    NodeFS.writeFileSync(
+      staging,
+      JSON.stringify({ ...decision, mac: signDecision(hookName, decision) }),
+    );
     NodeFS.renameSync(staging, target);
   } catch {
     // The waiting hook falls back to denying when its deadline passes, which
@@ -617,7 +643,22 @@ async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHook
       const raw = NodeFS.readFileSync(target, "utf8");
       const parsed: unknown = JSON.parse(raw);
       if (isRecord(parsed) && (parsed["decision"] === "allow" || parsed["decision"] === "deny")) {
-        return parsed as unknown as AgyHookDecision;
+        const decision = { decision: parsed["decision"] } as AgyHookDecision;
+        const expected = signDecision(hookName, decision);
+        const presented = typeof parsed["mac"] === "string" ? parsed["mac"] : "";
+        // Length-checked before comparing: `timingSafeEqual` throws on a
+        // mismatch, and an unsigned file is a forgery either way.
+        if (
+          presented.length === expected.length &&
+          NodeCrypto.timingSafeEqual(Buffer.from(presented), Buffer.from(expected))
+        ) {
+          return {
+            decision: decision.decision,
+            ...(typeof parsed["reason"] === "string" ? { reason: parsed["reason"] } : {}),
+          };
+        }
+        // Unsigned or forged: ignore it and keep waiting, so a planted file
+        // cannot allow a tool and cannot short-circuit a real decision either.
       }
     } catch {
       // Not written yet, or written partially; try again.
@@ -825,7 +866,48 @@ interface TurnOutcome {
   readonly failure?: string;
 }
 
+/**
+ * Per-process secret authenticating approval decisions. Reaches hook processes
+ * through their environment and never touches disk.
+ */
+const hookSecret = NodeCrypto.randomBytes(32).toString("hex");
+
 let activeChild: NodeChildProcess.ChildProcess | null = null;
+
+/**
+ * Stop the running turn's whole process group, escalating if it lingers.
+ *
+ * Signalling only the direct child leaves anything it spawned running: a tool
+ * mid-write keeps changing the workspace after the user pressed Stop, and its
+ * output can still arrive against a turn that has been reported cancelled.
+ */
+function killActiveChild(): void {
+  const child = activeChild;
+  if (!child?.pid) {
+    return;
+  }
+  const { pid } = child;
+  const signalGroup = (signal: NodeJS.Signals) => {
+    try {
+      // Negative pid targets the group, which `detached: true` gave the child.
+      process.kill(-pid, signal);
+    } catch {
+      // Already gone, or never got a group; fall back to the child alone.
+      try {
+        child.kill(signal);
+      } catch {
+        // Nothing left to signal.
+      }
+    }
+  };
+  signalGroup("SIGTERM");
+  const escalation = setTimeout(() => {
+    if (activeChild === child && child.exitCode === null && child.signalCode === null) {
+      signalGroup("SIGKILL");
+    }
+  }, KILL_ESCALATION_MS);
+  escalation.unref?.();
+}
 /** Session whose turn is currently running, if any. Gates `session/cancel`. */
 let activeTurnSessionId: string | null = null;
 /**
@@ -1120,8 +1202,12 @@ async function runTurn(
       }),
       {
         cwd: session.cwd,
-        env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
+        env: { ...process.env, [HOOK_DIR_ENV]: hookDir, [HOOK_SECRET_ENV]: hookSecret },
         stdio: ["ignore", "pipe", "pipe"],
+        // Its own process group, so cancelling can reach the tools `agy`
+        // spawned rather than only `agy` itself. A tool left running keeps
+        // modifying the workspace after Stop.
+        detached: true,
       },
     );
   } catch (error) {
@@ -1155,7 +1241,7 @@ async function runTurn(
   activeChild = child;
   // A cancel during startup had no process to signal; deliver it now.
   if (cancelledSessions.has(sessionId)) {
-    child.kill("SIGTERM");
+    killActiveChild();
   }
 
   let stdout = "";
@@ -1412,7 +1498,7 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       ) {
         activeTurnToken.live = false;
         cancelledSessions.add(sessionId);
-        activeChild?.kill("SIGTERM");
+        killActiveChild();
       }
       return;
     }
@@ -1441,7 +1527,7 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // that carried an epoch is stopped only if that epoch was cancelled.
         if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
           cancelledSessions.add(sessionId);
-          activeChild?.kill("SIGTERM");
+          killActiveChild();
         }
       }
       return;
@@ -1555,6 +1641,6 @@ export async function runAgyBridge(): Promise<void> {
   // only resolves when `agy` exits, so waiting first would keep the bridge and
   // its child alive for the whole print timeout — hours — after the client
   // disconnected.
-  activeChild?.kill("SIGTERM");
+  killActiveChild();
   await queue;
 }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -236,23 +236,36 @@ function sendSessionUpdate(sessionId: string, update: AgySessionUpdate): void {
 let nextOutboundId = 1;
 const pendingOutbound = new Map<
   number,
-  { readonly resolve: (value: unknown) => void; readonly reject: (error: Error) => void }
+  {
+    readonly resolve: (value: unknown) => void;
+    readonly reject: (error: Error) => void;
+    /** Deadline for this request; cleared when it settles. */
+    timer?: ReturnType<typeof setTimeout>;
+  }
 >();
 
 function sendRequest(method: string, params: unknown, timeoutMs?: number): Promise<unknown> {
   const id = nextOutboundId;
   nextOutboundId += 1;
   return new Promise((resolve, reject) => {
-    pendingOutbound.set(id, { resolve, reject });
+    const pending: {
+      readonly resolve: (value: unknown) => void;
+      readonly reject: (error: Error) => void;
+      timer?: ReturnType<typeof setTimeout>;
+    } = { resolve, reject };
+    pendingOutbound.set(id, pending);
     if (timeoutMs !== undefined) {
       // A client that never answers would otherwise pin this entry for the
-      // life of the bridge process.
+      // life of the bridge process. Held on the entry so an answered request
+      // can drop it — `unref` keeps the timer from holding the loop open but
+      // still retains the closure until it fires.
       const timer = setTimeout(() => {
         if (pendingOutbound.delete(id)) {
           reject(new Error(`${method} timed out`));
         }
       }, timeoutMs);
       timer.unref?.();
+      pending.timer = timer;
     }
     writeMessage({ jsonrpc: "2.0", id, method, params });
   });
@@ -272,6 +285,9 @@ function resolveOutbound(message: Record<string, unknown>): boolean {
   if (!pending) {
     return false;
   }
+  if (pending.timer) {
+    clearTimeout(pending.timer);
+  }
   const error = message["error"];
   if (isRecord(error)) {
     const detail = typeof error["message"] === "string" ? error["message"] : "request failed";
@@ -285,6 +301,9 @@ function resolveOutbound(message: Record<string, unknown>): boolean {
 /** Reject everything still outstanding; used when the client goes away. */
 function failPendingOutbound(reason: string): void {
   for (const [, pending] of pendingOutbound) {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
     pending.reject(new Error(reason));
   }
   pendingOutbound.clear();

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -249,8 +249,25 @@ function lookupConversationId(sessionId: string): string | undefined {
 
 // ── JSON-RPC plumbing ─────────────────────────────────────────────────
 
+/**
+ * Set while stdout has reported that it is behind.
+ *
+ * Node buffers whatever `write` cannot hand over immediately, so ignoring its
+ * return value turns a slow reader into unbounded growth inside this process.
+ * Polling pauses while this is set. Nothing is lost by waiting: the transcript
+ * stays on disk and is read from its own byte offset, so a skipped poll only
+ * defers work to the next one.
+ */
+let stdoutBlocked = false;
+
 function writeMessage(value: unknown): void {
-  process.stdout.write(`${JSON.stringify(value)}\n`);
+  const flushed = process.stdout.write(`${JSON.stringify(value)}\n`);
+  if (!flushed && !stdoutBlocked) {
+    stdoutBlocked = true;
+    process.stdout.once("drain", () => {
+      stdoutBlocked = false;
+    });
+  }
 }
 
 function sendResult(id: unknown, result: unknown): void {
@@ -1720,6 +1737,12 @@ async function runTurn(
   });
 
   const poller = setInterval(() => {
+    // Skipped rather than queued behind a reader that is already behind. Only
+    // the interval pauses: the final drain below runs regardless, so a turn
+    // ending while stdout is congested still reports everything it owes.
+    if (stdoutBlocked) {
+      return;
+    }
     drain({
       sessionId,
       hookDir,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1507,19 +1507,25 @@ async function runTurn(
   // and stderr only has to carry enough to explain a failure.
   let stdout = "";
   let stderr = "";
-  const appendBounded = (current: string, chunk: string): string => {
+  let stdoutTruncated = false;
+  let stderrTruncated = false;
+  const appendBounded = (current: string, chunk: string): [string, boolean] => {
     const combined = current + chunk;
     return combined.length <= MAX_CAPTURED_OUTPUT
-      ? combined
-      : combined.slice(combined.length - MAX_CAPTURED_OUTPUT);
+      ? [combined, false]
+      : [combined.slice(combined.length - MAX_CAPTURED_OUTPUT), true];
   };
   child.stdout?.setEncoding("utf8");
   child.stdout?.on("data", (chunk: string) => {
-    stdout = appendBounded(stdout, chunk);
+    const [next, dropped] = appendBounded(stdout, chunk);
+    stdout = next;
+    stdoutTruncated = stdoutTruncated || dropped;
   });
   child.stderr?.setEncoding("utf8");
   child.stderr?.on("data", (chunk: string) => {
-    stderr = appendBounded(stderr, chunk);
+    const [next, dropped] = appendBounded(stderr, chunk);
+    stderr = next;
+    stderrTruncated = stderrTruncated || dropped;
   });
 
   const poller = setInterval(() => {
@@ -1599,7 +1605,13 @@ async function runTurn(
     return { stopReason: "cancelled" };
   }
   if (exitCode !== 0) {
-    const detail = stderr.trim() || stdout.trim() || `agy exited with code ${exitCode}`;
+    const captured = stderr.trim() || stdout.trim();
+    const truncated = stderr.trim() ? stderrTruncated : stdoutTruncated;
+    const detail = captured
+      ? truncated
+        ? `[earlier output dropped] ${captured}`
+        : captured
+      : `agy exited with code ${exitCode}`;
     return { stopReason: "end_turn", failure: detail };
   }
 
@@ -1607,9 +1619,15 @@ async function runTurn(
   // when transcript observation produced nothing, so the reply is never
   // duplicated.
   if (!assistantText.emitted && stdout.trim().length > 0) {
+    // Says so when it is only the tail. Presenting a suffix as the whole reply
+    // reads as a complete answer that happens to begin mid-sentence, which is
+    // worse than admitting the beginning was dropped.
+    const text = stdoutTruncated
+      ? `[Earlier output dropped: the reply exceeded ${Math.floor(MAX_CAPTURED_OUTPUT / 1024)} KiB.]\n\n${stdout.trim()}`
+      : stdout.trim();
     sendSessionUpdate(sessionId, {
       sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text: stdout.trim() },
+      content: { type: "text", text },
     });
   }
   return { stopReason: "end_turn" };
@@ -1779,40 +1797,36 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      if (sessionId && sessions.has(sessionId) && sessionId !== activeTurnSessionId) {
-        // No turn running for it yet. Banked only when a prompt is genuinely
-        // waiting: a cancel that merely arrived after its own turn finished
-        // would otherwise sit here and stop something sent much later. A prompt
-        // carrying an epoch is already covered by the mark and consumes no
-        // marker, so this only ever applies to an untagged one.
+      if (!sessionId || !sessions.has(sessionId)) {
+        return;
+      }
+      // Recorded before anything else. A cancel bypasses the request queue and
+      // its prompt does not, so the two can arrive together with the prompt
+      // still waiting — and returning early below would drop the epoch and let
+      // that prompt spawn `agy` after the Stop that was meant to catch it.
+      const cancelEpoch = typeof params["epoch"] === "number" ? params["epoch"] : undefined;
+      if (cancelEpoch !== undefined) {
+        cancelledThroughEpoch.set(sessionId, Math.max(cancelledThrough(sessionId), cancelEpoch));
+      }
+      if (sessionId !== activeTurnSessionId) {
+        // No turn running for it yet. An untagged prompt has no epoch to be
+        // measured against, so it needs a marker — banked only when one is
+        // genuinely waiting, or a cancel that merely arrived after its own turn
+        // finished would sit here and stop something sent much later.
         if (queuedUntagged(sessionId) > 0) {
           unscopedCancels.add(sessionId);
         }
         return;
       }
-      if (sessionId && sessions.has(sessionId) && sessionId === activeTurnSessionId) {
-        // Only the turn actually running is stopped, and only when its epoch
-        // has been cancelled. A prompt accepted after the fence carries a
-        // higher epoch and must survive this notification, which the runtime
-        // forks and can therefore deliver late.
-        //
-        // A cancel carries the epoch it covers, so it can stand in for a fence
-        // that failed to send without reaching past its own turn. Promoting the
-        // mark to whatever happened to be running would let a late cancel kill
-        // a prompt accepted after it — the runtime forks this notification, so
-        // arriving late is normal.
-        const cancelEpoch = typeof params["epoch"] === "number" ? params["epoch"] : undefined;
-        if (cancelEpoch !== undefined) {
-          cancelledThroughEpoch.set(sessionId, Math.max(cancelledThrough(sessionId), cancelEpoch));
-        }
-        // Judged by the running turn's own mode, not by anything the session
-        // did earlier. A turn whose prompt carried no epoch cannot be scoped by
-        // a mark it never contributed to, so it takes plain ACP semantics; one
-        // that carried an epoch is stopped only if that epoch was cancelled.
-        if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
-          cancelledSessions.add(sessionId);
-          killActiveChild();
-        }
+      // Only the turn actually running is stopped, and only when its epoch has
+      // been cancelled: a prompt accepted after the fence carries a higher one
+      // and must survive this notification, which the runtime forks and can
+      // therefore deliver late. A turn whose prompt carried no epoch cannot be
+      // scoped by a mark it never contributed to, so it takes plain ACP
+      // semantics.
+      if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
+        cancelledSessions.add(sessionId);
+        killActiveChild();
       }
       return;
     }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -841,14 +841,18 @@ const cancelledSessions = new Set<string>();
  */
 const cancelGenerations = new Map<string, number>();
 /**
- * Sessions cancelled while no turn was running.
+ * Sessions with a prompt the client has cancelled but which has not arrived.
  *
  * The generation check compares a prompt's enqueue-time value against its
  * run-time value, which cannot see a cancel that landed *before* the prompt
- * arrived — the prompt simply reads the post-cancel value and matches. The
- * runtime forks its cancel notification, so that ordering is real. This
- * one-shot marker is consumed by the next prompt for the session, which then
- * refuses to start.
+ * arrived — the prompt simply reads the post-cancel value and matches, and the
+ * runtime forks its cancel notification, so that ordering is real.
+ *
+ * Set only by the explicit `t3/fence` notification, which the adapter sends —
+ * and awaits — before cancelling, and only when it actually has a prompt
+ * outstanding. Inferring it from "no turn is running" instead would fence a
+ * cancel that merely arrived after its own turn finished, killing the next
+ * unrelated prompt.
  */
 const pendingCancelMarkers = new Set<string>();
 /** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
@@ -1309,14 +1313,17 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       return;
     }
     case "session/prompt": {
+      // Read and cleared before the session is validated: an unknown session
+      // returns early below, and leaving the entry behind would grow this map
+      // for every bad id a client sends.
+      const queuedAt = queuedPromptGenerations.get(id);
+      queuedPromptGenerations.delete(id);
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
       const session = sessionId ? sessions.get(sessionId) : undefined;
       if (!sessionId || !session) {
         sendError(id, -32602, "unknown sessionId");
         return;
       }
-      const queuedAt = queuedPromptGenerations.get(id);
-      queuedPromptGenerations.delete(id);
       // Consumed here, so exactly one prompt is stopped by a cancel that
       // outran it; anything the user sends afterwards runs normally.
       const cancelledInTransit = pendingCancelMarkers.delete(sessionId);
@@ -1341,16 +1348,22 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       sendResult(id, { stopReason: outcome.stopReason });
       return;
     }
+    // Sent by the adapter immediately before it cancels, and only while it has
+    // a prompt outstanding. Notifications carry no id, so nothing is replied.
+    case "t3/fence": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      if (sessionId && sessions.has(sessionId)) {
+        pendingCancelMarkers.add(sessionId);
+      }
+      return;
+    }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      if (sessionId) {
+      if (sessionId && sessions.has(sessionId)) {
         // Always recorded, so prompts already queued for this session can see
         // that a cancel happened and refuse to start.
         cancelGenerations.set(sessionId, cancelGeneration(sessionId) + 1);
-        if (sessionId !== activeTurnSessionId) {
-          // No turn to interrupt, so this cancel is for one still in transit.
-          pendingCancelMarkers.add(sessionId);
-        }
+
         // Only a cancel aimed at the turn actually running decides its stop
         // reason. Cancels bypass the request queue, so one arriving after a
         // turn finished — or targeting an idle session — must not sit in the
@@ -1419,7 +1432,7 @@ export async function runAgyBridge(): Promise<void> {
       // exactly the window a cancel has to arrive in while this prompt waits.
       if (pending["method"] === "session/prompt") {
         const target = (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"];
-        if (typeof target === "string" && pending["id"] !== undefined) {
+        if (typeof target === "string" && pending["id"] !== undefined && sessions.has(target)) {
           queuedPromptGenerations.set(pending["id"], cancelGeneration(target));
         }
       }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1,0 +1,646 @@
+/**
+ * ACP compatibility bridge for the Antigravity CLI (`agy`).
+ *
+ * Antigravity exposes no native agent protocol. This module speaks the slice
+ * of ACP that `AcpSessionRuntime` uses over stdio and executes each turn
+ * through Antigravity's documented non-interactive `--print` mode, while
+ * reconstructing a live event stream from hooks and the trajectory transcript
+ * (see `agyEvents.ts` and `agyTranscript.ts`).
+ *
+ * Runs as a subcommand of the server binary (`t3 agy-acp`) so it ships inside
+ * the same bundle rather than as a loose script.
+ *
+ * @module provider/acp/antigravity/agyBridge
+ */
+// @effect-diagnostics nodeBuiltinImport:off - Standalone stdio bridge process, not an Effect runtime.
+// @effect-diagnostics globalTimers:off - Polls Antigravity hook output outside any Effect runtime.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeCrypto from "node:crypto";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import packageJson from "../../../../package.json" with { type: "json" };
+import {
+  agyHookResponse,
+  agyTargetPath,
+  agyToolKind,
+  hookSessionUpdate,
+  makeAgyTurnState,
+  type AgyHookEvent,
+  type AgyHookPayload,
+  type AgySessionUpdate,
+  type AgyTurnState,
+} from "./agyEvents.ts";
+import {
+  AgyTranscriptCursor,
+  parseTranscriptLine,
+  transcriptRecordUpdates,
+} from "./agyTranscript.ts";
+
+const HOOK_DIR_ENV = "T3_AGY_HOOK_DIR";
+const HOOK_POLL_INTERVAL_MS = 50;
+const DEFAULT_PRINT_TIMEOUT = "2h";
+const HOOKS_KEY = "t3code-antigravity-observer";
+
+interface BridgeSession {
+  readonly cwd: string;
+  systemPrompt: string | undefined;
+  conversationId: string | undefined;
+}
+
+const sessions = new Map<string, BridgeSession>();
+
+// ── Session id ⇄ Antigravity conversation id ──────────────────────────
+//
+// `session/new` must return an id before the first turn runs, which is before
+// Antigravity has created a trajectory. The mapping is persisted so a later
+// `session/load` — potentially in a fresh bridge process — can still resume
+// the right conversation.
+
+function stateFilePath(): string {
+  const appDataDir =
+    process.env["T3_AGY_APP_DATA_DIR"]?.trim() ||
+    NodePath.join(NodeOS.homedir(), ".gemini", "antigravity-cli");
+  return NodePath.join(appDataDir, "t3code-acp-sessions.json");
+}
+
+function readSessionMap(): Record<string, string> {
+  try {
+    const parsed: unknown = JSON.parse(NodeFS.readFileSync(stateFilePath(), "utf8"));
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistConversationId(sessionId: string, conversationId: string): void {
+  try {
+    const target = stateFilePath();
+    NodeFS.mkdirSync(NodePath.dirname(target), { recursive: true });
+    const map = readSessionMap();
+    if (map[sessionId] === conversationId) {
+      return;
+    }
+    map[sessionId] = conversationId;
+    NodeFS.writeFileSync(target, JSON.stringify(map, null, 2));
+  } catch {
+    // Losing the mapping costs conversation continuity on the next resume,
+    // which is not worth failing a turn over.
+  }
+}
+
+function lookupConversationId(sessionId: string): string | undefined {
+  const mapped = readSessionMap()[sessionId]?.trim();
+  if (mapped) {
+    return mapped;
+  }
+  // A caller may hand back an Antigravity conversation UUID directly.
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)
+    ? sessionId
+    : undefined;
+}
+
+// ── JSON-RPC plumbing ─────────────────────────────────────────────────
+
+function writeMessage(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function sendResult(id: unknown, result: unknown): void {
+  writeMessage({ jsonrpc: "2.0", id, result });
+}
+
+function sendError(id: unknown, code: number, message: string): void {
+  writeMessage({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function sendSessionUpdate(sessionId: string, update: AgySessionUpdate): void {
+  writeMessage({
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: { sessionId, update },
+  });
+}
+
+// ── Hook observer ─────────────────────────────────────────────────────
+
+/**
+ * Hook command the bridge registers with Antigravity. Re-invokes this same
+ * binary so the observer always matches the running bridge.
+ */
+function hookCommandFor(event: string): string {
+  const entry = process.argv[1];
+  const base = entry
+    ? `${quoteArg(process.execPath)} ${quoteArg(entry)}`
+    : quoteArg(process.execPath);
+  return `${base} agy-hook --event ${event}`;
+}
+
+function quoteArg(value: string): string {
+  return /[\s"']/.test(value) ? `"${value.replace(/(["\\$`])/g, "\\$1")}"` : value;
+}
+
+/**
+ * Build a throwaway workspace directory whose only purpose is carrying
+ * `.agents/hooks.json`. Antigravity loads `.agents` from every `--add-dir`
+ * path, so the observer attaches without writing anything into the user's
+ * repository.
+ */
+function createHookWorkspace(): string {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hooks-"));
+  const agentsDir = NodePath.join(dir, ".agents");
+  NodeFS.mkdirSync(agentsDir, { recursive: true });
+  const toolHook = (event: string) => [
+    { matcher: "*", hooks: [{ type: "command", command: hookCommandFor(event), timeout: 10 }] },
+  ];
+  NodeFS.writeFileSync(
+    NodePath.join(agentsDir, "hooks.json"),
+    JSON.stringify(
+      {
+        [HOOKS_KEY]: {
+          PreToolUse: toolHook("pre-tool-use"),
+          PostToolUse: toolHook("post-tool-use"),
+          Stop: [{ type: "command", command: hookCommandFor("stop"), timeout: 10 }],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  return dir;
+}
+
+function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<AgyHookEvent> {
+  let entries: Array<string>;
+  try {
+    entries = NodeFS.readdirSync(hookDir);
+  } catch {
+    return [];
+  }
+  const events: Array<AgyHookEvent> = [];
+  for (const name of entries.filter((n) => n.endsWith(".json")).sort()) {
+    if (seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    try {
+      const raw = NodeFS.readFileSync(NodePath.join(hookDir, name), "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null) {
+        events.push(parsed as AgyHookEvent);
+      }
+    } catch {
+      // A half-written hook file is picked up on the next poll.
+      seen.delete(name);
+    }
+  }
+  return events;
+}
+
+/**
+ * Largest file the hook will inline into its event record. A diff of anything
+ * bigger is not worth the memory it would cost on both sides.
+ */
+const MAX_CAPTURED_FILE_BYTES = 2 * 1024 * 1024;
+
+function captureFileText(path: string | undefined): string | null {
+  if (!path) {
+    return null;
+  }
+  try {
+    const stats = NodeFS.statSync(path);
+    if (!stats.isFile() || stats.size > MAX_CAPTURED_FILE_BYTES) {
+      return null;
+    }
+    return NodeFS.readFileSync(path, "utf8");
+  } catch {
+    // A new file has no prior contents; that is a valid diff with no oldText.
+    return null;
+  }
+}
+
+/** Entry point for `t3 agy-hook <event>`. */
+export async function runAgyHook(event: string): Promise<void> {
+  let raw = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    raw += chunk;
+  }
+
+  const hookDir = process.env[HOOK_DIR_ENV]?.trim();
+  if (hookDir) {
+    try {
+      const payload = JSON.parse(raw) as AgyHookPayload;
+      const record: AgyHookEvent = {
+        event,
+        payload,
+        // Snapshot the file here, while the hook still brackets the tool call.
+        ...(agyToolKind(payload?.toolCall?.name) === "edit"
+          ? { capturedFileText: captureFileText(agyTargetPath(payload?.toolCall)) }
+          : {}),
+      };
+      const name = `${process.hrtime.bigint().toString().padStart(24, "0")}-${event}.json`;
+      // Write then rename so the poller never observes a partial file.
+      const finalPath = NodePath.join(hookDir, name);
+      const tempPath = `${finalPath}.tmp`;
+      NodeFS.writeFileSync(tempPath, JSON.stringify(record));
+      NodeFS.renameSync(tempPath, finalPath);
+    } catch {
+      // Observation is best-effort: a hook must never break a tool call.
+    }
+  }
+
+  process.stdout.write(JSON.stringify(agyHookResponse(event, Boolean(hookDir))));
+}
+
+// ── Turn execution ────────────────────────────────────────────────────
+
+function buildAgyArgs(
+  session: BridgeSession,
+  hookWorkspace: string,
+  prompt: string,
+): Array<string> {
+  const args = [
+    "--dangerously-skip-permissions",
+    "--print-timeout",
+    process.env["T3_AGY_PRINT_TIMEOUT"]?.trim() || DEFAULT_PRINT_TIMEOUT,
+  ];
+  const model = process.env["T3_AGY_MODEL"]?.trim();
+  if (model) {
+    args.push("--model", model);
+  }
+  const effort = process.env["T3_AGY_EFFORT"]?.trim();
+  if (effort) {
+    args.push("--effort", effort);
+  }
+  if (session.conversationId) {
+    args.push("--conversation", session.conversationId);
+  }
+  // Print mode does not infer workspace customizations from cwd alone. The
+  // session workspace is registered so its `.agents` skills and rules load;
+  // the hook workspace is registered so the observer attaches.
+  args.push("--add-dir", session.cwd, "--add-dir", hookWorkspace);
+  args.push("--print", prompt);
+  return args;
+}
+
+function renderPrompt(session: BridgeSession, promptBlocks: unknown): string | null {
+  if (!Array.isArray(promptBlocks)) {
+    return null;
+  }
+  const text = promptBlocks
+    .filter(
+      (block): block is { type: string; text: string } =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string",
+    )
+    .map((block) => block.text)
+    .join("\n\n");
+  if (text.trim().length === 0) {
+    return null;
+  }
+  const systemPrompt = session.systemPrompt?.trim();
+  return systemPrompt ? `System instructions:\n${systemPrompt}\n\nRequest:\n${text}` : text;
+}
+
+interface TurnOutcome {
+  readonly stopReason: "end_turn" | "cancelled";
+  readonly failure?: string;
+}
+
+let activeChild: NodeChildProcess.ChildProcess | null = null;
+const cancelledSessions = new Set<string>();
+
+/**
+ * Drain everything Antigravity has produced so far and emit it as ACP updates.
+ *
+ * Hooks are read first so a tool call is always announced before the
+ * transcript record carrying its output is matched against it.
+ */
+function drain(input: {
+  readonly sessionId: string;
+  readonly hookDir: string;
+  readonly seenHooks: Set<string>;
+  readonly state: AgyTurnState;
+  readonly cursor: AgyTranscriptCursor;
+  readonly transcriptOffset: { value: number };
+  readonly assistantText: { emitted: boolean };
+  readonly final: boolean;
+}): void {
+  for (const hook of readHookEvents(input.hookDir, input.seenHooks)) {
+    // Diffing the file contents each hook captured, rather than the arguments
+    // of the edit, keeps this correct across tools whose argument shapes
+    // differ (`replace_file_content` sends a fragment, `write_to_file` sends
+    // the whole file).
+    const fileText = hook.capturedFileText ?? undefined;
+    const update = hookSessionUpdate(hook, input.state, fileText);
+    if (update) {
+      sendSessionUpdate(input.sessionId, update);
+    }
+  }
+
+  const transcriptPath = resolveTranscriptPath(input.state);
+  if (transcriptPath) {
+    let chunk = "";
+    try {
+      const stats = NodeFS.statSync(transcriptPath);
+      if (stats.size > input.transcriptOffset.value) {
+        const fd = NodeFS.openSync(transcriptPath, "r");
+        try {
+          const length = stats.size - input.transcriptOffset.value;
+          const buffer = Buffer.alloc(length);
+          NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
+          chunk = buffer.toString("utf8");
+          input.transcriptOffset.value = stats.size;
+        } finally {
+          NodeFS.closeSync(fd);
+        }
+      }
+    } catch {
+      chunk = "";
+    }
+
+    const lines = chunk.length > 0 ? input.cursor.push(chunk) : [];
+    const allLines = input.final ? [...lines, ...input.cursor.flush()] : lines;
+    for (const line of allLines) {
+      const record = parseTranscriptLine(line);
+      if (!record) {
+        continue;
+      }
+      const result = transcriptRecordUpdates(record, input.state);
+      for (const update of result.updates) {
+        sendSessionUpdate(input.sessionId, update);
+      }
+      if (result.emittedAssistantText) {
+        input.assistantText.emitted = true;
+      }
+    }
+  }
+}
+
+/**
+ * Hooks report `transcript_full.jsonl`; the sibling `transcript.jsonl` holds
+ * the same steps without internal model chatter and is the better stream to
+ * render.
+ */
+function resolveTranscriptPath(state: AgyTurnState): string | undefined {
+  const reported = state.transcriptPath;
+  if (!reported) {
+    return undefined;
+  }
+  const condensed = reported.replace(/transcript_full\.jsonl$/, "transcript.jsonl");
+  return NodeFS.existsSync(condensed) ? condensed : reported;
+}
+
+async function runTurn(
+  sessionId: string,
+  session: BridgeSession,
+  prompt: string,
+): Promise<TurnOutcome> {
+  const hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
+  const hookWorkspace = createHookWorkspace();
+  const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
+  const state = makeAgyTurnState(session.conversationId);
+  const seenHooks = new Set<string>();
+  const cursor = new AgyTranscriptCursor();
+  const transcriptOffset = { value: 0 };
+  const assistantText = { emitted: false };
+
+  const child = NodeChildProcess.spawn(command, buildAgyArgs(session, hookWorkspace, prompt), {
+    cwd: session.cwd,
+    env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  activeChild = child;
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const poller = setInterval(() => {
+    drain({
+      sessionId,
+      hookDir,
+      seenHooks,
+      state,
+      cursor,
+      transcriptOffset,
+      assistantText,
+      final: false,
+    });
+  }, HOOK_POLL_INTERVAL_MS);
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    child.on("error", () => resolve(null));
+    child.on("close", (code) => resolve(code));
+  });
+
+  clearInterval(poller);
+  activeChild = null;
+  drain({
+    sessionId,
+    hookDir,
+    seenHooks,
+    state,
+    cursor,
+    transcriptOffset,
+    assistantText,
+    final: true,
+  });
+
+  // Any tool still open at exit would otherwise render as spinning forever.
+  for (const [, active] of state.activeToolCalls) {
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: active.toolCallId,
+      status: "failed",
+      rawOutput: { isError: true, error: "Antigravity exited before the tool reported completion" },
+    });
+  }
+  state.activeToolCalls.clear();
+
+  if (state.conversationId) {
+    session.conversationId = state.conversationId;
+    persistConversationId(sessionId, state.conversationId);
+  }
+
+  cleanupDir(hookDir);
+  cleanupDir(hookWorkspace);
+
+  if (cancelledSessions.delete(sessionId)) {
+    return { stopReason: "cancelled" };
+  }
+  if (exitCode !== 0) {
+    const detail = stderr.trim() || stdout.trim() || `agy exited with code ${exitCode}`;
+    return { stopReason: "end_turn", failure: detail };
+  }
+
+  // The transcript already streamed the assistant text. stdout is only used
+  // when transcript observation produced nothing, so the reply is never
+  // duplicated.
+  if (!assistantText.emitted && stdout.trim().length > 0) {
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: stdout.trim() },
+    });
+  }
+  return { stopReason: "end_turn" };
+}
+
+function cleanupDir(dir: string): void {
+  try {
+    NodeFS.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Temp directories are reclaimed by the OS.
+  }
+}
+
+// ── Request dispatch ──────────────────────────────────────────────────
+
+async function handleRequest(message: Record<string, unknown>): Promise<void> {
+  const method = typeof message["method"] === "string" ? message["method"] : undefined;
+  const id = message["id"];
+  const params = (message["params"] ?? {}) as Record<string, unknown>;
+
+  if (!method) {
+    return;
+  }
+
+  switch (method) {
+    case "initialize": {
+      const requested =
+        typeof params["protocolVersion"] === "number" ? params["protocolVersion"] : 1;
+      sendResult(id, {
+        protocolVersion: Math.min(requested, 1),
+        agentCapabilities: {
+          loadSession: true,
+          promptCapabilities: { image: false, audio: false, embeddedContext: false },
+          mcpCapabilities: { http: false, sse: false },
+        },
+        authMethods: [],
+        // The bridge has no version of its own; it ships with the server, so
+        // that is the version worth reporting. The Antigravity CLI version is
+        // reported separately by the provider snapshot (`agy --version`).
+        agentInfo: { name: "Antigravity", version: packageJson.version },
+      });
+      return;
+    }
+    // Antigravity manages its own Google sign-in; there is nothing for the
+    // client to authenticate against, but the handshake still requires a
+    // successful reply.
+    case "authenticate": {
+      sendResult(id, {});
+      return;
+    }
+    case "session/new":
+    case "session/load": {
+      const cwd = typeof params["cwd"] === "string" ? params["cwd"] : "";
+      if (!cwd || !NodePath.isAbsolute(cwd)) {
+        sendError(id, -32602, `${method} requires an absolute cwd`);
+        return;
+      }
+      const requestedSessionId =
+        typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const sessionId =
+        method === "session/load" && requestedSessionId
+          ? requestedSessionId
+          : NodeCrypto.randomUUID();
+      sessions.set(sessionId, {
+        cwd,
+        systemPrompt:
+          typeof params["systemPrompt"] === "string" ? params["systemPrompt"] : undefined,
+        conversationId: requestedSessionId ? lookupConversationId(requestedSessionId) : undefined,
+      });
+      sendResult(id, method === "session/load" ? {} : { sessionId });
+      return;
+    }
+    case "session/prompt": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const session = sessionId ? sessions.get(sessionId) : undefined;
+      if (!sessionId || !session) {
+        sendError(id, -32602, "unknown sessionId");
+        return;
+      }
+      const prompt = renderPrompt(session, params["prompt"]);
+      if (prompt === null) {
+        sendError(id, -32602, "session/prompt requires at least one text block");
+        return;
+      }
+      const outcome = await runTurn(sessionId, session, prompt);
+      if (outcome.failure) {
+        sendError(id, -32000, `Antigravity turn failed: ${outcome.failure}`);
+        return;
+      }
+      sendResult(id, { stopReason: outcome.stopReason });
+      return;
+    }
+    case "session/cancel": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      if (sessionId) {
+        cancelledSessions.add(sessionId);
+      }
+      activeChild?.kill("SIGTERM");
+      return;
+    }
+    default: {
+      if (id !== undefined) {
+        sendError(id, -32601, `method not found: ${method}`);
+      }
+    }
+  }
+}
+
+/** Entry point for `t3 agy-acp`. */
+export async function runAgyBridge(): Promise<void> {
+  let buffer = "";
+  // Requests are handled strictly in order: a turn holds the agent busy, and
+  // ACP clients do not pipeline prompts for one session.
+  let queue: Promise<void> = Promise.resolve();
+
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    buffer += chunk;
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+      if (line.trim().length === 0) {
+        continue;
+      }
+
+      let message: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed !== "object" || parsed === null) {
+          continue;
+        }
+        message = parsed as Record<string, unknown>;
+      } catch {
+        sendError(null, -32700, "invalid JSON");
+        continue;
+      }
+
+      // Cancellation must interrupt an in-flight turn, so it bypasses the
+      // queue that would otherwise make it wait for that turn to finish.
+      if (message["method"] === "session/cancel") {
+        void handleRequest(message);
+        continue;
+      }
+      queue = queue.then(() => handleRequest(message)).catch(() => undefined);
+    }
+  }
+
+  await queue;
+  activeChild?.kill("SIGTERM");
+}

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -961,66 +961,59 @@ let activeChild: NodeChildProcess.ChildProcess | null = null;
  * output can still arrive against a turn that has been reported cancelled.
  */
 /**
- * Groups signalled but not yet confirmed dead, keyed by the child that owns
- * them so a pending escalation can be cancelled and never runs twice.
- *
- * A group id is only safe to signal while a member is alive: once the group is
- * empty the OS may reuse the number, and a delayed SIGKILL would land on
- * whatever inherited it.
+ * Children whose group has been signalled, so a fence and the cancel behind it
+ * do not arm two backstops for the same process.
  */
 const pendingKills = new Map<
   NodeChildProcess.ChildProcess,
   { readonly pid: number; timer?: ReturnType<typeof setTimeout> }
 >();
 
+/**
+ * Signal a child's process group — but only while the child is alive.
+ *
+ * A group id is safe to use only while the leader still holds it. Once the
+ * leader has been reaped the number is free for reuse, and a signal sent then
+ * can land on whatever inherited it. Every call site is therefore guarded on
+ * the leader being alive, and nothing signals a group after its `exit` event.
+ *
+ * The cost is that a tool which deliberately outlives `agy` is not reaped. That
+ * is the same boundary the approval gate draws: code the user has already
+ * approved can do what it likes, including backgrounding itself.
+ */
 function signalGroupOf(
   child: NodeChildProcess.ChildProcess,
   pid: number,
   signal: NodeJS.Signals,
 ): void {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  if (process.platform === "win32") {
+    // No process groups; this walks the tree while the leader still anchors it.
+    try {
+      NodeChildProcess.execFileSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+    } catch {
+      try {
+        child.kill(signal);
+      } catch {
+        // Nothing left to signal.
+      }
+    }
+    return;
+  }
   try {
     // Negative pid targets the group, which `detached: true` gave the child.
     process.kill(-pid, signal);
   } catch {
-    // Already gone, or never got a group; fall back to the child alone.
     try {
       child.kill(signal);
     } catch {
       // Nothing left to signal.
     }
   }
-}
-
-/**
- * Take ownership of a freshly spawned child's process group.
- *
- * Attached at spawn, not when cancelling. Registering it later loses the race
- * where the leader has already exited — the handler would never fire, and the
- * timed backstop skips a leader it can see is gone — leaving anything the
- * leader started alive with nothing tracking it.
- *
- * The group is killed when the leader exits, whatever the reason. A turn's
- * tools have no business outliving the turn, and this is the last moment the
- * group id is certainly still ours.
- */
-function ownChildGroup(child: NodeChildProcess.ChildProcess, pid: number): void {
-  child.once("exit", () => {
-    if (process.platform === "win32") {
-      // Best effort only: once the leader pid is gone `taskkill /T` has no tree
-      // left to walk. Reliably reaping survivors here needs a Job Object, which
-      // is not reachable without a native addon.
-      try {
-        NodeChildProcess.execFileSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
-          stdio: "ignore",
-        });
-      } catch {
-        // Nothing left, or nothing we can do.
-      }
-    } else {
-      signalGroupOf(child, pid, "SIGKILL");
-    }
-    clearPendingKill(child);
-  });
 }
 
 function clearPendingKill(child: NodeChildProcess.ChildProcess): void {
@@ -1031,7 +1024,14 @@ function clearPendingKill(child: NodeChildProcess.ChildProcess): void {
   pendingKills.delete(child);
 }
 
-/** SIGKILL every group still awaiting escalation. Used on shutdown. */
+/** Release tracking when a child ends, so nothing signals it afterwards. */
+function forgetChildOnExit(child: NodeChildProcess.ChildProcess): void {
+  child.once("exit", () => {
+    clearPendingKill(child);
+  });
+}
+
+/** Kill every group still being tracked. Used on shutdown. */
 function killPendingGroups(): void {
   for (const [child, pending] of pendingKills) {
     signalGroupOf(child, pending.pid, "SIGKILL");
@@ -1431,9 +1431,9 @@ async function runTurn(
   activeTurnToken = turnToken;
   activeChild = child;
   if (child.pid !== undefined) {
-    // Owned from the moment it exists, so nothing it spawns can outlive it
-    // unnoticed.
-    ownChildGroup(child, child.pid);
+    // Tracking is released the moment it ends, so nothing ever signals a group
+    // id that is no longer ours.
+    forgetChildOnExit(child);
   }
   // A cancel during startup had no process to signal; deliver it now.
   if (cancelledSessions.has(sessionId)) {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1365,10 +1365,11 @@ function drain(input: {
           !input.state.transcriptPrimingOverflowed &&
           !input.cursor.retainWithinLimit(trimmed, MAX_TRANSCRIPT_LINE_CHARS)
         ) {
-          // Give up on what was scanned, including the partial record at the
-          // read cutoff. Priming while unread bytes remain would replay another
-          // turn's output as this one's, and retaining again before a later
-          // boundary would merely rebuild the discarded historical suffix.
+          // Complete retained history is discarded, but a bounded partial line
+          // at the read cutoff is preserved because it may be this turn's
+          // USER_INPUT. Suppression remains active until that boundary is
+          // observed, so a historical record completed from the carry is still
+          // never emitted as current-turn output.
           input.state.transcriptPrimingOverflowed = true;
         }
         allLines = [];

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -186,11 +186,21 @@ const pendingOutbound = new Map<
   { readonly resolve: (value: unknown) => void; readonly reject: (error: Error) => void }
 >();
 
-function sendRequest(method: string, params: unknown): Promise<unknown> {
+function sendRequest(method: string, params: unknown, timeoutMs?: number): Promise<unknown> {
   const id = nextOutboundId;
   nextOutboundId += 1;
   return new Promise((resolve, reject) => {
     pendingOutbound.set(id, { resolve, reject });
+    if (timeoutMs !== undefined) {
+      // A client that never answers would otherwise pin this entry for the
+      // life of the bridge process.
+      const timer = setTimeout(() => {
+        if (pendingOutbound.delete(id)) {
+          reject(new Error(`${method} timed out`));
+        }
+      }, timeoutMs);
+      timer.unref?.();
+    }
     writeMessage({ jsonrpc: "2.0", id, method, params });
   });
 }
@@ -351,21 +361,25 @@ function requestToolApproval(input: {
 }): void {
   const toolCall = input.payload.toolCall;
   const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
-  void sendRequest("session/request_permission", {
-    sessionId: input.sessionId,
-    toolCall: {
-      toolCallId: agyToolCallId(input.payload.conversationId, stepIdx),
-      title: agyToolTitle(toolCall),
-      kind: agyToolKind(toolCall?.name),
-      status: "pending",
-      rawInput: toolCall?.args ?? null,
-      ...(agyTargetPath(toolCall) ? { locations: [{ path: agyTargetPath(toolCall) }] } : {}),
+  void sendRequest(
+    "session/request_permission",
+    {
+      sessionId: input.sessionId,
+      toolCall: {
+        toolCallId: agyToolCallId(input.payload.conversationId, stepIdx),
+        title: agyToolTitle(toolCall),
+        kind: agyToolKind(toolCall?.name),
+        status: "pending",
+        rawInput: toolCall?.args ?? null,
+        ...(agyTargetPath(toolCall) ? { locations: [{ path: agyTargetPath(toolCall) }] } : {}),
+      },
+      options: [
+        { optionId: APPROVE_OPTION, name: "Allow", kind: "allow_once" },
+        { optionId: REJECT_OPTION, name: "Reject", kind: "reject_once" },
+      ],
     },
-    options: [
-      { optionId: APPROVE_OPTION, name: "Allow", kind: "allow_once" },
-      { optionId: REJECT_OPTION, name: "Reject", kind: "reject_once" },
-    ],
-  })
+    APPROVAL_WAIT_MS,
+  )
     .then((result) => {
       writeDecision(
         input.hookDir,
@@ -412,6 +426,12 @@ export async function runAgyHook(event: string): Promise<void> {
   }
 
   const hookDir = process.env[HOOK_DIR_ENV]?.trim();
+  // When approvals are required this process is a security gate, not an
+  // observer. Any failure below — unparseable payload, unwritable hook
+  // directory, a bridge that never answers — must deny, because the CLI has
+  // already been told to skip its own permission prompts and nothing else
+  // stands between the model and the tool.
+  const gating = Boolean(hookDir) && approvalRequired() && event === "pre-tool-use";
   if (hookDir) {
     try {
       const payload = JSON.parse(raw) as AgyHookPayload;
@@ -433,13 +453,23 @@ export async function runAgyHook(event: string): Promise<void> {
       // With approvals on, this process is the gate: block until the bridge
       // reports the user's answer. `deny` here genuinely stops the tool —
       // Antigravity reports the reason back to the model.
-      if (approvalRequired() && event === "pre-tool-use" && payload?.toolCall) {
+      if (gating && payload?.toolCall) {
         const decision = await awaitDecision(hookDir, name);
         process.stdout.write(JSON.stringify(decision));
         return;
       }
     } catch {
-      // Observation is best-effort: a hook must never break a tool call.
+      // Observation is best-effort: a hook must never break a tool call —
+      // unless it is the approval gate, handled below.
+      if (gating) {
+        process.stdout.write(
+          JSON.stringify({
+            decision: "deny",
+            reason: "T3 Code could not record this tool call for approval",
+          } satisfies AgyHookDecision),
+        );
+        return;
+      }
     }
   }
 
@@ -612,6 +642,22 @@ function stageAttachments(attachments: ReadonlyArray<PromptAttachment>): {
   }
   const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-attach-"));
   const staged: Array<PromptAttachment> = [];
+  try {
+    stageInto(dir, attachments, staged);
+  } catch (error) {
+    // Copies that already succeeded are user uploads; leaving them in /tmp
+    // because a later one failed would outlive the turn that needed them.
+    cleanupDir(dir);
+    throw error;
+  }
+  return { dir, staged };
+}
+
+function stageInto(
+  dir: string,
+  attachments: ReadonlyArray<PromptAttachment>,
+  staged: Array<PromptAttachment>,
+): void {
   attachments.forEach((attachment, index) => {
     // Index-prefixed and sanitised so two attachments sharing a basename cannot
     // collide and a crafted name cannot escape the staging directory.
@@ -623,7 +669,6 @@ function stageAttachments(attachments: ReadonlyArray<PromptAttachment>): {
     NodeFS.copyFileSync(attachment.path, target);
     staged.push({ path: target, name: safeName, mimeType: attachment.mimeType });
   });
-  return { dir, staged };
 }
 
 function composePromptText(
@@ -651,6 +696,23 @@ let activeChild: NodeChildProcess.ChildProcess | null = null;
 /** Session whose turn is currently running, if any. Gates `session/cancel`. */
 let activeTurnSessionId: string | null = null;
 const cancelledSessions = new Set<string>();
+/**
+ * Cancels seen per session, counted rather than flagged.
+ *
+ * A prompt records this value when it is queued. If the count has moved by the
+ * time the prompt reaches the front, a cancel arrived while it waited and the
+ * prompt must not run — turns are serialized, so a steer queued behind a long
+ * turn would otherwise start executing tools after the user pressed Stop. A
+ * counter rather than a flag is what keeps this from also swallowing a cancel
+ * that lands harmlessly between two turns.
+ */
+const cancelGenerations = new Map<string, number>();
+/** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
+const queuedPromptGenerations = new Map<unknown, number>();
+
+function cancelGeneration(sessionId: string): number {
+  return cancelGenerations.get(sessionId) ?? 0;
+}
 
 /**
  * Drain everything Antigravity has produced so far and emit it as ACP updates.
@@ -677,10 +739,16 @@ function drain(input: {
     const update = hookSessionUpdate(hook, input.state, fileText);
     if (update) {
       const stepIdx = hook.payload?.stepIdx;
-      if (hook.event === "post-tool-use" && typeof stepIdx === "number") {
+      if (
+        hook.event === "post-tool-use" &&
+        typeof stepIdx === "number" &&
+        !input.state.transcriptSeenSteps.has(stepIdx)
+      ) {
         // Held back rather than sent: the transcript record carrying this
         // step's real output is usually read later in this same pass, and a
-        // completed call can no longer take content.
+        // completed call can no longer take content. Once that record has been
+        // seen there is nothing left to wait for — and nothing to wait on,
+        // since the transcript is read once by byte offset.
         input.state.pendingTerminal.set(stepIdx, update);
       } else {
         sendSessionUpdate(input.sessionId, update);
@@ -688,7 +756,14 @@ function drain(input: {
     }
     // The hook process is blocked until a decision file appears, so this has
     // to be started for every announced tool call.
-    if (approvalRequired() && hook.event === "pre-tool-use" && hook.payload?.toolCall) {
+    // Not during the final drain: the child has already exited, so no tool is
+    // waiting on the answer and the request would never be settled.
+    if (
+      !input.final &&
+      approvalRequired() &&
+      hook.event === "pre-tool-use" &&
+      hook.payload?.toolCall
+    ) {
       requestToolApproval({
         sessionId: input.sessionId,
         hookDir: input.hookDir,
@@ -1033,6 +1108,13 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "unknown sessionId");
         return;
       }
+      const queuedAt = queuedPromptGenerations.get(id);
+      queuedPromptGenerations.delete(id);
+      if (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId)) {
+        // Cancelled while it sat in the queue; never spawn `agy` for it.
+        sendResult(id, { stopReason: "cancelled" });
+        return;
+      }
       const prompt = renderPrompt(session, params["prompt"]);
       if (prompt === null) {
         sendError(id, -32602, "session/prompt requires at least one text block");
@@ -1048,13 +1130,18 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      // Only a cancel aimed at the turn actually running can decide its stop
-      // reason. Cancels bypass the request queue, so one that arrives after a
-      // turn has already finished — or targets an idle session — would
-      // otherwise sit in the set and mark the next successful turn cancelled.
-      if (sessionId && sessionId === activeTurnSessionId) {
-        cancelledSessions.add(sessionId);
-        activeChild?.kill("SIGTERM");
+      if (sessionId) {
+        // Always recorded, so prompts already queued for this session can see
+        // that a cancel happened and refuse to start.
+        cancelGenerations.set(sessionId, cancelGeneration(sessionId) + 1);
+        // Only a cancel aimed at the turn actually running decides its stop
+        // reason. Cancels bypass the request queue, so one arriving after a
+        // turn finished — or targeting an idle session — must not sit in the
+        // set and mark the next successful turn cancelled.
+        if (sessionId === activeTurnSessionId) {
+          cancelledSessions.add(sessionId);
+          activeChild?.kill("SIGTERM");
+        }
       }
       return;
     }
@@ -1111,6 +1198,14 @@ export async function runAgyBridge(): Promise<void> {
         continue;
       }
       const pending = message;
+      // Captured now, not when the turn starts: the gap between the two is
+      // exactly the window a cancel has to arrive in while this prompt waits.
+      if (pending["method"] === "session/prompt") {
+        const target = (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"];
+        if (typeof target === "string" && pending["id"] !== undefined) {
+          queuedPromptGenerations.set(pending["id"], cancelGeneration(target));
+        }
+      }
       queue = queue
         .then(() => handleRequest(pending))
         .catch((error: unknown) => {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -830,57 +830,34 @@ let activeChild: NodeChildProcess.ChildProcess | null = null;
 let activeTurnSessionId: string | null = null;
 const cancelledSessions = new Set<string>();
 /**
- * Cancels seen per session, counted rather than flagged.
+ * Highest cancelled epoch per session.
  *
- * A prompt records this value when it is queued. If the count has moved by the
- * time the prompt reaches the front, a cancel arrived while it waited and the
- * prompt must not run — turns are serialized, so a steer queued behind a long
- * turn would otherwise start executing tools after the user pressed Stop. A
- * counter rather than a flag is what keeps this from also swallowing a cancel
- * that lands harmlessly between two turns.
- */
-const cancelGenerations = new Map<string, number>();
-/**
- * Ids of individual prompts the client cancelled before they arrived.
+ * Each submission carries the adapter's cancel epoch, and an interrupt names
+ * the epoch it is cancelling *through*. Everything at or below that is
+ * cancelled; anything accepted afterwards has a higher epoch and is untouched.
  *
- * The generation check compares a prompt's enqueue-time value against its
- * run-time value, which cannot see a cancel that landed *before* the prompt
- * arrived — the prompt simply reads the post-cancel value and matches, and the
- * runtime forks its cancel notification, so that ordering is real.
- *
- * Keyed by prompt, not by session: every session-scoped variant of this ends
- * up cancelling some later, unrelated prompt, because "a cancel happened and
- * no turn is running" also describes a cancel that merely arrived after its
- * own turn finished. The adapter stamps each submission with an id and names
- * that exact id when it fences, so a fence can only ever stop the prompt it
- * was meant for.
+ * This replaces a set of individual prompt ids. Keying by id needed the set to
+ * be bounded, and any eviction policy can drop a fence whose prompt has not
+ * arrived yet — which would let exactly the prompt being cancelled run. A
+ * single high-water mark per session cannot lose one and cannot grow.
  */
-const fencedPromptIds = new Set<string>();
-/**
- * Upper bound on remembered fences. A fence whose prompt already arrived is
- * applied immediately instead of stored, so this only holds ids still in
- * transit; the cap exists so a client that fences prompts it never sends
- * cannot grow the set without limit.
- */
-const MAX_FENCED_PROMPT_IDS = 256;
-/** Prompt id of the turn currently running, so a fence can reach it. */
-let activeTurnPromptId: string | undefined;
-/** Token of the turn currently running, retired when its prompt is fenced. */
-let activeTurnToken: TurnToken | undefined;
+const cancelledThroughEpoch = new Map<string, number>();
 
-/** The adapter's per-submission id, carried in `_meta.t3.promptId`. */
-function promptIdOf(params: Record<string, unknown>): string | undefined {
+function cancelledThrough(sessionId: string): number {
+  return cancelledThroughEpoch.get(sessionId) ?? -1;
+}
+
+/** The adapter's cancel epoch for a submission, carried in `_meta.t3.epoch`. */
+function promptEpochOf(params: Record<string, unknown>): number | undefined {
   const meta = params["_meta"];
   const t3 = isRecord(meta) ? meta["t3"] : undefined;
-  const promptId = isRecord(t3) ? t3["promptId"] : undefined;
-  return typeof promptId === "string" && promptId.length > 0 ? promptId : undefined;
+  const epoch = isRecord(t3) ? t3["epoch"] : undefined;
+  return typeof epoch === "number" ? epoch : undefined;
 }
-/** Cancel generation captured when each queued prompt was accepted, by JSON-RPC id. */
-const queuedPromptGenerations = new Map<unknown, number>();
-
-function cancelGeneration(sessionId: string): number {
-  return cancelGenerations.get(sessionId) ?? 0;
-}
+/** Cancel epoch of the turn currently running, so a fence can reach it. */
+let activeTurnEpoch = -1;
+/** Token of that turn, retired when its epoch is cancelled. */
+let activeTurnToken: TurnToken | undefined;
 
 /**
  * Drain everything Antigravity has produced so far and emit it as ACP updates.
@@ -1078,7 +1055,7 @@ async function runTurn(
   sessionId: string,
   session: BridgeSession,
   prompt: RenderedPrompt,
-  promptId: string | undefined,
+  promptEpoch: number,
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
@@ -1139,9 +1116,9 @@ async function runTurn(
   }
   const assistantText = { emitted: false };
   const turnToken: TurnToken = { sessionId, live: true };
-  // Published so an out-of-band fence naming this prompt can retire the turn
-  // rather than being stored for an arrival that already happened.
-  activeTurnPromptId = promptId;
+  // Published so an out-of-band fence covering this epoch can retire the turn
+  // rather than being recorded for an arrival that already happened.
+  activeTurnEpoch = promptEpoch;
   activeTurnToken = turnToken;
   activeChild = child;
   // A cancel during startup had no process to signal; deliver it now.
@@ -1219,12 +1196,8 @@ async function runTurn(
   // now resolves to a denial rather than writing into a vanishing directory or
   // banking a blanket approval for the next turn.
   turnToken.live = false;
-  activeTurnPromptId = undefined;
+  activeTurnEpoch = -1;
   activeTurnToken = undefined;
-  if (promptId !== undefined) {
-    // Its fence, if any, has been dealt with; nothing may consume it later.
-    fencedPromptIds.delete(promptId);
-  }
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
   cleanupDir(attachmentDir);
@@ -1342,26 +1315,18 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       return;
     }
     case "session/prompt": {
-      // Read and cleared before the session is validated: an unknown session
-      // returns early below, and leaving the entry behind would grow this map
-      // for every bad id a client sends.
-      const queuedAt = queuedPromptGenerations.get(id);
-      queuedPromptGenerations.delete(id);
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
       const session = sessionId ? sessions.get(sessionId) : undefined;
       if (!sessionId || !session) {
         sendError(id, -32602, "unknown sessionId");
         return;
       }
-      // Consumed by id, so a fence can only stop the prompt it named; anything
-      // the user sends afterwards runs normally.
-      const promptId = promptIdOf(params);
-      const cancelledInTransit = promptId !== undefined && fencedPromptIds.delete(promptId);
-      if (
-        cancelledInTransit ||
-        (queuedAt !== undefined && queuedAt !== cancelGeneration(sessionId))
-      ) {
-        // Cancelled while it sat in the queue; never spawn `agy` for it.
+      // Compared against the session's cancelled high-water mark. A cancel
+      // that outran this prompt raised that mark, and anything the user sends
+      // afterwards carries a higher epoch and is unaffected.
+      const promptEpoch = promptEpochOf(params) ?? 0;
+      if (promptEpoch <= cancelledThrough(sessionId)) {
+        // Cancelled before it could start; never spawn `agy` for it.
         sendResult(id, { stopReason: "cancelled" });
         return;
       }
@@ -1370,7 +1335,7 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         sendError(id, -32602, "session/prompt requires at least one text block");
         return;
       }
-      const outcome = await runTurn(sessionId, session, prompt, promptId);
+      const outcome = await runTurn(sessionId, session, prompt, promptEpoch);
       if (outcome.failure) {
         sendError(id, -32000, `Antigravity turn failed: ${outcome.failure}`);
         return;
@@ -1378,45 +1343,36 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       sendResult(id, { stopReason: outcome.stopReason });
       return;
     }
-    // Sent by the adapter immediately before it cancels, and only while it has
-    // a prompt outstanding. Notifications carry no id, so nothing is replied.
+    // Sent by the adapter immediately before it cancels, naming the epoch it
+    // is cancelling through. Handled out of band: queued, it would sit behind
+    // the very prompt it is meant to stop. Notifications carry no id, so
+    // nothing is replied.
     case "t3/fence": {
-      const promptId = typeof params["promptId"] === "string" ? params["promptId"] : undefined;
-      if (!promptId) {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const epoch = typeof params["epoch"] === "number" ? params["epoch"] : undefined;
+      if (!sessionId || epoch === undefined) {
         return;
       }
-      if (activeTurnToken && promptId === activeTurnPromptId) {
-        // Already running: there is nothing to stop on arrival, so the fence is
-        // applied to the turn itself. Retiring the token denies any approval
-        // still in flight, including ones the adapter would auto-approve.
+      cancelledThroughEpoch.set(sessionId, Math.max(cancelledThrough(sessionId), epoch));
+      // A turn already running under a cancelled epoch has nothing left to
+      // stop on arrival, so it is stopped here. Retiring the token is what
+      // makes an approval still in flight deny, including one the client
+      // would auto-approve.
+      if (activeTurnToken?.sessionId === sessionId && activeTurnEpoch <= epoch) {
         activeTurnToken.live = false;
-        cancelledSessions.add(activeTurnToken.sessionId);
+        cancelledSessions.add(sessionId);
         activeChild?.kill("SIGTERM");
-        return;
       }
-      if (fencedPromptIds.size >= MAX_FENCED_PROMPT_IDS) {
-        // Oldest first: a fence this stale describes a prompt that is never
-        // going to arrive.
-        const oldest = fencedPromptIds.values().next();
-        if (!oldest.done) {
-          fencedPromptIds.delete(oldest.value);
-        }
-      }
-      fencedPromptIds.add(promptId);
       return;
     }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      if (sessionId && sessions.has(sessionId)) {
-        // Always recorded, so prompts already queued for this session can see
-        // that a cancel happened and refuse to start.
-        cancelGenerations.set(sessionId, cancelGeneration(sessionId) + 1);
-
-        // Only a cancel aimed at the turn actually running decides its stop
-        // reason. Cancels bypass the request queue, so one arriving after a
-        // turn finished — or targeting an idle session — must not sit in the
-        // set and mark the next successful turn cancelled.
-        if (sessionId === activeTurnSessionId) {
+      if (sessionId && sessions.has(sessionId) && sessionId === activeTurnSessionId) {
+        // Only the turn actually running is stopped, and only when its epoch
+        // has been cancelled. A prompt accepted after the fence carries a
+        // higher epoch and must survive this notification, which the runtime
+        // forks and can therefore deliver late.
+        if (activeTurnEpoch <= cancelledThrough(sessionId)) {
           cancelledSessions.add(sessionId);
           activeChild?.kill("SIGTERM");
         }
@@ -1484,14 +1440,6 @@ export async function runAgyBridge(): Promise<void> {
         continue;
       }
       const pending = message;
-      // Captured now, not when the turn starts: the gap between the two is
-      // exactly the window a cancel has to arrive in while this prompt waits.
-      if (pending["method"] === "session/prompt") {
-        const target = (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"];
-        if (typeof target === "string" && pending["id"] !== undefined && sessions.has(target)) {
-          queuedPromptGenerations.set(pending["id"], cancelGeneration(target));
-        }
-      }
       queue = queue
         .then(() => handleRequest(pending))
         .catch((error: unknown) => {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -72,6 +72,17 @@ const HOOK_POLL_INTERVAL_MS = 50;
  * short enough that a step no hook will ever cover does not stall the stream.
  */
 const MAX_DEFERRED_DRAINS = 20;
+
+/**
+ * Aggregate ceiling on records held waiting for a tool call to be announced.
+ *
+ * `MAX_DEFERRED_DRAINS` expires the head of the queue, which is enough when
+ * unmatched records are occasional. It is not enough when they arrive faster
+ * than one per drain, which is what a transcript full of internal planner steps
+ * looks like — hence a cap on the queue as a whole.
+ */
+const MAX_DEFERRED_RECORDS = 512;
+const MAX_DEFERRED_CHARS = 8 * 1024 * 1024;
 /**
  * Cap on the `agy` output held in memory per stream. Only the tail is kept:
  * stdout is a fallback used when the transcript streamed nothing, and stderr
@@ -1329,16 +1340,20 @@ function drain(input: {
     // conversation carries every prior turn. Trim once, then stream.
     if (!input.state.transcriptPrimed && allLines.length > 0) {
       const trimmed = dropPriorTurnRecords(allLines);
+      // Measured over the batch itself, not just the cursor's carry: `retain`
+      // puts whole lines back, and the next `push` hands them straight back
+      // here as complete lines. Carry stays small the whole time while the
+      // retained batch grows without limit, so budgeting on carry alone was no
+      // budget at all. Past the limit the batch is accepted as-is — replaying
+      // some earlier output is a worse transcript, but an unbounded hold is a
+      // worse process.
+      const heldChars =
+        input.cursor.carryLength + allLines.reduce((total, line) => total + line.length + 1, 0);
       if (
         trimmed.length === allLines.length &&
         input.state.resumedConversation &&
         !input.final &&
-        // Held content is re-examined against every later read, so a
-        // conversation whose opening record never appears would accumulate the
-        // whole transcript in the cursor. Past the budget the batch is accepted
-        // as-is: replaying some earlier output is a worse transcript, but an
-        // unbounded hold is a worse process.
-        input.cursor.carryLength <= MAX_TRANSCRIPT_LINE_CHARS
+        heldChars <= MAX_TRANSCRIPT_LINE_CHARS
       ) {
         // Resuming, and this batch holds no `USER_INPUT` — so the current
         // turn's opening record has not been written yet and everything here
@@ -1392,6 +1407,19 @@ function drain(input: {
       } else {
         held.push(...records.slice(index).filter((entry) => entry !== undefined));
         input.state.deferredDrains += 1;
+        // Aged out one at a time, but refilled by every poll. Antigravity emits
+        // internal steps far faster than one record per drain interval, so on a
+        // transcript with unhookable steps the queue grows no matter how
+        // patiently the head expires. Trimmed from the front: the oldest held
+        // records are the ones whose hook is least likely to ever arrive.
+        let heldChars = held.reduce((total, entry) => total + (entry.content?.length ?? 0), 0);
+        while (held.length > MAX_DEFERRED_RECORDS || heldChars > MAX_DEFERRED_CHARS) {
+          const dropped = held.shift();
+          if (dropped === undefined) {
+            break;
+          }
+          heldChars -= dropped.content?.length ?? 0;
+        }
         break;
       }
       for (const update of result.updates) {
@@ -1643,8 +1671,9 @@ async function runTurn(
   // cursor while bytes remain would emit a half-written record as if it were
   // whole, and leave the rest of that line to be read as a fragment.
   let finalPasses = 0;
-  while (
-    drain({
+  let transcriptRemains = true;
+  while (transcriptRemains && finalPasses < MAX_FINAL_DRAIN_PASSES) {
+    transcriptRemains = drain({
       sessionId,
       hookDir,
       seenHooks,
@@ -1655,10 +1684,22 @@ async function runTurn(
       assistantText,
       turnToken,
       final: false,
-    }) &&
-    finalPasses < MAX_FINAL_DRAIN_PASSES
-  ) {
+    });
     finalPasses += 1;
+  }
+  if (transcriptRemains) {
+    // The budget ran out with bytes still unread. Flushing the cursor now would
+    // present a half-written line as a whole record and then abandon the rest
+    // in silence, so the partial line is dropped and the shortfall is said out
+    // loud instead.
+    cursor.flush();
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "[Transcript truncated: Antigravity produced more output than this turn could read.]",
+      },
+    });
   }
   drain({
     sessionId,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -991,6 +991,38 @@ function signalGroupOf(
   }
 }
 
+/**
+ * Take ownership of a freshly spawned child's process group.
+ *
+ * Attached at spawn, not when cancelling. Registering it later loses the race
+ * where the leader has already exited — the handler would never fire, and the
+ * timed backstop skips a leader it can see is gone — leaving anything the
+ * leader started alive with nothing tracking it.
+ *
+ * The group is killed when the leader exits, whatever the reason. A turn's
+ * tools have no business outliving the turn, and this is the last moment the
+ * group id is certainly still ours.
+ */
+function ownChildGroup(child: NodeChildProcess.ChildProcess, pid: number): void {
+  child.once("exit", () => {
+    if (process.platform === "win32") {
+      // Best effort only: once the leader pid is gone `taskkill /T` has no tree
+      // left to walk. Reliably reaping survivors here needs a Job Object, which
+      // is not reachable without a native addon.
+      try {
+        NodeChildProcess.execFileSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+          stdio: "ignore",
+        });
+      } catch {
+        // Nothing left, or nothing we can do.
+      }
+    } else {
+      signalGroupOf(child, pid, "SIGKILL");
+    }
+    clearPendingKill(child);
+  });
+}
+
 function clearPendingKill(child: NodeChildProcess.ChildProcess): void {
   const pending = pendingKills.get(child);
   if (pending?.timer) {
@@ -1041,20 +1073,17 @@ function killActiveChild(options?: { readonly immediate?: boolean }): void {
     // second timer would be another delayed signal nobody cancels.
     return;
   }
+  if (child.exitCode !== null || child.signalCode !== null) {
+    // Leader already gone: the spawn-time handler has this, or has run.
+    signalGroupOf(child, pid, "SIGKILL");
+    return;
+  }
   signalGroupOf(child, pid, "SIGTERM");
   const pending: { readonly pid: number; timer?: ReturnType<typeof setTimeout> } = { pid };
   pendingKills.set(child, pending);
-  // `agy` can die on SIGTERM while a tool it started ignores it and keeps the
-  // group busy. Killing at that moment is what makes the group id safe to use:
-  // it belongs to us while any member lives, and this runs the instant the
-  // leader goes rather than seconds later, when the number may have been
-  // recycled onto something unrelated.
-  child.once("exit", () => {
-    if (pendingKills.get(child) === pending) {
-      signalGroupOf(child, pid, "SIGKILL");
-      clearPendingKill(child);
-    }
-  });
+  // The group is killed when the leader exits by the handler installed at
+  // spawn, so nothing needs attaching here.
+  //
   // Backstop for a leader that ignores SIGTERM outright. Safe to target by
   // group, because the leader is by definition still alive if this fires.
   const escalation = setTimeout(() => {
@@ -1401,6 +1430,11 @@ async function runTurn(
   activeTurnEpoch = promptEpoch;
   activeTurnToken = turnToken;
   activeChild = child;
+  if (child.pid !== undefined) {
+    // Owned from the moment it exists, so nothing it spawns can outlive it
+    // unnoticed.
+    ownChildGroup(child, child.pid);
+  }
   // A cancel during startup had no process to signal; deliver it now.
   if (cancelledSessions.has(sessionId)) {
     killActiveChild();

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -19,6 +19,7 @@ import * as NodeCrypto from "node:crypto";
 import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeStringDecoder from "node:string_decoder";
 import * as NodeURL from "node:url";
 
 import packageJson from "../../../../package.json" with { type: "json" };
@@ -324,7 +325,16 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
 // ── Tool approval ─────────────────────────────────────────────────────
 
 const APPROVE_OPTION = "allow";
+const APPROVE_SESSION_OPTION = "allow-session";
 const REJECT_OPTION = "reject";
+/**
+ * Sessions the user has approved wholesale via "always allow".
+ *
+ * Without an `allow_always` option the client maps that choice to no option id
+ * at all and the reply reads as cancelled — which this gate denies. Offering
+ * it and honouring it here is what makes the button mean what it says.
+ */
+const sessionWideApprovals = new Set<string>();
 
 function approvalRequired(): boolean {
   return process.env[REQUIRE_APPROVAL_ENV]?.trim() === "1";
@@ -353,12 +363,23 @@ function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecis
  * Fire-and-forget by design: `drain` runs on a timer and must not block the
  * transcript reader while a human decides.
  */
+function selectedOptionId(result: unknown): string | undefined {
+  const outcome = isRecord(result) ? result["outcome"] : undefined;
+  const optionId = isRecord(outcome) ? outcome["optionId"] : undefined;
+  return typeof optionId === "string" ? optionId : undefined;
+}
+
 function requestToolApproval(input: {
   readonly sessionId: string;
   readonly hookDir: string;
   readonly hookName: string;
   readonly payload: AgyHookPayload;
 }): void {
+  // Already approved for the whole session: answer without troubling the user.
+  if (sessionWideApprovals.has(input.sessionId)) {
+    writeDecision(input.hookDir, input.hookName, { decision: "allow" });
+    return;
+  }
   const toolCall = input.payload.toolCall;
   const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
   void sendRequest(
@@ -375,17 +396,22 @@ function requestToolApproval(input: {
       },
       options: [
         { optionId: APPROVE_OPTION, name: "Allow", kind: "allow_once" },
+        {
+          optionId: APPROVE_SESSION_OPTION,
+          name: "Allow for this session",
+          kind: "allow_always",
+        },
         { optionId: REJECT_OPTION, name: "Reject", kind: "reject_once" },
       ],
     },
     APPROVAL_WAIT_MS,
   )
     .then((result) => {
-      writeDecision(
-        input.hookDir,
-        input.hookName,
-        approvalOutcomeToDecision(result, APPROVE_OPTION),
-      );
+      const decision = approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      if (decision.decision === "allow" && selectedOptionId(result) === APPROVE_SESSION_OPTION) {
+        sessionWideApprovals.add(input.sessionId);
+      }
+      writeDecision(input.hookDir, input.hookName, decision);
     })
     .catch(() => {
       writeDecision(input.hookDir, input.hookName, {
@@ -726,6 +752,7 @@ function drain(input: {
   readonly seenHooks: Set<string>;
   readonly state: AgyTurnState;
   readonly cursor: AgyTranscriptCursor;
+  readonly decoder: NodeStringDecoder.StringDecoder;
   readonly transcriptOffset: { value: number };
   readonly assistantText: { emitted: boolean };
   readonly final: boolean;
@@ -784,7 +811,11 @@ function drain(input: {
           const length = stats.size - input.transcriptOffset.value;
           const buffer = Buffer.alloc(length);
           NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
-          chunk = buffer.toString("utf8");
+          // Decoded through the turn's streaming decoder, not `toString`: a
+          // write can land mid-multibyte-character, and decoding each slice
+          // independently would replace the partial sequence with U+FFFD and
+          // advance past it, silently corrupting non-ASCII output.
+          chunk = input.decoder.write(buffer);
           input.transcriptOffset.value = stats.size;
         } finally {
           NodeFS.closeSync(fd);
@@ -799,8 +830,18 @@ function drain(input: {
     // Reading always starts at byte 0, so the first batch of a resumed
     // conversation carries every prior turn. Trim once, then stream.
     if (!input.state.transcriptPrimed && allLines.length > 0) {
-      allLines = [...dropPriorTurnRecords(allLines)];
-      input.state.transcriptPrimed = true;
+      const trimmed = dropPriorTurnRecords(allLines);
+      if (trimmed.length === allLines.length && input.state.resumedConversation && !input.final) {
+        // Resuming, and this batch holds no `USER_INPUT` — so the current
+        // turn's opening record has not been written yet and everything here
+        // belongs to a previous turn. Emitting it would replay old output;
+        // hold off and re-examine once more has been appended.
+        input.cursor.retain(allLines);
+        allLines = [];
+      } else {
+        allLines = [...trimmed];
+        input.state.transcriptPrimed = true;
+      }
     }
     for (const line of allLines) {
       const record = parseTranscriptLine(line);
@@ -915,6 +956,7 @@ async function runTurn(
   const state = makeAgyTurnState(session.conversationId);
   const seenHooks = new Set<string>();
   const cursor = new AgyTranscriptCursor();
+  const decoder = new NodeStringDecoder.StringDecoder("utf8");
   const transcriptOffset = { value: 0 };
   const assistantText = { emitted: false };
   activeChild = child;
@@ -941,6 +983,7 @@ async function runTurn(
       seenHooks,
       state,
       cursor,
+      decoder,
       transcriptOffset,
       assistantText,
       final: false,
@@ -961,6 +1004,7 @@ async function runTurn(
     seenHooks,
     state,
     cursor,
+    decoder,
     transcriptOffset,
     assistantText,
     final: true,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1157,6 +1157,21 @@ function promptEpochOf(params: Record<string, unknown>): number | undefined {
  * contributes to.
  */
 let activeTurnEpoch: number | undefined;
+/**
+ * Temp directories the running turn owns.
+ *
+ * Tracked outside `runTurn` so a signal that ends the process can still remove
+ * them: `process.exit` skips the cleanup at the end of the turn, and these hold
+ * copies of the user's attachments and file contents captured around edits.
+ */
+const activeTurnTempDirs = new Set<string>();
+
+function cleanupActiveTurnTempDirs(): void {
+  for (const dir of activeTurnTempDirs) {
+    cleanupDir(dir);
+  }
+  activeTurnTempDirs.clear();
+}
 /** Token of that turn, retired when its epoch is cancelled. */
 let activeTurnToken: TurnToken | undefined;
 
@@ -1416,9 +1431,14 @@ async function runTurn(
   let child: NodeChildProcess.ChildProcess;
   try {
     hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
+    activeTurnTempDirs.add(hookDir);
     hookWorkspace = createHookWorkspace();
+    activeTurnTempDirs.add(hookWorkspace);
     const attachments = stageAttachments(prompt.attachments);
     attachmentDir = attachments.dir;
+    if (attachmentDir) {
+      activeTurnTempDirs.add(attachmentDir);
+    }
     const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
     child = NodeChildProcess.spawn(
       command,
@@ -1445,6 +1465,9 @@ async function runTurn(
     cleanupDir(hookDir);
     cleanupDir(hookWorkspace);
     cleanupDir(attachmentDir);
+    if (hookDir) activeTurnTempDirs.delete(hookDir);
+    if (hookWorkspace) activeTurnTempDirs.delete(hookWorkspace);
+    if (attachmentDir) activeTurnTempDirs.delete(attachmentDir);
     throw error;
   }
 
@@ -1566,6 +1589,11 @@ async function runTurn(
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
   cleanupDir(attachmentDir);
+  activeTurnTempDirs.delete(hookDir);
+  activeTurnTempDirs.delete(hookWorkspace);
+  if (attachmentDir) {
+    activeTurnTempDirs.delete(attachmentDir);
+  }
 
   if (cancelledSessions.delete(sessionId)) {
     return { stopReason: "cancelled" };
@@ -1768,15 +1796,14 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // higher epoch and must survive this notification, which the runtime
         // forks and can therefore deliver late.
         //
-        // A cancel is authoritative for the turn that is running: the fence
-        // that would normally have raised the mark is a separate notification
-        // and can fail to send, and without this the child would survive a Stop
-        // the client believes it delivered.
-        if (activeTurnEpoch !== undefined) {
-          cancelledThroughEpoch.set(
-            sessionId,
-            Math.max(cancelledThrough(sessionId), activeTurnEpoch),
-          );
+        // A cancel carries the epoch it covers, so it can stand in for a fence
+        // that failed to send without reaching past its own turn. Promoting the
+        // mark to whatever happened to be running would let a late cancel kill
+        // a prompt accepted after it — the runtime forks this notification, so
+        // arriving late is normal.
+        const cancelEpoch = typeof params["epoch"] === "number" ? params["epoch"] : undefined;
+        if (cancelEpoch !== undefined) {
+          cancelledThroughEpoch.set(sessionId, Math.max(cancelledThrough(sessionId), cancelEpoch));
         }
         // Judged by the running turn's own mode, not by anything the session
         // did earlier. A turn whose prompt carried no epoch cannot be scoped by
@@ -1809,6 +1836,9 @@ export async function runAgyBridge(): Promise<void> {
   const stopChildOnExit = () => {
     shuttingDown = true;
     killActiveChild({ immediate: true });
+    // The turn's own cleanup never runs when the process is going down, and
+    // these hold copies of the user's attachments and captured file contents.
+    cleanupActiveTurnTempDirs();
     // Groups whose leader already exited are known only to their pending
     // escalation, and `process.exit` runs no timers.
     killPendingGroups();

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -19,6 +19,7 @@ import * as NodeCrypto from "node:crypto";
 import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
 
 import packageJson from "../../../../package.json" with { type: "json" };
 import {
@@ -34,6 +35,7 @@ import {
 } from "./agyEvents.ts";
 import {
   AgyTranscriptCursor,
+  dropPriorTurnRecords,
   parseTranscriptLine,
   transcriptRecordUpdates,
 } from "./agyTranscript.ts";
@@ -47,6 +49,14 @@ interface BridgeSession {
   readonly cwd: string;
   systemPrompt: string | undefined;
   conversationId: string | undefined;
+  /**
+   * Model and effort for the next turn. Seeded from the spawn environment and
+   * replaced by `session/set_model`; both are command-line flags on every
+   * spawn, so a change takes effect on the following turn without disturbing
+   * the conversation it resumes.
+   */
+  model: string | undefined;
+  effort: string | undefined;
 }
 
 const sessions = new Map<string, BridgeSession>();
@@ -68,7 +78,19 @@ function stateFilePath(): string {
 function readSessionMap(): Record<string, string> {
   try {
     const parsed: unknown = JSON.parse(NodeFS.readFileSync(stateFilePath(), "utf8"));
-    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, string>) : {};
+    if (typeof parsed !== "object" || parsed === null) {
+      return {};
+    }
+    // The bridge does not exclusively own this file, so entries are validated
+    // rather than cast. A non-string value reaching a caller would throw and
+    // leave the request it came from unanswered.
+    const map: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === "string") {
+        map[key] = value;
+      }
+    }
+    return map;
   } catch {
     return {};
   }
@@ -83,7 +105,14 @@ function persistConversationId(sessionId: string, conversationId: string): void 
       return;
     }
     map[sessionId] = conversationId;
-    NodeFS.writeFileSync(target, JSON.stringify(map, null, 2));
+    // Written through a uniquely-named temp file and renamed into place. The
+    // map is now the sole resume authority and several bridge processes can
+    // finish turns at once; a partial write would be read back as empty JSON
+    // and silently start a fresh conversation. Rename is atomic within a
+    // filesystem, so a reader sees either the old file or the complete new one.
+    const staging = `${target}.${process.pid}.${NodeCrypto.randomUUID()}.tmp`;
+    NodeFS.writeFileSync(staging, JSON.stringify(map, null, 2));
+    NodeFS.renameSync(staging, target);
   } catch {
     // Losing the mapping costs conversation continuity on the next resume,
     // which is not worth failing a turn over.
@@ -259,21 +288,25 @@ export async function runAgyHook(event: string): Promise<void> {
 
 // ── Turn execution ────────────────────────────────────────────────────
 
-function buildAgyArgs(
-  session: BridgeSession,
-  hookWorkspace: string,
-  prompt: string,
-): Array<string> {
+function buildAgyArgs(input: {
+  readonly session: BridgeSession;
+  readonly hookWorkspace: string;
+  readonly attachmentDir: string | undefined;
+  readonly promptText: string;
+}): Array<string> {
+  const { session, hookWorkspace, attachmentDir } = input;
   const args = [
     "--dangerously-skip-permissions",
     "--print-timeout",
     process.env["T3_AGY_PRINT_TIMEOUT"]?.trim() || DEFAULT_PRINT_TIMEOUT,
   ];
-  const model = process.env["T3_AGY_MODEL"]?.trim();
+  // Per session, not per process: `--model` applies to the turn being spawned
+  // and composes with `--conversation`, so the trajectory survives a switch.
+  const model = session.model?.trim();
   if (model) {
     args.push("--model", model);
   }
-  const effort = process.env["T3_AGY_EFFORT"]?.trim();
+  const effort = session.effort?.trim();
   if (effort) {
     args.push("--effort", effort);
   }
@@ -284,29 +317,127 @@ function buildAgyArgs(
   // session workspace is registered so its `.agents` skills and rules load;
   // the hook workspace is registered so the observer attaches.
   args.push("--add-dir", session.cwd, "--add-dir", hookWorkspace);
-  args.push("--print", prompt);
+  if (attachmentDir) {
+    args.push("--add-dir", attachmentDir);
+  }
+  args.push("--print", input.promptText);
   return args;
 }
 
-function renderPrompt(session: BridgeSession, promptBlocks: unknown): string | null {
+/** A local file referenced by a `resource_link` prompt block. */
+interface PromptAttachment {
+  readonly path: string;
+  readonly name: string;
+  readonly mimeType: string | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Extract local files from `resource_link` blocks.
+ *
+ * Only `file:` URIs are taken: a remote URL is left in the prompt text for the
+ * agent's own fetch tool, and passing one to `--add-dir` would be meaningless.
+ */
+function collectAttachments(promptBlocks: ReadonlyArray<unknown>): ReadonlyArray<PromptAttachment> {
+  const attachments: Array<PromptAttachment> = [];
+  for (const block of promptBlocks) {
+    if (!isRecord(block) || block["type"] !== "resource_link") {
+      continue;
+    }
+    const uri = block["uri"];
+    if (typeof uri !== "string" || !uri.startsWith("file://")) {
+      continue;
+    }
+    let filePath: string;
+    try {
+      filePath = NodeURL.fileURLToPath(uri);
+    } catch {
+      continue;
+    }
+    const name = typeof block["name"] === "string" ? block["name"] : NodePath.basename(filePath);
+    attachments.push({
+      path: filePath,
+      name,
+      mimeType: typeof block["mimeType"] === "string" ? block["mimeType"] : undefined,
+    });
+  }
+  return attachments;
+}
+
+interface RenderedPrompt {
+  readonly baseText: string;
+  readonly attachments: ReadonlyArray<PromptAttachment>;
+}
+
+function renderPrompt(session: BridgeSession, promptBlocks: unknown): RenderedPrompt | null {
   if (!Array.isArray(promptBlocks)) {
     return null;
   }
   const text = promptBlocks
     .filter(
       (block): block is { type: string; text: string } =>
-        typeof block === "object" &&
-        block !== null &&
-        (block as { type?: unknown }).type === "text" &&
-        typeof (block as { text?: unknown }).text === "string",
+        isRecord(block) && block["type"] === "text" && typeof block["text"] === "string",
     )
     .map((block) => block.text)
-    .join("\n\n");
-  if (text.trim().length === 0) {
+    .join("\n\n")
+    .trim();
+
+  const attachments = collectAttachments(promptBlocks);
+  if (text.length === 0 && attachments.length === 0) {
     return null;
   }
+
   const systemPrompt = session.systemPrompt?.trim();
-  return systemPrompt ? `System instructions:\n${systemPrompt}\n\nRequest:\n${text}` : text;
+  return {
+    baseText: systemPrompt ? `System instructions:\n${systemPrompt}\n\nRequest:\n${text}` : text,
+    attachments,
+  };
+}
+
+/**
+ * Copy this turn's attachments into a throwaway directory.
+ *
+ * `agy --print` has no attachment flag, so files must be named by path with
+ * their directory registered via `--add-dir`. Registering the attachment store
+ * itself would hand an auto-approving agent read access to every thread's
+ * uploads, so only the files this turn references are staged, and the staging
+ * directory dies with the turn.
+ */
+function stageAttachments(attachments: ReadonlyArray<PromptAttachment>): {
+  readonly dir: string | undefined;
+  readonly staged: ReadonlyArray<PromptAttachment>;
+} {
+  if (attachments.length === 0) {
+    return { dir: undefined, staged: [] };
+  }
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-attach-"));
+  const staged: Array<PromptAttachment> = [];
+  attachments.forEach((attachment, index) => {
+    // Index-prefixed and sanitised so two attachments sharing a basename cannot
+    // collide and a crafted name cannot escape the staging directory.
+    const safeName = `${index}-${NodePath.basename(attachment.name).replace(/[^\w.-]+/g, "_")}`;
+    const target = NodePath.join(dir, safeName);
+    try {
+      NodeFS.copyFileSync(attachment.path, target);
+    } catch {
+      // An unreadable attachment is dropped rather than failing the whole turn.
+      return;
+    }
+    staged.push({ path: target, name: safeName, mimeType: attachment.mimeType });
+  });
+  return { dir, staged };
+}
+
+function composePromptText(baseText: string, staged: ReadonlyArray<PromptAttachment>): string {
+  if (staged.length === 0) {
+    return baseText;
+  }
+  const list = staged.map((a) => `- ${a.path}${a.mimeType ? ` (${a.mimeType})` : ""}`).join("\n");
+  const block = `Attached files (read them from these paths):\n${list}`;
+  return baseText.length > 0 ? `${baseText}\n\n${block}` : block;
 }
 
 interface TurnOutcome {
@@ -369,7 +500,13 @@ function drain(input: {
     }
 
     const lines = chunk.length > 0 ? input.cursor.push(chunk) : [];
-    const allLines = input.final ? [...lines, ...input.cursor.flush()] : lines;
+    let allLines = input.final ? [...lines, ...input.cursor.flush()] : lines;
+    // Reading always starts at byte 0, so the first batch of a resumed
+    // conversation carries every prior turn. Trim once, then stream.
+    if (!input.state.transcriptPrimed && allLines.length > 0) {
+      allLines = [...dropPriorTurnRecords(allLines)];
+      input.state.transcriptPrimed = true;
+    }
     for (const line of allLines) {
       const record = parseTranscriptLine(line);
       if (!record) {
@@ -413,26 +550,59 @@ function resolveTranscriptPath(state: AgyTurnState): string | undefined {
 async function runTurn(
   sessionId: string,
   session: BridgeSession,
-  prompt: string,
+  prompt: RenderedPrompt,
 ): Promise<TurnOutcome> {
   // A cancel that raced the end of an earlier turn must not decide this one.
   cancelledSessions.delete(sessionId);
-  const hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
-  const hookWorkspace = createHookWorkspace();
-  const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
+  // Claimed before any setup work: spawning `agy` takes long enough that a
+  // cancel can land first, and cancels are only honoured for the session
+  // holding this claim. Leaving it unset until after the spawn would silently
+  // drop those, letting an auto-approving child run on past a cancelled turn.
+  activeTurnSessionId = sessionId;
+  let hookDir: string | undefined;
+  let hookWorkspace: string | undefined;
+  let attachmentDir: string | undefined;
+  let child: NodeChildProcess.ChildProcess;
+  try {
+    hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
+    hookWorkspace = createHookWorkspace();
+    const attachments = stageAttachments(prompt.attachments);
+    attachmentDir = attachments.dir;
+    const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
+    child = NodeChildProcess.spawn(
+      command,
+      buildAgyArgs({
+        session,
+        hookWorkspace,
+        attachmentDir,
+        promptText: composePromptText(prompt.baseText, attachments.staged),
+      }),
+      {
+        cwd: session.cwd,
+        env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch (error) {
+    // Setup failed, so no turn is running: release the claim and reclaim the
+    // directories, or repeated failures would leak one set each time.
+    activeTurnSessionId = null;
+    cleanupDir(hookDir);
+    cleanupDir(hookWorkspace);
+    cleanupDir(attachmentDir);
+    throw error;
+  }
+
   const state = makeAgyTurnState(session.conversationId);
   const seenHooks = new Set<string>();
   const cursor = new AgyTranscriptCursor();
   const transcriptOffset = { value: 0 };
   const assistantText = { emitted: false };
-
-  const child = NodeChildProcess.spawn(command, buildAgyArgs(session, hookWorkspace, prompt), {
-    cwd: session.cwd,
-    env: { ...process.env, [HOOK_DIR_ENV]: hookDir },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
   activeChild = child;
-  activeTurnSessionId = sessionId;
+  // A cancel during startup had no process to signal; deliver it now.
+  if (cancelledSessions.has(sessionId)) {
+    child.kill("SIGTERM");
+  }
 
   let stdout = "";
   let stderr = "";
@@ -498,6 +668,7 @@ async function runTurn(
 
   cleanupDir(hookDir);
   cleanupDir(hookWorkspace);
+  cleanupDir(attachmentDir);
 
   if (cancelledSessions.delete(sessionId)) {
     return { stopReason: "cancelled" };
@@ -519,7 +690,10 @@ async function runTurn(
   return { stopReason: "end_turn" };
 }
 
-function cleanupDir(dir: string): void {
+function cleanupDir(dir: string | undefined): void {
+  if (!dir) {
+    return;
+  }
   try {
     NodeFS.rmSync(dir, { recursive: true, force: true });
   } catch {
@@ -546,6 +720,8 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         protocolVersion: Math.min(requested, 1),
         agentCapabilities: {
           loadSession: true,
+          // Images ride in as `resource_link` blocks (an ACP baseline type)
+          // rather than inline base64, so the `image` capability stays off.
           promptCapabilities: { image: false, audio: false, embeddedContext: false },
           mcpCapabilities: { http: false, sse: false },
         },
@@ -582,8 +758,28 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         systemPrompt:
           typeof params["systemPrompt"] === "string" ? params["systemPrompt"] : undefined,
         conversationId: requestedSessionId ? lookupConversationId(requestedSessionId) : undefined,
+        model: process.env["T3_AGY_MODEL"]?.trim() || undefined,
+        effort: process.env["T3_AGY_EFFORT"]?.trim() || undefined,
       });
       sendResult(id, method === "session/load" ? {} : { sessionId });
+      return;
+    }
+    // `--model` is a per-spawn flag that composes with `--conversation`, so a
+    // switch applies from the next turn while the trajectory carries over.
+    case "session/set_model": {
+      const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      const session = sessionId ? sessions.get(sessionId) : undefined;
+      if (!session) {
+        sendError(id, -32602, "unknown sessionId");
+        return;
+      }
+      const modelId = typeof params["modelId"] === "string" ? params["modelId"].trim() : "";
+      if (modelId.length === 0) {
+        sendError(id, -32602, "session/set_model requires a modelId");
+        return;
+      }
+      session.model = modelId;
+      sendResult(id, {});
       return;
     }
     case "session/prompt": {
@@ -663,7 +859,17 @@ export async function runAgyBridge(): Promise<void> {
         void handleRequest(message);
         continue;
       }
-      queue = queue.then(() => handleRequest(message)).catch(() => undefined);
+      const pending = message;
+      queue = queue
+        .then(() => handleRequest(pending))
+        .catch((error: unknown) => {
+          // Every request must be answered. Swallowing a handler failure would
+          // leave the client blocked on a response that never arrives.
+          if (pending["id"] !== undefined) {
+            const detail = error instanceof Error ? error.message : String(error);
+            sendError(pending["id"], -32603, `internal bridge error: ${detail}`);
+          }
+        });
     }
   }
 

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -842,9 +842,23 @@ const cancelledSessions = new Set<string>();
  * single high-water mark per session cannot lose one and cannot grow.
  */
 const cancelledThroughEpoch = new Map<string, number>();
+/**
+ * Sessions whose next queued prompt has been cancelled without an epoch.
+ *
+ * Only for clients that do not send fences: without an epoch there is nothing
+ * to compare a queued prompt against, so a plain `session/cancel` for a
+ * session whose turn has not started yet would be dropped and its prompt would
+ * run afterwards. Consumed by the next prompt for that session.
+ */
+const unscopedCancels = new Set<string>();
 
 function cancelledThrough(sessionId: string): number {
   return cancelledThroughEpoch.get(sessionId) ?? -1;
+}
+
+/** Whether this session's client uses the epoch extension. */
+function usesEpochs(sessionId: string): boolean {
+  return cancelledThroughEpoch.has(sessionId);
 }
 
 /** The adapter's cancel epoch for a submission, carried in `_meta.t3.epoch`. */
@@ -1334,7 +1348,12 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
       // so there is no mark it could be measured against — refusing it would
       // reject every prompt such a client ever sends once a mark exists.
       const promptEpoch = promptEpochOf(params);
-      if (promptEpoch !== undefined && promptEpoch <= cancelledThrough(sessionId)) {
+      // One-shot, and only reachable for a client that sends no epochs.
+      const unscopedCancelled = promptEpoch === undefined && unscopedCancels.delete(sessionId);
+      if (
+        unscopedCancelled ||
+        (promptEpoch !== undefined && promptEpoch <= cancelledThrough(sessionId))
+      ) {
         // Cancelled before it could start; never spawn `agy` for it.
         sendResult(id, { stopReason: "cancelled" });
         return;
@@ -1380,15 +1399,30 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
+      if (sessionId && sessions.has(sessionId) && sessionId !== activeTurnSessionId) {
+        // No turn running for it yet. A fencing client has already raised the
+        // mark, so its queued prompt is covered; one that does not fence needs
+        // this marker or its queued prompt would start after the cancel.
+        if (!usesEpochs(sessionId)) {
+          unscopedCancels.add(sessionId);
+        }
+        return;
+      }
       if (sessionId && sessions.has(sessionId) && sessionId === activeTurnSessionId) {
         // Only the turn actually running is stopped, and only when its epoch
         // has been cancelled. A prompt accepted after the fence carries a
         // higher epoch and must survive this notification, which the runtime
         // forks and can therefore deliver late.
         //
-        // An untagged turn has no epoch to scope by, so it is cancelled
-        // outright — that is the plain ACP behaviour its client expects.
-        if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
+        // An untagged turn is cancelled outright — plain ACP behaviour — but
+        // only when this session's client never fences. In a session that does,
+        // a delayed cancel belonging to an already-fenced turn would otherwise
+        // kill an untagged follow-up that started in the meantime.
+        const unscoped = activeTurnEpoch === undefined && !usesEpochs(sessionId);
+        if (
+          unscoped ||
+          (activeTurnEpoch !== undefined && activeTurnEpoch <= cancelledThrough(sessionId))
+        ) {
           cancelledSessions.add(sessionId);
           activeChild?.kill("SIGTERM");
         }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1856,12 +1856,8 @@ async function runTurn(
   // whole, and leave the rest of that line to be read as a fragment.
   const stdoutDrainDeadline = Date.now() + STDOUT_DRAIN_GRACE_MS;
   let finalPasses = 0;
-  let transcriptRemains = true;
-  while (transcriptRemains && finalPasses < MAX_FINAL_DRAIN_PASSES) {
-    const stdoutDrainTimedOut = await waitForStdoutDrain(stdoutDrainDeadline);
-    if (stdoutDrainTimedOut) {
-      break;
-    }
+  let transcriptRemains: boolean;
+  do {
     transcriptRemains = drain({
       sessionId,
       hookDir,
@@ -1875,12 +1871,19 @@ async function runTurn(
       final: false,
     });
     finalPasses += 1;
-  }
+    if (!transcriptRemains || finalPasses >= MAX_FINAL_DRAIN_PASSES) {
+      break;
+    }
+    const stdoutDrainTimedOut = await waitForStdoutDrain(stdoutDrainDeadline);
+    if (stdoutDrainTimedOut) {
+      break;
+    }
+  } while (transcriptRemains);
   if (transcriptRemains) {
-    // The budget ran out with bytes still unread. Flushing the cursor now would
-    // present a half-written line as a whole record and then abandon the rest
-    // in silence, so the partial line is dropped and the shortfall is said out
-    // loud instead.
+    // Final draining stopped with bytes still unread. Flushing the cursor now
+    // would present a half-written line as a whole record and then abandon the
+    // rest in silence, so the partial line is dropped and the shortfall is said
+    // out loud instead.
     cursor.flush();
     await waitForStdoutDrain(stdoutDrainDeadline);
     sendSessionUpdate(sessionId, {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -14,6 +14,7 @@
  */
 // @effect-diagnostics nodeBuiltinImport:off - Standalone stdio bridge process, not an Effect runtime.
 // @effect-diagnostics globalTimers:off - Polls Antigravity hook output outside any Effect runtime.
+// @effect-diagnostics globalDate:off - Approval deadlines are measured in the hook subprocess, which has no Clock.
 /* eslint-disable t3code/no-global-process-runtime -- Standalone process: there
    is no Effect runtime here to inject HostProcessPlatform from. */
 import * as NodeChildProcess from "node:child_process";
@@ -43,6 +44,7 @@ import {
 import {
   AgyTranscriptCursor,
   dropPriorTurnRecords,
+  MAX_TRANSCRIPT_LINE_CHARS,
   parseTranscriptLine,
   transcriptRecordUpdates,
 } from "./agyTranscript.ts";
@@ -76,6 +78,20 @@ const MAX_DEFERRED_DRAINS = 20;
  * only needs to explain a failure.
  */
 const MAX_CAPTURED_OUTPUT = 256 * 1024;
+
+/**
+ * Ceiling on one transcript read. Keeps a single poll from allocating a buffer
+ * the size of whatever a tool just wrote; the rest is read by the next poll.
+ */
+const MAX_TRANSCRIPT_READ_BYTES = 1024 * 1024;
+
+/**
+ * Backstop on how many extra passes the final drain will make to consume a
+ * transcript tail larger than one read. Set far above any real transcript —
+ * this exists so a file being appended to faster than it is read cannot spin
+ * the exit path forever, not to bound normal output.
+ */
+const MAX_FINAL_DRAIN_PASSES = 512;
 const DEFAULT_PRINT_TIMEOUT = "2h";
 const HOOKS_KEY = "t3code-antigravity-observer";
 
@@ -427,6 +443,18 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
         }
         hookPayloadDigests.set(name, digestPayload(raw));
         events.push({ name, event: { ...record, payload } });
+        // Reclaimed as soon as its contents are in memory. An edit hook carries
+        // the file it is about to change, up to `MAX_CAPTURED_FILE_BYTES` each,
+        // and the directory only went away at the end of the turn — so a long
+        // turn editing large files held every version of every one of them on
+        // disk at once. The waiting hook never reads this file back; it polls
+        // for its `.decision` sibling, which is written separately.
+        try {
+          NodeFS.unlinkSync(NodePath.join(hookDir, name));
+        } catch {
+          // Losing the reclaim is not worth failing the hook over; the whole
+          // directory is removed when the turn ends.
+        }
       }
     } catch {
       // A half-written hook file is picked up on the next poll.
@@ -1192,7 +1220,7 @@ function drain(input: {
   readonly assistantText: { emitted: boolean };
   readonly turnToken: TurnToken;
   readonly final: boolean;
-}): void {
+}): boolean {
   for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
     // Diffing the file contents each hook captured, rather than the arguments
     // of the edit, keeps this correct across tools whose argument shapes
@@ -1242,6 +1270,7 @@ function drain(input: {
   }
 
   const transcriptPath = resolveTranscriptPath(input.state);
+  let moreTranscript = false;
   if (transcriptPath) {
     let chunk = "";
     try {
@@ -1249,7 +1278,15 @@ function drain(input: {
       if (stats.size > input.transcriptOffset.value) {
         const fd = NodeFS.openSync(transcriptPath, "r");
         try {
-          const length = stats.size - input.transcriptOffset.value;
+          // Capped rather than sized to the whole unread region: a tool that
+          // writes a very large record would otherwise have the bridge
+          // allocate a buffer as big as its output in one go, which the 256
+          // KiB stdout cap does nothing to prevent. Whatever is left is picked
+          // up by the next poll, and the final drain loops until it is gone.
+          const length = Math.min(
+            stats.size - input.transcriptOffset.value,
+            MAX_TRANSCRIPT_READ_BYTES,
+          );
           const buffer = Buffer.alloc(length);
           // `readSync` may return fewer bytes than asked for. Decoding the
           // whole buffer would feed the zero-filled tail through as content
@@ -1277,6 +1314,7 @@ function drain(input: {
           // advance past it, silently corrupting non-ASCII output.
           chunk = bytesRead > 0 ? input.decoder.write(buffer.subarray(0, bytesRead)) : "";
           input.transcriptOffset.value += bytesRead;
+          moreTranscript = stats.size > input.transcriptOffset.value && bytesRead > 0;
         } finally {
           NodeFS.closeSync(fd);
         }
@@ -1291,7 +1329,17 @@ function drain(input: {
     // conversation carries every prior turn. Trim once, then stream.
     if (!input.state.transcriptPrimed && allLines.length > 0) {
       const trimmed = dropPriorTurnRecords(allLines);
-      if (trimmed.length === allLines.length && input.state.resumedConversation && !input.final) {
+      if (
+        trimmed.length === allLines.length &&
+        input.state.resumedConversation &&
+        !input.final &&
+        // Held content is re-examined against every later read, so a
+        // conversation whose opening record never appears would accumulate the
+        // whole transcript in the cursor. Past the budget the batch is accepted
+        // as-is: replaying some earlier output is a worse transcript, but an
+        // unbounded hold is a worse process.
+        input.cursor.carryLength <= MAX_TRANSCRIPT_LINE_CHARS
+      ) {
         // Resuming, and this batch holds no `USER_INPUT` — so the current
         // turn's opening record has not been written yet and everything here
         // belongs to a previous turn. Emitting it would replay old output;
@@ -1369,6 +1417,8 @@ function drain(input: {
       sendSessionUpdate(input.sessionId, terminal);
     }
   }
+
+  return moreTranscript;
 }
 
 function flushTerminal(sessionId: string, state: AgyTurnState, stepIdx: number): void {
@@ -1403,6 +1453,13 @@ function resolveTranscriptPath(state: AgyTurnState): string | undefined {
   state.resolvedTranscriptPath = NodeFS.existsSync(condensed) ? condensed : reported;
   return state.resolvedTranscriptPath;
 }
+
+/**
+ * Thrown when a cancel lands in the window between claiming the turn and
+ * spawning `agy`. Carries no message: it never surfaces to the client, it only
+ * unwinds setup through the same path a spawn failure takes.
+ */
+class TurnCancelledBeforeSpawn extends Error {}
 
 async function runTurn(
   sessionId: string,
@@ -1443,6 +1500,24 @@ async function runTurn(
     if (attachmentDir) {
       activeTurnTempDirs.add(attachmentDir);
     }
+    // Yielded to the event loop once, with the claim held and the directories
+    // staged, before anything is spawned.
+    //
+    // Everything above this point is synchronous, so a `t3/fence` or
+    // `session/cancel` already sitting in the stdin buffer could not be parsed
+    // until after `agy` was running: the turn the user stopped still reached
+    // the model, and was only killed afterwards. One turn of the event loop is
+    // enough for the reader to deliver it, and the recheck below then declines
+    // to spawn at all.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (
+      shuttingDown ||
+      cancelledSessions.has(sessionId) ||
+      (promptEpoch !== undefined && promptEpoch <= cancelledThrough(sessionId))
+    ) {
+      throw new TurnCancelledBeforeSpawn();
+    }
+
     const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
     child = NodeChildProcess.spawn(
       command,
@@ -1463,15 +1538,24 @@ async function runTurn(
       },
     );
   } catch (error) {
-    // Setup failed, so no turn is running: release the claim and reclaim the
-    // directories, or repeated failures would leak one set each time.
+    // Setup failed or the turn was cancelled before it started, so no turn is
+    // running: release the claim and reclaim the directories, or repeated
+    // failures would leak one set each time.
     activeTurnSessionId = null;
+    activeTurnEpoch = undefined;
     cleanupDir(hookDir);
     cleanupDir(hookWorkspace);
     cleanupDir(attachmentDir);
     if (hookDir) activeTurnTempDirs.delete(hookDir);
     if (hookWorkspace) activeTurnTempDirs.delete(hookWorkspace);
     if (attachmentDir) activeTurnTempDirs.delete(attachmentDir);
+    if (error instanceof TurnCancelledBeforeSpawn) {
+      // Nothing ran, so there is nothing to report but the cancellation. The
+      // flag is consumed here because no later stage will reach the drain that
+      // normally clears it.
+      cancelledSessions.delete(sessionId);
+      return { stopReason: "cancelled" };
+    }
     throw error;
   }
 
@@ -1554,6 +1638,28 @@ async function runTurn(
   clearInterval(poller);
   activeChild = null;
   activeTurnSessionId = null;
+  // Each pass reads at most `MAX_TRANSCRIPT_READ_BYTES`, so the tail of a large
+  // transcript needs several. Only the last one runs as `final`: flushing the
+  // cursor while bytes remain would emit a half-written record as if it were
+  // whole, and leave the rest of that line to be read as a fragment.
+  let finalPasses = 0;
+  while (
+    drain({
+      sessionId,
+      hookDir,
+      seenHooks,
+      state,
+      cursor,
+      decoder,
+      transcriptOffset,
+      assistantText,
+      turnToken,
+      final: false,
+    }) &&
+    finalPasses < MAX_FINAL_DRAIN_PASSES
+  ) {
+    finalPasses += 1;
+  }
   drain({
     sessionId,
     hookDir,
@@ -1604,7 +1710,31 @@ async function runTurn(
     activeTurnTempDirs.delete(attachmentDir);
   }
 
-  if (cancelledSessions.delete(sessionId)) {
+  const cancelled = cancelledSessions.delete(sessionId);
+
+  // The transcript already streamed the assistant text. stdout is only used
+  // when transcript observation produced nothing, so the reply is never
+  // duplicated.
+  //
+  // Emitted before the cancelled check, not after: a turn stopped mid-reply is
+  // exactly the case where the transcript may not have been discovered yet,
+  // and the partial answer already captured from stdout is the only record of
+  // what the model said. A nonzero exit is excluded because it reports the same
+  // bytes as its failure detail.
+  if ((cancelled || exitCode === 0) && !assistantText.emitted && stdout.trim().length > 0) {
+    // Says so when it is only the tail. Presenting a suffix as the whole reply
+    // reads as a complete answer that happens to begin mid-sentence, which is
+    // worse than admitting the beginning was dropped.
+    const text = stdoutTruncated
+      ? `[Earlier output dropped: the reply exceeded ${Math.floor(MAX_CAPTURED_OUTPUT / 1024)} KiB.]\n\n${stdout.trim()}`
+      : stdout.trim();
+    sendSessionUpdate(sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text },
+    });
+  }
+
+  if (cancelled) {
     return { stopReason: "cancelled" };
   }
   if (exitCode !== 0) {
@@ -1618,21 +1748,6 @@ async function runTurn(
     return { stopReason: "end_turn", failure: detail };
   }
 
-  // The transcript already streamed the assistant text. stdout is only used
-  // when transcript observation produced nothing, so the reply is never
-  // duplicated.
-  if (!assistantText.emitted && stdout.trim().length > 0) {
-    // Says so when it is only the tail. Presenting a suffix as the whole reply
-    // reads as a complete answer that happens to begin mid-sentence, which is
-    // worse than admitting the beginning was dropped.
-    const text = stdoutTruncated
-      ? `[Earlier output dropped: the reply exceeded ${Math.floor(MAX_CAPTURED_OUTPUT / 1024)} KiB.]\n\n${stdout.trim()}`
-      : stdout.trim();
-    sendSessionUpdate(sessionId, {
-      sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text },
-    });
-  }
   return { stopReason: "end_turn" };
 }
 

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -264,6 +264,16 @@ function quoteArg(value: string): string {
  */
 function createHookWorkspace(): string {
   const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hooks-"));
+  try {
+    return writeHookWorkspace(dir);
+  } catch (error) {
+    // The caller never received the path, so it cannot clean this up itself.
+    cleanupDir(dir);
+    throw error;
+  }
+}
+
+function writeHookWorkspace(dir: string): string {
   const agentsDir = NodePath.join(dir, ".agents");
   NodeFS.mkdirSync(agentsDir, { recursive: true });
   // A gating PreToolUse hook blocks while the user decides, so its timeout has

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1418,6 +1418,10 @@ async function runTurn(
   // holding this claim. Leaving it unset until after the spawn would silently
   // drop those, letting an auto-approving child run on past a cancelled turn.
   activeTurnSessionId = sessionId;
+  // Claimed together. Setting the epoch later left a window where this turn
+  // looked untagged, and an untagged turn is cancelled unconditionally — so a
+  // late cancel carrying an older epoch would kill a turn it does not cover.
+  activeTurnEpoch = promptEpoch;
   // Rotated before the spawn, so the child is handed this turn's secret: a tool
   // approved in an earlier turn holds that turn's, and cannot sign anything
   // this one will accept.
@@ -1487,7 +1491,6 @@ async function runTurn(
   const turnToken: TurnToken = { sessionId, live: true };
   // Published so an out-of-band fence covering this epoch can retire the turn
   // rather than being recorded for an arrival that already happened.
-  activeTurnEpoch = promptEpoch;
   activeTurnToken = turnToken;
   activeChild = child;
   if (child.pid !== undefined) {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -90,15 +90,18 @@ function persistConversationId(sessionId: string, conversationId: string): void 
   }
 }
 
+/**
+ * Map a bridge session id to the Antigravity conversation it should resume.
+ *
+ * The persisted map is the only authority. Bridge session ids are themselves
+ * random UUIDs, so an id that merely looks like a conversation id is
+ * indistinguishable from one the bridge minted — falling back to the shape of
+ * the string would make `session/load` resume a conversation that never
+ * existed whenever the map is missing or unreadable. Returning `undefined`
+ * starts a fresh conversation, which is the recoverable outcome.
+ */
 function lookupConversationId(sessionId: string): string | undefined {
-  const mapped = readSessionMap()[sessionId]?.trim();
-  if (mapped) {
-    return mapped;
-  }
-  // A caller may hand back an Antigravity conversation UUID directly.
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)
-    ? sessionId
-    : undefined;
+  return readSessionMap()[sessionId]?.trim() || undefined;
 }
 
 // ── JSON-RPC plumbing ─────────────────────────────────────────────────
@@ -312,6 +315,8 @@ interface TurnOutcome {
 }
 
 let activeChild: NodeChildProcess.ChildProcess | null = null;
+/** Session whose turn is currently running, if any. Gates `session/cancel`. */
+let activeTurnSessionId: string | null = null;
 const cancelledSessions = new Set<string>();
 
 /**
@@ -385,14 +390,24 @@ function drain(input: {
  * Hooks report `transcript_full.jsonl`; the sibling `transcript.jsonl` holds
  * the same steps without internal model chatter and is the better stream to
  * render.
+ *
+ * The choice is pinned for the rest of the turn. `transcriptOffset` and the
+ * line cursor are byte positions into whichever file was picked, so switching
+ * once the condensed file appears would resume reading at an offset that means
+ * nothing in the new file — skipping records, or re-emitting ones already
+ * streamed from the other one.
  */
 function resolveTranscriptPath(state: AgyTurnState): string | undefined {
+  if (state.resolvedTranscriptPath) {
+    return state.resolvedTranscriptPath;
+  }
   const reported = state.transcriptPath;
   if (!reported) {
     return undefined;
   }
   const condensed = reported.replace(/transcript_full\.jsonl$/, "transcript.jsonl");
-  return NodeFS.existsSync(condensed) ? condensed : reported;
+  state.resolvedTranscriptPath = NodeFS.existsSync(condensed) ? condensed : reported;
+  return state.resolvedTranscriptPath;
 }
 
 async function runTurn(
@@ -400,6 +415,8 @@ async function runTurn(
   session: BridgeSession,
   prompt: string,
 ): Promise<TurnOutcome> {
+  // A cancel that raced the end of an earlier turn must not decide this one.
+  cancelledSessions.delete(sessionId);
   const hookDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hookout-"));
   const hookWorkspace = createHookWorkspace();
   const command = process.env["T3_AGY_COMMAND"]?.trim() || "agy";
@@ -415,6 +432,7 @@ async function runTurn(
     stdio: ["ignore", "pipe", "pipe"],
   });
   activeChild = child;
+  activeTurnSessionId = sessionId;
 
   let stdout = "";
   let stderr = "";
@@ -447,6 +465,7 @@ async function runTurn(
 
   clearInterval(poller);
   activeChild = null;
+  activeTurnSessionId = null;
   drain({
     sessionId,
     hookDir,
@@ -459,15 +478,18 @@ async function runTurn(
   });
 
   // Any tool still open at exit would otherwise render as spinning forever.
-  for (const [, active] of state.activeToolCalls) {
+  for (const [, call] of state.toolCalls) {
+    if (call.completed) {
+      continue;
+    }
     sendSessionUpdate(sessionId, {
       sessionUpdate: "tool_call_update",
-      toolCallId: active.toolCallId,
+      toolCallId: call.toolCallId,
       status: "failed",
       rawOutput: { isError: true, error: "Antigravity exited before the tool reported completion" },
     });
   }
-  state.activeToolCalls.clear();
+  state.toolCalls.clear();
 
   if (state.conversationId) {
     session.conversationId = state.conversationId;
@@ -586,10 +608,14 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     }
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
-      if (sessionId) {
+      // Only a cancel aimed at the turn actually running can decide its stop
+      // reason. Cancels bypass the request queue, so one that arrives after a
+      // turn has already finished — or targets an idle session — would
+      // otherwise sit in the set and mark the next successful turn cancelled.
+      if (sessionId && sessionId === activeTurnSessionId) {
         cancelledSessions.add(sessionId);
+        activeChild?.kill("SIGTERM");
       }
-      activeChild?.kill("SIGTERM");
       return;
     }
     default: {

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -107,29 +107,27 @@ function transcriptDirFor(conversationId: string): string {
  * output as live. Returns 0 when the file cannot be measured, which falls back
  * to the marker heuristic rather than skipping the turn's own output.
  */
-function transcriptBaseline(conversationId: string | undefined): number {
+function transcriptBaseline(
+  conversationId: string | undefined,
+): { readonly path: string; readonly size: number } | undefined {
   if (!conversationId) {
-    return 0;
+    return undefined;
   }
-  // Measured against the same file `resolveTranscriptPath` will pin, and the
-  // path is remembered so the two cannot disagree. A byte offset taken from
-  // `transcript_full.jsonl` means nothing in the condensed file: if it exceeded
-  // that file's size the turn would read nothing at all.
+  // Path and size come from one measurement and are used together. Deciding
+  // the file twice would let the condensed transcript appear between the two
+  // and apply an offset taken from `transcript_full.jsonl` to a different
+  // file — which, if it exceeded that file's size, reads nothing at all.
   const dir = transcriptDirFor(conversationId);
   const condensed = NodePath.join(dir, "transcript.jsonl");
   const full = NodePath.join(dir, "transcript_full.jsonl");
-  const target = NodeFS.existsSync(condensed) ? condensed : full;
-  try {
-    return NodeFS.statSync(target).size;
-  } catch {
-    return 0;
+  for (const path of [condensed, full]) {
+    try {
+      return { path, size: NodeFS.statSync(path).size };
+    } catch {
+      // Try the sibling, then report nothing measurable.
+    }
   }
-}
-
-function baselineTranscriptPath(conversationId: string): string {
-  const dir = transcriptDirFor(conversationId);
-  const condensed = NodePath.join(dir, "transcript.jsonl");
-  return NodeFS.existsSync(condensed) ? condensed : NodePath.join(dir, "transcript_full.jsonl");
+  return undefined;
 }
 
 function stateDirPath(): string {
@@ -1030,13 +1028,13 @@ async function runTurn(
   const seenHooks = new Set<string>();
   const cursor = new AgyTranscriptCursor();
   const decoder = new NodeStringDecoder.StringDecoder("utf8");
-  const transcriptOffset = { value: baseline };
-  if (baseline > 0 && session.conversationId) {
+  const transcriptOffset = { value: baseline?.size ?? 0 };
+  if (baseline && baseline.size > 0) {
     // Reading starts past every earlier turn, so there is no prior-turn
-    // content left for the `USER_INPUT` heuristic to guess at. The path is
-    // pinned to the file the baseline was measured from.
+    // content left for the `USER_INPUT` heuristic to guess at. The turn is
+    // pinned to the exact file the baseline was measured from.
     state.transcriptPrimed = true;
-    state.resolvedTranscriptPath = baselineTranscriptPath(session.conversationId);
+    state.resolvedTranscriptPath = baseline.path;
   }
   const assistantText = { emitted: false };
   activeChild = child;

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1346,7 +1346,12 @@ function drain(input: {
     if (!input.state.transcriptPrimed && allLines.length > 0) {
       const trimmed = dropPriorTurnRecords(allLines);
       const foundBoundary = trimmed.length !== allLines.length;
-      input.state.transcriptBoundarySeen = input.state.transcriptBoundarySeen || foundBoundary;
+      if (foundBoundary) {
+        // A boundary observed after an overflow makes its suffix eligible
+        // again: everything retained from here belongs after that input, while
+        // text discarded before it remains permanently excluded.
+        input.state.transcriptPrimingOverflowed = false;
+      }
       if (input.state.resumedConversation && !input.final && moreTranscript) {
         // Still short of the end of the file, so no `USER_INPUT` seen so far can
         // be trusted to be this turn's: the current turn's opening record may
@@ -1356,21 +1361,22 @@ function drain(input: {
         // What is held back is `trimmed`, not the whole batch — history is
         // discarded as it is scanned, which is both what the turn wants and
         // what keeps the hold bounded to a single turn's output.
-        const heldChars =
-          input.cursor.carryLength + trimmed.reduce((total, line) => total + line.length + 1, 0);
-        if (!input.state.transcriptBoundarySeen && heldChars > MAX_TRANSCRIPT_LINE_CHARS) {
-          // No boundary anywhere in a budget's worth of scanning. Give up on
-          // what was scanned, including the partial record at the read cutoff:
-          // this turn loses whatever preceded this point, which is the right
-          // way to be wrong. Priming while unread bytes remain would replay
-          // another turn's output as this one's.
-          input.cursor.discardThroughNextNewline();
-        } else {
-          input.cursor.retain(trimmed);
+        if (
+          !input.state.transcriptPrimingOverflowed &&
+          !input.cursor.retainWithinLimit(trimmed, MAX_TRANSCRIPT_LINE_CHARS)
+        ) {
+          // Give up on what was scanned, including the partial record at the
+          // read cutoff. Priming while unread bytes remain would replay another
+          // turn's output as this one's, and retaining again before a later
+          // boundary would merely rebuild the discarded historical suffix.
+          input.state.transcriptPrimingOverflowed = true;
         }
         allLines = [];
       } else {
-        allLines = [...trimmed];
+        // Overflow discarded an unknown part of the candidate turn. Without a
+        // later input boundary, the remaining tail is just as likely to be old
+        // history and must not be surfaced as current-turn output.
+        allLines = input.state.transcriptPrimingOverflowed ? [] : [...trimmed];
         input.state.transcriptPrimed = true;
       }
     }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -14,6 +14,8 @@
  */
 // @effect-diagnostics nodeBuiltinImport:off - Standalone stdio bridge process, not an Effect runtime.
 // @effect-diagnostics globalTimers:off - Polls Antigravity hook output outside any Effect runtime.
+/* eslint-disable t3code/no-global-process-runtime -- Standalone process: there
+   is no Effect runtime here to inject HostProcessPlatform from. */
 import * as NodeChildProcess from "node:child_process";
 import * as NodeCrypto from "node:crypto";
 import * as NodeFS from "node:fs";
@@ -372,6 +374,10 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<Obser
       const raw = NodeFS.readFileSync(NodePath.join(hookDir, name), "utf8");
       const parsed: unknown = JSON.parse(raw);
       if (typeof parsed === "object" && parsed !== null) {
+        // Digested from the bytes on disk, which is what the hook itself
+        // hashed; a file swapped in between changes this and the hook rejects
+        // the decision rather than acting on a request nobody approved.
+        hookPayloadDigests.set(name, digestPayload((parsed as AgyHookEvent).rawPayload ?? ""));
         events.push({ name, event: parsed as AgyHookEvent });
       }
     } catch {
@@ -429,15 +435,30 @@ function decisionPath(hookDir: string, hookName: string): string {
  * generated per bridge process and reaches the hook through its environment,
  * so a forged file fails the check and is treated as no decision at all.
  */
-function signDecision(hookName: string, decision: AgyHookDecision): string {
-  // Both sides resolve the same value: the bridge holds it in memory, and the
-  // hook — a separate process — reads the copy handed to it in its
-  // environment.
-  const secret = process.env[HOOK_SECRET_ENV] || hookSecret;
+function signDecision(
+  secret: string,
+  hookName: string,
+  decision: AgyHookDecision,
+  payloadDigest: string,
+): string {
+  // The payload digest is part of what is signed, so a decision cannot be
+  // lifted onto a different request. Without it, a watcher could swap a
+  // dangerous hook payload for a harmless one, let the user approve what they
+  // were shown, and have the signed answer authorise the original.
   return NodeCrypto.createHmac("sha256", secret)
-    .update(`${hookName}:${decision.decision}`)
+    .update(`${hookName}:${decision.decision}:${payloadDigest}`)
     .digest("hex");
 }
+
+function digestPayload(raw: string): string {
+  return NodeCrypto.createHash("sha256").update(raw).digest("hex");
+}
+
+/**
+ * Digest of each observed hook's raw payload, so a decision can be bound to the
+ * exact request the user was shown.
+ */
+const hookPayloadDigests = new Map<string, string>();
 
 function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecision): void {
   try {
@@ -445,7 +466,15 @@ function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecis
     const staging = `${target}.tmp`;
     NodeFS.writeFileSync(
       staging,
-      JSON.stringify({ ...decision, mac: signDecision(hookName, decision) }),
+      JSON.stringify({
+        ...decision,
+        mac: signDecision(
+          turnHookSecret,
+          hookName,
+          decision,
+          hookPayloadDigests.get(hookName) ?? "",
+        ),
+      }),
     );
     NodeFS.renameSync(staging, target);
   } catch {
@@ -583,6 +612,7 @@ export async function runAgyHook(event: string): Promise<void> {
       const record: AgyHookEvent = {
         event,
         payload,
+        rawPayload: raw,
         // Snapshot the file here, while the hook still brackets the tool call.
         ...(agyToolKind(payload?.toolCall?.name) === "edit"
           ? { capturedFileText: captureFileText(agyTargetPath(payload?.toolCall)) }
@@ -603,7 +633,7 @@ export async function runAgyHook(event: string): Promise<void> {
         // fall through to the observation-only response, which allows — so a
         // change in Antigravity's payload shape would have run tools unapproved.
         const decision = payload?.toolCall
-          ? await awaitDecision(hookDir, name)
+          ? await awaitDecision(hookDir, name, digestPayload(raw))
           : ({
               decision: "deny",
               reason: "T3 Code could not identify this tool call for approval",
@@ -635,7 +665,11 @@ export async function runAgyHook(event: string): Promise<void> {
  * Fails closed: if the bridge dies, the client never answers, or the deadline
  * passes, the tool is denied rather than quietly allowed.
  */
-async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHookDecision> {
+async function awaitDecision(
+  hookDir: string,
+  hookName: string,
+  payloadDigest: string,
+): Promise<AgyHookDecision> {
   const target = decisionPath(hookDir, hookName);
   const deadline = Date.now() + APPROVAL_WAIT_MS;
   while (Date.now() < deadline) {
@@ -644,7 +678,12 @@ async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHook
       const parsed: unknown = JSON.parse(raw);
       if (isRecord(parsed) && (parsed["decision"] === "allow" || parsed["decision"] === "deny")) {
         const decision = { decision: parsed["decision"] } as AgyHookDecision;
-        const expected = signDecision(hookName, decision);
+        const expected = signDecision(
+          process.env[HOOK_SECRET_ENV] ?? "",
+          hookName,
+          decision,
+          payloadDigest,
+        );
         const presented = typeof parsed["mac"] === "string" ? parsed["mac"] : "";
         // Length-checked before comparing: `timingSafeEqual` throws on a
         // mismatch, and an unsigned file is a forgery either way.
@@ -867,10 +906,14 @@ interface TurnOutcome {
 }
 
 /**
- * Per-process secret authenticating approval decisions. Reaches hook processes
- * through their environment and never touches disk.
+ * Secret authenticating this turn's approval decisions.
+ *
+ * Rotated per turn, not per process. The secret has to reach the hook, the hook
+ * is spawned by `agy`, and every tool `agy` runs inherits that environment — so
+ * an approved tool can always forge decisions for the turn it is part of.
+ * Rotating means it cannot forge for any later turn.
  */
-const hookSecret = NodeCrypto.randomBytes(32).toString("hex");
+let turnHookSecret = "";
 
 let activeChild: NodeChildProcess.ChildProcess | null = null;
 
@@ -887,6 +930,21 @@ function killActiveChild(): void {
     return;
   }
   const { pid } = child;
+  if (process.platform === "win32") {
+    // Windows has no process groups to signal; this walks the tree instead.
+    try {
+      NodeChildProcess.execFileSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+    } catch {
+      try {
+        child.kill();
+      } catch {
+        // Nothing left to kill.
+      }
+    }
+    return;
+  }
   const signalGroup = (signal: NodeJS.Signals) => {
     try {
       // Negative pid targets the group, which `detached: true` gave the child.
@@ -901,10 +959,12 @@ function killActiveChild(): void {
     }
   };
   signalGroup("SIGTERM");
+  // Escalation does not depend on the leader still being alive. `agy` can exit
+  // on SIGTERM while a tool it started ignores the signal and keeps the group —
+  // and the workspace — busy; signalling a group that has genuinely gone is
+  // harmless, the error is caught above.
   const escalation = setTimeout(() => {
-    if (activeChild === child && child.exitCode === null && child.signalCode === null) {
-      signalGroup("SIGKILL");
-    }
+    signalGroup("SIGKILL");
   }, KILL_ESCALATION_MS);
   escalation.unref?.();
 }
@@ -1179,6 +1239,10 @@ async function runTurn(
   // holding this claim. Leaving it unset until after the spawn would silently
   // drop those, letting an auto-approving child run on past a cancelled turn.
   activeTurnSessionId = sessionId;
+  // Rotated before the spawn, so the child is handed this turn's secret: a tool
+  // approved in an earlier turn holds that turn's, and cannot sign anything
+  // this one will accept.
+  turnHookSecret = NodeCrypto.randomBytes(32).toString("hex");
   // Measured before `agy` starts: whatever the transcript already holds
   // belongs to earlier turns of the conversation being resumed.
   const baseline = transcriptBaseline(session.conversationId);
@@ -1202,7 +1266,7 @@ async function runTurn(
       }),
       {
         cwd: session.cwd,
-        env: { ...process.env, [HOOK_DIR_ENV]: hookDir, [HOOK_SECRET_ENV]: hookSecret },
+        env: { ...process.env, [HOOK_DIR_ENV]: hookDir, [HOOK_SECRET_ENV]: turnHookSecret },
         stdio: ["ignore", "pipe", "pipe"],
         // Its own process group, so cancelling can reach the tools `agy`
         // spawned rather than only `agy` itself. A tool left running keeps
@@ -1542,6 +1606,24 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
 
 /** Entry point for `t3 agy-acp`. */
 export async function runAgyBridge(): Promise<void> {
+  // `detached: true` means the child outlives this process unless it is told
+  // otherwise. Losing the bridge — a signal, a crashing parent — would
+  // otherwise leave `agy` and its tools running against the user's workspace
+  // with nothing left to stop them.
+  const stopChildOnExit = () => {
+    shuttingDown = true;
+    killActiveChild();
+  };
+  process.once("SIGTERM", () => {
+    stopChildOnExit();
+    process.exit(0);
+  });
+  process.once("SIGINT", () => {
+    stopChildOnExit();
+    process.exit(0);
+  });
+  process.once("exit", stopChildOnExit);
+
   let buffer = "";
   // Requests are handled strictly in order: a turn holds the agent busy, and
   // ACP clients do not pipeline prompts for one session.

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -48,6 +48,7 @@ import {
   dropPriorTurnRecords,
   MAX_TRANSCRIPT_LINE_CHARS,
   parseTranscriptLine,
+  serializedTranscriptRecordSize,
   transcriptRecordUpdates,
 } from "./agyTranscript.ts";
 
@@ -65,9 +66,13 @@ const APPROVAL_HOOK_TIMEOUT_SECONDS = 11 * 60;
 const APPROVAL_POLL_INTERVAL_MS = 50;
 /** Grace period before a cancelled process group is killed outright. */
 const KILL_ESCALATION_MS = 5_000;
+/** Backstop when a child reports `error` but never follows it with `close`. */
+const CHILD_ERROR_CLOSE_GRACE_MS = KILL_ESCALATION_MS + 1_000;
 /** Secret shared with hook processes so a decision cannot be forged. */
 const HOOK_SECRET_ENV = "T3_AGY_HOOK_SECRET";
 const HOOK_POLL_INTERVAL_MS = 50;
+/** Total finalization time allowed for stdout to recover from backpressure. */
+const STDOUT_DRAIN_GRACE_MS = 1_000;
 /**
  * Drains a transcript record waits for the hook that would announce its tool
  * call. Twenty polls is a second — long enough for a hook that is merely late,
@@ -268,6 +273,35 @@ function writeMessage(value: unknown): void {
       stdoutBlocked = false;
     });
   }
+}
+
+/**
+ * Wait for stdout to accept more data, but never past the finalization budget.
+ *
+ * `writeMessage` remains synchronous: this wait is used only by async turn
+ * finalization between transcript drain passes. Its own listener continues to
+ * clear `stdoutBlocked`, including when no turn is currently waiting here.
+ */
+function waitForStdoutDrain(deadline: number): Promise<void> {
+  if (!stdoutBlocked) {
+    return Promise.resolve();
+  }
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = () => {
+      process.stdout.off("drain", finish);
+      if (timer) {
+        clearTimeout(timer);
+      }
+      resolve();
+    };
+    process.stdout.once("drain", finish);
+    timer = setTimeout(finish, remaining);
+  });
 }
 
 function sendResult(id: unknown, result: unknown): void {
@@ -1401,9 +1435,22 @@ function drain(input: {
     // Records held from an earlier pass go first: their hook may have arrived
     // since, and they are older than anything read just now.
     const carried = input.state.deferredRecords.splice(0, input.state.deferredRecords.length);
+    let remainingRecordChars = input.state.deferredRecordChars;
+    input.state.deferredRecordChars = 0;
     const records = [
       ...carried,
-      ...allLines.map((line) => parseTranscriptLine(line)).filter((r) => r !== null),
+      ...allLines.flatMap((line) => {
+        const record = parseTranscriptLine(line);
+        if (record === null) {
+          return [];
+        }
+        const deferred = {
+          record,
+          serializedChars: serializedTranscriptRecordSize(record),
+        };
+        remainingRecordChars += deferred.serializedChars;
+        return [deferred];
+      }),
     ];
 
     // A deferral is a barrier, not a skip: everything after it is held too.
@@ -1420,24 +1467,28 @@ function drain(input: {
     // would discard a record read moments ago that has had no chance at all.
     const agedHead = carried.length > 0 && input.state.deferredDrains >= MAX_DEFERRED_DRAINS;
     for (let index = 0; index < records.length; index += 1) {
-      const record = records[index];
-      if (record === undefined) {
+      const deferredRecord = records[index];
+      if (deferredRecord === undefined) {
         continue;
       }
+      const record = deferredRecord.record;
       const result = transcriptRecordUpdates(record, input.state);
       if (!result.deferred) {
         // Something matched, so whatever was blocking the queue has cleared.
         input.state.deferredDrains = 0;
       } else if (input.final) {
         // Nothing further is coming; holding it would only lose it silently.
+        remainingRecordChars -= deferredRecord.serializedChars;
         continue;
       } else if (index === 0 && agedHead) {
         // Waited its full budget with no hook. Drop just this one and let the
         // rest of the batch start over with a fresh budget.
         input.state.deferredDrains = 0;
+        remainingRecordChars -= deferredRecord.serializedChars;
         continue;
       } else {
         held.push(...records.slice(index).filter((entry) => entry !== undefined));
+        input.state.deferredRecordChars = remainingRecordChars;
         input.state.deferredDrains += 1;
         // Aged out one at a time, but refilled by every poll. Antigravity emits
         // internal steps far faster than one record per drain interval, so on a
@@ -1448,7 +1499,7 @@ function drain(input: {
         // unmatchable one may have had its own hook arrive in the meantime, and
         // dropping it unexamined would lose that tool's output for good. Each is
         // offered again on the way out; only those still unmatched are dropped.
-        let heldChars = held.reduce((total, entry) => total + (entry.content?.length ?? 0), 0);
+        let heldChars = input.state.deferredRecordChars;
         let trimmed = false;
         while (held.length > MAX_DEFERRED_RECORDS || heldChars > MAX_DEFERRED_CHARS) {
           const candidate = held.shift();
@@ -1456,14 +1507,14 @@ function drain(input: {
             break;
           }
           trimmed = true;
-          heldChars -= candidate.content?.length ?? 0;
-          const retried = transcriptRecordUpdates(candidate, input.state);
+          heldChars -= candidate.serializedChars;
+          const retried = transcriptRecordUpdates(candidate.record, input.state);
           if (retried.deferred) {
             continue;
           }
           for (const update of retried.updates) {
             bufferedUpdates.push({
-              stepIdx: candidate.step_index,
+              stepIdx: candidate.record.step_index,
               phase: "transcript",
               update,
             });
@@ -1471,7 +1522,7 @@ function drain(input: {
           if (retried.emittedAssistantText) {
             input.assistantText.emitted = true;
           }
-          const retriedStep = candidate.step_index;
+          const retriedStep = candidate.record.step_index;
           if (typeof retriedStep === "number") {
             const terminal = takeTerminal(input.state, retriedStep);
             if (terminal) {
@@ -1483,6 +1534,7 @@ function drain(input: {
             }
           }
         }
+        input.state.deferredRecordChars = heldChars;
         if (trimmed) {
           // The head that had been accruing age is gone, so its budget must not
           // carry over to whatever is now in front — that record would expire
@@ -1513,6 +1565,7 @@ function drain(input: {
           });
         }
       }
+      remainingRecordChars -= deferredRecord.serializedChars;
     }
   }
 
@@ -1737,9 +1790,9 @@ async function runTurn(
   });
 
   const poller = setInterval(() => {
-    // Skipped rather than queued behind a reader that is already behind. Only
-    // the interval pauses: the final drain below runs regardless, so a turn
-    // ending while stdout is congested still reports everything it owes.
+    // Skipped rather than queued behind a reader that is already behind.
+    // `writeMessage` clears the flag on `drain`, so a later interval resumes
+    // only after stdout has accepted its buffered data.
     if (stdoutBlocked) {
       return;
     }
@@ -1759,6 +1812,18 @@ async function runTurn(
 
   let childError: Error | undefined;
   const exitCode = await new Promise<number | null>((resolve) => {
+    let settled = false;
+    let missingCloseTimer: ReturnType<typeof setTimeout> | undefined;
+    const settle = (code: number | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (missingCloseTimer) {
+        clearTimeout(missingCloseTimer);
+      }
+      resolve(code);
+    };
     child.on("error", (error) => {
       childError = error;
       // An error can report a failed kill while the process is still alive.
@@ -1772,8 +1837,13 @@ async function runTurn(
       ) {
         killActiveChild();
       }
+      // Node normally follows `error` with `close`, including failed spawns.
+      // Keep that path intact, but do not let a platform/runtime that omits
+      // `close` pin the turn and its temp directories forever. The grace
+      // outlasts the ordinary process-group escalation above.
+      missingCloseTimer ??= setTimeout(() => settle(child.exitCode), CHILD_ERROR_CLOSE_GRACE_MS);
     });
-    child.once("close", (code) => resolve(code));
+    child.once("close", settle);
   });
 
   clearInterval(poller);
@@ -1783,9 +1853,11 @@ async function runTurn(
   // transcript needs several. Only the last one runs as `final`: flushing the
   // cursor while bytes remain would emit a half-written record as if it were
   // whole, and leave the rest of that line to be read as a fragment.
+  const stdoutDrainDeadline = Date.now() + STDOUT_DRAIN_GRACE_MS;
   let finalPasses = 0;
   let transcriptRemains = true;
   while (transcriptRemains && finalPasses < MAX_FINAL_DRAIN_PASSES) {
+    await waitForStdoutDrain(stdoutDrainDeadline);
     transcriptRemains = drain({
       sessionId,
       hookDir,
@@ -1806,6 +1878,7 @@ async function runTurn(
     // in silence, so the partial line is dropped and the shortfall is said out
     // loud instead.
     cursor.flush();
+    await waitForStdoutDrain(stdoutDrainDeadline);
     sendSessionUpdate(sessionId, {
       sessionUpdate: "agent_message_chunk",
       content: {
@@ -1814,6 +1887,7 @@ async function runTurn(
       },
     });
   }
+  await waitForStdoutDrain(stdoutDrainDeadline);
   drain({
     sessionId,
     hookDir,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1231,6 +1231,8 @@ function drain(input: {
   readonly assistantText: { emitted: boolean };
   readonly turnToken: TurnToken;
   readonly final: boolean;
+  /** Defaults to true; set false to run hook and terminal cleanup only. */
+  readonly readTranscript?: boolean;
 }): boolean {
   for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
     // Diffing the file contents each hook captured, rather than the arguments
@@ -1280,7 +1282,8 @@ function drain(input: {
     }
   }
 
-  const transcriptPath = resolveTranscriptPath(input.state);
+  const transcriptPath =
+    input.readTranscript === false ? undefined : resolveTranscriptPath(input.state);
   let moreTranscript = false;
   if (transcriptPath) {
     let chunk = "";
@@ -1340,26 +1343,27 @@ function drain(input: {
     // conversation carries every prior turn. Trim once, then stream.
     if (!input.state.transcriptPrimed && allLines.length > 0) {
       const trimmed = dropPriorTurnRecords(allLines);
-      // Measured over the batch itself, not just the cursor's carry: `retain`
-      // puts whole lines back, and the next `push` hands them straight back
-      // here as complete lines. Carry stays small the whole time while the
-      // retained batch grows without limit, so budgeting on carry alone was no
-      // budget at all. Past the limit the batch is accepted as-is — replaying
-      // some earlier output is a worse transcript, but an unbounded hold is a
-      // worse process.
-      const heldChars =
-        input.cursor.carryLength + allLines.reduce((total, line) => total + line.length + 1, 0);
-      if (
-        trimmed.length === allLines.length &&
-        input.state.resumedConversation &&
-        !input.final &&
-        heldChars <= MAX_TRANSCRIPT_LINE_CHARS
-      ) {
-        // Resuming, and this batch holds no `USER_INPUT` — so the current
-        // turn's opening record has not been written yet and everything here
-        // belongs to a previous turn. Emitting it would replay old output;
-        // hold off and re-examine once more has been appended.
-        input.cursor.retain(allLines);
+      const foundBoundary = trimmed.length !== allLines.length;
+      if (input.state.resumedConversation && !input.final && moreTranscript) {
+        // Still short of the end of the file, so no `USER_INPUT` seen so far can
+        // be trusted to be this turn's: the current turn's opening record may
+        // sit in bytes not yet read. Reads are capped, so this is the ordinary
+        // case for a long transcript rather than an edge one.
+        //
+        // What is held back is `trimmed`, not the whole batch — history is
+        // discarded as it is scanned, which is both what the turn wants and
+        // what keeps the hold bounded to a single turn's output.
+        const heldChars =
+          input.cursor.carryLength + trimmed.reduce((total, line) => total + line.length + 1, 0);
+        if (!foundBoundary && heldChars > MAX_TRANSCRIPT_LINE_CHARS) {
+          // No boundary anywhere in a budget's worth of scanning. Give up on
+          // locating it and drop what was scanned: this turn loses whatever
+          // preceded this point, which is the right way to be wrong. Priming on
+          // it instead would replay another turn's output as this one's.
+          input.state.transcriptPrimed = true;
+        } else {
+          input.cursor.retain(trimmed);
+        }
         allLines = [];
       } else {
         allLines = [...trimmed];
@@ -1410,15 +1414,41 @@ function drain(input: {
         // Aged out one at a time, but refilled by every poll. Antigravity emits
         // internal steps far faster than one record per drain interval, so on a
         // transcript with unhookable steps the queue grows no matter how
-        // patiently the head expires. Trimmed from the front: the oldest held
-        // records are the ones whose hook is least likely to ever arrive.
+        // patiently the head expires.
+        //
+        // Overflow is consumed rather than discarded: a record stuck behind an
+        // unmatchable one may have had its own hook arrive in the meantime, and
+        // dropping it unexamined would lose that tool's output for good. Each is
+        // offered again on the way out; only those still unmatched are dropped.
         let heldChars = held.reduce((total, entry) => total + (entry.content?.length ?? 0), 0);
+        let trimmed = false;
         while (held.length > MAX_DEFERRED_RECORDS || heldChars > MAX_DEFERRED_CHARS) {
-          const dropped = held.shift();
-          if (dropped === undefined) {
+          const candidate = held.shift();
+          if (candidate === undefined) {
             break;
           }
-          heldChars -= dropped.content?.length ?? 0;
+          trimmed = true;
+          heldChars -= candidate.content?.length ?? 0;
+          const retried = transcriptRecordUpdates(candidate, input.state);
+          if (retried.deferred) {
+            continue;
+          }
+          for (const update of retried.updates) {
+            sendSessionUpdate(input.sessionId, update);
+          }
+          if (retried.emittedAssistantText) {
+            input.assistantText.emitted = true;
+          }
+          const retriedStep = candidate.step_index;
+          if (typeof retriedStep === "number") {
+            flushTerminal(input.sessionId, input.state, retriedStep);
+          }
+        }
+        if (trimmed) {
+          // The head that had been accruing age is gone, so its budget must not
+          // carry over to whatever is now in front — that record would expire
+          // without ever having waited.
+          input.state.deferredDrains = 0;
         }
         break;
       }
@@ -1712,6 +1742,11 @@ async function runTurn(
     assistantText,
     turnToken,
     final: true,
+    // Reading more after announcing truncation would emit records that follow
+    // the notice, and abandon everything past that one extra read just as
+    // silently. Once truncation is declared the transcript is closed; this pass
+    // exists only to flush hooks and any terminal state still owed.
+    readTranscript: !transcriptRemains,
   });
 
   // Any tool still open at exit would otherwise render as spinning forever.

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -438,6 +438,8 @@ function requestToolApproval(input: {
   }
   const toolCall = input.payload.toolCall;
   const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
+  // An allow decided while Stop was landing must not be written as an allow.
+  const requestedAtGeneration = cancelGeneration(input.sessionId);
   void sendRequest(
     "session/request_permission",
     {
@@ -463,7 +465,13 @@ function requestToolApproval(input: {
     APPROVAL_WAIT_MS,
   )
     .then((result) => {
-      const decision = approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
+      const decision =
+        cancelGeneration(input.sessionId) !== requestedAtGeneration
+          ? ({
+              decision: "deny",
+              reason: "Cancelled before this tool was approved",
+            } satisfies AgyHookDecision)
+          : approvalOutcomeToDecision(result, [APPROVE_OPTION, APPROVE_SESSION_OPTION]);
       if (decision.decision === "allow" && selectedOptionId(result) === APPROVE_SESSION_OPTION) {
         sessionWideApprovals.add(input.sessionId);
       }
@@ -584,6 +592,12 @@ async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHook
       }
     } catch {
       // Not written yet, or written partially; try again.
+    }
+    if (!NodeFS.existsSync(hookDir)) {
+      // The turn is over and its directory reclaimed, so no decision can ever
+      // land here. Stop waiting rather than polling a path that will not come
+      // back.
+      return { decision: "deny", reason: "Antigravity turn ended before approval" };
     }
     await new Promise((resolve) => setTimeout(resolve, APPROVAL_POLL_INTERVAL_MS));
   }
@@ -847,20 +861,24 @@ function drain(input: {
     }
     // The hook process is blocked until a decision file appears, so this has
     // to be started for every announced tool call.
-    // Not during the final drain: the child has already exited, so no tool is
-    // waiting on the answer and the request would never be settled.
-    if (
-      !input.final &&
-      approvalRequired() &&
-      hook.event === "pre-tool-use" &&
-      hook.payload?.toolCall
-    ) {
-      requestToolApproval({
-        sessionId: input.sessionId,
-        hookDir: input.hookDir,
-        hookName: name,
-        payload: hook.payload,
-      });
+    if (approvalRequired() && hook.event === "pre-tool-use" && hook.payload?.toolCall) {
+      if (input.final) {
+        // The child has exited, so nothing will consume an approval — but the
+        // hook subprocess may still be polling, and its directory is about to
+        // be removed. Deny explicitly so it stops now instead of spinning until
+        // its own timeout with no possible answer.
+        writeDecision(input.hookDir, name, {
+          decision: "deny",
+          reason: "Antigravity turn ended before this tool was approved",
+        });
+      } else {
+        requestToolApproval({
+          sessionId: input.sessionId,
+          hookDir: input.hookDir,
+          hookName: name,
+          payload: hook.payload,
+        });
+      }
     }
   }
 

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -856,9 +856,11 @@ function cancelledThrough(sessionId: string): number {
   return cancelledThroughEpoch.get(sessionId) ?? -1;
 }
 
-/** Whether this session's client uses the epoch extension. */
-function usesEpochs(sessionId: string): boolean {
-  return cancelledThroughEpoch.has(sessionId);
+/** Prompts accepted for a session but not yet handled, by session id. */
+const queuedPromptCounts = new Map<string, number>();
+
+function queuedPrompts(sessionId: string): number {
+  return queuedPromptCounts.get(sessionId) ?? 0;
 }
 
 /** The adapter's cancel epoch for a submission, carried in `_meta.t3.epoch`. */
@@ -1400,10 +1402,12 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
     case "session/cancel": {
       const sessionId = typeof params["sessionId"] === "string" ? params["sessionId"] : undefined;
       if (sessionId && sessions.has(sessionId) && sessionId !== activeTurnSessionId) {
-        // No turn running for it yet. A fencing client has already raised the
-        // mark, so its queued prompt is covered; one that does not fence needs
-        // this marker or its queued prompt would start after the cancel.
-        if (!usesEpochs(sessionId)) {
+        // No turn running for it yet. Banked only when a prompt is genuinely
+        // waiting: a cancel that merely arrived after its own turn finished
+        // would otherwise sit here and stop something sent much later. A prompt
+        // carrying an epoch is already covered by the mark and consumes no
+        // marker, so this only ever applies to an untagged one.
+        if (queuedPrompts(sessionId) > 0) {
           unscopedCancels.add(sessionId);
         }
         return;
@@ -1414,15 +1418,11 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // higher epoch and must survive this notification, which the runtime
         // forks and can therefore deliver late.
         //
-        // An untagged turn is cancelled outright — plain ACP behaviour — but
-        // only when this session's client never fences. In a session that does,
-        // a delayed cancel belonging to an already-fenced turn would otherwise
-        // kill an untagged follow-up that started in the meantime.
-        const unscoped = activeTurnEpoch === undefined && !usesEpochs(sessionId);
-        if (
-          unscoped ||
-          (activeTurnEpoch !== undefined && activeTurnEpoch <= cancelledThrough(sessionId))
-        ) {
+        // Judged by the running turn's own mode, not by anything the session
+        // did earlier. A turn whose prompt carried no epoch cannot be scoped by
+        // a mark it never contributed to, so it takes plain ACP semantics; one
+        // that carried an epoch is stopped only if that epoch was cancelled.
+        if (activeTurnEpoch === undefined || activeTurnEpoch <= cancelledThrough(sessionId)) {
           cancelledSessions.add(sessionId);
           activeChild?.kill("SIGTERM");
         }
@@ -1490,8 +1490,27 @@ export async function runAgyBridge(): Promise<void> {
         continue;
       }
       const pending = message;
+      // Counted from acceptance to handling, so a cancel can tell "a prompt is
+      // waiting" from "nothing is outstanding".
+      const queuedSessionId =
+        pending["method"] === "session/prompt"
+          ? (pending["params"] as Record<string, unknown> | undefined)?.["sessionId"]
+          : undefined;
+      if (typeof queuedSessionId === "string") {
+        queuedPromptCounts.set(queuedSessionId, queuedPrompts(queuedSessionId) + 1);
+      }
       queue = queue
         .then(() => handleRequest(pending))
+        .finally(() => {
+          if (typeof queuedSessionId === "string") {
+            const remaining = queuedPrompts(queuedSessionId) - 1;
+            if (remaining > 0) {
+              queuedPromptCounts.set(queuedSessionId, remaining);
+            } else {
+              queuedPromptCounts.delete(queuedSessionId);
+            }
+          }
+        })
         .catch((error: unknown) => {
           // Every request must be answered. Swallowing a handler failure would
           // leave the client blocked on a response that never arrives.

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -70,6 +70,12 @@ const HOOK_POLL_INTERVAL_MS = 50;
  * short enough that a step no hook will ever cover does not stall the stream.
  */
 const MAX_DEFERRED_DRAINS = 20;
+/**
+ * Cap on the `agy` output held in memory per stream. Only the tail is kept:
+ * stdout is a fallback used when the transcript streamed nothing, and stderr
+ * only needs to explain a failure.
+ */
+const MAX_CAPTURED_OUTPUT = 256 * 1024;
 const DEFAULT_PRINT_TIMEOUT = "2h";
 const HOOKS_KEY = "t3code-antigravity-observer";
 
@@ -1471,15 +1477,26 @@ async function runTurn(
     killActiveChild();
   }
 
+  // Both are kept as bounded tails. A turn that prints a large file — or a tool
+  // that loops — would otherwise grow these strings for the whole run and take
+  // the bridge's heap with it, turning a noisy turn into a dead provider.
+  // stdout is only ever a fallback for when the transcript produced nothing,
+  // and stderr only has to carry enough to explain a failure.
   let stdout = "";
   let stderr = "";
+  const appendBounded = (current: string, chunk: string): string => {
+    const combined = current + chunk;
+    return combined.length <= MAX_CAPTURED_OUTPUT
+      ? combined
+      : combined.slice(combined.length - MAX_CAPTURED_OUTPUT);
+  };
   child.stdout?.setEncoding("utf8");
   child.stdout?.on("data", (chunk: string) => {
-    stdout += chunk;
+    stdout = appendBounded(stdout, chunk);
   });
   child.stderr?.setEncoding("utf8");
   child.stderr?.on("data", (chunk: string) => {
-    stderr += chunk;
+    stderr = appendBounded(stderr, chunk);
   });
 
   const poller = setInterval(() => {
@@ -1751,6 +1768,16 @@ async function handleRequest(message: Record<string, unknown>): Promise<void> {
         // higher epoch and must survive this notification, which the runtime
         // forks and can therefore deliver late.
         //
+        // A cancel is authoritative for the turn that is running: the fence
+        // that would normally have raised the mark is a separate notification
+        // and can fail to send, and without this the child would survive a Stop
+        // the client believes it delivered.
+        if (activeTurnEpoch !== undefined) {
+          cancelledThroughEpoch.set(
+            sessionId,
+            Math.max(cancelledThrough(sessionId), activeTurnEpoch),
+          );
+        }
         // Judged by the running turn's own mode, not by anything the session
         // did earlier. A turn whose prompt carried no epoch cannot be scoped by
         // a mark it never contributed to, so it takes plain ACP semantics; one

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -111,15 +111,25 @@ function transcriptBaseline(conversationId: string | undefined): number {
   if (!conversationId) {
     return 0;
   }
+  // Measured against the same file `resolveTranscriptPath` will pin, and the
+  // path is remembered so the two cannot disagree. A byte offset taken from
+  // `transcript_full.jsonl` means nothing in the condensed file: if it exceeded
+  // that file's size the turn would read nothing at all.
   const dir = transcriptDirFor(conversationId);
-  for (const name of ["transcript.jsonl", "transcript_full.jsonl"]) {
-    try {
-      return NodeFS.statSync(NodePath.join(dir, name)).size;
-    } catch {
-      // Try the sibling, then give up.
-    }
+  const condensed = NodePath.join(dir, "transcript.jsonl");
+  const full = NodePath.join(dir, "transcript_full.jsonl");
+  const target = NodeFS.existsSync(condensed) ? condensed : full;
+  try {
+    return NodeFS.statSync(target).size;
+  } catch {
+    return 0;
   }
-  return 0;
+}
+
+function baselineTranscriptPath(conversationId: string): string {
+  const dir = transcriptDirFor(conversationId);
+  const condensed = NodePath.join(dir, "transcript.jsonl");
+  return NodeFS.existsSync(condensed) ? condensed : NodePath.join(dir, "transcript_full.jsonl");
 }
 
 function stateDirPath(): string {
@@ -866,13 +876,17 @@ function drain(input: {
         try {
           const length = stats.size - input.transcriptOffset.value;
           const buffer = Buffer.alloc(length);
-          NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
+          // `readSync` may return fewer bytes than asked for. Decoding the
+          // whole buffer would feed the zero-filled tail through as content
+          // and skip the real bytes for good, so only what was actually read
+          // is consumed; the rest is picked up on the next poll.
+          const bytesRead = NodeFS.readSync(fd, buffer, 0, length, input.transcriptOffset.value);
           // Decoded through the turn's streaming decoder, not `toString`: a
           // write can land mid-multibyte-character, and decoding each slice
           // independently would replace the partial sequence with U+FFFD and
           // advance past it, silently corrupting non-ASCII output.
-          chunk = input.decoder.write(buffer);
-          input.transcriptOffset.value = stats.size;
+          chunk = bytesRead > 0 ? input.decoder.write(buffer.subarray(0, bytesRead)) : "";
+          input.transcriptOffset.value += bytesRead;
         } finally {
           NodeFS.closeSync(fd);
         }
@@ -1017,10 +1031,12 @@ async function runTurn(
   const cursor = new AgyTranscriptCursor();
   const decoder = new NodeStringDecoder.StringDecoder("utf8");
   const transcriptOffset = { value: baseline };
-  if (baseline > 0) {
+  if (baseline > 0 && session.conversationId) {
     // Reading starts past every earlier turn, so there is no prior-turn
-    // content left for the `USER_INPUT` heuristic to guess at.
+    // content left for the `USER_INPUT` heuristic to guess at. The path is
+    // pinned to the file the baseline was measured from.
     state.transcriptPrimed = true;
+    state.resolvedTranscriptPath = baselineTranscriptPath(session.conversationId);
   }
   const assistantText = { emitted: false };
   activeChild = child;
@@ -1330,6 +1346,10 @@ export async function runAgyBridge(): Promise<void> {
   // stdin closed: no approval can still be answered, so unblock the hooks
   // waiting on them (they fail closed) rather than letting them time out.
   failPendingOutbound("T3 Code disconnected before approving this tool call");
-  await queue;
+  // Killed before awaiting the queue, not after: an in-flight `session/prompt`
+  // only resolves when `agy` exits, so waiting first would keep the bridge and
+  // its child alive for the whole print timeout — hours — after the client
+  // disconnected.
   activeChild?.kill("SIGTERM");
+  await queue;
 }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1289,9 +1289,7 @@ function drain(input: {
       ...carried,
       ...allLines.map((line) => parseTranscriptLine(line)).filter((r) => r !== null),
     ];
-    if (carried.length === 0) {
-      input.state.deferredDrains = 0;
-    }
+
     // A deferral is a barrier, not a skip: everything after it is held too.
     // Emitting later records while an earlier one waits would put a tool's
     // output after text that followed it, and replay it out of order next pass.
@@ -1301,20 +1299,31 @@ function drain(input: {
     // order and any still unmatched are dropped, so an unhookable step costs
     // its own output rather than stalling everything behind it.
     const held = input.state.deferredRecords;
-    const releasing = input.final || input.state.deferredDrains >= MAX_DEFERRED_DRAINS;
+    // Only the record that actually waited out the bound is given up on, and
+    // only while it is still at the head. Applying its age to the whole batch
+    // would discard a record read moments ago that has had no chance at all.
+    const agedHead = carried.length > 0 && input.state.deferredDrains >= MAX_DEFERRED_DRAINS;
     for (let index = 0; index < records.length; index += 1) {
       const record = records[index];
       if (record === undefined) {
         continue;
       }
       const result = transcriptRecordUpdates(record, input.state);
-      if (result.deferred && !releasing) {
+      if (!result.deferred) {
+        // Something matched, so whatever was blocking the queue has cleared.
+        input.state.deferredDrains = 0;
+      } else if (input.final) {
+        // Nothing further is coming; holding it would only lose it silently.
+        continue;
+      } else if (index === 0 && agedHead) {
+        // Waited its full budget with no hook. Drop just this one and let the
+        // rest of the batch start over with a fresh budget.
+        input.state.deferredDrains = 0;
+        continue;
+      } else {
         held.push(...records.slice(index).filter((entry) => entry !== undefined));
         input.state.deferredDrains += 1;
         break;
-      }
-      if (result.deferred) {
-        continue;
       }
       for (const update of result.updates) {
         sendSessionUpdate(input.sessionId, update);

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -1048,21 +1048,9 @@ function killActiveChild(options?: { readonly immediate?: boolean }): void {
     return;
   }
   const { pid } = child;
-  if (process.platform === "win32") {
-    // Windows has no process groups to signal; this walks the tree instead.
-    try {
-      NodeChildProcess.execFileSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
-        stdio: "ignore",
-      });
-    } catch {
-      try {
-        child.kill();
-      } catch {
-        // Nothing left to kill.
-      }
-    }
-    return;
-  }
+  // Windows goes through the same guarded helper. A `taskkill` here would run
+  // against a numeric pid with no liveness check, and `close` can lag `exit`
+  // long enough for Windows to have reused it.
   if (options?.immediate) {
     signalGroupOf(child, pid, "SIGKILL");
     clearPendingKill(child);
@@ -1288,12 +1276,23 @@ function drain(input: {
         input.state.transcriptPrimed = true;
       }
     }
-    for (const line of allLines) {
-      const record = parseTranscriptLine(line);
-      if (!record) {
+    // Records held from an earlier pass go first: their hook may have arrived
+    // since, and they are older than anything read just now.
+    const held = input.state.deferredRecords.splice(0, input.state.deferredRecords.length);
+    const records = [
+      ...held,
+      ...allLines.map((line) => parseTranscriptLine(line)).filter((r) => r !== null),
+    ];
+    for (const record of records) {
+      const result = transcriptRecordUpdates(record, input.state);
+      if (result.deferred) {
+        // Its tool call has not been announced yet. On the final pass nothing
+        // more is coming, so holding it would only lose it silently.
+        if (!input.final) {
+          input.state.deferredRecords.push(record);
+        }
         continue;
       }
-      const result = transcriptRecordUpdates(record, input.state);
       for (const update of result.updates) {
         sendSessionUpdate(input.sessionId, update);
       }

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -282,25 +282,26 @@ function writeMessage(value: unknown): void {
  * finalization between transcript drain passes. Its own listener continues to
  * clear `stdoutBlocked`, including when no turn is currently waiting here.
  */
-function waitForStdoutDrain(deadline: number): Promise<void> {
+function waitForStdoutDrain(deadline: number): Promise<boolean> {
   if (!stdoutBlocked) {
-    return Promise.resolve();
+    return Promise.resolve(false);
   }
   const remaining = deadline - Date.now();
   if (remaining <= 0) {
-    return Promise.resolve();
+    return Promise.resolve(stdoutBlocked);
   }
   return new Promise((resolve) => {
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const finish = () => {
-      process.stdout.off("drain", finish);
+    const finish = (timedOut: boolean) => {
+      process.stdout.off("drain", onDrain);
       if (timer) {
         clearTimeout(timer);
       }
-      resolve();
+      resolve(timedOut);
     };
-    process.stdout.once("drain", finish);
-    timer = setTimeout(finish, remaining);
+    const onDrain = () => finish(false);
+    process.stdout.once("drain", onDrain);
+    timer = setTimeout(() => finish(stdoutBlocked), remaining);
   });
 }
 
@@ -1857,7 +1858,10 @@ async function runTurn(
   let finalPasses = 0;
   let transcriptRemains = true;
   while (transcriptRemains && finalPasses < MAX_FINAL_DRAIN_PASSES) {
-    await waitForStdoutDrain(stdoutDrainDeadline);
+    const stdoutDrainTimedOut = await waitForStdoutDrain(stdoutDrainDeadline);
+    if (stdoutDrainTimedOut) {
+      break;
+    }
     transcriptRemains = drain({
       sessionId,
       hookDir,

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -960,6 +960,28 @@ let activeChild: NodeChildProcess.ChildProcess | null = null;
  * mid-write keeps changing the workspace after the user pressed Stop, and its
  * output can still arrive against a turn that has been reported cancelled.
  */
+/**
+ * Process groups signalled but not yet confirmed dead.
+ *
+ * `agy` can exit on SIGTERM while a tool it started ignores the signal, and
+ * `runTurn` then clears `activeChild`. Only the pending escalation still knew
+ * that group existed — and a shutdown inside that window runs no timers, so the
+ * tool survived with nothing left to stop it.
+ */
+const pendingKillGroups = new Set<number>();
+
+/** SIGKILL every group still awaiting escalation. Used on shutdown. */
+function killPendingGroups(): void {
+  for (const pid of pendingKillGroups) {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+  pendingKillGroups.clear();
+}
+
 function killActiveChild(options?: { readonly immediate?: boolean }): void {
   const child = activeChild;
   if (!child?.pid) {
@@ -996,15 +1018,18 @@ function killActiveChild(options?: { readonly immediate?: boolean }): void {
   };
   if (options?.immediate) {
     signalGroup("SIGKILL");
+    pendingKillGroups.delete(pid);
     return;
   }
   signalGroup("SIGTERM");
+  pendingKillGroups.add(pid);
   // Escalation does not depend on the leader still being alive. `agy` can exit
   // on SIGTERM while a tool it started ignores the signal and keeps the group —
   // and the workspace — busy; signalling a group that has genuinely gone is
   // harmless, the error is caught above.
   const escalation = setTimeout(() => {
     signalGroup("SIGKILL");
+    pendingKillGroups.delete(pid);
   }, KILL_ESCALATION_MS);
   escalation.unref?.();
 }
@@ -1659,6 +1684,9 @@ export async function runAgyBridge(): Promise<void> {
   const stopChildOnExit = () => {
     shuttingDown = true;
     killActiveChild({ immediate: true });
+    // Groups whose leader already exited are known only to their pending
+    // escalation, and `process.exit` runs no timers.
+    killPendingGroups();
   };
   process.once("SIGTERM", () => {
     stopChildOnExit();

--- a/apps/server/src/provider/acp/antigravity/agyBridge.ts
+++ b/apps/server/src/provider/acp/antigravity/agyBridge.ts
@@ -24,10 +24,14 @@ import * as NodeURL from "node:url";
 import packageJson from "../../../../package.json" with { type: "json" };
 import {
   agyHookResponse,
+  approvalOutcomeToDecision,
   agyTargetPath,
+  agyToolCallId,
   agyToolKind,
+  agyToolTitle,
   hookSessionUpdate,
   makeAgyTurnState,
+  type AgyHookDecision,
   type AgyHookEvent,
   type AgyHookPayload,
   type AgySessionUpdate,
@@ -41,6 +45,17 @@ import {
 } from "./agyTranscript.ts";
 
 const HOOK_DIR_ENV = "T3_AGY_HOOK_DIR";
+const REQUIRE_APPROVAL_ENV = "T3_AGY_REQUIRE_APPROVAL";
+/** Suffix of the file the bridge writes to answer a waiting `PreToolUse` hook. */
+const DECISION_SUFFIX = ".decision";
+/**
+ * How long a `PreToolUse` hook blocks waiting for the user. Antigravity's own
+ * hook timeout is set above this so the deny below is what actually lands,
+ * rather than the CLI abandoning the hook first.
+ */
+const APPROVAL_WAIT_MS = 10 * 60 * 1000;
+const APPROVAL_HOOK_TIMEOUT_SECONDS = 11 * 60;
+const APPROVAL_POLL_INTERVAL_MS = 50;
 const HOOK_POLL_INTERVAL_MS = 50;
 const DEFAULT_PRINT_TIMEOUT = "2h";
 const HOOKS_KEY = "t3code-antigravity-observer";
@@ -155,6 +170,58 @@ function sendSessionUpdate(sessionId: string, update: AgySessionUpdate): void {
   });
 }
 
+// ── Outbound requests ─────────────────────────────────────────────────
+//
+// The bridge is the ACP agent, so asking the client to approve a tool means
+// issuing a request in the other direction and correlating the reply.
+
+let nextOutboundId = 1;
+const pendingOutbound = new Map<
+  number,
+  { readonly resolve: (value: unknown) => void; readonly reject: (error: Error) => void }
+>();
+
+function sendRequest(method: string, params: unknown): Promise<unknown> {
+  const id = nextOutboundId;
+  nextOutboundId += 1;
+  return new Promise((resolve, reject) => {
+    pendingOutbound.set(id, { resolve, reject });
+    writeMessage({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+/**
+ * Settle an outbound request from a client reply. Returns false when the id is
+ * not one of ours, so the caller can treat the message as a request instead.
+ */
+function resolveOutbound(message: Record<string, unknown>): boolean {
+  const id = message["id"];
+  if (typeof id !== "number" || !pendingOutbound.has(id)) {
+    return false;
+  }
+  const pending = pendingOutbound.get(id);
+  pendingOutbound.delete(id);
+  if (!pending) {
+    return false;
+  }
+  const error = message["error"];
+  if (isRecord(error)) {
+    const detail = typeof error["message"] === "string" ? error["message"] : "request failed";
+    pending.reject(new Error(detail));
+  } else {
+    pending.resolve(message["result"]);
+  }
+  return true;
+}
+
+/** Reject everything still outstanding; used when the client goes away. */
+function failPendingOutbound(reason: string): void {
+  for (const [, pending] of pendingOutbound) {
+    pending.reject(new Error(reason));
+  }
+  pendingOutbound.clear();
+}
+
 // ── Hook observer ─────────────────────────────────────────────────────
 
 /**
@@ -183,16 +250,19 @@ function createHookWorkspace(): string {
   const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-agy-hooks-"));
   const agentsDir = NodePath.join(dir, ".agents");
   NodeFS.mkdirSync(agentsDir, { recursive: true });
-  const toolHook = (event: string) => [
-    { matcher: "*", hooks: [{ type: "command", command: hookCommandFor(event), timeout: 10 }] },
+  // A gating PreToolUse hook blocks while the user decides, so its timeout has
+  // to outlast the bridge's own wait; observation-only hooks stay short.
+  const preToolTimeout = approvalRequired() ? APPROVAL_HOOK_TIMEOUT_SECONDS : 10;
+  const toolHook = (event: string, timeout: number) => [
+    { matcher: "*", hooks: [{ type: "command", command: hookCommandFor(event), timeout }] },
   ];
   NodeFS.writeFileSync(
     NodePath.join(agentsDir, "hooks.json"),
     JSON.stringify(
       {
         [HOOKS_KEY]: {
-          PreToolUse: toolHook("pre-tool-use"),
-          PostToolUse: toolHook("post-tool-use"),
+          PreToolUse: toolHook("pre-tool-use", preToolTimeout),
+          PostToolUse: toolHook("post-tool-use", 10),
           Stop: [{ type: "command", command: hookCommandFor("stop"), timeout: 10 }],
         },
       },
@@ -203,14 +273,20 @@ function createHookWorkspace(): string {
   return dir;
 }
 
-function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<AgyHookEvent> {
+/** A hook event plus the file it came from, which keys its decision reply. */
+interface ObservedHook {
+  readonly name: string;
+  readonly event: AgyHookEvent;
+}
+
+function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<ObservedHook> {
   let entries: Array<string>;
   try {
     entries = NodeFS.readdirSync(hookDir);
   } catch {
     return [];
   }
-  const events: Array<AgyHookEvent> = [];
+  const events: Array<ObservedHook> = [];
   for (const name of entries.filter((n) => n.endsWith(".json")).sort()) {
     if (seen.has(name)) {
       continue;
@@ -220,7 +296,7 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<AgyHo
       const raw = NodeFS.readFileSync(NodePath.join(hookDir, name), "utf8");
       const parsed: unknown = JSON.parse(raw);
       if (typeof parsed === "object" && parsed !== null) {
-        events.push(parsed as AgyHookEvent);
+        events.push({ name, event: parsed as AgyHookEvent });
       }
     } catch {
       // A half-written hook file is picked up on the next poll.
@@ -228,6 +304,76 @@ function readHookEvents(hookDir: string, seen: Set<string>): ReadonlyArray<AgyHo
     }
   }
   return events;
+}
+
+// ── Tool approval ─────────────────────────────────────────────────────
+
+const APPROVE_OPTION = "allow";
+const REJECT_OPTION = "reject";
+
+function approvalRequired(): boolean {
+  return process.env[REQUIRE_APPROVAL_ENV]?.trim() === "1";
+}
+
+function decisionPath(hookDir: string, hookName: string): string {
+  return NodePath.join(hookDir, `${hookName}${DECISION_SUFFIX}`);
+}
+
+function writeDecision(hookDir: string, hookName: string, decision: AgyHookDecision): void {
+  try {
+    const target = decisionPath(hookDir, hookName);
+    const staging = `${target}.tmp`;
+    NodeFS.writeFileSync(staging, JSON.stringify(decision));
+    NodeFS.renameSync(staging, target);
+  } catch {
+    // The waiting hook falls back to denying when its deadline passes, which
+    // is the safe outcome for a permission gate.
+  }
+}
+
+/**
+ * Ask the client to approve one tool call, then hand the answer to the waiting
+ * hook process through the shared directory.
+ *
+ * Fire-and-forget by design: `drain` runs on a timer and must not block the
+ * transcript reader while a human decides.
+ */
+function requestToolApproval(input: {
+  readonly sessionId: string;
+  readonly hookDir: string;
+  readonly hookName: string;
+  readonly payload: AgyHookPayload;
+}): void {
+  const toolCall = input.payload.toolCall;
+  const stepIdx = typeof input.payload.stepIdx === "number" ? input.payload.stepIdx : 0;
+  void sendRequest("session/request_permission", {
+    sessionId: input.sessionId,
+    toolCall: {
+      toolCallId: agyToolCallId(input.payload.conversationId, stepIdx),
+      title: agyToolTitle(toolCall),
+      kind: agyToolKind(toolCall?.name),
+      status: "pending",
+      rawInput: toolCall?.args ?? null,
+      ...(agyTargetPath(toolCall) ? { locations: [{ path: agyTargetPath(toolCall) }] } : {}),
+    },
+    options: [
+      { optionId: APPROVE_OPTION, name: "Allow", kind: "allow_once" },
+      { optionId: REJECT_OPTION, name: "Reject", kind: "reject_once" },
+    ],
+  })
+    .then((result) => {
+      writeDecision(
+        input.hookDir,
+        input.hookName,
+        approvalOutcomeToDecision(result, APPROVE_OPTION),
+      );
+    })
+    .catch(() => {
+      writeDecision(input.hookDir, input.hookName, {
+        decision: "deny",
+        reason: "T3 Code could not obtain approval for this tool call",
+      });
+    });
 }
 
 /**
@@ -278,12 +424,45 @@ export async function runAgyHook(event: string): Promise<void> {
       const tempPath = `${finalPath}.tmp`;
       NodeFS.writeFileSync(tempPath, JSON.stringify(record));
       NodeFS.renameSync(tempPath, finalPath);
+
+      // With approvals on, this process is the gate: block until the bridge
+      // reports the user's answer. `deny` here genuinely stops the tool —
+      // Antigravity reports the reason back to the model.
+      if (approvalRequired() && event === "pre-tool-use" && payload?.toolCall) {
+        const decision = await awaitDecision(hookDir, name);
+        process.stdout.write(JSON.stringify(decision));
+        return;
+      }
     } catch {
       // Observation is best-effort: a hook must never break a tool call.
     }
   }
 
   process.stdout.write(JSON.stringify(agyHookResponse(event, Boolean(hookDir))));
+}
+
+/**
+ * Wait for the bridge's answer to one `PreToolUse` hook.
+ *
+ * Fails closed: if the bridge dies, the client never answers, or the deadline
+ * passes, the tool is denied rather than quietly allowed.
+ */
+async function awaitDecision(hookDir: string, hookName: string): Promise<AgyHookDecision> {
+  const target = decisionPath(hookDir, hookName);
+  const deadline = Date.now() + APPROVAL_WAIT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const raw = NodeFS.readFileSync(target, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (isRecord(parsed) && (parsed["decision"] === "allow" || parsed["decision"] === "deny")) {
+        return parsed as unknown as AgyHookDecision;
+      }
+    } catch {
+      // Not written yet, or written partially; try again.
+    }
+    await new Promise((resolve) => setTimeout(resolve, APPROVAL_POLL_INTERVAL_MS));
+  }
+  return { decision: "deny", reason: "Timed out waiting for approval in T3 Code" };
 }
 
 // ── Turn execution ────────────────────────────────────────────────────
@@ -466,7 +645,7 @@ function drain(input: {
   readonly assistantText: { emitted: boolean };
   readonly final: boolean;
 }): void {
-  for (const hook of readHookEvents(input.hookDir, input.seenHooks)) {
+  for (const { name, event: hook } of readHookEvents(input.hookDir, input.seenHooks)) {
     // Diffing the file contents each hook captured, rather than the arguments
     // of the edit, keeps this correct across tools whose argument shapes
     // differ (`replace_file_content` sends a fragment, `write_to_file` sends
@@ -475,6 +654,16 @@ function drain(input: {
     const update = hookSessionUpdate(hook, input.state, fileText);
     if (update) {
       sendSessionUpdate(input.sessionId, update);
+    }
+    // The hook process is blocked until a decision file appears, so this has
+    // to be started for every announced tool call.
+    if (approvalRequired() && hook.event === "pre-tool-use" && hook.payload?.toolCall) {
+      requestToolApproval({
+        sessionId: input.sessionId,
+        hookDir: input.hookDir,
+        hookName: name,
+        payload: hook.payload,
+      });
     }
   }
 
@@ -853,6 +1042,13 @@ export async function runAgyBridge(): Promise<void> {
         continue;
       }
 
+      // A reply to one of the bridge's own requests (tool approval) carries an
+      // id but no method, and must never enter the request queue — the turn
+      // holding that queue is exactly what is waiting on the answer.
+      if (message["method"] === undefined && resolveOutbound(message)) {
+        continue;
+      }
+
       // Cancellation must interrupt an in-flight turn, so it bypasses the
       // queue that would otherwise make it wait for that turn to finish.
       if (message["method"] === "session/cancel") {
@@ -873,6 +1069,9 @@ export async function runAgyBridge(): Promise<void> {
     }
   }
 
+  // stdin closed: no approval can still be answered, so unblock the hooks
+  // waiting on them (they fail closed) rather than letting them time out.
+  failPendingOutbound("T3 Code disconnected before approving this tool call");
   await queue;
   activeChild?.kill("SIGTERM");
 }

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -243,6 +243,18 @@ describe("orderAgySessionUpdates", () => {
       ]),
     ).toEqual([update("announce"), update("output"), update("complete")]);
   });
+
+  it("keeps an unindexed planner response between the steps surrounding it", () => {
+    const update = (name: string) => ({ name });
+
+    expect(
+      orderAgySessionUpdates([
+        { stepIdx: 2, phase: "transcript", update: update("step 2") },
+        { stepIdx: undefined, phase: "transcript", update: update("unindexed PLANNER_RESPONSE") },
+        { stepIdx: 3, phase: "transcript", update: update("step 3") },
+      ]),
+    ).toEqual([update("step 2"), update("unindexed PLANNER_RESPONSE"), update("step 3")]);
+  });
 });
 
 describe("approvalOutcomeToDecision", () => {

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -80,7 +80,7 @@ describe("hookSessionUpdate", () => {
       status: "in_progress",
       rawInput: { CommandLine: "ls -la src" },
     });
-    expect(state.activeToolCalls.has(3)).toBe(true);
+    expect(state.toolCalls.get(3)?.completed).toBe(false);
   });
 
   it("learns the conversation and transcript from any hook, not just stop", () => {
@@ -102,7 +102,7 @@ describe("hookSessionUpdate", () => {
     );
 
     expect(update).toBeNull();
-    expect(state.activeToolCalls.size).toBe(0);
+    expect(state.toolCalls.size).toBe(0);
   });
 
   it("completes a tool call that was announced", () => {
@@ -121,7 +121,21 @@ describe("hookSessionUpdate", () => {
       status: "completed",
       rawOutput: { isError: false },
     });
-    expect(state.activeToolCalls.size).toBe(0);
+    // Retained, not deleted: the transcript record carrying this step's output
+    // is often read in the same drain pass and still needs the tool call id.
+    expect(state.toolCalls.get(3)?.completed).toBe(true);
+  });
+
+  it("ignores a duplicate post hook for an already completed step", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+    const post = {
+      event: "post-tool-use",
+      payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+    } as const;
+
+    expect(hookSessionUpdate(post, state)).not.toBeNull();
+    expect(hookSessionUpdate(post, state)).toBeNull();
   });
 
   it("marks a tool call failed and carries the error through", () => {

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -9,6 +9,7 @@ import {
   agyToolTitle,
   hookSessionUpdate,
   makeAgyTurnState,
+  orderAgySessionUpdates,
   type AgyHookEvent,
 } from "./agyEvents.ts";
 
@@ -216,6 +217,31 @@ describe("hookSessionUpdate", () => {
     );
 
     expect(update).not.toHaveProperty("content");
+  });
+});
+
+describe("orderAgySessionUpdates", () => {
+  it("orders hooks and transcript updates by step", () => {
+    const update = (name: string) => ({ name });
+
+    expect(
+      orderAgySessionUpdates([
+        { stepIdx: 3, phase: "pre", update: update("tool 3") },
+        { stepIdx: 2, phase: "transcript", update: update("assistant 2") },
+      ]),
+    ).toEqual([update("assistant 2"), update("tool 3")]);
+  });
+
+  it("announces a call before its output and completes it afterwards", () => {
+    const update = (name: string) => ({ name });
+
+    expect(
+      orderAgySessionUpdates([
+        { stepIdx: 4, phase: "terminal", update: update("complete") },
+        { stepIdx: 4, phase: "pre", update: update("announce") },
+        { stepIdx: 4, phase: "transcript", update: update("output") },
+      ]),
+    ).toEqual([update("announce"), update("output"), update("complete")]);
   });
 });
 

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  agyHookResponse,
+  agyTargetPath,
+  agyToolCallId,
+  agyToolKind,
+  agyToolTitle,
+  hookSessionUpdate,
+  makeAgyTurnState,
+  type AgyHookEvent,
+} from "./agyEvents.ts";
+
+const preToolUse = (overrides: Record<string, unknown> = {}): AgyHookEvent => ({
+  event: "pre-tool-use",
+  payload: {
+    conversationId: "conversation-1",
+    stepIdx: 3,
+    transcriptPath: "/brain/conversation-1/.system_generated/logs/transcript_full.jsonl",
+    modelName: "gemini-3.1-pro-high",
+    toolCall: { name: "run_command", args: { CommandLine: "ls -la src" } },
+    ...overrides,
+  },
+});
+
+describe("agyToolKind", () => {
+  it("maps Antigravity tool names onto ACP kinds", () => {
+    expect(agyToolKind("replace_file_content")).toBe("edit");
+    expect(agyToolKind("write_to_file")).toBe("edit");
+    expect(agyToolKind("view_file")).toBe("read");
+    expect(agyToolKind("list_dir")).toBe("read");
+    expect(agyToolKind("grep_search")).toBe("search");
+    expect(agyToolKind("run_command")).toBe("execute");
+    expect(agyToolKind("delete_file")).toBe("delete");
+  });
+
+  it("treats browser tools as fetch and unknown tools as other", () => {
+    expect(agyToolKind("browser_navigate")).toBe("fetch");
+    expect(agyToolKind("some_future_tool")).toBe("other");
+    expect(agyToolKind(undefined)).toBe("other");
+  });
+});
+
+describe("agyToolTitle", () => {
+  it("prefers Antigravity's own summary over the raw tool name", () => {
+    expect(agyToolTitle({ name: "run_command", args: { toolSummary: "List files in src" } })).toBe(
+      "List files in src",
+    );
+  });
+
+  it("falls back through toolAction to the tool name", () => {
+    expect(agyToolTitle({ name: "run_command", args: { toolAction: "Listing files" } })).toBe(
+      "Listing files",
+    );
+    expect(agyToolTitle({ name: "run_command", args: {} })).toBe("run_command");
+    expect(agyToolTitle(null)).toBe("Antigravity tool");
+  });
+});
+
+describe("agyTargetPath", () => {
+  it("reads the path from whichever PascalCase key the tool used", () => {
+    expect(agyTargetPath({ name: "replace_file_content", args: { TargetFile: "/a/b.ts" } })).toBe(
+      "/a/b.ts",
+    );
+    expect(agyTargetPath({ name: "view_file", args: { AbsolutePath: "/a/c.ts" } })).toBe("/a/c.ts");
+    expect(agyTargetPath({ name: "list_dir", args: { DirectoryPath: "/a" } })).toBe("/a");
+    expect(agyTargetPath({ name: "run_command", args: { CommandLine: "ls" } })).toBeUndefined();
+  });
+});
+
+describe("hookSessionUpdate", () => {
+  it("announces a tool call and records it as in flight", () => {
+    const state = makeAgyTurnState();
+    const update = hookSessionUpdate(preToolUse(), state);
+
+    expect(update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: agyToolCallId("conversation-1", 3),
+      kind: "execute",
+      status: "in_progress",
+      rawInput: { CommandLine: "ls -la src" },
+    });
+    expect(state.activeToolCalls.has(3)).toBe(true);
+  });
+
+  it("learns the conversation and transcript from any hook, not just stop", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+
+    expect(state.conversationId).toBe("conversation-1");
+    expect(state.modelName).toBe("gemini-3.1-pro-high");
+    expect(state.transcriptPath).toBe(
+      "/brain/conversation-1/.system_generated/logs/transcript_full.jsonl",
+    );
+  });
+
+  it("ignores hook pairs for internal planner steps that carry no tool", () => {
+    const state = makeAgyTurnState();
+    const update = hookSessionUpdate(
+      { event: "pre-tool-use", payload: { conversationId: "c", stepIdx: 1, toolCall: null } },
+      state,
+    );
+
+    expect(update).toBeNull();
+    expect(state.activeToolCalls.size).toBe(0);
+  });
+
+  it("completes a tool call that was announced", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+      },
+      state,
+    );
+
+    expect(update).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      status: "completed",
+      rawOutput: { isError: false },
+    });
+    expect(state.activeToolCalls.size).toBe(0);
+  });
+
+  it("marks a tool call failed and carries the error through", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(preToolUse(), state);
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "exit status 1" },
+      },
+      state,
+    );
+
+    expect(update).toMatchObject({
+      status: "failed",
+      rawOutput: { isError: true, error: "exit status 1" },
+    });
+  });
+
+  it("drops a post hook whose pre hook was never observed", () => {
+    const state = makeAgyTurnState();
+    const update = hookSessionUpdate(
+      { event: "post-tool-use", payload: { conversationId: "c", stepIdx: 9, error: "" } },
+      state,
+    );
+
+    expect(update).toBeNull();
+  });
+
+  it("emits a diff from the file contents captured around an edit", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(
+      preToolUse({
+        toolCall: { name: "replace_file_content", args: { TargetFile: "/repo/greet.js" } },
+      }),
+      state,
+      'return "hi";',
+    );
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+      },
+      state,
+      'return "hello";',
+    );
+
+    expect(update).toMatchObject({
+      status: "completed",
+      content: [
+        {
+          type: "diff",
+          path: "/repo/greet.js",
+          oldText: 'return "hi";',
+          newText: 'return "hello";',
+        },
+      ],
+    });
+  });
+
+  it("omits the diff when an edit left the file byte-identical", () => {
+    const state = makeAgyTurnState();
+    hookSessionUpdate(
+      preToolUse({
+        toolCall: { name: "write_to_file", args: { TargetFile: "/repo/a.ts" } },
+      }),
+      state,
+      "same",
+    );
+    const update = hookSessionUpdate(
+      {
+        event: "post-tool-use",
+        payload: { conversationId: "conversation-1", stepIdx: 3, error: "" },
+      },
+      state,
+      "same",
+    );
+
+    expect(update).not.toHaveProperty("content");
+  });
+});
+
+describe("agyHookResponse", () => {
+  it("allows tools only while a bridge observer is attached", () => {
+    expect(agyHookResponse("pre-tool-use", true)).toEqual({ decision: "allow" });
+    expect(agyHookResponse("pre-tool-use", false)).toMatchObject({ decision: "ask" });
+  });
+
+  it("answers the stop contract with a decision", () => {
+    expect(agyHookResponse("stop", true)).toEqual({ decision: "stop" });
+    expect(agyHookResponse("post-tool-use", true)).toEqual({});
+  });
+});

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   agyHookResponse,
+  approvalOutcomeToDecision,
   agyTargetPath,
   agyToolCallId,
   agyToolKind,
@@ -215,6 +216,31 @@ describe("hookSessionUpdate", () => {
     );
 
     expect(update).not.toHaveProperty("content");
+  });
+});
+
+describe("approvalOutcomeToDecision", () => {
+  it("allows only an explicit selection of the approve option", () => {
+    expect(
+      approvalOutcomeToDecision({ outcome: { outcome: "selected", optionId: "allow" } }, "allow"),
+    ).toEqual({ decision: "allow" });
+  });
+
+  it("denies every other reply", () => {
+    // This is the only gate in front of a CLI already told to skip its own
+    // permission prompts, so anything ambiguous has to deny.
+    for (const reply of [
+      { outcome: { outcome: "selected", optionId: "reject" } },
+      { outcome: { outcome: "cancelled" } },
+      { outcome: { outcome: "selected" } },
+      { outcome: null },
+      {},
+      null,
+      undefined,
+      "allow",
+    ]) {
+      expect(approvalOutcomeToDecision(reply, "allow").decision).toBe("deny");
+    }
   });
 });
 

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -220,9 +220,20 @@ describe("hookSessionUpdate", () => {
 });
 
 describe("approvalOutcomeToDecision", () => {
+  it("accepts any of the configured approve options", () => {
+    // The client renders an "always allow" choice; without it in this list a
+    // user pressing it would have their tool denied.
+    expect(
+      approvalOutcomeToDecision({ outcome: { outcome: "selected", optionId: "allow-session" } }, [
+        "allow",
+        "allow-session",
+      ]).decision,
+    ).toBe("allow");
+  });
+
   it("allows only an explicit selection of the approve option", () => {
     expect(
-      approvalOutcomeToDecision({ outcome: { outcome: "selected", optionId: "allow" } }, "allow"),
+      approvalOutcomeToDecision({ outcome: { outcome: "selected", optionId: "allow" } }, ["allow"]),
     ).toEqual({ decision: "allow" });
   });
 
@@ -239,7 +250,7 @@ describe("approvalOutcomeToDecision", () => {
       undefined,
       "allow",
     ]) {
-      expect(approvalOutcomeToDecision(reply, "allow").decision).toBe("deny");
+      expect(approvalOutcomeToDecision(reply, ["allow"]).decision).toBe("deny");
     }
   });
 });

--- a/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.test.ts
@@ -255,6 +255,18 @@ describe("orderAgySessionUpdates", () => {
       ]),
     ).toEqual([update("step 2"), update("unindexed PLANNER_RESPONSE"), update("step 3")]);
   });
+
+  it("keeps an unindexed response after the terminal update it followed", () => {
+    const update = (name: string) => ({ name });
+
+    expect(
+      orderAgySessionUpdates([
+        { stepIdx: 2, phase: "transcript", update: update("tool output") },
+        { stepIdx: 2, phase: "terminal", update: update("tool complete") },
+        { stepIdx: undefined, phase: "transcript", update: update("assistant after tool") },
+      ]),
+    ).toEqual([update("tool output"), update("tool complete"), update("assistant after tool")]);
+  });
 });
 
 describe("approvalOutcomeToDecision", () => {

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -302,13 +302,19 @@ export function orderAgySessionUpdates(
   entries: ReadonlyArray<AgyOrderedSessionUpdate>,
 ): ReadonlyArray<AgySessionUpdate> {
   const phaseOrder = { pre: 0, transcript: 1, terminal: 2 } as const;
-  return [...entries]
-    .sort((left, right) => {
-      const leftStep = left.stepIdx ?? Number.POSITIVE_INFINITY;
-      const rightStep = right.stepIdx ?? Number.POSITIVE_INFINITY;
-      return leftStep - rightStep || phaseOrder[left.phase] - phaseOrder[right.phase];
+  let precedingStep = Number.NEGATIVE_INFINITY;
+  return entries
+    .map((entry) => {
+      // PLANNER_RESPONSE records may omit step_index. Giving one the preceding
+      // key lets the stable sort leave it where the transcript reader put it,
+      // between that step and the next, instead of moving it to the batch end.
+      precedingStep = entry.stepIdx ?? precedingStep;
+      return { entry, step: precedingStep };
     })
-    .map((entry) => entry.update);
+    .sort((left, right) => {
+      return left.step - right.step || phaseOrder[left.entry.phase] - phaseOrder[right.entry.phase];
+    })
+    .map(({ entry }) => entry.update);
 }
 
 /**

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -72,6 +72,15 @@ export interface AgyHookEvent {
    * place that observes the true pre-edit state.
    */
   readonly capturedFileText?: string | null;
+  /**
+   * The hook's own stdin, verbatim.
+   *
+   * Written by the hook and hashed by both sides, so an approval is bound to
+   * the exact request the user saw: a payload swapped on disk between the hook
+   * writing it and the bridge reading it produces a different digest, and the
+   * decision is rejected.
+   */
+  readonly rawPayload?: string;
 }
 
 /**

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -1,0 +1,359 @@
+/**
+ * Pure translation layer for the Antigravity ACP bridge.
+ *
+ * Antigravity exposes no native agent protocol, so the bridge reconstructs an
+ * ACP event stream from two independent sources that Antigravity *does*
+ * document:
+ *
+ *   - **Hooks** (`PreToolUse` / `PostToolUse` / `Stop`) deliver the tool name,
+ *     its arguments, a human-readable summary, and completion status.
+ *   - **The trajectory transcript** (`transcript.jsonl`) delivers assistant
+ *     text and real tool output, appended progressively while the turn runs.
+ *
+ * The two correlate exactly: a hook's `stepIdx` is the transcript record's
+ * `step_index`. Neither source alone is sufficient — hooks never carry tool
+ * output, and the transcript never carries tool arguments.
+ *
+ * Everything here is pure so it can be tested without spawning `agy`. IO lives
+ * in `agyBridge.ts`.
+ *
+ * @module provider/acp/antigravity/agyEvents
+ */
+
+/** Tool-call lifecycle kinds understood by ACP clients. */
+export type AcpToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";
+
+export type AgyHookEventName = "pre-tool-use" | "post-tool-use" | "stop";
+
+export interface AgyToolCall {
+  readonly name?: string;
+  readonly args?: Record<string, unknown> | null;
+}
+
+/**
+ * Documented Antigravity hook payload. Every event carries `conversationId`
+ * and `transcriptPath`, which is what lets the bridge resume a trajectory and
+ * locate its transcript without guessing.
+ */
+export interface AgyHookPayload {
+  readonly conversationId?: string;
+  readonly stepIdx?: number;
+  readonly toolCall?: AgyToolCall | null;
+  readonly error?: string;
+  readonly modelName?: string;
+  readonly transcriptPath?: string;
+  readonly artifactDirectoryPath?: string;
+  readonly workspacePaths?: ReadonlyArray<string>;
+  readonly fullyIdle?: boolean;
+  readonly terminationReason?: string;
+  readonly executionNum?: number;
+}
+
+export interface AgyHookEvent {
+  readonly event: AgyHookEventName | string;
+  readonly payload: AgyHookPayload;
+  /**
+   * Contents of the tool's target file, captured by the hook process itself.
+   *
+   * This cannot be read by the bridge when it drains hook output: both hooks
+   * for a fast edit land inside a single poll interval, by which point the
+   * edit has already been written and "before" would read back as "after".
+   * The hook runs synchronously within the tool lifecycle, so it is the only
+   * place that observes the true pre-edit state.
+   */
+  readonly capturedFileText?: string | null;
+}
+
+/**
+ * Antigravity tool names, mapped onto ACP kinds so clients can pick the right
+ * affordance. Unknown tools degrade to `other` rather than being dropped.
+ */
+export function agyToolKind(name: string | undefined): AcpToolKind {
+  switch (name) {
+    case "write_to_file":
+    case "replace_file_content":
+    case "multi_replace_file_content":
+    case "edit_file":
+      return "edit";
+    case "view_file":
+    case "view_code_item":
+    case "list_dir":
+    case "read_url_content":
+      return "read";
+    case "grep_search":
+    case "find_by_name":
+    case "codebase_search":
+    case "search_web":
+      return "search";
+    case "run_command":
+    case "command_status":
+      return "execute";
+    case "delete_file":
+      return "delete";
+    default:
+      if (name && name.startsWith("browser_")) {
+        return "fetch";
+      }
+      return "other";
+  }
+}
+
+/**
+ * Stable identity for one tool call across its hook pair and its transcript
+ * record. `stepIdx` is unique within a conversation and is echoed verbatim as
+ * the transcript's `step_index`.
+ */
+export function agyToolCallId(conversationId: string | undefined, stepIdx: number): string {
+  return `agy-${conversationId ?? "unknown"}-${stepIdx}`;
+}
+
+/**
+ * Prefer Antigravity's own human-readable summary over the raw tool name.
+ * `PostToolUse` enriches `args` with `toolSummary`/`toolAction`; `PreToolUse`
+ * usually has neither, so the tool name is the fallback.
+ */
+export function agyToolTitle(toolCall: AgyToolCall | null | undefined): string {
+  const args = toolCall?.args;
+  const summary = typeof args?.["toolSummary"] === "string" ? args["toolSummary"].trim() : "";
+  if (summary.length > 0) {
+    return summary;
+  }
+  const action = typeof args?.["toolAction"] === "string" ? args["toolAction"].trim() : "";
+  if (action.length > 0) {
+    return action;
+  }
+  return toolCall?.name?.trim() || "Antigravity tool";
+}
+
+/**
+ * File path a tool acts on, when it names one. Antigravity uses PascalCase
+ * argument keys and is not consistent about which one carries the path.
+ */
+export function agyTargetPath(toolCall: AgyToolCall | null | undefined): string | undefined {
+  const args = toolCall?.args;
+  if (!args) {
+    return undefined;
+  }
+  for (const key of ["TargetFile", "AbsolutePath", "FilePath", "Path", "DirectoryPath"]) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Metadata echoed onto every emitted update for debugging and traceability. */
+export function agyUpdateMeta(event: string, payload: AgyHookPayload): Record<string, unknown> {
+  return {
+    antigravity: {
+      event,
+      conversationId: payload.conversationId ?? null,
+      stepIdx: payload.stepIdx ?? null,
+      modelName: payload.modelName ?? null,
+      transcriptPath: payload.transcriptPath ?? null,
+      artifactDirectoryPath: payload.artifactDirectoryPath ?? null,
+    },
+  };
+}
+
+export interface AgyActiveToolCall {
+  readonly toolCallId: string;
+  readonly name: string | undefined;
+  readonly kind: AcpToolKind;
+  readonly targetPath: string | undefined;
+  /** File contents captured at `PreToolUse`, used to build an edit diff. */
+  readonly beforeText: string | undefined;
+}
+
+/**
+ * Mutable bookkeeping shared by the hook and transcript readers for one turn.
+ */
+export interface AgyTurnState {
+  readonly activeToolCalls: Map<number, AgyActiveToolCall>;
+  conversationId: string | undefined;
+  transcriptPath: string | undefined;
+  modelName: string | undefined;
+}
+
+export function makeAgyTurnState(conversationId?: string): AgyTurnState {
+  return {
+    activeToolCalls: new Map(),
+    conversationId,
+    transcriptPath: undefined,
+    modelName: undefined,
+  };
+}
+
+/** A `session/update` payload, shaped for ACP but kept as plain JSON. */
+export type AgySessionUpdate = Record<string, unknown>;
+
+/**
+ * Translate one `PreToolUse` hook into an ACP `tool_call` announcement.
+ *
+ * `beforeText` is threaded in by the caller (which does the file read) so this
+ * function stays pure.
+ */
+export function preToolUseUpdate(
+  payload: AgyHookPayload,
+  state: AgyTurnState,
+  beforeText?: string,
+): AgySessionUpdate | null {
+  const stepIdx = payload.stepIdx;
+  if (typeof stepIdx !== "number") {
+    return null;
+  }
+  const toolCall = payload.toolCall;
+  // Antigravity emits hook pairs for internal planner steps with no tool
+  // attached. Those are not tool calls and must not render as one.
+  if (!toolCall || !toolCall.name) {
+    return null;
+  }
+
+  const toolCallId = agyToolCallId(payload.conversationId, stepIdx);
+  const kind = agyToolKind(toolCall.name);
+  const targetPath = agyTargetPath(toolCall);
+  state.activeToolCalls.set(stepIdx, {
+    toolCallId,
+    name: toolCall.name,
+    kind,
+    targetPath,
+    beforeText,
+  });
+
+  return {
+    sessionUpdate: "tool_call",
+    toolCallId,
+    title: agyToolTitle(toolCall),
+    kind,
+    status: "in_progress",
+    rawInput: toolCall.args ?? null,
+    ...(targetPath ? { locations: [{ path: targetPath }] } : {}),
+    _meta: agyUpdateMeta("pre-tool-use", payload),
+  };
+}
+
+/**
+ * Translate one `PostToolUse` hook into an ACP `tool_call_update`.
+ *
+ * `afterText` is the on-disk content of an edited file, read by the caller
+ * after the tool ran. Diffing captured before/after content sidesteps having
+ * to interpret Antigravity's edit arguments, whose semantics vary by tool.
+ */
+export function postToolUseUpdate(
+  payload: AgyHookPayload,
+  state: AgyTurnState,
+  afterText?: string,
+): AgySessionUpdate | null {
+  const stepIdx = payload.stepIdx;
+  if (typeof stepIdx !== "number") {
+    return null;
+  }
+  const active = state.activeToolCalls.get(stepIdx);
+  // Only complete calls whose `PreToolUse` we actually observed; Antigravity
+  // emits unpaired post hooks for internal steps.
+  if (!active) {
+    return null;
+  }
+  state.activeToolCalls.delete(stepIdx);
+
+  const error = typeof payload.error === "string" ? payload.error.trim() : "";
+  const failed = error.length > 0;
+
+  const content: Array<Record<string, unknown>> = [];
+  if (
+    !failed &&
+    active.kind === "edit" &&
+    active.targetPath &&
+    afterText !== undefined &&
+    afterText !== active.beforeText
+  ) {
+    content.push({
+      type: "diff",
+      path: active.targetPath,
+      ...(active.beforeText === undefined ? {} : { oldText: active.beforeText }),
+      newText: afterText,
+    });
+  }
+
+  return {
+    sessionUpdate: "tool_call_update",
+    toolCallId: active.toolCallId,
+    status: failed ? "failed" : "completed",
+    ...(content.length > 0 ? { content } : {}),
+    rawOutput: failed ? { isError: true, error } : { isError: false },
+    _meta: agyUpdateMeta("post-tool-use", payload),
+  };
+}
+
+/**
+ * Fold a hook event into turn state, returning the update to emit (if any).
+ *
+ * `Stop` carries no user-visible update; it exists to publish the conversation
+ * id that lets the next turn resume the same trajectory.
+ */
+export function hookSessionUpdate(
+  hook: AgyHookEvent,
+  state: AgyTurnState,
+  fileText?: string,
+): AgySessionUpdate | null {
+  const payload = hook.payload ?? {};
+  // Every hook carries the conversation id, so the bridge learns it from the
+  // first event of the turn rather than waiting for `Stop`.
+  const conversationId = payload.conversationId?.trim();
+  if (conversationId) {
+    state.conversationId = conversationId;
+  }
+  const transcriptPath = payload.transcriptPath?.trim();
+  if (transcriptPath) {
+    state.transcriptPath = transcriptPath;
+  }
+  const modelName = payload.modelName?.trim();
+  if (modelName) {
+    state.modelName = modelName;
+  }
+
+  switch (hook.event) {
+    case "pre-tool-use":
+      return preToolUseUpdate(payload, state, fileText);
+    case "post-tool-use":
+      return postToolUseUpdate(payload, state, fileText);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Response Antigravity requires on stdout for each hook event.
+ *
+ * `pre-tool-use` must return a decision. When no bridge observer is attached
+ * the safe answer is `ask`: a hook that silently allowed every tool outside a
+ * managed turn would be a permission bypass.
+ */
+export function agyHookResponse(event: string, observerAttached: boolean): Record<string, unknown> {
+  switch (event) {
+    case "pre-tool-use":
+      return observerAttached
+        ? { decision: "allow" }
+        : {
+            decision: "ask",
+            reason: "T3 Code hook observer is not attached to a managed Antigravity turn",
+          };
+    // Antigravity's Stop contract requires a decision; anything other than
+    // "continue" lets the completed execution stop.
+    case "stop":
+      return { decision: "stop" };
+    default:
+      return {};
+  }
+}

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -245,6 +245,12 @@ export interface AgyTurnState {
    */
   transcriptPrimed: boolean;
   /**
+   * Whether priming has crossed a `USER_INPUT` record. The marker itself is
+   * removed from the retained suffix, so later capped reads cannot rediscover
+   * it and must remember that the suffix already follows a boundary.
+   */
+  transcriptBoundarySeen: boolean;
+  /**
    * Whether this turn resumed an existing conversation. Only then can the
    * transcript already hold other turns' records at byte 0.
    */
@@ -263,6 +269,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,
     transcriptPrimed: false,
+    transcriptBoundarySeen: false,
     resumedConversation: conversationId !== undefined,
     modelName: undefined,
   };
@@ -277,6 +284,32 @@ export interface AgyTranscriptRecordLike {
 
 /** A `session/update` payload, shaped for ACP but kept as plain JSON. */
 export type AgySessionUpdate = Record<string, unknown>;
+
+export interface AgyOrderedSessionUpdate {
+  readonly stepIdx: number | undefined;
+  readonly phase: "pre" | "transcript" | "terminal";
+  readonly update: AgySessionUpdate;
+}
+
+/**
+ * Order updates reconstructed from independent hook and transcript sources.
+ *
+ * Step index preserves the order Antigravity executed them in. Within one
+ * step, the call must exist before output is attached and must stay open until
+ * that output has been sent.
+ */
+export function orderAgySessionUpdates(
+  entries: ReadonlyArray<AgyOrderedSessionUpdate>,
+): ReadonlyArray<AgySessionUpdate> {
+  const phaseOrder = { pre: 0, transcript: 1, terminal: 2 } as const;
+  return [...entries]
+    .sort((left, right) => {
+      const leftStep = left.stepIdx ?? Number.POSITIVE_INFINITY;
+      const rightStep = right.stepIdx ?? Number.POSITIVE_INFINITY;
+      return leftStep - rightStep || phaseOrder[left.phase] - phaseOrder[right.phase];
+    })
+    .map((entry) => entry.update);
+}
 
 /**
  * Translate one `PreToolUse` hook into an ACP `tool_call` announcement.

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -197,6 +197,13 @@ export interface AgyTurnState {
    * a second, never-completed item.
    */
   readonly pendingTerminal: Map<number, AgySessionUpdate>;
+  /**
+   * Steps whose transcript output has already been streamed. The transcript is
+   * read once by byte offset, so a record consumed before its `PostToolUse`
+   * hook appeared will never be revisited — without this the tool would render
+   * as running until the turn ended.
+   */
+  readonly transcriptSeenSteps: Set<number>;
   conversationId: string | undefined;
   transcriptPath: string | undefined;
   /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
@@ -213,6 +220,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
   return {
     toolCalls: new Map(),
     pendingTerminal: new Map(),
+    transcriptSeenSteps: new Set(),
     conversationId,
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -190,6 +190,13 @@ export interface AgyTurnState {
    * output would be dropped whenever both arrive within one poll.
    */
   readonly toolCalls: Map<number, AgyToolCallRecord>;
+  /**
+   * Terminal `tool_call_update`s held back until the transcript record with
+   * that step's output has been streamed. `AcpSessionRuntime` drops its tool
+   * state once a call completes, so output emitted afterwards would surface as
+   * a second, never-completed item.
+   */
+  readonly pendingTerminal: Map<number, AgySessionUpdate>;
   conversationId: string | undefined;
   transcriptPath: string | undefined;
   /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
@@ -205,6 +212,7 @@ export interface AgyTurnState {
 export function makeAgyTurnState(conversationId?: string): AgyTurnState {
   return {
     toolCalls: new Map(),
+    pendingTerminal: new Map(),
     conversationId,
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -362,6 +362,38 @@ export function hookSessionUpdate(
  * the safe answer is `ask`: a hook that silently allowed every tool outside a
  * managed turn would be a permission bypass.
  */
+export interface AgyHookDecision {
+  readonly decision: "allow" | "deny" | "ask";
+  readonly reason?: string;
+}
+
+/**
+ * Translate the client's `session/request_permission` reply into the decision
+ * the blocked `PreToolUse` hook will print.
+ *
+ * Fails closed: only an explicit selection of the approve option allows the
+ * tool. A cancelled prompt, an unknown option id, or a malformed reply all
+ * deny, because this is the only thing standing between the model and a tool
+ * that `agy` has already been told to run without asking.
+ */
+export function approvalOutcomeToDecision(
+  result: unknown,
+  approveOptionId: string,
+): AgyHookDecision {
+  const outcome =
+    typeof result === "object" && result !== null
+      ? (result as { outcome?: unknown }).outcome
+      : undefined;
+  const selected =
+    typeof outcome === "object" && outcome !== null
+      ? (outcome as { outcome?: unknown; optionId?: unknown })
+      : undefined;
+  if (selected?.outcome === "selected" && selected.optionId === approveOptionId) {
+    return { decision: "allow" };
+  }
+  return { decision: "deny", reason: "Rejected in T3 Code" };
+}
+
 export function agyHookResponse(event: string, observerAttached: boolean): Record<string, unknown> {
   switch (event) {
     case "pre-tool-use":

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -245,11 +245,11 @@ export interface AgyTurnState {
    */
   transcriptPrimed: boolean;
   /**
-   * Whether priming has crossed a `USER_INPUT` record. The marker itself is
-   * removed from the retained suffix, so later capped reads cannot rediscover
-   * it and must remember that the suffix already follows a boundary.
+   * Whether resumed-transcript priming discarded its candidate suffix after
+   * exceeding the memory budget. Records that follow can still be history, so
+   * none are emitted until a later `USER_INPUT` establishes a new boundary.
    */
-  transcriptBoundarySeen: boolean;
+  transcriptPrimingOverflowed: boolean;
   /**
    * Whether this turn resumed an existing conversation. Only then can the
    * transcript already hold other turns' records at byte 0.
@@ -269,7 +269,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,
     transcriptPrimed: false,
-    transcriptBoundarySeen: false,
+    transcriptPrimingOverflowed: false,
     resumedConversation: conversationId !== undefined,
     modelName: undefined,
   };
@@ -302,17 +302,25 @@ export function orderAgySessionUpdates(
   entries: ReadonlyArray<AgyOrderedSessionUpdate>,
 ): ReadonlyArray<AgySessionUpdate> {
   const phaseOrder = { pre: 0, transcript: 1, terminal: 2 } as const;
-  let precedingStep = Number.NEGATIVE_INFINITY;
+  let precedingKey: { readonly step: number; readonly phase: number } | undefined;
   return entries
     .map((entry) => {
-      // PLANNER_RESPONSE records may omit step_index. Giving one the preceding
-      // key lets the stable sort leave it where the transcript reader put it,
-      // between that step and the next, instead of moving it to the batch end.
-      precedingStep = entry.stepIdx ?? precedingStep;
-      return { entry, step: precedingStep };
+      // PLANNER_RESPONSE records may omit step_index. Reusing the preceding
+      // entry's complete ordering key lets the stable sort keep the response
+      // immediately after that entry, including when it followed a terminal
+      // update, while indexed entries still use step and lifecycle phase.
+      const key =
+        entry.stepIdx === undefined
+          ? (precedingKey ?? {
+              step: Number.NEGATIVE_INFINITY,
+              phase: phaseOrder[entry.phase],
+            })
+          : { step: entry.stepIdx, phase: phaseOrder[entry.phase] };
+      precedingKey = key;
+      return { entry, key };
     })
     .sort((left, right) => {
-      return left.step - right.step || phaseOrder[left.entry.phase] - phaseOrder[right.entry.phase];
+      return left.key.step - right.key.step || left.key.phase - right.key.phase;
     })
     .map(({ entry }) => entry.update);
 }

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -213,6 +213,11 @@ export interface AgyTurnState {
    * byte 0, which on a resumed conversation is the start of the whole history.
    */
   transcriptPrimed: boolean;
+  /**
+   * Whether this turn resumed an existing conversation. Only then can the
+   * transcript already hold other turns' records at byte 0.
+   */
+  readonly resumedConversation: boolean;
   modelName: string | undefined;
 }
 
@@ -225,6 +230,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,
     transcriptPrimed: false,
+    resumedConversation: conversationId !== undefined,
     modelName: undefined,
   };
 }
@@ -394,7 +400,7 @@ export interface AgyHookDecision {
  */
 export function approvalOutcomeToDecision(
   result: unknown,
-  approveOptionId: string,
+  approveOptionIds: ReadonlyArray<string>,
 ): AgyHookDecision {
   const outcome =
     typeof result === "object" && result !== null
@@ -404,7 +410,11 @@ export function approvalOutcomeToDecision(
     typeof outcome === "object" && outcome !== null
       ? (outcome as { outcome?: unknown; optionId?: unknown })
       : undefined;
-  if (selected?.outcome === "selected" && selected.optionId === approveOptionId) {
+  if (
+    selected?.outcome === "selected" &&
+    typeof selected.optionId === "string" &&
+    approveOptionIds.includes(selected.optionId)
+  ) {
     return { decision: "allow" };
   }
   return { decision: "deny", reason: "Rejected in T3 Code" };

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -181,8 +181,15 @@ export interface AgyToolCallRecord {
   readonly name: string | undefined;
   readonly kind: AcpToolKind;
   readonly targetPath: string | undefined;
-  /** File contents captured at `PreToolUse`, used to build an edit diff. */
-  readonly beforeText: string | undefined;
+  /**
+   * File contents captured at `PreToolUse`, used to build an edit diff.
+   *
+   * Released as soon as that diff has been built. Records are kept for the
+   * whole turn so late transcript output can still attach to them, and holding
+   * every edited file's prior contents for that long is what turns a long edit
+   * loop into gigabytes of heap.
+   */
+  beforeText: string | undefined;
   /** Set by `PostToolUse`. Records are kept after completion so a transcript
    * record that lands in the same poll can still attach the tool's output. */
   completed: boolean;
@@ -362,6 +369,10 @@ export function postToolUseUpdate(
       newText: afterText,
     });
   }
+  // The diff is built, so the captured contents have no further use. This is
+  // the only thing held here that scales with file size rather than with the
+  // number of steps.
+  active.beforeText = undefined;
 
   return {
     sessionUpdate: "tool_call_update",

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -222,6 +222,12 @@ export interface AgyTurnState {
    * rather than dropped and retried on the next pass.
    */
   readonly deferredRecords: Array<AgyTranscriptRecordLike>;
+  /**
+   * Drains the held records have waited. Antigravity emits unpaired steps for
+   * its own internal work, so a record whose hook is never coming must not
+   * block the stream indefinitely.
+   */
+  deferredDrains: number;
   conversationId: string | undefined;
   transcriptPath: string | undefined;
   /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
@@ -245,6 +251,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     pendingTerminal: new Map(),
     transcriptSeenSteps: new Set(),
     deferredRecords: [],
+    deferredDrains: 0,
     conversationId,
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -194,6 +194,11 @@ export interface AgyTurnState {
   transcriptPath: string | undefined;
   /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
   resolvedTranscriptPath: string | undefined;
+  /**
+   * Whether records predating this turn have been discarded. Reading starts at
+   * byte 0, which on a resumed conversation is the start of the whole history.
+   */
+  transcriptPrimed: boolean;
   modelName: string | undefined;
 }
 
@@ -203,6 +208,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     conversationId,
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,
+    transcriptPrimed: false,
     modelName: undefined,
   };
 }

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -228,7 +228,14 @@ export interface AgyTurnState {
    * it to. The transcript is consumed once by byte offset, so these are held
    * rather than dropped and retried on the next pass.
    */
-  readonly deferredRecords: Array<AgyTranscriptRecordLike>;
+  readonly deferredRecords: Array<AgyDeferredTranscriptRecord>;
+  /**
+   * Serialized size of `deferredRecords`.
+   *
+   * Maintained as entries enter and leave the queue so enforcing the aggregate
+   * cap does not have to rescan every retained record on every drain pass.
+   */
+  deferredRecordChars: number;
   /**
    * Drains the held records have waited. Antigravity emits unpaired steps for
    * its own internal work, so a record whose hook is never coming must not
@@ -264,6 +271,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     pendingTerminal: new Map(),
     transcriptSeenSteps: new Set(),
     deferredRecords: [],
+    deferredRecordChars: 0,
     deferredDrains: 0,
     conversationId,
     transcriptPath: undefined,
@@ -280,6 +288,12 @@ export interface AgyTranscriptRecordLike {
   readonly step_index?: number;
   readonly type?: string;
   readonly content?: string;
+}
+
+/** A retained transcript record and its one-time complete serialized size. */
+export interface AgyDeferredTranscriptRecord {
+  readonly record: AgyTranscriptRecordLike;
+  readonly serializedChars: number;
 }
 
 /** A `session/update` payload, shaped for ACP but kept as plain JSON. */

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -167,30 +167,42 @@ export function agyUpdateMeta(event: string, payload: AgyHookPayload): Record<st
   };
 }
 
-export interface AgyActiveToolCall {
+export interface AgyToolCallRecord {
   readonly toolCallId: string;
   readonly name: string | undefined;
   readonly kind: AcpToolKind;
   readonly targetPath: string | undefined;
   /** File contents captured at `PreToolUse`, used to build an edit diff. */
   readonly beforeText: string | undefined;
+  /** Set by `PostToolUse`. Records are kept after completion so a transcript
+   * record that lands in the same poll can still attach the tool's output. */
+  completed: boolean;
 }
 
 /**
  * Mutable bookkeeping shared by the hook and transcript readers for one turn.
  */
 export interface AgyTurnState {
-  readonly activeToolCalls: Map<number, AgyActiveToolCall>;
+  /**
+   * Every tool call seen this turn, keyed by step index — completed ones
+   * included. The two event sources are drained in the same pass, so a step
+   * must stay addressable after its `PostToolUse` hook or its transcript
+   * output would be dropped whenever both arrive within one poll.
+   */
+  readonly toolCalls: Map<number, AgyToolCallRecord>;
   conversationId: string | undefined;
   transcriptPath: string | undefined;
+  /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
+  resolvedTranscriptPath: string | undefined;
   modelName: string | undefined;
 }
 
 export function makeAgyTurnState(conversationId?: string): AgyTurnState {
   return {
-    activeToolCalls: new Map(),
+    toolCalls: new Map(),
     conversationId,
     transcriptPath: undefined,
+    resolvedTranscriptPath: undefined,
     modelName: undefined,
   };
 }
@@ -223,12 +235,13 @@ export function preToolUseUpdate(
   const toolCallId = agyToolCallId(payload.conversationId, stepIdx);
   const kind = agyToolKind(toolCall.name);
   const targetPath = agyTargetPath(toolCall);
-  state.activeToolCalls.set(stepIdx, {
+  state.toolCalls.set(stepIdx, {
     toolCallId,
     name: toolCall.name,
     kind,
     targetPath,
     beforeText,
+    completed: false,
   });
 
   return {
@@ -259,13 +272,16 @@ export function postToolUseUpdate(
   if (typeof stepIdx !== "number") {
     return null;
   }
-  const active = state.activeToolCalls.get(stepIdx);
+  const active = state.toolCalls.get(stepIdx);
   // Only complete calls whose `PreToolUse` we actually observed; Antigravity
   // emits unpaired post hooks for internal steps.
-  if (!active) {
+  if (!active || active.completed) {
     return null;
   }
-  state.activeToolCalls.delete(stepIdx);
+  // Marked rather than removed: the transcript record carrying this step's
+  // output is often read in the same drain pass, and dropping the entry here
+  // would leave it with no tool call to attach to.
+  active.completed = true;
 
   const error = typeof payload.error === "string" ? payload.error.trim() : "";
   const failed = error.length > 0;

--- a/apps/server/src/provider/acp/antigravity/agyEvents.ts
+++ b/apps/server/src/provider/acp/antigravity/agyEvents.ts
@@ -213,6 +213,15 @@ export interface AgyTurnState {
    * as running until the turn ended.
    */
   readonly transcriptSeenSteps: Set<number>;
+  /**
+   * Transcript records whose tool call has not been announced yet.
+   *
+   * The hook directory is listed before the transcript is read, so a tool whose
+   * `PreToolUse` file lands in between produces a record with nothing to attach
+   * it to. The transcript is consumed once by byte offset, so these are held
+   * rather than dropped and retried on the next pass.
+   */
+  readonly deferredRecords: Array<AgyTranscriptRecordLike>;
   conversationId: string | undefined;
   transcriptPath: string | undefined;
   /** Transcript file pinned for the turn; see `resolveTranscriptPath`. */
@@ -235,6 +244,7 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     toolCalls: new Map(),
     pendingTerminal: new Map(),
     transcriptSeenSteps: new Set(),
+    deferredRecords: [],
     conversationId,
     transcriptPath: undefined,
     resolvedTranscriptPath: undefined,
@@ -242,6 +252,13 @@ export function makeAgyTurnState(conversationId?: string): AgyTurnState {
     resumedConversation: conversationId !== undefined,
     modelName: undefined,
   };
+}
+
+/** Minimal shape of a transcript record, kept here to avoid a circular import. */
+export interface AgyTranscriptRecordLike {
+  readonly step_index?: number;
+  readonly type?: string;
+  readonly content?: string;
 }
 
 /** A `session/update` payload, shaped for ACP but kept as plain JSON. */

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -4,6 +4,7 @@ import { hookSessionUpdate, makeAgyTurnState, type AgyTurnState } from "./agyEve
 import {
   AgyTranscriptCursor,
   dropPriorTurnRecords,
+  MAX_TRANSCRIPT_LINE_CHARS,
   normalizeToolOutput,
   parseTranscriptLine,
   transcriptRecordUpdates,
@@ -246,5 +247,37 @@ describe("AgyTranscriptCursor", () => {
 
     expect(cursor.flush()).toEqual(['{"b":2}']);
     expect(cursor.flush()).toEqual([]);
+  });
+
+  it("gives up on a record that never terminates, and resumes at the next one", () => {
+    // Nothing else bounds a held-back line: the transcript is read in capped
+    // chunks, so a record with no newline would be accumulated in full.
+    const cursor = new AgyTranscriptCursor();
+    const huge = "x".repeat(MAX_TRANSCRIPT_LINE_CHARS + 1);
+
+    expect(cursor.push(huge)).toEqual([]);
+    expect(cursor.carryLength).toBe(0);
+
+    // The rest of the abandoned record is swallowed up to its newline; the
+    // record after it is intact.
+    expect(cursor.push('more-of-the-same\n{"a":1}\n')).toEqual(['{"a":1}']);
+  });
+
+  it("does not flush the tail of an abandoned record as if it were one", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push("y".repeat(MAX_TRANSCRIPT_LINE_CHARS + 1));
+
+    expect(cursor.push("trailing-fragment")).toEqual([]);
+    expect(cursor.flush()).toEqual([]);
+  });
+
+  it("keeps counting consumed bytes across an abandoned record", () => {
+    // The offset is what the next read starts from, so dropping content must
+    // not desynchronise it from the file.
+    const cursor = new AgyTranscriptCursor();
+    const huge = "z".repeat(MAX_TRANSCRIPT_LINE_CHARS + 1);
+    cursor.push(huge);
+
+    expect(cursor.bytesConsumed).toBe(Buffer.byteLength(huge, "utf8"));
   });
 });

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -307,4 +307,23 @@ describe("AgyTranscriptCursor", () => {
 
     expect(cursor.bytesConsumed).toBe(Buffer.byteLength(huge, "utf8"));
   });
+
+  it("discards a scanned partial record through its next newline", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push('{"historical":"partial');
+
+    cursor.discardThroughNextNewline();
+
+    expect(cursor.carryLength).toBe(0);
+    expect(cursor.push(' record"}\n{"current":true}\n')).toEqual(['{"current":true}']);
+  });
+
+  it("discards retained history when abandoning a scan", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.retain(['{"historical":true}']);
+
+    cursor.discardThroughNextNewline();
+
+    expect(cursor.push('{"current":true}\n')).toEqual(['{"current":true}']);
+  });
 });

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_TRANSCRIPT_LINE_CHARS,
   normalizeToolOutput,
   parseTranscriptLine,
+  serializedTranscriptRecordSize,
   transcriptRecordUpdates,
 } from "./agyTranscript.ts";
 
@@ -33,6 +34,20 @@ describe("parseTranscriptLine", () => {
       step_index: 2,
       type: "PLANNER_RESPONSE",
     });
+  });
+
+  it("sizes the complete parsed record rather than only string content", () => {
+    const record = parseTranscriptLine(
+      JSON.stringify({
+        step_index: 2,
+        type: "RUN_COMMAND",
+        content: { summary: "small" },
+        metadata: { payload: "x".repeat(4_096) },
+      }),
+    );
+
+    expect(record).not.toBeNull();
+    expect(serializedTranscriptRecordSize(record!)).toBeGreaterThan(4_096);
   });
 });
 

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { hookSessionUpdate, makeAgyTurnState, type AgyTurnState } from "./agyEvents.ts";
+import {
+  AgyTranscriptCursor,
+  normalizeToolOutput,
+  parseTranscriptLine,
+  transcriptRecordUpdates,
+} from "./agyTranscript.ts";
+
+function stateWithActiveTool(stepIdx: number, name = "run_command"): AgyTurnState {
+  const state = makeAgyTurnState();
+  hookSessionUpdate(
+    {
+      event: "pre-tool-use",
+      payload: { conversationId: "conversation-1", stepIdx, toolCall: { name, args: {} } },
+    },
+    state,
+  );
+  return state;
+}
+
+describe("parseTranscriptLine", () => {
+  it("returns null for blank and half-written lines", () => {
+    expect(parseTranscriptLine("")).toBeNull();
+    expect(parseTranscriptLine('{"step_index": 1, "type": "RUN_COM')).toBeNull();
+  });
+
+  it("parses a complete record", () => {
+    expect(parseTranscriptLine('{"step_index":2,"type":"PLANNER_RESPONSE"}')).toMatchObject({
+      step_index: 2,
+      type: "PLANNER_RESPONSE",
+    });
+  });
+});
+
+describe("normalizeToolOutput", () => {
+  it("strips the timestamp preamble", () => {
+    const output = normalizeToolOutput(
+      "Created At: 2026-07-24T17:31:41-04:00\nCompleted At: 2026-07-24T17:31:41-04:00\nresult",
+    );
+    expect(output).toBe("result");
+  });
+
+  it("dedents Antigravity's tab-indented framing without touching flush-left output", () => {
+    // Antigravity indents its own framing with tabs but writes the tool's real
+    // output flush left, so a plain common-prefix dedent would find zero.
+    const output = normalizeToolOutput(
+      "Created At: x\n\n\t\t\t\tThe command exited with code 0.\n\t\t\t\tOutput:\n\t\t\t\ttotal 16\ndrwxr-xr-x  4 alex staff",
+    );
+    expect(output).toBe(
+      "The command exited with code 0.\nOutput:\ntotal 16\ndrwxr-xr-x  4 alex staff",
+    );
+  });
+
+  it("dedents tab-indented source uniformly", () => {
+    expect(normalizeToolOutput("\t\tconst a = 1;\n\t\t\tconst b = 2;")).toBe(
+      "const a = 1;\n\tconst b = 2;",
+    );
+  });
+});
+
+describe("transcriptRecordUpdates", () => {
+  it("streams assistant text as an agent message chunk", () => {
+    const result = transcriptRecordUpdates(
+      { step_index: 7, source: "MODEL", type: "PLANNER_RESPONSE", content: "All done." },
+      makeAgyTurnState(),
+    );
+
+    expect(result.emittedAssistantText).toBe(true);
+    expect(result.updates[0]).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "All done." },
+    });
+  });
+
+  it("skips empty planner responses", () => {
+    const result = transcriptRecordUpdates(
+      { step_index: 2, source: "MODEL", type: "PLANNER_RESPONSE", content: "   " },
+      makeAgyTurnState(),
+    );
+
+    expect(result.updates).toHaveLength(0);
+    expect(result.emittedAssistantText).toBe(false);
+  });
+
+  it("ignores bookkeeping records that would read as assistant output", () => {
+    for (const type of ["CHECKPOINT", "CONVERSATION_HISTORY", "USER_INPUT", "SYSTEM_MESSAGE"]) {
+      const result = transcriptRecordUpdates(
+        { step_index: 1, source: "SYSTEM", type, content: "internal" },
+        makeAgyTurnState(),
+      );
+      expect(result.updates).toHaveLength(0);
+    }
+  });
+
+  it("attaches tool output to the call the matching hook announced", () => {
+    const state = stateWithActiveTool(3);
+    const result = transcriptRecordUpdates(
+      {
+        step_index: 3,
+        source: "MODEL",
+        type: "RUN_COMMAND",
+        content:
+          "Created At: x\n\t\t\t\tThe command exited with code 0.\n\t\t\t\tOutput:\n\t\t\t\tok",
+      },
+      state,
+    );
+
+    expect(result.updates[0]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "agy-conversation-1-3",
+      content: [
+        {
+          type: "content",
+          content: { type: "text", text: "The command exited with code 0.\nOutput:\nok" },
+        },
+      ],
+    });
+  });
+
+  it("drops tool output with no announced call rather than inventing one", () => {
+    const result = transcriptRecordUpdates(
+      { step_index: 99, source: "MODEL", type: "RUN_COMMAND", content: "orphan" },
+      makeAgyTurnState(),
+    );
+
+    expect(result.updates).toHaveLength(0);
+  });
+});
+
+describe("AgyTranscriptCursor", () => {
+  it("holds back a partial trailing line until the rest arrives", () => {
+    const cursor = new AgyTranscriptCursor();
+
+    expect(cursor.push('{"a":1}\n{"b":')).toEqual(['{"a":1}']);
+    expect(cursor.push("2}\n")).toEqual(['{"b":2}']);
+  });
+
+  it("tracks the byte offset it has consumed", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push("abc\n");
+
+    expect(cursor.bytesConsumed).toBe(4);
+  });
+
+  it("flushes the trailing line once the writer is finished", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push('{"a":1}\n{"b":2}');
+
+    expect(cursor.flush()).toEqual(['{"b":2}']);
+    expect(cursor.flush()).toEqual([]);
+  });
+});

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -306,12 +306,38 @@ describe("AgyTranscriptCursor", () => {
     expect(cursor.push('{"current":true}\n')).toEqual(['{"current":true}']);
   });
 
-  it("counts a partial record when bounding a retained suffix", () => {
+  it("preserves a bounded partial boundary when retained history overflows", () => {
     const cursor = new AgyTranscriptCursor();
-    cursor.push("partial");
+    const boundary = '{"type":"USER_INPUT","content":"current turn"}';
+    const cutoff = 17;
+    cursor.push(boundary.slice(0, cutoff));
 
-    expect(cursor.retainWithinLimit(["12"], 9)).toBe(false);
-    expect(cursor.push(' tail\n{"current":true}\n')).toEqual(['{"current":true}']);
+    expect(cursor.retainWithinLimit(["historical"], 20)).toBe(false);
+    expect(cursor.carryLength).toBe(cutoff);
+    expect(cursor.push(`${boundary.slice(cutoff)}\n{"current":true}\n`)).toEqual([
+      boundary,
+      '{"current":true}',
+    ]);
+  });
+
+  it("keeps historical carry suppressible until a later boundary is observed", () => {
+    const cursor = new AgyTranscriptCursor();
+    const historical = '{"type":"PLANNER_RESPONSE","content":"old"}';
+    const boundary = '{"type":"USER_INPUT","content":"current turn"}';
+    const cutoff = 19;
+    cursor.push(historical.slice(0, cutoff));
+
+    expect(cursor.retainWithinLimit(["older history"], 24)).toBe(false);
+    const completedHistory = cursor.push(`${historical.slice(cutoff)}\n`);
+    // No boundary makes this eligible on its own; the bridge's overflow state
+    // is what suppresses it rather than losing the carry needed for parsing.
+    expect(dropPriorTurnRecords(completedHistory)).toEqual([historical]);
+
+    expect(
+      dropPriorTurnRecords(
+        cursor.push(`${boundary}\n{"type":"PLANNER_RESPONSE","content":"new"}\n`),
+      ),
+    ).toEqual(['{"type":"PLANNER_RESPONSE","content":"new"}']);
   });
 
   it("keeps counting consumed bytes across an abandoned record", () => {
@@ -324,22 +350,15 @@ describe("AgyTranscriptCursor", () => {
     expect(cursor.bytesConsumed).toBe(Buffer.byteLength(huge, "utf8"));
   });
 
-  it("discards a scanned partial record through its next newline", () => {
-    const cursor = new AgyTranscriptCursor();
-    cursor.push('{"historical":"partial');
-
-    cursor.discardThroughNextNewline();
-
-    expect(cursor.carryLength).toBe(0);
-    expect(cursor.push(' record"}\n{"current":true}\n')).toEqual(['{"current":true}']);
-  });
-
-  it("discards retained history when abandoning a scan", () => {
+  it("discards complete retained history while preserving a partial line", () => {
     const cursor = new AgyTranscriptCursor();
     cursor.retain(['{"historical":true}']);
+    cursor.push('{"type":"USER_INPUT"');
 
-    cursor.discardThroughNextNewline();
-
-    expect(cursor.push('{"current":true}\n')).toEqual(['{"current":true}']);
+    expect(cursor.retainWithinLimit([], 1)).toBe(false);
+    expect(cursor.push('}\n{"current":true}\n')).toEqual([
+      '{"type":"USER_INPUT"}',
+      '{"current":true}',
+    ]);
   });
 });

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -119,6 +119,28 @@ describe("transcriptRecordUpdates", () => {
     });
   });
 
+  it("still attaches output after the post hook completed the call", () => {
+    // One drain pass reads hooks before the transcript, so for a fast tool the
+    // PostToolUse hook and the record carrying its output arrive together. If
+    // completing a call dropped its bookkeeping, that output would be lost.
+    const state = stateWithActiveTool(3);
+    hookSessionUpdate(
+      { event: "post-tool-use", payload: { conversationId: "conversation-1", stepIdx: 3 } },
+      state,
+    );
+
+    const result = transcriptRecordUpdates(
+      { step_index: 3, source: "MODEL", type: "RUN_COMMAND", content: "Created At: x\nok" },
+      state,
+    );
+
+    expect(result.updates[0]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "agy-conversation-1-3",
+      content: [{ type: "content", content: { type: "text", text: "ok" } }],
+    });
+  });
+
   it("drops tool output with no announced call rather than inventing one", () => {
     const result = transcriptRecordUpdates(
       { step_index: 99, source: "MODEL", type: "RUN_COMMAND", content: "orphan" },

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -142,6 +142,19 @@ describe("transcriptRecordUpdates", () => {
     });
   });
 
+  it("records the steps whose output has been streamed", () => {
+    // The transcript is read once by byte offset, so a step consumed before
+    // its PostToolUse hook appears is never revisited; the bridge uses this to
+    // complete the call immediately instead of waiting for a second record.
+    const state = stateWithActiveTool(3);
+    transcriptRecordUpdates(
+      { step_index: 3, source: "MODEL", type: "RUN_COMMAND", content: "Created At: x\nok" },
+      state,
+    );
+
+    expect(state.transcriptSeenSteps.has(3)).toBe(true);
+  });
+
   it("drops tool output with no announced call rather than inventing one", () => {
     const result = transcriptRecordUpdates(
       { step_index: 99, source: "MODEL", type: "RUN_COMMAND", content: "orphan" },

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -271,6 +271,33 @@ describe("AgyTranscriptCursor", () => {
     expect(cursor.flush()).toEqual([]);
   });
 
+  it("keeps retained records out of the abandoned record's path", () => {
+    // Retained lines used to be prepended to the carry, which put finished
+    // records in the same buffer as a half-written one: the first retained line
+    // was then consumed as the abandoned record's tail and the real fragment
+    // emitted in its place.
+    const cursor = new AgyTranscriptCursor();
+    cursor.push("x".repeat(MAX_TRANSCRIPT_LINE_CHARS + 1));
+    cursor.retain(['{"legit":1}']);
+
+    expect(cursor.push('tail-of-abandoned\n{"next":2}\n')).toEqual(['{"legit":1}', '{"next":2}']);
+  });
+
+  it("still owes retained records at EOF", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.retain(['{"held":1}']);
+
+    expect(cursor.flush()).toEqual(['{"held":1}']);
+    expect(cursor.flush()).toEqual([]);
+  });
+
+  it("counts retained records against the caller's budget", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.retain(['{"a":1}', '{"b":2}']);
+
+    expect(cursor.carryLength).toBe('{"a":1}'.length + 1 + '{"b":2}'.length + 1);
+  });
+
   it("keeps counting consumed bytes across an abandoned record", () => {
     // The offset is what the next read starts from, so dropping content must
     // not desynchronise it from the file.

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -298,6 +298,22 @@ describe("AgyTranscriptCursor", () => {
     expect(cursor.carryLength).toBe('{"a":1}'.length + 1 + '{"b":2}'.length + 1);
   });
 
+  it("drops an aggregate retained suffix that exceeds its budget", () => {
+    const cursor = new AgyTranscriptCursor();
+
+    expect(cursor.retainWithinLimit(["1234", "5678"], 9)).toBe(false);
+    expect(cursor.carryLength).toBe(0);
+    expect(cursor.push('{"current":true}\n')).toEqual(['{"current":true}']);
+  });
+
+  it("counts a partial record when bounding a retained suffix", () => {
+    const cursor = new AgyTranscriptCursor();
+    cursor.push("partial");
+
+    expect(cursor.retainWithinLimit(["12"], 9)).toBe(false);
+    expect(cursor.push(' tail\n{"current":true}\n')).toEqual(['{"current":true}']);
+  });
+
   it("keeps counting consumed bytes across an abandoned record", () => {
     // The offset is what the next read starts from, so dropping content must
     // not desynchronise it from the file.

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { hookSessionUpdate, makeAgyTurnState, type AgyTurnState } from "./agyEvents.ts";
 import {
   AgyTranscriptCursor,
+  dropPriorTurnRecords,
   normalizeToolOutput,
   parseTranscriptLine,
   transcriptRecordUpdates,
@@ -148,6 +149,43 @@ describe("transcriptRecordUpdates", () => {
     );
 
     expect(result.updates).toHaveLength(0);
+  });
+});
+
+describe("dropPriorTurnRecords", () => {
+  const line = (step: number, type: string) => JSON.stringify({ step_index: step, type });
+
+  it("keeps only what follows the last USER_INPUT", () => {
+    // Shape taken from a real two-turn transcript: one append-only file per
+    // conversation, each turn opening with USER_INPUT.
+    const lines = [
+      line(0, "USER_INPUT"),
+      line(1, "CONVERSATION_HISTORY"),
+      line(2, "PLANNER_RESPONSE"),
+      line(3, "LIST_DIRECTORY"),
+      line(4, "CHECKPOINT"),
+      line(5, "PLANNER_RESPONSE"),
+      line(6, "USER_INPUT"),
+      line(7, "SYSTEM_MESSAGE"),
+      line(8, "PLANNER_RESPONSE"),
+    ];
+
+    expect(dropPriorTurnRecords(lines)).toEqual([
+      line(7, "SYSTEM_MESSAGE"),
+      line(8, "PLANNER_RESPONSE"),
+    ]);
+  });
+
+  it("drops this turn's own opening record on a fresh conversation", () => {
+    expect(dropPriorTurnRecords([line(0, "USER_INPUT"), line(1, "PLANNER_RESPONSE")])).toEqual([
+      line(1, "PLANNER_RESPONSE"),
+    ]);
+  });
+
+  it("keeps everything when the opening record has not been written yet", () => {
+    const lines = [line(2, "PLANNER_RESPONSE")];
+    expect(dropPriorTurnRecords(lines)).toEqual(lines);
+    expect(dropPriorTurnRecords([])).toEqual([]);
   });
 });
 

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.test.ts
@@ -155,13 +155,36 @@ describe("transcriptRecordUpdates", () => {
     expect(state.transcriptSeenSteps.has(3)).toBe(true);
   });
 
-  it("drops tool output with no announced call rather than inventing one", () => {
-    const result = transcriptRecordUpdates(
-      { step_index: 99, source: "MODEL", type: "RUN_COMMAND", content: "orphan" },
-      makeAgyTurnState(),
-    );
+  it("holds tool output whose call has not been announced yet", () => {
+    // The hook directory is listed before the transcript is read, so a tool
+    // whose PreToolUse file lands in between arrives here first. Dropping it
+    // would lose that output for good — the transcript is read once by offset.
+    const state = makeAgyTurnState();
+    const record = { step_index: 99, source: "MODEL", type: "RUN_COMMAND", content: "orphan" };
 
-    expect(result.updates).toHaveLength(0);
+    const deferredResult = transcriptRecordUpdates(record, state);
+    expect(deferredResult.updates).toHaveLength(0);
+    expect(deferredResult.deferred).toBe(true);
+    expect(state.transcriptSeenSteps.has(99)).toBe(false);
+
+    // Once the hook arrives, replaying the held record attaches its output.
+    hookSessionUpdate(
+      {
+        event: "pre-tool-use",
+        payload: {
+          conversationId: "conversation-1",
+          stepIdx: 99,
+          toolCall: { name: "run_command", args: {} },
+        },
+      },
+      state,
+    );
+    const replayed = transcriptRecordUpdates(record, state);
+    expect(replayed.deferred).toBeUndefined();
+    expect(replayed.updates[0]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "agy-conversation-1-99",
+    });
   });
 });
 

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -291,6 +291,25 @@ export class AgyTranscriptCursor {
   }
 
   /**
+   * Retain a candidate suffix only while all held transcript text fits within
+   * the caller's budget.
+   *
+   * Resumed conversations are scanned from byte zero when no baseline was
+   * measurable. Dropping the whole candidate on overflow prevents an
+   * append-only history from accumulating in memory while the caller searches
+   * for the current turn's final `USER_INPUT` boundary.
+   */
+  retainWithinLimit(lines: ReadonlyArray<string>, maxChars: number): boolean {
+    const lineChars = lines.reduce((total, line) => total + line.length + 1, 0);
+    if (this.carryLength + lineChars > maxChars) {
+      this.discardThroughNextNewline();
+      return false;
+    }
+    this.retain(lines);
+    return true;
+  }
+
+  /**
    * Abandon everything scanned so far and resume after the current record.
    *
    * A capped read can stop inside a record. Clearing only the completed lines

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -29,6 +29,16 @@ export interface AgyTranscriptRecord {
  * particular holds a summary of truncated context and would read as the
  * assistant talking to itself.
  */
+/**
+ * Ceiling on a single held-back transcript line.
+ *
+ * The transcript is read incrementally, so nothing else bounds a record that
+ * never terminates: the cursor would hold every byte of it waiting for a
+ * newline. Generous enough that a real tool output is never truncated — the
+ * largest observed records are a few hundred KiB.
+ */
+export const MAX_TRANSCRIPT_LINE_CHARS = 4 * 1024 * 1024;
+
 const IGNORED_RECORD_TYPES = new Set([
   "CONVERSATION_HISTORY",
   "CHECKPOINT",
@@ -201,9 +211,20 @@ export function dropPriorTurnRecords(lines: ReadonlyArray<string>): ReadonlyArra
 export class AgyTranscriptCursor {
   private offset = 0;
   private carry = "";
+  /**
+   * Set once a single record has grown past {@link MAX_TRANSCRIPT_LINE_CHARS}.
+   * Its bytes keep arriving, so the remainder is swallowed up to the next
+   * newline rather than surfacing as a fragment that parses as nothing.
+   */
+  private discarding = false;
 
   get bytesConsumed(): number {
     return this.offset;
+  }
+
+  /** Size of the held-back partial line, for callers enforcing their own budget. */
+  get carryLength(): number {
+    return this.carry.length;
   }
 
   /**
@@ -215,7 +236,27 @@ export class AgyTranscriptCursor {
     const combined = this.carry + chunk;
     const lines = combined.split("\n");
     this.carry = lines.pop() ?? "";
-    return lines;
+
+    let completed: ReadonlyArray<string> = lines;
+    if (this.discarding) {
+      // The first line to complete here is the tail of the record that was
+      // given up on; everything after it is intact.
+      if (lines.length > 0) {
+        completed = lines.slice(1);
+        this.discarding = false;
+      } else {
+        completed = [];
+      }
+    }
+
+    // A record with no newline in sight would otherwise be held in full, so a
+    // single malformed or enormous transcript entry could exhaust memory no
+    // matter how small each read is.
+    if (this.carry.length > MAX_TRANSCRIPT_LINE_CHARS) {
+      this.carry = "";
+      this.discarding = true;
+    }
+    return completed;
   }
 
   /**
@@ -233,6 +274,11 @@ export class AgyTranscriptCursor {
   flush(): ReadonlyArray<string> {
     const remaining = this.carry;
     this.carry = "";
+    if (this.discarding) {
+      // Whatever is left is the tail of an abandoned record, not a record.
+      this.discarding = false;
+      return [];
+    }
     return remaining.trim().length > 0 ? [remaining] : [];
   }
 }

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -130,6 +130,10 @@ export function transcriptRecordUpdates(
   if (typeof stepIndex !== "number") {
     return { updates: [], emittedAssistantText: false };
   }
+  // Recorded before the early returns below: the transcript is read once by
+  // byte offset, so "this step's record has gone by" holds even when it
+  // carried nothing worth emitting.
+  state.transcriptSeenSteps.add(stepIndex);
   // Completed calls stay in the map precisely so this lookup still resolves:
   // a fast tool's `PostToolUse` hook and its transcript record routinely land
   // in the same drain pass, and hooks are read first.

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -64,6 +64,16 @@ export function parseTranscriptLine(line: string): AgyTranscriptRecord | null {
 }
 
 /**
+ * Size of the complete parsed record retained by the bridge.
+ *
+ * Computed once when a record enters the deferred queue; callers carry the
+ * result with the record instead of repeatedly serializing held entries.
+ */
+export function serializedTranscriptRecordSize(record: AgyTranscriptRecord): number {
+  return JSON.stringify(record).length;
+}
+
+/**
  * Strip the `Created At:` / `Completed At:` preamble Antigravity prepends to
  * tool records, then dedent. Tool output arrives indented with tabs, which
  * would otherwise render as a code block in the client.

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -208,6 +208,17 @@ export class AgyTranscriptCursor {
     return lines;
   }
 
+  /**
+   * Push whole lines back to the front of the stream.
+   *
+   * Used when a batch cannot be interpreted yet — on a resumed conversation the
+   * current turn's opening record may not have been written — so the same lines
+   * are re-examined against the next read rather than emitted or discarded.
+   */
+  retain(lines: ReadonlyArray<string>): void {
+    this.carry = lines.length > 0 ? `${lines.join("\n")}\n${this.carry}` : this.carry;
+  }
+
   /** Flush the trailing line once the writer is known to be finished. */
   flush(): ReadonlyArray<string> {
     const remaining = this.carry;

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -290,6 +290,20 @@ export class AgyTranscriptCursor {
     }
   }
 
+  /**
+   * Abandon everything scanned so far and resume after the current record.
+   *
+   * A capped read can stop inside a record. Clearing only the completed lines
+   * leaves that fragment in `carry`, where the next read can complete and emit
+   * a historical record as though it belonged to the current turn.
+   */
+  discardThroughNextNewline(): void {
+    const endedInsideRecord = this.carry.length > 0 || this.discarding;
+    this.carry = "";
+    this.retained = [];
+    this.discarding = endedInsideRecord;
+  }
+
   /** Flush the trailing line once the writer is known to be finished. */
   flush(): ReadonlyArray<string> {
     const remaining = this.carry;

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -86,6 +86,11 @@ export interface TranscriptUpdateResult {
   readonly updates: ReadonlyArray<AgySessionUpdate>;
   /** True when the record produced assistant-visible text. */
   readonly emittedAssistantText: boolean;
+  /**
+   * True when the record belongs to a tool call that has not been announced
+   * yet. The caller should hold it and try again after reading more hooks.
+   */
+  readonly deferred?: boolean;
 }
 
 /**
@@ -130,17 +135,22 @@ export function transcriptRecordUpdates(
   if (typeof stepIndex !== "number") {
     return { updates: [], emittedAssistantText: false };
   }
-  // Recorded before the early returns below: the transcript is read once by
-  // byte offset, so "this step's record has gone by" holds even when it
-  // carried nothing worth emitting.
-  state.transcriptSeenSteps.add(stepIndex);
   // Completed calls stay in the map precisely so this lookup still resolves:
   // a fast tool's `PostToolUse` hook and its transcript record routinely land
   // in the same drain pass, and hooks are read first.
   const active = state.toolCalls.get(stepIndex);
   if (!active) {
-    return { updates: [], emittedAssistantText: false };
+    // The hook directory is listed before the transcript is read, so a tool
+    // whose `PreToolUse` file appeared in between has a record here and no
+    // call yet. The transcript is consumed once by byte offset, so dropping it
+    // loses that tool's output for good — it is held instead and retried once
+    // the hook shows up.
+    return { updates: [], emittedAssistantText: false, deferred: true };
   }
+  // Recorded only once the record has actually been matched: marking a step
+  // seen before that would tell the caller a tool it has not announced yet is
+  // already finished.
+  state.transcriptSeenSteps.add(stepIndex);
   const output = normalizeToolOutput(content);
   if (output.length === 0) {
     return { updates: [], emittedAssistantText: false };

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -156,6 +156,29 @@ export function transcriptRecordUpdates(
 }
 
 /**
+ * Drop transcript records belonging to earlier turns.
+ *
+ * One conversation keeps a single append-only transcript, and every turn opens
+ * with a `USER_INPUT` record, so the last one in the file marks where the
+ * current turn begins. Resuming a conversation starts reading at byte 0 — the
+ * turn's own records cannot be located any other way — which without this trim
+ * would replay every prior assistant message as new output.
+ *
+ * Applied only to the first batch of a turn. Returns the input unchanged when
+ * no `USER_INPUT` is present, which is the correct read for a transcript whose
+ * opening record has not been written yet.
+ */
+export function dropPriorTurnRecords(lines: ReadonlyArray<string>): ReadonlyArray<string> {
+  let lastUserInput = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (parseTranscriptLine(lines[index] ?? "")?.type === "USER_INPUT") {
+      lastUserInput = index;
+    }
+  }
+  return lastUserInput === -1 ? lines : lines.slice(lastUserInput + 1);
+}
+
+/**
  * Incremental transcript cursor.
  *
  * Tracks a byte offset and holds back a trailing partial line so a record that

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -295,32 +295,19 @@ export class AgyTranscriptCursor {
    * the caller's budget.
    *
    * Resumed conversations are scanned from byte zero when no baseline was
-   * measurable. Dropping the whole candidate on overflow prevents an
-   * append-only history from accumulating in memory while the caller searches
-   * for the current turn's final `USER_INPUT` boundary.
+   * measurable. Complete history is expendable on overflow, but the bounded
+   * partial line may be the current turn's `USER_INPUT` boundary. Its caller
+   * keeps suppressing completed records until that boundary is observed, so
+   * preserving the partial line cannot surface historical output.
    */
   retainWithinLimit(lines: ReadonlyArray<string>, maxChars: number): boolean {
     const lineChars = lines.reduce((total, line) => total + line.length + 1, 0);
     if (this.carryLength + lineChars > maxChars) {
-      this.discardThroughNextNewline();
+      this.retained = [];
       return false;
     }
     this.retain(lines);
     return true;
-  }
-
-  /**
-   * Abandon everything scanned so far and resume after the current record.
-   *
-   * A capped read can stop inside a record. Clearing only the completed lines
-   * leaves that fragment in `carry`, where the next read can complete and emit
-   * a historical record as though it belonged to the current turn.
-   */
-  discardThroughNextNewline(): void {
-    const endedInsideRecord = this.carry.length > 0 || this.discarding;
-    this.carry = "";
-    this.retained = [];
-    this.discarding = endedInsideRecord;
   }
 
   /** Flush the trailing line once the writer is known to be finished. */

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -130,7 +130,10 @@ export function transcriptRecordUpdates(
   if (typeof stepIndex !== "number") {
     return { updates: [], emittedAssistantText: false };
   }
-  const active = state.activeToolCalls.get(stepIndex);
+  // Completed calls stay in the map precisely so this lookup still resolves:
+  // a fast tool's `PostToolUse` hook and its transcript record routinely land
+  // in the same drain pass, and hooks are read first.
+  const active = state.toolCalls.get(stepIndex);
   if (!active) {
     return { updates: [], emittedAssistantText: false };
   }

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -1,0 +1,187 @@
+/**
+ * Reader for Antigravity's trajectory transcript.
+ *
+ * Antigravity appends one JSON record per step to
+ * `<brain>/<conversation-uuid>/.system_generated/logs/transcript.jsonl` while a
+ * turn is running, not just at the end. Tailing it is what lets the bridge
+ * stream assistant text and surface real tool output — neither of which the
+ * hook payloads carry.
+ *
+ * The record format is undocumented. Everything here is written to degrade to
+ * "emit nothing" rather than throw, so an Antigravity update that changes the
+ * shape costs observability but never breaks a turn.
+ *
+ * @module provider/acp/antigravity/agyTranscript
+ */
+import type { AgySessionUpdate, AgyTurnState } from "./agyEvents.ts";
+
+export interface AgyTranscriptRecord {
+  readonly step_index?: number;
+  readonly source?: string;
+  readonly type?: string;
+  readonly status?: string;
+  readonly created_at?: string;
+  readonly content?: string;
+}
+
+/**
+ * Record types that are bookkeeping rather than conversation. `CHECKPOINT` in
+ * particular holds a summary of truncated context and would read as the
+ * assistant talking to itself.
+ */
+const IGNORED_RECORD_TYPES = new Set([
+  "CONVERSATION_HISTORY",
+  "CHECKPOINT",
+  "USER_INPUT",
+  "SYSTEM_MESSAGE",
+]);
+
+export function parseTranscriptLine(line: string): AgyTranscriptRecord | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+    return parsed as AgyTranscriptRecord;
+  } catch {
+    // A partially-flushed final line is expected while tailing a live turn.
+    return null;
+  }
+}
+
+/**
+ * Strip the `Created At:` / `Completed At:` preamble Antigravity prepends to
+ * tool records, then dedent. Tool output arrives indented with tabs, which
+ * would otherwise render as a code block in the client.
+ */
+export function normalizeToolOutput(content: string): string {
+  const withoutTimestamps = content
+    .split("\n")
+    .filter((line) => !/^\s*(Created At|Completed At):/.test(line))
+    .join("\n");
+
+  // Antigravity indents its own framing ("The command exited with code 0.",
+  // "Output:") with tabs while leaving the tool's real output flush left, so a
+  // plain common-prefix dedent finds an indent of zero and does nothing.
+  // Dedent across tab-indented lines only: that strips the framing here, and
+  // still behaves like a normal dedent when the payload is tab-indented source.
+  const lines = withoutTimestamps.split("\n");
+  const tabDepths = lines
+    .filter((line) => line.trim().length > 0 && line.startsWith("\t"))
+    .map((line) => line.match(/^\t*/)?.[0].length ?? 0);
+  const commonTabs = tabDepths.length > 0 ? Math.min(...tabDepths) : 0;
+  const dedented =
+    commonTabs > 0
+      ? lines.map((line) => (line.startsWith("\t") ? line.slice(commonTabs) : line)).join("\n")
+      : withoutTimestamps;
+
+  return dedented.trim();
+}
+
+export interface TranscriptUpdateResult {
+  readonly updates: ReadonlyArray<AgySessionUpdate>;
+  /** True when the record produced assistant-visible text. */
+  readonly emittedAssistantText: boolean;
+}
+
+/**
+ * Translate one transcript record into ACP updates.
+ *
+ * Assistant text becomes an `agent_message_chunk`. A tool record is matched to
+ * the in-flight tool call announced by the matching `PreToolUse` hook — the
+ * hook's `stepIdx` and the record's `step_index` are the same number — and its
+ * body is attached as that call's output.
+ */
+export function transcriptRecordUpdates(
+  record: AgyTranscriptRecord,
+  state: AgyTurnState,
+): TranscriptUpdateResult {
+  const type = record.type;
+  if (!type || IGNORED_RECORD_TYPES.has(type)) {
+    return { updates: [], emittedAssistantText: false };
+  }
+
+  const content = typeof record.content === "string" ? record.content : "";
+
+  if (type === "PLANNER_RESPONSE") {
+    const text = content.trim();
+    if (text.length === 0) {
+      return { updates: [], emittedAssistantText: false };
+    }
+    return {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text },
+        },
+      ],
+      emittedAssistantText: true,
+    };
+  }
+
+  // Any other MODEL record is a tool step. Attach its body to the tool call
+  // the hook already announced; without a matching hook there is no tool call
+  // to update, so the output is dropped rather than invented.
+  const stepIndex = record.step_index;
+  if (typeof stepIndex !== "number") {
+    return { updates: [], emittedAssistantText: false };
+  }
+  const active = state.activeToolCalls.get(stepIndex);
+  if (!active) {
+    return { updates: [], emittedAssistantText: false };
+  }
+  const output = normalizeToolOutput(content);
+  if (output.length === 0) {
+    return { updates: [], emittedAssistantText: false };
+  }
+
+  return {
+    updates: [
+      {
+        sessionUpdate: "tool_call_update",
+        toolCallId: active.toolCallId,
+        content: [{ type: "content", content: { type: "text", text: output } }],
+        _meta: { antigravity: { event: "transcript", recordType: type, stepIdx: stepIndex } },
+      },
+    ],
+    emittedAssistantText: false,
+  };
+}
+
+/**
+ * Incremental transcript cursor.
+ *
+ * Tracks a byte offset and holds back a trailing partial line so a record that
+ * is still being written is parsed once, on the next read, rather than twice.
+ */
+export class AgyTranscriptCursor {
+  private offset = 0;
+  private carry = "";
+
+  get bytesConsumed(): number {
+    return this.offset;
+  }
+
+  /**
+   * Feed a freshly-read chunk starting at the current offset, returning whole
+   * lines only.
+   */
+  push(chunk: string): ReadonlyArray<string> {
+    this.offset += Buffer.byteLength(chunk, "utf8");
+    const combined = this.carry + chunk;
+    const lines = combined.split("\n");
+    this.carry = lines.pop() ?? "";
+    return lines;
+  }
+
+  /** Flush the trailing line once the writer is known to be finished. */
+  flush(): ReadonlyArray<string> {
+    const remaining = this.carry;
+    this.carry = "";
+    return remaining.trim().length > 0 ? [remaining] : [];
+  }
+}

--- a/apps/server/src/provider/acp/antigravity/agyTranscript.ts
+++ b/apps/server/src/provider/acp/antigravity/agyTranscript.ts
@@ -217,14 +217,23 @@ export class AgyTranscriptCursor {
    * newline rather than surfacing as a fragment that parses as nothing.
    */
   private discarding = false;
+  /**
+   * Whole lines handed back by {@link retain}, kept apart from {@link carry}.
+   *
+   * They were once prepended to the carry, which put finished records into the
+   * same buffer as a half-written one: retaining while a record was being
+   * abandoned made the first retained line look like that record's tail, so it
+   * was dropped and the real fragment emitted in its place.
+   */
+  private retained: Array<string> = [];
 
   get bytesConsumed(): number {
     return this.offset;
   }
 
-  /** Size of the held-back partial line, for callers enforcing their own budget. */
+  /** Size of everything held back, for callers enforcing their own budget. */
   get carryLength(): number {
-    return this.carry.length;
+    return this.retained.reduce((total, line) => total + line.length + 1, this.carry.length);
   }
 
   /**
@@ -256,6 +265,15 @@ export class AgyTranscriptCursor {
       this.carry = "";
       this.discarding = true;
     }
+
+    // Retained lines go back in front, where they were read from, and are not
+    // subject to the discard above — they are complete records that have
+    // already been through it once.
+    if (this.retained.length > 0) {
+      const restored = this.retained;
+      this.retained = [];
+      return [...restored, ...completed];
+    }
     return completed;
   }
 
@@ -267,18 +285,24 @@ export class AgyTranscriptCursor {
    * are re-examined against the next read rather than emitted or discarded.
    */
   retain(lines: ReadonlyArray<string>): void {
-    this.carry = lines.length > 0 ? `${lines.join("\n")}\n${this.carry}` : this.carry;
+    if (lines.length > 0) {
+      this.retained.push(...lines);
+    }
   }
 
   /** Flush the trailing line once the writer is known to be finished. */
   flush(): ReadonlyArray<string> {
     const remaining = this.carry;
     this.carry = "";
+    // Retained records are whole and still owed to the caller even at EOF.
+    const restored = this.retained;
+    this.retained = [];
     if (this.discarding) {
-      // Whatever is left is the tail of an abandoned record, not a record.
+      // Whatever is left of the carry is the tail of an abandoned record, not a
+      // record. The retained lines are unaffected.
       this.discarding = false;
-      return [];
+      return restored;
     }
-    return remaining.trim().length > 0 ? [remaining] : [];
+    return remaining.trim().length > 0 ? [...restored, remaining] : restored;
   }
 }

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -20,6 +20,7 @@
  *
  * @module provider/builtInDrivers
  */
+import { AntigravityDriver, type AntigravityDriverEnv } from "./Drivers/AntigravityDriver.ts";
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
@@ -37,7 +38,8 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | AntigravityDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -50,4 +52,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,
+  AntigravityDriver,
 ];

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.ts
@@ -1,0 +1,254 @@
+/**
+ * Text generation (commit messages, PR content, branch names, thread titles)
+ * backed by the Antigravity CLI through T3 Code's ACP bridge.
+ *
+ * The model is bound when the bridge spawns `agy`, so unlike the Grok
+ * implementation there is no post-start model switch to apply.
+ *
+ * @module textGeneration/AntigravityTextGeneration
+ */
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import { type AntigravitySettings, type ModelSelection } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { TextGenerationError } from "@t3tools/contracts";
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import {
+  makeAntigravityAcpRuntime,
+  resolveAntigravityBaseModelId,
+} from "../provider/acp/AntigravityAcpSupport.ts";
+
+/**
+ * Antigravity print mode carries a fixed startup cost per invocation, so this
+ * budget is deliberately generous relative to a hosted API call.
+ */
+const ANTIGRAVITY_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+export const makeAntigravityTextGeneration = Effect.fn("makeAntigravityTextGeneration")(function* (
+  antigravitySettings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const runAntigravityJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeAntigravityAcpRuntime({
+        antigravitySettings,
+        environment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        model: resolveAntigravityBaseModelId(modelSelection.model),
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      }).pipe(Effect.provideService(Crypto.Crypto, crypto));
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        yield* runtime.start();
+        return yield* runtime.prompt({ prompt: [{ type: "text", text: prompt }] });
+      }).pipe(
+        Effect.timeoutOption(ANTIGRAVITY_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({
+                  operation,
+                  detail: "Antigravity request timed out.",
+                }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause: EffectAcpErrors.AcpError | TextGenerationError) =>
+          isTextGenerationError(cause)
+            ? cause
+            : new TextGenerationError({
+                operation,
+                detail: "Antigravity request failed.",
+                cause,
+              }),
+        ),
+      );
+
+      const trimmed = (yield* Ref.get(outputRef)).trim();
+      if (!trimmed) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "Antigravity request was cancelled."
+              : "Antigravity returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(trimmed)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "Antigravity returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "Antigravity text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGeneration.TextGeneration["Service"]["generateCommitMessage"] =
+    Effect.fn("AntigravityTextGeneration.generateCommitMessage")(function* (input) {
+      const { prompt, outputSchema } = buildCommitMessagePrompt({
+        branch: input.branch,
+        stagedSummary: input.stagedSummary,
+        stagedPatch: input.stagedPatch,
+        includeBranch: input.includeBranch === true,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateCommitMessage",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        subject: sanitizeCommitSubject(generated.subject),
+        body: generated.body.trim(),
+        ...("branch" in generated && typeof generated.branch === "string"
+          ? { branch: sanitizeFeatureBranchName(generated.branch) }
+          : {}),
+      };
+    });
+
+  const generatePrContent: TextGeneration.TextGeneration["Service"]["generatePrContent"] =
+    Effect.fn("AntigravityTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body.trim(),
+      };
+    });
+
+  const generateBranchName: TextGeneration.TextGeneration["Service"]["generateBranchName"] =
+    Effect.fn("AntigravityTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return { branch: sanitizeBranchFragment(generated.branch) };
+    });
+
+  const generateThreadTitle: TextGeneration.TextGeneration["Service"]["generateThreadTitle"] =
+    Effect.fn("AntigravityTextGeneration.generateThreadTitle")(function* (input) {
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizeThreadTitle(generated.title),
+      } satisfies TextGeneration.ThreadTitleGenerationResult;
+    });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGeneration.TextGeneration["Service"];
+});

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,13 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +16,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("antigravity")]: AntigravityIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,4 +1,5 @@
 import {
+  AntigravitySettings,
   ClaudeSettings,
   CodexSettings,
   CursorSettings,
@@ -7,7 +8,15 @@ import {
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  AntigravityIcon,
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -66,6 +75,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Antigravity",
+    icon: AntigravityIcon,
+    badgeLabel: "Experimental",
+    settingsSchema: AntigravitySettings,
   },
 ];
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -51,6 +51,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Antigravity",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -152,6 +153,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "gemini-3.1-pro-high",
 };
 
 /** Per-provider text generation model defaults. */
@@ -162,6 +164,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "gemini-3.6-flash-low",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -211,6 +214,16 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  // AGY model slugs carry their reasoning tier inline (`-high`, `-medium`,
+  // `-low`), so the bare family name has to resolve to a concrete tier.
+  [ANTIGRAVITY_DRIVER_KIND]: {
+    "gemini-3.1-pro": "gemini-3.1-pro-high",
+    pro: "gemini-3.1-pro-high",
+    "gemini-3.6-flash": "gemini-3.6-flash-medium",
+    flash: "gemini-3.6-flash-medium",
+    "gemini-3.5-flash": "gemini-3.5-flash-medium",
+    "gpt-oss-120b": "gpt-oss-120b-medium",
+  },
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -221,4 +234,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ANTIGRAVITY_DRIVER_KIND]: "Antigravity",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -339,6 +339,51 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const AntigravitySettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("agy").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Antigravity CLI binary.",
+        providerSettingsForm: { placeholder: "agy", clearWhenEmpty: "omit" },
+      }),
+    ),
+    // Antigravity has no native agent protocol, so every turn runs through
+    // `agy --print`. A turn holds one process open for its whole duration;
+    // the default matches the bridge's own ceiling.
+    printTimeout: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Print timeout",
+        description: "Max duration for a single turn, passed to `agy --print-timeout`.",
+        providerSettingsForm: { placeholder: "2h", clearWhenEmpty: "omit" },
+      }),
+    ),
+    // Trajectory discovery reads this root only when the Stop hook does not
+    // report a conversation id. Overridable for non-default AGY installs.
+    appDataDir: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "App data directory",
+        description: "Overrides ~/.gemini/antigravity-cli for conversation discovery.",
+        providerSettingsForm: { placeholder: "~/.gemini/antigravity-cli", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "printTimeout", "appDataDir"],
+  },
+);
+export type AntigravitySettings = typeof AntigravitySettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -433,6 +478,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    antigravity: AntigravitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -528,6 +574,14 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const AntigravitySettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  printTimeout: Schema.optionalKey(TrimmedString),
+  appDataDir: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -558,6 +612,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      antigravity: Schema.optionalKey(AntigravitySettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -373,13 +373,25 @@ export const AntigravitySettings = makeProviderSettingsSchema(
         providerSettingsForm: { placeholder: "~/.gemini/antigravity-cli", clearWhenEmpty: "omit" },
       }),
     ),
+    // Print mode cannot prompt, so `agy` runs with permissions skipped and the
+    // bridge's PreToolUse hook becomes the gate instead: it blocks the tool
+    // until T3 Code answers, and a denial is reported back to the model.
+    // Off by default because every approval blocks the turn on a human.
+    requireToolApproval: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({
+        title: "Ask before running tools",
+        description:
+          "Approve each tool call before Antigravity runs it. Turns block until you answer.",
+      }),
+    ),
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
   },
   {
-    order: ["binaryPath", "printTimeout", "appDataDir"],
+    order: ["binaryPath", "printTimeout", "appDataDir", "requireToolApproval"],
   },
 );
 export type AntigravitySettings = typeof AntigravitySettings.Type;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -376,9 +376,10 @@ export const AntigravitySettings = makeProviderSettingsSchema(
     // Print mode cannot prompt, so `agy` runs with permissions skipped and the
     // bridge's PreToolUse hook becomes the gate instead: it blocks the tool
     // until T3 Code answers, and a denial is reported back to the model.
-    // Off by default because every approval blocks the turn on a human.
+    // On by default: without it nothing stands between the model and an
+    // auto-approved tool, and a gate that has to be discovered protects no one.
     requireToolApproval: Schema.Boolean.pipe(
-      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.withDecodingDefault(Effect.succeed(true)),
       Schema.annotateKey({
         title: "Ask before running tools",
         description:
@@ -591,6 +592,7 @@ const AntigravitySettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   printTimeout: Schema.optionalKey(TrimmedString),
   appDataDir: Schema.optionalKey(TrimmedString),
+  requireToolApproval: Schema.optionalKey(Schema.Boolean),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 


### PR DESCRIPTION
Adds `antigravity` as a provider driver alongside Codex, Claude, Cursor, Grok and OpenCode.

**Up front, re: CONTRIBUTING:** this is large (+3442) and unsolicited, and I did not open an issue first. Opening it anyway as a working reference rather than a request for your time — if the answer is no, close it and it costs you nothing. Notes on scope and on splitting it are at the bottom.

## Why this needs a bridge rather than another ACP driver

Antigravity ships no native agent protocol. Verified against `agy` 1.1.7:

- `agy agent stdio` → `unexpected arguments: [stdio]` (Grok's entrypoint is `grok agent stdio`)
- no `--acp` flag; the binary carries `jsonrpc2` and MCP, but no ACP methods
- `Antigravity.app/Contents/Resources/bin/language_server` speaks Codeium gRPC (`exa.language_server_pb`), not ACP

So `provider/acp/antigravity/agyBridge.ts` presents the ACP surface `AcpSessionRuntime` already expects, and runs each turn through the documented non-interactive `agy --print`. It ships as hidden subcommands of the server binary (`t3 agy-acp`, `t3 agy-hook`) so it versions with the server and adds no build artifact.

## How the event stream is reconstructed

Two documented Antigravity sources correlate on step index — a hook's `stepIdx` is the transcript record's `step_index`:

| Signal | Source |
|---|---|
| Tool start, name, args, human title (`toolSummary`) | `PreToolUse` hook |
| Tool **output** (real stdout / file contents) | transcript record with matching `step_index` |
| Tool completed/failed | `PostToolUse` hook |
| Assistant text, streamed during the turn | `PLANNER_RESPONSE` records as they land |
| `conversationId` for resume | present on *every* hook |

Neither source alone is sufficient: hooks never carry tool output, the transcript never carries tool arguments.

## Three things that cost real debugging time

**`--add-dir` replaces the workspace, it does not extend cwd.** Hooks are registered via a throwaway `--add-dir` workspace so nothing is written into the user's repo — but passing only that dir makes the project invisible to the agent. Both the session cwd and the hook workspace are passed.

**Edit diffs must be captured inside the hook process.** Both hooks for a fast edit land within one 50ms poll, so reading the file while draining hook output makes "before" read back as "after". The hook brackets the tool call and is the only place that sees true pre-edit state.

**Probes must set `stdin: "ignore"`.** `agy` starts a language server and emits nothing while stdin stays open; `ChildProcess` defaults `stdin` to `"pipe"`, which hangs it. Presented as `installed: true, models: 0` while `agy models` worked by hand.

## Known constraints

All inherent to print mode, documented in `AGENTS.md`:

- tools auto-approve (`--dangerously-skip-permissions`); no approval flow is possible
- no image attachments, no session modes
- model binds at spawn, so `sessionModelSwitch` is `"unsupported"`
- assistant text streams per planner step, not per token

The trajectory JSONL format is undocumented. Every parse path degrades to emitting nothing rather than failing a turn, so an `agy` release that changes it costs observability, not correctness.

## UI surface

No new components. The provider renders through the existing rows: `PROVIDER_OPTIONS`, `PROVIDER_ICON_BY_PROVIDER`, and `PROVIDER_CLIENT_DEFINITIONS`, reusing the `AntigravityIcon` already in `Icons.tsx` for the editor integration, with an `Experimental` badge in the same slot Cursor and Grok use for `Early Access`. CONTRIBUTING asks for before/after images on UI changes — I don't have a clean way to attach them here; the visible delta is one additional provider row.

## Verification

- 1076 tests pass (6 skipped), including 39 new across `agyEvents`, `agyTranscript`, `AntigravityAcpSupport`
- 0 type errors, 0 lint errors, format clean
- `pnpm build` clean; bridge bundles into `dist/bin.mjs` and all three entrypoints work off the built binary
- live probe: `status: ready | version: 1.1.7 | models: 11`
- a full turn driven through the **built** binary against real `agy`: tool calls, real tool output, a file edit with diff, `stopReason: end_turn`, file on disk actually changed

Three `ProviderRegistry` fixtures assert an exact provider list or that only the subject provider probes, so they gain the new driver.

## On size

Most of the diff is `AntigravityAdapter.ts` (~690 lines), which follows the existing convention of one standalone adapter per provider (Cursor 1.2k, Grok 1.5k, Claude 3.9k) over the shared ACP helpers. I deliberately did not refactor a shared adapter core out of `GrokAdapter`, since that would mean touching a working provider to land a new one.

Happy to split this into (1) contracts + bridge + tests and (2) driver + UI wiring, or to drop the text-generation backend, if either would make it reviewable. Equally happy for you to take the bridge approach and reimplement it your way — the `--add-dir`, hook-timing and `stdin` findings above are the parts that were expensive to discover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new process bridge and session adapter with tool-approval and subprocess lifecycle semantics; mistakes affect security boundaries and turn cancellation across providers using shared `AcpSessionRuntime`.
> 
> **Overview**
> Adds an **Antigravity** built-in provider that talks to the `agy` CLI through a bundled **ACP compatibility bridge** (`t3 agy-acp` / `t3 agy-hook`), since `agy` has no native agent protocol. Each turn is driven in print mode; the server reconstructs streaming updates from **tool hooks** and **trajectory transcript** records correlated by step index.
> 
> **Server wiring:** new driver, large session adapter (turn lifecycle, optional **PreToolUse tool approval** when `requireToolApproval` is on, attachments as `resource_link` `file:` URIs via `attachmentFileUrl`), health/model discovery (`agy models` / `--version` with `stdin: "ignore"`), and registry test fixtures that include `antigravity`. **Shared ACP runtime** gains a `dispatchGate` and cancellation generation so `cancel()` reliably stops in-flight and **queued** prompts instead of racing prompt dispatch.
> 
> **Docs:** `AGENTS.md` documents bridge constraints (workspace `--add-dir` behavior, approval HMAC limits, process-group kill on cancel, probe stdin, no provider rollback).
> 
> Capabilities exposed to the UI include **in-session model switches** on the next `agy` spawn and explicit failure for **thread rollback** when the trajectory cannot be truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7342f6cda053f59743a61c0b11d043534c7c0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Antigravity (agy) CLI provider via an ACP compatibility bridge
> - Introduces a full `antigravity` provider driver that spawns the `agy` CLI via a stdio ACP bridge, exposing it as a selectable provider in the UI with model discovery, health probing, and settings (binary path, print timeout, tool approval gating).
> - Adds `t3 agy-acp` and `t3 agy-hook` CLI subcommands in [bin.ts](https://github.com/pingdotgg/t3code/pull/4497/files#diff-49e5d719869710e6cd7800547c130d0f20fcf22e14bb44b6ea8db436bb9a5a5f) to run the bridge and handle tool lifecycle hooks from the `agy` process.
> - Implements incremental transcript parsing ([agyTranscript.ts](https://github.com/pingdotgg/t3code/pull/4497/files#diff-e42c4b0dfd9e9b779938743f96fe29632a64ad64e1d33b4d66ddc00a788d4f76)) and hook event translation ([agyEvents.ts](https://github.com/pingdotgg/t3code/pull/4497/files#diff-329a75f126cd71bfdd23c0b64e87c710a2a0132d23216b6e8930295ca092da70)) to reconstruct ACP session updates (assistant text chunks, tool call announce/complete, diffs) from `agy`'s print-mode output.
> - Adds an Antigravity-backed text generation service for commit messages, PR content, branch names, and thread titles by running single-turn ACP sessions and decoding structured JSON responses.
> - Fixes a race in `AcpSessionRuntime` where prompts queued for serialization were not cancelled when `cancel()` was called before they were sent; they now resolve with `stopReason: "cancelled"` immediately.
> - Risk: the Antigravity provider is marked Experimental and requires the `agy` binary to be installed and accessible at the configured path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7342f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->