### PR TITLE
Mark newly discovered completed threads unread

### DIFF
--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.test.ts
@@ -1,0 +1,72 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveFirstSeenCompletedThreads } from "./useMarkFirstSeenCompletedThreadsUnread";
+
+const localEnvironmentId = EnvironmentId.make("environment-local");
+const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+function thread(
+  id: string,
+  state: "completed" | "running" = "completed",
+  environmentId = localEnvironmentId,
+) {
+  return {
+    environmentId,
+    id: ThreadId.make(id),
+    latestTurn: {
+      state,
+      completedAt: "2026-06-18T09:00:00.000Z",
+    },
+  } as const;
+}
+
+describe("resolveFirstSeenCompletedThreads", () => {
+  it("seeds initial snapshot history without marking it unread", () => {
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("historical")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslySeenThreadKeysByEnvironment: new Map(),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([]);
+    expect(result.nextSeenThreadKeysByEnvironment.get(localEnvironmentId)).toEqual(
+      new Set([scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make("historical")))]),
+    );
+  });
+
+  it("marks a completed thread that first appears after bootstrap unread", () => {
+    const historicalKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("historical")),
+    );
+    const completedKey = scopedThreadKey(
+      scopeThreadRef(localEnvironmentId, ThreadId.make("completed")),
+    );
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("historical"), thread("completed")],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslySeenThreadKeysByEnvironment: new Map([
+        [localEnvironmentId, new Set([historicalKey])],
+      ]),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([
+      {
+        threadKey: completedKey,
+        completedAt: "2026-06-18T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("does not mark a new unfinished thread or a thread outside a snapshot environment", () => {
+    const result = resolveFirstSeenCompletedThreads({
+      threads: [thread("running", "running"), thread("remote", "completed", remoteEnvironmentId)],
+      environmentSnapshotIds: [localEnvironmentId],
+      previouslySeenThreadKeysByEnvironment: new Map([[localEnvironmentId, new Set()]]),
+    });
+
+    expect(result.newlyUnreadThreads).toEqual([]);
+    expect(result.nextSeenThreadKeysByEnvironment.has(remoteEnvironmentId)).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -1,0 +1,57 @@
+import { useAtomValue } from "@effect/atom-react";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { Atom } from "effect/unstable/reactivity";
+import { useEffect, useRef } from "react";
+
+import { environmentCatalog } from "../connection/catalog";
+import { useThreadShells } from "../state/entities";
+import { environmentShell } from "../state/shell";
+import { useUiStateStore } from "../uiStateStore";
+
+const environmentSnapshotIdsAtom = Atom.make((get): ReadonlyArray<EnvironmentId> => {
+  const environmentIds: EnvironmentId[] = [];
+  for (const environmentId of get(environmentCatalog.catalogValueAtom).entries.keys()) {
+    if (Option.isSome(get(environmentShell.stateValueAtom(environmentId)).snapshot)) {
+      environmentIds.push(environmentId);
+    }
+  }
+  return environmentIds;
+}).pipe(Atom.withLabel("completed-thread-unread:snapshot-environments"));
+
+export function useMarkFirstSeenCompletedThreadsUnread(): void {
+  const threads = useThreadShells();
+  const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
+  const seenThreadKeysByEnvironmentRef = useRef<Map<EnvironmentId, Set<string>>>(new Map());
+
+  useEffect(() => {
+    const snapshotEnvironmentIds = new Set(environmentSnapshotIds);
+    const nextThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
+    for (const environmentId of snapshotEnvironmentIds) {
+      nextThreadKeysByEnvironment.set(environmentId, new Set());
+    }
+
+    for (const thread of threads) {
+      if (!snapshotEnvironmentIds.has(thread.environmentId)) {
+        continue;
+      }
+
+      const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+      const threadKey = scopedThreadKey(threadRef);
+      const nextThreadKeys = nextThreadKeysByEnvironment.get(thread.environmentId);
+      nextThreadKeys?.add(threadKey);
+
+      const previousThreadKeys = seenThreadKeysByEnvironmentRef.current.get(thread.environmentId);
+      if (
+        previousThreadKeys !== undefined &&
+        !previousThreadKeys.has(threadKey) &&
+        thread.latestTurn?.state === "completed"
+      ) {
+        useUiStateStore.getState().markThreadUnread(threadKey, thread.latestTurn.completedAt);
+      }
+    }
+
+    seenThreadKeysByEnvironmentRef.current = nextThreadKeysByEnvironment;
+  }, [environmentSnapshotIds, threads]);
+}

--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -1,6 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { Atom } from "effect/unstable/reactivity";
 import { useEffect, useRef } from "react";
@@ -20,38 +20,78 @@ const environmentSnapshotIdsAtom = Atom.make((get): ReadonlyArray<EnvironmentId>
   return environmentIds;
 }).pipe(Atom.withLabel("completed-thread-unread:snapshot-environments"));
 
+interface FirstSeenThreadInput {
+  readonly environmentId: EnvironmentId;
+  readonly id: ThreadId;
+  readonly latestTurn: {
+    readonly state: string;
+    readonly completedAt: string | null;
+  } | null;
+}
+
+export function resolveFirstSeenCompletedThreads(input: {
+  readonly threads: ReadonlyArray<FirstSeenThreadInput>;
+  readonly environmentSnapshotIds: ReadonlyArray<EnvironmentId>;
+  readonly previouslySeenThreadKeysByEnvironment: ReadonlyMap<EnvironmentId, ReadonlySet<string>>;
+}): {
+  readonly nextSeenThreadKeysByEnvironment: Map<EnvironmentId, Set<string>>;
+  readonly newlyUnreadThreads: ReadonlyArray<{
+    readonly threadKey: string;
+    readonly completedAt: string | null;
+  }>;
+} {
+  const snapshotEnvironmentIds = new Set(input.environmentSnapshotIds);
+  const nextSeenThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
+  const newlyUnreadThreads: Array<{
+    readonly threadKey: string;
+    readonly completedAt: string | null;
+  }> = [];
+  for (const environmentId of snapshotEnvironmentIds) {
+    nextSeenThreadKeysByEnvironment.set(environmentId, new Set());
+  }
+
+  for (const thread of input.threads) {
+    if (!snapshotEnvironmentIds.has(thread.environmentId)) {
+      continue;
+    }
+
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    nextSeenThreadKeysByEnvironment.get(thread.environmentId)?.add(threadKey);
+
+    const previousThreadKeys = input.previouslySeenThreadKeysByEnvironment.get(
+      thread.environmentId,
+    );
+    if (
+      previousThreadKeys !== undefined &&
+      !previousThreadKeys.has(threadKey) &&
+      thread.latestTurn?.state === "completed"
+    ) {
+      newlyUnreadThreads.push({
+        threadKey,
+        completedAt: thread.latestTurn.completedAt,
+      });
+    }
+  }
+
+  return { nextSeenThreadKeysByEnvironment, newlyUnreadThreads };
+}
+
 export function useMarkFirstSeenCompletedThreadsUnread(): void {
   const threads = useThreadShells();
   const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
   const seenThreadKeysByEnvironmentRef = useRef<Map<EnvironmentId, Set<string>>>(new Map());
 
   useEffect(() => {
-    const snapshotEnvironmentIds = new Set(environmentSnapshotIds);
-    const nextThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
-    for (const environmentId of snapshotEnvironmentIds) {
-      nextThreadKeysByEnvironment.set(environmentId, new Set());
+    const { nextSeenThreadKeysByEnvironment, newlyUnreadThreads } =
+      resolveFirstSeenCompletedThreads({
+        threads,
+        environmentSnapshotIds,
+        previouslySeenThreadKeysByEnvironment: seenThreadKeysByEnvironmentRef.current,
+      });
+    for (const thread of newlyUnreadThreads) {
+      useUiStateStore.getState().markThreadUnread(thread.threadKey, thread.completedAt);
     }
 
-    for (const thread of threads) {
-      if (!snapshotEnvironmentIds.has(thread.environmentId)) {
-        continue;
-      }
-
-      const threadRef = scopeThreadRef(thread.environmentId, thread.id);
-      const threadKey = scopedThreadKey(threadRef);
-      const nextThreadKeys = nextThreadKeysByEnvironment.get(thread.environmentId);
-      nextThreadKeys?.add(threadKey);
-
-      const previousThreadKeys = seenThreadKeysByEnvironmentRef.current.get(thread.environmentId);
-      if (
-        previousThreadKeys !== undefined &&
-        !previousThreadKeys.has(threadKey) &&
-        thread.latestTurn?.state === "completed"
-      ) {
-        useUiStateStore.getState().markThreadUnread(threadKey, thread.latestTurn.completedAt);
-      }
-    }
-
-    seenThreadKeysByEnvironmentRef.current = nextThreadKeysByEnvironment;
+    seenThreadKeysByEnvironmentRef.current = nextSeenThreadKeysByEnvironment;
   }, [environmentSnapshotIds, threads]);
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -27,6 +27,7 @@ import {
   toastManager,
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
+import { useMarkFirstSeenCompletedThreadsUnread } from "../hooks/useMarkFirstSeenCompletedThreadsUnread";
 import { useClientSettings } from "../hooks/useSettings";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -277,6 +278,8 @@ function AuthenticatedTracingBootstrap() {
 }
 
 function EventRouter() {
+  useMarkFirstSeenCompletedThreadsUnread();
+
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);


### PR DESCRIPTION
## What Changed

- Observe authoritative thread snapshots after each environment has completed its initial bootstrap.
- Remember the thread keys already seen in each environment.
- Mark a thread unread when it first appears after bootstrap with an already-completed latest turn.
- Keep observation history environment-scoped so remote and local snapshots cannot affect one another.

## Why

The existing completion indicator is timestamp-based and intentionally treats threads without a visit marker as read. That leaves a narrow gap for a thread created elsewhere that first appears in the current client only after it has already completed.

This draft explores treating that newly discovered completion as unread without lighting up historical threads from the initial snapshot.

## Scope

- This does not change sidebar presentation or manual `Mark unread` behavior.
- Initial bootstrap history remains read.
- This only handles threads first discovered in the completed state; ordinary completion handling remains unchanged.
- The change is independent and can be evaluated as an optional follow-up.

## Attribution

The original implementation is authored by Wout Stiens; that authorship is preserved in the commit history.

## Verification

- 3 focused tests passed:
  - initial snapshot history is seeded without becoming unread
  - a newly discovered completed thread becomes unread
  - unfinished and non-authoritative-environment threads remain unchanged
- Scoped formatting and lint checks passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark newly discovered completed threads as unread on first appearance
> - Adds a `useMarkFirstSeenCompletedThreadsUnread` hook that tracks which threads have been seen per snapshot environment and calls `markThreadUnread` the first time a completed thread appears after the initial bootstrap.
> - A pure `resolveFirstSeenCompletedThreads` utility handles the stateless computation, comparing current thread keys against a previously-seen set to find newly completed threads.
> - The hook is mounted in `EventRouter` in [__root.tsx](https://github.com/pingdotgg/t3code/pull/4501/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) so it runs for the lifetime of the app.
> - Behavioral Change: threads completed while the user is away will be marked unread when they next load the app, but only for snapshot environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fc354d8. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->