### PR TITLE
Show answered questions in the thread timeline

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1011,6 +1011,152 @@ describe("deriveMessagesTimelineRows", () => {
       expanded: true,
     });
   });
+
+  it("keeps a clarifying-question exchange out of the collapsed work group", () => {
+    const userInput = {
+      requestId: "req-1",
+      answered: true,
+      questions: [
+        {
+          id: "Approach?",
+          header: "Approach",
+          question: "Approach?",
+          multiSelect: false,
+          options: [{ label: "Ship it", description: "Merge as-is" }],
+          selectedLabels: ["Ship it"],
+        },
+      ],
+    };
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-entry-1",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:01Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:01Z",
+            label: "read",
+            tone: "tool" as const,
+          },
+        },
+        {
+          id: "user-input-entry",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:02Z",
+          entry: {
+            id: "user-input-1",
+            createdAt: "2026-01-01T00:00:02Z",
+            label: "Question: Approach",
+            tone: "info" as const,
+            userInput,
+          },
+        },
+        {
+          id: "work-entry-2",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:03Z",
+          entry: {
+            id: "work-2",
+            createdAt: "2026-01-01T00:00:03Z",
+            label: "edit",
+            tone: "tool" as const,
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["work-entry-1", "user-input-entry", "work-entry-2"]);
+    expect(rows.find((row) => row.kind === "user-input")).toMatchObject({ userInput });
+  });
+
+  it("keeps a clarifying-question exchange visible after its turn folds", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-entry",
+          kind: "message" as const,
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user" as const,
+            text: "ship the fix",
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-entry-1",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:05Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:05Z",
+            turnId: "turn-1" as never,
+            label: "Ran command",
+            tone: "tool" as const,
+          },
+        },
+        {
+          id: "user-input-entry",
+          kind: "work" as const,
+          createdAt: "2026-01-01T00:00:08Z",
+          entry: {
+            id: "user-input-1",
+            createdAt: "2026-01-01T00:00:08Z",
+            turnId: "turn-1" as never,
+            label: "Question: Approach",
+            tone: "info" as const,
+            userInput: {
+              requestId: "req-1",
+              answered: true,
+              questions: [
+                {
+                  id: "Approach?",
+                  header: "Approach",
+                  question: "Approach?",
+                  multiSelect: false,
+                  options: [{ label: "Ship it", description: "Merge as-is" }],
+                  selectedLabels: ["Ship it"],
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: "assistant-final-entry",
+          kind: "message" as const,
+          createdAt: "2026-01-01T00:00:20Z",
+          message: {
+            id: "assistant-final" as never,
+            role: "assistant" as const,
+            text: "Shipped",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:20Z",
+            updatedAt: "2026-01-01T00:00:22Z",
+            streaming: false,
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "user-entry",
+      "turn-fold:turn-1",
+      "user-input-entry",
+      "assistant-final-entry",
+    ]);
+  });
 });
 
 describe("computeStableMessagesTimelineRows", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -5,6 +5,7 @@ import {
   workLogEntryIsToolLike,
   type TimelineEntry,
   type WorkLogEntry,
+  type WorkLogUserInput,
 } from "../../session-logic";
 import { type ChatMessage, type ProposedPlan, type TurnDiffSummary } from "../../types";
 import { type MessageId, type OrchestrationLatestTurn, type TurnId } from "@t3tools/contracts";
@@ -174,6 +175,13 @@ export type MessagesTimelineRow =
       id: string;
       createdAt: string;
       proposedPlan: ProposedPlan;
+    }
+  | {
+      kind: "user-input";
+      id: string;
+      createdAt: string;
+      entry: WorkLogEntry;
+      userInput: WorkLogUserInput;
     }
   | { kind: "working"; id: string; createdAt: string | null };
 
@@ -352,9 +360,15 @@ function deriveTurnFolds(input: {
     }
     const hiddenEntryIds = new Set<string>();
     for (const entry of group.entries) {
-      if (entry.id !== group.terminalEntry?.id) {
-        hiddenEntryIds.add(entry.id);
+      if (entry.id === group.terminalEntry?.id) {
+        continue;
       }
+      // A clarifying question and its answer record a decision the user made;
+      // keep them readable once the turn settles instead of folding them away.
+      if (entry.kind === "work" && entry.entry.userInput !== undefined) {
+        continue;
+      }
+      hiddenEntryIds.add(entry.id);
     }
     if (hiddenEntryIds.size === 0) {
       continue;
@@ -460,6 +474,20 @@ export function deriveMessagesTimelineRows(input: {
     }
 
     if (timelineEntry.kind === "work") {
+      // Clarifying-question exchanges are conversation, not tool noise: they get
+      // their own row so neither work-group collapsing nor a turn fold hides them.
+      const userInput = timelineEntry.entry.userInput;
+      if (userInput) {
+        nextRows.push({
+          kind: "user-input",
+          id: timelineEntry.id,
+          createdAt: timelineEntry.createdAt,
+          entry: timelineEntry.entry,
+          userInput,
+        });
+        continue;
+      }
+
       const groupedEntries = [timelineEntry.entry];
       let cursor = index + 1;
       while (cursor < input.timelineEntries.length) {
@@ -467,6 +495,7 @@ export function deriveMessagesTimelineRows(input: {
         if (
           !nextEntry ||
           nextEntry.kind !== "work" ||
+          nextEntry.entry.userInput !== undefined ||
           collapsedEntryIds.has(nextEntry.id) ||
           foldsByAnchorEntryId.has(nextEntry.id)
         ) {
@@ -612,6 +641,9 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
 
     case "work":
       return Equal.equals(a.groupedEntries, (b as typeof a).groupedEntries);
+
+    case "user-input":
+      return Equal.equals(a.userInput, (b as typeof a).userInput);
 
     case "work-toggle": {
       const bw = b as typeof a;

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -527,6 +527,89 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Work Log");
   });
 
+  it("renders a clarifying question with the answer it received", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Question: Approach",
+              tone: "info",
+              userInput: {
+                requestId: "req-1",
+                answered: true,
+                questions: [
+                  {
+                    id: "How should we proceed?",
+                    header: "Approach",
+                    question: "How should we proceed?",
+                    multiSelect: false,
+                    options: [
+                      { label: "Ship it", description: "Merge as-is" },
+                      { label: "Iterate", description: "Another review round" },
+                    ],
+                    selectedLabels: ["Iterate"],
+                  },
+                ],
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Approach");
+    expect(markup).toContain("How should we proceed?");
+    expect(markup).toContain("Iterate");
+    expect(markup).toContain("Show options");
+    // The chosen answer reads on its own; alternatives stay behind the toggle.
+    expect(markup).not.toContain("Another review round");
+  });
+
+  it("marks an unanswered clarifying question as awaiting a reply", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Question: Approach",
+              tone: "info",
+              userInput: {
+                requestId: "req-1",
+                answered: false,
+                questions: [
+                  {
+                    id: "How should we proceed?",
+                    header: "Approach",
+                    question: "How should we proceed?",
+                    multiSelect: false,
+                    options: [{ label: "Ship it", description: "Merge as-is" }],
+                    selectedLabels: [],
+                  },
+                ],
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Awaiting your answer");
+    expect(markup).not.toContain("Work Log");
+  });
+
   it("formats changed file paths from the workspace root", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -834,6 +834,10 @@ type TimelineEntry = ReturnType<typeof deriveTimelineEntries>[number];
 type TimelineMessage = Extract<TimelineEntry, { kind: "message" }>["message"];
 type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"][number];
 type TimelineRow = MessagesTimelineRow;
+type TimelineUserInputQuestion = Extract<
+  MessagesTimelineRow,
+  { kind: "user-input" }
+>["userInput"]["questions"][number];
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
   return (
@@ -861,6 +865,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
         <AssistantTimelineRow row={row} />
       ) : null}
       {row.kind === "proposed-plan" ? <ProposedPlanTimelineRow row={row} /> : null}
+      {row.kind === "user-input" ? <UserInputTimelineRow row={row} /> : null}
       {row.kind === "working" ? <WorkingTimelineRow row={row} /> : null}
     </div>
   );
@@ -1230,6 +1235,113 @@ function WorkGroupToggleTimelineRow({
         </span>
       )}
     </button>
+  );
+}
+
+/**
+ * A clarifying-question round trip: what the agent asked and what the user
+ * picked. The interactive prompt lives in the composer, so this row is the
+ * thread's only lasting record of the exchange.
+ */
+const UserInputTimelineRow = memo(function UserInputTimelineRow({
+  row,
+}: {
+  row: Extract<TimelineRow, { kind: "user-input" }>;
+}) {
+  const [showOptions, setShowOptions] = useState(false);
+  const { userInput } = row;
+  const hasUnpickedOptions = userInput.questions.some(
+    (question) => question.options.length > question.selectedLabels.length,
+  );
+
+  return (
+    <section
+      className="rounded-lg border border-border/45 bg-muted/16 px-3 py-2.5"
+      aria-label={row.entry.label}
+    >
+      {userInput.questions.map((question, index) => (
+        <div key={question.id} className={cn(index > 0 && "mt-3 border-t border-border/40 pt-3")}>
+          <div className="flex items-center gap-1.5 text-muted-foreground/60">
+            <MessageCircleIcon className="size-3.5 shrink-0 stroke-[1.8]" aria-hidden />
+            <span className="min-w-0 truncate text-[11px] font-semibold uppercase tracking-widest">
+              {question.header}
+            </span>
+          </div>
+          <p className="mt-1.5 text-[13px] leading-5 text-foreground/85">{question.question}</p>
+          <UserInputAnswer answered={userInput.answered} question={question} />
+          {showOptions && question.options.length > 0 ? (
+            <ul className="mt-2 space-y-1">
+              {question.options.map((option) => {
+                const picked = question.selectedLabels.includes(option.label);
+                return (
+                  <li
+                    key={option.label}
+                    className={cn(
+                      "rounded-md px-2 py-1 text-[12px] leading-4",
+                      picked ? "bg-primary/8 text-foreground/85" : "text-muted-foreground/70",
+                    )}
+                  >
+                    <span className="font-medium">{option.label}</span>
+                    {option.description && option.description !== option.label ? (
+                      <span className="ms-1.5 text-muted-foreground/60">{option.description}</span>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </div>
+      ))}
+      {hasUnpickedOptions ? (
+        <button
+          type="button"
+          className="mt-2 flex cursor-pointer items-center gap-1 rounded-md text-[11px] text-muted-foreground/60 transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
+          aria-expanded={showOptions}
+          onClick={() => setShowOptions((value) => !value)}
+        >
+          <ChevronDownIcon
+            className={cn("size-3 transition-transform duration-200", showOptions && "rotate-180")}
+            aria-hidden
+          />
+          {showOptions ? "Hide options" : "Show options"}
+        </button>
+      ) : null}
+    </section>
+  );
+});
+
+function UserInputAnswer({
+  answered,
+  question,
+}: {
+  answered: boolean;
+  question: TimelineUserInputQuestion;
+}) {
+  const { selectedLabels, customAnswer } = question;
+
+  if (selectedLabels.length === 0 && !customAnswer) {
+    return (
+      <p className="mt-2 text-[12px] italic leading-5 text-muted-foreground/60">
+        {answered ? "No answer recorded" : "Awaiting your answer"}
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-2 space-y-1">
+      {selectedLabels.map((label) => (
+        <p key={label} className="flex items-start gap-1.5 text-[12px] leading-5 text-foreground">
+          <CheckIcon className="mt-0.5 size-3 shrink-0 text-primary" aria-hidden />
+          <span className="min-w-0 font-medium">{label}</span>
+        </p>
+      ))}
+      {customAnswer ? (
+        <p className="flex items-start gap-1.5 text-[12px] leading-5 text-foreground/90">
+          <CheckIcon className="mt-0.5 size-3 shrink-0 text-primary" aria-hidden />
+          <span className="min-w-0 whitespace-pre-wrap italic">{customAnswer}</span>
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1595,6 +1595,61 @@ describe("deriveWorkLogEntries clarifying questions", () => {
     expect(entries[0]?.userInput?.questions[0]?.customAnswer).toBeUndefined();
   });
 
+  it("keeps an option label that contains a comma whole", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "ask",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-1",
+          questions: [
+            {
+              id: "Scope?",
+              header: "Scope",
+              question: "Scope?",
+              options: [
+                { label: "Small, safe change", description: "Minimal diff" },
+                { label: "Tests", description: "Add coverage" },
+              ],
+              multiSelect: true,
+            },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "answer",
+        createdAt: "2026-02-23T00:00:09.000Z",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        tone: "info",
+        payload: { requestId: "req-1", answers: { "Scope?": "Small, safe change, Tests" } },
+      }),
+    ]);
+
+    expect(entries[0]?.userInput?.questions[0]?.selectedLabels).toEqual([
+      "Small, safe change",
+      "Tests",
+    ]);
+    expect(entries[0]?.userInput?.questions[0]?.customAnswer).toBeUndefined();
+  });
+
+  it("keeps a multi-select free-text answer containing a comma intact", () => {
+    const entries = deriveWorkLogEntries(
+      makeQuestionActivities({
+        multiSelect: true,
+        answers: { "How should we proceed?": "Ship it, but revert the migration first" },
+      }),
+    );
+
+    expect(entries[0]?.userInput?.questions[0]?.selectedLabels).toEqual([]);
+    expect(entries[0]?.userInput?.questions[0]?.customAnswer).toBe(
+      "Ship it, but revert the migration first",
+    );
+  });
+
   it("shows the question while it is still unanswered", () => {
     const entries = deriveWorkLogEntries(makeQuestionActivities({}));
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1581,6 +1581,20 @@ describe("deriveWorkLogEntries clarifying questions", () => {
     expect(entries[0]?.userInput?.questions[0]?.selectedLabels).toEqual(["Ship it", "Iterate"]);
   });
 
+  it("classifies comma-joined multi-select answers from OpenCode", () => {
+    const entries = deriveWorkLogEntries(
+      makeQuestionActivities({
+        multiSelect: true,
+        answers: { "How should we proceed?": "Iterate, Ship it" },
+      }),
+    );
+
+    expect(entries[0]?.userInput?.questions[0]).toMatchObject({
+      selectedLabels: ["Ship it", "Iterate"],
+    });
+    expect(entries[0]?.userInput?.questions[0]?.customAnswer).toBeUndefined();
+  });
+
   it("shows the question while it is still unanswered", () => {
     const entries = deriveWorkLogEntries(makeQuestionActivities({}));
 
@@ -1664,6 +1678,43 @@ describe("deriveWorkLogEntries clarifying questions", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.userInput).toBeUndefined();
     expect(entries[0]?.label).toBe("User input requested");
+  });
+
+  it("replaces an unparsed request row when its answer arrives", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "ask-broken",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: { requestId: "req-1", questions: [{ header: "Approach" }] },
+      }),
+      makeActivity({
+        id: "answer",
+        createdAt: "2026-02-23T00:00:09.000Z",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        tone: "info",
+        payload: {
+          requestId: "req-1",
+          answers: { "How should we proceed?": "Ship it" },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe("ask-broken");
+    expect(entries[0]?.userInput).toMatchObject({
+      requestId: "req-1",
+      answered: true,
+      questions: [
+        {
+          question: "How should we proceed?",
+          customAnswer: "Ship it",
+        },
+      ],
+    });
   });
 });
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1668,6 +1668,17 @@ describe("deriveWorkLogEntries clarifying questions", () => {
         payload: { itemType: "dynamic_tool_call", detail: "AskUserQuestion: {}" },
       }),
       makeActivity({
+        id: "tool-updated",
+        createdAt: "2026-02-23T00:00:00.750Z",
+        kind: "tool.updated",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          detail: 'AskUserQuestion: {"questions":[{"question":"How should we proceed?"}]}',
+          data: { toolName: "AskUserQuestion" },
+        },
+      }),
+      makeActivity({
         id: "tool-completed",
         createdAt: "2026-02-23T00:00:10.000Z",
         kind: "tool.completed",
@@ -1683,6 +1694,78 @@ describe("deriveWorkLogEntries clarifying questions", () => {
 
     expect(entries).toHaveLength(1);
     expect(entries[0]?.userInput?.answered).toBe(true);
+  });
+
+  it("keeps the AskUserQuestion tool fallback when structured questions cannot be parsed", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "tool-started",
+        createdAt: "2026-02-23T00:00:00.500Z",
+        kind: "tool.started",
+        summary: "Tool call started",
+        payload: { itemType: "dynamic_tool_call", detail: "AskUserQuestion: {}" },
+      }),
+      makeActivity({
+        id: "ask-broken",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: { requestId: "req-1", questions: [{ header: "Approach" }] },
+      }),
+      makeActivity({
+        id: "tool-completed",
+        createdAt: "2026-02-23T00:00:10.000Z",
+        kind: "tool.completed",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          detail: 'AskUserQuestion: {"questions":[{"question":"How should we proceed?"}]}',
+          data: { toolName: "AskUserQuestion" },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: "ask-broken",
+      label: "User input requested",
+    });
+    expect(entries[1]).toMatchObject({
+      id: "tool-completed",
+      sourceActivityKind: "tool.completed",
+      detail: 'AskUserQuestion: {"questions":[{"question":"How should we proceed?"}]}',
+    });
+  });
+
+  it("marks a stale unanswered request as no longer awaiting an answer", () => {
+    const entries = deriveWorkLogEntries([
+      ...makeQuestionActivities({}),
+      makeActivity({
+        id: "user-input-failed-stale",
+        createdAt: "2026-02-23T00:00:09.000Z",
+        kind: "provider.user-input.respond.failed",
+        summary: "Provider user input response failed",
+        tone: "error",
+        payload: {
+          requestId: "req-1",
+          detail:
+            "Provider adapter request failed (codex) for item/tool/requestUserInput: Unknown pending Codex user input request: req-1",
+        },
+      }),
+    ]);
+
+    expect(entries[0]?.userInput).toMatchObject({
+      requestId: "req-1",
+      answered: true,
+    });
+    expect(entries[0]?.userInput?.questions[0]).toMatchObject({
+      selectedLabels: [],
+    });
+    expect(entries[1]).toMatchObject({
+      id: "user-input-failed-stale",
+      tone: "error",
+    });
   });
 
   it("still shows the answer when the request activity is out of view", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1492,6 +1492,181 @@ describe("deriveWorkLogEntries", () => {
   });
 });
 
+describe("deriveWorkLogEntries clarifying questions", () => {
+  function makeQuestionActivities(options: {
+    readonly multiSelect?: boolean;
+    readonly answers?: Record<string, unknown>;
+  }): OrchestrationThreadActivity[] {
+    const requested = makeActivity({
+      id: "ask",
+      createdAt: "2026-02-23T00:00:01.000Z",
+      kind: "user-input.requested",
+      summary: "User input requested",
+      tone: "info",
+      payload: {
+        requestId: "req-1",
+        questions: [
+          {
+            id: "How should we proceed?",
+            header: "Approach",
+            question: "How should we proceed?",
+            options: [
+              { label: "Ship it", description: "Merge as-is" },
+              { label: "Iterate", description: "Another review round" },
+            ],
+            multiSelect: options.multiSelect === true,
+          },
+        ],
+      },
+    });
+    if (!options.answers) {
+      return [requested];
+    }
+    return [
+      requested,
+      makeActivity({
+        id: "answer",
+        createdAt: "2026-02-23T00:00:09.000Z",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        tone: "info",
+        payload: { requestId: "req-1", answers: options.answers },
+      }),
+    ];
+  }
+
+  it("merges the request and its answer into one entry carrying the picked option", () => {
+    const entries = deriveWorkLogEntries(
+      makeQuestionActivities({ answers: { "How should we proceed?": "Iterate" } }),
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.label).toBe("Question: Approach");
+    expect(entries[0]?.userInput).toEqual({
+      requestId: "req-1",
+      answered: true,
+      questions: [
+        {
+          id: "How should we proceed?",
+          header: "Approach",
+          question: "How should we proceed?",
+          multiSelect: false,
+          options: [
+            { label: "Ship it", description: "Merge as-is" },
+            { label: "Iterate", description: "Another review round" },
+          ],
+          selectedLabels: ["Iterate"],
+        },
+      ],
+    });
+  });
+
+  it("keeps a free-text answer that matched no option", () => {
+    const entries = deriveWorkLogEntries(
+      makeQuestionActivities({ answers: { "How should we proceed?": "  Split it in two  " } }),
+    );
+
+    expect(entries[0]?.userInput?.questions[0]?.selectedLabels).toEqual([]);
+    expect(entries[0]?.userInput?.questions[0]?.customAnswer).toBe("Split it in two");
+  });
+
+  it("lists multi-select answers in question order", () => {
+    const entries = deriveWorkLogEntries(
+      makeQuestionActivities({
+        multiSelect: true,
+        answers: { "How should we proceed?": ["Iterate", "Ship it"] },
+      }),
+    );
+
+    expect(entries[0]?.userInput?.questions[0]?.selectedLabels).toEqual(["Ship it", "Iterate"]);
+  });
+
+  it("shows the question while it is still unanswered", () => {
+    const entries = deriveWorkLogEntries(makeQuestionActivities({}));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.userInput?.answered).toBe(false);
+    expect(entries[0]?.userInput?.questions[0]?.selectedLabels).toEqual([]);
+  });
+
+  it("drops the duplicate AskUserQuestion tool rows", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "tool-started",
+        createdAt: "2026-02-23T00:00:00.500Z",
+        kind: "tool.started",
+        summary: "Tool call started",
+        payload: { itemType: "dynamic_tool_call", detail: "AskUserQuestion: {}" },
+      }),
+      makeActivity({
+        id: "tool-completed",
+        createdAt: "2026-02-23T00:00:10.000Z",
+        kind: "tool.completed",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          detail: 'AskUserQuestion: {"questions":[{"question":"How should we proceed?"}]}',
+          data: { toolName: "AskUserQuestion" },
+        },
+      }),
+      ...makeQuestionActivities({ answers: { "How should we proceed?": "Ship it" } }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.userInput?.answered).toBe(true);
+  });
+
+  it("still shows the answer when the request activity is out of view", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "answer-only",
+        createdAt: "2026-02-23T00:00:09.000Z",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        tone: "info",
+        payload: {
+          requestId: "req-1",
+          answers: { "How should we proceed?": "Ship it" },
+        },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.userInput).toEqual({
+      requestId: "req-1",
+      answered: true,
+      questions: [
+        {
+          id: "How should we proceed?",
+          header: "Answer",
+          question: "How should we proceed?",
+          multiSelect: false,
+          options: [],
+          selectedLabels: [],
+          customAnswer: "Ship it",
+        },
+      ],
+    });
+  });
+
+  it("falls back to the generic row when the questions cannot be parsed", () => {
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "ask-broken",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: { requestId: "req-1", questions: [{ header: "Approach" }] },
+      }),
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.userInput).toBeUndefined();
+    expect(entries[0]?.label).toBe("User input requested");
+  });
+});
+
 describe("deriveTimelineEntries", () => {
   it("includes proposed plans alongside messages and work entries in chronological order", () => {
     const entries = deriveTimelineEntries(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -483,8 +483,18 @@ function parseUserInputQuestions(
   return parsed.length > 0 ? parsed : null;
 }
 
-function parseUserInputAnswerValues(value: unknown): ReadonlyArray<string> {
-  const values = typeof value === "string" ? [value] : Array.isArray(value) ? value : [];
+function parseUserInputAnswerValues(
+  value: unknown,
+  splitCommaSeparated: boolean = false,
+): ReadonlyArray<string> {
+  const values =
+    typeof value === "string"
+      ? splitCommaSeparated
+        ? value.split(",")
+        : [value]
+      : Array.isArray(value)
+        ? value
+        : [];
   return values.flatMap((entry) => {
     if (typeof entry !== "string") return [];
     const trimmed = entry.trim();
@@ -506,8 +516,14 @@ function toWorkLogUserInputQuestion(
   question: AskedUserInputQuestion,
   answers: Record<string, unknown> | null,
 ): WorkLogUserInputQuestion {
-  const answered = parseUserInputAnswerValues(answers?.[question.id]);
   const optionLabels = new Set(question.options.map((option) => option.label));
+  const rawAnswer = answers?.[question.id];
+  const rawAnswerIsExactOption =
+    typeof rawAnswer === "string" && optionLabels.has(rawAnswer.trim());
+  const answered = parseUserInputAnswerValues(
+    rawAnswer,
+    question.multiSelect === true && !rawAnswerIsExactOption,
+  );
   // Keep question order rather than answer order so multi-select reads consistently.
   const selectedLabels = question.options
     .map((option) => option.label)
@@ -781,15 +797,17 @@ export function deriveWorkLogEntries(
       const payload = asRecord(activity.payload);
       const requestId = asTrimmedString(payload?.requestId);
       const questions = parseUserInputQuestions(payload);
-      if (requestId && questions) {
-        const derived = toWorkLogUserInputEntry(activity, {
-          requestId,
-          answered: false,
-          questions: questions.map((question) => toWorkLogUserInputQuestion(question, null)),
-        });
+      if (requestId) {
         userInputEntryIndexByRequestId.set(requestId, entries.length);
-        entries.push(derived);
-        continue;
+        if (questions) {
+          const derived = toWorkLogUserInputEntry(activity, {
+            requestId,
+            answered: false,
+            questions: questions.map((question) => toWorkLogUserInputQuestion(question, null)),
+          });
+          entries.push(derived);
+          continue;
+        }
       }
     }
 
@@ -811,6 +829,20 @@ export function deriveWorkLogEntries(
           };
           continue;
         }
+        if (asked && requestId && answers) {
+          const questions = toOrphanedWorkLogUserInputQuestions(answers);
+          if (questions.length > 0) {
+            entries[askedIndex] = {
+              ...asked,
+              label: userInputWorkLogLabel(questions),
+              tone: "info",
+              userInput: { requestId, answered: true, questions },
+            };
+          }
+        }
+        // The matching request already represents this lifecycle. Keep one
+        // generic row when neither side has enough structure for a Q&A card.
+        continue;
       }
       if (requestId && answers) {
         const questions = toOrphanedWorkLogUserInputQuestions(answers);

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -803,30 +803,58 @@ export function deriveWorkLogEntries(
   // Answers arrive in a separate activity from the questions; fold them back
   // into the entry that asked, so one round trip renders as one Q&A card.
   const userInputEntryIndexByRequestId = new Map<string, number>();
+  // Claude emits an AskUserQuestion tool lifecycle alongside the structured
+  // user-input lifecycle. Suppress the former only after the latter has
+  // successfully produced a Q&A card; malformed structured payloads still
+  // need the tool row's raw question JSON as a fallback.
+  const removableUserInputToolEntryIds = new Set<string>();
+  let suppressUserInputToolEntries = false;
   for (const activity of ordered) {
+    if (isUserInputToolActivity(activity)) {
+      if (activity.kind === "tool.started") {
+        removableUserInputToolEntryIds.clear();
+        suppressUserInputToolEntries = false;
+        continue;
+      }
+      if (suppressUserInputToolEntries) {
+        continue;
+      }
+      entries.push(toDerivedWorkLogEntry(activity));
+      removableUserInputToolEntryIds.add(activity.id);
+      continue;
+    }
     if (activity.kind === "tool.started") continue;
     if (activity.kind === "task.started") continue;
     if (activity.kind === "context-window.updated") continue;
     if (activity.summary === "Checkpoint captured") continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
-    if (isUserInputToolActivity(activity)) continue;
 
     if (activity.kind === "user-input.requested") {
       const payload = asRecord(activity.payload);
       const requestId = asTrimmedString(payload?.requestId);
       const questions = parseUserInputQuestions(payload);
       if (requestId) {
-        userInputEntryIndexByRequestId.set(requestId, entries.length);
         if (questions) {
           const derived = toWorkLogUserInputEntry(activity, {
             requestId,
             answered: false,
             questions: questions.map((question) => toWorkLogUserInputQuestion(question, null)),
           });
+          for (let index = entries.length - 1; index >= 0; index -= 1) {
+            if (removableUserInputToolEntryIds.has(entries[index]!.id)) {
+              entries.splice(index, 1);
+            }
+          }
+          removableUserInputToolEntryIds.clear();
+          suppressUserInputToolEntries = true;
+          userInputEntryIndexByRequestId.set(requestId, entries.length);
           entries.push(derived);
           continue;
         }
+        userInputEntryIndexByRequestId.set(requestId, entries.length);
       }
+      removableUserInputToolEntryIds.clear();
+      suppressUserInputToolEntries = false;
     }
 
     if (activity.kind === "user-input.resolved") {
@@ -867,6 +895,22 @@ export function deriveWorkLogEntries(
         if (questions.length > 0) {
           entries.push(toWorkLogUserInputEntry(activity, { requestId, answered: true, questions }));
           continue;
+        }
+      }
+    }
+
+    if (activity.kind === "provider.user-input.respond.failed") {
+      const payload = asRecord(activity.payload);
+      const requestId = asTrimmedString(payload?.requestId);
+      const detail = asTrimmedString(payload?.detail);
+      const askedIndex = requestId ? userInputEntryIndexByRequestId.get(requestId) : undefined;
+      if (askedIndex !== undefined && isStalePendingRequestFailureDetail(detail ?? undefined)) {
+        const asked = entries[askedIndex];
+        if (asked?.userInput && !asked.userInput.answered) {
+          entries[askedIndex] = {
+            ...asked,
+            userInput: { ...asked.userInput, answered: true },
+          };
         }
       }
     }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -468,7 +468,7 @@ function parseUserInputQuestions(
           };
         })
         .filter((option): option is UserInputQuestion["options"][number] => option !== null);
-      if (options.length === 0) {
+      if (options.length === 0 || options.length !== question.options.length) {
         return null;
       }
       return {
@@ -480,7 +480,7 @@ function parseUserInputQuestions(
       };
     })
     .filter((question): question is UserInputQuestion => question !== null);
-  return parsed.length > 0 ? parsed : null;
+  return parsed.length > 0 && parsed.length === questions.length ? parsed : null;
 }
 
 function parseUserInputAnswerValues(value: unknown): ReadonlyArray<string> {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -483,23 +483,39 @@ function parseUserInputQuestions(
   return parsed.length > 0 ? parsed : null;
 }
 
-function parseUserInputAnswerValues(
-  value: unknown,
-  splitCommaSeparated: boolean = false,
-): ReadonlyArray<string> {
-  const values =
-    typeof value === "string"
-      ? splitCommaSeparated
-        ? value.split(",")
-        : [value]
-      : Array.isArray(value)
-        ? value
-        : [];
+function parseUserInputAnswerValues(value: unknown): ReadonlyArray<string> {
+  const values = typeof value === "string" ? [value] : Array.isArray(value) ? value : [];
   return values.flatMap((entry) => {
     if (typeof entry !== "string") return [];
     const trimmed = entry.trim();
     return trimmed.length > 0 ? [trimmed] : [];
   });
+}
+
+/**
+ * OpenCode reports a multi-select reply as one `", "`-joined string rather than
+ * a list. Consume the value label by label, longest first, so a label that
+ * itself contains a comma survives; anything that is not a run of option labels
+ * is left alone as free text.
+ */
+function splitJoinedOptionLabels(
+  value: string,
+  optionLabels: ReadonlySet<string>,
+): ReadonlyArray<string> | null {
+  const labelsByLength = [...optionLabels].toSorted((left, right) => right.length - left.length);
+  const picked: string[] = [];
+  let rest = value.trim();
+  while (rest.length > 0) {
+    const label = labelsByLength.find(
+      (candidate) => rest === candidate || rest.startsWith(`${candidate},`),
+    );
+    if (label === undefined) {
+      return null;
+    }
+    picked.push(label);
+    rest = rest.slice(label.length).replace(/^,\s*/, "");
+  }
+  return picked.length > 1 ? picked : null;
 }
 
 /** Structural shape shared by a freshly parsed question and an already-derived one. */
@@ -517,13 +533,15 @@ function toWorkLogUserInputQuestion(
   answers: Record<string, unknown> | null,
 ): WorkLogUserInputQuestion {
   const optionLabels = new Set(question.options.map((option) => option.label));
-  const rawAnswer = answers?.[question.id];
-  const rawAnswerIsExactOption =
-    typeof rawAnswer === "string" && optionLabels.has(rawAnswer.trim());
-  const answered = parseUserInputAnswerValues(
-    rawAnswer,
-    question.multiSelect === true && !rawAnswerIsExactOption,
-  );
+  const reported = parseUserInputAnswerValues(answers?.[question.id]);
+  const [onlyValue] = reported;
+  const answered =
+    (question.multiSelect === true &&
+    reported.length === 1 &&
+    onlyValue !== undefined &&
+    !optionLabels.has(onlyValue)
+      ? splitJoinedOptionLabels(onlyValue, optionLabels)
+      : null) ?? reported;
   // Keep question order rather than answer order so multi-select reads consistently.
   const selectedLabels = question.options
     .map((option) => option.label)

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -894,6 +894,7 @@ export function deriveWorkLogEntries(
             label: userInputWorkLogLabel(questions),
             userInput: { ...asked.userInput, answered: true, questions },
           };
+          removableUserInputEntryIds.delete(asked.id);
           continue;
         }
         if (asked && requestId && answers) {
@@ -905,6 +906,7 @@ export function deriveWorkLogEntries(
               tone: "info",
               userInput: { requestId, answered: true, questions },
             };
+            removableUserInputEntryIds.delete(asked.id);
           }
         }
         // The matching request already represents this lifecycle. Keep one

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -807,20 +807,36 @@ export function deriveWorkLogEntries(
   // user-input lifecycle. Suppress the former only after the latter has
   // successfully produced a Q&A card; malformed structured payloads still
   // need the tool row's raw question JSON as a fallback.
-  const removableUserInputToolEntryIds = new Set<string>();
+  const removableUserInputEntryIds = new Set<string>();
+  let activeUserInputRequestId: string | null = null;
+  let activeUserInputToolCallId: string | null = null;
+  let startedUserInputToolWithoutCallId = false;
   let suppressUserInputToolEntries = false;
   for (const activity of ordered) {
     if (isUserInputToolActivity(activity)) {
+      const toolCallId = extractToolCallId(asRecord(activity.payload));
       if (activity.kind === "tool.started") {
-        removableUserInputToolEntryIds.clear();
+        removableUserInputEntryIds.clear();
+        activeUserInputToolCallId = toolCallId;
+        startedUserInputToolWithoutCallId = toolCallId === null;
         suppressUserInputToolEntries = false;
         continue;
+      }
+      if (toolCallId !== null && toolCallId !== activeUserInputToolCallId) {
+        if (startedUserInputToolWithoutCallId) {
+          activeUserInputToolCallId = toolCallId;
+          startedUserInputToolWithoutCallId = false;
+        } else {
+          removableUserInputEntryIds.clear();
+          activeUserInputToolCallId = toolCallId;
+          suppressUserInputToolEntries = false;
+        }
       }
       if (suppressUserInputToolEntries) {
         continue;
       }
       entries.push(toDerivedWorkLogEntry(activity));
-      removableUserInputToolEntryIds.add(activity.id);
+      removableUserInputEntryIds.add(activity.id);
       continue;
     }
     if (activity.kind === "tool.started") continue;
@@ -834,6 +850,11 @@ export function deriveWorkLogEntries(
       const requestId = asTrimmedString(payload?.requestId);
       const questions = parseUserInputQuestions(payload);
       if (requestId) {
+        if (activeUserInputRequestId !== null && requestId !== activeUserInputRequestId) {
+          removableUserInputEntryIds.clear();
+          suppressUserInputToolEntries = false;
+        }
+        activeUserInputRequestId = requestId;
         if (questions) {
           const derived = toWorkLogUserInputEntry(activity, {
             requestId,
@@ -841,19 +862,19 @@ export function deriveWorkLogEntries(
             questions: questions.map((question) => toWorkLogUserInputQuestion(question, null)),
           });
           for (let index = entries.length - 1; index >= 0; index -= 1) {
-            if (removableUserInputToolEntryIds.has(entries[index]!.id)) {
+            if (removableUserInputEntryIds.has(entries[index]!.id)) {
               entries.splice(index, 1);
             }
           }
-          removableUserInputToolEntryIds.clear();
+          removableUserInputEntryIds.clear();
           suppressUserInputToolEntries = true;
           userInputEntryIndexByRequestId.set(requestId, entries.length);
           entries.push(derived);
           continue;
         }
         userInputEntryIndexByRequestId.set(requestId, entries.length);
+        removableUserInputEntryIds.add(activity.id);
       }
-      removableUserInputToolEntryIds.clear();
       suppressUserInputToolEntries = false;
     }
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -60,6 +60,29 @@ export type WorkLogToolLifecycleStatus =
   | "declined"
   | "stopped";
 
+/** One question from a clarifying-question round trip, with what the user picked. */
+export interface WorkLogUserInputQuestion {
+  id: string;
+  header: string;
+  question: string;
+  multiSelect: boolean;
+  options: ReadonlyArray<{ label: string; description: string }>;
+  /** Chosen option labels, in the order the question listed them. */
+  selectedLabels: ReadonlyArray<string>;
+  /** Free-text answer that matched no option (the "Other" escape hatch). */
+  customAnswer?: string;
+}
+
+/**
+ * A `user-input.requested` / `user-input.resolved` pair merged into one entry so
+ * the timeline can show the question alongside the answer it received.
+ */
+export interface WorkLogUserInput {
+  requestId: string;
+  answered: boolean;
+  questions: ReadonlyArray<WorkLogUserInputQuestion>;
+}
+
 export interface WorkLogEntry {
   id: string;
   createdAt: string;
@@ -78,6 +101,8 @@ export interface WorkLogEntry {
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
   /** Originating orchestration activity kind (e.g. `user-input.requested`) for row chrome. */
   sourceActivityKind?: OrchestrationThreadActivity["kind"];
+  /** Present on clarifying-question entries; rendered as a Q&A card, never folded away. */
+  userInput?: WorkLogUserInput;
 }
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
@@ -458,6 +483,118 @@ function parseUserInputQuestions(
   return parsed.length > 0 ? parsed : null;
 }
 
+function parseUserInputAnswerValues(value: unknown): ReadonlyArray<string> {
+  const values = typeof value === "string" ? [value] : Array.isArray(value) ? value : [];
+  return values.flatMap((entry) => {
+    if (typeof entry !== "string") return [];
+    const trimmed = entry.trim();
+    return trimmed.length > 0 ? [trimmed] : [];
+  });
+}
+
+/** Structural shape shared by a freshly parsed question and an already-derived one. */
+interface AskedUserInputQuestion {
+  readonly id: string;
+  readonly header: string;
+  readonly question: string;
+  readonly multiSelect?: boolean | undefined;
+  readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>;
+}
+
+/** Pairs one asked question with the answer recorded for it, when there is one. */
+function toWorkLogUserInputQuestion(
+  question: AskedUserInputQuestion,
+  answers: Record<string, unknown> | null,
+): WorkLogUserInputQuestion {
+  const answered = parseUserInputAnswerValues(answers?.[question.id]);
+  const optionLabels = new Set(question.options.map((option) => option.label));
+  // Keep question order rather than answer order so multi-select reads consistently.
+  const selectedLabels = question.options
+    .map((option) => option.label)
+    .filter((label) => answered.includes(label));
+  const customAnswer = answered.filter((value) => !optionLabels.has(value)).join("\n");
+  return {
+    id: question.id,
+    header: question.header,
+    question: question.question,
+    multiSelect: question.multiSelect === true,
+    options: question.options.map((option) => ({
+      label: option.label,
+      description: option.description,
+    })),
+    selectedLabels,
+    ...(customAnswer.length > 0 ? { customAnswer } : {}),
+  };
+}
+
+/**
+ * `user-input.resolved` without its request in view (older activity trimmed
+ * away) still carries the questions as answer keys — enough to show the answer.
+ */
+function toOrphanedWorkLogUserInputQuestions(
+  answers: Record<string, unknown>,
+): WorkLogUserInputQuestion[] {
+  return Object.entries(answers).flatMap(([question, value]) => {
+    const answered = parseUserInputAnswerValues(value);
+    if (answered.length === 0) return [];
+    return [
+      {
+        id: question,
+        header: "Answer",
+        question,
+        multiSelect: answered.length > 1,
+        options: [],
+        selectedLabels: [],
+        customAnswer: answered.join("\n"),
+      },
+    ];
+  });
+}
+
+function toWorkLogUserInputEntry(
+  activity: OrchestrationThreadActivity,
+  userInput: WorkLogUserInput,
+): DerivedWorkLogEntry {
+  return {
+    id: activity.id,
+    createdAt: activity.createdAt,
+    turnId: activity.turnId,
+    label: userInputWorkLogLabel(userInput.questions),
+    tone: "info",
+    activityKind: activity.kind,
+    userInput,
+  };
+}
+
+function userInputWorkLogLabel(questions: ReadonlyArray<WorkLogUserInputQuestion>): string {
+  const [first] = questions;
+  if (questions.length === 1 && first) {
+    return `Question: ${first.header}`;
+  }
+  return `${questions.length} questions`;
+}
+
+/**
+ * Claude surfaces `AskUserQuestion` through the user-input event channel, so its
+ * tool row is a duplicate whose only content is the raw question JSON.
+ */
+function isUserInputToolActivity(activity: OrchestrationThreadActivity): boolean {
+  if (
+    activity.kind !== "tool.started" &&
+    activity.kind !== "tool.updated" &&
+    activity.kind !== "tool.completed"
+  ) {
+    return false;
+  }
+  const payload = asRecord(activity.payload);
+  const toolName = asTrimmedString(asRecord(payload?.data)?.toolName);
+  if (toolName === "AskUserQuestion") {
+    return true;
+  }
+  // `tool.started` lands before any input streams, leaving only the detail prefix.
+  return asTrimmedString(payload?.detail)?.startsWith("AskUserQuestion:") === true;
+}
+
 export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingUserInput[] {
@@ -629,12 +766,61 @@ export function deriveWorkLogEntries(
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries: DerivedWorkLogEntry[] = [];
+  // Answers arrive in a separate activity from the questions; fold them back
+  // into the entry that asked, so one round trip renders as one Q&A card.
+  const userInputEntryIndexByRequestId = new Map<string, number>();
   for (const activity of ordered) {
     if (activity.kind === "tool.started") continue;
     if (activity.kind === "task.started") continue;
     if (activity.kind === "context-window.updated") continue;
     if (activity.summary === "Checkpoint captured") continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
+    if (isUserInputToolActivity(activity)) continue;
+
+    if (activity.kind === "user-input.requested") {
+      const payload = asRecord(activity.payload);
+      const requestId = asTrimmedString(payload?.requestId);
+      const questions = parseUserInputQuestions(payload);
+      if (requestId && questions) {
+        const derived = toWorkLogUserInputEntry(activity, {
+          requestId,
+          answered: false,
+          questions: questions.map((question) => toWorkLogUserInputQuestion(question, null)),
+        });
+        userInputEntryIndexByRequestId.set(requestId, entries.length);
+        entries.push(derived);
+        continue;
+      }
+    }
+
+    if (activity.kind === "user-input.resolved") {
+      const payload = asRecord(activity.payload);
+      const requestId = asTrimmedString(payload?.requestId);
+      const answers = asRecord(payload?.answers);
+      const askedIndex = requestId ? userInputEntryIndexByRequestId.get(requestId) : undefined;
+      if (askedIndex !== undefined) {
+        const asked = entries[askedIndex];
+        if (asked?.userInput) {
+          const questions = asked.userInput.questions.map((question) =>
+            toWorkLogUserInputQuestion(question, answers),
+          );
+          entries[askedIndex] = {
+            ...asked,
+            label: userInputWorkLogLabel(questions),
+            userInput: { ...asked.userInput, answered: true, questions },
+          };
+          continue;
+        }
+      }
+      if (requestId && answers) {
+        const questions = toOrphanedWorkLogUserInputQuestions(answers);
+        if (questions.length > 0) {
+          entries.push(toWorkLogUserInputEntry(activity, { requestId, answered: true, questions }));
+          continue;
+        }
+      }
+    }
+
     entries.push(toDerivedWorkLogEntry(activity));
   }
   return collapseDerivedWorkLogEntries(entries).map((entry) => {


### PR DESCRIPTION
## What Changed

A clarifying-question round trip (Claude's `AskUserQuestion`, and the same
`user-input.*` events from the other providers) now renders as a single Q&A card
in the thread timeline: the question header, the question, and the option(s) the
user picked — or their free-text answer. The alternatives stay one click away
behind "Show options".

- `deriveWorkLogEntries` merges `user-input.requested` with its
  `user-input.resolved` into one entry (`entry.userInput`), resolving each answer
  against the question's options so a picked label and an "Other" answer render
  differently. A resolution whose request has scrolled out of the activity window
  still shows its answer.
- Q&A entries get their own timeline row, so neither the work-group collapse nor
  the settled-turn fold hides them — the exchange records a decision, so it stays
  readable in history.
- The duplicate `AskUserQuestion` tool rows are dropped, the same way
  `ExitPlanMode` rows are already suppressed.

## Why

The answers were already persisted — `user-input.resolved` carries
`{"answers": {"<question>": "<label>"}}` — but nothing rendered them. The
timeline showed two contentless rows, `User input requested` and
`User input submitted`, neither expandable, plus a `Tool call` row whose only
content was truncated request JSON (`AskUserQuestion: {"questions":[{"header"...`).
Both sat inside the work-group collapse (`MAX_VISIBLE_WORK_LOG_ENTRIES = 1`) and
the turn fold, so in practice a finished thread showed no trace of the question
or the answer at all.

That is a real gap in the transcript: the interactive prompt lives in the
composer and disappears once answered, so the timeline is the only lasting record
of what the agent asked and what the user decided.

## UI Changes

Same seeded thread in every shot: two questions (one single-select answered with
free text, one multi-select), plus the `AskUserQuestion` tool rows Claude emits
alongside the events.

**Before** — settled turn, as you first see it. The exchange is entirely absent:

![before, folded](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/qna-timeline/docs/qna-timeline/before-folded.png)

**Before** — after expanding both the turn fold and the work group. Two empty
rows and a JSON dump; the answers appear nowhere:

![before, expanded](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/qna-timeline/docs/qna-timeline/before-expanded.png)

**After** — settled turn, no expansion needed:

![after, folded](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/qna-timeline/docs/qna-timeline/after-folded.png)

**After** — "Show options" reveals the alternatives, with the picked ones highlighted:

![after, options shown](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/qna-timeline/docs/qna-timeline/after-options.png)

**After** — turn fold expanded: the card sits inline where the question was
asked, surrounding tool calls still collapse as before, and the raw
`AskUserQuestion` row is gone:

![after, turn expanded](https://raw.githubusercontent.com/colonelpanic8/t3code/assets/qna-timeline/docs/qna-timeline/after-expanded.png)

Scope note: `apps/mobile/src/lib/threadActivity.ts` carries its own copy of this
derivation and has the same gap. Left out to keep this PR focused on one surface.

## Validation

```
vp test run src/session-logic.test.ts                              # 66 passed (7 new)
vp test run src/components/chat/MessagesTimeline.logic.test.ts     # 30 passed (2 new)
vp test run src/components/chat/MessagesTimeline.test.tsx          # 16 passed (2 new)
tsgo --noEmit                          # apps/web, clean
vp lint --report-unused-disable-directives <changed files>         # clean
vp fmt <changed files>
```

Plus an integrated pass in a browser against an isolated dev environment
(`vp run dev --home-dir …`) with the seeded thread above — that is where the
screenshots come from.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — n/a, no motion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Web chat timeline and session-logic derivation only; behavior is covered by new unit tests with no auth or data migration impact.
> 
> **Overview**
> **Clarifying-question exchanges now show up as dedicated Q&A cards in the thread timeline** instead of disappearing inside work-log collapse and turn folds.
> 
> `deriveWorkLogEntries` merges `user-input.requested` / `user-input.resolved` into one work entry with a `userInput` payload (options, selected labels, free-text answers), including comma-joined multi-select parsing and orphaned answers when the request scrolled away. Duplicate `AskUserQuestion` tool rows are dropped when structured Q&A data is available.
> 
> Timeline derivation adds a `user-input` row type, excludes those entries from work grouping and turn-fold hiding, and `UserInputTimelineRow` renders question text, the chosen answer, optional “Show options,” and “Awaiting your answer” when pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf61aeb38823ab88ad4160ef5aefb232fee34d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show answered clarifying questions as Q&A cards in the thread timeline
> - Adds a new `user-input` row variant to `MessagesTimelineRow` in [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/4506/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe), surfacing clarifying-question exchanges as dedicated timeline entries instead of hiding them inside work groups.
> - Extends `deriveWorkLogEntries` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/4506/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to merge `user-input.requested` and `user-input.resolved` events into a single `WorkLogEntry` with a `userInput` payload; handles orphaned answers, stale requests, and suppresses duplicate `AskUserQuestion` tool rows when structured data is valid.
> - Renders the new row type in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/4506/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) via a new `UserInputTimelineRow` component that shows the question, selected answers with checkmarks, and a toggle for unpicked options; unanswered exchanges show an "Awaiting your answer" status.
> - Turn-fold collapse logic is updated to skip `userInput` entries so clarifying-question rows remain visible when a turn is folded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf61aeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->