### PR TITLE
fix(web): keep Codex service tier labels readable

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -16,6 +16,22 @@ function fastModeDescriptor(
   return { id: "fastMode", label: "Fast Mode", type: "boolean", currentValue };
 }
 
+function serviceTierDescriptor(
+  currentValue: "default" | "priority" | "flex",
+): Extract<ProviderOptionDescriptor, { type: "select" }> {
+  return {
+    id: "serviceTier",
+    label: "Service Tier",
+    type: "select",
+    options: [
+      { id: "default", label: "Standard", isDefault: true },
+      { id: "priority", label: "Fast" },
+      { id: "flex", label: "Flex" },
+    ],
+    currentValue,
+  };
+}
+
 const EFFORT = selectDescriptor(
   "reasoningEffort",
   [
@@ -59,23 +75,32 @@ describe("buildTraitsTriggerDisplay", () => {
     });
   });
 
-  it("renders Codex's Standard and Fast service tiers as fast mode", () => {
-    const serviceTier = selectDescriptor(
-      "serviceTier",
-      [
-        { id: "default", label: "Standard", isDefault: true },
-        { id: "priority", label: "Fast" },
-      ],
-      "default",
-    );
-
-    expect(display([EFFORT, serviceTier])).toEqual({
+  it("treats Codex standard and fast service tiers as fast mode states", () => {
+    expect(display([EFFORT, serviceTierDescriptor("default")])).toEqual({
       label: "High",
       showFastModeIcon: false,
     });
-    expect(display([EFFORT, { ...serviceTier, currentValue: "priority" }])).toEqual({
+    expect(display([EFFORT, serviceTierDescriptor("priority")])).toEqual({
       label: "High",
       showFastModeIcon: true,
+    });
+  });
+
+  it("keeps other Codex service tiers in the label", () => {
+    expect(display([EFFORT, serviceTierDescriptor("flex")])).toEqual({
+      label: "High · Flex",
+      showFastModeIcon: false,
+    });
+  });
+
+  it("keeps the Codex service tier readable when it is the only trait", () => {
+    expect(display([serviceTierDescriptor("default")])).toEqual({
+      label: "Standard",
+      showFastModeIcon: false,
+    });
+    expect(display([serviceTierDescriptor("priority")])).toEqual({
+      label: "Fast",
+      showFastModeIcon: false,
     });
   });
 

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -382,10 +382,11 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
 
 /**
  * Build the traits trigger's text label plus whether the fast-mode bolt should
- * render. Fast mode is a lightning bolt when on and nothing at all when off —
- * "Normal" is the near-universal case and isn't worth the horizontal space. The
- * one exception is when fast mode is the only trait, where a bare bolt (or bare
- * chevron) would leave the trigger unreadable.
+ * render. Claude and Cursor expose fast mode as a boolean, while Codex exposes
+ * it through the Standard/Fast service tiers. In either form, fast mode is a
+ * lightning bolt when on and nothing at all when off. The one exception is when
+ * fast mode is the only trait, where a bare bolt (or bare chevron) would leave
+ * the trigger unreadable.
  */
 export function buildTraitsTriggerDisplay(input: {
   provider: ProviderDriverKind;
@@ -393,13 +394,13 @@ export function buildTraitsTriggerDisplay(input: {
   primarySelectDescriptorId: string | null;
   ultrathinkPromptControlled: boolean;
 }): { label: string; showFastModeIcon: boolean } {
-  let hasFastMode = false;
+  let fastModeFallbackLabel: string | null = null;
   let fastModeEnabled = false;
   const labels: Array<string> = [];
   for (const descriptor of input.descriptors) {
     if (descriptor.id === "fastMode" && descriptor.type === "boolean") {
-      hasFastMode = true;
       fastModeEnabled = descriptor.currentValue === true;
+      fastModeFallbackLabel = fastModeEnabled ? "Fast" : "Normal";
       continue;
     }
     if (
@@ -410,8 +411,10 @@ export function buildTraitsTriggerDisplay(input: {
       const currentValue = getProviderOptionCurrentValue(descriptor);
       const fastTier = descriptor.options.find(({ label }) => label === "Fast");
       if (fastTier && (currentValue === "default" || currentValue === fastTier.id)) {
-        hasFastMode = true;
         fastModeEnabled = currentValue === fastTier.id;
+        fastModeFallbackLabel =
+          descriptor.options.find(({ id }) => id === currentValue)?.label ??
+          (fastModeEnabled ? "Fast" : "Normal");
         continue;
       }
     }
@@ -429,8 +432,8 @@ export function buildTraitsTriggerDisplay(input: {
   // Only fall back to text when fast mode is genuinely the sole trait. Keying
   // off an empty label list alone would also catch descriptors that resolved to
   // no label at all, printing a bogus "Normal" for a model without fast mode.
-  if (labels.length === 0 && hasFastMode) {
-    return { label: fastModeEnabled ? "Fast" : "Normal", showFastModeIcon: false };
+  if (labels.length === 0 && fastModeFallbackLabel !== null) {
+    return { label: fastModeFallbackLabel, showFastModeIcon: false };
   }
   return { label: labels.join(" · "), showFastModeIcon: fastModeEnabled };
 }


### PR DESCRIPTION
## What this PR originally did

This PR originally extended #4488's compact fast-mode trigger to Codex service tiers:

- hide `Standard` when it appears beside another trait
- show the bolt instead of `Fast`
- keep distinct tiers such as `Flex` visible
- keep `Standard` / `Fast` readable when the service tier is the only trait

It also moved fast-mode detection into `buildTraitsTriggerDisplay` so the display state came directly from provider descriptors.

## Why it changed

While this PR was open, #4784 added Codex-scoped handling for the default service tier and #4947 landed the Standard/Fast bolt behavior. Rebasing the original patch onto current `main` therefore conflicted with behavior that is already shipped.

Rather than duplicate or replace #4947, this PR now keeps its safer Codex-scoped, descriptor-driven implementation and focuses only on the edge cases that were still missing.

## What it does now

- preserves non-fast Codex service tiers such as `Flex` in the joined trigger label
- uses the selected service-tier label when it is the only trait, so the fallback is `Standard` / `Fast` instead of `Normal` / `Fast`
- adds focused regression coverage for Standard, Fast, Flex, and service-tier-only displays

This remains a UI-only change in `TraitsPicker`; it does not change provider capabilities, persistence, or wire contracts.

## Verification

- `pnpm exec vp test run apps/web/src/components/chat/TraitsPicker.test.ts` — 9 tests passed
- `pnpm exec vp run @t3tools/web#typecheck`
- `pnpm exec vp lint apps/web/src/components/chat/TraitsPicker.tsx apps/web/src/components/chat/TraitsPicker.test.ts`

Made by GPT-5.6-Sol with the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label logic in TraitsPicker with focused unit tests; no API, persistence, or provider contract changes.
> 
> **Overview**
> **Fixes Codex traits trigger labeling** in `buildTraitsTriggerDisplay` so Standard/Fast service tiers still map to the fast-mode bolt behavior, while edge cases stay readable.
> 
> When **Flex** (or other non–Standard/Fast tiers) is selected alongside traits like reasoning effort, the tier name is **included** in the joined label (e.g. `High · Flex`) instead of being dropped. When **service tier is the only trait**, the trigger shows **Standard** or **Fast** as text (no bolt) rather than generic **Normal**/**Fast** from the boolean fast-mode path.
> 
> Implementation swaps the `hasFastMode` flag for a nullable **`fastModeFallbackLabel`** derived from the actual tier option labels for Codex `serviceTier`. Comments are updated to document Codex vs boolean fast mode. **Tests** add a `serviceTierDescriptor` helper and cover Flex, tier-only, and existing Standard/Fast bolt cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef96de5d1b4a46eb2b41f216fe01a639ca9f47e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex service tier labels in `buildTraitsTriggerDisplay` to stay readable
> - When the Codex `serviceTier` select is the only active trait, the trigger label now shows the tier name ('Standard' or 'Fast') as plain text instead of rendering just a bolt icon with no label.
> - Non-fast tiers like 'Flex' are included in the composed label rather than being silently dropped.
> - Standard and Fast tiers are treated as fast-mode states that control bolt visibility only.
> - Behavioral Change: replaces the `hasFastMode` boolean sentinel with a nullable `fastModeFallbackLabel` string in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/4503/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45), changing how the final label fallback is resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef96de5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->