### PR TITLE
Back off checkpoint capture after repeated failures

### DIFF
--- a/apps/server/src/checkpointing/CaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { cooldownForFailureCount, makeCaptureBackoff } from "./CaptureBackoff.ts";
+
+const MINUTE = 60_000;
+const CWD = "/repo/workspace";
+
+describe("cooldownForFailureCount", () => {
+  it("tolerates transient failures before opening a cooldown", () => {
+    expect(cooldownForFailureCount(1)).toBe(0);
+    expect(cooldownForFailureCount(2)).toBe(0);
+  });
+
+  it("backs off further the longer capture keeps failing", () => {
+    expect(cooldownForFailureCount(3)).toBe(5 * MINUTE);
+    expect(cooldownForFailureCount(4)).toBe(10 * MINUTE);
+    expect(cooldownForFailureCount(5)).toBe(20 * MINUTE);
+  });
+
+  it("caps the cooldown so a workspace is retried eventually", () => {
+    expect(cooldownForFailureCount(20)).toBe(60 * MINUTE);
+    expect(cooldownForFailureCount(500)).toBe(60 * MINUTE);
+  });
+});
+
+describe("makeCaptureBackoff", () => {
+  it("does not skip before the failure threshold is reached", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    backoff.recordFailure(CWD, 0, "timeout");
+    backoff.recordFailure(CWD, 1_000, "timeout");
+
+    expect(backoff.evaluate(CWD, 2_000).skip).toBe(false);
+  });
+
+  it("skips and replays the recorded failure once capture keeps failing", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 1_000, 2_000]) {
+      backoff.recordFailure(CWD, at, "git add timed out");
+    }
+
+    const decision = backoff.evaluate(CWD, 3_000);
+    expect(decision.skip).toBe(true);
+    expect(decision.lastError).toBe("git add timed out");
+    expect(decision.remainingMs).toBeGreaterThan(0);
+  });
+
+  it("retries again once the cooldown elapses", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+
+    expect(backoff.evaluate(CWD, 5 * MINUTE - 1).skip).toBe(true);
+    expect(backoff.evaluate(CWD, 5 * MINUTE).skip).toBe(false);
+  });
+
+  it("clears the record after a capture succeeds", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+    expect(backoff.evaluate(CWD, 1_000).skip).toBe(true);
+
+    backoff.recordSuccess(CWD);
+
+    expect(backoff.evaluate(CWD, 1_000).skip).toBe(false);
+    expect(backoff.trackedWorkspaceCount).toBe(0);
+  });
+
+  it("tracks each workspace independently", () => {
+    const backoff = makeCaptureBackoff<string>();
+    const healthy = "/repo/other";
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+
+    expect(backoff.evaluate(CWD, 1_000).skip).toBe(true);
+    expect(backoff.evaluate(healthy, 1_000).skip).toBe(false);
+  });
+
+  it("keeps extending the cooldown while failures continue", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+    const firstRemaining = backoff.evaluate(CWD, 0).remainingMs;
+
+    // The next attempt after the cooldown fails again, so the wait grows.
+    backoff.recordFailure(CWD, 5 * MINUTE, "timeout");
+    const secondRemaining = backoff.evaluate(CWD, 5 * MINUTE).remainingMs;
+
+    expect(secondRemaining).toBeGreaterThan(firstRemaining);
+  });
+});

--- a/apps/server/src/checkpointing/CaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.test.ts
@@ -30,7 +30,7 @@ describe("makeCaptureBackoff", () => {
     backoff.recordFailure(CWD, 0, "timeout");
     backoff.recordFailure(CWD, 1_000, "timeout");
 
-    expect(backoff.evaluate(CWD, 2_000).skip).toBe(false);
+    expect(backoff.beginAttempt(CWD, 2_000).skip).toBe(false);
   });
 
   it("skips and replays the recorded failure once capture keeps failing", () => {
@@ -40,7 +40,7 @@ describe("makeCaptureBackoff", () => {
       backoff.recordFailure(CWD, at, "git add timed out");
     }
 
-    const decision = backoff.evaluate(CWD, 3_000);
+    const decision = backoff.beginAttempt(CWD, 3_000);
     expect(decision.skip).toBe(true);
     expect(decision.lastError).toBe("git add timed out");
     expect(decision.remainingMs).toBeGreaterThan(0);
@@ -53,8 +53,8 @@ describe("makeCaptureBackoff", () => {
       backoff.recordFailure(CWD, at, "timeout");
     }
 
-    expect(backoff.evaluate(CWD, 5 * MINUTE - 1).skip).toBe(true);
-    expect(backoff.evaluate(CWD, 5 * MINUTE).skip).toBe(false);
+    expect(backoff.beginAttempt(CWD, 5 * MINUTE - 1).skip).toBe(true);
+    expect(backoff.beginAttempt(CWD, 5 * MINUTE).skip).toBe(false);
   });
 
   it("clears the record after a capture succeeds", () => {
@@ -63,11 +63,11 @@ describe("makeCaptureBackoff", () => {
     for (const at of [0, 0, 0]) {
       backoff.recordFailure(CWD, at, "timeout");
     }
-    expect(backoff.evaluate(CWD, 1_000).skip).toBe(true);
+    expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(true);
 
     backoff.recordSuccess(CWD);
 
-    expect(backoff.evaluate(CWD, 1_000).skip).toBe(false);
+    expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(false);
     expect(backoff.trackedWorkspaceCount).toBe(0);
   });
 
@@ -79,8 +79,8 @@ describe("makeCaptureBackoff", () => {
       backoff.recordFailure(CWD, at, "timeout");
     }
 
-    expect(backoff.evaluate(CWD, 1_000).skip).toBe(true);
-    expect(backoff.evaluate(healthy, 1_000).skip).toBe(false);
+    expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(true);
+    expect(backoff.beginAttempt(healthy, 1_000).skip).toBe(false);
   });
 
   it("bounds how many workspaces it retains", () => {
@@ -93,8 +93,12 @@ describe("makeCaptureBackoff", () => {
     expect(backoff.trackedWorkspaceCount).toBe(256);
     // The oldest entries are the ones dropped: an evicted workspace starts
     // counting again from one, a retained one continues.
-    expect(backoff.recordFailure("/repo/workspace-0", 1_000, "timeout")).toBe(1);
-    expect(backoff.recordFailure("/repo/workspace-399", 1_000, "timeout")).toBe(2);
+    expect(backoff.recordFailure("/repo/workspace-0", 1_000, "timeout").consecutiveFailures).toBe(
+      1,
+    );
+    expect(backoff.recordFailure("/repo/workspace-399", 1_000, "timeout").consecutiveFailures).toBe(
+      2,
+    );
   });
 
   it("keeps a repeatedly failing workspace alive through eviction pressure", () => {
@@ -107,7 +111,56 @@ describe("makeCaptureBackoff", () => {
       backoff.recordFailure(`/repo/other-${index}`, index, "timeout");
     }
 
-    expect(backoff.evaluate(CWD, 400).skip).toBe(true);
+    expect(backoff.beginAttempt(CWD, 400).skip).toBe(true);
+  });
+
+  it("keeps a workspace that is only being skipped safe from eviction", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+
+    // A skipped workspace never calls recordFailure again, so only the skip
+    // itself can keep it ahead of churn from unrelated workspaces.
+    for (let index = 0; index < 400; index += 1) {
+      expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(true);
+      backoff.recordFailure(`/repo/other-${index}`, index, "timeout");
+    }
+
+    expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(true);
+  });
+
+  it("releases only one caller when the cooldown expires", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+
+    // Threads sharing a workspace can complete turns together, and only the
+    // first past the cooldown should pay for the capture.
+    const released = [
+      backoff.beginAttempt(CWD, 5 * MINUTE),
+      backoff.beginAttempt(CWD, 5 * MINUTE),
+      backoff.beginAttempt(CWD, 5 * MINUTE),
+    ].filter((decision) => !decision.skip);
+
+    expect(released).toHaveLength(1);
+  });
+
+  it("lets the reservation lapse when an attempt never reports back", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (const at of [0, 0, 0]) {
+      backoff.recordFailure(CWD, at, "timeout");
+    }
+    backoff.beginAttempt(CWD, 5 * MINUTE);
+
+    // An interrupted capture reports neither success nor failure, so the
+    // reservation must expire on its own rather than wedge the workspace.
+    expect(backoff.beginAttempt(CWD, 5 * MINUTE + 30_000).skip).toBe(true);
+    expect(backoff.beginAttempt(CWD, 6 * MINUTE + 1).skip).toBe(false);
   });
 
   it("keeps extending the cooldown while failures continue", () => {
@@ -116,11 +169,11 @@ describe("makeCaptureBackoff", () => {
     for (const at of [0, 0, 0]) {
       backoff.recordFailure(CWD, at, "timeout");
     }
-    const firstRemaining = backoff.evaluate(CWD, 0).remainingMs;
+    const firstRemaining = backoff.beginAttempt(CWD, 0).remainingMs;
 
     // The next attempt after the cooldown fails again, so the wait grows.
     backoff.recordFailure(CWD, 5 * MINUTE, "timeout");
-    const secondRemaining = backoff.evaluate(CWD, 5 * MINUTE).remainingMs;
+    const secondRemaining = backoff.beginAttempt(CWD, 5 * MINUTE).remainingMs;
 
     expect(secondRemaining).toBeGreaterThan(firstRemaining);
   });

--- a/apps/server/src/checkpointing/CaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.test.ts
@@ -83,6 +83,33 @@ describe("makeCaptureBackoff", () => {
     expect(backoff.evaluate(healthy, 1_000).skip).toBe(false);
   });
 
+  it("bounds how many workspaces it retains", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    for (let index = 0; index < 400; index += 1) {
+      backoff.recordFailure(`/repo/workspace-${index}`, index, "timeout");
+    }
+
+    expect(backoff.trackedWorkspaceCount).toBe(256);
+    // The oldest entries are the ones dropped: an evicted workspace starts
+    // counting again from one, a retained one continues.
+    expect(backoff.recordFailure("/repo/workspace-0", 1_000, "timeout")).toBe(1);
+    expect(backoff.recordFailure("/repo/workspace-399", 1_000, "timeout")).toBe(2);
+  });
+
+  it("keeps a repeatedly failing workspace alive through eviction pressure", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    // A workspace in active use fails on every turn while many one-off
+    // workspaces churn past it.
+    for (let index = 0; index < 400; index += 1) {
+      backoff.recordFailure(CWD, index, "timeout");
+      backoff.recordFailure(`/repo/other-${index}`, index, "timeout");
+    }
+
+    expect(backoff.evaluate(CWD, 400).skip).toBe(true);
+  });
+
   it("keeps extending the cooldown while failures continue", () => {
     const backoff = makeCaptureBackoff<string>();
 

--- a/apps/server/src/checkpointing/CaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.test.ts
@@ -131,6 +131,17 @@ describe("makeCaptureBackoff", () => {
     expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(true);
   });
 
+  it("does not reserve for a workspace that has not reached the threshold", () => {
+    const backoff = makeCaptureBackoff<string>();
+
+    backoff.recordFailure(CWD, 0, "timeout");
+
+    // One transient failure must not suppress a capture running alongside it.
+    expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(false);
+    expect(backoff.beginAttempt(CWD, 1_000).skip).toBe(false);
+    expect(backoff.beginAttempt(CWD, 2_000).skip).toBe(false);
+  });
+
   it("releases only one caller when the cooldown expires", () => {
     const backoff = makeCaptureBackoff<string>();
 

--- a/apps/server/src/checkpointing/CaptureBackoff.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.ts
@@ -98,6 +98,13 @@ export function makeCaptureBackoff<E>() {
       }
 
       touch(cwd, record);
+      // Below the threshold a workspace has no cooldown at all, and its zero
+      // deadline must not read as one that just expired: reserving there
+      // would let a single transient failure suppress a concurrent capture.
+      if (record.consecutiveFailures < FAILURE_THRESHOLD) {
+        return { skip: false, remainingMs: 0, lastError: null };
+      }
+
       if (nowMs < record.skipUntilMs) {
         return {
           skip: true,

--- a/apps/server/src/checkpointing/CaptureBackoff.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.ts
@@ -1,0 +1,90 @@
+/**
+ * Consecutive-failure backoff for workspace checkpoint capture.
+ *
+ * Capture runs a full-tree `git add -A` under a temporary index after every
+ * completed turn. On a repository large enough to exceed the VCS process
+ * timeout, that capture can never succeed, so the unguarded retry pegs a CPU
+ * core for as long as any thread is in use and litters `.git/objects/pack`
+ * with `tmp_pack_*` files from each killed process.
+ *
+ * After a few consecutive failures for a workspace, capture is skipped for a
+ * growing cooldown instead of being retried every turn. Any success clears
+ * the record, so a transient failure (a lock held by a concurrent git
+ * command) costs nothing.
+ *
+ * @module CaptureBackoff
+ */
+
+/** Failures tolerated before a workspace enters cooldown. */
+const FAILURE_THRESHOLD = 3;
+const BASE_COOLDOWN_MS = 5 * 60_000;
+const MAX_COOLDOWN_MS = 60 * 60_000;
+
+export interface CaptureBackoffDecision<E> {
+  readonly skip: boolean;
+  /** Milliseconds left in the cooldown, for logging. Zero when not skipping. */
+  readonly remainingMs: number;
+  /**
+   * The failure that opened the cooldown. Replayed instead of inventing a new
+   * error, so callers keep seeing the real reason capture is unavailable and
+   * the error channel is unchanged.
+   */
+  readonly lastError: E | null;
+}
+
+export function cooldownForFailureCount(consecutiveFailures: number): number {
+  if (consecutiveFailures < FAILURE_THRESHOLD) return 0;
+  const doublings = consecutiveFailures - FAILURE_THRESHOLD;
+  // Clamp the exponent before shifting so a long-lived workspace cannot
+  // overflow into a negative or infinite cooldown.
+  const scale = 2 ** Math.min(doublings, 10);
+  return Math.min(BASE_COOLDOWN_MS * scale, MAX_COOLDOWN_MS);
+}
+
+interface WorkspaceRecord<E> {
+  consecutiveFailures: number;
+  skipUntilMs: number;
+  lastError: E;
+}
+
+/**
+ * Tracks capture health per workspace. Callers ask whether to skip, then
+ * report the outcome of any capture they actually ran.
+ */
+export function makeCaptureBackoff<E>() {
+  const recordByCwd = new Map<string, WorkspaceRecord<E>>();
+
+  return {
+    evaluate(cwd: string, nowMs: number): CaptureBackoffDecision<E> {
+      const record = recordByCwd.get(cwd);
+      if (!record || nowMs >= record.skipUntilMs) {
+        return { skip: false, remainingMs: 0, lastError: null };
+      }
+      return {
+        skip: true,
+        remainingMs: record.skipUntilMs - nowMs,
+        lastError: record.lastError,
+      };
+    },
+
+    recordSuccess(cwd: string): void {
+      recordByCwd.delete(cwd);
+    },
+
+    /** Returns the resulting consecutive failure count for this workspace. */
+    recordFailure(cwd: string, nowMs: number, error: E): number {
+      const consecutiveFailures = (recordByCwd.get(cwd)?.consecutiveFailures ?? 0) + 1;
+      const cooldownMs = cooldownForFailureCount(consecutiveFailures);
+      recordByCwd.set(cwd, {
+        consecutiveFailures,
+        skipUntilMs: cooldownMs === 0 ? 0 : nowMs + cooldownMs,
+        lastError: error,
+      });
+      return consecutiveFailures;
+    },
+
+    get trackedWorkspaceCount(): number {
+      return recordByCwd.size;
+    },
+  };
+}

--- a/apps/server/src/checkpointing/CaptureBackoff.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.ts
@@ -28,6 +28,16 @@ const MAX_COOLDOWN_MS = 60 * 60_000;
  */
 const MAX_TRACKED_WORKSPACES = 256;
 
+/**
+ * How long the first caller past an expired cooldown holds the retry to
+ * itself. Threads sharing a workspace complete turns independently, so
+ * without this they would all be released at once and launch the same
+ * expensive capture together. Comfortably longer than the VCS process
+ * timeout that kills a stuck capture, and it lapses on its own, so an
+ * attempt that never reports back cannot wedge the workspace.
+ */
+const ATTEMPT_RESERVATION_MS = 60_000;
+
 export interface CaptureBackoffDecision<E> {
   readonly skip: boolean;
   /** Milliseconds left in the cooldown, for logging. Zero when not skipping. */
@@ -49,6 +59,12 @@ export function cooldownForFailureCount(consecutiveFailures: number): number {
   return Math.min(BASE_COOLDOWN_MS * scale, MAX_COOLDOWN_MS);
 }
 
+export interface CaptureFailureOutcome {
+  readonly consecutiveFailures: number;
+  /** Zero while the workspace is still under the failure threshold. */
+  readonly cooldownMs: number;
+}
+
 interface WorkspaceRecord<E> {
   consecutiveFailures: number;
   skipUntilMs: number;
@@ -62,31 +78,46 @@ interface WorkspaceRecord<E> {
 export function makeCaptureBackoff<E>() {
   const recordByCwd = new Map<string, WorkspaceRecord<E>>();
 
+  /** Move a record to the most-recent position so eviction sees real usage. */
+  const touch = (cwd: string, record: WorkspaceRecord<E>) => {
+    recordByCwd.delete(cwd);
+    recordByCwd.set(cwd, record);
+  };
+
   return {
-    evaluate(cwd: string, nowMs: number): CaptureBackoffDecision<E> {
+    /**
+     * Decide whether this caller should run a capture. Mutating: a caller
+     * released past an expired cooldown reserves the attempt, and any read
+     * refreshes eviction recency so a workspace being actively skipped is not
+     * evicted by churn from unrelated workspaces.
+     */
+    beginAttempt(cwd: string, nowMs: number): CaptureBackoffDecision<E> {
       const record = recordByCwd.get(cwd);
-      if (!record || nowMs >= record.skipUntilMs) {
+      if (!record) {
         return { skip: false, remainingMs: 0, lastError: null };
       }
-      return {
-        skip: true,
-        remainingMs: record.skipUntilMs - nowMs,
-        lastError: record.lastError,
-      };
+
+      touch(cwd, record);
+      if (nowMs < record.skipUntilMs) {
+        return {
+          skip: true,
+          remainingMs: record.skipUntilMs - nowMs,
+          lastError: record.lastError,
+        };
+      }
+
+      record.skipUntilMs = nowMs + ATTEMPT_RESERVATION_MS;
+      return { skip: false, remainingMs: 0, lastError: null };
     },
 
     recordSuccess(cwd: string): void {
       recordByCwd.delete(cwd);
     },
 
-    /** Returns the resulting consecutive failure count for this workspace. */
-    recordFailure(cwd: string, nowMs: number, error: E): number {
+    recordFailure(cwd: string, nowMs: number, error: E): CaptureFailureOutcome {
       const consecutiveFailures = (recordByCwd.get(cwd)?.consecutiveFailures ?? 0) + 1;
       const cooldownMs = cooldownForFailureCount(consecutiveFailures);
-      // Re-insert so Map iteration order tracks recency, keeping the
-      // workspaces actually in use ahead of stale ones during eviction.
-      recordByCwd.delete(cwd);
-      recordByCwd.set(cwd, {
+      touch(cwd, {
         consecutiveFailures,
         skipUntilMs: cooldownMs === 0 ? 0 : nowMs + cooldownMs,
         lastError: error,
@@ -98,7 +129,7 @@ export function makeCaptureBackoff<E>() {
         recordByCwd.delete(oldestCwd);
       }
 
-      return consecutiveFailures;
+      return { consecutiveFailures, cooldownMs };
     },
 
     get trackedWorkspaceCount(): number {

--- a/apps/server/src/checkpointing/CaptureBackoff.ts
+++ b/apps/server/src/checkpointing/CaptureBackoff.ts
@@ -20,6 +20,14 @@ const FAILURE_THRESHOLD = 3;
 const BASE_COOLDOWN_MS = 5 * 60_000;
 const MAX_COOLDOWN_MS = 60 * 60_000;
 
+/**
+ * Only a workspace that later succeeds clears its own record, so a workspace
+ * that fails once and is then abandoned would otherwise be retained for the
+ * lifetime of the server. Bound the tracked set and evict least-recently
+ * touched entries; dropping one only costs a workspace its failure history.
+ */
+const MAX_TRACKED_WORKSPACES = 256;
+
 export interface CaptureBackoffDecision<E> {
   readonly skip: boolean;
   /** Milliseconds left in the cooldown, for logging. Zero when not skipping. */
@@ -75,11 +83,21 @@ export function makeCaptureBackoff<E>() {
     recordFailure(cwd: string, nowMs: number, error: E): number {
       const consecutiveFailures = (recordByCwd.get(cwd)?.consecutiveFailures ?? 0) + 1;
       const cooldownMs = cooldownForFailureCount(consecutiveFailures);
+      // Re-insert so Map iteration order tracks recency, keeping the
+      // workspaces actually in use ahead of stale ones during eviction.
+      recordByCwd.delete(cwd);
       recordByCwd.set(cwd, {
         consecutiveFailures,
         skipUntilMs: cooldownMs === 0 ? 0 : nowMs + cooldownMs,
         lastError: error,
       });
+
+      while (recordByCwd.size > MAX_TRACKED_WORKSPACES) {
+        const oldestCwd = recordByCwd.keys().next().value;
+        if (oldestCwd === undefined) break;
+        recordByCwd.delete(oldestCwd);
+      }
+
       return consecutiveFailures;
     },
 

--- a/apps/server/src/checkpointing/CheckpointCaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CheckpointCaptureBackoff.test.ts
@@ -1,0 +1,103 @@
+import { it } from "@effect/vitest";
+import { ThreadId, VcsProcessTimeoutError } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { describe, expect } from "vite-plus/test";
+
+import * as CheckpointStore from "./CheckpointStore.ts";
+import { checkpointRefForThreadTurn } from "./Utils.ts";
+import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
+import type * as VcsDriver from "../vcs/VcsDriver.ts";
+
+const CWD = "/repo/huge-monorepo";
+const THREAD_ID = ThreadId.make("thread-checkpoint-backoff");
+
+const captureTimeout = new VcsProcessTimeoutError({
+  operation: "GitVcsDriver.checkpoints.captureCheckpoint",
+  command: "git add",
+  cwd: CWD,
+  timeoutMs: 30_000,
+});
+
+/**
+ * A driver whose capture always exceeds the process timeout, matching a
+ * repository too large for a full-tree `git add -A` to finish in time.
+ */
+function makeAlwaysTimingOutRegistry(captureAttempts: { count: number }) {
+  const checkpoints = {
+    captureCheckpoint: () =>
+      Effect.sync(() => {
+        captureAttempts.count += 1;
+      }).pipe(Effect.andThen(Effect.fail(captureTimeout))),
+    hasCheckpointRef: () => Effect.succeed(false),
+    restoreCheckpoint: () => Effect.succeed(false),
+    diffCheckpoints: () => Effect.succeed(""),
+    deleteCheckpointRefs: () => Effect.void,
+  } as unknown as VcsDriver.VcsCheckpointOps;
+
+  const handle = {
+    kind: "git" as const,
+    repository: {
+      kind: "git" as const,
+      rootPath: CWD,
+      metadataPath: `${CWD}/.git`,
+      freshness: { source: "cache" as const, checkedAt: 0 },
+    },
+    driver: { checkpoints } as unknown as VcsDriver.VcsDriver["Service"],
+  } as unknown as VcsDriverRegistry.VcsDriverHandle;
+
+  return Layer.succeed(
+    VcsDriverRegistry.VcsDriverRegistry,
+    VcsDriverRegistry.VcsDriverRegistry.of({
+      get: () => Effect.succeed(handle.driver),
+      detect: () => Effect.succeed(handle),
+      resolve: () => Effect.succeed(handle),
+    }),
+  );
+}
+
+describe("checkpoint capture backoff", () => {
+  it.effect("stops re-running a capture that keeps timing out", () => {
+    const captureAttempts = { count: 0 };
+    let nowMs = 0;
+
+    return Effect.gen(function* () {
+      const store = yield* CheckpointStore.CheckpointStore;
+      const capture = (turn: number) =>
+        store
+          .captureCheckpoint({
+            cwd: CWD,
+            checkpointRef: checkpointRefForThreadTurn(THREAD_ID, turn),
+          })
+          .pipe(Effect.flip);
+
+      // The first three turns each pay for a real capture attempt.
+      for (let turn = 1; turn <= 3; turn += 1) {
+        nowMs = turn * 1_000;
+        const error = yield* capture(turn);
+        expect(error._tag).toBe("VcsProcessTimeoutError");
+      }
+      expect(captureAttempts.count).toBe(3);
+
+      // Subsequent turns inside the cooldown replay the same failure without
+      // spawning git again.
+      for (let turn = 4; turn <= 10; turn += 1) {
+        nowMs = turn * 1_000;
+        const error = yield* capture(turn);
+        expect(error).toBe(captureTimeout);
+      }
+      expect(captureAttempts.count).toBe(3);
+
+      // Once the cooldown lapses the workspace is retried exactly once.
+      nowMs = 6 * 60_000;
+      yield* capture(11);
+      expect(captureAttempts.count).toBe(4);
+    }).pipe(
+      Effect.provide(
+        CheckpointStore.layerWith({ now: () => nowMs }).pipe(
+          Layer.provide(makeAlwaysTimingOutRegistry(captureAttempts)),
+        ),
+      ),
+    );
+  });
+});

--- a/apps/server/src/checkpointing/CheckpointCaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CheckpointCaptureBackoff.test.ts
@@ -23,12 +23,18 @@ const captureTimeout = new VcsProcessTimeoutError({
  * A driver whose capture always exceeds the process timeout, matching a
  * repository too large for a full-tree `git add -A` to finish in time.
  */
-function makeAlwaysTimingOutRegistry(captureAttempts: { count: number }) {
+function makeAlwaysTimingOutRegistry(
+  captureAttempts: { count: number },
+  options: { readonly succeedOnAttempt?: number } = {},
+) {
   const checkpoints = {
     captureCheckpoint: () =>
-      Effect.sync(() => {
+      Effect.suspend(() => {
         captureAttempts.count += 1;
-      }).pipe(Effect.andThen(Effect.fail(captureTimeout))),
+        return captureAttempts.count === options.succeedOnAttempt
+          ? Effect.void
+          : Effect.fail(captureTimeout);
+      }),
     hasCheckpointRef: () => Effect.succeed(false),
     restoreCheckpoint: () => Effect.succeed(false),
     diffCheckpoints: () => Effect.succeed(""),
@@ -59,7 +65,6 @@ function makeAlwaysTimingOutRegistry(captureAttempts: { count: number }) {
 describe("checkpoint capture backoff", () => {
   it.effect("stops re-running a capture that keeps timing out", () => {
     const captureAttempts = { count: 0 };
-    let nowMs = 0;
 
     return Effect.gen(function* () {
       const store = yield* CheckpointStore.CheckpointStore;
@@ -73,29 +78,51 @@ describe("checkpoint capture backoff", () => {
 
       // The first three turns each pay for a real capture attempt.
       for (let turn = 1; turn <= 3; turn += 1) {
-        nowMs = turn * 1_000;
         const error = yield* capture(turn);
         expect(error._tag).toBe("VcsProcessTimeoutError");
       }
       expect(captureAttempts.count).toBe(3);
 
-      // Subsequent turns inside the cooldown replay the same failure without
-      // spawning git again.
-      for (let turn = 4; turn <= 10; turn += 1) {
-        nowMs = turn * 1_000;
+      // Every later turn inside the cooldown replays the recorded failure
+      // without spawning git again. The cooldown is minutes long, so the rest
+      // of this test runs well inside it.
+      for (let turn = 4; turn <= 20; turn += 1) {
         const error = yield* capture(turn);
         expect(error).toBe(captureTimeout);
       }
       expect(captureAttempts.count).toBe(3);
-
-      // Once the cooldown lapses the workspace is retried exactly once.
-      nowMs = 6 * 60_000;
-      yield* capture(11);
-      expect(captureAttempts.count).toBe(4);
     }).pipe(
       Effect.provide(
-        CheckpointStore.layerWith({ now: () => nowMs }).pipe(
-          Layer.provide(makeAlwaysTimingOutRegistry(captureAttempts)),
+        CheckpointStore.layer.pipe(Layer.provide(makeAlwaysTimingOutRegistry(captureAttempts))),
+      ),
+    );
+  });
+
+  it.effect("keeps capturing for a workspace that recovers", () => {
+    const captureAttempts = { count: 0 };
+
+    return Effect.gen(function* () {
+      const store = yield* CheckpointStore.CheckpointStore;
+      const capture = (turn: number) =>
+        store.captureCheckpoint({
+          cwd: CWD,
+          checkpointRef: checkpointRefForThreadTurn(THREAD_ID, turn),
+        });
+
+      // Two failures stay under the threshold, and the success that follows
+      // clears them, so a later isolated failure does not open a cooldown.
+      yield* capture(1).pipe(Effect.flip);
+      yield* capture(2).pipe(Effect.flip);
+      yield* capture(3);
+      yield* capture(4).pipe(Effect.flip);
+      yield* capture(5).pipe(Effect.flip);
+      yield* capture(6).pipe(Effect.flip);
+
+      expect(captureAttempts.count).toBe(6);
+    }).pipe(
+      Effect.provide(
+        CheckpointStore.layer.pipe(
+          Layer.provide(makeAlwaysTimingOutRegistry(captureAttempts, { succeedOnAttempt: 3 })),
         ),
       ),
     );

--- a/apps/server/src/checkpointing/CheckpointCaptureBackoff.test.ts
+++ b/apps/server/src/checkpointing/CheckpointCaptureBackoff.test.ts
@@ -98,6 +98,44 @@ describe("checkpoint capture backoff", () => {
     );
   });
 
+  it.effect("does not hold a workspace when the driver cannot be resolved", () => {
+    const captureAttempts = { count: 0 };
+    const registryFailure = new VcsProcessTimeoutError({
+      operation: "VcsDriverRegistry.resolve",
+      command: "git rev-parse",
+      cwd: CWD,
+      timeoutMs: 5_000,
+    });
+    const failingRegistry = Layer.succeed(
+      VcsDriverRegistry.VcsDriverRegistry,
+      VcsDriverRegistry.VcsDriverRegistry.of({
+        get: () => Effect.fail(registryFailure),
+        detect: () => Effect.fail(registryFailure),
+        resolve: () => Effect.fail(registryFailure),
+      }) as never,
+    );
+
+    return Effect.gen(function* () {
+      const store = yield* CheckpointStore.CheckpointStore;
+      const capture = (turn: number) =>
+        store
+          .captureCheckpoint({
+            cwd: CWD,
+            checkpointRef: checkpointRefForThreadTurn(THREAD_ID, turn),
+          })
+          .pipe(Effect.flip);
+
+      // Failing before the driver runs still counts as a failure, so the
+      // first two turns stay under the threshold and keep retrying rather
+      // than being held by a stale reservation.
+      for (let turn = 1; turn <= 2; turn += 1) {
+        const error = yield* capture(turn);
+        expect(error).toBe(registryFailure);
+      }
+      expect(captureAttempts.count).toBe(0);
+    }).pipe(Effect.provide(CheckpointStore.layer.pipe(Layer.provide(failingRegistry))));
+  });
+
   it.effect("keeps capturing for a workspace that recovers", () => {
     const captureAttempts = { count: 0 };
 

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -126,7 +126,7 @@ export const make = Effect.gen(function* () {
     "captureCheckpoint",
   )(function* (input) {
     const startedAt = yield* Clock.currentTimeMillis;
-    const decision = captureBackoff.evaluate(input.cwd, startedAt);
+    const decision = captureBackoff.beginAttempt(input.cwd, startedAt);
     if (decision.skip && decision.lastError) {
       // Spawning git here would repeat a capture that cannot succeed, so
       // replay the failure the caller already handles instead of burning a
@@ -144,11 +144,11 @@ export const make = Effect.gen(function* () {
       Effect.tapError((error) =>
         Effect.gen(function* () {
           const failedAt = yield* Clock.currentTimeMillis;
-          const consecutiveFailures = captureBackoff.recordFailure(input.cwd, failedAt, error);
+          const outcome = captureBackoff.recordFailure(input.cwd, failedAt, error);
           yield* Effect.logWarning("Checkpoint capture failed", {
             cwdLength: input.cwd.length,
-            consecutiveFailures,
-            cooldownMs: captureBackoff.evaluate(input.cwd, failedAt).remainingMs,
+            consecutiveFailures: outcome.consecutiveFailures,
+            cooldownMs: outcome.cooldownMs,
             error,
           });
         }),

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -14,10 +14,12 @@
  * @module CheckpointStore
  */
 import { VcsUnsupportedOperationError, type CheckpointRef } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
+import { makeCaptureBackoff } from "./CaptureBackoff.ts";
 import type { CheckpointStoreError } from "./Errors.ts";
 import type { VcsCheckpointOps } from "../vcs/VcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -96,75 +98,115 @@ export class CheckpointStore extends Context.Service<
   }
 >()("t3/checkpointing/CheckpointStore") {}
 
-export const make = Effect.gen(function* () {
-  const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
+export interface CheckpointStoreOptions {
+  /** Overridable clock for deterministic backoff tests. */
+  readonly now?: () => number;
+}
 
-  const resolveCheckpoints = Effect.fn("CheckpointStore.resolveCheckpoints")(function* (
-    operation: string,
-    cwd: string,
-  ) {
-    const handle = yield* vcsRegistry.resolve({ cwd });
-    if (!handle.driver.checkpoints) {
-      return yield* new VcsUnsupportedOperationError({
-        operation,
-        kind: handle.kind,
-        detail: `${handle.kind} driver does not implement checkpoint operations.`,
-      });
-    }
-    return handle.driver.checkpoints satisfies VcsCheckpointOps;
+export const makeWith = (options: CheckpointStoreOptions = {}) =>
+  Effect.gen(function* () {
+    const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
+    const currentTimeMillis = options.now ? Effect.sync(options.now) : Clock.currentTimeMillis;
+    const captureBackoff = makeCaptureBackoff<CheckpointStoreError>();
+
+    const resolveCheckpoints = Effect.fn("CheckpointStore.resolveCheckpoints")(function* (
+      operation: string,
+      cwd: string,
+    ) {
+      const handle = yield* vcsRegistry.resolve({ cwd });
+      if (!handle.driver.checkpoints) {
+        return yield* new VcsUnsupportedOperationError({
+          operation,
+          kind: handle.kind,
+          detail: `${handle.kind} driver does not implement checkpoint operations.`,
+        });
+      }
+      return handle.driver.checkpoints satisfies VcsCheckpointOps;
+    });
+
+    const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
+      vcsRegistry
+        .detect({ cwd, requestedKind: "git" })
+        .pipe(Effect.map((repository) => repository !== null));
+
+    const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
+      "captureCheckpoint",
+    )(function* (input) {
+      const startedAt = yield* currentTimeMillis;
+      const decision = captureBackoff.evaluate(input.cwd, startedAt);
+      if (decision.skip && decision.lastError) {
+        // Spawning git here would repeat a capture that cannot succeed, so
+        // replay the failure the caller already handles instead of burning a
+        // CPU core and leaving another orphaned tmp_pack behind.
+        yield* Effect.logDebug("Skipping checkpoint capture during failure cooldown", {
+          cwdLength: input.cwd.length,
+          remainingMs: decision.remainingMs,
+        });
+        return yield* Effect.fail(decision.lastError);
+      }
+
+      const checkpoints = yield* resolveCheckpoints("CheckpointStore.captureCheckpoint", input.cwd);
+      return yield* checkpoints.captureCheckpoint(input).pipe(
+        Effect.tap(() => Effect.sync(() => captureBackoff.recordSuccess(input.cwd))),
+        Effect.tapError((error) =>
+          Effect.gen(function* () {
+            const failedAt = yield* currentTimeMillis;
+            const consecutiveFailures = captureBackoff.recordFailure(input.cwd, failedAt, error);
+            yield* Effect.logWarning("Checkpoint capture failed", {
+              cwdLength: input.cwd.length,
+              consecutiveFailures,
+              cooldownMs: captureBackoff.evaluate(input.cwd, failedAt).remainingMs,
+              error,
+            });
+          }),
+        ),
+      );
+    });
+
+    const hasCheckpointRef: CheckpointStore["Service"]["hasCheckpointRef"] = Effect.fn(
+      "hasCheckpointRef",
+    )(function* (input) {
+      const checkpoints = yield* resolveCheckpoints("CheckpointStore.hasCheckpointRef", input.cwd);
+      return yield* checkpoints.hasCheckpointRef(input);
+    });
+
+    const restoreCheckpoint: CheckpointStore["Service"]["restoreCheckpoint"] = Effect.fn(
+      "restoreCheckpoint",
+    )(function* (input) {
+      const checkpoints = yield* resolveCheckpoints("CheckpointStore.restoreCheckpoint", input.cwd);
+      return yield* checkpoints.restoreCheckpoint(input);
+    });
+
+    const diffCheckpoints: CheckpointStore["Service"]["diffCheckpoints"] = Effect.fn(
+      "diffCheckpoints",
+    )(function* (input) {
+      const checkpoints = yield* resolveCheckpoints("CheckpointStore.diffCheckpoints", input.cwd);
+      return yield* checkpoints.diffCheckpoints(input);
+    });
+
+    const deleteCheckpointRefs: CheckpointStore["Service"]["deleteCheckpointRefs"] = Effect.fn(
+      "deleteCheckpointRefs",
+    )(function* (input) {
+      const checkpoints = yield* resolveCheckpoints(
+        "CheckpointStore.deleteCheckpointRefs",
+        input.cwd,
+      );
+      return yield* checkpoints.deleteCheckpointRefs(input);
+    });
+
+    return CheckpointStore.of({
+      isGitRepository,
+      captureCheckpoint,
+      hasCheckpointRef,
+      restoreCheckpoint,
+      diffCheckpoints,
+      deleteCheckpointRefs,
+    });
   });
 
-  const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
-    vcsRegistry
-      .detect({ cwd, requestedKind: "git" })
-      .pipe(Effect.map((repository) => repository !== null));
-
-  const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
-    "captureCheckpoint",
-  )(function* (input) {
-    const checkpoints = yield* resolveCheckpoints("CheckpointStore.captureCheckpoint", input.cwd);
-    return yield* checkpoints.captureCheckpoint(input);
-  });
-
-  const hasCheckpointRef: CheckpointStore["Service"]["hasCheckpointRef"] = Effect.fn(
-    "hasCheckpointRef",
-  )(function* (input) {
-    const checkpoints = yield* resolveCheckpoints("CheckpointStore.hasCheckpointRef", input.cwd);
-    return yield* checkpoints.hasCheckpointRef(input);
-  });
-
-  const restoreCheckpoint: CheckpointStore["Service"]["restoreCheckpoint"] = Effect.fn(
-    "restoreCheckpoint",
-  )(function* (input) {
-    const checkpoints = yield* resolveCheckpoints("CheckpointStore.restoreCheckpoint", input.cwd);
-    return yield* checkpoints.restoreCheckpoint(input);
-  });
-
-  const diffCheckpoints: CheckpointStore["Service"]["diffCheckpoints"] = Effect.fn(
-    "diffCheckpoints",
-  )(function* (input) {
-    const checkpoints = yield* resolveCheckpoints("CheckpointStore.diffCheckpoints", input.cwd);
-    return yield* checkpoints.diffCheckpoints(input);
-  });
-
-  const deleteCheckpointRefs: CheckpointStore["Service"]["deleteCheckpointRefs"] = Effect.fn(
-    "deleteCheckpointRefs",
-  )(function* (input) {
-    const checkpoints = yield* resolveCheckpoints(
-      "CheckpointStore.deleteCheckpointRefs",
-      input.cwd,
-    );
-    return yield* checkpoints.deleteCheckpointRefs(input);
-  });
-
-  return CheckpointStore.of({
-    isGitRepository,
-    captureCheckpoint,
-    hasCheckpointRef,
-    restoreCheckpoint,
-    diffCheckpoints,
-    deleteCheckpointRefs,
-  });
-});
+export const make = makeWith();
 
 export const layer = Layer.effect(CheckpointStore, make);
+
+export const layerWith = (options: CheckpointStoreOptions) =>
+  Layer.effect(CheckpointStore, makeWith(options));

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -138,8 +138,13 @@ export const make = Effect.gen(function* () {
       return yield* Effect.fail(decision.lastError);
     }
 
-    const checkpoints = yield* resolveCheckpoints("CheckpointStore.captureCheckpoint", input.cwd);
-    return yield* checkpoints.captureCheckpoint(input).pipe(
+    // Resolving the driver sits inside the reported scope so that a failure
+    // before the capture runs still replaces this caller's reservation with a
+    // real outcome, rather than leaving the workspace held until it lapses.
+    return yield* Effect.gen(function* () {
+      const checkpoints = yield* resolveCheckpoints("CheckpointStore.captureCheckpoint", input.cwd);
+      return yield* checkpoints.captureCheckpoint(input);
+    }).pipe(
       Effect.tap(() => Effect.sync(() => captureBackoff.recordSuccess(input.cwd))),
       Effect.tapError((error) =>
         Effect.gen(function* () {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -98,115 +98,103 @@ export class CheckpointStore extends Context.Service<
   }
 >()("t3/checkpointing/CheckpointStore") {}
 
-export interface CheckpointStoreOptions {
-  /** Overridable clock for deterministic backoff tests. */
-  readonly now?: () => number;
-}
+export const make = Effect.gen(function* () {
+  const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
+  const captureBackoff = makeCaptureBackoff<CheckpointStoreError>();
 
-export const makeWith = (options: CheckpointStoreOptions = {}) =>
-  Effect.gen(function* () {
-    const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
-    const currentTimeMillis = options.now ? Effect.sync(options.now) : Clock.currentTimeMillis;
-    const captureBackoff = makeCaptureBackoff<CheckpointStoreError>();
-
-    const resolveCheckpoints = Effect.fn("CheckpointStore.resolveCheckpoints")(function* (
-      operation: string,
-      cwd: string,
-    ) {
-      const handle = yield* vcsRegistry.resolve({ cwd });
-      if (!handle.driver.checkpoints) {
-        return yield* new VcsUnsupportedOperationError({
-          operation,
-          kind: handle.kind,
-          detail: `${handle.kind} driver does not implement checkpoint operations.`,
-        });
-      }
-      return handle.driver.checkpoints satisfies VcsCheckpointOps;
-    });
-
-    const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
-      vcsRegistry
-        .detect({ cwd, requestedKind: "git" })
-        .pipe(Effect.map((repository) => repository !== null));
-
-    const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
-      "captureCheckpoint",
-    )(function* (input) {
-      const startedAt = yield* currentTimeMillis;
-      const decision = captureBackoff.evaluate(input.cwd, startedAt);
-      if (decision.skip && decision.lastError) {
-        // Spawning git here would repeat a capture that cannot succeed, so
-        // replay the failure the caller already handles instead of burning a
-        // CPU core and leaving another orphaned tmp_pack behind.
-        yield* Effect.logDebug("Skipping checkpoint capture during failure cooldown", {
-          cwdLength: input.cwd.length,
-          remainingMs: decision.remainingMs,
-        });
-        return yield* Effect.fail(decision.lastError);
-      }
-
-      const checkpoints = yield* resolveCheckpoints("CheckpointStore.captureCheckpoint", input.cwd);
-      return yield* checkpoints.captureCheckpoint(input).pipe(
-        Effect.tap(() => Effect.sync(() => captureBackoff.recordSuccess(input.cwd))),
-        Effect.tapError((error) =>
-          Effect.gen(function* () {
-            const failedAt = yield* currentTimeMillis;
-            const consecutiveFailures = captureBackoff.recordFailure(input.cwd, failedAt, error);
-            yield* Effect.logWarning("Checkpoint capture failed", {
-              cwdLength: input.cwd.length,
-              consecutiveFailures,
-              cooldownMs: captureBackoff.evaluate(input.cwd, failedAt).remainingMs,
-              error,
-            });
-          }),
-        ),
-      );
-    });
-
-    const hasCheckpointRef: CheckpointStore["Service"]["hasCheckpointRef"] = Effect.fn(
-      "hasCheckpointRef",
-    )(function* (input) {
-      const checkpoints = yield* resolveCheckpoints("CheckpointStore.hasCheckpointRef", input.cwd);
-      return yield* checkpoints.hasCheckpointRef(input);
-    });
-
-    const restoreCheckpoint: CheckpointStore["Service"]["restoreCheckpoint"] = Effect.fn(
-      "restoreCheckpoint",
-    )(function* (input) {
-      const checkpoints = yield* resolveCheckpoints("CheckpointStore.restoreCheckpoint", input.cwd);
-      return yield* checkpoints.restoreCheckpoint(input);
-    });
-
-    const diffCheckpoints: CheckpointStore["Service"]["diffCheckpoints"] = Effect.fn(
-      "diffCheckpoints",
-    )(function* (input) {
-      const checkpoints = yield* resolveCheckpoints("CheckpointStore.diffCheckpoints", input.cwd);
-      return yield* checkpoints.diffCheckpoints(input);
-    });
-
-    const deleteCheckpointRefs: CheckpointStore["Service"]["deleteCheckpointRefs"] = Effect.fn(
-      "deleteCheckpointRefs",
-    )(function* (input) {
-      const checkpoints = yield* resolveCheckpoints(
-        "CheckpointStore.deleteCheckpointRefs",
-        input.cwd,
-      );
-      return yield* checkpoints.deleteCheckpointRefs(input);
-    });
-
-    return CheckpointStore.of({
-      isGitRepository,
-      captureCheckpoint,
-      hasCheckpointRef,
-      restoreCheckpoint,
-      diffCheckpoints,
-      deleteCheckpointRefs,
-    });
+  const resolveCheckpoints = Effect.fn("CheckpointStore.resolveCheckpoints")(function* (
+    operation: string,
+    cwd: string,
+  ) {
+    const handle = yield* vcsRegistry.resolve({ cwd });
+    if (!handle.driver.checkpoints) {
+      return yield* new VcsUnsupportedOperationError({
+        operation,
+        kind: handle.kind,
+        detail: `${handle.kind} driver does not implement checkpoint operations.`,
+      });
+    }
+    return handle.driver.checkpoints satisfies VcsCheckpointOps;
   });
 
-export const make = makeWith();
+  const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
+    vcsRegistry
+      .detect({ cwd, requestedKind: "git" })
+      .pipe(Effect.map((repository) => repository !== null));
+
+  const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
+    "captureCheckpoint",
+  )(function* (input) {
+    const startedAt = yield* Clock.currentTimeMillis;
+    const decision = captureBackoff.evaluate(input.cwd, startedAt);
+    if (decision.skip && decision.lastError) {
+      // Spawning git here would repeat a capture that cannot succeed, so
+      // replay the failure the caller already handles instead of burning a
+      // CPU core and leaving another orphaned tmp_pack behind.
+      yield* Effect.logDebug("Skipping checkpoint capture during failure cooldown", {
+        cwdLength: input.cwd.length,
+        remainingMs: decision.remainingMs,
+      });
+      return yield* Effect.fail(decision.lastError);
+    }
+
+    const checkpoints = yield* resolveCheckpoints("CheckpointStore.captureCheckpoint", input.cwd);
+    return yield* checkpoints.captureCheckpoint(input).pipe(
+      Effect.tap(() => Effect.sync(() => captureBackoff.recordSuccess(input.cwd))),
+      Effect.tapError((error) =>
+        Effect.gen(function* () {
+          const failedAt = yield* Clock.currentTimeMillis;
+          const consecutiveFailures = captureBackoff.recordFailure(input.cwd, failedAt, error);
+          yield* Effect.logWarning("Checkpoint capture failed", {
+            cwdLength: input.cwd.length,
+            consecutiveFailures,
+            cooldownMs: captureBackoff.evaluate(input.cwd, failedAt).remainingMs,
+            error,
+          });
+        }),
+      ),
+    );
+  });
+
+  const hasCheckpointRef: CheckpointStore["Service"]["hasCheckpointRef"] = Effect.fn(
+    "hasCheckpointRef",
+  )(function* (input) {
+    const checkpoints = yield* resolveCheckpoints("CheckpointStore.hasCheckpointRef", input.cwd);
+    return yield* checkpoints.hasCheckpointRef(input);
+  });
+
+  const restoreCheckpoint: CheckpointStore["Service"]["restoreCheckpoint"] = Effect.fn(
+    "restoreCheckpoint",
+  )(function* (input) {
+    const checkpoints = yield* resolveCheckpoints("CheckpointStore.restoreCheckpoint", input.cwd);
+    return yield* checkpoints.restoreCheckpoint(input);
+  });
+
+  const diffCheckpoints: CheckpointStore["Service"]["diffCheckpoints"] = Effect.fn(
+    "diffCheckpoints",
+  )(function* (input) {
+    const checkpoints = yield* resolveCheckpoints("CheckpointStore.diffCheckpoints", input.cwd);
+    return yield* checkpoints.diffCheckpoints(input);
+  });
+
+  const deleteCheckpointRefs: CheckpointStore["Service"]["deleteCheckpointRefs"] = Effect.fn(
+    "deleteCheckpointRefs",
+  )(function* (input) {
+    const checkpoints = yield* resolveCheckpoints(
+      "CheckpointStore.deleteCheckpointRefs",
+      input.cwd,
+    );
+    return yield* checkpoints.deleteCheckpointRefs(input);
+  });
+
+  return CheckpointStore.of({
+    isGitRepository,
+    captureCheckpoint,
+    hasCheckpointRef,
+    restoreCheckpoint,
+    diffCheckpoints,
+    deleteCheckpointRefs,
+  });
+});
 
 export const layer = Layer.effect(CheckpointStore, make);
-
-export const layerWith = (options: CheckpointStoreOptions) =>
-  Layer.effect(CheckpointStore, makeWith(options));


### PR DESCRIPTION
## What Changed

`CheckpointStore.captureCheckpoint` tracks consecutive failures per workspace. After three, capture is skipped for a growing cooldown (5 minutes, doubling, capped at an hour) instead of being retried on every turn. Any success clears the record.

## Why

Checkpoint capture runs a full-tree `git add -A` under a temporary index after every completed turn. On a repository large enough that this cannot finish inside the 30s VCS process timeout, the process is killed every single time, so the retry buys nothing and costs a great deal: one CPU core pegged for as long as any thread is in use, plus an orphaned `tmp_pack_*` in `.git/objects/pack` for every kill that lands mid-pack-write.

A skipped capture replays the failure recorded when the cooldown opened, so callers see the same error and the same `missing` turn-diff status they see today, and the error channel is unchanged. Three failures of tolerance keeps a transient failure (an index lock held by a concurrent git command) from disabling capture, and the hour cap means a workspace that becomes healthy is picked up again on its own.

This is the "skip-with-backoff after N consecutive capture failures" option from the issue. The other suggestions there (a disable setting, an adaptive timeout, `tmp_pack_*` cleanup) are deliberately left out to keep this focused.

Fixes #3646

## Testing

- `vp test run apps/server/src/checkpointing/` passes (23/23). New coverage: the backoff policy itself (threshold, doubling, cap, per-workspace isolation, reset on success) and an end-to-end test driving `CheckpointStore` against a driver that always times out, asserting the driver is invoked exactly 3 times across 10 turns and exactly once more after the cooldown lapses
- `vp test run apps/server/src/orchestration/` passes, 214 tests total across both directories
- `pnpm typecheck` in apps/server clean
- `vp lint` on changed files clean

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when checkpoints are captured for unhealthy workspaces (skipped turns still error the same way) but reduces runaway CPU/git load; logic is well-tested and scoped to capture only.
> 
> **Overview**
> Adds per-workspace **capture backoff** so repeatedly failing checkpoint captures stop spawning expensive `git add` work on every turn.
> 
> New `CaptureBackoff` tracks consecutive failures per `cwd` (tolerates 2, then exponential cooldown from 5 minutes up to 1 hour, LRU cap of 256 workspaces, 60s single-flight reservation after cooldown). **`CheckpointStore.captureCheckpoint`** consults `beginAttempt` first; during cooldown it fails immediately with the **same** stored error instead of calling the VCS driver. Success clears state; failures (including driver resolve errors) update backoff and log warnings.
> 
> Unit tests cover the policy; integration tests assert only three real capture attempts across many turns when capture always times out, plus recovery and registry-failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a76e3509fde1fbefb729931800a8d299f6aceb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Back off checkpoint capture in `CheckpointStore` after repeated failures
> - Introduces [`CaptureBackoff`](https://github.com/pingdotgg/t3code/pull/4517/files#diff-dec16a40eadb0173831587e2853959055f8c3e08872b3c288cbb5d7b30025cad), a per-workspace LRU-bounded tracker that computes exponential cooldown durations once a failure threshold is crossed, capping at an absolute maximum.
> - Integrates backoff into [`CheckpointStore.captureCheckpoint`](https://github.com/pingdotgg/t3code/pull/4517/files#diff-81ee8314218d1cb6f56ad7eece6b007318c109b5fbcb1f3a83ef99c8eb581c9d): during cooldown, the method short-circuits and replays the last error without invoking the VCS driver; a single caller is reserved for the first post-cooldown retry.
> - On success, backoff state is cleared; on failure, the consecutive failure count increments, cooldown extends, and a warning log emits the backoff details.
> - Risk: `captureCheckpoint` callers in cooldown now receive a replayed error immediately rather than triggering a new capture attempt, which is a behavioral change for any caller that retries on every error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a76e35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->