### PR TITLE
feat: Add new "Chat" feature for non-project threads

### DIFF
--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -3,6 +3,7 @@ import {
   derivePhysicalProjectKey,
   deriveProjectGroupLabel,
 } from "@t3tools/client-runtime/state/project-grouping";
+import { projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
@@ -113,7 +114,10 @@ export function buildHomeProjectScopes(input: {
     const representative = projects[0]!;
     return {
       key,
-      title: deriveProjectGroupLabel({ representative, members: projects }),
+      title:
+        projects.length === 1
+          ? projectDisplayTitle(representative)
+          : deriveProjectGroupLabel({ representative, members: projects }),
       representative,
       projects,
       projectRefs: projectRefsByGroup.get(key) ?? [],

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -3,7 +3,7 @@ import {
   derivePhysicalProjectKey,
   deriveProjectGroupLabel,
 } from "@t3tools/client-runtime/state/project-grouping";
-import { projectDisplayTitle } from "@t3tools/client-runtime/state/models";
+import { isChatsProject, projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import type {
   EnvironmentProject,
   EnvironmentThreadShell,
@@ -114,10 +114,12 @@ export function buildHomeProjectScopes(input: {
     const representative = projects[0]!;
     return {
       key,
-      title:
-        projects.length === 1
-          ? projectDisplayTitle(representative)
-          : deriveProjectGroupLabel({ representative, members: projects }),
+      // Only the Chat pseudo-project overrides its label. Real projects keep
+      // the derived group label, which prefers the repository name over the
+      // directory name even when the group has a single member.
+      title: isChatsProject(representative)
+        ? projectDisplayTitle(representative)
+        : deriveProjectGroupLabel({ representative, members: projects }),
       representative,
       projects,
       projectRefs: projectRefsByGroup.get(key) ?? [],

--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -392,17 +392,21 @@ function useThreadGitHeaderActionItems(props: ThreadGitControlsProps): ThreadGit
 
 export function useThreadGitRightHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
+  const hidden = props.showActionControls === false;
   return useMemo(
-    () => [actionItems.git, actionItems.files, actionItems.terminal] as HeaderItems,
-    [actionItems],
+    () =>
+      hidden ? [] : ([actionItems.git, actionItems.files, actionItems.terminal] as HeaderItems),
+    [actionItems, hidden],
   );
 }
 
 export function useThreadGitCenterHeaderItems(props: ThreadGitControlsProps): HeaderItems {
   const actionItems = useThreadGitHeaderActionItems(props);
+  const hidden = props.showActionControls === false;
   return useMemo(
-    () => [actionItems.files, actionItems.git, actionItems.terminal] as HeaderItems,
-    [actionItems],
+    () =>
+      hidden ? [] : ([actionItems.files, actionItems.git, actionItems.terminal] as HeaderItems),
+    [actionItems, hidden],
   );
 }
 

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -8,6 +8,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import * as Option from "effect/Option";
 import { EnvironmentId, ThreadId, type ProjectScript } from "@t3tools/contracts";
+import { isChatsProject } from "@t3tools/client-runtime/state/models";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -206,9 +207,18 @@ function ThreadRouteContent(
   const [inspectorSelection, setInspectorSelection] = useState<ThreadInspectorSelection | null>(
     () => (props.renderInspector ? { routeThreadIdentity, mode: "route" } : null),
   );
+  // The reserved Chats pseudo-project has no real codebase, so files/git
+  // inspectors, terminals and git controls are hidden for its threads.
+  const selectedProjectIsChats = isChatsProject(selectedThreadProject);
   const inspectorMode = (() => {
     if (inspectorSelection?.routeThreadIdentity === routeThreadIdentity) {
       if (inspectorSelection.mode === "files" && selectedThreadCwd === null) {
+        return null;
+      }
+      if (
+        selectedProjectIsChats &&
+        (inspectorSelection.mode === "files" || inspectorSelection.mode === "git")
+      ) {
         return null;
       }
       return inspectorSelection.mode;
@@ -594,22 +604,29 @@ function ThreadRouteContent(
     environmentId: environmentIdRaw ?? "",
     threadId: threadId ?? "",
     auxiliaryPaneControl:
-      !layout.usesSplitView && fileInspector.supported && selectedThreadCwd !== null
+      !layout.usesSplitView &&
+      fileInspector.supported &&
+      selectedThreadCwd !== null &&
+      !selectedProjectIsChats
         ? {
             accessibilityLabel: "Toggle inspector",
             onPress: handleToggleInspector,
           }
         : undefined,
     onOpenFilesInspector:
-      fileInspector.supported && selectedThreadCwd !== null ? handleOpenFilesInspector : undefined,
-    onOpenGitInspector: fileInspector.supported ? handleOpenGitInspector : undefined,
+      fileInspector.supported && selectedThreadCwd !== null && !selectedProjectIsChats
+        ? handleOpenFilesInspector
+        : undefined,
+    onOpenGitInspector:
+      fileInspector.supported && !selectedProjectIsChats ? handleOpenGitInspector : undefined,
     currentBranch: selectedThread?.branch ?? null,
     gitStatus: gitStatus.data,
     gitOperationLabel: gitState.gitOperationLabel,
-    canOpenTerminal: Boolean(selectedThreadProject?.workspaceRoot),
-    canOpenFiles: Boolean(selectedThreadProject?.workspaceRoot),
-    projectScripts: selectedThreadProject?.scripts ?? [],
+    canOpenTerminal: Boolean(selectedThreadProject?.workspaceRoot) && !selectedProjectIsChats,
+    canOpenFiles: Boolean(selectedThreadProject?.workspaceRoot) && !selectedProjectIsChats,
+    projectScripts: selectedProjectIsChats ? [] : (selectedThreadProject?.scripts ?? []),
     terminalSessions: terminalMenuSessions,
+    showActionControls: !selectedProjectIsChats,
     showDirectFileControl: layout.usesSplitView,
     onOpenTerminal: handleOpenTerminal,
     onOpenNewTerminal: handleOpenNewTerminal,
@@ -743,7 +760,10 @@ function ThreadRouteContent(
   const serverConfig = routeEnvironmentRuntime?.serverConfig ?? null;
   const renderThreadRouteBody = (showActionControls: boolean) => (
     <>
-      <ThreadGitControls {...threadGitControlProps} showActionControls={showActionControls} />
+      <ThreadGitControls
+        {...threadGitControlProps}
+        showActionControls={showActionControls && !selectedProjectIsChats}
+      />
 
       <GitActionProgressOverlay progress={gitActionProgress} onDismiss={dismissGitActionResult} />
 

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -228,7 +228,10 @@ function ThreadRouteContent(
   useEffect(() => {
     if (
       fileInspector.supported &&
-      selectedThreadCwd === null &&
+      // Chat threads suppress the files/git inspectors while keeping a real
+      // workspace root, so the pane has to close on the kind too — otherwise
+      // switching into one leaves an empty trailing column.
+      (selectedThreadCwd === null || selectedProjectIsChats) &&
       inspectorMode === null &&
       panes.auxiliaryPaneVisible
     ) {
@@ -238,6 +241,7 @@ function ThreadRouteContent(
     fileInspector.supported,
     inspectorMode,
     panes.auxiliaryPaneVisible,
+    selectedProjectIsChats,
     selectedThreadCwd,
     toggleAuxiliaryPane,
   ]);
@@ -688,6 +692,10 @@ function ThreadRouteContent(
         onPress: props.onReturnToThread,
       });
     }
+    // The Chat pseudo-project has no codebase behind it, so the Android
+    // header keeps only the navigation action above. Its workspace root is a
+    // real directory, so the cwd/workspaceRoot guards below never catch it.
+    if (selectedProjectIsChats) return actions;
     if (selectedThreadCwd !== null) {
       actions.push({
         accessibilityLabel: "Open files",
@@ -722,6 +730,7 @@ function ThreadRouteContent(
     handleOpenGitInspector,
     handleToggleInspector,
     props.onReturnToThread,
+    selectedProjectIsChats,
     selectedThreadCwd,
     selectedThreadProject?.workspaceRoot,
   ]);

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -32,6 +32,7 @@ export interface ServerDerivedPaths {
   readonly settingsPath: string;
   readonly providerStatusCacheDir: string;
   readonly worktreesDir: string;
+  readonly chatsDir: string;
   readonly attachmentsDir: string;
   readonly logsDir: string;
   readonly serverLogPath: string;
@@ -118,6 +119,7 @@ export const deriveServerPaths = Effect.fn(function* (
     settingsPath: join(stateDir, "settings.json"),
     providerStatusCacheDir,
     worktreesDir: join(baseDir, "worktrees"),
+    chatsDir: join(baseDir, "chats"),
     attachmentsDir,
     logsDir,
     serverLogPath: join(logsDir, "server.log"),
@@ -144,6 +146,7 @@ export const ensureServerDirectories = Effect.fn(function* (derivedPaths: Server
       fs.makeDirectory(derivedPaths.terminalLogsDir, { recursive: true }),
       fs.makeDirectory(derivedPaths.attachmentsDir, { recursive: true }),
       fs.makeDirectory(derivedPaths.worktreesDir, { recursive: true }),
+      fs.makeDirectory(derivedPaths.chatsDir, { recursive: true }),
       fs.makeDirectory(path.dirname(derivedPaths.keybindingsConfigPath), { recursive: true }),
       fs.makeDirectory(path.dirname(derivedPaths.settingsPath), { recursive: true }),
       fs.makeDirectory(derivedPaths.providerStatusCacheDir, { recursive: true }),

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -34,9 +34,26 @@ const projectionSnapshotLayer = it.layer(
   ),
 );
 
+const projectKindRepositoryIdentityResolveCalls: string[] = [];
 const projectionSnapshotWithServerConfigLayer = it.layer(
   OrchestrationProjectionSnapshotQueryLive.pipe(
-    Layer.provideMerge(RepositoryIdentityResolver.layer),
+    Layer.provideMerge(
+      Layer.succeed(RepositoryIdentityResolver.RepositoryIdentityResolver, {
+        resolve: (cwd: string) =>
+          Effect.sync(() => {
+            projectKindRepositoryIdentityResolveCalls.push(cwd);
+            return {
+              canonicalKey: "github.com/acme/parent-repository",
+              locator: {
+                source: "git-remote" as const,
+                remoteName: "origin",
+                remoteUrl: "https://github.com/acme/parent-repository.git",
+              },
+              rootPath: cwd,
+            };
+          }),
+      }),
+    ),
     Layer.provideMerge(SqlitePersistenceMemory),
     Layer.provideMerge(
       Layer.fresh(
@@ -53,6 +70,7 @@ projectionSnapshotWithServerConfigLayer("ProjectionSnapshotQuery project kind", 
       const snapshotQuery = yield* ProjectionSnapshotQuery;
       const serverConfig = yield* ServerConfigModule.ServerConfig;
       const sql = yield* SqlClient.SqlClient;
+      projectKindRepositoryIdentityResolveCalls.length = 0;
 
       yield* sql`DELETE FROM projection_projects`;
       yield* sql`
@@ -95,6 +113,13 @@ projectionSnapshotWithServerConfigLayer("ProjectionSnapshotQuery project kind", 
       );
       assert.equal(kindsById.get(asProjectId("project-chats")), "chats");
       assert.equal(kindsById.get(asProjectId("project-standard")), "standard");
+      const projectsById = new Map(shellSnapshot.projects.map((project) => [project.id, project]));
+      assert.equal(projectsById.get(asProjectId("project-chats"))?.repositoryIdentity, null);
+      assert.equal(
+        projectsById.get(asProjectId("project-standard"))?.repositoryIdentity?.rootPath,
+        "/tmp/project-standard",
+      );
+      assert.deepStrictEqual(projectKindRepositoryIdentityResolveCalls, ["/tmp/project-standard"]);
 
       const chatsProject = yield* snapshotQuery.getActiveProjectByWorkspaceRoot(
         serverConfig.chatsDir,
@@ -102,7 +127,9 @@ projectionSnapshotWithServerConfigLayer("ProjectionSnapshotQuery project kind", 
       assert.equal(chatsProject._tag, "Some");
       if (chatsProject._tag === "Some") {
         assert.equal(chatsProject.value.kind, "chats");
+        assert.equal(chatsProject.value.repositoryIdentity, null);
       }
+      assert.deepStrictEqual(projectKindRepositoryIdentityResolveCalls, ["/tmp/project-standard"]);
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -13,6 +13,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import * as ServerConfigModule from "../../config.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
 import { ORCHESTRATION_PROJECTOR_NAMES } from "./ProjectionPipeline.ts";
@@ -32,6 +33,79 @@ const projectionSnapshotLayer = it.layer(
     Layer.provideMerge(NodeServices.layer),
   ),
 );
+
+const projectionSnapshotWithServerConfigLayer = it.layer(
+  OrchestrationProjectionSnapshotQueryLive.pipe(
+    Layer.provideMerge(RepositoryIdentityResolver.layer),
+    Layer.provideMerge(SqlitePersistenceMemory),
+    Layer.provideMerge(
+      Layer.fresh(
+        ServerConfigModule.layerTest(process.cwd(), { prefix: "t3code-project-kind-test-" }),
+      ),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+projectionSnapshotWithServerConfigLayer("ProjectionSnapshotQuery project kind", (it) => {
+  it.effect("derives the chats kind for the project rooted at the chats dir", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const serverConfig = yield* ServerConfigModule.ServerConfig;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES
+          (
+            'project-chats',
+            'Chats',
+            ${serverConfig.chatsDir},
+            NULL,
+            '[]',
+            '2026-02-24T00:00:00.000Z',
+            '2026-02-24T00:00:01.000Z',
+            NULL
+          ),
+          (
+            'project-standard',
+            'Standard',
+            '/tmp/project-standard',
+            NULL,
+            '[]',
+            '2026-02-24T00:00:00.000Z',
+            '2026-02-24T00:00:01.000Z',
+            NULL
+          )
+      `;
+
+      const shellSnapshot = yield* snapshotQuery.getShellSnapshot();
+      const kindsById = new Map(
+        shellSnapshot.projects.map((project) => [project.id, project.kind]),
+      );
+      assert.equal(kindsById.get(asProjectId("project-chats")), "chats");
+      assert.equal(kindsById.get(asProjectId("project-standard")), "standard");
+
+      const chatsProject = yield* snapshotQuery.getActiveProjectByWorkspaceRoot(
+        serverConfig.chatsDir,
+      );
+      assert.equal(chatsProject._tag, "Some");
+      if (chatsProject._tag === "Some") {
+        assert.equal(chatsProject.value.kind, "chats");
+      }
+    }),
+  );
+});
 
 projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
   it.effect("hydrates read model from projection tables and computes snapshot sequence", () =>
@@ -261,6 +335,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           id: asProjectId("project-1"),
           title: "Project 1",
           workspaceRoot: "/tmp/project-1",
+          kind: "standard",
           repositoryIdentity: null,
           defaultModelSelection: {
             instanceId: ProviderInstanceId.make("codex"),
@@ -376,6 +451,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           id: asProjectId("project-1"),
           title: "Project 1",
           workspaceRoot: "/tmp/project-1",
+          kind: "standard",
           repositoryIdentity: null,
           defaultModelSelection: {
             instanceId: ProviderInstanceId.make("codex"),

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -277,6 +277,14 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
   ).pipe(Option.getOrUndefined);
   const projectKindForWorkspaceRoot = (workspaceRoot: string) =>
     resolveProjectKind(workspaceRoot, chatsDir);
+  const resolveRepositoryIdentityForWorkspaceRoot = Effect.fn(
+    "ProjectionSnapshotQuery.resolveRepositoryIdentityForWorkspaceRoot",
+  )(function* (workspaceRoot: string) {
+    if (projectKindForWorkspaceRoot(workspaceRoot) === "chats") {
+      return null;
+    }
+    return yield* repositoryIdentityResolver.resolve(workspaceRoot);
+  });
   const repositoryIdentityResolutionConcurrency = 4;
   const resolveRepositoryIdentitiesForProjects = Effect.fn(
     "ProjectionSnapshotQuery.resolveRepositoryIdentitiesForProjects",
@@ -295,9 +303,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       yield* Effect.forEach(
         uniqueWorkspaceRoots,
         (workspaceRoot) =>
-          repositoryIdentityResolver
-            .resolve(workspaceRoot)
-            .pipe(Effect.map((identity) => [workspaceRoot, identity] as const)),
+          resolveRepositoryIdentityForWorkspaceRoot(workspaceRoot).pipe(
+            Effect.map((identity) => [workspaceRoot, identity] as const),
+          ),
         { concurrency: repositoryIdentityResolutionConcurrency },
       ),
     );
@@ -1771,7 +1779,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         Effect.flatMap((option) =>
           Option.isNone(option)
             ? Effect.succeed(Option.none<OrchestrationProject>())
-            : repositoryIdentityResolver.resolve(option.value.workspaceRoot).pipe(
+            : resolveRepositoryIdentityForWorkspaceRoot(option.value.workspaceRoot).pipe(
                 Effect.map((repositoryIdentity) =>
                   Option.some({
                     id: option.value.projectId,
@@ -1801,19 +1809,17 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       Effect.flatMap((option) =>
         Option.isNone(option)
           ? Effect.succeed(Option.none<OrchestrationProjectShell>())
-          : repositoryIdentityResolver
-              .resolve(option.value.workspaceRoot)
-              .pipe(
-                Effect.map((repositoryIdentity) =>
-                  Option.some(
-                    mapProjectShellRow(
-                      option.value,
-                      repositoryIdentity,
-                      projectKindForWorkspaceRoot(option.value.workspaceRoot),
-                    ),
+          : resolveRepositoryIdentityForWorkspaceRoot(option.value.workspaceRoot).pipe(
+              Effect.map((repositoryIdentity) =>
+                Option.some(
+                  mapProjectShellRow(
+                    option.value,
+                    repositoryIdentity,
+                    projectKindForWorkspaceRoot(option.value.workspaceRoot),
                   ),
                 ),
               ),
+            ),
       ),
     );
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -21,6 +21,7 @@ import {
   type OrchestrationSession,
   type OrchestrationThreadActivity,
   type OrchestrationThreadShell,
+  type ProjectKind,
   ModelSelection,
   ProjectId,
   ThreadId,
@@ -50,6 +51,8 @@ import { ProjectionThreadProposedPlan } from "../../persistence/Services/Project
 import { ProjectionThreadSession } from "../../persistence/Services/ProjectionThreadSessions.ts";
 import { ProjectionThread } from "../../persistence/Services/ProjectionThreads.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
+import { resolveProjectKind } from "../../project/ProjectKind.ts";
+import { ServerConfig } from "../../config.ts";
 import { ORCHESTRATION_PROJECTOR_NAMES } from "./ProjectionPipeline.ts";
 import {
   ProjectionSnapshotQuery,
@@ -227,11 +230,13 @@ function mapSessionRow(
 function mapProjectShellRow(
   row: Schema.Schema.Type<typeof ProjectionProjectDbRowSchema>,
   repositoryIdentity: OrchestrationProject["repositoryIdentity"],
+  kind: ProjectKind,
 ): OrchestrationProjectShell {
   return {
     id: row.projectId,
     title: row.title,
     workspaceRoot: row.workspaceRoot,
+    kind,
     repositoryIdentity,
     defaultModelSelection: row.defaultModelSelection,
     scripts: row.scripts,
@@ -264,6 +269,14 @@ function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: st
 const makeProjectionSnapshotQuery = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
   const repositoryIdentityResolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+  // Optional so test layer stacks without ServerConfig keep working; without a
+  // configured chats dir every project resolves to "standard".
+  const chatsDir = Option.map(
+    yield* Effect.serviceOption(ServerConfig),
+    (config) => config.chatsDir,
+  ).pipe(Option.getOrUndefined);
+  const projectKindForWorkspaceRoot = (workspaceRoot: string) =>
+    resolveProjectKind(workspaceRoot, chatsDir);
   const repositoryIdentityResolutionConcurrency = 4;
   const resolveRepositoryIdentitiesForProjects = Effect.fn(
     "ProjectionSnapshotQuery.resolveRepositoryIdentitiesForProjects",
@@ -1181,6 +1194,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 id: row.projectId,
                 title: row.title,
                 workspaceRoot: row.workspaceRoot,
+                kind: projectKindForWorkspaceRoot(row.workspaceRoot),
                 repositoryIdentity: repositoryIdentities.get(row.projectId) ?? null,
                 defaultModelSelection: row.defaultModelSelection,
                 scripts: row.scripts,
@@ -1518,7 +1532,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               projects: Arr.filterMap(projectRows, (row) =>
                 row.deletedAt === null
                   ? Result.succeed(
-                      mapProjectShellRow(row, repositoryIdentities.get(row.projectId) ?? null),
+                      mapProjectShellRow(
+                        row,
+                        repositoryIdentities.get(row.projectId) ?? null,
+                        projectKindForWorkspaceRoot(row.workspaceRoot),
+                      ),
                     )
                   : Result.failVoid,
               ),
@@ -1657,7 +1675,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               projects: Arr.filterMap(projectRows, (row) =>
                 row.deletedAt === null && activeProjectIds.has(row.projectId)
                   ? Result.succeed(
-                      mapProjectShellRow(row, repositoryIdentities.get(row.projectId) ?? null),
+                      mapProjectShellRow(
+                        row,
+                        repositoryIdentities.get(row.projectId) ?? null,
+                        projectKindForWorkspaceRoot(row.workspaceRoot),
+                      ),
                     )
                   : Result.failVoid,
               ),
@@ -1755,6 +1777,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                     id: option.value.projectId,
                     title: option.value.title,
                     workspaceRoot: option.value.workspaceRoot,
+                    kind: projectKindForWorkspaceRoot(option.value.workspaceRoot),
                     repositoryIdentity,
                     defaultModelSelection: option.value.defaultModelSelection,
                     scripts: option.value.scripts,
@@ -1782,7 +1805,13 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               .resolve(option.value.workspaceRoot)
               .pipe(
                 Effect.map((repositoryIdentity) =>
-                  Option.some(mapProjectShellRow(option.value, repositoryIdentity)),
+                  Option.some(
+                    mapProjectShellRow(
+                      option.value,
+                      repositoryIdentity,
+                      projectKindForWorkspaceRoot(option.value.workspaceRoot),
+                    ),
+                  ),
                 ),
               ),
       ),

--- a/apps/server/src/project/ProjectKind.test.ts
+++ b/apps/server/src/project/ProjectKind.test.ts
@@ -1,0 +1,16 @@
+import { assert, it } from "@effect/vitest";
+
+import { resolveProjectKind } from "./ProjectKind.ts";
+
+it("marks projects rooted at the chats dir as chats", () => {
+  assert.equal(resolveProjectKind("/home/user/.t3/chats", "/home/user/.t3/chats"), "chats");
+});
+
+it("keeps other projects standard", () => {
+  assert.equal(resolveProjectKind("/home/user/dev/app", "/home/user/.t3/chats"), "standard");
+  assert.equal(resolveProjectKind("/home/user/dev/chats", "/home/user/.t3/chats"), "standard");
+});
+
+it("treats a missing chats dir as standard", () => {
+  assert.equal(resolveProjectKind("/home/user/.t3/chats", undefined), "standard");
+});

--- a/apps/server/src/project/ProjectKind.ts
+++ b/apps/server/src/project/ProjectKind.ts
@@ -1,0 +1,16 @@
+/**
+ * ProjectKind - Derives the project kind from its workspace root.
+ *
+ * The reserved "Chats" pseudo-project lives at `<baseDir>/chats` and hosts
+ * one-off conversations that are not tied to a real codebase. The kind is
+ * derived at read time (never persisted) so it stays correct across base-dir
+ * moves and pre-existing rows.
+ *
+ * @module ProjectKind
+ */
+import type { ProjectKind } from "@t3tools/contracts";
+
+export const resolveProjectKind = (
+  workspaceRoot: string,
+  chatsDir: string | undefined,
+): ProjectKind => (chatsDir !== undefined && workspaceRoot === chatsDir ? "chats" : "standard");

--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -107,6 +107,102 @@ it.effect("launchStartupHeartbeat does not block the caller while counts are loa
   ),
 );
 
+it.effect("ensureChatsProject creates the Chats project when missing", () =>
+  Effect.gen(function* () {
+    const dispatchedCommands = yield* Ref.make<ReadonlyArray<Record<string, unknown>>>([]);
+    yield* ServerRuntimeStartup.ensureChatsProject.pipe(
+      Effect.provideService(ServerConfig.ServerConfig, {
+        chatsDir: "/tmp/t3-home/chats",
+      } as never),
+      Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
+        getCommandReadModel: () => Effect.die("unused"),
+        getSnapshot: () => Effect.die("unused"),
+        getShellSnapshot: () => Effect.die("unused"),
+        getArchivedShellSnapshot: () => Effect.die("unused"),
+        getSnapshotSequence: () => Effect.die("unused"),
+        getCounts: () => Effect.die("unused"),
+        getActiveProjectByWorkspaceRoot: () => Effect.succeed(Option.none()),
+        getProjectShellById: () => Effect.die("unused"),
+        getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
+        getThreadCheckpointContext: () => Effect.succeed(Option.none()),
+        getFullThreadDiffContext: () => Effect.succeed(Option.none()),
+        getThreadShellById: () => Effect.die("unused"),
+        getThreadDetailById: () => Effect.die("unused"),
+        getThreadDetailSnapshot: () => Effect.die("unused"),
+      }),
+      Effect.provideService(OrchestrationEngine.OrchestrationEngineService, {
+        readEvents: () => Stream.empty,
+        dispatch: (command) =>
+          Ref.update(dispatchedCommands, (calls) => [...calls, command]).pipe(
+            Effect.as({ sequence: 1 }),
+          ),
+        streamDomainEvents: Stream.empty,
+        latestSequence: Effect.succeed(0),
+      } satisfies OrchestrationEngine.OrchestrationEngineService["Service"]),
+      Effect.provide(NodeServices.layer),
+    );
+
+    const commands = yield* Ref.get(dispatchedCommands);
+    assert.equal(commands.length, 1);
+    assert.equal(commands[0]?.type, "project.create");
+    assert.equal(commands[0]?.title, ServerRuntimeStartup.CHATS_PROJECT_TITLE);
+    assert.equal(commands[0]?.workspaceRoot, "/tmp/t3-home/chats");
+    assert.equal(commands[0]?.createWorkspaceRootIfMissing, true);
+  }),
+);
+
+it.effect("ensureChatsProject leaves an existing Chats project untouched", () =>
+  Effect.gen(function* () {
+    const dispatchedCommands = yield* Ref.make<ReadonlyArray<string>>([]);
+    yield* ServerRuntimeStartup.ensureChatsProject.pipe(
+      Effect.provideService(ServerConfig.ServerConfig, {
+        chatsDir: "/tmp/t3-home/chats",
+      } as never),
+      Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
+        getCommandReadModel: () => Effect.die("unused"),
+        getSnapshot: () => Effect.die("unused"),
+        getShellSnapshot: () => Effect.die("unused"),
+        getArchivedShellSnapshot: () => Effect.die("unused"),
+        getSnapshotSequence: () => Effect.die("unused"),
+        getCounts: () => Effect.die("unused"),
+        getActiveProjectByWorkspaceRoot: () =>
+          Effect.succeed(
+            Option.some({
+              id: ProjectId.make("project-chats"),
+              title: ServerRuntimeStartup.CHATS_PROJECT_TITLE,
+              workspaceRoot: "/tmp/t3-home/chats",
+              kind: "chats" as const,
+              defaultModelSelection: null,
+              scripts: [],
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+              deletedAt: null,
+            }),
+          ),
+        getProjectShellById: () => Effect.die("unused"),
+        getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
+        getThreadCheckpointContext: () => Effect.succeed(Option.none()),
+        getFullThreadDiffContext: () => Effect.succeed(Option.none()),
+        getThreadShellById: () => Effect.die("unused"),
+        getThreadDetailById: () => Effect.die("unused"),
+        getThreadDetailSnapshot: () => Effect.die("unused"),
+      }),
+      Effect.provideService(OrchestrationEngine.OrchestrationEngineService, {
+        readEvents: () => Stream.empty,
+        dispatch: (command) =>
+          Ref.update(dispatchedCommands, (calls) => [...calls, command.type]).pipe(
+            Effect.as({ sequence: 1 }),
+          ),
+        streamDomainEvents: Stream.empty,
+        latestSequence: Effect.succeed(0),
+      } satisfies OrchestrationEngine.OrchestrationEngineService["Service"]),
+      Effect.provide(NodeServices.layer),
+    );
+
+    assert.deepStrictEqual(yield* Ref.get(dispatchedCommands), []);
+  }),
+);
+
 it.effect("resolveWelcomeBase derives cwd and project name from server config", () =>
   Effect.gen(function* () {
     const welcome = yield* ServerRuntimeStartup.resolveWelcomeBase.pipe(

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -166,6 +166,37 @@ export const getAutoBootstrapDefaultModelSelection = (): ModelSelection => ({
   model: DEFAULT_MODEL,
 });
 
+export const CHATS_PROJECT_TITLE = "Chat";
+
+/**
+ * Ensures the reserved Chat pseudo-project exists. It points at the
+ * `<baseDir>/chats` directory and hosts one-off conversations that are not
+ * tied to a real codebase. The directory is created when missing.
+ */
+export const ensureChatsProject = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const serverConfig = yield* ServerConfig.ServerConfig;
+  const projectionReadModelQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+  const orchestrationEngine = yield* OrchestrationEngine.OrchestrationEngineService;
+
+  const existingProject = yield* projectionReadModelQuery.getActiveProjectByWorkspaceRoot(
+    serverConfig.chatsDir,
+  );
+  if (Option.isSome(existingProject)) {
+    return;
+  }
+
+  yield* orchestrationEngine.dispatch({
+    type: "project.create",
+    commandId: CommandId.make(yield* crypto.randomUUIDv4),
+    projectId: ProjectId.make(yield* crypto.randomUUIDv4),
+    title: CHATS_PROJECT_TITLE,
+    workspaceRoot: serverConfig.chatsDir,
+    createWorkspaceRootIfMissing: true,
+    createdAt: DateTime.formatIso(yield* DateTime.now),
+  });
+});
+
 export const resolveWelcomeBase = Effect.gen(function* () {
   const serverConfig = yield* ServerConfig.ServerConfig;
   const segments = serverConfig.cwd.split(/[/\\]/).filter(Boolean);
@@ -344,6 +375,18 @@ export const make = Effect.gen(function* () {
         yield* orchestrationReactor.start().pipe(Scope.provide(reactorScope));
         yield* providerSessionReaper.start().pipe(Scope.provide(reactorScope));
       }),
+    );
+
+    yield* Effect.forkScoped(
+      runStartupPhase(
+        "chats.ensure",
+        ensureChatsProject.pipe(
+          Effect.provideService(Crypto.Crypto, crypto),
+          Effect.catch((cause) =>
+            Effect.logWarning("startup chats project ensure failed", { cause }),
+          ),
+        ),
+      ),
     );
 
     const welcomeBase = yield* resolveWelcomeBase;

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -22,6 +22,7 @@ import {
   getStartedThreadModelChangeBlockReason,
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
+  isWorkspaceShortcutBlockedForChats,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
   resolveThreadMetadataUpdateForNextTurn,
@@ -35,6 +36,16 @@ const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
 const now = "2026-03-29T00:00:00.000Z";
+
+describe("isWorkspaceShortcutBlockedForChats", () => {
+  it("blocks terminal and diff shortcuts only for Chat projects", () => {
+    expect(isWorkspaceShortcutBlockedForChats("terminal.new", true)).toBe(true);
+    expect(isWorkspaceShortcutBlockedForChats("terminal.split", true)).toBe(true);
+    expect(isWorkspaceShortcutBlockedForChats("diff.toggle", true)).toBe(true);
+    expect(isWorkspaceShortcutBlockedForChats("rightPanel.toggle", true)).toBe(false);
+    expect(isWorkspaceShortcutBlockedForChats("terminal.new", false)).toBe(false);
+  });
+});
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,6 +1,7 @@
 import {
   type EnvironmentId,
   isProviderDriverKind,
+  type KeybindingCommand,
   ProjectId,
   type ModelSelection,
   type ProviderDriverKind,
@@ -25,6 +26,20 @@ import type { DraftThreadEnvMode } from "../composerDraftStore";
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
 export const MAX_HIDDEN_MOUNTED_TERMINAL_THREADS = 10;
 export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
+
+export function isWorkspaceShortcutBlockedForChats(
+  command: KeybindingCommand,
+  activeProjectIsChats: boolean,
+): boolean {
+  return (
+    activeProjectIsChats &&
+    (command === "terminal.toggle" ||
+      command === "terminal.split" ||
+      command === "terminal.splitVertical" ||
+      command === "terminal.new" ||
+      command === "diff.toggle")
+  );
+}
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -26,6 +26,7 @@ import {
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
 import { effectiveSettled, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
+import { isChatsProject, projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import {
   parseScopedThreadKey,
   scopedThreadKey,
@@ -1606,6 +1607,10 @@ function ChatViewContent(props: ChatViewProps) {
   const handleNewThreadInActiveProject = useCallback(() => {
     startNewThreadForProject(activeProjectRef, handleNewThread);
   }, [activeProjectRef, handleNewThread]);
+  // The reserved Chats pseudo-project has no real codebase, so project-scoped
+  // surfaces (diff, files, terminal, branches/worktrees, git actions) are
+  // hidden for it.
+  const activeProjectIsChats = isChatsProject(activeProject);
   const activeEnvironmentShell = useEnvironmentQuery(
     activeThread ? environmentShell.stateAtom(activeThread.environmentId) : null,
   );
@@ -1644,8 +1649,13 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     if (!activeThreadRef || !activeEnvironmentBootstrapComplete) return;
-    useRightPanelStore.getState().reconcileFileSurfaces(activeThreadRef, activeProject !== null);
-  }, [activeEnvironmentBootstrapComplete, activeProject, activeThreadRef]);
+    useRightPanelStore
+      .getState()
+      .reconcileFileSurfaces(activeThreadRef, activeProject !== null && !activeProjectIsChats);
+    useRightPanelStore
+      .getState()
+      .reconcileWorkspaceSurfaces(activeThreadRef, !activeProjectIsChats);
+  }, [activeEnvironmentBootstrapComplete, activeProject, activeProjectIsChats, activeThreadRef]);
 
   // Compute the list of environments this logical project spans, used to
   // drive the environment picker in BranchToolbar.
@@ -2425,7 +2435,7 @@ function ChatViewContent(props: ChatViewProps) {
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
-  const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
+  const isGitRepo = (gitStatusQuery.data?.isRepo ?? true) && !activeProjectIsChats;
   const showComposerContextStrip = isGitRepo && activeProject !== null;
   const initialDiffPanelGitScope =
     gitStatusQuery.data?.hasWorkingTreeChanges === true ? "unstaged" : "branch";
@@ -2563,7 +2573,7 @@ function ChatViewContent(props: ChatViewProps) {
     if (!activeThreadRef) return;
     const nextOpen = !terminalUiState.terminalOpen;
     if (nextOpen && terminalUiState.terminalIds.length === 0) {
-      if (!activeThreadId || !activeProject) {
+      if (!activeThreadId || !activeProject || activeProjectIsChats) {
         return;
       }
       const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2591,6 +2601,7 @@ function ChatViewContent(props: ChatViewProps) {
   }, [
     activeKnownTerminalIds,
     activeProject,
+    activeProjectIsChats,
     activeThreadId,
     activeThreadRef,
     activeThreadWorktreePath,
@@ -3054,15 +3065,15 @@ function ChatViewContent(props: ChatViewProps) {
     planSidebarOpen,
   ]);
   const addFilesSurface = useCallback(() => {
-    if (!activeThreadRef || !activeProject) return;
+    if (!activeThreadRef || !activeProject || activeProjectIsChats) return;
     useRightPanelStore.getState().open(activeThreadRef, "files");
-  }, [activeProject, activeThreadRef]);
+  }, [activeProject, activeProjectIsChats, activeThreadRef]);
   const openFileSurface = useCallback(
     (relativePath: string) => {
-      if (!activeThreadRef || !activeProject) return;
+      if (!activeThreadRef || !activeProject || activeProjectIsChats) return;
       useRightPanelStore.getState().openFile(activeThreadRef, relativePath);
     },
-    [activeProject, activeThreadRef],
+    [activeProject, activeProjectIsChats, activeThreadRef],
   );
   const togglePreviewPanel = useCallback(() => {
     if (!activeThreadRef || !isPreviewSupportedInRuntime()) return;
@@ -3084,7 +3095,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
   }, [activeThreadRef]);
   const addTerminalSurface = useCallback(() => {
-    if (!activeThreadRef || !activeThreadId || !activeProject) return;
+    if (!activeThreadRef || !activeThreadId || !activeProject || activeProjectIsChats) return;
     const cwd = gitCwd ?? activeProject.workspaceRoot;
     const terminalId = nextTerminalId([...activeKnownTerminalIds, ...panelTerminalIds]);
     useRightPanelStore.getState().openTerminal(activeThreadRef, terminalId);
@@ -3105,6 +3116,7 @@ function ChatViewContent(props: ChatViewProps) {
   }, [
     activeKnownTerminalIds,
     activeProject,
+    activeProjectIsChats,
     activeThreadId,
     activeThreadRef,
     activeThreadWorktreePath,
@@ -4405,6 +4417,7 @@ function ChatViewContent(props: ChatViewProps) {
     return () => window.removeEventListener("keydown", handler, true);
   }, [
     activeProject,
+    activeProjectIsChats,
     activeRightPanelSurface,
     addTerminalSurface,
     terminalUiState.terminalOpen,
@@ -5559,7 +5572,7 @@ function ChatViewContent(props: ChatViewProps) {
 
   const panelToggleControls = (
     <PanelLayoutControls
-      terminalAvailable={activeProject !== null}
+      terminalAvailable={activeProject !== null && !activeProjectIsChats}
       terminalOpen={terminalUiState.terminalOpen}
       terminalShortcutLabel={shortcutLabelForCommand(keybindings, "terminal.toggle")}
       rightPanelAvailable={activeProject !== null}
@@ -5687,7 +5700,7 @@ function ChatViewContent(props: ChatViewProps) {
             activeThreadId={activeThread.id}
             {...(routeKind === "draft" && draftId ? { draftId } : {})}
             activeThreadTitle={activeThread.title}
-            activeProjectName={activeProject?.title}
+            activeProjectName={activeProject ? projectDisplayTitle(activeProject) : undefined}
             activeProjectCwd={activeProject?.workspaceRoot ?? null}
             openInCwd={gitCwd}
             activeProjectScripts={activeProject?.scripts}
@@ -5699,6 +5712,7 @@ function ChatViewContent(props: ChatViewProps) {
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}
             onNewThreadInProject={handleNewThreadInActiveProject}
+            isChatsProject={activeProjectIsChats}
             onRunProjectScript={runProjectScript}
             onAddProjectScript={saveProjectScript}
             onUpdateProjectScript={updateProjectScript}
@@ -5809,7 +5823,10 @@ function ChatViewContent(props: ChatViewProps) {
                       >
                         <DraftHeroHeadline
                           activeProjectRef={activeProjectRef}
-                          activeProjectTitle={activeProject?.title ?? null}
+                          activeProjectTitle={
+                            activeProject ? projectDisplayTitle(activeProject) : null
+                          }
+                          isChatsProject={activeProjectIsChats}
                         />
                       </div>
                       <ComposerBannerStack className="relative z-0" items={composerBannerItems} />
@@ -6063,7 +6080,8 @@ function ChatViewContent(props: ChatViewProps) {
           onAddFiles={addFilesSurface}
           browserAvailable={isPreviewSupportedInRuntime()}
           diffAvailable={isServerThread && isGitRepo}
-          filesAvailable={activeProject !== null}
+          filesAvailable={activeProject !== null && !activeProjectIsChats}
+          terminalAvailable={activeProject !== null && !activeProjectIsChats}
         >
           {rightPanelContent}
         </RightPanelTabs>
@@ -6090,7 +6108,8 @@ function ChatViewContent(props: ChatViewProps) {
             onAddFiles={addFilesSurface}
             browserAvailable={isPreviewSupportedInRuntime()}
             diffAvailable={isServerThread && isGitRepo}
-            filesAvailable={activeProject !== null}
+            filesAvailable={activeProject !== null && !activeProjectIsChats}
+            terminalAvailable={activeProject !== null && !activeProjectIsChats}
           >
             {rightPanelContent}
           </RightPanelTabs>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -261,6 +261,7 @@ import {
   dismissBranchMismatchForSession,
   hasServerAcknowledgedLocalDispatch,
   isBranchMismatchDismissedForSession,
+  isWorkspaceShortcutBlockedForChats,
   shouldShowBranchMismatchBanner,
   getStartedThreadModelChangeBlockReason,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
@@ -1655,7 +1656,16 @@ function ChatViewContent(props: ChatViewProps) {
     useRightPanelStore
       .getState()
       .reconcileWorkspaceSurfaces(activeThreadRef, !activeProjectIsChats);
-  }, [activeEnvironmentBootstrapComplete, activeProject, activeProjectIsChats, activeThreadRef]);
+    if (activeProjectIsChats) {
+      storeSetTerminalOpen(activeThreadRef, false);
+    }
+  }, [
+    activeEnvironmentBootstrapComplete,
+    activeProject,
+    activeProjectIsChats,
+    activeThreadRef,
+    storeSetTerminalOpen,
+  ]);
 
   // Compute the list of environments this logical project spans, used to
   // drive the environment picker in BranchToolbar.
@@ -2467,7 +2477,7 @@ function ChatViewContent(props: ChatViewProps) {
     [keybindings, terminalShortcutLabelOptions],
   );
   const onToggleDiff = useCallback(() => {
-    if (!isServerThread) {
+    if (!isServerThread || !isGitRepo) {
       return;
     }
     if (!diffOpen) {
@@ -2476,7 +2486,7 @@ function ChatViewContent(props: ChatViewProps) {
     if (activeThreadRef) {
       useRightPanelStore.getState().toggle(activeThreadRef, "diff");
     }
-  }, [activeThreadRef, diffOpen, isServerThread, onDiffPanelOpen]);
+  }, [activeThreadRef, diffOpen, isGitRepo, isServerThread, onDiffPanelOpen]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -2570,10 +2580,10 @@ function ChatViewContent(props: ChatViewProps) {
     [activeThreadRef, storeSetTerminalOpen],
   );
   const toggleTerminalVisibility = useCallback(() => {
-    if (!activeThreadRef) return;
+    if (!activeThreadRef || activeProjectIsChats) return;
     const nextOpen = !terminalUiState.terminalOpen;
     if (nextOpen && terminalUiState.terminalIds.length === 0) {
-      if (!activeThreadId || !activeProject || activeProjectIsChats) {
+      if (!activeThreadId || !activeProject) {
         return;
       }
       const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2616,7 +2626,13 @@ function ChatViewContent(props: ChatViewProps) {
   ]);
   const splitTerminal = useCallback(
     (direction: "horizontal" | "vertical" = "horizontal") => {
-      if (!activeThreadRef || hasReachedSplitLimit || !activeThreadId || !activeProject) {
+      if (
+        !activeThreadRef ||
+        hasReachedSplitLimit ||
+        !activeThreadId ||
+        !activeProject ||
+        activeProjectIsChats
+      ) {
         return;
       }
       const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2646,6 +2662,7 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [
       activeProject,
+      activeProjectIsChats,
       activeKnownTerminalIds,
       activeThreadId,
       activeThreadRef,
@@ -2659,7 +2676,7 @@ function ChatViewContent(props: ChatViewProps) {
     ],
   );
   const createNewTerminal = useCallback(() => {
-    if (!activeThreadRef || !activeThreadId || !activeProject) {
+    if (!activeThreadRef || !activeThreadId || !activeProject || activeProjectIsChats) {
       return;
     }
     const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2684,6 +2701,7 @@ function ChatViewContent(props: ChatViewProps) {
     });
   }, [
     activeProject,
+    activeProjectIsChats,
     activeKnownTerminalIds,
     activeThreadId,
     activeThreadRef,
@@ -3130,6 +3148,7 @@ function ChatViewContent(props: ChatViewProps) {
         !activeThreadRef ||
         !activeThreadId ||
         !activeProject ||
+        activeProjectIsChats ||
         activeRightPanelSurface?.kind !== "terminal" ||
         activeRightPanelSurface.terminalIds.length >= MAX_TERMINALS_PER_GROUP
       ) {
@@ -3158,6 +3177,7 @@ function ChatViewContent(props: ChatViewProps) {
     [
       activeKnownTerminalIds,
       activeProject,
+      activeProjectIsChats,
       activeRightPanelSurface,
       activeThreadId,
       activeThreadRef,
@@ -4323,6 +4343,12 @@ function ChatViewContent(props: ChatViewProps) {
       });
       if (!command) return;
 
+      if (isWorkspaceShortcutBlockedForChats(command, activeProjectIsChats)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
       if (command === "terminal.toggle") {
         event.preventDefault();
         event.stopPropagation();
@@ -4407,6 +4433,11 @@ function ChatViewContent(props: ChatViewProps) {
 
       const scriptId = projectScriptIdFromCommand(command);
       if (!scriptId || !activeProject) return;
+      if (activeProjectIsChats) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       const script = activeProject.scripts.find((entry) => entry.id === scriptId);
       if (!script) return;
       event.preventDefault();

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -6,7 +6,9 @@ import {
   buildProjectActionItems,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
+  findChatsProjectForEnvironment,
   filterCommandPaletteGroups,
+  selectPreferredProjectEntry,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -272,5 +274,33 @@ describe("buildProjectActionItems", () => {
 
     expect(item?.title).toBe("t3code");
     expect(item?.description).toBe("/dev/t3code");
+  });
+
+  it("selects the Chat project from the contextual environment", () => {
+    const localChats = makeProject({
+      id: ProjectId.make("chat-local"),
+      environmentId: EnvironmentId.make("env-local"),
+      kind: "chats",
+    });
+    const remoteChats = makeProject({
+      id: ProjectId.make("chat-remote"),
+      environmentId: EnvironmentId.make("env-remote"),
+      kind: "chats",
+    });
+
+    expect(
+      findChatsProjectForEnvironment([localChats, remoteChats], EnvironmentId.make("env-remote"))
+        ?.id,
+    ).toBe(ProjectId.make("chat-remote"));
+    expect(findChatsProjectForEnvironment([localChats], null)).toBeNull();
+  });
+
+  it("selects the preferred codebase entry and otherwise falls back to the first", () => {
+    const first = { id: "first", isPreferred: false };
+    const preferred = { id: "preferred", isPreferred: true };
+
+    expect(selectPreferredProjectEntry([first, preferred])).toBe(preferred);
+    expect(selectPreferredProjectEntry([first])).toBe(first);
+    expect(selectPreferredProjectEntry([])).toBeNull();
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
-import type { Thread } from "../types";
+import type { Project, Thread } from "../types";
 import {
   buildBrowseGroups,
+  buildProjectActionItems,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
@@ -230,5 +231,46 @@ describe("buildBrowseGroups", () => {
     finishNavigation?.();
     await action;
     expect(actionSettled).toBe(true);
+  });
+});
+
+describe("buildProjectActionItems", () => {
+  const makeProject = (overrides: Partial<Project> = {}): Project =>
+    ({
+      id: ProjectId.make("project-1"),
+      environmentId: EnvironmentId.make("env-1"),
+      title: "Chats",
+      workspaceRoot: "/home/user/.t3/chats",
+      defaultModelSelection: null,
+      scripts: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      ...overrides,
+    }) as Project;
+
+  it("labels the chats pseudo-project and hides its workspace path", () => {
+    const [item] = buildProjectActionItems({
+      projects: [makeProject({ kind: "chats" })],
+      valuePrefix: "project",
+      icon: () => null,
+      runProject: async () => undefined,
+    });
+
+    expect(item?.title).toBe("Chat");
+    expect(item?.description).toBeUndefined();
+    // The directory stays searchable even though it is not displayed.
+    expect(item?.searchTerms).toContain("/home/user/.t3/chats");
+  });
+
+  it("keeps the title and path for standard projects", () => {
+    const [item] = buildProjectActionItems({
+      projects: [makeProject({ title: "t3code", workspaceRoot: "/dev/t3code" })],
+      valuePrefix: "project",
+      icon: () => null,
+      runProject: async () => undefined,
+    });
+
+    expect(item?.title).toBe("t3code");
+    expect(item?.description).toBe("/dev/t3code");
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -10,6 +10,7 @@ import { type ReactNode } from "react";
 import { sortThreads } from "../lib/threadSort";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { type Project, type SidebarThreadSummary, type Thread } from "../types";
+import { isChatsProject, projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 
 export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-muted-foreground/80";
@@ -46,7 +47,8 @@ export interface CommandPaletteSubmenuItem extends CommandPaletteItem {
 
 export interface CommandPaletteGroup {
   readonly value: string;
-  readonly label: string;
+  /** Omitted for single-item groups that read as standalone actions. */
+  readonly label?: string;
   readonly items: ReadonlyArray<CommandPaletteActionItem | CommandPaletteSubmenuItem>;
 }
 
@@ -86,8 +88,10 @@ export function buildProjectActionItems(input: {
     kind: "action",
     value: `${input.valuePrefix}:${project.environmentId}:${project.id}`,
     searchTerms: [project.title, project.workspaceRoot, ...(input.searchTerms?.(project) ?? [])],
-    title: project.title,
-    description: project.workspaceRoot,
+    title: projectDisplayTitle(project),
+    // The Chat pseudo-project's directory is an implementation detail, so it
+    // stays hidden even though it is still searchable above.
+    ...(isChatsProject(project) ? {} : { description: project.workspaceRoot }),
     icon: input.icon(project),
     ...(input.shortcutCommand !== undefined ? { shortcutCommand: input.shortcutCommand } : {}),
     run: async () => {
@@ -260,7 +264,9 @@ export function filterCommandPaletteGroups(input: {
       return [];
     }
 
-    return [{ value: group.value, label: group.label, items }];
+    return [
+      { value: group.value, ...(group.label === undefined ? {} : { label: group.label }), items },
+    ];
   });
 }
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -58,6 +58,24 @@ export interface CommandPaletteView {
   readonly initialQuery?: string;
 }
 
+export function findChatsProjectForEnvironment<T extends Pick<Project, "environmentId" | "kind">>(
+  projects: ReadonlyArray<T>,
+  environmentId: Project["environmentId"] | null,
+): T | null {
+  if (environmentId === null) return null;
+  return (
+    projects.find(
+      (project) => project.environmentId === environmentId && isChatsProject(project),
+    ) ?? null
+  );
+}
+
+export function selectPreferredProjectEntry<T extends { readonly isPreferred: boolean }>(
+  entries: ReadonlyArray<T>,
+): T | null {
+  return entries.find((entry) => entry.isPreferred) ?? entries[0] ?? null;
+}
+
 export function enumerateCommandPaletteItems(
   items: ReadonlyArray<CommandPaletteActionItem>,
 ): CommandPaletteActionItem[] {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { isChatsProject, projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
@@ -35,6 +36,7 @@ import {
   MessageSquareIcon,
   SettingsIcon,
   SquarePenIcon,
+  MessageCircleIcon,
 } from "lucide-react";
 import {
   useCallback,
@@ -598,6 +600,31 @@ function OpenCommandPaletteDialog(props: {
       })),
     [projectPickerEntries],
   );
+  // The Chat pseudo-project is not a codebase: it never appears in project
+  // lists, and is reachable only through its own "Start a new chat" action.
+  const chatProject = useMemo(
+    () => pickerProjects.find((project) => isChatsProject(project)) ?? null,
+    [pickerProjects],
+  );
+  const codebasePickerProjects = useMemo(
+    () => pickerProjects.filter((project) => !isChatsProject(project)),
+    [pickerProjects],
+  );
+  const startNewChat = useCallback(async () => {
+    if (!chatProject) return;
+    await handleNewThread(scopeProjectRef(chatProject.environmentId, chatProject.id));
+  }, [chatProject, handleNewThread]);
+  const startNewChatItem = useMemo(
+    (): CommandPaletteActionItem => ({
+      kind: "action",
+      value: "action:new-chat",
+      searchTerms: ["start a new chat", "chat", "new chat", "conversation", "ask"],
+      title: "Start a new chat",
+      icon: <MessageCircleIcon className={ITEM_ICON_CLASS} />,
+      run: startNewChat,
+    }),
+    [startNewChat],
+  );
   const projectGroupByTargetKey = useMemo(
     () =>
       new Map(
@@ -711,7 +738,10 @@ function OpenCommandPaletteDialog(props: {
     [projects],
   );
   const projectTitleById = useMemo(
-    () => new Map<ProjectId, string>(projects.map((project) => [project.id, project.title])),
+    () =>
+      new Map<ProjectId, string>(
+        projects.map((project) => [project.id, projectDisplayTitle(project)]),
+      ),
     [projects],
   );
 
@@ -837,7 +867,7 @@ function OpenCommandPaletteDialog(props: {
   const projectSearchItems = useMemo(
     () =>
       buildProjectActionItems({
-        projects: pickerProjects,
+        projects: codebasePickerProjects,
         valuePrefix: "project",
         searchTerms: (project) => {
           const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
@@ -849,19 +879,20 @@ function OpenCommandPaletteDialog(props: {
           <ProjectFavicon
             environmentId={project.environmentId}
             cwd={project.workspaceRoot}
+            kind={project.kind}
             className={ITEM_ICON_CLASS}
           />
         ),
         runProject: openProjectFromSearch,
       }),
-    [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
+    [codebasePickerProjects, openProjectFromSearch, projectGroupByTargetKey],
   );
 
   const projectThreadItems = useMemo(
     () =>
       enumerateCommandPaletteItems(
         buildProjectActionItems({
-          projects: pickerProjects,
+          projects: codebasePickerProjects,
           valuePrefix: "new-thread-in",
           searchTerms: (project) => {
             const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
@@ -873,6 +904,7 @@ function OpenCommandPaletteDialog(props: {
             <ProjectFavicon
               environmentId={project.environmentId}
               cwd={project.workspaceRoot}
+              kind={project.kind}
               className={ITEM_ICON_CLASS}
             />
           ),
@@ -893,7 +925,7 @@ function OpenCommandPaletteDialog(props: {
           },
         }),
       ),
-    [contextualProjectRef, handleNewThread, pickerProjects, projectGroupByTargetKey],
+    [codebasePickerProjects, contextualProjectRef, handleNewThread, projectGroupByTargetKey],
   );
 
   const allThreadItems = useMemo(
@@ -1214,6 +1246,7 @@ function OpenCommandPaletteDialog(props: {
     pushPaletteView({
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
       groups: [
+        ...(chatProject ? [{ value: "chat", items: [startNewChatItem] }] : []),
         {
           value: "projects",
           label: "Projects",
@@ -1222,6 +1255,7 @@ function OpenCommandPaletteDialog(props: {
       ],
     });
   }, [
+    chatProject,
     clearOpenIntent,
     browseNavigation,
     currentProjectEnvironmentId,
@@ -1229,14 +1263,21 @@ function OpenCommandPaletteDialog(props: {
     openIntent,
     projectThreadItems,
     pushPaletteView,
+    startNewChatItem,
   ]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
 
-  if (projects.length > 0) {
+  if (codebasePickerProjects.length > 0) {
+    const codebasePickerEntries = projectPickerEntries.filter(
+      (entry) => !isChatsProject(entry.targetProject),
+    );
+    // "New thread in X" always names a real codebase, even while a chat
+    // thread is the active one.
     const activeProjectTitle =
-      projectPickerEntries.find((entry) => entry.isPreferred)?.group.displayName ??
-      (currentProjectId ? (projectTitleById.get(currentProjectId) ?? null) : null);
+      codebasePickerEntries.find((entry) => entry.isPreferred)?.group.displayName ??
+      codebasePickerEntries[0]?.group.displayName ??
+      null;
 
     if (activeProjectTitle) {
       actionItems.push({
@@ -1268,8 +1309,15 @@ function OpenCommandPaletteDialog(props: {
       title: "New thread in...",
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
-      groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+      groups: [
+        ...(chatProject ? [{ value: "chat", items: [startNewChatItem] }] : []),
+        { value: "projects", label: "Projects", items: projectThreadItems },
+      ],
     });
+  }
+
+  if (chatProject) {
+    actionItems.push(startNewChatItem);
   }
 
   actionItems.push({

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -66,7 +66,7 @@ import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
-import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
+import { resolveThreadActionProjectRef } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
   ensureBrowseDirectoryPath,
@@ -97,12 +97,14 @@ import {
   buildRootGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
+  findChatsProjectForEnvironment,
   type CommandPaletteActionItem,
   type CommandPaletteSubmenuItem,
   type CommandPaletteView,
   filterCommandPaletteGroups,
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
+  selectPreferredProjectEntry,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
 } from "./CommandPalette.logic";
@@ -603,8 +605,12 @@ function OpenCommandPaletteDialog(props: {
   // The Chat pseudo-project is not a codebase: it never appears in project
   // lists, and is reachable only through its own "Start a new chat" action.
   const chatProject = useMemo(
-    () => pickerProjects.find((project) => isChatsProject(project)) ?? null,
-    [pickerProjects],
+    () =>
+      findChatsProjectForEnvironment(
+        pickerProjects,
+        contextualProjectRef?.environmentId ?? primaryEnvironmentId,
+      ),
+    [contextualProjectRef?.environmentId, pickerProjects, primaryEnvironmentId],
   );
   const codebasePickerProjects = useMemo(
     () => pickerProjects.filter((project) => !isChatsProject(project)),
@@ -1274,30 +1280,28 @@ function OpenCommandPaletteDialog(props: {
     );
     // "New thread in X" always names a real codebase, even while a chat
     // thread is the active one.
-    const activeProjectTitle =
-      codebasePickerEntries.find((entry) => entry.isPreferred)?.group.displayName ??
-      codebasePickerEntries[0]?.group.displayName ??
-      null;
+    const activeCodebaseEntry = selectPreferredProjectEntry(codebasePickerEntries);
 
-    if (activeProjectTitle) {
+    if (activeCodebaseEntry) {
       actionItems.push({
         kind: "action",
         value: "action:new-thread",
         searchTerms: ["new thread", "chat", "create", "draft"],
         title: (
           <>
-            New thread in <span className="font-semibold">{activeProjectTitle}</span>
+            New thread in{" "}
+            <span className="font-semibold">{activeCodebaseEntry.group.displayName}</span>
           </>
         ),
         icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
         shortcutCommand: "chat.new",
         run: async () => {
-          await startNewThreadFromContext({
-            activeDraftThread,
-            activeThread: activeThread ?? undefined,
-            defaultProjectRef,
-            handleNewThread,
-          });
+          await handleNewThread(
+            scopeProjectRef(
+              activeCodebaseEntry.targetProject.environmentId,
+              activeCodebaseEntry.targetProject.id,
+            ),
+          );
         },
       });
     }

--- a/apps/web/src/components/CommandPaletteResults.tsx
+++ b/apps/web/src/components/CommandPaletteResults.tsx
@@ -41,7 +41,9 @@ export function CommandPaletteResults(props: CommandPaletteResultsProps) {
     <CommandList>
       {props.groups.map((group) => (
         <CommandGroup items={group.items} key={group.value}>
-          <CommandGroupLabel className="ps-[9px]">{group.label}</CommandGroupLabel>
+          {group.label ? (
+            <CommandGroupLabel className="ps-[9px]">{group.label}</CommandGroupLabel>
+          ) : null}
           <CommandCollection>
             {(item) =>
               item.disabled ? (

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -1,6 +1,6 @@
-import type { EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId, ProjectKind } from "@t3tools/contracts";
 import { isProjectFaviconFallbackUrl } from "@t3tools/shared/projectFavicon";
-import { FolderIcon } from "lucide-react";
+import { FolderIcon, MessageCircleIcon } from "lucide-react";
 import type { ComponentType } from "react";
 import { useState } from "react";
 import { useAssetUrl } from "../assets/assetUrls";
@@ -13,14 +13,18 @@ export function ProjectFavicon(input: {
   cwd: string;
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
+  kind?: ProjectKind | undefined;
 }) {
   const src = useAssetUrl(input.environmentId, {
     _tag: "project-favicon",
     cwd: input.cwd,
   });
-  const FallbackIcon = input.fallbackIcon ?? FolderIcon;
+  // The Chat pseudo-project has no repository to source a favicon from, and
+  // its directory is an implementation detail — always show the chat bubble.
+  const FallbackIcon =
+    input.kind === "chats" ? MessageCircleIcon : (input.fallbackIcon ?? FolderIcon);
 
-  if (!src || isProjectFaviconFallbackUrl(src)) {
+  if (input.kind === "chats" || !src || isProjectFaviconFallbackUrl(src)) {
     return <ProjectFaviconFallback className={input.className} icon={FallbackIcon} />;
   }
 

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -47,6 +47,7 @@ interface RightPanelTabsProps {
   browserAvailable: boolean;
   diffAvailable: boolean;
   filesAvailable: boolean;
+  terminalAvailable: boolean;
   children: ReactNode;
 }
 
@@ -54,6 +55,7 @@ const SURFACE_DISABLED_REASONS = {
   browser: "Browser previews are only available in the T3 Code desktop app.",
   files: "Files are only available when a project is open.",
   diff: "Diff is only available for server threads in Git repositories.",
+  terminal: "Terminals are only available when a project workspace is open.",
 } as const;
 
 type TabContextMenuAction = "copy-path" | "close" | "close-others" | "close-to-right" | "close-all";
@@ -94,6 +96,7 @@ function RightPanelEmptyState(props: {
   browserAvailable: boolean;
   diffAvailable: boolean;
   filesAvailable: boolean;
+  terminalAvailable: boolean;
 }) {
   const actions = [
     {
@@ -108,8 +111,8 @@ function RightPanelEmptyState(props: {
       label: "Terminal",
       description: "Start a shell in this workspace.",
       icon: TerminalSquare,
-      available: true,
-      disabledReason: null,
+      available: props.terminalAvailable,
+      disabledReason: SURFACE_DISABLED_REASONS.terminal,
       onClick: props.onAddTerminal,
     },
     {
@@ -451,7 +454,11 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
                     <Globe2 />
                     Browser
                   </SurfaceMenuItem>
-                  <SurfaceMenuItem available onClick={props.onAddTerminal}>
+                  <SurfaceMenuItem
+                    available={props.terminalAvailable}
+                    disabledReason={SURFACE_DISABLED_REASONS.terminal}
+                    onClick={props.onAddTerminal}
+                  >
                     <TerminalSquare />
                     Terminal
                   </SurfaceMenuItem>
@@ -488,6 +495,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
             browserAvailable={props.browserAvailable}
             diffAvailable={props.diffAvailable}
             filesAvailable={props.filesAvailable}
+            terminalAvailable={props.terminalAvailable}
           />
         ) : (
           props.children

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2256,7 +2256,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
               }`}
             />
           )}
-          <ProjectFavicon environmentId={project.environmentId} cwd={project.workspaceRoot} />
+          <ProjectFavicon
+            environmentId={project.environmentId}
+            cwd={project.workspaceRoot}
+            kind={project.kind}
+          />
           <span className="flex min-w-0 flex-1 items-center gap-2">
             <span className="truncate text-sm font-medium text-sidebar-foreground/90">
               {project.displayName}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -62,6 +62,7 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { isChatsProject } from "@t3tools/client-runtime/state/models";
 import { useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
@@ -1113,6 +1114,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const sidebarThreadPreviewCount = useClientSettings<SidebarThreadPreviewCount>(
     (settings) => settings.sidebarThreadPreviewCount,
   );
+  const projectIsChats = isChatsProject(project);
+  const projectIsSortable = isManualProjectSorting && !projectIsChats;
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
@@ -2217,16 +2220,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     <>
       <div className="group/project-header relative">
         <SidebarMenuButton
-          ref={isManualProjectSorting ? dragHandleProps?.setActivatorNodeRef : undefined}
+          ref={projectIsSortable ? dragHandleProps?.setActivatorNodeRef : undefined}
           className={`pr-8 group-hover/project-header:bg-sidebar-row-hover group-hover/project-header:text-sidebar-foreground max-sm:pr-14 ${
-            isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : ""
+            projectIsSortable ? "cursor-grab active:cursor-grabbing" : ""
           }`}
-          {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
-          {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.listeners : {})}
+          {...(projectIsSortable && dragHandleProps ? dragHandleProps.attributes : {})}
+          {...(projectIsSortable && dragHandleProps ? dragHandleProps.listeners : {})}
           onPointerDownCapture={handleProjectButtonPointerDownCapture}
           onClick={handleProjectButtonClick}
           onKeyDown={handleProjectButtonKeyDown}
-          onContextMenu={handleProjectButtonContextMenu}
+          onContextMenu={projectIsChats ? undefined : handleProjectButtonContextMenu}
         >
           {!projectExpanded && projectStatus ? (
             <Tooltip>
@@ -2922,7 +2925,11 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 strategy={verticalListSortingStrategy}
               >
                 {sortedProjects.map((project) => (
-                  <SortableProjectItem key={project.projectKey} projectId={project.projectKey}>
+                  <SortableProjectItem
+                    key={project.projectKey}
+                    projectId={project.projectKey}
+                    disabled={isChatsProject(project)}
+                  >
                     {(dragHandleProps) => (
                       <SidebarProjectItem
                         project={project}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -6,13 +6,20 @@ import {
   effectiveSnoozed,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
-import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import {
+  isChatsProject,
+  type EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type { ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
+import type {
+  ProjectKind,
+  ScopedThreadRef,
+  SidebarProjectGroupingMode,
+} from "@t3tools/contracts";
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
@@ -224,6 +231,7 @@ function SidebarV2ThreadTooltip({
   thread,
   projectTitle,
   projectCwd,
+  projectKind,
   environmentLabel,
   driverKind,
   modelInstanceId,
@@ -233,6 +241,7 @@ function SidebarV2ThreadTooltip({
   thread: SidebarThreadSummary;
   projectTitle: string | null;
   projectCwd: string | null;
+  projectKind: ProjectKind | undefined;
   environmentLabel: string | null;
   driverKind: ProviderInstanceEntry["driverKind"] | null;
   modelInstanceId: string;
@@ -260,6 +269,7 @@ function SidebarV2ThreadTooltip({
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={projectCwd ?? ""}
+                kind={projectKind}
                 className="size-3 shrink-0 stroke-muted-foreground"
               />
               <div className="min-w-0 truncate text-foreground/75">{projectTitle}</div>
@@ -381,6 +391,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   environmentLabel: string | null;
   projectCwd: string | null;
   projectTitle: string | null;
+  projectKind: ProjectKind | undefined;
   providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
   onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
   onThreadActivate: (threadRef: ScopedThreadRef) => void;
@@ -537,6 +548,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       thread={thread}
       projectTitle={props.projectTitle}
       projectCwd={props.projectCwd}
+      projectKind={props.projectKind}
       environmentLabel={props.environmentLabel}
       driverKind={driverKind}
       modelInstanceId={modelInstanceId}
@@ -769,6 +781,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
+                kind={props.projectKind}
                 className="size-4"
                 fallbackIcon={MessageSquareIcon}
               />
@@ -845,6 +858,28 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   }
 
   const diff = latestTurnDiff(thread);
+  const hasThreadMetaRow = Boolean(thread.branch) || prBadge !== null || diff !== null;
+  const threadMetaIcons = (
+    <span
+      aria-hidden
+      className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
+    >
+      {isRemote ? (
+        <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
+          <ServerIcon aria-hidden className="size-3.5" />
+        </span>
+      ) : null}
+      {driverKind ? (
+        <span className="inline-flex shrink-0 items-center opacity-60">
+          <ProviderInstanceIcon
+            driverKind={driverKind}
+            displayName={thread.session?.providerName ?? modelInstanceId}
+            iconClassName="size-3.5"
+          />
+        </span>
+      ) : null}
+    </span>
+  );
 
   return (
     <li
@@ -866,11 +901,17 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
             />
           }
         >
-          <div className="relative z-10 h-[4.875rem] px-2.5 py-2">
+          <div
+            className={cn(
+              "relative z-10 px-2.5 py-2",
+              hasThreadMetaRow ? "h-[4.875rem]" : undefined,
+            )}
+          >
             <div className="flex h-5 min-w-0 items-center gap-1.5">
               <ProjectFavicon
                 environmentId={thread.environmentId}
                 cwd={props.projectCwd ?? ""}
+                kind={props.projectKind}
                 className="size-4 shrink-0"
               />
               {props.projectTitle ? (
@@ -953,40 +994,29 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 ) : null}
               </span>
             </div>
-            <div className="mt-1 flex min-w-0">{title}</div>
-            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
-              {thread.branch ? (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {prBadge}
-              {diff ? (
-                <span className="shrink-0 font-mono">
-                  <span className="text-emerald-600 dark:text-emerald-400">+{diff.insertions}</span>{" "}
-                  <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
-                </span>
-              ) : null}
-              <span
-                aria-hidden
-                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-              >
-                {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <ServerIcon aria-hidden className="size-3.5" />
-                  </span>
-                ) : null}
-                {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center opacity-60">
-                    <ProviderInstanceIcon
-                      driverKind={driverKind}
-                      displayName={thread.session?.providerName ?? modelInstanceId}
-                      iconClassName="size-3.5"
-                    />
-                  </span>
-                ) : null}
-              </span>
+            <div className="mt-1 flex min-w-0 items-center gap-1.5">
+              {title}
+              {!hasThreadMetaRow ? threadMetaIcons : null}
             </div>
+            {hasThreadMetaRow ? (
+              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
+                {thread.branch ? (
+                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
+                ) : (
+                  <span className="flex-1" />
+                )}
+                {prBadge}
+                {diff ? (
+                  <span className="shrink-0 font-mono">
+                    <span className="text-emerald-600 dark:text-emerald-400">
+                      +{diff.insertions}
+                    </span>{" "}
+                    <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
+                  </span>
+                ) : null}
+                {threadMetaIcons}
+              </div>
+            ) : null}
           </div>
           {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
         </TooltipTrigger>
@@ -1123,6 +1153,10 @@ export default function SidebarV2() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
+  const manageableProjectGroups = useMemo(
+    () => projectGroups.filter((group) => !group.memberProjects.some(isChatsProject)),
+    [projectGroups],
+  );
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const providerEntryByInstanceId = useMemo(
     () =>
@@ -1141,6 +1175,11 @@ export default function SidebarV2() {
           project.workspaceRoot,
         ]),
       ),
+    [projects],
+  );
+  const projectKindByKey = useMemo(
+    () =>
+      new Map(projects.map((project) => [`${project.environmentId}:${project.id}`, project.kind])),
     [projects],
   );
   const projectDisplayNameByKey = useMemo(
@@ -1193,8 +1232,8 @@ export default function SidebarV2() {
     () =>
       projectScopeKey === null
         ? null
-        : (projectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
-    [projectGroups, projectScopeKey],
+        : (manageableProjectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+    [manageableProjectGroups, projectScopeKey],
   );
   const scopedProjectKeys = useMemo(
     () =>
@@ -2207,7 +2246,7 @@ export default function SidebarV2() {
   // for multi-project setups.
   const handleNewThreadClick = useCallback(() => {
     // One project: nothing to pick, create immediately.
-    if (projectGroups.length <= 1) {
+    if (manageableProjectGroups.length <= 1) {
       if (isMobile) setOpenMobile(false);
       void startNewThreadFromContext({
         activeDraftThread: newThreadContext.activeDraftThread,
@@ -2219,7 +2258,7 @@ export default function SidebarV2() {
     }
     if (isMobile) setOpenMobile(false);
     openCommandPalette({ open: "new-thread-in" });
-  }, [isMobile, newThreadContext, projectGroups.length, setOpenMobile]);
+  }, [isMobile, manageableProjectGroups.length, newThreadContext, setOpenMobile]);
 
   const commandPaletteShortcutLabel = shortcutLabelForCommand(keybindings, "commandPalette.toggle");
   // Same resolution as v1: prefer the local-thread binding, fall back to
@@ -2283,7 +2322,7 @@ export default function SidebarV2() {
                 </Tooltip>
               </div>
             </div>
-            {projectGroups.length > 0 ? (
+            {manageableProjectGroups.length > 0 ? (
               <div className="flex items-center gap-1">
                 <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
                   <MenuTrigger
@@ -2298,6 +2337,7 @@ export default function SidebarV2() {
                       <ProjectFavicon
                         environmentId={scopedProjectGroup.environmentId}
                         cwd={scopedProjectGroup.workspaceRoot}
+                        kind={scopedProjectGroup.kind}
                         className="size-4 shrink-0"
                       />
                     ) : (
@@ -2323,7 +2363,7 @@ export default function SidebarV2() {
                         <FolderIcon className="size-4 shrink-0" />
                         <span className="min-w-0 truncate text-sm">All projects</span>
                       </MenuRadioItem>
-                      {projectGroups.map((project) => {
+                      {manageableProjectGroups.map((project) => {
                         const scopeKey = project.projectKey;
                         return (
                           <MenuRadioItem
@@ -2335,6 +2375,7 @@ export default function SidebarV2() {
                             <ProjectFavicon
                               environmentId={project.environmentId}
                               cwd={project.workspaceRoot}
+                              kind={project.kind}
                               className="size-4 shrink-0"
                             />
                             <span className="min-w-0 truncate text-sm">{project.displayName}</span>
@@ -2454,6 +2495,9 @@ export default function SidebarV2() {
                           `${thread.environmentId}:${thread.projectId}`,
                         ) ?? null
                       }
+                      projectKind={projectKindByKey.get(
+                        `${thread.environmentId}:${thread.projectId}`,
+                      )}
                       providerEntryByInstanceId={providerEntryByInstanceId}
                       onThreadClick={handleThreadClick}
                       onThreadActivate={navigateToThread}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -6,20 +6,13 @@ import {
   effectiveSnoozed,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
-import {
-  isChatsProject,
-  type EnvironmentThreadShell,
-} from "@t3tools/client-runtime/state/models";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
 import {
   scopeProjectRef,
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import type {
-  ProjectKind,
-  ScopedThreadRef,
-  SidebarProjectGroupingMode,
-} from "@t3tools/contracts";
+import type { ProjectKind, ScopedThreadRef, SidebarProjectGroupingMode } from "@t3tools/contracts";
 import {
   AlarmClockIcon,
   AlarmClockOffIcon,
@@ -83,6 +76,7 @@ import {
 } from "../logicalProject";
 import {
   buildSidebarProjectSnapshots,
+  filterManageableSidebarProjectSnapshots,
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
@@ -1154,7 +1148,7 @@ export default function SidebarV2() {
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
   const manageableProjectGroups = useMemo(
-    () => projectGroups.filter((group) => !group.memberProjects.some(isChatsProject)),
+    () => filterManageableSidebarProjectSnapshots(projectGroups),
     [projectGroups],
   );
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
@@ -1232,7 +1226,8 @@ export default function SidebarV2() {
     () =>
       projectScopeKey === null
         ? null
-        : (manageableProjectGroups.find((project) => project.projectKey === projectScopeKey) ?? null),
+        : (manageableProjectGroups.find((project) => project.projectKey === projectScopeKey) ??
+          null),
     [manageableProjectGroups, projectScopeKey],
   );
   const scopedProjectKeys = useMemo(

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -35,6 +35,11 @@ interface ChatHeaderProps {
   rightPanelOpen: boolean;
   gitCwd: string | null;
   onNewThreadInProject: () => void;
+  /**
+   * True for the reserved Chats pseudo-project: scripts, open-in and git
+   * actions are hidden because there is no real codebase behind the thread.
+   */
+  isChatsProject: boolean;
   onRunProjectScript: (script: ProjectScript) => void;
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<ProjectScriptActionResult>;
   onUpdateProjectScript: (
@@ -71,6 +76,7 @@ export const ChatHeader = memo(function ChatHeader({
   rightPanelOpen,
   gitCwd,
   onNewThreadInProject,
+  isChatsProject,
   onRunProjectScript,
   onAddProjectScript,
   onUpdateProjectScript,
@@ -79,13 +85,15 @@ export const ChatHeader = memo(function ChatHeader({
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const fileScripts = useT3ProjectFileScripts(
     activeThreadEnvironmentId,
-    activeProjectScripts ? activeProjectCwd : null,
+    activeProjectScripts && !isChatsProject ? activeProjectCwd : null,
   );
-  const showOpenInPicker = shouldShowOpenInPicker({
-    activeProjectName,
-    activeThreadEnvironmentId,
-    primaryEnvironmentId,
-  });
+  const showOpenInPicker =
+    !isChatsProject &&
+    shouldShowOpenInPicker({
+      activeProjectName,
+      activeThreadEnvironmentId,
+      primaryEnvironmentId,
+    });
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
@@ -108,6 +116,7 @@ export const ChatHeader = memo(function ChatHeader({
                 <ProjectFavicon
                   environmentId={activeThreadEnvironmentId}
                   cwd={activeProjectCwd ?? ""}
+                  kind={isChatsProject ? "chats" : undefined}
                   className="size-3.5"
                 />
                 <span className="max-w-40 truncate text-sm font-medium">{activeProjectName}</span>
@@ -140,7 +149,7 @@ export const ChatHeader = memo(function ChatHeader({
           rightPanelOpen ? "pr-0" : "pr-16",
         )}
       >
-        {activeProjectScripts && (
+        {activeProjectScripts && !isChatsProject && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}
             fileScripts={fileScripts}
@@ -160,7 +169,7 @@ export const ChatHeader = memo(function ChatHeader({
             openInCwd={openInCwd}
           />
         )}
-        {activeProjectName && (
+        {activeProjectName && !isChatsProject && (
           <GitActionsControl
             gitCwd={gitCwd}
             activeThreadRef={scopeThreadRef(activeThreadEnvironmentId, activeThreadId)}

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -27,11 +27,17 @@ import {
 interface DraftHeroHeadlineProps {
   readonly activeProjectRef: ScopedProjectRef | null;
   readonly activeProjectTitle: string | null;
+  /**
+   * The Chat pseudo-project is not a codebase, so the build-oriented prompt
+   * is replaced with a neutral one.
+   */
+  readonly isChatsProject: boolean;
 }
 
 export function DraftHeroHeadline({
   activeProjectRef,
   activeProjectTitle,
+  isChatsProject,
 }: DraftHeroHeadlineProps) {
   const projects = useProjects();
   const threads = useThreadShells();
@@ -146,7 +152,9 @@ export function DraftHeroHeadline({
 
   return (
     <h1 className="mx-auto w-full max-w-5xl text-center font-normal text-2xl text-foreground tracking-tight sm:text-3xl">
-      {hasResolvedProject ? (
+      {hasResolvedProject && isChatsProject ? (
+        <>What&rsquo;s on your mind?</>
+      ) : hasResolvedProject ? (
         <>What should we build in {projectSelector}?</>
       ) : canChooseProject ? (
         <>{projectSelector} to start</>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -137,6 +137,7 @@ import {
   useRelativeTimeTick,
 } from "./settingsLayout";
 import { ProjectFavicon } from "../ProjectFavicon";
+import { projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import { useAtomCommand } from "../../state/use-atom-command";
 
 const THEME_OPTIONS = [
@@ -2229,8 +2230,9 @@ export function ArchivedThreadsPanel() {
               {
                 id: project.id,
                 environmentId,
-                name: project.title,
+                name: projectDisplayTitle(project),
                 cwd: project.workspaceRoot,
+                kind: project.kind,
               },
             ] as const,
         ),
@@ -2348,7 +2350,13 @@ export function ArchivedThreadsPanel() {
           <SettingsSection
             key={project.id}
             title={project.name}
-            icon={<ProjectFavicon environmentId={project.environmentId} cwd={project.cwd} />}
+            icon={
+              <ProjectFavicon
+                environmentId={project.environmentId}
+                cwd={project.cwd}
+                kind={project.kind}
+              />
+            }
           >
             {projectThreads.map((thread) => (
               <SettingsRow

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -12,6 +12,7 @@ import {
   buildPhysicalToLogicalProjectKeyMap,
   buildSidebarProjectPickerEntries,
   buildSidebarProjectSnapshots,
+  filterManageableSidebarProjectSnapshots,
 } from "./sidebarProjectGrouping";
 import { orderItemsByPreferredIds } from "./components/Sidebar.logic";
 import { legacyProjectCwdPreferenceKey } from "./uiStateStore";
@@ -79,6 +80,29 @@ describe("environment grouping", () => {
     }).length;
 
     expect(projectGroupCount).toBe(1);
+  });
+
+  it("keeps the reserved Chat project out of project management groups", () => {
+    const chats = makeProject({
+      id: ProjectId.make("project-chats"),
+      title: "Chats",
+      workspaceRoot: "/tmp/chats",
+      kind: "chats",
+    });
+    const codebase = makeProject({
+      id: ProjectId.make("project-codebase"),
+      title: "t3code",
+    });
+    const groups = buildSidebarProjectSnapshots({
+      projects: [chats, codebase],
+      settings: defaultGroupingSettings,
+      primaryEnvironmentId,
+      resolveEnvironmentLabel: () => null,
+    });
+
+    expect(filterManageableSidebarProjectSnapshots(groups).map((group) => group.id)).toEqual([
+      ProjectId.make("project-codebase"),
+    ]);
   });
 
   it("keeps projects without repository identity physically scoped", () => {

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -69,6 +69,11 @@ interface RightPanelStoreState {
   closeAllSurfaces: (ref: ScopedThreadRef) => void;
   reconcileBrowserSurfaces: (ref: ScopedThreadRef, tabIds: readonly string[]) => void;
   reconcileFileSurfaces: (ref: ScopedThreadRef, workspaceAvailable: boolean) => void;
+  /**
+   * Drops persisted diff and terminal tabs when the thread's project cannot
+   * host them (e.g. the reserved Chats pseudo-project).
+   */
+  reconcileWorkspaceSurfaces: (ref: ScopedThreadRef, workspaceSurfacesAvailable: boolean) => void;
   show: (ref: ScopedThreadRef) => void;
   close: (ref: ScopedThreadRef) => void;
   toggleVisibility: (ref: ScopedThreadRef) => void;
@@ -463,6 +468,27 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             if (workspaceAvailable) return current;
             const surfaces = current.surfaces.filter(
               (surface) => surface.kind !== "files" && surface.kind !== "file",
+            );
+            if (surfaces.length === current.surfaces.length) return current;
+            const activeStillExists = surfaces.some(
+              (surface) => surface.id === current.activeSurfaceId,
+            );
+            return {
+              ...current,
+              isOpen: surfaces.length > 0 ? current.isOpen : false,
+              surfaces,
+              activeSurfaceId: activeStillExists
+                ? current.activeSurfaceId
+                : (surfaces.at(-1)?.id ?? null),
+            };
+          }),
+        })),
+      reconcileWorkspaceSurfaces: (ref, workspaceSurfacesAvailable) =>
+        set((state) => ({
+          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+            if (workspaceSurfacesAvailable) return current;
+            const surfaces = current.surfaces.filter(
+              (surface) => surface.kind !== "diff" && surface.kind !== "terminal",
             );
             if (surfaces.length === current.surfaces.length) return current;
             const activeStillExists = surfaces.some(

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,5 +1,5 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
-import { projectDisplayTitle } from "@t3tools/client-runtime/state/models";
+import { isChatsProject, projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -36,6 +36,12 @@ export interface SidebarProjectPickerEntry {
   group: SidebarProjectSnapshot;
   targetProject: SidebarProjectGroupMember;
   isPreferred: boolean;
+}
+
+export function filterManageableSidebarProjectSnapshots(
+  groups: ReadonlyArray<SidebarProjectSnapshot>,
+): SidebarProjectSnapshot[] {
+  return groups.filter((group) => !group.memberProjects.some(isChatsProject));
 }
 
 interface SidebarProjectGroupCandidate {

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,4 +1,5 @@
 import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+import { projectDisplayTitle } from "@t3tools/client-runtime/state/models";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -205,7 +206,7 @@ export function buildSidebarProjectSnapshots(input: {
               representative,
               members,
             })
-          : representative.title,
+          : projectDisplayTitle(representative),
       groupedProjectCount: members.length,
       environmentPresence:
         hasLocal && hasRemote ? "mixed" : hasRemote ? "remote-only" : "local-only",

--- a/packages/client-runtime/src/state/models.ts
+++ b/packages/client-runtime/src/state/models.ts
@@ -22,6 +22,30 @@ export interface EnvironmentThread extends OrchestrationThread {
   readonly environmentId: EnvironmentId;
 }
 
+/**
+ * The reserved Chat pseudo-project hosts one-off conversations with no
+ * real codebase behind them, so project-scoped surfaces (diff, files,
+ * branches, worktrees, terminal, git actions) are hidden for it.
+ */
+export function isChatsProject(
+  project: Pick<OrchestrationProjectShell, "kind"> | null | undefined,
+): boolean {
+  return project?.kind === "chats";
+}
+
+/**
+ * Label shown wherever the Chat pseudo-project is named. Overriding the
+ * stored title keeps already-created projects consistent with the current
+ * wording without a data migration.
+ */
+export const CHATS_PROJECT_LABEL = "Chat";
+
+export function projectDisplayTitle(
+  project: Pick<OrchestrationProjectShell, "kind" | "title">,
+): string {
+  return isChatsProject(project) ? CHATS_PROJECT_LABEL : project.title;
+}
+
 export function scopeProject(
   environmentId: EnvironmentId,
   project: OrchestrationProjectShell,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -208,10 +208,20 @@ export const ProjectScript = Schema.Struct({
 });
 export type ProjectScript = typeof ProjectScript.Type;
 
+/**
+ * Discriminates the reserved "Chats" pseudo-project (workspace root at
+ * `<baseDir>/chats`) from normal projects. Derived server-side from the
+ * workspace root — never persisted — so it stays correct across base-dir
+ * changes and older snapshots.
+ */
+export const ProjectKind = Schema.Literals(["standard", "chats"]);
+export type ProjectKind = typeof ProjectKind.Type;
+
 export const OrchestrationProject = Schema.Struct({
   id: ProjectId,
   title: TrimmedNonEmptyString,
   workspaceRoot: TrimmedNonEmptyString,
+  kind: Schema.optional(ProjectKind),
   repositoryIdentity: Schema.optional(Schema.NullOr(RepositoryIdentity)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
@@ -389,6 +399,7 @@ export const OrchestrationProjectShell = Schema.Struct({
   id: ProjectId,
   title: TrimmedNonEmptyString,
   workspaceRoot: TrimmedNonEmptyString,
+  kind: Schema.optional(ProjectKind),
   repositoryIdentity: Schema.optional(Schema.NullOr(RepositoryIdentity)),
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/7271998b-a309-45ad-bbe3-286ca15e761b

<img width="1280" height="820" alt="chat-project-1-thread" src="https://github.com/user-attachments/assets/464d1cb5-cc06-4740-a880-fbebe84bffe9" />
<img width="1280" height="820" alt="chat-project-2-command-palette" src="https://github.com/user-attachments/assets/7302206c-518f-4b80-a08f-732ff6f7bf3e" />
<img width="1280" height="820" alt="chat-project-3-new-thread-picker" src="https://github.com/user-attachments/assets/b598f55a-0241-40fe-8f9a-532121b37617" />
<img width="1280" height="820" alt="chat-project-4-control-t3code" src="https://github.com/user-attachments/assets/a34da927-bda6-45e8-9e44-35bbe36954e0" />

## What Changed

Adds a reserved **Chat** pseudo-project for one-off conversations that aren't tied to any repository, and hides the project-scoped UI that has no meaning without a codebase.

**Server**
- Derive `chatsDir` (`<baseDir>/chats`) in `deriveServerPaths` and create it in `ensureServerDirectories`, alongside `worktrees/`, `caches/` etc.
- New `chats.ensure` startup phase creates the project once, through the normal `project.create` command path (idempotent, non-fatal on failure).
- New `kind: "standard" | "chats"` discriminator on `OrchestrationProject` / `OrchestrationProjectShell`. It is **derived at read time** from the workspace root rather than persisted, so it needs no migration, stays correct if the base dir moves, and applies to pre-existing rows. `ServerConfig` is read via `Effect.serviceOption` so test layers without it keep working.

**Client (web + mobile)**
- Chat threads hide: diff, files, terminal, the branch/worktree/env-mode strip, git actions, project scripts and open-in-editor. Persisted diff/terminal/file tabs are reconciled away.
- Chat shows a chat-bubble icon and no filesystem path, and is kept out of project lists entirely — a dedicated **"Start a new chat"** action replaces it in the ⌘K root (between "New thread in…" and "Add project") and above the Projects group in the project picker. "New thread in X" always names a real codebase.
- Generic composer greeting ("What's on your mind?") instead of "What should we build in …?".
- Sidebar thread cards collapse their meta row when a thread has no branch, PR or diff, so the provider icon sits inline instead of leaving an empty gutter (60px vs 78px).

## Why

Not every conversation is about code. Today the only way to have one is to pick some unrelated repo, which pollutes that project's thread list and surrounds a plain chat with diff/branch/worktree affordances that can't do anything useful.

The kind is derived rather than stored deliberately: the alternative (a persisted column) needs a migration, goes stale if `--base-dir` changes, and duplicates state that the workspace root already determines. This mirrors how `repositoryIdentity` is already resolved at read time.

## UI Changes

<!-- Annotated screenshots to be attached. -->

1. **Chat thread** — no diff/files/terminal/branch strip/git actions/scripts, bubble icon, no folder path, compact sidebar card with the provider logo inline.
2. **⌘K root** — "New thread in **t3code**" (never "in Chat"), with "Start a new chat" between "New thread in…" and "Add project".
3. **"New thread in…" picker** — standalone "Start a new chat" above the Projects group; Projects lists only real codebases.
4. **Control: t3code project** — scripts, Open-in, git actions, terminal and the branch strip all unchanged.

## Verification

Checked against this branch's base (`upstream/main`), in a clean worktree with its own `pnpm install`:

- `apps/web`, `apps/server`, `apps/mobile` typecheck clean.
- 84 focused tests pass: `apps/server/src/project`, `serverRuntimeStartup.test.ts`, `ProjectionSnapshotQuery.test.ts` (50) and `CommandPalette.logic.test.ts`, `rightPanelStore.test.ts` (34).
- New tests cover kind resolution, the idempotent startup ensure (creates once / no-ops when present), `kind` flowing through `getShellSnapshot` and `getActiveProjectByWorkspaceRoot`, and the palette's Chat labelling/path-hiding.
- Manually exercised in an isolated dev environment: booting with a fresh home dir creates `chats/` and the project, and `/api/orchestration/shell` returns `"kind": "chats"` for it.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Chat' pseudo-project for non-repository threads
> - Introduces a `chats` project kind backed by a dedicated `chatsDir` on the server; at startup, `ensureChatsProject` creates a 'Chat' project at that path if one does not exist.
> - Disables terminal, diff, git, and file surfaces/controls when the active project is the chats pseudo-project, across web ([ChatView.tsx](https://github.com/pingdotgg/t3code/pull/4515/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)), mobile ([ThreadRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/4515/files#diff-6335d58d7c246073ba2e7cd1c773675c00c0019ceaecf67ff39734bed4dea283)), and the right panel store.
> - Adds `isChatsProject`, `projectDisplayTitle`, and `resolveProjectKind` utilities; chats projects display 'Chat' instead of their raw title and show a chat-bubble favicon throughout the sidebar, command palette, and settings.
> - The command palette gains a dedicated 'Start a new chat' action scoped to the current environment's Chat project, and excludes it from codebase project lists.
> - Chats projects are excluded from drag-and-drop sorting, project management groups, and context menus in the sidebar.
> - Behavioral Change: keybindings for terminal and diff shortcuts are blocked when the active project is chats; workspace surfaces (diff/terminal tabs) are force-removed from the right panel when entering a chats thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22afd7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server startup, projection read models, and broad UI gating across web/mobile; failures are mostly non-fatal on ensure, but mis-classifying `kind` could hide or expose workspace features incorrectly.
> 
> **Overview**
> Introduces a **Chat** pseudo-project for conversations not tied to a repository. The server provisions `<baseDir>/chats`, runs an idempotent `chats.ensure` startup phase that dispatches `project.create` when missing, and attaches **`kind: "standard" | "chats"`** on orchestration project shells by comparing `workspaceRoot` to `chatsDir` at read time (not persisted). Chat projects skip repository-identity resolution.
> 
> **Web and mobile** use `isChatsProject` / `projectDisplayTitle` to hide diff, files, terminal, git actions, scripts, and branch tooling; reconcile away persisted workspace panels; block related keyboard shortcuts; and show a chat-bubble favicon without surfacing the chats directory path. The command palette adds **Start a new chat** and keeps Chat out of normal project lists; **New thread in X** targets real codebases only. Sidebar treats Chat as non-draggable / non-manageable where applicable.
> 
> Contracts gain optional `ProjectKind`; client-runtime exports shared helpers and label **Chat**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22afd7cb7ca05c8f07b0aebe415ea917fb56556b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->