### PR TITLE
Make ClaudeTextGeneration tests hermetic on Windows

### DIFF
--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -1,13 +1,13 @@
-import { isHostWindows } from "@t3tools/shared/hostProcess";
-import { ClaudeSettings, ProviderInstanceId } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import { ClaudeSettings, ProviderInstanceId } from "@t3tools/contracts";
+import { isHostWindows } from "@t3tools/shared/hostProcess";
+import { createModelSelection } from "@t3tools/shared/model";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import { createModelSelection } from "@t3tools/shared/model";
 import { expect } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
@@ -77,7 +77,7 @@ function makeFakeClaudeBinary(dir: string) {
         "}",
         "",
         'process.stdout.write(process.env.T3_FAKE_CLAUDE_OUTPUT ?? "");',
-        "process.exit(Number(process.env.T3_FAKE_CLAUDE_EXIT_CODE ?? 0));",
+        "process.exitCode = Number(process.env.T3_FAKE_CLAUDE_EXIT_CODE ?? 0);",
         "",
       ].join("\n"),
     );

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -1,3 +1,4 @@
+import { isHostWindows } from "@t3tools/shared/hostProcess";
 import { ClaudeSettings, ProviderInstanceId } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
@@ -23,47 +24,80 @@ function makeFakeClaudeBinary(dir: string) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
+    const isWindows = yield* isHostWindows;
     const binDir = path.join(dir, "bin");
-    const claudePath = path.join(binDir, "claude");
+    const stubPath = path.join(binDir, "claude-stub.mjs");
     yield* fs.makeDirectory(binDir, { recursive: true });
 
+    // The stub behaviour lives in Node rather than a `#!/bin/sh` script so the
+    // same implementation is usable on Windows, where a shebang file is not
+    // executable and would fall through to the real Claude CLI on PATH.
     yield* fs.writeFileString(
-      claudePath,
+      stubPath,
       [
-        "#!/bin/sh",
-        'args="$*"',
-        'stdin_content="$(cat)"',
-        'if [ -n "$T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN" ]; then',
-        '  printf "%s" "$args" | grep -F -- "$T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN" >/dev/null || {',
-        '    printf "%s\\n" "args missing expected content" >&2',
-        "    exit 2",
+        'const args = process.argv.slice(2).join(" ");',
+        "",
+        "function fail(message, code) {",
+        '  process.stderr.write(message + "\\n");',
+        "  process.exit(code);",
+        "}",
+        "",
+        'let stdinContent = "";',
+        "if (!process.stdin.isTTY) {",
+        "  const chunks = [];",
+        "  for await (const chunk of process.stdin) {",
+        "    chunks.push(chunk);",
         "  }",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN" ]; then',
-        '  if printf "%s" "$args" | grep -F -- "$T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN" >/dev/null; then',
-        '    printf "%s\\n" "args contained forbidden content" >&2',
-        "    exit 3",
-        "  fi",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN" ]; then',
-        '  printf "%s" "$stdin_content" | grep -F -- "$T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN" >/dev/null || {',
-        '    printf "%s\\n" "stdin missing expected content" >&2',
-        "    exit 4",
-        "  }",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE" ] && [ "$CLAUDE_CONFIG_DIR" != "$T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE" ]; then',
-        '  printf "%s\\n" "CLAUDE_CONFIG_DIR was $CLAUDE_CONFIG_DIR" >&2',
-        "  exit 5",
-        "fi",
-        'if [ -n "$T3_FAKE_CLAUDE_STDERR" ]; then',
-        '  printf "%s\\n" "$T3_FAKE_CLAUDE_STDERR" >&2',
-        "fi",
-        'printf "%s" "$T3_FAKE_CLAUDE_OUTPUT"',
-        'exit "${T3_FAKE_CLAUDE_EXIT_CODE:-0}"',
+        '  stdinContent = Buffer.concat(chunks).toString("utf8");',
+        "}",
+        "",
+        "const argsMustContain = process.env.T3_FAKE_CLAUDE_ARGS_MUST_CONTAIN;",
+        "if (argsMustContain && !args.includes(argsMustContain)) {",
+        '  fail("args missing expected content", 2);',
+        "}",
+        "",
+        "const argsMustNotContain = process.env.T3_FAKE_CLAUDE_ARGS_MUST_NOT_CONTAIN;",
+        "if (argsMustNotContain && args.includes(argsMustNotContain)) {",
+        '  fail("args contained forbidden content", 3);',
+        "}",
+        "",
+        "const stdinMustContain = process.env.T3_FAKE_CLAUDE_STDIN_MUST_CONTAIN;",
+        "if (stdinMustContain && !stdinContent.includes(stdinMustContain)) {",
+        '  fail("stdin missing expected content", 4);',
+        "}",
+        "",
+        "const configDirMustBe = process.env.T3_FAKE_CLAUDE_CONFIG_DIR_MUST_BE;",
+        "if (configDirMustBe && process.env.CLAUDE_CONFIG_DIR !== configDirMustBe) {",
+        '  fail("CLAUDE_CONFIG_DIR was " + (process.env.CLAUDE_CONFIG_DIR ?? ""), 5);',
+        "}",
+        "",
+        "const stderrText = process.env.T3_FAKE_CLAUDE_STDERR;",
+        "if (stderrText) {",
+        '  process.stderr.write(stderrText + "\\n");',
+        "}",
+        "",
+        'process.stdout.write(process.env.T3_FAKE_CLAUDE_OUTPUT ?? "");',
+        "process.exit(Number(process.env.T3_FAKE_CLAUDE_EXIT_CODE ?? 0));",
         "",
       ].join("\n"),
     );
-    yield* fs.chmod(claudePath, 0o755);
+
+    if (isWindows) {
+      // Windows resolves executables through PATHEXT, so the entry point has to
+      // carry a real extension. `resolveSpawnCommand` spawns `.cmd` via a shell.
+      yield* fs.writeFileString(
+        path.join(binDir, "claude.cmd"),
+        ["@echo off", 'node "%~dp0claude-stub.mjs" %*', "exit /b %ERRORLEVEL%", ""].join("\r\n"),
+      );
+    } else {
+      const claudePath = path.join(binDir, "claude");
+      yield* fs.writeFileString(
+        claudePath,
+        ["#!/bin/sh", 'exec node "$(dirname "$0")/claude-stub.mjs" "$@"', ""].join("\n"),
+      );
+      yield* fs.chmod(claudePath, 0o755);
+    }
+
     return binDir;
   });
 }
@@ -85,6 +119,7 @@ function withFakeClaudeEnv<A, E, R>(
     const fs = yield* FileSystem.FileSystem;
     const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-claude-text-" });
     const binDir = yield* makeFakeClaudeBinary(tempDir);
+    const pathDelimiter = (yield* isHostWindows) ? ";" : ":";
     const previousPath = process.env.PATH;
     const previousOutput = process.env.T3_FAKE_CLAUDE_OUTPUT;
     const previousExitCode = process.env.T3_FAKE_CLAUDE_EXIT_CODE;
@@ -96,7 +131,7 @@ function withFakeClaudeEnv<A, E, R>(
 
     yield* Effect.acquireRelease(
       Effect.sync(() => {
-        process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+        process.env.PATH = `${binDir}${pathDelimiter}${previousPath ?? ""}`;
         process.env.T3_FAKE_CLAUDE_OUTPUT = input.output;
 
         if (input.exitCode !== undefined) {


### PR DESCRIPTION
## What Changed

The `ClaudeTextGeneration` test fixture now works on Windows. The fake `claude` binary is a Node script with a platform-appropriate entry point — `claude.cmd` on Windows, a `#!/bin/sh` shim elsewhere — and PATH is built with the platform's separator instead of a hardcoded `:`.

One file, test-only. No production code changes.

## Why

Fixes #4507.

On Windows all 5 tests in this file fail on unmodified `main`. The fixture never takes effect, so the real installed Claude CLI runs instead: assertions compare fixture strings against live model output, and the run makes real billed API calls.

Two POSIX-only assumptions caused it:

1. PATH was joined with a literal `:`. Windows uses `;`, so the fixture's `bin` directory never became its own PATH entry.
2. The stub was written as extension-less `bin/claude` containing a `#!/bin/sh` script. Windows resolves executables through `PATHEXT`, so an extension-less file is skipped — and even with a correct extension a shebang script is not executable there.

Fixing only the separator is not enough, since the shebang stub still would not run. So the stub logic moved into Node (`claude-stub.mjs`) with a thin platform-specific launcher in front of it. The `T3_FAKE_CLAUDE_*` env contract and every exit code are unchanged.

No production change was needed: `resolveSpawnCommand` already resolves through `PATHEXT` and spawns `.cmd` with `shell: true`.

## Validation

Windows 11, this file only:

| | result |
| --- | --- |
| before | 5 failed, 134.28s (live API calls) |
| after | 5 passed, 4.09s (stub invoked) |

The 134s to 4s drop is the signal that no network calls happen anymore.

`vp fmt`, `vp lint --report-unused-disable-directives`, `git diff --check`, and `pnpm --filter t3 typecheck` are all clean for this scope.

I do not have a POSIX machine, so the shell shim is verified behaviourally under `sh` rather than by running the suite: happy path, args-must-contain pass and fail, stdin-must-contain pass and fail, custom exit code, and config-dir mismatch all return the same exit codes as the old script (0, 0, 2, 4, 0, 7, 5). The full suite on Linux and macOS is unverified by me and worth confirming in CI.

One note so it is not a surprise: on Windows the run now emits `DEP0190` (passing args with `shell: true`). That comes from the existing `resolveSpawnCommand` path and is not introduced here — it simply was not reachable from this test before, because the stub never resolved.

## Not included

`ClaudeTextGeneration.test.ts` builds `claudeConfigDir` from `process.cwd()`, which leaves a `.claude-work-test/` directory behind in the repo after the run. It is recorded in #4507 and left out here to keep this focused.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — n/a, no UI changes
- [ ] I included a video for animation/interaction changes — n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to one test file; no production code paths are modified.
> 
> **Overview**
> **Makes `ClaudeTextGeneration` tests use a portable fake Claude CLI** so Windows runs hit the stub instead of the real CLI on PATH (which caused failures, live API calls, and slow runs).
> 
> The test fixture’s fake `claude` binary is no longer a single `#!/bin/sh` script. Stub logic lives in **`claude-stub.mjs`** (same `T3_FAKE_CLAUDE_*` env checks and exit codes). **Windows** gets **`claude.cmd`** that forwards to Node; **Unix** keeps a small executable shim that `exec`s the same stub.
> 
> **`withFakeClaudeEnv`** prepends the fake `bin` to **`PATH`** using **`;` on Windows** and **`:` elsewhere**, so the fixture directory is actually discoverable on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d1bb1501b937c125540cf4fc6a5f4a45708583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `ClaudeTextGeneration` tests hermetic on Windows
> - Replaces the POSIX shell-based fake `claude` binary with a Node stub (`claude-stub.mjs`) that replicates the same validation logic using `process` APIs.
> - On Windows, a `claude.cmd` batch file invokes the Node stub; on non-Windows, a shell launcher script is written and marked executable.
> - Fixes PATH assembly in `withFakeClaudeEnv` to use `;` as the delimiter on Windows instead of `:`.
> - Platform detection uses `isHostWindows` from `@t3tools/shared/hostProcess`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68d1bb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->