### PR TITLE
fix: add missing space before 'GitHub releases page' link on download page

### DIFF
--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -60,7 +60,7 @@ import { RELEASES_URL } from "../lib/releases";
   </div>
 
   <p class="releases-link">
-    Looking for older versions? Check the
+    Looking for older versions? Check the{" "}
     <a href="https://github.com/pingdotgg/t3code/releases" target="_blank" rel="noopener noreferrer">
       GitHub releases page<span aria-hidden="true"> &#8599;</span>
     </a>


### PR DESCRIPTION
The whitespace between 'Check the' and the anchor tag was being collapsed by HTML parsing, causing the text to render as 'Check the**GitHub releases page**' instead of 'Check the **GitHub releases page**'.

Added `{" "}` to force a space between the text and the link.

**Before:** Looking for older versions? Check theGitHub releases page ↗  
**After:** Looking for older versions? Check the GitHub releases page ↗

<img width="692" height="107" alt="image" src="https://github.com/user-attachments/assets/06004cf6-2792-46a8-8f4b-8f8cc27e1985" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line marketing copy fix with no logic, API, or security impact.
> 
> **Overview**
> Fixes a **copy rendering bug** on the download page where “Check the” ran directly into the GitHub releases link (`Check theGitHub releases page`).
> 
> Inserts an explicit `{" "}` after “Check the” in `download.astro`, matching the whitespace pattern already used on other marketing pages so HTML whitespace collapse does not eat the gap before the anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f0f7a9926e53a810bbedf6587f48b69860e273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing space before 'GitHub releases page' link on download page
> Adds an explicit `{' '}` space literal in [download.astro](https://github.com/pingdotgg/t3code/pull/4511/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926) between 'Check the' and the anchor element, fixing a rendering bug where the two ran together.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4f0f7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->