### PR TITLE
follow-up normalization after #4700.

### DIFF
--- a/apps/web/src/components/ProjectScriptsControl.test.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.test.tsx
@@ -1,0 +1,65 @@
+import type { ProjectScript, ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import ProjectScriptsControl from "./ProjectScriptsControl";
+
+const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
+const PRIMARY_SCRIPT: ProjectScript = {
+  id: "dev",
+  name: "Dev",
+  command: "vp dev",
+  icon: "play",
+  runOnWorktreeCreate: false,
+};
+
+function renderControl(scripts: ReadonlyArray<ProjectScript>) {
+  return renderToStaticMarkup(
+    <ProjectScriptsControl
+      scripts={scripts}
+      keybindings={EMPTY_KEYBINDINGS}
+      onRunScript={() => {}}
+      onAddScript={async () => undefined as never}
+      onUpdateScript={async () => undefined as never}
+      onDeleteScript={async () => undefined as never}
+    />,
+  );
+}
+
+function buttonTag(html: string, ariaLabel: string) {
+  return html.match(new RegExp(`<button[^>]*aria-label="${ariaLabel}"[^>]*>`))?.[0];
+}
+
+function expectResponsiveXsControl(markup: string | undefined) {
+  expect(markup).toBeDefined();
+  expect(markup).toContain("h-7");
+  expect(markup).toContain("gap-1");
+  expect(markup).toContain("text-sm");
+  expect(markup).toContain("sm:h-6");
+  expect(markup).toContain("sm:text-xs");
+  expect(markup).toContain("w-7");
+  expect(markup).toContain("px-0");
+  expect(markup).toContain("sm:w-6");
+  expect(markup).toContain("@3xl/header-actions:w-auto!");
+  expect(markup).toContain("@3xl/header-actions:px-[calc(--spacing(2)-1px)]");
+}
+
+describe("ProjectScriptsControl compact controls", () => {
+  it("keeps the primary Run control compact and expands it with its label", () => {
+    const html = renderControl([PRIMARY_SCRIPT]);
+
+    expectResponsiveXsControl(buttonTag(html, "Run Dev"));
+    expect(html).toContain(
+      'class="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5"',
+    );
+  });
+
+  it("keeps the standalone Add control compact and expands it with its label", () => {
+    const html = renderControl([]);
+
+    expectResponsiveXsControl(buttonTag(html, "Add action"));
+    expect(html).toContain(
+      'class="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5"',
+    );
+  });
+});

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -341,6 +341,7 @@ export default function ProjectScriptsControl({
                 <Button
                   size="xs"
                   variant="outline"
+                  className="w-7 px-0 sm:w-6 @3xl/header-actions:w-auto! @3xl/header-actions:px-[calc(--spacing(2)-1px)]"
                   aria-label={`Run ${primaryScript.name}`}
                   onClick={() => onRunScript(primaryScript)}
                 />
@@ -441,7 +442,13 @@ export default function ProjectScriptsControl({
         <Tooltip>
           <TooltipTrigger
             render={
-              <Button size="xs" variant="outline" aria-label="Add action" onClick={openAddDialog} />
+              <Button
+                size="xs"
+                variant="outline"
+                className="w-7 px-0 sm:w-6 @3xl/header-actions:w-auto! @3xl/header-actions:px-[calc(--spacing(2)-1px)]"
+                aria-label="Add action"
+                onClick={openAddDialog}
+              />
             }
           >
             <PlusIcon className="size-3.5" />

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -261,9 +261,9 @@ function SidebarV2ThreadTooltip({
       align="start"
       sideOffset={4}
       variant="glass"
-      className="max-w-80 text-left whitespace-normal"
+      className="max-w-80 text-left whitespace-normal [&_[data-slot=tooltip-viewport]]:p-0"
     >
-      <div className="flex min-w-0 max-w-80 flex-col gap-2 px-0.5 py-1.5">
+      <div className="flex min-w-0 max-w-80 flex-col gap-2 p-[var(--floating-content-inset)]">
         <div className="min-w-0 truncate text-xs leading-none font-medium text-foreground">
           {thread.title}
         </div>
@@ -918,7 +918,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
             />
           }
         >
-          <div className="relative z-10 h-[4.875rem] px-2.5 py-2">
+          <div className="relative z-10 h-[4.875rem] px-[var(--sidebar-row-content-inset)] py-[var(--sidebar-content-inset)]">
             <div className="flex h-5 min-w-0 items-center gap-1.5">
               <ProjectFavicon
                 environmentId={thread.environmentId}
@@ -2410,7 +2410,7 @@ export default function SidebarV2() {
       <SidebarContent
         className="gap-0"
         fixedHeader={
-          <SidebarGroup className="gap-1 p-2">
+          <SidebarGroup className="gap-1 p-[var(--sidebar-content-inset)]">
             <div className="flex items-center gap-1">
               <div className="min-w-0 flex-1">
                 <CommandDialogTrigger
@@ -2558,7 +2558,7 @@ export default function SidebarV2() {
           </SidebarGroup>
         }
       >
-        <SidebarGroup className="px-2 pb-1 pt-0">
+        <SidebarGroup className="px-[var(--sidebar-content-inset)] pb-1 pt-0">
           <TooltipProvider
             key="sidebar-thread-tooltips-150"
             delay={150}

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -75,7 +75,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
   return (
     <>
       <SidebarContent className="overflow-x-hidden">
-        <SidebarGroup className="p-2">
+        <SidebarGroup className="p-[var(--sidebar-content-inset)]">
           <SidebarMenu>
             {SETTINGS_NAV_ITEMS.map((item) => {
               const Icon = item.icon;
@@ -95,7 +95,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
           </SidebarMenu>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter className="p-2">
+      <SidebarFooter className="p-[var(--sidebar-content-inset)]">
         <T3ConnectSidebarSignIn />
         <div className="flex items-center gap-1">
           <SidebarMenu className="min-w-0 flex-1">

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -119,7 +119,7 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   }, [isMobile, navigate, setOpenMobile]);
 
   return (
-    <SidebarFooter className="p-2">
+    <SidebarFooter className="p-[var(--sidebar-content-inset)]">
       <SidebarProviderUpdatePill />
       <SidebarUpdatePill />
       <SidebarMenu>

--- a/apps/web/src/components/ui/button.test.tsx
+++ b/apps/web/src/components/ui/button.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+import { FlaskConicalIcon } from "lucide-react";
+
+import { Button } from "./button";
+
+describe("button geometry tokens", () => {
+  it("uses the shared control radius and an opaque semantic icon color", () => {
+    const html = renderToStaticMarkup(
+      <Button size="icon-xs" variant="outline" aria-label="Run tests">
+        <FlaskConicalIcon />
+      </Button>,
+    );
+
+    expect(html).toContain("rounded-[var(--control-radius)]");
+    expect(html).toContain("[--control-icon-color:var(--muted-foreground)]");
+    expect(html).toContain("text-[var(--control-icon-color)]");
+    expect(html).not.toContain("opacity-80");
+  });
+
+  it("keeps compact icon buttons square at every breakpoint", () => {
+    const html = renderToStaticMarkup(
+      <Button size="icon-xs" aria-label="Add action">
+        <span>+</span>
+      </Button>,
+    );
+
+    expect(html).toContain("size-7");
+    expect(html).toContain("sm:size-6");
+  });
+});

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ import type * as React from "react";
 import { cn } from "~/lib/utils";
 
 const buttonVariants = cva(
-  "[&_svg]:-mx-0.5 relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-lg border font-medium text-base outline-none transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 sm:text-sm [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "[--control-icon-color:currentColor] [&_svg]:-mx-0.5 relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-[var(--control-radius)] border font-medium text-base outline-none transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--control-radius)-1px)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 sm:text-sm [&_svg:not([class*='text-'])]:text-[var(--control-icon-color)] [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     defaultVariants: {
       size: "default",
@@ -23,11 +23,11 @@ const buttonVariants = cva(
         "icon-xl":
           "size-11 sm:size-10 [&_svg:not([class*='size-'])]:size-5 sm:[&_svg:not([class*='size-'])]:size-4.5",
         "icon-xs":
-          "size-7 rounded-md before:rounded-[calc(var(--radius-md)-1px)] sm:size-6 not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-4 sm:not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-3.5",
+          "size-7 sm:size-6 not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-4 sm:not-in-data-[slot=input-group]:[&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-10 px-[calc(--spacing(3.5)-1px)] sm:h-9",
         sm: "h-8 gap-1.5 px-[calc(--spacing(2.5)-1px)] sm:h-7",
         xl: "h-11 px-[calc(--spacing(4)-1px)] text-lg sm:h-10 sm:text-base [&_svg:not([class*='size-'])]:size-5 sm:[&_svg:not([class*='size-'])]:size-4.5",
-        xs: "h-7 gap-1 rounded-md px-[calc(--spacing(2)-1px)] text-sm before:rounded-[calc(var(--radius-md)-1px)] sm:h-6 sm:text-xs [&_svg:not([class*='size-'])]:size-4 sm:[&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-7 gap-1 px-[calc(--spacing(2)-1px)] text-sm sm:h-6 sm:text-xs [&_svg:not([class*='size-'])]:size-4 sm:[&_svg:not([class*='size-'])]:size-3.5",
       },
       variant: {
         default:
@@ -37,10 +37,10 @@ const buttonVariants = cva(
         "destructive-outline":
           "border-input bg-popover not-dark:bg-clip-padding text-destructive-foreground shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [:disabled,:active,[data-pressed]]:shadow-none [:hover,[data-pressed]]:border-destructive/32 [:hover,[data-pressed]]:bg-destructive/4",
         ghost:
-          "border-transparent text-foreground data-pressed:bg-accent [:hover,[data-pressed]]:bg-accent [&_svg:not([class*='text-'])]:text-muted-foreground",
+          "[--control-icon-color:var(--muted-foreground)] border-transparent text-foreground data-pressed:bg-accent [:hover,[data-pressed]]:bg-accent",
         link: "border-transparent underline-offset-4 [:hover,[data-pressed]]:underline",
         outline:
-          "border-input bg-popover not-dark:bg-clip-padding text-foreground shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [:disabled,:active,[data-pressed]]:shadow-none [:hover,[data-pressed]]:bg-accent/50 dark:[:hover,[data-pressed]]:bg-input/64 [&_svg:not([class*='text-'])]:text-muted-foreground",
+          "[--control-icon-color:var(--muted-foreground)] border-input bg-popover not-dark:bg-clip-padding text-foreground shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [:disabled,:active,[data-pressed]]:shadow-none [:hover,[data-pressed]]:bg-accent/50 dark:[:hover,[data-pressed]]:bg-input/64",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [:active,[data-pressed]]:bg-secondary/80 [:hover,[data-pressed]]:bg-secondary/90",
       },

--- a/apps/web/src/components/ui/command.test.tsx
+++ b/apps/web/src/components/ui/command.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { Command, CommandFooter, CommandInput } from "./command";
+
+describe("command compact geometry", () => {
+  it("keeps shell selectors on the wrapper and direct-input padding on AutocompleteInput", () => {
+    const html = renderToStaticMarkup(
+      <Command>
+        <CommandInput placeholder="Search commands" />
+      </Command>,
+    );
+    const shellClass = html.match(/class="([^"]*px-\[var\(--command-shell-inset\)[^"]*)"/)?.[1];
+    const inputClass = html.match(/class="([^"]*has-focus-visible:ring-0[^"]*)"/)?.[1];
+
+    expect(shellClass).toContain(
+      "[&amp;_[data-slot=autocomplete-start-addon]]:ps-[calc(var(--command-shell-inset)+0.0625rem)]",
+    );
+    expect(shellClass).not.toContain("sm:*:data-[slot=autocomplete-input]");
+    expect(inputClass).toContain(
+      "sm:*:data-[slot=autocomplete-input]:ps-[calc(var(--command-shell-inset)+1.5rem)]!",
+    );
+  });
+
+  it("uses the semantic footer inset without changing compact vertical padding", () => {
+    const html = renderToStaticMarkup(<CommandFooter>Shortcuts</CommandFooter>);
+
+    expect(html).toContain("px-[var(--command-content-inset)]");
+    expect(html).toContain("py-2.5");
+  });
+});

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -103,11 +103,16 @@ function CommandInput({
   wrapperClassName?: string | undefined;
 }) {
   return (
-    <div className={cn("px-1.25 py-1.5", wrapperClassName)}>
+    <div
+      className={cn(
+        "px-[var(--command-shell-inset)] py-1.5 [&_[data-slot=autocomplete-start-addon]]:ps-[calc(var(--command-shell-inset)+0.0625rem)]",
+        wrapperClassName,
+      )}
+    >
       <AutocompleteInput
         autoFocus
         className={cn(
-          "border-transparent! bg-transparent! shadow-none before:hidden has-focus-visible:ring-0 placeholder:text-muted-foreground/80 *:data-[slot=autocomplete-input]:ps-9! sm:*:data-[slot=autocomplete-input]:ps-8.5!",
+          "border-transparent! bg-transparent! shadow-none before:hidden has-focus-visible:ring-0 placeholder:text-muted-foreground/80 *:data-[slot=autocomplete-input]:ps-9! sm:*:data-[slot=autocomplete-input]:ps-[calc(var(--command-shell-inset)+1.5rem)]!",
           className,
         )}
         placeholder={placeholder}
@@ -211,7 +216,7 @@ function CommandFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "relative flex items-center justify-between gap-2 rounded-b-[calc(var(--radius-2xl)-1px)] bg-foreground/[0.025] px-4 py-2.5 font-medium text-sm text-muted-foreground [&_[data-slot=kbd-group]]:font-sans [&_[data-slot=kbd]]:bg-foreground/[0.08] [&_[data-slot=kbd]]:text-foreground [&_[data-slot=kbd]]:ring-0",
+        "relative flex items-center justify-between gap-2 rounded-b-[calc(var(--radius-2xl)-1px)] bg-foreground/[0.025] px-[var(--command-content-inset)] py-2.5 font-medium text-sm text-muted-foreground [&_[data-slot=kbd-group]]:font-sans [&_[data-slot=kbd]]:bg-foreground/[0.08] [&_[data-slot=kbd]]:text-foreground [&_[data-slot=kbd]]:ring-0",
         className,
       )}
       data-slot="command-footer"

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -55,12 +55,15 @@ describe("sidebar interactive cursors", () => {
 
     expect(html).toContain('data-slot="sidebar-menu-button"');
     expect(html).toContain("h-8");
-    expect(html).toContain("rounded-md");
-    expect(html).toContain("px-2");
+    expect(html).toContain("rounded-[var(--control-radius)]");
+    expect(html).toContain("px-[var(--sidebar-row-content-inset)]");
     expect(html).toContain("py-1.5");
     expect(html).toContain("]:size-4");
     expect(html).toContain("]:shrink-0");
     expect(html).toContain("cursor-pointer");
+    expect(html).toContain("gap-[var(--sidebar-control-gap)]");
+    expect(html).toContain("text-[var(--sidebar-icon-color)]");
+    expect(html).not.toContain("[&amp;&gt;svg]:opacity-60");
   });
 
   it("applies the shared default treatment to icon-only menu buttons", () => {

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -712,7 +712,10 @@ function SidebarContent({
 function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn(
+        "relative flex w-full min-w-0 flex-col p-[var(--sidebar-content-inset)]",
+        className,
+      )}
       data-sidebar="group"
       data-slot="sidebar-group"
       {...props}
@@ -792,7 +795,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full cursor-pointer items-center gap-2 overflow-hidden text-left outline-hidden ring-ring transition-[width,height,padding] hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 active:bg-sidebar-row-active active:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pe-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-row-selected data-[active=true]:font-medium data-[active=true]:text-sidebar-foreground data-[state=open]:hover:bg-sidebar-row-hover data-[state=open]:hover:text-sidebar-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg:not([class*='size-'])]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-muted-foreground [&>svg]:opacity-60 hover:[&>svg]:text-sidebar-foreground hover:[&>svg]:opacity-100 active:[&>svg]:text-sidebar-foreground active:[&>svg]:opacity-100 data-[active=true]:[&>svg]:text-sidebar-foreground data-[active=true]:[&>svg]:opacity-100",
+  "peer/menu-button flex w-full cursor-pointer items-center gap-[var(--sidebar-control-gap)] overflow-hidden text-left outline-hidden ring-ring transition-[width,height,padding] hover:bg-sidebar-row-hover hover:text-sidebar-foreground focus-visible:ring-2 active:bg-sidebar-row-active active:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pe-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-row-selected data-[active=true]:font-medium data-[active=true]:text-sidebar-foreground data-[state=open]:hover:bg-sidebar-row-hover data-[state=open]:hover:text-sidebar-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-[var(--sidebar-content-inset)]! [&>span:last-child]:truncate [&>svg:not([class*='size-'])]:size-4 [&>svg]:shrink-0 [&>svg]:text-[var(--sidebar-icon-color)] hover:[&>svg]:text-sidebar-foreground active:[&>svg]:text-sidebar-foreground data-[active=true]:[&>svg]:text-sidebar-foreground",
   {
     defaultVariants: {
       size: "default",
@@ -800,8 +803,9 @@ const sidebarMenuButtonVariants = cva(
     },
     variants: {
       size: {
-        default: "h-8 rounded-md px-2.5 py-1.5 text-sm",
-        icon: "size-8 justify-center rounded-md p-0",
+        default:
+          "h-8 rounded-[var(--control-radius)] px-[var(--sidebar-row-content-inset)] py-1.5 text-sm",
+        icon: "size-8 justify-center rounded-[var(--control-radius)] p-0",
         lg: "h-12 rounded-lg p-2 text-sm group-data-[collapsible=icon]:p-0!",
         sm: "h-7 rounded-lg p-2 text-xs",
       },

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -79,6 +79,18 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --app-scrollbar-width: 6px;
   --app-scrollbar-thumb: rgb(217 217 217);
   --app-scrollbar-thumb-hover: rgb(191 191 191);
+  /*
+   * Compact UI geometry. Keep these values semantic so sidebar, palette,
+   * tooltip, and toolbar controls cannot quietly drift apart.
+   */
+  --control-radius: 0.5rem;
+  --sidebar-content-inset: 0.5rem;
+  --sidebar-control-gap: 0.5rem;
+  --sidebar-icon-color: color-mix(in srgb, var(--sidebar-muted-foreground) 60%, var(--sidebar));
+  --sidebar-row-content-inset: 0.625rem;
+  --command-shell-inset: 0.5rem;
+  --command-content-inset: 1rem;
+  --floating-content-inset: 0.75rem;
   --glass-blur: 12px;
   --glass-opacity: 80%;
   --glass-saturation: 1.14;


### PR DESCRIPTION
## Summary

- introduce semantic design tokens for compact control radius, sidebar spacing, command-palette alignment, tooltip padding, and opaque sidebar icon color
- normalize Sidebar V2 cards, project filters, settings footer rows, and T3 Connect controls around those tokens
- align command-palette search, results, group labels, and footer to one content axis
- make compact project-action buttons truly square and remove translucent SVG treatment that darkened overlapping strokes

## Fixed UI close-ups

These captures are from the isolated local verification build for the latest PR head, [334dd292dc](https://github.com/pingdotgg/t3code/pull/4498/commits/334dd292dcb6ebb1c4b01410e801c9aaa0ded343).

| Command-palette alignment | Sidebar spacing and opaque icons |
| --- | --- |
| <img src="https://raw.githubusercontent.com/shivamhwp/t3code/36006fb60fbd4e6f77edde3f231eacc50b847908/command-palette-alignment.png" alt="Aligned command-palette content" width="520"> | <img src="https://raw.githubusercontent.com/shivamhwp/t3code/36006fb60fbd4e6f77edde3f231eacc50b847908/sidebar-row-spacing.png" alt="Normalized sidebar spacing and opaque icons" width="255"> |

| Square compact controls | Thread tooltip padding |
| --- | --- |
| <img src="https://raw.githubusercontent.com/shivamhwp/t3code/36006fb60fbd4e6f77edde3f231eacc50b847908/compact-header-controls.png" alt="Square compact header controls with consistent radii" width="270"> | <img src="https://raw.githubusercontent.com/shivamhwp/t3code/36006fb60fbd4e6f77edde3f231eacc50b847908/tooltip-padding.png" alt="Thread tooltip with balanced 12 pixel padding" width="245"> |

| Settings navigation controls | Settings Back row |
| --- | --- |
| <img src="https://raw.githubusercontent.com/shivamhwp/t3code/36006fb60fbd4e6f77edde3f231eacc50b847908/settings-nav-controls.png" alt="Consistent settings navigation controls" width="255"> | <img src="https://raw.githubusercontent.com/shivamhwp/t3code/36006fb60fbd4e6f77edde3f231eacc50b847908/settings-back-spacing.png" alt="Symmetric settings Back row spacing" width="255"> |

## Root cause

The redesigned surfaces used independent Tailwind spacing, radius, and opacity values. Reserved scrollbar gutter space also added an extra six pixels to the right side of Sidebar V2 rows, while the settings footer's explicit empty grid column added four pixels when no avatar rendered. Tooltip viewport and child padding stacked asymmetrically.

## Impact

Compact controls now share an 8px radius and tokenized geometry. Sidebar rows and settings footer actions have symmetric insets, thread tooltip content has 12px padding on every edge, command-palette content shares a 16px alignment axis, compact project actions render at 24×24px, and detailed SVG icons render with an opaque semantic color.

## Verification

- `vp test run apps/web/src/components/ProjectScriptsControl.test.tsx apps/web/src/components/ui/button.test.tsx apps/web/src/components/ui/command.test.tsx apps/web/src/components/ui/sidebar.test.tsx` — 14 tests passed
- `vp run --filter @t3tools/web typecheck`
- focused `vp lint` over all changed web files
- `vp run --filter @t3tools/web build`
- isolated authenticated web-app pass with a disposable project/thread fixture:
  - Sidebar V2 row outer inset measured approximately 8px on both sides; row content measured 8px/8px
  - settings Back action measured approximately 8px on both sides
  - thread tooltip measured 12px on all four sides
  - command-palette search icon and result icon measured on the same axis; labels and footer align at 16px
  - compact Add action measured 24×24px
  - reviewed controls measured an 8px radius
  - compact and Flask SVG icons measured at opacity 1

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize compact UI geometry using shared CSS tokens across sidebar and button components
> - Introduces semantic CSS custom properties in [index.css](https://github.com/pingdotgg/t3code/pull/4498/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) (`--control-radius`, `--sidebar-content-inset`, `--sidebar-row-content-inset`, `--command-shell-inset`, `--floating-content-inset`, etc.) to drive consistent spacing and radius across the app.
> - Updates [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/4498/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd), [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4498/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c), [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/4498/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11), and [SettingsSidebarNav.tsx](https://github.com/pingdotgg/t3code/pull/4498/files#diff-0c64e545aee60962b27c61f412d1b564c5896199b9538212702b7da60246d134) to replace hardcoded padding values with these tokens.
> - Updates the `xs` button size in [button.tsx](https://github.com/pingdotgg/t3code/pull/4498/files#diff-7eedccc2b49d7116e34e431c4d35c952723c7d4101de809118aeb956cf37a822) with responsive height/padding/gap classes, and tokenizes icon color in the ghost variant via `--control-icon-color`.
> - Updates [ProjectScriptsControl.tsx](https://github.com/pingdotgg/t3code/pull/4498/files#diff-e891caffa18ba1b7506cceb8fe52ad48887e3161ef59bee56d37cd57b61c511b) so Run and Add buttons collapse to icon-only at narrow breakpoints and expand at `@3xl/header-actions`.
> - Behavioral Change: sidebar rows, groups, and footer padding values change from hardcoded pixel values to token-driven sizes, which may shift visual spacing if token values differ from previous hardcoded values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 334dd29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and spacing-token changes across shared UI primitives with no auth, data, or API behavior changes; regression risk is limited to layout and icon appearance.
> 
> **Overview**
> Introduces shared CSS variables in `index.css` (`--control-radius`, sidebar insets/gap/icon color, command palette insets) so compact controls, sidebars, and the command palette stay aligned instead of using scattered Tailwind values.
> 
> **Buttons** now use `rounded-[var(--control-radius)]` and `--control-icon-color` for SVGs (replacing default `opacity-80` on outline/ghost). **Sidebar** groups, menu buttons, and chrome/settings footers swap fixed `p-2` / `px-2` for the sidebar tokens; icons use opaque `--sidebar-icon-color` instead of faded SVG opacity. **Command palette** search shell and footer horizontal padding use `--command-shell-inset` and `--command-content-inset`. **Project script** Run/Add `xs` controls are square at narrow widths and expand with labels at `@3xl/header-actions`.
> 
> Static markup tests lock in the new classes for button, command, sidebar, and `ProjectScriptsControl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f802705cad7ba01914e7d40be79ce765c1cce1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
