### PR TITLE
fix(orchestrator): Wake settled parents when delegated children finish

### DIFF
--- a/apps/server/src/mcp/OrchestratorMcpService.ts
+++ b/apps/server/src/mcp/OrchestratorMcpService.ts
@@ -1053,6 +1053,10 @@ const make = Effect.gen(function* () {
             modelSelection: target.modelSelection,
             runtimeMode,
             interactionMode,
+            // Async delegations wake the parent on every child terminal; wait
+            // delegations deliver through the blocking tool call, so a wake is
+            // only needed if the parent settled first (timeout, disconnect).
+            completionWake: input.mode === "wait" ? "settled_only" : "always",
           })
           .pipe(
             Effect.mapError((error) =>
@@ -1072,18 +1076,59 @@ const make = Effect.gen(function* () {
             "Delegated task command did not produce a task projection.",
           );
         }
+        const taskId = taskEvent.event.payload.id;
 
         if (input.mode !== "wait") {
-          return yield* readTask(scope, taskEvent.event.payload.id);
+          return yield* readTask(scope, taskId);
         }
         const timeoutMs = Math.min(
           MAX_WAIT_TIMEOUT_MS,
           Math.max(1, input.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS),
         );
-        const waited = yield* waitForTask(scope, taskEvent.event.payload.id, timeoutMs);
-        return Option.isSome(waited)
-          ? waited.value
-          : yield* readTask(scope, taskEvent.event.payload.id, true);
+        const waited = yield* waitForTask(scope, taskId, timeoutMs);
+        if (Option.isSome(waited)) {
+          return waited.value;
+        }
+        // The blocking wait timed out, so it no longer owns delivery: upgrade
+        // the task so a later terminal wakes the parent even mid-turn. Best
+        // effort; on failure the settled_only policy still wakes a settled
+        // parent.
+        yield* threadManagement
+          .dispatch({
+            type: "delegated_task.wake-policy",
+            commandId: stableCommandId({
+              scope,
+              requestKey: key,
+              operation: "delegate-task-wake-policy",
+            }),
+            parentThreadId: scope.threadId,
+            taskId,
+            completionWake: "always",
+          })
+          .pipe(
+            // The tool result is the timed-out task either way, so failures
+            // stay warnings. Keep the two shapes apart: a rejected receipt
+            // means this exact command id already failed (a replay of a
+            // no-op upgrade), while anything else is a fresh dispatch fault.
+            Effect.catch((error) =>
+              Effect.logWarning("orchestrator-mcp.delegate-task.wake-policy-failed", {
+                taskId,
+                outcome:
+                  error._tag === "OrchestratorCommandPreviouslyRejectedError"
+                    ? "previously_rejected"
+                    : "dispatch_failed",
+                error,
+              }),
+            ),
+            Effect.catchCause((cause) =>
+              Effect.logWarning("orchestrator-mcp.delegate-task.wake-policy-failed", {
+                taskId,
+                outcome: "defect",
+                cause,
+              }),
+            ),
+          );
+        return yield* readTask(scope, taskId, true);
       }),
     taskStatus: (scope, taskId) => readTask(scope, taskId),
     cancelTask: (scope, input) =>

--- a/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
+++ b/apps/server/src/mcp/OrchestratorMcpToolkit.integration.test.ts
@@ -52,6 +52,10 @@ import {
   type ProviderAdapterV2TurnInput,
 } from "../orchestration-v2/ProviderAdapter.ts";
 import { makeLayer as makeProviderAdapterRegistryLayer } from "../orchestration-v2/ProviderAdapterRegistry.ts";
+import {
+  type ProviderContinuationRequest,
+  ProviderContinuationRequests,
+} from "../orchestration-v2/ProviderContinuationRequests.ts";
 import { checkpointWorkspace } from "../orchestration-v2/testkit/ReplayFixtureWorkspace.ts";
 import { makeOrchestratorV2ReplayLayerWithRegistry } from "../orchestration-v2/testkit/ProviderReplayHarness.ts";
 import { makeProviderRegistryLayer } from "../provider/testUtils/providerRegistryMock.ts";
@@ -411,6 +415,38 @@ describe("orchestrator MCP toolkit", () => {
                   : `Claude completed: ${turn.message.text}`,
             }),
           ]);
+          // Captures parent-wake offers made when a delegated child
+          // terminalizes after the parent run settled.
+          const continuationOffers = yield* Ref.make<ReadonlyArray<ProviderContinuationRequest>>(
+            [],
+          );
+          const continuationProbeLayer = Layer.succeed(ProviderContinuationRequests, {
+            offer: (request) =>
+              Ref.update(continuationOffers, (existing) => [...existing, request]),
+            take: Effect.never,
+          });
+          // Offers land after the finalize projection writes, so poll briefly
+          // instead of asserting counts immediately.
+          const waitForContinuationOffers = (count: number) =>
+            Effect.gen(function* () {
+              for (let attempt = 0; attempt < 1_000; attempt += 1) {
+                const current = yield* Ref.get(continuationOffers);
+                if (current.length >= count) {
+                  return current;
+                }
+                yield* Effect.sleep("5 millis");
+              }
+              return yield* Ref.get(continuationOffers);
+            });
+          // Absence has no event to await, so sample repeatedly instead of
+          // trusting a single sleep to outlast a late offer.
+          const expectOffersToStay = (count: number) =>
+            Effect.gen(function* () {
+              for (let sample = 0; sample < 4; sample += 1) {
+                yield* Effect.sleep("50 millis");
+                expect(yield* Ref.get(continuationOffers)).toHaveLength(count);
+              }
+            });
           const orchestratorLayer = makeOrchestratorV2ReplayLayerWithRegistry(
             {
               name: "orchestrator-mcp-toolkit",
@@ -425,7 +461,7 @@ describe("orchestrator MCP toolkit", () => {
               },
             },
             registryLayer,
-          );
+          ).pipe(Layer.provide(continuationProbeLayer));
           const orchestrationLayer = Layer.merge(
             orchestratorLayer,
             threadManagementServiceLayer.pipe(Layer.provide(orchestratorLayer)),
@@ -781,6 +817,11 @@ describe("orchestrator MCP toolkit", () => {
             expect(delegatedStatus.status).toBe("completed");
             expect(delegatedStatus.resultContextTransferId).not.toBeNull();
 
+            // A wait-mode child (completionWake settled_only) that completes
+            // while the parent run is live does not offer a wake: the
+            // blocking delegate_task call above already returned the result.
+            yield* expectOffersToStay(0);
+
             const repeatedDelegatedCall = yield* invoke("delegate_task", {
               task: delegatedPrompt,
               target: {
@@ -885,6 +926,18 @@ describe("orchestrator MCP toolkit", () => {
               cancelledStatusCall.structuredContent,
             ).pipe(Effect.orDie);
             expect(cancelledStatus.status).toBe("interrupted");
+
+            // The cancelled async child carries completionWake "always", so
+            // its terminal offers a wake even though the parent run is live;
+            // queue_after_active sequences the continuation behind it.
+            const offersAfterCancel = yield* waitForContinuationOffers(1);
+            expect(offersAfterCancel).toHaveLength(1);
+            expect(offersAfterCancel[0]).toMatchObject({
+              threadId: parentThreadId,
+              delivery: "message_text",
+            });
+            expect(offersAfterCancel[0]?.detail).toContain(cancellable.taskId);
+            expect(offersAfterCancel[0]?.detail).toContain("interrupted");
 
             const createInput = {
               clientRequestId: "create-thread-batch-1",
@@ -1232,6 +1285,178 @@ describe("orchestrator MCP toolkit", () => {
             expect(
               listed.threads.some((thread) => thread.relationshipToParent === "subagent"),
             ).toBe(false);
+
+            // A wait-mode delegation whose blocking wait times out no longer
+            // owns delivery, so delegate_task upgrades the task to "always".
+            // Its terminal then wakes the parent even mid-turn.
+            const upgradedCall = yield* invoke("delegate_task", {
+              task: cancellationPrompt,
+              target: {
+                providerInstanceId: codexInstanceId,
+                model: codexModel,
+              },
+              mode: "wait",
+              timeoutMs: 1,
+              clientRequestId: "delegate-wait-upgrade-1",
+            });
+            const upgradedDelegated = yield* decodeDelegateTaskResult(
+              upgradedCall.structuredContent,
+            ).pipe(Effect.orDie);
+            expect(upgradedDelegated.status).toBe("running");
+            yield* waitForProjection(orchestrator, upgradedDelegated.childThreadId, (projection) =>
+              projection.providerTurns.some((turn) => turn.status === "running"),
+            );
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === upgradedDelegated.taskId,
+              )?.completionWake,
+            ).toBe("always");
+            const upgradeCancelCall = yield* invoke("task_cancel", {
+              taskId: upgradedDelegated.taskId,
+              reason: "Terminalize while the parent run is live.",
+              clientRequestId: "cancel-wait-upgrade-1",
+            });
+            expect(upgradeCancelCall.isError).toBe(false);
+            yield* waitForProjection(orchestrator, parentThreadId, (projection) =>
+              projection.subagents.some(
+                (task) => task.id === upgradedDelegated.taskId && task.status === "interrupted",
+              ),
+            );
+            const offersAfterUpgrade = yield* waitForContinuationOffers(2);
+            expect(offersAfterUpgrade).toHaveLength(2);
+            expect(offersAfterUpgrade[1]).toMatchObject({
+              threadId: parentThreadId,
+              delivery: "message_text",
+            });
+            expect(offersAfterUpgrade[1]?.detail).toContain(upgradedDelegated.taskId);
+
+            // The MCP tool cannot force the reverse interleaving (child
+            // terminal before the upgrade lands), so dispatch the command
+            // directly. The first wait-mode delegation completed while the
+            // parent run was live, so finalize skipped its offer under
+            // settled_only; the upgrade must accept, persist the policy, and
+            // deliver the wake finalize declined.
+            const terminalUpgrade = yield* orchestrator.dispatch({
+              type: "delegated_task.wake-policy",
+              commandId: CommandId.make("command:mcp-parent:wake-policy-terminal"),
+              parentThreadId,
+              taskId: delegated.taskId,
+              completionWake: "always",
+            });
+            expect(
+              terminalUpgrade.storedEvents.some(
+                (stored) =>
+                  stored.event.type === "subagent.updated" &&
+                  stored.event.payload.id === delegated.taskId &&
+                  stored.event.payload.completionWake === "always",
+              ),
+            ).toBe(true);
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === delegated.taskId,
+              )?.completionWake,
+            ).toBe("always");
+            const offersAfterTerminalUpgrade = yield* waitForContinuationOffers(3);
+            expect(offersAfterTerminalUpgrade).toHaveLength(3);
+            expect(offersAfterTerminalUpgrade[2]).toMatchObject({
+              threadId: parentThreadId,
+              delivery: "message_text",
+            });
+            expect(offersAfterTerminalUpgrade[2]?.detail).toContain(delegated.taskId);
+
+            // Legacy records omit completionWake and stay settled_only. The
+            // MCP service always sets the field now, so dispatch the request
+            // directly to cover the legacy shape.
+            if (parentRun === undefined || parentRun.rootNodeId === null) {
+              return yield* Effect.die(new Error("Parent run missing."));
+            }
+            const legacyDispatch = yield* orchestrator.dispatch({
+              type: "delegated_task.request",
+              createdBy: "agent",
+              creationSource: "mcp",
+              commandId: CommandId.make("command:mcp-parent:delegate-legacy"),
+              parentThreadId,
+              parentRunId: parentRun.id,
+              parentNodeId: parentRun.rootNodeId,
+              task: cancellationPrompt,
+              modelSelection: codexSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+            });
+            const legacyTaskEvent = legacyDispatch.storedEvents.find(
+              (stored) =>
+                stored.event.type === "subagent.updated" &&
+                stored.event.payload.origin === "app_owned",
+            );
+            if (legacyTaskEvent?.event.type !== "subagent.updated") {
+              return yield* Effect.die(new Error("Legacy delegated task projection missing."));
+            }
+            const legacyTask = legacyTaskEvent.event.payload;
+            expect(legacyTask.completionWake).toBeUndefined();
+            if (legacyTask.childThreadId === null) {
+              return yield* Effect.die(new Error("Legacy delegated task child thread missing."));
+            }
+            const legacyChildThreadId = legacyTask.childThreadId;
+            yield* waitForProjection(orchestrator, legacyChildThreadId, (projection) =>
+              projection.providerTurns.some((turn) => turn.status === "running"),
+            );
+            // Nothing terminalized here, so the offer count must hold.
+            yield* expectOffersToStay(3);
+
+            yield* orchestrator.dispatch({
+              type: "run.interrupt",
+              commandId: CommandId.make("command:mcp-parent:interrupt-wake"),
+              threadId: parentThreadId,
+              runId: parentRun.id,
+              reason: "Settle the parent before the legacy child terminalizes.",
+            });
+            yield* waitForProjection(orchestrator, parentThreadId, (projection) =>
+              projection.runs.every(
+                (run) =>
+                  run.status !== "preparing" &&
+                  run.status !== "starting" &&
+                  run.status !== "running",
+              ),
+            );
+            const legacyCancelCall = yield* invoke("task_cancel", {
+              taskId: legacyTask.id,
+              reason: "Terminalize the legacy child after the parent settled.",
+              clientRequestId: "cancel-legacy-1",
+            });
+            expect(legacyCancelCall.isError).toBe(false);
+            yield* waitForProjection(orchestrator, legacyChildThreadId, (projection) =>
+              projection.runs.some((run) => run.status === "interrupted"),
+            );
+            const offers = yield* waitForContinuationOffers(4);
+            expect(offers).toHaveLength(4);
+            expect(offers[3]).toMatchObject({ threadId: parentThreadId, delivery: "message_text" });
+            expect(offers[3]?.detail).toContain(legacyTask.id);
+            expect(offers[3]?.detail).toContain("task_status");
+
+            // Same command against a terminal task whose finalize already
+            // offered (the parent was settled then, and still is): the policy
+            // must persist without a second offer, or the parent wakes twice.
+            const settledUpgrade = yield* orchestrator.dispatch({
+              type: "delegated_task.wake-policy",
+              commandId: CommandId.make("command:mcp-parent:wake-policy-settled"),
+              parentThreadId,
+              taskId: legacyTask.id,
+              completionWake: "always",
+            });
+            expect(
+              settledUpgrade.storedEvents.some(
+                (stored) =>
+                  stored.event.type === "subagent.updated" &&
+                  stored.event.payload.id === legacyTask.id &&
+                  stored.event.payload.completionWake === "always",
+              ),
+            ).toBe(true);
+            expect(
+              (yield* orchestrator.getThreadProjection(parentThreadId)).subagents.find(
+                (task) => task.id === legacyTask.id,
+              )?.completionWake,
+            ).toBe("always");
+            yield* expectOffersToStay(4);
           }).pipe(Effect.provide(testLayer));
         }),
       ),

--- a/apps/server/src/mcp/toolkits/orchestrator/tools.ts
+++ b/apps/server/src/mcp/toolkits/orchestrator/tools.ts
@@ -49,7 +49,7 @@ export const OrchestratorCapabilitiesTool = Tool.make("orchestrator_capabilities
 
 export const DelegateTaskTool = Tool.make("delegate_task", {
   description:
-    "Delegate one task to a T3-owned child agent/subagent of THIS thread and run it with only the supplied task prompt, without copying parent conversation history. Use this whenever the user asks for an agent, subagent, worker, delegated task, or parallel help—including cross-provider work. The childThreadId is backing storage, not an ordinary top-level thread. Provider, model, model options (see orchestrator_capabilities), runtime mode, and interaction mode inherit unless target overrides them. Prefer mode='async' and poll task_status for long work; mode='wait' blocks until completion or timeout.",
+    "Delegate one task to a T3-owned child agent/subagent of THIS thread and run it with only the supplied task prompt, without copying parent conversation history. Use this whenever the user asks for an agent, subagent, worker, delegated task, or parallel help—including cross-provider work. The childThreadId is backing storage, not an ordinary top-level thread. Provider, model, model options (see orchestrator_capabilities), runtime mode, and interaction mode inherit unless target overrides them. Prefer mode='async' for long work; mode='wait' blocks until completion or timeout. An async child's completion wakes this thread with a continuation message naming the task (queued behind any turn in progress), so end the turn instead of polling or spawning watchers; use task_status only when the result is needed mid-turn.",
   parameters: OrchestratorMcpDelegateTaskInput,
   success: OrchestratorMcpDelegateTaskResult,
   failure: OrchestratorMcpFailure,

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
@@ -25,6 +25,7 @@ import {
 import { assert, describe, it } from "@effect/vitest";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
@@ -1141,18 +1142,43 @@ describe("ClaudeAdapterV2 background wake turns", () => {
     uuid: "00000000-0000-4000-8000-000000000101",
     session_id: WAKE_NATIVE_SESSION,
   });
+  const makeAssistantTextFrame = (input: { readonly uuid: string; readonly text: string }) =>
+    claudeSdkFrame({
+      type: "assistant",
+      message: {
+        model: "claude-sonnet-4-6",
+        id: `msg_${input.uuid}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: input.text }],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: input.uuid,
+      session_id: WAKE_NATIVE_SESSION,
+    });
   const makeResultFrame = (input: {
     readonly uuid: string;
     readonly result: string;
     readonly numTurns?: number;
     readonly origin?: { readonly kind: "task-notification" };
+    readonly subtype?: string;
+    readonly isError?: boolean;
+    readonly errors?: ReadonlyArray<string>;
   }) =>
     claudeSdkFrame({
       type: "result",
-      subtype: "success",
+      subtype: input.subtype ?? "success",
       duration_ms: 10,
       duration_api_ms: 10,
-      is_error: false,
+      is_error: input.isError ?? false,
       num_turns: input.numTurns ?? 1,
       result: input.result,
       stop_reason: "end_turn",
@@ -1168,6 +1194,7 @@ describe("ClaudeAdapterV2 background wake turns", () => {
       uuid: input.uuid,
       session_id: WAKE_NATIVE_SESSION,
       ...(input.origin === undefined ? {} : { origin: input.origin }),
+      ...(input.errors === undefined ? {} : { errors: input.errors }),
     });
   const turnOneResult = makeResultFrame({
     uuid: "00000000-0000-4000-8000-000000000102",
@@ -1208,87 +1235,92 @@ describe("ClaudeAdapterV2 background wake turns", () => {
       return yield* Effect.die(`Timed out waiting for ${label}.`);
     });
 
-  const makeWakeHarness = Effect.gen(function* () {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const idAllocator = yield* IdAllocatorV2;
-    const attachmentsDir = yield* fileSystem.makeTempDirectoryScoped({
-      prefix: "t3-claude-v2-wake-",
-    });
-    const sdkMessages = yield* Queue.unbounded<SDKMessage>();
-    const offeredMessages: Array<SDKUserMessage> = [];
-    const continuationRequests: Array<ProviderContinuationRequest> = [];
-    const adapter = makeClaudeAdapterV2({
-      instanceId: CLAUDE_DEFAULT_INSTANCE_ID,
-      settings: DEFAULT_CLAUDE_SETTINGS,
-      environment: {},
-      attachmentsDir,
-      fileSystem,
-      idAllocator,
-      continuationRequests: {
-        offer: (request) =>
+  const makeWakeHarnessWithOptions = (options?: {
+    readonly close?: (sdkMessages: Queue.Queue<SDKMessage>) => Effect.Effect<void>;
+    readonly interrupt?: Effect.Effect<void>;
+  }) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const idAllocator = yield* IdAllocatorV2;
+      const attachmentsDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-claude-v2-wake-",
+      });
+      const sdkMessages = yield* Queue.unbounded<SDKMessage>();
+      const offeredMessages: Array<SDKUserMessage> = [];
+      const continuationRequests: Array<ProviderContinuationRequest> = [];
+      const adapter = makeClaudeAdapterV2({
+        instanceId: CLAUDE_DEFAULT_INSTANCE_ID,
+        settings: DEFAULT_CLAUDE_SETTINGS,
+        environment: {},
+        attachmentsDir,
+        fileSystem,
+        idAllocator,
+        continuationRequests: {
+          offer: (request) =>
+            Effect.sync(() => {
+              continuationRequests.push(request);
+            }),
+        },
+        queryRunner: {
+          allocateSessionId: Effect.succeed(WAKE_NATIVE_SESSION),
+          open: () =>
+            Effect.succeed({
+              messages: Stream.fromQueue(sdkMessages),
+              offer: (message) =>
+                Effect.sync(() => {
+                  offeredMessages.push(message);
+                }),
+              setModel: () => Effect.void,
+              interrupt: options?.interrupt ?? Effect.void,
+              close: options?.close?.(sdkMessages) ?? Effect.void,
+            }),
+          forkSession: () => Effect.die("unused forkSession"),
+          assertComplete: Effect.void,
+        },
+      });
+      const threadId = ThreadId.make("thread-claude-wake");
+      const runtime = yield* adapter.openSession({
+        threadId,
+        providerSessionId: ProviderSessionId.make("provider-session-claude-wake"),
+        modelSelection: CLAUDE_TEST_MODEL_SELECTION,
+        runtimePolicy: CLAUDE_TEST_RUNTIME_POLICY,
+      });
+      const providerThread = yield* runtime.ensureThread({
+        threadId,
+        modelSelection: CLAUDE_TEST_MODEL_SELECTION,
+        runtimePolicy: CLAUDE_TEST_RUNTIME_POLICY,
+      });
+      const events: Array<ProviderAdapterV2Event> = [];
+      yield* runtime.events.pipe(
+        Stream.runForEach((event) =>
           Effect.sync(() => {
-            continuationRequests.push(request);
+            events.push(event);
           }),
-      },
-      queryRunner: {
-        allocateSessionId: Effect.succeed(WAKE_NATIVE_SESSION),
-        open: () =>
-          Effect.succeed({
-            messages: Stream.fromQueue(sdkMessages),
-            offer: (message) =>
-              Effect.sync(() => {
-                offeredMessages.push(message);
-              }),
-            setModel: () => Effect.void,
-            interrupt: Effect.void,
-            close: Effect.void,
-          }),
-        forkSession: () => Effect.die("unused forkSession"),
-        assertComplete: Effect.void,
-      },
-    });
-    const threadId = ThreadId.make("thread-claude-wake");
-    const runtime = yield* adapter.openSession({
-      threadId,
-      providerSessionId: ProviderSessionId.make("provider-session-claude-wake"),
-      modelSelection: CLAUDE_TEST_MODEL_SELECTION,
-      runtimePolicy: CLAUDE_TEST_RUNTIME_POLICY,
-    });
-    const providerThread = yield* runtime.ensureThread({
-      threadId,
-      modelSelection: CLAUDE_TEST_MODEL_SELECTION,
-      runtimePolicy: CLAUDE_TEST_RUNTIME_POLICY,
-    });
-    const events: Array<ProviderAdapterV2Event> = [];
-    yield* runtime.events.pipe(
-      Stream.runForEach((event) =>
-        Effect.sync(() => {
-          events.push(event);
-        }),
-      ),
-      Effect.forkScoped,
-    );
-    if (runtime.hasPendingBackgroundWork === undefined) {
-      throw new Error("Claude adapter runtime must expose hasPendingBackgroundWork.");
-    }
-    const hasPendingBackgroundWork = runtime.hasPendingBackgroundWork;
-    const terminalEvents = () =>
-      events.filter(
-        (event): event is Extract<ProviderAdapterV2Event, { type: "turn.terminal" }> =>
-          event.type === "turn.terminal",
+        ),
+        Effect.forkScoped,
       );
-    return {
-      runtime,
-      providerThread,
-      threadId,
-      sdkMessages,
-      offeredMessages,
-      continuationRequests,
-      events,
-      terminalEvents,
-      hasPendingBackgroundWork,
-    };
-  });
+      if (runtime.hasPendingBackgroundWork === undefined) {
+        throw new Error("Claude adapter runtime must expose hasPendingBackgroundWork.");
+      }
+      const hasPendingBackgroundWork = runtime.hasPendingBackgroundWork;
+      const terminalEvents = () =>
+        events.filter(
+          (event): event is Extract<ProviderAdapterV2Event, { type: "turn.terminal" }> =>
+            event.type === "turn.terminal",
+        );
+      return {
+        runtime,
+        providerThread,
+        threadId,
+        sdkMessages,
+        offeredMessages,
+        continuationRequests,
+        events,
+        terminalEvents,
+        hasPendingBackgroundWork,
+      };
+    });
+  const makeWakeHarness = makeWakeHarnessWithOptions();
 
   it.effect("buffers wake output and requests a single continuation run", () =>
     Effect.scoped(
@@ -1475,7 +1507,107 @@ describe("ClaudeAdapterV2 background wake turns", () => {
     ),
   );
 
-  it.effect("ignores a live task-notification origin result during a normal user turn", () =>
+  it.effect("terminalizes an agent server wake from a positive task-notification result", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeWakeHarness;
+        const now = yield* DateTime.now;
+        const wakeText = "The background command completed.";
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId: RunAttemptId.make("attempt-claude-agent-server-wake"),
+            text: "Background task completed.",
+            attachments: [],
+            messageCreatedBy: "agent",
+            messageCreationSource: "server",
+          }),
+        );
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeAssistantTextFrame({
+            uuid: "00000000-0000-4000-8000-00000000010b",
+            text: wakeText,
+          }),
+        );
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeResultFrame({
+            uuid: "00000000-0000-4000-8000-00000000010c",
+            result: wakeText,
+            numTurns: 154,
+            origin: { kind: "task-notification" },
+          }),
+        );
+        yield* awaitUntil(() => harness.terminalEvents().length === 1, "server wake terminal");
+        assert.equal(harness.terminalEvents()[0]?.status, "completed");
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId: RunAttemptId.make("attempt-claude-agent-server-next"),
+            text: "What finished?",
+            attachments: [],
+            providerTurnOrdinal: 2,
+          }),
+        );
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeResultFrame({
+            uuid: "00000000-0000-4000-8000-00000000010d",
+            result: "The background command finished.",
+          }),
+        );
+        yield* awaitUntil(() => harness.terminalEvents().length === 2, "queued turn terminal");
+        assert.equal(harness.terminalEvents()[1]?.status, "completed");
+      }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+    ),
+  );
+
+  it.effect("terminalizes a user mobile turn from a positive task-notification result", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeWakeHarness;
+        const now = yield* DateTime.now;
+        const fallbackText = "The ordinary mobile turn completed.";
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId: RunAttemptId.make("attempt-claude-mobile-notif-origin"),
+            text: "Complete this task.",
+            attachments: [],
+            messageCreationSource: "mobile",
+          }),
+        );
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeResultFrame({
+            uuid: "00000000-0000-4000-8000-00000000010e",
+            result: fallbackText,
+            numTurns: 60,
+            origin: { kind: "task-notification" },
+          }),
+        );
+        yield* awaitUntil(() => harness.terminalEvents().length === 1, "mobile turn terminal");
+        assert.equal(harness.terminalEvents()[0]?.status, "completed");
+        assert.isTrue(
+          harness.events.some(
+            (event) => event.type === "message.updated" && event.message.text === fallbackText,
+          ),
+        );
+      }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+    ),
+  );
+
+  it.effect("ignores a zero-turn task-notification origin result during a normal user turn", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const harness = yield* makeWakeHarness;
@@ -1565,6 +1697,208 @@ describe("ClaudeAdapterV2 background wake turns", () => {
         assert.equal(harness.terminalEvents()[0]?.status, "completed");
         assert.isTrue(hasMessageText(recoveryAssistantText));
         assert.isFalse(hasMessageText(staleResultText));
+      }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+    ),
+  );
+
+  it.effect("terminalizes a zero-turn task-notification result in a provider continuation", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeWakeHarness;
+        const now = yield* DateTime.now;
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId: RunAttemptId.make("attempt-claude-zero-continuation-1"),
+            text: "Run the build in the background.",
+            attachments: [],
+          }),
+        );
+        yield* Queue.offer(harness.sdkMessages, wakeTaskStarted);
+        yield* Queue.offer(harness.sdkMessages, turnOneResult);
+        yield* awaitUntil(() => harness.terminalEvents().length === 1, "first turn terminal");
+        yield* Queue.offer(harness.sdkMessages, wakeNotification);
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeResultFrame({
+            uuid: "00000000-0000-4000-8000-00000000010f",
+            result: "Wake result with no model turns.",
+            numTurns: 0,
+            origin: { kind: "task-notification" },
+          }),
+        );
+        yield* awaitUntil(() => harness.continuationRequests.length === 1, "continuation request");
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId: RunAttemptId.make("attempt-claude-zero-continuation-2"),
+            text: "Background task completed.",
+            attachments: [],
+            providerTurnOrdinal: 2,
+            messageCreatedBy: "agent",
+            messageCreationSource: "provider",
+          }),
+        );
+        yield* awaitUntil(() => harness.terminalEvents().length === 2, "continuation terminal");
+        assert.equal(harness.terminalEvents()[1]?.status, "completed");
+      }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+    ),
+  );
+
+  it.effect(
+    "emits one interrupted terminal for a positive task-notification result racing interrupt",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const closeGate = yield* Deferred.make<void>();
+          const testScope = yield* Scope.Scope;
+          yield* Scope.addFinalizer(testScope, Deferred.succeed(closeGate, undefined));
+          const interruptStarted = yield* Deferred.make<void>();
+          const harness = yield* makeWakeHarnessWithOptions({
+            close: (sdkMessages) =>
+              Deferred.await(closeGate).pipe(Effect.andThen(Queue.shutdown(sdkMessages))),
+            interrupt: Deferred.succeed(interruptStarted, undefined),
+          });
+          const idAllocator = yield* IdAllocatorV2;
+          const now = yield* DateTime.now;
+          const attemptId = RunAttemptId.make("attempt-claude-interrupt-positive-notif");
+          const providerTurnId = idAllocator.derive.providerTurn({
+            driver: CLAUDE_PROVIDER,
+            nativeTurnId: `turn:${attemptId}`,
+          });
+
+          yield* harness.runtime.startTurn(
+            makeClaudeTestTurnInput({
+              threadId: harness.threadId,
+              providerThread: harness.providerThread,
+              now,
+              attemptId,
+              text: "Stop this task.",
+              attachments: [],
+            }),
+          );
+          yield* harness.runtime
+            .interruptTurn({ providerThread: harness.providerThread, providerTurnId })
+            .pipe(Effect.forkScoped);
+          yield* Deferred.await(interruptStarted);
+          yield* Queue.offer(
+            harness.sdkMessages,
+            makeResultFrame({
+              uuid: "00000000-0000-4000-8000-000000000115",
+              result: "Late result after interrupt.",
+              numTurns: 7,
+              origin: { kind: "task-notification" },
+            }),
+          );
+          const terminalized = Exit.isSuccess(
+            yield* awaitUntil(
+              () => harness.terminalEvents().length === 1,
+              "interrupted terminal",
+            ).pipe(Effect.exit),
+          );
+          yield* Deferred.succeed(closeGate, undefined);
+          assert.isTrue(terminalized);
+          assert.equal(harness.terminalEvents()[0]?.status, "interrupted");
+          assert.lengthOf(harness.terminalEvents(), 1);
+        }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+      ),
+  );
+
+  it.effect("drops zero-turn task-notification debris racing interrupt", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const closeGate = yield* Deferred.make<void>();
+        const testScope = yield* Scope.Scope;
+        yield* Scope.addFinalizer(testScope, Deferred.succeed(closeGate, undefined));
+        const interruptStarted = yield* Deferred.make<void>();
+        const harness = yield* makeWakeHarnessWithOptions({
+          close: (sdkMessages) =>
+            Deferred.await(closeGate).pipe(Effect.andThen(Queue.shutdown(sdkMessages))),
+          interrupt: Deferred.succeed(interruptStarted, undefined),
+        });
+        const idAllocator = yield* IdAllocatorV2;
+        const now = yield* DateTime.now;
+        const attemptId = RunAttemptId.make("attempt-claude-interrupt-zero-notif");
+        const providerTurnId = idAllocator.derive.providerTurn({
+          driver: CLAUDE_PROVIDER,
+          nativeTurnId: `turn:${attemptId}`,
+        });
+        const staleText = "Zero-turn debris must not leak.";
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId,
+            text: "Stop this task.",
+            attachments: [],
+          }),
+        );
+        yield* harness.runtime
+          .interruptTurn({ providerThread: harness.providerThread, providerTurnId })
+          .pipe(Effect.forkScoped);
+        yield* Deferred.await(interruptStarted);
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeResultFrame({
+            uuid: "00000000-0000-4000-8000-000000000116",
+            result: staleText,
+            numTurns: 0,
+            origin: { kind: "task-notification" },
+          }),
+        );
+        let debrisYields = 0;
+        yield* awaitUntil(() => debrisYields++ >= 50, "zero-turn debris consumed");
+        yield* Deferred.succeed(closeGate, undefined);
+        yield* awaitUntil(() => harness.terminalEvents().length === 1, "interrupted terminal");
+        assert.lengthOf(harness.terminalEvents(), 1);
+        assert.equal(harness.terminalEvents()[0]?.status, "interrupted");
+        assert.isFalse(
+          harness.events.some(
+            (event) => event.type === "message.updated" && event.message.text === staleText,
+          ),
+        );
+      }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+    ),
+  );
+
+  it.effect("fails a positive task-notification error result", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeWakeHarness;
+        const now = yield* DateTime.now;
+
+        yield* harness.runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId: harness.threadId,
+            providerThread: harness.providerThread,
+            now,
+            attemptId: RunAttemptId.make("attempt-claude-positive-notif-error"),
+            text: "Run the task.",
+            attachments: [],
+          }),
+        );
+        yield* Queue.offer(
+          harness.sdkMessages,
+          makeResultFrame({
+            uuid: "00000000-0000-4000-8000-000000000117",
+            result: "The task failed.",
+            numTurns: 7,
+            origin: { kind: "task-notification" },
+            subtype: "error_during_execution",
+            isError: true,
+            errors: ["The task failed."],
+          }),
+        );
+        yield* awaitUntil(() => harness.terminalEvents().length === 1, "failed terminal");
+        assert.equal(harness.terminalEvents()[0]?.status, "failed");
       }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
     ),
   );

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -3281,16 +3281,57 @@ export function makeClaudeAdapterV2(
             return;
           }
 
-          // Task-notification-origin results can interleave during a normal
-          // user turn (for example a stale background stop after interrupt
-          // recovery). They must not finalize that turn or supply fallback
-          // assistant text. Provider continuation turns still consume them
-          // when draining buffered wake messages.
+          // A zero-turn task-notification-origin result is almost always
+          // lifecycle debris, so it must not finalize a normal turn or supply
+          // fallback assistant text. Provider continuation turns still consume
+          // it when draining buffered wake messages.
+          //
+          // "Almost always" is the honest word: num_turns is a workload count,
+          // not a causal link to the prompt this turn is waiting on. A genuine
+          // wake that fails before any model turn also reports zero, and is
+          // dropped here, so that turn hangs until query exit. Narrowing the
+          // drop to zero-turn results only shrinks a pre-existing drop; closing
+          // the residue needs a correlation id on the result, which the wire
+          // does not carry today.
+          if (
+            isClaudeTaskNotificationOriginResult(message) &&
+            !isClaudeProviderContinuationTurn(context.input) &&
+            message.num_turns === 0
+          ) {
+            // Routine lifecycle noise, so debug rather than warning: interrupt
+            // recovery produces this every time.
+            yield* Effect.logDebug("orchestration-v2.claude-task-notification-result-dropped", {
+              providerTurnId: context.providerTurnId,
+              num_turns: message.num_turns,
+              stop_reason: message.stop_reason,
+              terminal_reason: message.terminal_reason,
+              uuid: message.uuid,
+              session_id: message.session_id,
+              createdBy: context.input.message.createdBy,
+              creationSource: context.input.message.creationSource,
+            });
+            return;
+          }
+
+          // The converse of the drop above, and the case actually worth
+          // watching: a positive-turn task-notification result settling a turn
+          // T3 did not mark as a continuation. That is the hang fix working,
+          // but it is also the shape a stale result would take if one ever
+          // carried model turns, which nothing on the wire lets us rule out.
           if (
             isClaudeTaskNotificationOriginResult(message) &&
             !isClaudeProviderContinuationTurn(context.input)
           ) {
-            return;
+            yield* Effect.logInfo("orchestration-v2.claude-task-notification-result-accepted", {
+              providerTurnId: context.providerTurnId,
+              num_turns: message.num_turns,
+              stop_reason: message.stop_reason,
+              terminal_reason: message.terminal_reason,
+              uuid: message.uuid,
+              session_id: message.session_id,
+              createdBy: context.input.message.createdBy,
+              creationSource: context.input.message.creationSource,
+            });
           }
 
           // An is_error result's text is the error message; it belongs on the

--- a/apps/server/src/orchestration-v2/Orchestrator.ts
+++ b/apps/server/src/orchestration-v2/Orchestrator.ts
@@ -45,6 +45,10 @@ import { makeKeyedSerialExecutor } from "./KeyedSerialExecutor.ts";
 import { applyToProjection, emptyProjection, ProjectionStoreV2 } from "./ProjectionStore.ts";
 import type { ProviderAdapterV2Shape } from "./ProviderAdapter.ts";
 import { ProviderAdapterRegistryV2 } from "./ProviderAdapterRegistry.ts";
+import {
+  type ProviderContinuationRequest,
+  ProviderContinuationRequests,
+} from "./ProviderContinuationRequests.ts";
 import { ProviderSessionManagerV2 } from "./ProviderSessionManager.ts";
 import { ProviderSwitchServiceV2 } from "./ProviderSwitchService.ts";
 import { RuntimePolicyV2 } from "./RuntimePolicy.ts";
@@ -197,6 +201,7 @@ function commandThreadId(command: OrchestrationV2Command): ThreadId {
     case "provider.switch":
       return command.threadId;
     case "delegated_task.request":
+    case "delegated_task.wake-policy":
     case "thread.created.record":
       return command.parentThreadId;
     case "thread.fork":
@@ -217,6 +222,60 @@ function isBlockingRun(run: OrchestrationV2Run): boolean {
     run.status === "starting" ||
     run.status === "running" ||
     run.status === "waiting"
+  );
+}
+
+/**
+ * A parent thread is "live" for wake purposes while a run is still producing
+ * agent output. A run parked at "waiting" is post-terminal drain, so its agent
+ * turn is over and a wake is still needed.
+ */
+function hasLiveRun(projection: OrchestrationV2ThreadProjection): boolean {
+  return projection.runs.some(
+    (run) => run.status === "preparing" || run.status === "starting" || run.status === "running",
+  );
+}
+
+function delegatedTaskWakeDetail(
+  task: Pick<OrchestrationV2Subagent, "id" | "title" | "status">,
+): string {
+  const label = task.title === null ? task.id : `"${task.title}"`;
+  return task.status === "completed"
+    ? `Delegated task ${label} completed. Use task_status with taskId ${task.id} to read the result.`
+    : `Delegated task ${label} ended with status ${task.status}. Use task_status with taskId ${task.id} for details.`;
+}
+
+/**
+ * Both app-owned wake producers must go through this. An app-owned child leaves
+ * nothing buffered in the adapter, so the detail text is the entire wake and has
+ * to reach the provider as a real prompt. Omitting `delivery` here would mark
+ * the dispatch as an adapter-buffered wake, which ClaudeAdapterV2 and
+ * AcpAdapterV2 both answer by discarding the text and settling the turn against
+ * an empty buffer.
+ */
+function delegatedTaskWakeRequest(input: {
+  readonly threadId: ThreadId;
+  readonly providerThread: Pick<
+    OrchestrationV2ThreadProjection["providerThreads"][number],
+    "id" | "driver"
+  >;
+  readonly task: Pick<OrchestrationV2Subagent, "id" | "title" | "status">;
+}): ProviderContinuationRequest {
+  return {
+    threadId: input.threadId,
+    providerThreadId: input.providerThread.id,
+    driver: input.providerThread.driver,
+    detail: delegatedTaskWakeDetail(input.task),
+    delivery: "message_text",
+  };
+}
+
+function isTerminalDelegatedTaskStatus(status: OrchestrationV2Subagent["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "interrupted"
   );
 }
 
@@ -410,6 +469,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
   const idAllocator = yield* IdAllocatorV2;
   const projectionStore = yield* ProjectionStoreV2;
   const providerAdapters = yield* ProviderAdapterRegistryV2;
+  const continuationRequests = yield* ProviderContinuationRequests;
   const providerSessions = yield* ProviderSessionManagerV2;
   const providerSwitchService = yield* ProviderSwitchServiceV2;
   const runtimePolicy = yield* RuntimePolicyV2;
@@ -3702,6 +3762,7 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         prompt: command.task,
         title: command.title ?? null,
         model: command.modelSelection.model,
+        ...(command.completionWake === undefined ? {} : { completionWake: command.completionWake }),
         status: "running",
         result: null,
         startedAt: now,
@@ -3852,6 +3913,98 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       });
     },
   );
+
+  // Rewrites a delegated task's completionWake after creation. The wait path
+  // uses this when its blocking window ends without a terminal (timeout), so
+  // a child that later terminalizes mid-parent-turn still wakes the parent.
+  // Runs under the parent thread's dispatch lock, which is also what finalize
+  // takes for its parent-side writes, so the two never interleave on this row.
+  const dispatchDelegatedTaskWakePolicy = Effect.fn(
+    "orchestrationV2.dispatch.delegatedTaskWakePolicy",
+  )(function* (
+    command: Extract<OrchestrationV2Command, { readonly type: "delegated_task.wake-policy" }>,
+    events: Ref.Ref<Array<OrchestrationV2DomainEvent>>,
+  ) {
+    const parentProjection = yield* projectionStore
+      .getThreadProjection(command.parentThreadId)
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new OrchestratorProjectionError({
+              threadId: command.parentThreadId,
+              cause,
+            }),
+        ),
+      );
+    const task = parentProjection.subagents.find(
+      (candidate) => candidate.id === command.taskId && candidate.origin === "app_owned",
+    );
+    // No-op commands reject with a descriptive cause, matching the thread
+    // mutation handlers ("already archived", "not archived").
+    if (task === undefined) {
+      return yield* new OrchestratorDispatchError({
+        commandId: command.commandId,
+        commandType: command.type,
+        cause: `Delegated task ${command.taskId} is not an app-owned task of thread ${command.parentThreadId}.`,
+      });
+    }
+    if (task.completionWake === command.completionWake) {
+      return yield* new OrchestratorDispatchError({
+        commandId: command.commandId,
+        commandType: command.type,
+        cause: `Delegated task ${command.taskId} already wakes the parent with completionWake ${command.completionWake}.`,
+      });
+    }
+    const now = yield* DateTime.now;
+    const emitEvent = emit(events, command);
+    yield* emitEvent({
+      type: "subagent.updated",
+      threadId: command.parentThreadId,
+      ...(task.runId === null ? {} : { runId: task.runId }),
+      nodeId: task.id,
+      driver: task.driver,
+      providerInstanceId: task.providerInstanceId,
+      occurredAt: now,
+      payload: { ...task, completionWake: command.completionWake, updatedAt: now },
+    });
+    // A non-terminal task needs no offer here: finalize reads the upgraded
+    // policy when the child terminalizes. Both writers hold this parent lock,
+    // so a terminal task means finalize already committed the terminal row and
+    // already made its offer decision under the pre-upgrade policy: under
+    // settled_only it offered iff the parent had no live run. Offer here only
+    // when the parent has a live run now, which is precisely the case where
+    // finalize skipped; queue_after_active then sequences the wake behind that
+    // run. When the parent is not live, finalize already offered and a second
+    // offer would wake the parent twice. (If the parent settled in between,
+    // this skips a wake that finalize also skipped; a missed wake is cheaper
+    // than a duplicate one, and the result is already in the projection.)
+    if (command.completionWake !== "always" || !isTerminalDelegatedTaskStatus(task.status)) {
+      return;
+    }
+    if (!hasLiveRun(parentProjection)) {
+      return;
+    }
+    const parentRun =
+      task.runId === null
+        ? undefined
+        : parentProjection.runs.find((candidate) => candidate.id === task.runId);
+    const parentProviderThread =
+      parentRun?.providerThreadId === null || parentRun?.providerThreadId === undefined
+        ? undefined
+        : parentProjection.providerThreads.find(
+            (candidate) => candidate.id === parentRun.providerThreadId,
+          );
+    if (parentProviderThread === undefined) {
+      return;
+    }
+    yield* continuationRequests.offer(
+      delegatedTaskWakeRequest({
+        threadId: command.parentThreadId,
+        providerThread: parentProviderThread,
+        task,
+      }),
+    );
+  });
 
   const dispatchCreatedThreadRecord = Effect.fn("orchestrationV2.dispatch.createdThreadRecord")(
     function* (
@@ -4893,6 +5046,31 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
       ]);
     });
 
+  /**
+   * Parent thread of an app-owned delegated child, or undefined when the
+   * thread is not one. Thread lineage and fork origin are immutable, so this
+   * is safe to read without holding either thread's dispatch lock.
+   */
+  const appOwnedSubagentParentThreadId = (childThreadId: ThreadId) =>
+    Effect.gen(function* () {
+      const childProjection = yield* projectionStore.getThreadProjection(childThreadId);
+      const lineage = childProjection.thread.lineage;
+      return lineage.relationshipToParent === "subagent" &&
+        lineage.parentThreadId !== null &&
+        childProjection.thread.forkedFrom?.type === "node"
+        ? lineage.parentThreadId
+        : undefined;
+    });
+
+  /**
+   * Transfers a terminal child's result into its parent and offers the parent
+   * wake. Every mutation here targets the PARENT thread, so callers must hold
+   * the parent thread's dispatch lock rather than the child's: the
+   * delegated_task.wake-policy handler rewrites the same subagent row under
+   * that lock with a full-row payload, and unserialized writers clobber each
+   * other (stale policy on the terminal row, or a terminal row regressed to
+   * running).
+   */
   const finalizeAppOwnedSubagent = (childThreadId: ThreadId) =>
     Effect.gen(function* () {
       const childProjection = yield* projectionStore.getThreadProjection(childThreadId);
@@ -5094,6 +5272,37 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           payload: resultTransfer,
         },
       ]);
+
+      // Nothing else re-invokes a parent that already settled: the child's
+      // result lands in the projection above, but no parent run starts to let
+      // the agent act on it. Offer a continuation (dispatched
+      // queue_after_active) so the parent wakes and collects the result.
+      // Policy comes from the task's completionWake: "always" (async
+      // delegations) offers on every terminal, sequencing behind a live
+      // parent run like a provider task notification; "settled_only" (wait
+      // delegations, and legacy records without the field) skips while the
+      // parent has a run in preparing/starting/running, because the blocking
+      // tool call already returns the result there. A run parked at
+      // "waiting" is post-terminal drain, so its agent turn is over and the
+      // wake is still needed. The result-transfer guard above makes this a
+      // single offer per child, replay included.
+      if (parentProviderThread === undefined) {
+        return;
+      }
+      if ((task.completionWake ?? "settled_only") === "settled_only") {
+        // Re-read under the parent lock so the gate sees the run states left
+        // by the writes above rather than the pre-write snapshot.
+        if (hasLiveRun(yield* projectionStore.getThreadProjection(parentThreadId))) {
+          return;
+        }
+      }
+      yield* continuationRequests.offer(
+        delegatedTaskWakeRequest({
+          threadId: parentThreadId,
+          providerThread: parentProviderThread,
+          task: updatedTask,
+        }),
+      );
     });
 
   const dispatchUnsupported = (command: OrchestrationV2Command) =>
@@ -5187,6 +5396,9 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
         break;
       case "delegated_task.request":
         yield* dispatchDelegatedTaskRequest(command, events, effects);
+        break;
+      case "delegated_task.wake-policy":
+        yield* dispatchDelegatedTaskWakePolicy(command, events);
         break;
       case "thread.created.record":
         yield* dispatchCreatedThreadRecord(command, events);
@@ -5339,14 +5551,20 @@ const makeOrchestrator = Effect.fn("orchestrationV2.Orchestrator.layer")(functio
           stored.event.payload.status === "rolled_back"),
     ),
     Stream.runForEach((stored) =>
-      threadDispatch
-        .withLock(
-          stored.event.threadId,
-          finalizeAppOwnedSubagent(stored.event.threadId).pipe(
-            Effect.andThen(startNextQueuedRun(stored.event.threadId)),
-          ),
-        )
-        .pipe(Effect.catchCause(() => Effect.void)),
+      Effect.gen(function* () {
+        const threadId = stored.event.threadId;
+        // finalize writes the parent thread and startNextQueuedRun writes this
+        // thread, so each takes its own thread's lock, sequentially and never
+        // nested: dispatchDelegatedTaskRequest already writes child events
+        // while holding the parent lock, so nesting the parent lock inside the
+        // child lock here would invert that order, and the keyed executor's
+        // semaphores are neither reentrant nor deadlock-aware.
+        const parentThreadId = yield* appOwnedSubagentParentThreadId(threadId);
+        if (parentThreadId !== undefined) {
+          yield* threadDispatch.withLock(parentThreadId, finalizeAppOwnedSubagent(threadId));
+        }
+        yield* threadDispatch.withLock(threadId, startNextQueuedRun(threadId));
+      }).pipe(Effect.catchCause(() => Effect.void)),
     ),
     Effect.forkDetach,
   );

--- a/apps/server/src/orchestration-v2/ProviderContinuationRequests.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationRequests.ts
@@ -10,6 +10,19 @@ export interface ProviderContinuationRequest {
   readonly providerThreadId: ProviderThreadId;
   readonly driver: ProviderDriverKind;
   readonly detail: string | null;
+  /**
+   * How the continuation turn gets its content.
+   *
+   * `adapter_buffered` (default) is the provider-native wake: the adapter has
+   * already buffered the CLI's wake output, and the dispatched message only
+   * triggers ingestion. `ClaudeAdapterV2` deliberately discards the message
+   * text on that path.
+   *
+   * `message_text` is for app-owned work with no buffered provider output, such
+   * as a delegated child finishing. The text is the entire wake, so it must
+   * reach the provider as a real prompt.
+   */
+  readonly delivery?: "adapter_buffered" | "message_text";
   readonly dispatchIfCurrent?: <A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ) => Effect.Effect<Option.Option<A>, E, R>;

--- a/apps/server/src/orchestration-v2/ProviderContinuationService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationService.test.ts
@@ -82,6 +82,55 @@ function testLayer(input: {
 }
 
 describe("ProviderContinuationService", () => {
+  it.effect("marks an adapter-buffered wake with the provider creation source", () => {
+    return Effect.gen(function* () {
+      const dispatched = yield* Queue.unbounded<unknown>();
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer(request());
+        const command = (yield* Queue.take(dispatched)) as { readonly creationSource: string };
+        // ClaudeAdapterV2 keys on this to attach buffered CLI output.
+        assert.equal(command.creationSource, "provider");
+      }).pipe(
+        Effect.provide(
+          testLayer({ dispatched, getThreadProjection: () => Effect.succeed(projection) }),
+        ),
+        Effect.scoped,
+      );
+    });
+  });
+
+  it.effect("delivers a message_text wake as a real prompt, not a buffered wake", () => {
+    return Effect.gen(function* () {
+      const dispatched = yield* Queue.unbounded<unknown>();
+      yield* Effect.gen(function* () {
+        const requests = yield* ProviderContinuationRequests;
+        yield* requests.offer({
+          threadId,
+          providerThreadId,
+          driver,
+          detail: "Delegated task completed.",
+          delivery: "message_text",
+        });
+        const command = (yield* Queue.take(dispatched)) as {
+          readonly creationSource: string;
+          readonly text: string;
+        };
+        // An app-owned child buffers nothing in the adapter, so this text is
+        // the whole wake. Marking it "provider" would make ClaudeAdapterV2
+        // drop it and settle the turn having prompted nothing.
+        assert.notEqual(command.creationSource, "provider");
+        assert.equal(command.creationSource, "server");
+        assert.equal(command.text, "Delegated task completed.");
+      }).pipe(
+        Effect.provide(
+          testLayer({ dispatched, getThreadProjection: () => Effect.succeed(projection) }),
+        ),
+        Effect.scoped,
+      );
+    });
+  });
+
   it.effect("dispatches a current request exactly once", () => {
     return Effect.gen(function* () {
       const dispatched = yield* Queue.unbounded<unknown>();

--- a/apps/server/src/orchestration-v2/ProviderContinuationService.ts
+++ b/apps/server/src/orchestration-v2/ProviderContinuationService.ts
@@ -58,7 +58,11 @@ export const workerLive = Layer.effectDiscard(
           attachments: [],
           dispatchMode: { type: "queue_after_active" },
           createdBy: "agent",
-          creationSource: "provider",
+          // "provider" marks an adapter-buffered wake, which ClaudeAdapterV2
+          // detects to attach the buffered CLI output and drop this text. A
+          // message_text wake has no buffered output, so it must not carry that
+          // marker or the turn settles immediately having prompted nothing.
+          creationSource: request.delivery === "message_text" ? "server" : "provider",
         });
         if (request.dispatchIfCurrent === undefined) {
           yield* dispatch;

--- a/apps/server/src/orchestration-v2/runtimeLayer.ts
+++ b/apps/server/src/orchestration-v2/runtimeLayer.ts
@@ -190,6 +190,9 @@ const orchestratorProvided = orchestratorLayer.pipe(
       contextHandoffServiceProvided,
       idAllocatorLayer,
       providerAdapterRegistryProvided,
+      // Same layer reference as the continuation worker and the adapter
+      // infrastructure so layer memoization yields one shared request queue.
+      providerContinuationRequestsLayer,
       providerEventIngestorProvided,
       runtimePolicyProvided,
       providerSessionManagerProvided,

--- a/apps/server/src/orchestration-v2/testkit/OrchestratorScenario.ts
+++ b/apps/server/src/orchestration-v2/testkit/OrchestratorScenario.ts
@@ -122,6 +122,7 @@ function commandThreadIds(command: OrchestrationV2Command): ReadonlyArray<Thread
     case "provider.switch":
       return [command.threadId];
     case "delegated_task.request":
+    case "delegated_task.wake-policy":
     case "thread.created.record":
       return [command.parentThreadId];
     case "thread.fork":

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1082,6 +1082,7 @@ const makeWsRpcLayer = (
                 command.type === "thread.fork" || command.type === "thread.merge_back"
                   ? command.targetThreadId
                   : command.type === "delegated_task.request" ||
+                      command.type === "delegated_task.wake-policy" ||
                       command.type === "thread.created.record"
                     ? command.parentThreadId
                     : command.threadId,

--- a/packages/contracts/src/orchestrationV2.test.ts
+++ b/packages/contracts/src/orchestrationV2.test.ts
@@ -190,6 +190,43 @@ describe("orchestration V2 contracts", () => {
     expect(command.parentNodeId).toBe(NodeId.make("node-parent-1"));
   });
 
+  it("decodes delegated task wake-policy commands", () => {
+    const command = decodeOrchestrationV2Command({
+      type: "delegated_task.wake-policy",
+      commandId: "command-delegate-wake-policy-1",
+      parentThreadId: "thread-parent-1",
+      taskId: "node-subagent-1",
+      completionWake: "always",
+    });
+
+    expect(command.type).toBe("delegated_task.wake-policy");
+    if (command.type !== "delegated_task.wake-policy") {
+      throw new Error("expected delegated_task.wake-policy");
+    }
+    expect(command.parentThreadId).toBe(ThreadId.make("thread-parent-1"));
+    expect(command.taskId).toBe(NodeId.make("node-subagent-1"));
+    expect(command.completionWake).toBe("always");
+
+    // The policy carries the whole decision, so it is required and closed.
+    expect(() =>
+      decodeOrchestrationV2Command({
+        type: "delegated_task.wake-policy",
+        commandId: "command-delegate-wake-policy-2",
+        parentThreadId: "thread-parent-1",
+        taskId: "node-subagent-1",
+      }),
+    ).toThrow();
+    expect(() =>
+      decodeOrchestrationV2Command({
+        type: "delegated_task.wake-policy",
+        commandId: "command-delegate-wake-policy-3",
+        parentThreadId: "thread-parent-1",
+        taskId: "node-subagent-1",
+        completionWake: "sometimes",
+      }),
+    ).toThrow();
+  });
+
   it("decodes durable created-thread timeline records", () => {
     const command = decodeOrchestrationV2Command({
       type: "thread.created.record",
@@ -412,6 +449,39 @@ describe("orchestration V2 contracts", () => {
     expect(turnItem.type).toBe("subagent");
     if (turnItem.type !== "subagent") throw new Error("expected subagent item");
     expect(turnItem.progress).toBe("Inspecting package metadata");
+  });
+
+  it("decodes app-owned subagent parent-wake policies", () => {
+    const appOwnedSubagent = {
+      id: "node-subagent-2",
+      threadId: "thread-1",
+      runId: "run-1",
+      parentNodeId: "node-root-1",
+      origin: "app_owned",
+      createdBy: "agent",
+      driver: "codex",
+      providerInstanceId: "codex",
+      providerThreadId: null,
+      childThreadId: "thread-child-1",
+      nativeTaskRef: null,
+      prompt: "Inspect the API boundary.",
+      title: "API inspection",
+      model: "gpt-5.4",
+      status: "running",
+      result: null,
+      startedAt: now,
+      completedAt: null,
+      updatedAt: now,
+    };
+    const decode = Schema.decodeUnknownSync(OrchestrationV2Subagent);
+
+    // Legacy records predate the field and must behave as settled_only.
+    expect(decode(appOwnedSubagent).completionWake).toBeUndefined();
+    expect(decode({ ...appOwnedSubagent, completionWake: "always" }).completionWake).toBe("always");
+    expect(decode({ ...appOwnedSubagent, completionWake: "settled_only" }).completionWake).toBe(
+      "settled_only",
+    );
+    expect(() => decode({ ...appOwnedSubagent, completionWake: "sometimes" })).toThrow();
   });
 
   it("decodes thread projections with an ordered turn item rendering stream", () => {

--- a/packages/contracts/src/orchestrationV2.ts
+++ b/packages/contracts/src/orchestrationV2.ts
@@ -442,6 +442,12 @@ export const OrchestrationV2Subagent = Schema.Struct({
   prompt: Schema.String,
   title: Schema.NullOr(Schema.String),
   model: Schema.NullOr(Schema.String),
+  // Parent-wake policy for app-owned tasks: "always" offers a continuation on
+  // every terminal (async delegations; queue_after_active sequences it behind
+  // a live parent run), "settled_only" offers only when the parent has no
+  // live run (wait-mode delegations, whose result returns through the
+  // blocking tool call). Absent on legacy records; treated as settled_only.
+  completionWake: Schema.optional(Schema.Literals(["always", "settled_only"])),
   status: Schema.Literals([
     "pending",
     "running",
@@ -1969,7 +1975,17 @@ export const OrchestrationV2Command = Schema.Union([
     modelSelection: ModelSelection,
     runtimeMode: RuntimeMode,
     interactionMode: ProviderInteractionMode,
+    // Omitted behaves as "settled_only" (no wake while the parent has a live
+    // run); producers that want fire-and-forget wakes must set "always".
+    completionWake: Schema.optional(Schema.Literals(["always", "settled_only"])),
     createdAt: Schema.optional(Schema.DateTimeUtc),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("delegated_task.wake-policy"),
+    commandId: CommandId,
+    parentThreadId: ThreadId,
+    taskId: NodeId,
+    completionWake: Schema.Literals(["always", "settled_only"]),
   }),
   Schema.Struct({
     type: Schema.Literal("thread.created.record"),


### PR DESCRIPTION
## Summary

- Wake a settled parent thread when an app-owned `delegate_task` child
  terminalizes, so an async delegation's result is acted on instead of waiting
  for the user's next message.
- Gate the wake on a per-task `completionWake` policy so async delegations and
  blocking waits do not double-deliver.
- Deliver the wake as a real prompt. A wake that only starts a run does not help
  if the provider never sees the text.
- Narrow the Claude adapter's task-notification drop, so the wake this PR
  introduces can actually settle its run. Carried as a second commit because it
  is an adapter concern rather than a wake concern, but it is a prerequisite:
  without it this PR ships a hang.

## Problem and Fix

| Problem and Why it Happened                                                                                                                                                                     | Fix                                                                                                                                                                                                                                                                                                        |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `finalizeAppOwnedSubagent` wrote the child result transfer but had no wake path, so the parent never ran again after an async delegation. The result card appeared and the thread simply parked. | Offer a `ProviderContinuationRequest` for the parent when a delegated child terminalizes. The existing `ProviderContinuationService` worker dispatches it as a `queue_after_active` `message.dispatch` that starts a wake run.                                                                              |
| An unconditional wake would double-deliver for blocking waits, where the tool call already returns the result, while a settled-only wake would miss async children that finish mid-turn.         | Record a per-task `completionWake` policy. `"always"` for async delegations offers on every child terminal and queues behind a live parent run. `"settled_only"` for wait-mode delegations, and for legacy records without the field, offers only when the parent has no run in preparing/starting/running. |
| A `settled_only` wait child that terminalized under a live parent lost its wake permanently once the blocking wait had timed out.                                                                | New `delegated_task.wake-policy` command. On wait timeout the MCP service upgrades the task to `"always"` best-effort, and for an already-terminal task it offers the wake directly when the parent has a live run, which is exactly the state where finalize's gate skipped it.                            |
| The gate could read a stale parent snapshot, and finalize wrote the parent subagent row while holding only the child dispatch lock, racing the wake-policy command's write of the same row.      | Resolve the parent from the child's immutable lineage, then run finalize under the parent thread lock and `startNextQueuedRun` under the child lock, sequentially and never nested. Gates re-read run state fresh inside the parent lock.                                                                   |
| The wake started a run but never prompted the model, so the agent still could not act on the result. `ProviderContinuationRequests` is provider-native: its dispatch only triggers ingestion of output an adapter already buffered, and both `ClaudeAdapterV2` and `AcpAdapterV2` discard the message text when it is marked `creationSource: "provider"`. An app-owned child buffers nothing, so the adapter drained an empty buffer and finalized the turn immediately. | Add `delivery` to `ProviderContinuationRequest`. `adapter_buffered` stays the default and preserves provider-native behavior; `message_text` dispatches `creationSource: "server"`, which no adapter mistakes for a buffered wake. Both offer sites build the request through one `delegatedTaskWakeRequest` helper so they cannot diverge. |
| Agents polled or spawned watchers for async children because the tool description did not say the thread wakes.                                                                                  | `delegate_task` description now states that async children wake the thread, so callers should end the turn rather than poll or spawn watchers.                                                                                                                                                             |
| The `message_text` wake above is dispatched as `creationSource: "server"` precisely so no adapter mistakes it for a buffered wake. But `ClaudeAdapterV2` keys its task-notification guard on that same `"provider"` marker, and dropped **every** task-notification-origin terminal result on a turn without it. So the wake run's own terminal was discarded, `finalizeActiveTurn` never ran, and the run stayed `running` while every run queued behind it stalled. Observed in production for 8h27m, with three terminal `success` results carrying `num_turns` 154, 60 and 7 all dropped, and five queued runs never dispatched. | `fix(claude): Settle positive task-notification results`, the second commit here, gates that drop on `message.num_turns === 0`. The stale interrupt-recovery debris the guard was written for is explicitly zero-turn and is still dropped; a result representing real model work now reaches the steering classifier and terminalization as normal. It drops strictly fewer results than before, so no previously working path can regress. |

## Manual test guide

Browsable scenario guide: <https://nam7nt0rbtm6.postplan.dev/>

Sections that cover this PR:

- [Claude · background 7, App-owned delegated child wakes the parent](https://nam7nt0rbtm6.postplan.dev/#claude-background-7).
  The scenario for this change. Automated equivalent is the
  `claude-delegated-task-wake` pack.
- [Claude · background 2, Background Bash post-settle wake](https://nam7nt0rbtm6.postplan.dev/#claude-background-2).
  The provider-native regression guard: this PR narrows when a continuation is
  offered, so a native background wake must still fire exactly once.
- [Claude · background 5, Background subagent post-settle](https://nam7nt0rbtm6.postplan.dev/#claude-background-5)
  and [6, Resume completed subagent](https://nam7nt0rbtm6.postplan.dev/#claude-background-6).
  Provider-native subagent wakes, which must keep working unchanged.

## Validation

- Focused suites: contracts decode tests for `completionWake` and the
  `delegated_task.wake-policy` command struct; `ProviderContinuationService`
  tests for both delivery mappings; MCP toolkit integration tests covering
  wait-completes, async-cancel under a live parent, wait-timeout upgrade, an
  already-terminal upgrade in both sub-cases, and a legacy field-omitted child.
  The integration probes assert `delivery` at every offer site.
- Full `apps/server` suite passes on this base: 1674 passed, 10 skipped.
- `vp check` and `vp run typecheck` clean.
- Live-verified on a packaged desktop build, reading the provider session
  transcript rather than the projection, because a projected message does not
  prove delivery:
  - Settled parent: the wake prompt reached the model, it called `task_status`,
    and replied with the child's result. The wake run took 5.5s, versus an 89ms
    empty run before the delivery fix.
  - Mid-turn `always` path: the child terminalized 35s before the root turn
    ended, the wake was requested while the parent was still live, queued behind
    it, and was delivered exactly once after the root settled.
  - Provider-native regression guard: a background Bash wake still attaches its
    buffered CLI output and responds normally.

- For the second commit: `ClaudeAdapterV2.test.ts` covers a server wake and a
  user turn settling from a positive task-notification result, a zero-turn
  result still being ignored on a normal turn, a zero-turn result still
  consumed by a provider continuation, debris racing an interrupt, and a
  positive error result. Removing only the `num_turns === 0` condition fails
  exactly the positive-turn cases, run independently as a negative check.
- Claude live packs on this base pass: in-turn background bash, foreground
  subagent, monitor, post-settle background bash wake, post-settle subagent, and
  resume subagent. These are the provider-native regression guard for the
  adapter change; the drop this commit narrows is not reachable from them,
  because a task-notification result only arrives on a provider continuation
  turn there, which the guard deliberately never applied to.

The unit and integration layers prove the offer and the delivery mapping; the
packaged run is what proves the model is actually prompted end to end.

## Known limitations

- The offer queue is in-memory. A crash between the result-transfer write and
  the worker dispatch loses that wake on replay, since the transfer guard blocks
  re-offering. A durable outbox keyed by the result transfer is the proper fix.
- One documented missed-wake window remains: finalize skips under
  `settled_only` with a live parent, the parent settles, and a late upgrade then
  also skips because the parent is no longer live. The MCP path awaits the
  upgrade inside the parent's turn, so this mostly affects direct command
  callers. Tracking wake delivery explicitly, rather than dual-gating on
  liveness, would close it.
- Reconcile-path run updates skip `finalizeAppOwnedSubagent` entirely, so
  recovery-cancelled children produce no transfer and no wake. Pre-existing.
- A wake can start ahead of a queued-only user run, because `queue_after_active`
  only queues behind blocking runs.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wake settled parent threads when delegated child tasks finish
> - Adds a `completionWake` policy field to subagent records and `delegated_task.request` commands: `settled_only` (wait mode) wakes the parent only when it has no live run; `always` (async mode) wakes it even mid-turn.
> - Adds a new `delegated_task.wake-policy` command so the orchestrator MCP service can upgrade a timed-out wait-mode task's wake policy to `always` after the blocking wait expires.
> - `ProviderContinuationService` now dispatches `message_text` wake requests as `server`-created prompts so adapters ingest the child result as a real message instead of a buffered wake signal.
> - `ClaudeAdapterV2` no longer finalizes normal (non-continuation) turns on zero-turn task-notification results, preventing spurious turn endings from async child completions.
> - Lock acquisition in `resumeQueuedRuns` is restructured to take the parent thread lock before the child lock, avoiding nested lock inversion during subagent finalization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 884d727.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches orchestration locking, MCP delegation delivery, and Claude turn finalization on a path that previously caused multi-hour stuck runs; incorrect wake gating or adapter handling could duplicate wakes, miss wakes, or leave runs non-terminal.
> 
> **Overview**
> **Settled parent threads now get a continuation when app-owned delegated children finish**, instead of parking until the user sends another message.
> 
> The orchestrator records a per-task **`completionWake`** policy (`always` for async MCP delegations, `settled_only` for blocking wait). When a child terminalizes, **`finalizeAppOwnedSubagent`** may **`offer`** a parent wake via **`ProviderContinuationRequest`**, gated on whether the parent still has a live run. A new **`delegated_task.wake-policy`** command rewrites that policy; MCP **`delegate_task`** dispatches it best-effort after a wait timeout so a late child finish can still wake a mid-turn parent. Finalization now takes the **parent** thread lock (child lock only for queueing), avoiding races on the subagent row.
> 
> **Wakes are delivered as real prompts:** **`delivery: "message_text"`** on continuation requests makes **`ProviderContinuationService`** dispatch with **`creationSource: "server"`** so adapters do not treat app-owned completion text as an empty buffered wake.
> 
> **`ClaudeAdapterV2`** only drops **zero-turn** task-notification-origin results on normal turns (stale debris); positive-turn results can settle the run so those continuations do not hang. **`delegate_task`** tool copy tells agents async children wake the thread and to avoid polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884d727dc3bb909cb587c3e6bc961490a50487d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


