### PR TITLE
Color environment indicators per environment

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -1,6 +1,6 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
-import { ClientSettingsSchema, type ClientSettings } from "@t3tools/contracts";
+import { ClientSettingsSchema, EnvironmentId, type ClientSettings } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -18,6 +18,9 @@ const clientSettings: ClientSettings = {
   confirmThreadDelete: false,
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
+  environmentAccentColors: {
+    [EnvironmentId.make("environment-1")]: "#2563eb",
+  },
   favorites: [],
   glassOpacity: 80,
   providerModelPreferences: {},

--- a/apps/web/src/accentColors.ts
+++ b/apps/web/src/accentColors.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared accent-color primitives.
+ *
+ * Accent colors are user-chosen hex strings used to tell otherwise identical
+ * UI affordances apart — provider instances in picker rails, environments in
+ * the sidebar. They are always stored normalized so rendering can treat a
+ * present value as directly usable in CSS.
+ */
+
+export const ACCENT_COLOR_SWATCHES = [
+  "#2563eb",
+  "#16a34a",
+  "#ea580c",
+  "#dc2626",
+  "#7c3aed",
+  "#0891b2",
+] as const;
+
+export const FALLBACK_ACCENT_COLOR = ACCENT_COLOR_SWATCHES[0];
+
+/** Accept only `#rrggbb`; anything else (including "") reads as "no color". */
+export function normalizeAccentColor(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return /^#[0-9a-fA-F]{6}$/u.test(trimmed) ? trimmed : undefined;
+}

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -2,6 +2,12 @@ import type { EnvironmentId } from "@t3tools/contracts";
 import { CloudIcon, MonitorIcon } from "lucide-react";
 import { memo, useMemo } from "react";
 
+import {
+  environmentAccentStyle,
+  resolveEnvironmentAccentColor,
+  useEnvironmentAccentColors,
+  type EnvironmentAccentColors,
+} from "../environmentAccentColors";
 import type { EnvironmentOption } from "./BranchToolbar.logic";
 import {
   Select,
@@ -22,12 +28,25 @@ interface BranchToolbarEnvironmentSelectorProps {
   onEnvironmentChange?: (environmentId: EnvironmentId) => void;
 }
 
+function EnvironmentIcon({
+  accentColors,
+  environment,
+}: {
+  readonly accentColors: EnvironmentAccentColors;
+  readonly environment: EnvironmentOption | null;
+}) {
+  const accentColor = resolveEnvironmentAccentColor(accentColors, environment?.environmentId);
+  const Icon = environment?.isPrimary ? MonitorIcon : CloudIcon;
+  return <Icon className="size-3 shrink-0" style={environmentAccentStyle(accentColor)} />;
+}
+
 export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvironmentSelector({
   envLocked,
   environmentId,
   availableEnvironments,
   onEnvironmentChange,
 }: BranchToolbarEnvironmentSelectorProps) {
+  const accentColors = useEnvironmentAccentColors();
   const activeEnvironment = useMemo(() => {
     return availableEnvironments.find((env) => env.environmentId === environmentId) ?? null;
   }, [availableEnvironments, environmentId]);
@@ -44,11 +63,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
   if (envLocked || onEnvironmentChange === undefined) {
     return (
       <span className="inline-flex min-w-0 max-w-full items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
-        {activeEnvironment?.isPrimary ? (
-          <MonitorIcon className="size-3 shrink-0" />
-        ) : (
-          <CloudIcon className="size-3 shrink-0" />
-        )}
+        <EnvironmentIcon accentColors={accentColors} environment={activeEnvironment} />
         <span className="truncate">{activeEnvironment?.label ?? "Run on"}</span>
       </span>
     );
@@ -67,11 +82,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         className="min-w-0 max-w-full font-medium"
         aria-label="Run on"
       >
-        {activeEnvironment?.isPrimary ? (
-          <MonitorIcon className="size-3 shrink-0" />
-        ) : (
-          <CloudIcon className="size-3 shrink-0" />
-        )}
+        <EnvironmentIcon accentColors={accentColors} environment={activeEnvironment} />
         <SelectValue />
       </SelectTrigger>
       <SelectPopup>
@@ -80,11 +91,7 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
           {availableEnvironments.map((env) => (
             <SelectItem key={env.environmentId} value={env.environmentId}>
               <span className="inline-flex items-center gap-1.5">
-                {env.isPrimary ? (
-                  <MonitorIcon className="size-3" />
-                ) : (
-                  <CloudIcon className="size-3" />
-                )}
+                <EnvironmentIcon accentColors={accentColors} environment={env} />
                 {env.label}
               </span>
             </SelectItem>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -191,6 +191,12 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
+import {
+  environmentAccentStyle,
+  resolveSharedEnvironmentAccentColor,
+  useEnvironmentAccentColor,
+  useEnvironmentAccentColors,
+} from "~/environmentAccentColors";
 import { primaryServerKeybindingsAtom } from "../state/server";
 import {
   derivePhysicalProjectKey,
@@ -396,6 +402,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   const threadEnvironmentLabel = isRemoteThread
     ? (remoteEnvLabel ?? (isDesktopLocalThread ? "Local" : "Remote"))
     : null;
+  const threadEnvironmentAccentColor = useEnvironmentAccentColor(thread.environmentId);
   // For grouped projects, the thread may belong to a different environment
   // than the representative project.  Look up the thread's own project cwd
   // so git status (and thus PR detection) queries the correct path.
@@ -835,7 +842,10 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                         />
                       }
                     >
-                      <CloudIcon className="size-3 text-muted-foreground/40" />
+                      <CloudIcon
+                        className="size-3 text-muted-foreground/40"
+                        style={environmentAccentStyle(threadEnvironmentAccentColor)}
+                      />
                     </TooltipTrigger>
                     <TooltipPopup side="top">{threadEnvironmentLabel}</TooltipPopup>
                   </Tooltip>
@@ -1100,6 +1110,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     (settings) => settings.confirmThreadArchive,
   );
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const environmentAccentColors = useEnvironmentAccentColors();
+  const remoteEnvironmentAccentColor = resolveSharedEnvironmentAccentColor(
+    environmentAccentColors,
+    project.remoteEnvironmentIds,
+  );
+  const remoteEnvironmentAccentStyle = environmentAccentStyle(remoteEnvironmentAccentColor);
   const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
@@ -2287,9 +2303,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
               }
             >
               {project.allRemoteMembersAreDesktopLocal ? (
-                <ContainerIcon className="size-3" />
+                <ContainerIcon className="size-3" style={remoteEnvironmentAccentStyle} />
               ) : (
-                <CloudIcon className="size-3" />
+                <CloudIcon className="size-3" style={remoteEnvironmentAccentStyle} />
               )}
             </TooltipTrigger>
             <TooltipPopup side="top">

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -12,7 +12,11 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  ScopedThreadRef,
+  SidebarProjectGroupingMode,
+} from "@t3tools/contracts";
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
@@ -86,6 +90,7 @@ import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { openCommandPalette } from "../commandPaletteBus";
 import { startNewThreadFromContext } from "../lib/chatThreadActions";
 import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
+import { environmentAccentStyle, useEnvironmentAccentColor } from "../environmentAccentColors";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
@@ -216,6 +221,17 @@ function WorkingDuration(props: { startedAt: string | null }) {
   return <span className="tabular-nums">{formatWorkingDurationLabel(Date.now() - startedMs)}</span>;
 }
 
+/** Server glyph tinted with the environment's accent color, when one is set. */
+function EnvironmentServerIcon({ environmentId }: { readonly environmentId: EnvironmentId }) {
+  const accentColor = useEnvironmentAccentColor(environmentId);
+  return (
+    <ServerIcon
+      className="size-4 shrink-0 stroke-muted-foreground"
+      style={environmentAccentStyle(accentColor, "stroke")}
+    />
+  );
+}
+
 function SidebarV2ThreadTooltip({
   thread,
   projectTitle,
@@ -261,7 +277,7 @@ function SidebarV2ThreadTooltip({
           ) : null}
           {environmentLabel ? (
             <div className="flex min-w-0 items-center gap-2">
-              <ServerIcon className="size-4 shrink-0 stroke-muted-foreground" />
+              <EnvironmentServerIcon environmentId={thread.environmentId} />
               <div className="min-w-0 wrap-break-word text-foreground/90">{environmentLabel}</div>
             </div>
           ) : null}
@@ -525,6 +541,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
 
   const isRemote =
     props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
+  const environmentAccentColor = useEnvironmentAccentColor(thread.environmentId);
 
   const detailsTooltip = (
     <SidebarV2ThreadTooltip
@@ -962,7 +979,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
               >
                 {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
+                  <span
+                    className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70"
+                    style={environmentAccentStyle(environmentAccentColor)}
+                  >
                     <ServerIcon aria-hidden className="size-3.5" />
                   </span>
                 ) : null}
@@ -2590,7 +2610,7 @@ export default function SidebarV2() {
                     />
                     <div className="min-w-0 flex-1">
                       <div className="flex min-w-0 items-center gap-1.5 text-base text-muted-foreground sm:text-sm">
-                        <ServerIcon className="size-4 shrink-0 stroke-muted-foreground" />
+                        <EnvironmentServerIcon environmentId={member.environmentId} />
                         <p className="min-w-0 truncate">
                           {member.environmentLabel ?? "Current environment"}
                         </p>

--- a/apps/web/src/components/settings/AccentColorPicker.tsx
+++ b/apps/web/src/components/settings/AccentColorPicker.tsx
@@ -6,26 +6,19 @@ import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } 
 import { ColorSelector } from "../color-selector";
 import { Button } from "../ui/button";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
-import { normalizeProviderAccentColor } from "../../providerInstances";
+import {
+  ACCENT_COLOR_SWATCHES,
+  FALLBACK_ACCENT_COLOR,
+  normalizeAccentColor,
+} from "../../accentColors";
 import { cn } from "../../lib/utils";
-
-const PROVIDER_ACCENT_SWATCHES = [
-  "#2563eb",
-  "#16a34a",
-  "#ea580c",
-  "#dc2626",
-  "#7c3aed",
-  "#0891b2",
-] as const;
-
-const FALLBACK_ACCENT_COLOR = PROVIDER_ACCENT_SWATCHES[0];
 
 function clamp(value: number, min = 0, max = 1) {
   return Math.min(max, Math.max(min, value));
 }
 
 function hexToHsv(hex: string) {
-  const normalized = normalizeProviderAccentColor(hex) ?? FALLBACK_ACCENT_COLOR;
+  const normalized = normalizeAccentColor(hex) ?? FALLBACK_ACCENT_COLOR;
   const numeric = Number.parseInt(normalized.slice(1), 16);
   const red = ((numeric >> 16) & 255) / 255;
   const green = ((numeric >> 8) & 255) / 255;
@@ -80,7 +73,7 @@ function hsvToHex(hue: number, saturation: number, value: number) {
     .join("")}`;
 }
 
-function ProviderCustomColorPanel(props: {
+function CustomColorPanel(props: {
   readonly value: string;
   readonly onCommit: (value: string) => void;
 }) {
@@ -178,13 +171,13 @@ function ProviderCustomColorPanel(props: {
   );
 }
 
-function ProviderCustomColorPicker(props: {
+function CustomColorPicker(props: {
   readonly displayName: string;
   readonly value: string | undefined;
   readonly selected: boolean;
   readonly onCommit: (value: string) => void;
 }) {
-  const normalized = normalizeProviderAccentColor(props.value) ?? FALLBACK_ACCENT_COLOR;
+  const normalized = normalizeAccentColor(props.value) ?? FALLBACK_ACCENT_COLOR;
 
   return (
     <Popover>
@@ -216,20 +209,30 @@ function ProviderCustomColorPicker(props: {
         sideOffset={6}
         className="overflow-hidden rounded-md p-0 [--viewport-inline-padding:0px] [&_[data-slot=popover-viewport]]:p-0"
       >
-        <ProviderCustomColorPanel value={normalized} onCommit={props.onCommit} />
+        <CustomColorPanel value={normalized} onCommit={props.onCommit} />
       </PopoverPopup>
     </Popover>
   );
 }
 
-export function ProviderAccentColorPicker(props: {
+export function AccentColorPicker(props: {
+  /** Name of the thing being colored; used to disambiguate the aria labels. */
   readonly displayName: string;
   readonly value: string | undefined;
   readonly onCommit: (value: string) => void;
+  /** Heading above the swatches. Pass `null` where the surrounding UI already names it. */
+  readonly label?: string | null;
   readonly description?: string;
   readonly commitDelayMs?: number;
 }) {
-  const { commitDelayMs = 0, description, displayName, onCommit, value } = props;
+  const {
+    commitDelayMs = 0,
+    description,
+    displayName,
+    label = "Accent color",
+    onCommit,
+    value,
+  } = props;
   const [optimisticValue, setOptimisticValue] = useState(() => value ?? "");
   const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingCommitRef = useRef<string | null>(null);
@@ -258,7 +261,7 @@ export function ProviderAccentColorPicker(props: {
 
   const commitAccentColor = useCallback(
     (value: string) => {
-      const normalizedValue = normalizeProviderAccentColor(value) ?? "";
+      const normalizedValue = normalizeAccentColor(value) ?? "";
       setOptimisticValue(normalizedValue);
 
       if (commitDelayMs <= 0) {
@@ -287,19 +290,19 @@ export function ProviderAccentColorPicker(props: {
     [commitDelayMs, onCommit],
   );
 
-  const normalized = normalizeProviderAccentColor(optimisticValue);
+  const normalized = normalizeAccentColor(optimisticValue);
   const selectedValue =
     normalized &&
-    PROVIDER_ACCENT_SWATCHES.includes(normalized as (typeof PROVIDER_ACCENT_SWATCHES)[number])
+    ACCENT_COLOR_SWATCHES.includes(normalized as (typeof ACCENT_COLOR_SWATCHES)[number])
       ? normalized
       : "";
   const customSelected = Boolean(normalized && selectedValue === "");
 
   return (
     <div className="grid gap-2">
-      <span className="text-xs font-medium text-foreground">Accent color</span>
+      {label === null ? null : <span className="text-xs font-medium text-foreground">{label}</span>}
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <ProviderCustomColorPicker
+        <CustomColorPicker
           displayName={displayName}
           value={normalized}
           selected={customSelected}
@@ -307,7 +310,7 @@ export function ProviderAccentColorPicker(props: {
         />
         <ColorSelector
           key={selectedValue}
-          colors={[...PROVIDER_ACCENT_SWATCHES]}
+          colors={[...ACCENT_COLOR_SWATCHES]}
           defaultValue={selectedValue}
           size="lg"
           onColorSelect={commitAccentColor}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -42,6 +42,7 @@ import { cn } from "../../lib/utils";
 import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import { applyWslEnableSelection } from "./ConnectionsSettings.logic";
+import { EnvironmentAccentColorControl } from "./EnvironmentAccentColorControl";
 import {
   SettingsPageContainer,
   SettingsRow,
@@ -1456,6 +1457,7 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
+          <EnvironmentAccentColorControl environmentId={environmentId} label={environment.label} />
           {isWslEnvironment ? (
             <Tooltip>
               <TooltipTrigger
@@ -2975,6 +2977,20 @@ export function ConnectionsSettings() {
     />
   );
 
+  const primaryAccentColorRow =
+    primaryEnvironmentId === null ? null : (
+      <SettingsRow
+        title="Accent color"
+        description="Tint this environment's icons in the sidebar and pickers so you can tell its threads apart at a glance."
+        control={
+          <EnvironmentAccentColorControl
+            environmentId={primaryEnvironmentId}
+            label={primaryEnvironment?.label ?? "this environment"}
+          />
+        }
+      />
+    );
+
   return (
     <SettingsPageContainer>
       {canManageLocalBackend ? (
@@ -3003,6 +3019,7 @@ export function ConnectionsSettings() {
                 }
               />
             ) : null}
+            {primaryAccentColorRow}
             {desktopBridge ? (
               <>
                 {renderNetworkAccessRow()}
@@ -3311,6 +3328,7 @@ export function ConnectionsSettings() {
             title="Administrative access"
             description="Pairing links and client-session management require the access:write scope for this backend."
           />
+          {primaryAccentColorRow}
           <CloudLinkRow canManageRelay={canManageRelay} />
         </SettingsSection>
       )}

--- a/apps/web/src/components/settings/EnvironmentAccentColorControl.tsx
+++ b/apps/web/src/components/settings/EnvironmentAccentColorControl.tsx
@@ -1,0 +1,62 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { PaletteIcon } from "lucide-react";
+import { memo, useCallback } from "react";
+
+import {
+  useEnvironmentAccentColor,
+  useSetEnvironmentAccentColor,
+} from "../../environmentAccentColors";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { AccentColorPicker } from "./AccentColorPicker";
+
+/**
+ * Compact accent-color control for one environment: a swatch that opens the
+ * shared picker. Environment rows are dense and there can be many of them, so
+ * the swatch row itself lives in a popover instead of expanding every row.
+ */
+export const EnvironmentAccentColorControl = memo(function EnvironmentAccentColorControl({
+  environmentId,
+  label,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+}) {
+  const accentColor = useEnvironmentAccentColor(environmentId);
+  const setEnvironmentAccentColor = useSetEnvironmentAccentColor();
+  const handleCommit = useCallback(
+    (value: string) => {
+      setEnvironmentAccentColor(environmentId, value);
+    },
+    [environmentId, setEnvironmentAccentColor],
+  );
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            className="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-full border border-border text-muted-foreground transition-transform duration-200 hover:scale-105 active:scale-90"
+            style={
+              accentColor ? { backgroundColor: accentColor, borderColor: accentColor } : undefined
+            }
+            aria-label={`Accent color for ${label}`}
+            data-environment-accent-color={accentColor}
+          >
+            {accentColor ? null : <PaletteIcon className="size-3.5" aria-hidden />}
+          </button>
+        }
+      />
+      <PopoverPopup side="bottom" align="end" sideOffset={6}>
+        <AccentColorPicker
+          displayName={label}
+          value={accentColor}
+          onCommit={handleCommit}
+          label={null}
+          description="Tints this environment's icons in the sidebar and pickers."
+          commitDelayMs={120}
+        />
+      </PopoverPopup>
+    </Popover>
+  );
+});

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -41,7 +41,7 @@ import type { DriverOption } from "./providerDriverMeta";
 import { ProviderSettingsForm } from "./ProviderSettingsForm";
 import { ProviderModelsSection } from "./ProviderModelsSection";
 import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
-import { ProviderAccentColorPicker } from "./ProviderAccentColorPicker";
+import { AccentColorPicker } from "./AccentColorPicker";
 import { RedactedSensitiveText } from "./RedactedSensitiveText";
 import {
   getProviderVersionAdvisoryPresentation,
@@ -748,7 +748,7 @@ export function ProviderInstanceCard({
             </div>
 
             <div>
-              <ProviderAccentColorPicker
+              <AccentColorPicker
                 displayName={displayName}
                 value={accentColor}
                 onCommit={updateAccentColor}

--- a/apps/web/src/environmentAccentColors.test.ts
+++ b/apps/web/src/environmentAccentColors.test.ts
@@ -1,0 +1,110 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  applyEnvironmentAccentColor,
+  environmentAccentStyle,
+  resolveEnvironmentAccentColor,
+  resolveSharedEnvironmentAccentColor,
+} from "./environmentAccentColors";
+
+const local = EnvironmentId.make("env-local");
+const remote = EnvironmentId.make("env-remote");
+const other = EnvironmentId.make("env-other");
+
+describe("resolveEnvironmentAccentColor", () => {
+  it("returns the stored color for an environment", () => {
+    expect(resolveEnvironmentAccentColor({ [local]: "#2563eb" }, local)).toBe("#2563eb");
+  });
+
+  it("returns undefined for an environment with no color", () => {
+    expect(resolveEnvironmentAccentColor({ [local]: "#2563eb" }, remote)).toBeUndefined();
+  });
+
+  it("returns undefined without an environment or a settings entry", () => {
+    expect(resolveEnvironmentAccentColor(undefined, local)).toBeUndefined();
+    expect(resolveEnvironmentAccentColor({ [local]: "#2563eb" }, null)).toBeUndefined();
+  });
+
+  it("ignores values that are not usable hex colors", () => {
+    expect(resolveEnvironmentAccentColor({ [local]: "rebeccapurple" }, local)).toBeUndefined();
+    expect(resolveEnvironmentAccentColor({ [local]: "#25f" }, local)).toBeUndefined();
+  });
+});
+
+describe("resolveSharedEnvironmentAccentColor", () => {
+  it("returns the color shared by every environment", () => {
+    expect(
+      resolveSharedEnvironmentAccentColor({ [local]: "#2563eb", [remote]: "#2563eb" }, [
+        local,
+        remote,
+      ]),
+    ).toBe("#2563eb");
+  });
+
+  it("returns undefined when the environments disagree", () => {
+    expect(
+      resolveSharedEnvironmentAccentColor({ [local]: "#2563eb", [remote]: "#16a34a" }, [
+        local,
+        remote,
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when only some environments are colored", () => {
+    expect(
+      resolveSharedEnvironmentAccentColor({ [local]: "#2563eb" }, [local, other]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an empty environment set", () => {
+    expect(resolveSharedEnvironmentAccentColor({ [local]: "#2563eb" }, [])).toBeUndefined();
+  });
+});
+
+describe("environmentAccentStyle", () => {
+  it("tints the glyph's fill by default", () => {
+    expect(environmentAccentStyle("#2563eb")).toEqual({ color: "#2563eb" });
+  });
+
+  it("tints stroke-drawn glyphs through the stroke property", () => {
+    expect(environmentAccentStyle("#2563eb", "stroke")).toEqual({ stroke: "#2563eb" });
+  });
+
+  it("leaves the default treatment in place for an uncolored environment", () => {
+    expect(environmentAccentStyle(undefined)).toBeUndefined();
+    expect(environmentAccentStyle(undefined, "stroke")).toBeUndefined();
+  });
+});
+
+describe("applyEnvironmentAccentColor", () => {
+  it("sets a color without disturbing the other environments", () => {
+    expect(applyEnvironmentAccentColor({ [local]: "#2563eb" }, remote, "#16a34a")).toEqual({
+      [local]: "#2563eb",
+      [remote]: "#16a34a",
+    });
+  });
+
+  it("replaces an existing color", () => {
+    expect(applyEnvironmentAccentColor({ [local]: "#2563eb" }, local, "#dc2626")).toEqual({
+      [local]: "#dc2626",
+    });
+  });
+
+  it("removes the key when the color is cleared", () => {
+    expect(
+      applyEnvironmentAccentColor({ [local]: "#2563eb", [remote]: "#16a34a" }, local, ""),
+    ).toEqual({ [remote]: "#16a34a" });
+    expect(applyEnvironmentAccentColor({ [local]: "#2563eb" }, local, undefined)).toEqual({});
+  });
+
+  it("drops values that are not usable hex colors instead of storing them", () => {
+    expect(applyEnvironmentAccentColor({ [local]: "#2563eb" }, local, "not-a-color")).toEqual({});
+  });
+
+  it("does not mutate the settings it was given", () => {
+    const accentColors = { [local]: "#2563eb" };
+    applyEnvironmentAccentColor(accentColors, local, undefined);
+    expect(accentColors).toEqual({ [local]: "#2563eb" });
+  });
+});

--- a/apps/web/src/environmentAccentColors.ts
+++ b/apps/web/src/environmentAccentColors.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-environment accent colors.
+ *
+ * Every environment indicator in the app (the sidebar cloud/server glyphs, the
+ * "Run on" selector, the project remote badge) is otherwise identical across
+ * environments, so a user running threads on several machines cannot tell at a
+ * glance *which* one a thread belongs to without hovering. Assigning a color
+ * per environment differentiates those existing glyphs without adding any
+ * text, which matters because sidebar rows have no horizontal room to spare.
+ *
+ * The mapping lives in client settings rather than server settings: it is a
+ * property of how *this* client distinguishes its environments, it must stay
+ * readable while an environment is disconnected, and no single backend should
+ * dictate it to the others.
+ *
+ * @module environmentAccentColors
+ */
+import type { ClientSettings, EnvironmentId } from "@t3tools/contracts";
+import { useCallback, type CSSProperties } from "react";
+
+import { normalizeAccentColor } from "./accentColors";
+import { useClientSettings, useUpdateClientSettings } from "./hooks/useSettings";
+
+export type EnvironmentAccentColors = ClientSettings["environmentAccentColors"];
+
+/**
+ * Read one environment's color, dropping anything that is not a usable hex
+ * value so callers can pass the result straight to CSS.
+ */
+export function resolveEnvironmentAccentColor(
+  accentColors: EnvironmentAccentColors | undefined,
+  environmentId: EnvironmentId | null | undefined,
+): string | undefined {
+  if (environmentId === null || environmentId === undefined) return undefined;
+  return normalizeAccentColor(accentColors?.[environmentId]);
+}
+
+/**
+ * Resolve the shared color for a set of environments: a mixed or uncolored set
+ * has no single color to show, so indicators that stand for several
+ * environments at once (a grouped project's remote badge) stay neutral.
+ */
+export function resolveSharedEnvironmentAccentColor(
+  accentColors: EnvironmentAccentColors | undefined,
+  environmentIds: readonly EnvironmentId[],
+): string | undefined {
+  const colors = new Set(
+    environmentIds.map((environmentId) =>
+      resolveEnvironmentAccentColor(accentColors, environmentId),
+    ),
+  );
+  const [color] = [...colors];
+  return colors.size === 1 ? color : undefined;
+}
+
+/**
+ * Set or clear one environment's color, leaving the rest of the map untouched.
+ * Clearing removes the key so the settings blob does not accumulate empties.
+ */
+export function applyEnvironmentAccentColor(
+  accentColors: EnvironmentAccentColors | undefined,
+  environmentId: EnvironmentId,
+  color: string | undefined,
+): Record<EnvironmentId, string> {
+  const next: Record<EnvironmentId, string> = { ...accentColors };
+  const normalized = normalizeAccentColor(color);
+  if (normalized === undefined) {
+    delete next[environmentId];
+  } else {
+    next[environmentId] = normalized;
+  }
+  return next;
+}
+
+/**
+ * Inline style that tints an environment glyph, or `undefined` to leave the
+ * glyph's default muted treatment in place. Returned as an inline style rather
+ * than a class so it can override the utility class already on the element;
+ * icons drawn with a stroke need `stroke` instead of `color`.
+ */
+export function environmentAccentStyle(
+  accentColor: string | undefined,
+  property: "color" | "stroke" = "color",
+): CSSProperties | undefined {
+  if (accentColor === undefined) return undefined;
+  return property === "stroke" ? { stroke: accentColor } : { color: accentColor };
+}
+
+export function useEnvironmentAccentColors(): EnvironmentAccentColors {
+  return useClientSettings((settings) => settings.environmentAccentColors);
+}
+
+export function useEnvironmentAccentColor(
+  environmentId: EnvironmentId | null | undefined,
+): string | undefined {
+  const accentColors = useEnvironmentAccentColors();
+  return resolveEnvironmentAccentColor(accentColors, environmentId);
+}
+
+export function useSetEnvironmentAccentColor(): (
+  environmentId: EnvironmentId,
+  color: string | undefined,
+) => void {
+  const accentColors = useEnvironmentAccentColors();
+  const updateSettings = useUpdateClientSettings();
+  return useCallback(
+    (environmentId, color) => {
+      updateSettings({
+        environmentAccentColors: applyEnvironmentAccentColor(accentColors, environmentId, color),
+      });
+    },
+    [accentColors, updateSettings],
+  );
+}

--- a/apps/web/src/environmentAccentColors.ts
+++ b/apps/web/src/environmentAccentColors.ts
@@ -19,7 +19,7 @@ import type { ClientSettings, EnvironmentId } from "@t3tools/contracts";
 import { useCallback, type CSSProperties } from "react";
 
 import { normalizeAccentColor } from "./accentColors";
-import { useClientSettings, useUpdateClientSettings } from "./hooks/useSettings";
+import { useClientSettings, useUpdateClientSettingsWith } from "./hooks/useSettings";
 
 export type EnvironmentAccentColors = ClientSettings["environmentAccentColors"];
 
@@ -101,14 +101,21 @@ export function useSetEnvironmentAccentColor(): (
   environmentId: EnvironmentId,
   color: string | undefined,
 ) => void {
-  const accentColors = useEnvironmentAccentColors();
-  const updateSettings = useUpdateClientSettings();
+  // Derived from the settings in effect at call time, not at render time: the
+  // picker commits on a delay, so two environments recolored in quick
+  // succession would otherwise both start from the same stale map and the
+  // second write would drop the first environment's color.
+  const updateSettings = useUpdateClientSettingsWith();
   return useCallback(
     (environmentId, color) => {
-      updateSettings({
-        environmentAccentColors: applyEnvironmentAccentColor(accentColors, environmentId, color),
-      });
+      updateSettings((settings) => ({
+        environmentAccentColors: applyEnvironmentAccentColor(
+          settings.environmentAccentColors,
+          environmentId,
+          color,
+        ),
+      }));
     },
-    [accentColors, updateSettings],
+    [updateSettings],
   );
 }

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -281,6 +281,25 @@ describe("environment grouping", () => {
     );
   });
 
+  it("reports the remote environments backing a group's remote labels", () => {
+    const primary = makeProject({ repositoryIdentity });
+    const remote = makeProject({
+      id: ProjectId.make("project-remote"),
+      environmentId: remoteEnvironmentId,
+      repositoryIdentity,
+    });
+    const [group] = buildSidebarProjectSnapshots({
+      projects: [primary, remote],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: (environmentId) =>
+        environmentId === remoteEnvironmentId ? "ryzen-shine" : null,
+    });
+
+    expect(group?.remoteEnvironmentIds).toEqual([remoteEnvironmentId]);
+    expect(group?.remoteEnvironmentLabels).toEqual(["ryzen-shine"]);
+  });
+
   it("builds one picker entry per logical project and targets the preferred environment", () => {
     const primary = makeProject({ repositoryIdentity });
     const remote = makeProject({

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -290,6 +290,25 @@ export function useUpdateClientSettings() {
   }, []);
 }
 
+/**
+ * Client-settings updater whose patch is derived from the settings in effect at
+ * call time rather than at render time.
+ *
+ * Use it whenever the new value is computed from the old one — merging one key
+ * into a record, toggling a flag. Deriving from a render-time snapshot loses
+ * writes when two updates run before React re-renders, because both start from
+ * the same stale value and the second overwrites the first.
+ */
+export function useUpdateClientSettingsWith() {
+  return useCallback((derivePatch: (settings: ClientSettings) => ClientSettingsPatch) => {
+    const settings = getClientSettingsSnapshot();
+    persistClientSettings({
+      ...settings,
+      ...derivePatch(settings),
+    });
+  }, []);
+}
+
 export function __resetClientSettingsPersistenceForTests(): void {
   clientSettingsHydrationGeneration += 1;
   clientSettingsSnapshot = DEFAULT_CLIENT_SETTINGS;

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -142,6 +142,19 @@ function persistClientSettings(settings: ClientSettings): void {
     });
 }
 
+function updateClientSettings(
+  deriveSettings: (settings: ClientSettings) => ClientSettings,
+): void {
+  if (!clientSettingsHydrated) {
+    void hydrateClientSettings().then(() => {
+      updateClientSettings(deriveSettings);
+    });
+    return;
+  }
+
+  persistClientSettings(deriveSettings(getClientSettingsSnapshot()));
+}
+
 // ── Key sets for routing patches ─────────────────────────────────────
 
 const SERVER_SETTINGS_KEYS = new Set<string>(Struct.keys(ServerSettings.fields));
@@ -261,10 +274,10 @@ function useUpdateSettingsTarget(environmentId: EnvironmentId | null) {
       }
 
       if (Object.keys(clientPatch).length > 0) {
-        persistClientSettings({
-          ...getClientSettingsSnapshot(),
+        updateClientSettings((settings) => ({
+          ...settings,
           ...clientPatch,
-        });
+        }));
       }
     },
     [environmentId, persistServerSettings],
@@ -283,10 +296,10 @@ export function useUpdatePrimarySettings() {
 
 export function useUpdateClientSettings() {
   return useCallback((patch: ClientSettingsPatch) => {
-    persistClientSettings({
-      ...getClientSettingsSnapshot(),
+    updateClientSettings((settings) => ({
+      ...settings,
       ...patch,
-    });
+    }));
   }, []);
 }
 
@@ -301,11 +314,10 @@ export function useUpdateClientSettings() {
  */
 export function useUpdateClientSettingsWith() {
   return useCallback((derivePatch: (settings: ClientSettings) => ClientSettingsPatch) => {
-    const settings = getClientSettingsSnapshot();
-    persistClientSettings({
+    updateClientSettings((settings) => ({
       ...settings,
       ...derivePatch(settings),
-    });
+    }));
   }, []);
 }
 

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -25,6 +25,7 @@ import {
   type ServerProviderState,
 } from "@t3tools/contracts";
 
+import { normalizeAccentColor } from "./accentColors";
 import { formatProviderDriverKindLabel } from "./providerModels";
 
 /**
@@ -110,9 +111,7 @@ function driverKindLabel(driverKind: ProviderDriverKind): string {
 }
 
 export function normalizeProviderAccentColor(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) return undefined;
-  return /^#[0-9a-fA-F]{6}$/u.test(trimmed) ? trimmed : undefined;
+  return normalizeAccentColor(value);
 }
 
 /**

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -29,6 +29,10 @@ export interface SidebarProjectSnapshot extends Project {
   memberProjects: readonly SidebarProjectGroupMember[];
   memberProjectRefs: readonly ScopedProjectRef[];
   remoteEnvironmentLabels: readonly string[];
+  // Environments backing `remoteEnvironmentLabels`, in the same order. The
+  // header badge stands for all of them at once, so it can only take on an
+  // accent color when they agree on one.
+  remoteEnvironmentIds: readonly EnvironmentId[];
 }
 
 export interface SidebarProjectPickerEntry {
@@ -191,6 +195,11 @@ export function buildSidebarProjectSnapshots(input: {
     const remoteEnvironmentLabels = remoteMembers
       .flatMap((member) => (member.environmentLabel ? [member.environmentLabel] : []))
       .filter((label, index, labels) => labels.indexOf(label) === index);
+    const remoteEnvironmentIds = remoteMembers
+      .map((member) => member.environmentId)
+      .filter(
+        (environmentId, index, environmentIds) => environmentIds.indexOf(environmentId) === index,
+      );
     const isDesktopLocal = input.isDesktopLocalEnvironment ?? (() => false);
     const allRemoteMembersAreDesktopLocal =
       remoteMembers.length > 0 &&
@@ -213,6 +222,7 @@ export function buildSidebarProjectSnapshots(input: {
       memberProjects: members,
       memberProjectRefs: projectRefsByLogicalKey.get(logicalKey) ?? [],
       remoteEnvironmentLabels,
+      remoteEnvironmentIds,
     });
   }
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,7 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
-import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
+import { EnvironmentId, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { DEFAULT_TEXT_GENERATION_MODEL, ProviderOptionSelections } from "./model.ts";
 import { ModelSelection } from "./orchestration.ts";
 import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.ts";
@@ -67,6 +67,14 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed([])),
   ),
   diffIgnoreWhitespace: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  // Per-environment accent colors, keyed by environment id. Client-local
+  // rather than server-backed: the color identifies an environment from *this*
+  // client's point of view, so it has to be readable even while that
+  // environment is disconnected, and it should not be dictated to other
+  // clients by whichever backend happens to be primary.
+  environmentAccentColors: Schema.Record(EnvironmentId, TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
   ),
@@ -627,6 +635,7 @@ export const ClientSettingsPatch = Schema.Struct({
       }),
     ),
   ),
+  environmentAccentColors: Schema.optionalKey(Schema.Record(EnvironmentId, TrimmedNonEmptyString)),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(


### PR DESCRIPTION
## What Changed

- Added a per-environment accent color, chosen by the user and stored in client settings (`environmentAccentColors`, keyed by `EnvironmentId`).
- Added an **Accent color** control to Settings → Connections, both for "This environment" and for every saved remote environment row.
- Tinted the environment glyphs that already exist with the chosen color — no new text anywhere:
  - the remote cloud glyph on sidebar thread rows,
  - the project header remote/sandbox badge (only when every remote member of the group agrees on one color),
  - the sidebar v2 row server glyph and its hover-tooltip environment row,
  - the sidebar v2 project-actions environment rows,
  - the `Run on` environment selector (trigger and each item).
- Generalized the existing `ProviderAccentColorPicker` into a reusable `AccentColorPicker` and reused it for environments rather than duplicating the swatch/custom-color UI.

## Why

Every environment indicator draws the same glyph, so someone running threads on several machines cannot tell *which* environment a thread belongs to without hovering. Color differentiates the indicators that are already on screen.

Deliberately no labels: sidebar rows have no horizontal room to spare, so this rides entirely on existing glyphs.

The mapping is client-local rather than server-backed on purpose. It describes how *this* client distinguishes its environments, it has to stay readable while an environment is disconnected, and no single backend should dictate it to the others.

## UI Changes

| Accent color row (unset) | Picker open | Color chosen |
| --- | --- | --- |
| ![Accent color row with no color set](https://raw.githubusercontent.com/colonelpanic8/t3code/87575adbe7f95b8e704433a99a0b2e8ecf64f5b1/environment-accent-color/settings-row-before.png) | ![Accent color picker popover with swatches](https://raw.githubusercontent.com/colonelpanic8/t3code/87575adbe7f95b8e704433a99a0b2e8ecf64f5b1/environment-accent-color/picker-open.png) | ![Accent color row showing the chosen green](https://raw.githubusercontent.com/colonelpanic8/t3code/87575adbe7f95b8e704433a99a0b2e8ecf64f5b1/environment-accent-color/settings-row-after.png) |

Verified live in the web app: the row renders for the current environment, the popover offers the six shared swatches plus the custom hex/HSV picker and a clear action, and the choice round-trips through client settings (`environmentAccentColors` in persisted client settings) and is reflected back in the control.

The tinted remote glyphs themselves need a second, genuinely remote backend to appear. I could not pair two local dev servers in a browser to capture that: cross-origin pairing is blocked because `/.well-known/t3/environment` and `/api/auth/pair` do not send `access-control-allow-origin` (pre-existing, unrelated to this change). The tinting logic is covered by tests instead, and the render sites are one-line style applications of `environmentAccentStyle`.

## Checklist

- [x] `vp test run apps/web/src/environmentAccentColors.test.ts apps/web/src/environmentGrouping.test.ts` (30 tests)
- [x] `vp test run apps/desktop/src/settings/DesktopClientSettings.test.ts` (7 tests)
- [x] `vp run --filter @t3tools/web typecheck`
- [x] `vp run --filter @t3tools/contracts typecheck`
- [x] `vp run --filter @t3tools/desktop typecheck`
- [x] `vp run --filter @t3tools/client-runtime typecheck`
- [x] `vp run --filter @t3tools/mobile typecheck`
- [x] `vp lint` and `vp fmt` on every changed file
- [x] Exercised the real settings flow in the running web app and confirmed persistence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-local UI preferences and presentation-only icon styling; schema adds an optional defaulted field with tests covering normalization and grouping.
> 
> **Overview**
> Adds **per-environment accent colors** stored in client settings (`environmentAccentColors`) so users can tell remote/local environments apart without extra labels.
> 
> **Settings & persistence:** New `Accent color` rows in Connections (primary + each remote environment) via `EnvironmentAccentColorControl`. Shared `accentColors` helpers and generalized `AccentColorPicker` (formerly provider-only); provider normalization delegates to the same `#rrggbb` rules.
> 
> **UI tinting:** Existing cloud/server/monitor glyphs get inline `environmentAccentStyle` tints in the sidebar, Sidebar v2, branch toolbar “Run on” selector, and grouped project remote badges (only when all remote members share one color). `sidebarProjectGrouping` now exposes `remoteEnvironmentIds` for that shared-color logic.
> 
> **Concurrency fix:** `useUpdateClientSettingsWith` and snapshot-based `updateClientSettings` so rapid color commits (and other merge-into-record patches) don’t overwrite each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb2df50fccda583fe0a75b725b3bad3b654210d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Color environment indicators per environment accent color in sidebar and toolbar
> - Adds a per-environment accent color map to `ClientSettingsSchema` (keyed by `EnvironmentId`) and supporting hooks/utilities in [`environmentAccentColors.ts`](https://github.com/pingdotgg/t3code/pull/4505/files#diff-8fb3987501434a3b363a3b314f3942d2ca492fac2f652d8e4018c60982ce9bb4) to read, write, and normalize colors.
> - Tints environment icons (server, cloud, monitor) throughout the sidebar, sidebar v2, and branch toolbar using the resolved accent color via inline styles.
> - Adds an `EnvironmentAccentColorControl` component and integrates it into the Connections settings page so users can set or clear per-environment colors from saved backend rows and the primary environment section.
> - Refactors `useUpdateClientSettings` and related hooks in [`useSettings.ts`](https://github.com/pingdotgg/t3code/pull/4505/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) to derive updates from the latest settings snapshot, preventing lost writes from concurrent updates.
> - Generalizes `AccentColorPicker` (previously provider-only) to support both provider and environment use cases with shared swatches and stricter `#rrggbb`-only normalization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffb2df5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->