### PR TITLE
feat(web): group sidebar v2 by worktree and scope panes to the checkout

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -38,6 +38,7 @@ import {
 } from "@t3tools/shared/dpop";
 import { RELAY_HEALTH_REQUEST_TYP, RELAY_MINT_REQUEST_TYP } from "@t3tools/shared/relayJwt";
 import * as RelayClient from "@t3tools/shared/relayClient";
+import { worktreeResourceThreadId } from "@t3tools/shared/worktreeResource";
 import { assert, it } from "@effect/vitest";
 import { assertFailure, assertInclude, assertTrue } from "@effect/vitest/utils";
 import * as Clock from "effect/Clock";
@@ -125,6 +126,7 @@ import * as Data from "effect/Data";
 
 const defaultProjectId = ProjectId.make("project-default");
 const defaultThreadId = ThreadId.make("thread-default");
+const defaultWorktreeResourceThreadId = worktreeResourceThreadId(defaultProjectId, null);
 const defaultDesktopBootstrapToken = "test-desktop-bootstrap-token";
 const defaultModelSelection = {
   instanceId: ProviderInstanceId.make("codex"),
@@ -6503,7 +6505,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.deepEqual(effects, [
         "dispatch:thread.archive",
         "dispatch:thread.session.stop",
-        `terminal.close:${threadId}`,
+        `terminal.close:${defaultWorktreeResourceThreadId}`,
       ]);
       const sessionStopCommand = dispatchedCommands[1];
       assert.equal(sessionStopCommand?.type, "thread.session.stop");
@@ -6582,7 +6584,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         "query:thread-shell:active",
         "dispatch:thread.archive",
         "dispatch:thread.session.stop",
-        `terminal.close:${threadId}`,
+        `terminal.close:${defaultWorktreeResourceThreadId}`,
       ]);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
@@ -6634,7 +6636,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       );
 
       assert.equal(dispatchResult.sequence, 1);
-      assert.deepEqual(effects, ["dispatch:thread.archive", `terminal.close:${threadId}`]);
+      assert.deepEqual(effects, [
+        "dispatch:thread.archive",
+        `terminal.close:${defaultWorktreeResourceThreadId}`,
+      ]);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
         ["thread.archive"],
@@ -6702,7 +6707,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         );
 
         assert.equal(dispatchResult.sequence, 1);
-        assert.deepEqual(effects, ["dispatch:thread.archive", `terminal.close:${threadId}`]);
+        assert.deepEqual(effects, [
+          "dispatch:thread.archive",
+          `terminal.close:${defaultWorktreeResourceThreadId}`,
+        ]);
         assert.deepEqual(
           dispatchedCommands.map((command) => command.type),
           ["thread.archive"],
@@ -6778,7 +6786,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.deepEqual(effects, [
         "dispatch:thread.archive",
         "dispatch:thread.session.stop",
-        `terminal.close:${threadId}`,
+        `terminal.close:${defaultWorktreeResourceThreadId}`,
       ]);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
@@ -6850,7 +6858,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.deepEqual(effects, [
         "dispatch:thread.archive",
         "dispatch:thread.session.stop",
-        `terminal.close:${threadId}`,
+        `terminal.close:${defaultWorktreeResourceThreadId}`,
       ]);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
@@ -6928,81 +6936,61 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  it.effect(
-    "closes the archived canonical terminal owner after the last live sibling archives",
-    () =>
-      Effect.gen(function* () {
-        const canonicalThreadId = ThreadId.make("thread-archive-canonical");
-        const finalSiblingId = ThreadId.make("thread-archive-final-sibling");
-        const worktreePath = "/tmp/worktrees/shared";
-        const effects: string[] = [];
+  it.effect("closes the stable worktree terminal owner after the last live sibling archives", () =>
+    Effect.gen(function* () {
+      const finalSiblingId = ThreadId.make("thread-archive-final-sibling");
+      const worktreePath = "/tmp/worktrees/shared";
+      const effects: string[] = [];
+      const finalSibling = makeDefaultOrchestrationThreadShell({
+        id: finalSiblingId,
+        createdAt: "2026-01-02T00:00:00.000Z",
+        worktreePath,
+      });
 
-        yield* buildAppUnderTest({
-          layers: {
-            terminalManager: {
-              close: (input) =>
-                Effect.sync(() => {
-                  effects.push(`terminal.close:${input.threadId}`);
-                }),
-            },
-            orchestrationEngine: {
-              dispatch: (command) =>
-                Effect.sync(() => {
-                  effects.push(`dispatch:${command.type}`);
-                  return { sequence: 1 };
-                }),
-            },
-            projectionSnapshotQuery: {
-              getThreadShellById: () =>
-                Effect.succeed(
-                  Option.some(
-                    makeDefaultOrchestrationThreadShell({
-                      id: finalSiblingId,
-                      createdAt: "2026-01-02T00:00:00.000Z",
-                      worktreePath,
-                    }),
-                  ),
-                ),
-              getShellSnapshot: () =>
-                Effect.succeed({
-                  snapshotSequence: 2,
-                  projects: [],
-                  threads: [],
-                  updatedAt: "2026-01-03T00:00:00.000Z",
-                }),
-              getArchivedShellSnapshot: () =>
-                Effect.succeed({
-                  snapshotSequence: 2,
-                  projects: [],
-                  threads: [
-                    makeDefaultOrchestrationThreadShell({
-                      id: canonicalThreadId,
-                      createdAt: "2026-01-01T00:00:00.000Z",
-                      worktreePath,
-                    }),
-                  ],
-                  updatedAt: "2026-01-03T00:00:00.000Z",
-                }),
-            },
+      yield* buildAppUnderTest({
+        layers: {
+          terminalManager: {
+            close: (input) =>
+              Effect.sync(() => {
+                effects.push(`terminal.close:${input.threadId}`);
+              }),
           },
-        });
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                effects.push(`dispatch:${command.type}`);
+                return { sequence: 1 };
+              }),
+          },
+          projectionSnapshotQuery: {
+            getThreadShellById: () => Effect.succeed(Option.some(finalSibling)),
+            getShellSnapshot: () =>
+              Effect.succeed({
+                snapshotSequence: 2,
+                projects: [],
+                threads: [],
+                updatedAt: "2026-01-03T00:00:00.000Z",
+              }),
+          },
+        },
+      });
 
-        const wsUrl = yield* getWsServerUrl("/ws");
-        yield* Effect.scoped(
-          withWsRpcClient(wsUrl, (client) =>
-            client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
-              type: "thread.archive",
-              commandId: CommandId.make("cmd-thread-archive-final-sibling"),
-              threadId: finalSiblingId,
-            }),
-          ),
-        );
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.archive",
+            commandId: CommandId.make("cmd-thread-archive-final-sibling"),
+            threadId: finalSiblingId,
+          }),
+        ),
+      );
 
-        assert.deepEqual(effects, [
-          "dispatch:thread.archive",
-          `terminal.close:${canonicalThreadId}`,
-        ]);
-      }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+      assert.deepEqual(effects, [
+        "dispatch:thread.archive",
+        `terminal.close:${worktreeResourceThreadId(finalSibling.projectId, worktreePath)}`,
+      ]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
   it.effect(

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6929,6 +6929,83 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
   );
 
   it.effect(
+    "closes the archived canonical terminal owner after the last live sibling archives",
+    () =>
+      Effect.gen(function* () {
+        const canonicalThreadId = ThreadId.make("thread-archive-canonical");
+        const finalSiblingId = ThreadId.make("thread-archive-final-sibling");
+        const worktreePath = "/tmp/worktrees/shared";
+        const effects: string[] = [];
+
+        yield* buildAppUnderTest({
+          layers: {
+            terminalManager: {
+              close: (input) =>
+                Effect.sync(() => {
+                  effects.push(`terminal.close:${input.threadId}`);
+                }),
+            },
+            orchestrationEngine: {
+              dispatch: (command) =>
+                Effect.sync(() => {
+                  effects.push(`dispatch:${command.type}`);
+                  return { sequence: 1 };
+                }),
+            },
+            projectionSnapshotQuery: {
+              getThreadShellById: () =>
+                Effect.succeed(
+                  Option.some(
+                    makeDefaultOrchestrationThreadShell({
+                      id: finalSiblingId,
+                      createdAt: "2026-01-02T00:00:00.000Z",
+                      worktreePath,
+                    }),
+                  ),
+                ),
+              getShellSnapshot: () =>
+                Effect.succeed({
+                  snapshotSequence: 2,
+                  projects: [],
+                  threads: [],
+                  updatedAt: "2026-01-03T00:00:00.000Z",
+                }),
+              getArchivedShellSnapshot: () =>
+                Effect.succeed({
+                  snapshotSequence: 2,
+                  projects: [],
+                  threads: [
+                    makeDefaultOrchestrationThreadShell({
+                      id: canonicalThreadId,
+                      createdAt: "2026-01-01T00:00:00.000Z",
+                      worktreePath,
+                    }),
+                  ],
+                  updatedAt: "2026-01-03T00:00:00.000Z",
+                }),
+            },
+          },
+        });
+
+        const wsUrl = yield* getWsServerUrl("/ws");
+        yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+              type: "thread.archive",
+              commandId: CommandId.make("cmd-thread-archive-final-sibling"),
+              threadId: finalSiblingId,
+            }),
+          ),
+        );
+
+        assert.deepEqual(effects, [
+          "dispatch:thread.archive",
+          `terminal.close:${canonicalThreadId}`,
+        ]);
+      }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect(
     "bootstraps first-send worktree turns on the server before dispatching turn start",
     () =>
       Effect.gen(function* () {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6859,6 +6859,75 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("skips closing terminals on archive while a sibling thread shares the worktree", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("thread-archive-shared-worktree");
+      const siblingThreadId = ThreadId.make("thread-archive-shared-sibling");
+      const worktreePath = "/tmp/worktrees/shared";
+      const effects: string[] = [];
+      const now = "2026-01-01T00:00:00.000Z";
+
+      yield* buildAppUnderTest({
+        layers: {
+          terminalManager: {
+            close: (input) =>
+              Effect.sync(() => {
+                effects.push(`terminal.close:${input.threadId}`);
+              }),
+          },
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                effects.push(`dispatch:${command.type}`);
+                return { sequence: 1 };
+              }),
+          },
+          projectionSnapshotQuery: {
+            getThreadShellById: () =>
+              Effect.succeed(
+                Option.some(
+                  makeDefaultOrchestrationThreadShell({
+                    id: threadId,
+                    updatedAt: now,
+                    worktreePath,
+                  }),
+                ),
+              ),
+            getShellSnapshot: () =>
+              Effect.succeed({
+                snapshotSequence: 1,
+                projects: [],
+                threads: [
+                  makeDefaultOrchestrationThreadShell({
+                    id: siblingThreadId,
+                    updatedAt: now,
+                    worktreePath,
+                  }),
+                ],
+                updatedAt: now,
+              }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.archive",
+            commandId: CommandId.make("cmd-thread-archive-shared-worktree"),
+            threadId,
+          }),
+        ),
+      );
+
+      // Terminals are worktree-scoped on the client: the sibling still uses
+      // the checkout, so its terminals (e.g. a running dev server) must
+      // survive the archive.
+      assert.deepEqual(effects, ["dispatch:thread.archive"]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect(
     "bootstraps first-send worktree turns on the server before dispatching turn start",
     () =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -56,6 +56,7 @@ import {
   WsRpcGroup,
 } from "@t3tools/contracts";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import { worktreeResourceThreadId } from "@t3tools/shared/worktreeResource";
 import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
@@ -1060,11 +1061,8 @@ const makeWsRpcLayer = (
                 const terminalOwnerToClose = yield* Option.match(threadShellBeforeArchive, {
                   onNone: () => Effect.succeed(Option.none<ThreadId>()),
                   onSome: (archivedThread) =>
-                    Effect.all([
-                      projectionSnapshotQuery.getShellSnapshot(),
-                      projectionSnapshotQuery.getArchivedShellSnapshot(),
-                    ]).pipe(
-                      Effect.map(([activeSnapshot, archivedSnapshot]) => {
+                    projectionSnapshotQuery.getShellSnapshot().pipe(
+                      Effect.map((activeSnapshot) => {
                         const sameWorktree = (thread: OrchestrationThreadShell) =>
                           thread.projectId === archivedThread.projectId &&
                           normalizeWorktreePathForArchive(thread.worktreePath) ===
@@ -1073,19 +1071,14 @@ const makeWsRpcLayer = (
                           (thread) => thread.id !== archivedThread.id && sameWorktree(thread),
                         );
                         if (worktreeStillInUse) return Option.none<ThreadId>();
-                        const canonicalOwner = [
-                          archivedThread,
-                          ...archivedSnapshot.threads.filter(
-                            (thread) => thread.id !== archivedThread.id && sameWorktree(thread),
+                        return Option.some(
+                          worktreeResourceThreadId(
+                            archivedThread.projectId,
+                            archivedThread.worktreePath,
                           ),
-                        ].toSorted(
-                          (left, right) =>
-                            left.createdAt.localeCompare(right.createdAt) ||
-                            left.id.localeCompare(right.id),
-                        )[0]!;
-                        return Option.some(canonicalOwner.id);
+                        );
                       }),
-                      // If either projection read fails, retain the sessions;
+                      // If the projection read fails, retain the sessions;
                       // closing the wrong checkout owner is more disruptive
                       // than a cleanup retry on a later lifecycle action.
                       Effect.orElseSucceed(() => Option.none<ThreadId>()),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -24,6 +24,7 @@ import {
   OrchestrationDispatchCommandError,
   type OrchestrationEvent,
   type OrchestrationShellStreamEvent,
+  type OrchestrationThreadShell,
   type OrchestrationShellStreamItem,
   type OrchestrationThreadStreamItem,
   OrchestrationGetFullThreadDiffError,
@@ -1001,6 +1002,13 @@ const makeWsRpcLayer = (
         };
       });
 
+      // Mirrors the client's worktree identity rule (worktreeCleanup.ts):
+      // blank and null both mean "the project's local checkout".
+      const normalizeWorktreePathForArchive = (worktreePath: string | null): string | null => {
+        const trimmed = worktreePath?.trim();
+        return trimmed !== undefined && trimmed.length > 0 ? trimmed : null;
+      };
+
       const refreshGitStatus = (cwd: string) =>
         vcsStatusBroadcaster
           .refreshStatus(cwd)
@@ -1012,21 +1020,17 @@ const makeWsRpcLayer = (
             ORCHESTRATION_WS_METHODS.dispatchCommand,
             Effect.gen(function* () {
               const normalizedCommand = yield* normalizeDispatchCommand(command);
-              const shouldStopSessionAfterArchive =
+              const threadShellBeforeArchive =
                 normalizedCommand.type === "thread.archive"
                   ? yield* projectionSnapshotQuery
                       .getThreadShellById(normalizedCommand.threadId)
-                      .pipe(
-                        Effect.map(
-                          Option.match({
-                            onNone: () => false,
-                            onSome: (thread) =>
-                              thread.session !== null && thread.session.status !== "stopped",
-                          }),
-                        ),
-                        Effect.orElseSucceed(() => false),
-                      )
-                  : false;
+                      .pipe(Effect.orElseSucceed(() => Option.none<OrchestrationThreadShell>()))
+                  : Option.none<OrchestrationThreadShell>();
+              const shouldStopSessionAfterArchive = Option.match(threadShellBeforeArchive, {
+                onNone: () => false,
+                onSome: (thread) =>
+                  thread.session !== null && thread.session.status !== "stopped",
+              });
               const result = yield* dispatchNormalizedCommand(normalizedCommand);
               if (normalizedCommand.type === "thread.archive") {
                 if (shouldStopSessionAfterArchive) {
@@ -1051,14 +1055,36 @@ const makeWsRpcLayer = (
                   );
                 }
 
-                yield* terminalManager.close({ threadId: normalizedCommand.threadId }).pipe(
-                  Effect.catch((error) =>
-                    Effect.logWarning("failed to close thread terminals after archive", {
-                      threadId: normalizedCommand.threadId,
-                      error: error.message,
-                    }),
-                  ),
-                );
+                // Terminals are worktree-scoped on the client (every thread in
+                // a checkout shares one set of ptys via a canonical thread id),
+                // so archiving one thread must not kill sessions that sibling
+                // threads still use — e.g. a running dev server.
+                const worktreeStillInUse = yield* Option.match(threadShellBeforeArchive, {
+                  onNone: () => Effect.succeed(false),
+                  onSome: (archivedThread) =>
+                    projectionSnapshotQuery.getShellSnapshot().pipe(
+                      Effect.map((snapshot) =>
+                        snapshot.threads.some(
+                          (thread) =>
+                            thread.id !== archivedThread.id &&
+                            thread.projectId === archivedThread.projectId &&
+                            normalizeWorktreePathForArchive(thread.worktreePath) ===
+                              normalizeWorktreePathForArchive(archivedThread.worktreePath),
+                        ),
+                      ),
+                      Effect.orElseSucceed(() => false),
+                    ),
+                });
+                if (!worktreeStillInUse) {
+                  yield* terminalManager.close({ threadId: normalizedCommand.threadId }).pipe(
+                    Effect.catch((error) =>
+                      Effect.logWarning("failed to close thread terminals after archive", {
+                        threadId: normalizedCommand.threadId,
+                        error: error.message,
+                      }),
+                    ),
+                  );
+                }
               }
               return result;
             }).pipe(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1005,8 +1005,7 @@ const makeWsRpcLayer = (
       // Mirrors the client's worktree identity rule (worktreeCleanup.ts):
       // blank and null both mean "the project's local checkout".
       const normalizeWorktreePathForArchive = (worktreePath: string | null): string | null => {
-        const trimmed = worktreePath?.trim();
-        return trimmed !== undefined && trimmed.length > 0 ? trimmed : null;
+        return worktreePath && worktreePath.length > 0 ? worktreePath : null;
       };
 
       const refreshGitStatus = (cwd: string) =>
@@ -1028,8 +1027,7 @@ const makeWsRpcLayer = (
                   : Option.none<OrchestrationThreadShell>();
               const shouldStopSessionAfterArchive = Option.match(threadShellBeforeArchive, {
                 onNone: () => false,
-                onSome: (thread) =>
-                  thread.session !== null && thread.session.status !== "stopped",
+                onSome: (thread) => thread.session !== null && thread.session.status !== "stopped",
               });
               const result = yield* dispatchNormalizedCommand(normalizedCommand);
               if (normalizedCommand.type === "thread.archive") {
@@ -1059,32 +1057,52 @@ const makeWsRpcLayer = (
                 // a checkout shares one set of ptys via a canonical thread id),
                 // so archiving one thread must not kill sessions that sibling
                 // threads still use — e.g. a running dev server.
-                const worktreeStillInUse = yield* Option.match(threadShellBeforeArchive, {
-                  onNone: () => Effect.succeed(false),
+                const terminalOwnerToClose = yield* Option.match(threadShellBeforeArchive, {
+                  onNone: () => Effect.succeed(Option.none<ThreadId>()),
                   onSome: (archivedThread) =>
-                    projectionSnapshotQuery.getShellSnapshot().pipe(
-                      Effect.map((snapshot) =>
-                        snapshot.threads.some(
-                          (thread) =>
-                            thread.id !== archivedThread.id &&
-                            thread.projectId === archivedThread.projectId &&
-                            normalizeWorktreePathForArchive(thread.worktreePath) ===
-                              normalizeWorktreePathForArchive(archivedThread.worktreePath),
-                        ),
-                      ),
-                      Effect.orElseSucceed(() => false),
+                    Effect.all([
+                      projectionSnapshotQuery.getShellSnapshot(),
+                      projectionSnapshotQuery.getArchivedShellSnapshot(),
+                    ]).pipe(
+                      Effect.map(([activeSnapshot, archivedSnapshot]) => {
+                        const sameWorktree = (thread: OrchestrationThreadShell) =>
+                          thread.projectId === archivedThread.projectId &&
+                          normalizeWorktreePathForArchive(thread.worktreePath) ===
+                            normalizeWorktreePathForArchive(archivedThread.worktreePath);
+                        const worktreeStillInUse = activeSnapshot.threads.some(
+                          (thread) => thread.id !== archivedThread.id && sameWorktree(thread),
+                        );
+                        if (worktreeStillInUse) return Option.none<ThreadId>();
+                        const canonicalOwner = [
+                          archivedThread,
+                          ...archivedSnapshot.threads.filter(
+                            (thread) => thread.id !== archivedThread.id && sameWorktree(thread),
+                          ),
+                        ].toSorted(
+                          (left, right) =>
+                            left.createdAt.localeCompare(right.createdAt) ||
+                            left.id.localeCompare(right.id),
+                        )[0]!;
+                        return Option.some(canonicalOwner.id);
+                      }),
+                      // If either projection read fails, retain the sessions;
+                      // closing the wrong checkout owner is more disruptive
+                      // than a cleanup retry on a later lifecycle action.
+                      Effect.orElseSucceed(() => Option.none<ThreadId>()),
                     ),
                 });
-                if (!worktreeStillInUse) {
-                  yield* terminalManager.close({ threadId: normalizedCommand.threadId }).pipe(
-                    Effect.catch((error) =>
-                      Effect.logWarning("failed to close thread terminals after archive", {
-                        threadId: normalizedCommand.threadId,
-                        error: error.message,
-                      }),
+                yield* Option.match(terminalOwnerToClose, {
+                  onNone: () => Effect.void,
+                  onSome: (threadId) =>
+                    terminalManager.close({ threadId }).pipe(
+                      Effect.catch((error) =>
+                        Effect.logWarning("failed to close thread terminals after archive", {
+                          threadId,
+                          error: error.message,
+                        }),
+                      ),
                     ),
-                  );
-                }
+                });
               }
               return result;
             }).pipe(

--- a/apps/web/src/browser/ElectronBrowserHost.tsx
+++ b/apps/web/src/browser/ElectronBrowserHost.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import { FILL_PREVIEW_VIEWPORT } from "@t3tools/contracts";
 import { useEffect, useMemo } from "react";
 
@@ -18,21 +17,14 @@ export function ElectronBrowserHost() {
   const previewByThreadKey = useActivePreviewSessions();
   const sessions = useMemo(
     () =>
-      Object.entries(previewByThreadKey).flatMap(([threadKey, previewState]) => {
-        const threadRef = parseScopedThreadKey(threadKey);
-        return threadRef
-          ? Object.values(previewState.sessions).map((snapshot) => ({
-              threadRef,
-              snapshot,
-              runtimeTabId: previewRuntimeTabId(
-                threadRef,
-                previewState.serverEpoch,
-                snapshot.tabId,
-              ),
-              zoomFactor: previewState.desktopByTabId[snapshot.tabId]?.zoomFactor ?? 1,
-            }))
-          : [];
-      }),
+      previewByThreadKey.flatMap(({ threadRef, state: previewState }) =>
+        Object.values(previewState.sessions).map((snapshot) => ({
+          threadRef,
+          snapshot,
+          runtimeTabId: previewRuntimeTabId(threadRef, previewState.serverEpoch, snapshot.tabId),
+          zoomFactor: previewState.desktopByTabId[snapshot.tabId]?.zoomFactor ?? 1,
+        })),
+      ),
     [previewByThreadKey],
   );
 

--- a/apps/web/src/browser/openFileInPreview.ts
+++ b/apps/web/src/browser/openFileInPreview.ts
@@ -21,6 +21,7 @@ import {
   rememberPreviewUrl,
 } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
+import { resolveWorktreeCanonicalThreadRef } from "~/worktreeScope";
 
 export const isBrowserPreviewFile = (path: string): boolean =>
   /\.(?:html?|pdf)$/i.test(path.split(/[?#]/, 1)[0] ?? "");
@@ -41,9 +42,12 @@ export async function openUrlInPreview<E>(input: {
   readonly url: string;
   readonly openPreview: OpenPreviewMutation<E>;
 }): Promise<AtomCommandResult<void, E>> {
+  // Preview sessions are worktree-scoped: open through the worktree's
+  // canonical thread id so sibling threads share one set of tabs.
+  const canonicalRef = resolveWorktreeCanonicalThreadRef(input.threadRef);
   const result = await input.openPreview({
-    environmentId: input.threadRef.environmentId,
-    input: { threadId: input.threadRef.threadId, url: input.url },
+    environmentId: canonicalRef.environmentId,
+    input: { threadId: canonicalRef.threadId, url: input.url },
   });
   return mapAtomCommandResult(result, (snapshot) => {
     applyPreviewServerSnapshot(input.threadRef, snapshot);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -216,10 +216,16 @@ import {
   useProjects,
   useThread,
   useThreadProposedPlans,
-  useThreadRefs,
   useThreadShell,
+  useThreadShells,
 } from "../state/entities";
 import { environmentShell } from "../state/shell";
+import {
+  threadWorktreeScopeKey,
+  useWorktreeCanonicalThreadRef,
+  useWorktreeScopeKeyForThreadRef,
+  worktreeCanonicalThreadRefsByScopeKey,
+} from "../worktreeScope";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
@@ -1361,8 +1367,6 @@ function ChatViewContent(props: ChatViewProps) {
   const storeNewTerminal = useTerminalUiStateStore((s) => s.newTerminal);
   const storeSetActiveTerminal = useTerminalUiStateStore((s) => s.setActiveTerminal);
   const storeCloseTerminal = useTerminalUiStateStore((s) => s.closeTerminal);
-  const serverThreadRefs = useThreadRefs();
-  const serverThreadKeys = useMemo(() => serverThreadRefs.map(scopedThreadKey), [serverThreadRefs]);
   const draftThreadsByThreadKey = useComposerDraftStore((store) => store.draftThreadsByThreadKey);
   const draftThreadKeys = useMemo(
     () =>
@@ -1371,14 +1375,34 @@ function ChatViewContent(props: ChatViewProps) {
       ),
     [draftThreadsByThreadKey],
   );
+  // Terminal drawers are WORKTREE-scoped: the terminal UI store keys by
+  // worktree scope key, and each mounted drawer speaks to the server through
+  // the worktree's canonical thread ref (drafts fall back to plain thread
+  // keys, which parse below).
+  const threadShells = useThreadShells();
+  const liveWorktreeScopeKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const shell of threadShells) {
+      if (shell.archivedAt === null) {
+        keys.add(threadWorktreeScopeKey(shell));
+      }
+    }
+    return keys;
+  }, [threadShells]);
+  const canonicalThreadRefByScopeKey = useMemo(
+    () => worktreeCanonicalThreadRefsByScopeKey(threadShells),
+    [threadShells],
+  );
   const [mountedTerminalThreadKeys, setMountedTerminalThreadKeys] = useState<string[]>([]);
   const mountedTerminalThreadRefs = useMemo(
     () =>
       mountedTerminalThreadKeys.flatMap((mountedThreadKey) => {
-        const mountedThreadRef = parseScopedThreadKey(mountedThreadKey);
+        const mountedThreadRef =
+          canonicalThreadRefByScopeKey.get(mountedThreadKey) ??
+          parseScopedThreadKey(mountedThreadKey);
         return mountedThreadRef ? [{ key: mountedThreadKey, threadRef: mountedThreadRef }] : [];
       }),
-    [mountedTerminalThreadKeys],
+    [canonicalThreadRefByScopeKey, mountedTerminalThreadKeys],
   );
 
   const fallbackDraftProjectRef = draftThread
@@ -1449,22 +1473,34 @@ function ChatViewContent(props: ChatViewProps) {
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
   const activeThreadId = activeThread?.id ?? null;
+  const activeThreadRef = useMemo(
+    () => (activeThread ? scopeThreadRef(activeThread.environmentId, activeThread.id) : null),
+    [activeThread],
+  );
+  const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
+  // Terminals, previews, and the right panel are WORKTREE-scoped: their wire
+  // calls go through the worktree's canonical thread id so every sibling
+  // thread in the checkout shares one set of server sessions (one terminal,
+  // one dev server, one set of browser tabs per worktree).
+  const canonicalWorktreeThreadRef = useWorktreeCanonicalThreadRef(activeThreadRef);
+  const terminalThreadId = canonicalWorktreeThreadRef?.threadId ?? null;
+  const activeWorktreeScopeKey = useWorktreeScopeKeyForThreadRef(activeThreadRef);
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: activeThread?.environmentId ?? null,
-    threadId: activeThreadId,
+    threadId: terminalThreadId,
   });
   const activeThreadKnownSessionsRaw = useKnownTerminalSessions({
     environmentId: activeThread?.environmentId ?? null,
-    threadId: activeThreadId,
+    threadId: terminalThreadId,
   });
   const activeThreadKnownSessions = useMemo(() => {
-    if (activeThreadId === null) {
+    if (terminalThreadId === null) {
       return [];
     }
     return activeThreadKnownSessionsRaw.filter(
-      (session) => session.target.threadId === activeThreadId,
+      (session) => session.target.threadId === terminalThreadId,
     );
-  }, [activeThreadId, activeThreadKnownSessionsRaw]);
+  }, [terminalThreadId, activeThreadKnownSessionsRaw]);
   const activeServerOrderedTerminalIds = useMemo(
     () => activeThreadKnownSessions.map((session) => session.target.terminalId),
     [activeThreadKnownSessions],
@@ -1483,11 +1519,6 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return labels;
   }, [activeThreadKnownSessions]);
-  const activeThreadRef = useMemo(
-    () => (activeThread ? scopeThreadRef(activeThread.environmentId, activeThread.id) : null),
-    [activeThread],
-  );
-  const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
   const [timelineAnchor, setTimelineAnchor] = useState<{
     readonly threadKey: string | null;
     readonly messageId: MessageId | null;
@@ -1556,9 +1587,12 @@ function ChatViewContent(props: ChatViewProps) {
   const planSidebarOpen = activeRightPanelKind === "plan";
 
   const existingOpenTerminalThreadKeys = useMemo(() => {
-    const existingThreadKeys = new Set<string>([...serverThreadKeys, ...draftThreadKeys]);
-    return openTerminalThreadKeys.filter((nextThreadKey) => existingThreadKeys.has(nextThreadKey));
-  }, [draftThreadKeys, openTerminalThreadKeys, serverThreadKeys]);
+    // Store keys are worktree scope keys for server threads and plain thread
+    // keys for drafts; anything not backed by a live worktree or draft is a
+    // leftover to skip.
+    const existingKeys = new Set<string>([...liveWorktreeScopeKeys, ...draftThreadKeys]);
+    return openTerminalThreadKeys.filter((nextThreadKey) => existingKeys.has(nextThreadKey));
+  }, [draftThreadKeys, liveWorktreeScopeKeys, openTerminalThreadKeys]);
   const activeLatestTurn = activeThread?.latestTurn ?? null;
   const sourcePlanThreadRef = useMemo(() => {
     const sourceThreadId = activeLatestTurn?.sourceProposedPlan?.threadId;
@@ -1588,8 +1622,8 @@ function ChatViewContent(props: ChatViewProps) {
       const nextThreadIds = reconcileMountedTerminalThreadIds({
         currentThreadIds,
         openThreadIds: existingOpenTerminalThreadKeys,
-        activeThreadId: activeThreadKey,
-        activeThreadTerminalOpen: Boolean(activeThreadKey && terminalUiState.terminalOpen),
+        activeThreadId: activeWorktreeScopeKey,
+        activeThreadTerminalOpen: Boolean(activeWorktreeScopeKey && terminalUiState.terminalOpen),
         maxHiddenThreadCount: MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
       });
       return currentThreadIds.length === nextThreadIds.length &&
@@ -1597,7 +1631,7 @@ function ChatViewContent(props: ChatViewProps) {
         ? currentThreadIds
         : nextThreadIds;
     });
-  }, [activeThreadKey, existingOpenTerminalThreadKeys, terminalUiState.terminalOpen]);
+  }, [activeWorktreeScopeKey, existingOpenTerminalThreadKeys, terminalUiState.terminalOpen]);
   const latestTurnSettled = isLatestTurnSettled(activeLatestTurn, activeThread?.session ?? null);
   const activeProjectRef = activeThread
     ? scopeProjectRef(activeThread.environmentId, activeThread.projectId)
@@ -2563,7 +2597,7 @@ function ChatViewContent(props: ChatViewProps) {
     if (!activeThreadRef) return;
     const nextOpen = !terminalUiState.terminalOpen;
     if (nextOpen && terminalUiState.terminalIds.length === 0) {
-      if (!activeThreadId || !activeProject) {
+      if (!terminalThreadId || !activeProject) {
         return;
       }
       const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2575,7 +2609,7 @@ function ChatViewContent(props: ChatViewProps) {
       void openTerminal({
         environmentId,
         input: {
-          threadId: activeThreadId,
+          threadId: terminalThreadId,
           terminalId,
           cwd: cwdForOpen,
           ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
@@ -2591,7 +2625,6 @@ function ChatViewContent(props: ChatViewProps) {
   }, [
     activeKnownTerminalIds,
     activeProject,
-    activeThreadId,
     activeThreadRef,
     activeThreadWorktreePath,
     environmentId,
@@ -2600,12 +2633,13 @@ function ChatViewContent(props: ChatViewProps) {
     panelTerminalIds,
     setTerminalOpen,
     storeEnsureTerminal,
+    terminalThreadId,
     terminalUiState.terminalIds.length,
     terminalUiState.terminalOpen,
   ]);
   const splitTerminal = useCallback(
     (direction: "horizontal" | "vertical" = "horizontal") => {
-      if (!activeThreadRef || hasReachedSplitLimit || !activeThreadId || !activeProject) {
+      if (!activeThreadRef || hasReachedSplitLimit || !terminalThreadId || !activeProject) {
         return;
       }
       const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2622,7 +2656,7 @@ function ChatViewContent(props: ChatViewProps) {
       void openTerminal({
         environmentId,
         input: {
-          threadId: activeThreadId,
+          threadId: terminalThreadId,
           terminalId,
           cwd: cwdForOpen,
           ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
@@ -2636,7 +2670,7 @@ function ChatViewContent(props: ChatViewProps) {
     [
       activeProject,
       activeKnownTerminalIds,
-      activeThreadId,
+      terminalThreadId,
       activeThreadRef,
       openTerminal,
       activeThreadWorktreePath,
@@ -2648,7 +2682,7 @@ function ChatViewContent(props: ChatViewProps) {
     ],
   );
   const createNewTerminal = useCallback(() => {
-    if (!activeThreadRef || !activeThreadId || !activeProject) {
+    if (!activeThreadRef || !terminalThreadId || !activeProject) {
       return;
     }
     const cwdForOpen = gitCwd ?? activeProject.workspaceRoot;
@@ -2661,7 +2695,7 @@ function ChatViewContent(props: ChatViewProps) {
     void openTerminal({
       environmentId,
       input: {
-        threadId: activeThreadId,
+        threadId: terminalThreadId,
         terminalId,
         cwd: cwdForOpen,
         ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
@@ -2674,7 +2708,7 @@ function ChatViewContent(props: ChatViewProps) {
   }, [
     activeProject,
     activeKnownTerminalIds,
-    activeThreadId,
+    terminalThreadId,
     activeThreadRef,
     openTerminal,
     activeThreadWorktreePath,
@@ -2684,17 +2718,17 @@ function ChatViewContent(props: ChatViewProps) {
   ]);
   const closeTerminal = useCallback(
     (terminalId: string) => {
-      if (!activeThreadId || !activeThreadRef) return;
+      if (!terminalThreadId || !activeThreadRef) return;
       const fallbackExitWrite = () =>
         writeTerminal({
           environmentId,
-          input: { threadId: activeThreadId, terminalId, data: "exit\n" },
+          input: { threadId: terminalThreadId, terminalId, data: "exit\n" },
         });
       void (async () => {
         const closeResult = await closeTerminalMutation({
           environmentId,
           input: {
-            threadId: activeThreadId,
+            threadId: terminalThreadId,
             terminalId,
             deleteHistory: true,
           },
@@ -2707,7 +2741,7 @@ function ChatViewContent(props: ChatViewProps) {
       setTerminalFocusRequestId((value) => value + 1);
     },
     [
-      activeThreadId,
+      terminalThreadId,
       activeThreadRef,
       closeTerminalMutation,
       environmentId,
@@ -2726,7 +2760,7 @@ function ChatViewContent(props: ChatViewProps) {
         rememberAsLastInvoked?: boolean;
       },
     ) => {
-      if (!activeThreadId || !activeProject || !activeThread) return;
+      if (!activeThreadId || !terminalThreadId || !activeProject || !activeThread) return;
       if (options?.rememberAsLastInvoked !== false) {
         setLastInvokedScriptByProjectId((current) => {
           if (current[activeProject.id] === script.id) return current;
@@ -2764,7 +2798,7 @@ function ChatViewContent(props: ChatViewProps) {
         : baseTerminalId;
       const openTerminalInput: TerminalOpenInput = shouldCreateNewTerminal
         ? {
-            threadId: activeThreadId,
+            threadId: terminalThreadId,
             terminalId: targetTerminalId,
             cwd: targetCwd,
             ...(targetWorktreePath !== null ? { worktreePath: targetWorktreePath } : {}),
@@ -2773,7 +2807,7 @@ function ChatViewContent(props: ChatViewProps) {
             rows: SCRIPT_TERMINAL_ROWS,
           }
         : {
-            threadId: activeThreadId,
+            threadId: terminalThreadId,
             terminalId: targetTerminalId,
             cwd: targetCwd,
             ...(targetWorktreePath !== null ? { worktreePath: targetWorktreePath } : {}),
@@ -2801,7 +2835,7 @@ function ChatViewContent(props: ChatViewProps) {
       const writeResult = await writeTerminal({
         environmentId,
         input: {
-          threadId: activeThreadId,
+          threadId: terminalThreadId,
           terminalId: targetTerminalId,
           data: `${script.command}\r`,
         },
@@ -2818,6 +2852,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeProject,
       activeThread,
       activeThreadId,
+      terminalThreadId,
       activeThreadRef,
       gitCwd,
       setTerminalOpen,
@@ -3084,7 +3119,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
   }, [activeThreadRef]);
   const addTerminalSurface = useCallback(() => {
-    if (!activeThreadRef || !activeThreadId || !activeProject) return;
+    if (!activeThreadRef || !terminalThreadId || !activeProject) return;
     const cwd = gitCwd ?? activeProject.workspaceRoot;
     const terminalId = nextTerminalId([...activeKnownTerminalIds, ...panelTerminalIds]);
     useRightPanelStore.getState().openTerminal(activeThreadRef, terminalId);
@@ -3092,7 +3127,7 @@ function ChatViewContent(props: ChatViewProps) {
     void openTerminal({
       environmentId: activeThreadRef.environmentId,
       input: {
-        threadId: activeThreadId,
+        threadId: terminalThreadId,
         terminalId,
         cwd,
         ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
@@ -3105,7 +3140,7 @@ function ChatViewContent(props: ChatViewProps) {
   }, [
     activeKnownTerminalIds,
     activeProject,
-    activeThreadId,
+    terminalThreadId,
     activeThreadRef,
     activeThreadWorktreePath,
     gitCwd,
@@ -3116,7 +3151,7 @@ function ChatViewContent(props: ChatViewProps) {
     (direction: "horizontal" | "vertical" = "horizontal") => {
       if (
         !activeThreadRef ||
-        !activeThreadId ||
+        !terminalThreadId ||
         !activeProject ||
         activeRightPanelSurface?.kind !== "terminal" ||
         activeRightPanelSurface.terminalIds.length >= MAX_TERMINALS_PER_GROUP
@@ -3132,7 +3167,7 @@ function ChatViewContent(props: ChatViewProps) {
       void openTerminal({
         environmentId: activeThreadRef.environmentId,
         input: {
-          threadId: activeThreadId,
+          threadId: terminalThreadId,
           terminalId,
           cwd,
           ...(activeThreadWorktreePath != null ? { worktreePath: activeThreadWorktreePath } : {}),
@@ -3147,7 +3182,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeKnownTerminalIds,
       activeProject,
       activeRightPanelSurface,
-      activeThreadId,
+      terminalThreadId,
       activeThreadRef,
       activeThreadWorktreePath,
       gitCwd,
@@ -3173,7 +3208,11 @@ function ChatViewContent(props: ChatViewProps) {
       if (!activeThreadRef || activeRightPanelSurface?.kind !== "terminal") return;
       void closeTerminalMutation({
         environmentId: activeThreadRef.environmentId,
-        input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
+        input: {
+          threadId: terminalThreadId ?? activeThreadRef.threadId,
+          terminalId,
+          deleteHistory: true,
+        },
       });
       storeCloseTerminal(activeThreadRef, terminalId);
       useRightPanelStore
@@ -3181,7 +3220,13 @@ function ChatViewContent(props: ChatViewProps) {
         .closeTerminal(activeThreadRef, activeRightPanelSurface.id, terminalId);
       setTerminalFocusRequestId((value) => value + 1);
     },
-    [activeRightPanelSurface, activeThreadRef, closeTerminalMutation, storeCloseTerminal],
+    [
+      activeRightPanelSurface,
+      activeThreadRef,
+      closeTerminalMutation,
+      storeCloseTerminal,
+      terminalThreadId,
+    ],
   );
   const activateRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
@@ -4258,16 +4303,16 @@ function ChatViewContent(props: ChatViewProps) {
   }, [activeThreadId, terminalUiState.terminalOpen]);
 
   useEffect(() => {
-    if (!activeThreadKey) return;
-    const previous = terminalUiOpenByThreadRef.current[activeThreadKey] ?? false;
+    if (!activeWorktreeScopeKey) return;
+    const previous = terminalUiOpenByThreadRef.current[activeWorktreeScopeKey] ?? false;
     const current = Boolean(terminalUiState.terminalOpen);
 
     if (!previous && current) {
-      terminalUiOpenByThreadRef.current[activeThreadKey] = current;
+      terminalUiOpenByThreadRef.current[activeWorktreeScopeKey] = current;
       setTerminalFocusRequestId((value) => value + 1);
       return;
     } else if (previous && !current) {
-      terminalUiOpenByThreadRef.current[activeThreadKey] = current;
+      terminalUiOpenByThreadRef.current[activeWorktreeScopeKey] = current;
       const frame = window.requestAnimationFrame(() => {
         focusComposer();
       });
@@ -4276,8 +4321,8 @@ function ChatViewContent(props: ChatViewProps) {
       };
     }
 
-    terminalUiOpenByThreadRef.current[activeThreadKey] = current;
-  }, [activeThreadKey, focusComposer, terminalUiState.terminalOpen]);
+    terminalUiOpenByThreadRef.current[activeWorktreeScopeKey] = current;
+  }, [activeWorktreeScopeKey, focusComposer, terminalUiState.terminalOpen]);
 
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
@@ -5585,7 +5630,7 @@ function ChatViewContent(props: ChatViewProps) {
       <Suspense fallback={null}>
         <PreviewPanel
           mode="embedded"
-          threadRef={activeThreadRef}
+          threadRef={canonicalWorktreeThreadRef ?? activeThreadRef}
           tabId={activeRightPanelSurface.resourceId}
           configuredUrls={configuredPreviewUrls}
           visible
@@ -5593,7 +5638,7 @@ function ChatViewContent(props: ChatViewProps) {
       </Suspense>
     ) : activeRightPanelSurface?.kind === "terminal" ? (
       <PersistentThreadTerminalPanel
-        threadRef={activeThreadRef}
+        threadRef={canonicalWorktreeThreadRef ?? activeThreadRef}
         surface={activeRightPanelSurface}
         launchContext={activeTerminalLaunchContext ?? null}
         focusRequestId={terminalFocusRequestId}
@@ -5612,7 +5657,7 @@ function ChatViewContent(props: ChatViewProps) {
     ) : activeRightPanelSurface?.kind === "diff" ? (
       <Suspense fallback={null}>
         <DiffPanel
-          key={`${activeThreadKey}:${diffPanelGitStatusResolutionKey}`}
+          key={`${activeWorktreeScopeKey}:${diffPanelGitStatusResolutionKey}`}
           mode="embedded"
           composerDraftTarget={composerDraftTarget}
           initialGitScope={initialDiffPanelGitScope}
@@ -6027,11 +6072,13 @@ function ChatViewContent(props: ChatViewProps) {
             key={mountedThreadKey}
             threadRef={mountedThreadRef}
             threadId={mountedThreadRef.threadId}
-            visible={mountedThreadKey === activeThreadKey && terminalUiState.terminalOpen}
+            visible={mountedThreadKey === activeWorktreeScopeKey && terminalUiState.terminalOpen}
             launchContext={
-              mountedThreadKey === activeThreadKey ? (activeTerminalLaunchContext ?? null) : null
+              mountedThreadKey === activeWorktreeScopeKey
+                ? (activeTerminalLaunchContext ?? null)
+                : null
             }
-            focusRequestId={mountedThreadKey === activeThreadKey ? terminalFocusRequestId : 0}
+            focusRequestId={mountedThreadKey === activeWorktreeScopeKey ? terminalFocusRequestId : 0}
             splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
             splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
             newShortcutLabel={newTerminalShortcutLabel ?? undefined}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -225,6 +225,7 @@ import {
   useWorktreeCanonicalThreadRef,
   useWorktreeScopeKeyForThreadRef,
   worktreeCanonicalThreadRefsByScopeKey,
+  worktreeRepresentativeThreadRefsByScopeKey,
 } from "../worktreeScope";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
@@ -1393,16 +1394,25 @@ function ChatViewContent(props: ChatViewProps) {
     () => worktreeCanonicalThreadRefsByScopeKey(threadShells),
     [threadShells],
   );
+  const representativeThreadRefByScopeKey = useMemo(
+    () => worktreeRepresentativeThreadRefsByScopeKey(threadShells),
+    [threadShells],
+  );
   const [mountedTerminalThreadKeys, setMountedTerminalThreadKeys] = useState<string[]>([]);
   const mountedTerminalThreadRefs = useMemo(
     () =>
       mountedTerminalThreadKeys.flatMap((mountedThreadKey) => {
-        const mountedThreadRef =
-          canonicalThreadRefByScopeKey.get(mountedThreadKey) ??
+        const threadRef =
+          representativeThreadRefByScopeKey.get(mountedThreadKey) ??
           parseScopedThreadKey(mountedThreadKey);
-        return mountedThreadRef ? [{ key: mountedThreadKey, threadRef: mountedThreadRef }] : [];
+        if (!threadRef) {
+          return [];
+        }
+        const terminalThreadId =
+          canonicalThreadRefByScopeKey.get(mountedThreadKey)?.threadId ?? threadRef.threadId;
+        return [{ key: mountedThreadKey, terminalThreadId, threadRef }];
       }),
-    [canonicalThreadRefByScopeKey, mountedTerminalThreadKeys],
+    [canonicalThreadRefByScopeKey, mountedTerminalThreadKeys, representativeThreadRefByScopeKey],
   );
 
   const fallbackDraftProjectRef = draftThread
@@ -6081,28 +6091,30 @@ function ChatViewContent(props: ChatViewProps) {
         </div>
         {/* end horizontal flex container */}
 
-        {mountedTerminalThreadRefs.map(({ key: mountedThreadKey, threadRef: mountedThreadRef }) => (
-          <PersistentThreadTerminalDrawer
-            key={mountedThreadKey}
-            threadRef={mountedThreadRef}
-            threadId={mountedThreadRef.threadId}
-            visible={mountedThreadKey === activeWorktreeScopeKey && terminalUiState.terminalOpen}
-            launchContext={
-              mountedThreadKey === activeWorktreeScopeKey
-                ? (activeTerminalLaunchContext ?? null)
-                : null
-            }
-            focusRequestId={
-              mountedThreadKey === activeWorktreeScopeKey ? terminalFocusRequestId : 0
-            }
-            splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
-            splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
-            newShortcutLabel={newTerminalShortcutLabel ?? undefined}
-            closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
-            keybindings={keybindings}
-            onAddTerminalContext={addTerminalContextToDraft}
-          />
-        ))}
+        {mountedTerminalThreadRefs.map(
+          ({ key: mountedThreadKey, terminalThreadId, threadRef: mountedThreadRef }) => (
+            <PersistentThreadTerminalDrawer
+              key={mountedThreadKey}
+              threadRef={mountedThreadRef}
+              threadId={terminalThreadId}
+              visible={mountedThreadKey === activeWorktreeScopeKey && terminalUiState.terminalOpen}
+              launchContext={
+                mountedThreadKey === activeWorktreeScopeKey
+                  ? (activeTerminalLaunchContext ?? null)
+                  : null
+              }
+              focusRequestId={
+                mountedThreadKey === activeWorktreeScopeKey ? terminalFocusRequestId : 0
+              }
+              splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
+              splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
+              newShortcutLabel={newTerminalShortcutLabel ?? undefined}
+              closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
+              keybindings={keybindings}
+              onAddTerminalContext={addTerminalContextToDraft}
+            />
+          ),
+        )}
       </div>
 
       {!shouldUsePlanSidebarSheet && rightPanelOpen && activeThreadRef ? (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -491,7 +491,7 @@ type ChatViewProps =
     };
 
 interface TerminalLaunchContext {
-  threadId: ThreadId;
+  scopeKey: string;
   cwd: string;
   worktreePath: string | null;
 }
@@ -2457,7 +2457,7 @@ function ChatViewContent(props: ChatViewProps) {
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
   const activeTerminalLaunchContext =
-    terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
+    terminalUiLaunchContext?.scopeKey === activeWorktreeScopeKey ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.
   const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
   const showComposerContextStrip = isGitRepo && activeProject !== null;
@@ -2760,7 +2760,15 @@ function ChatViewContent(props: ChatViewProps) {
         rememberAsLastInvoked?: boolean;
       },
     ) => {
-      if (!activeThreadId || !terminalThreadId || !activeProject || !activeThread) return;
+      if (
+        !activeThreadId ||
+        !terminalThreadId ||
+        !activeProject ||
+        !activeThread ||
+        !activeWorktreeScopeKey
+      ) {
+        return;
+      }
       if (options?.rememberAsLastInvoked !== false) {
         setLastInvokedScriptByProjectId((current) => {
           if (current[activeProject.id] === script.id) return current;
@@ -2776,7 +2784,7 @@ function ChatViewContent(props: ChatViewProps) {
       const targetWorktreePath = options?.worktreePath ?? activeThread.worktreePath ?? null;
 
       setTerminalUiLaunchContext({
-        threadId: activeThreadId,
+        scopeKey: activeWorktreeScopeKey,
         cwd: targetCwd,
         worktreePath: targetWorktreePath,
       });
@@ -2852,6 +2860,7 @@ function ChatViewContent(props: ChatViewProps) {
       activeProject,
       activeThread,
       activeThreadId,
+      activeWorktreeScopeKey,
       terminalThreadId,
       activeThreadRef,
       gitCwd,
@@ -3288,7 +3297,11 @@ function ChatViewContent(props: ChatViewProps) {
             storeCloseTerminal(activeThreadRef, terminalId);
             void closeTerminalMutation({
               environmentId: activeThreadRef.environmentId,
-              input: { threadId: activeThreadRef.threadId, terminalId, deleteHistory: true },
+              input: {
+                threadId: terminalThreadId ?? activeThreadRef.threadId,
+                terminalId,
+                deleteHistory: true,
+              },
             });
           }
         }
@@ -3301,6 +3314,7 @@ function ChatViewContent(props: ChatViewProps) {
       closeTerminalMutation,
       dismissPlanSidebarForCurrentTurn,
       storeCloseTerminal,
+      terminalThreadId,
     ],
   );
   const syncActivePreviewSurface = useCallback(() => {
@@ -4260,23 +4274,23 @@ function ChatViewContent(props: ChatViewProps) {
   }, [canOverrideServerThreadEnvMode]);
 
   useEffect(() => {
-    if (!activeThreadId) {
+    if (!activeWorktreeScopeKey) {
       setTerminalUiLaunchContext(null);
       return;
     }
     setTerminalUiLaunchContext((current) => {
       if (!current) return current;
-      if (current.threadId === activeThreadId) return current;
+      if (current.scopeKey === activeWorktreeScopeKey) return current;
       return null;
     });
-  }, [activeThreadId]);
+  }, [activeWorktreeScopeKey]);
 
   useEffect(() => {
     if (!activeThreadId || !activeProjectCwd) {
       return;
     }
     setTerminalUiLaunchContext((current) => {
-      if (!current || current.threadId !== activeThreadId) {
+      if (!current || current.scopeKey !== activeWorktreeScopeKey) {
         return current;
       }
       const settledCwd = projectScriptCwd({
@@ -4291,16 +4305,16 @@ function ChatViewContent(props: ChatViewProps) {
       }
       return current;
     });
-  }, [activeProjectCwd, activeThreadId, activeThreadWorktreePath]);
+  }, [activeProjectCwd, activeThreadWorktreePath, activeWorktreeScopeKey]);
 
   useEffect(() => {
     if (terminalUiState.terminalOpen) {
       return;
     }
     setTerminalUiLaunchContext((current) =>
-      current?.threadId === activeThreadId ? null : current,
+      current?.scopeKey === activeWorktreeScopeKey ? null : current,
     );
-  }, [activeThreadId, terminalUiState.terminalOpen]);
+  }, [activeWorktreeScopeKey, terminalUiState.terminalOpen]);
 
   useEffect(() => {
     if (!activeWorktreeScopeKey) return;
@@ -6078,7 +6092,9 @@ function ChatViewContent(props: ChatViewProps) {
                 ? (activeTerminalLaunchContext ?? null)
                 : null
             }
-            focusRequestId={mountedThreadKey === activeWorktreeScopeKey ? terminalFocusRequestId : 0}
+            focusRequestId={
+              mountedThreadKey === activeWorktreeScopeKey ? terminalFocusRequestId : 0
+            }
             splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
             splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
             newShortcutLabel={newTerminalShortcutLabel ?? undefined}

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -20,11 +20,10 @@ import {
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   formatWorkingDurationLabel,
+  resolveSettledTimestamp,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
   sortLogicalProjectsForSidebar,
-  sortSettledThreadsForSidebarV2,
-  sortThreadsForSidebarV2,
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
@@ -654,97 +653,51 @@ describe("resolveSidebarV2Status", () => {
   });
 });
 
-describe("sortThreadsForSidebarV2", () => {
-  const sortable = (input: { id: string; createdAt: string }) => ({
-    id: input.id,
-    createdAt: input.createdAt,
-  });
-
-  it("orders by creation time, newest first, ignoring activity", () => {
-    const sorted = sortThreadsForSidebarV2([
-      sortable({ id: "oldest", createdAt: "2026-03-09T08:00:00.000Z" }),
-      sortable({ id: "newest", createdAt: "2026-03-09T12:00:00.000Z" }),
-      sortable({ id: "middle", createdAt: "2026-03-09T10:00:00.000Z" }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["newest", "middle", "oldest"]);
-  });
-
-  it("breaks creation-time ties by id so the order is stable", () => {
-    const sorted = sortThreadsForSidebarV2([
-      sortable({ id: "b", createdAt: "2026-03-09T10:00:00.000Z" }),
-      sortable({ id: "a", createdAt: "2026-03-09T10:00:00.000Z" }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
-  });
-});
-
-describe("sortSettledThreadsForSidebarV2", () => {
+describe("resolveSettledTimestamp", () => {
   const settled = (input: {
-    id: string;
     settledAt?: string | null;
     latestUserMessageAt?: string | null;
     latestTurn?: OrchestrationLatestTurn | null;
     updatedAt?: string;
   }) => ({
-    id: input.id,
     settledAt: input.settledAt ?? null,
     latestUserMessageAt: input.latestUserMessageAt ?? null,
     latestTurn: input.latestTurn ?? null,
     updatedAt: input.updatedAt ?? "2026-03-09T09:00:00.000Z",
   });
 
-  it("orders by settle time, most recently settled first", () => {
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({
-        id: "settled-first",
-        settledAt: "2026-03-09T10:00:00.000Z",
-        // Created/active later than the other thread: settle time must win.
-        latestUserMessageAt: "2026-03-09T09:59:00.000Z",
-      }),
-      settled({
-        id: "settled-last",
-        settledAt: "2026-03-09T12:00:00.000Z",
-        latestUserMessageAt: "2026-03-09T08:00:00.000Z",
-      }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["settled-last", "settled-first"]);
+  it("prefers the explicit settledAt stamp over later activity", () => {
+    expect(
+      resolveSettledTimestamp(
+        settled({
+          settledAt: "2026-03-09T10:00:00.000Z",
+          latestUserMessageAt: "2026-03-09T11:00:00.000Z",
+        }),
+      ),
+    ).toBe("2026-03-09T10:00:00.000Z");
   });
 
   it("falls back to last activity for auto-settled threads without a settledAt stamp", () => {
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({ id: "auto-old", latestUserMessageAt: "2026-03-09T08:00:00.000Z" }),
-      settled({ id: "explicit", settledAt: "2026-03-09T10:00:00.000Z" }),
-      settled({ id: "auto-recent", latestUserMessageAt: "2026-03-09T11:00:00.000Z" }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["auto-recent", "explicit", "auto-old"]);
+    expect(
+      resolveSettledTimestamp(settled({ latestUserMessageAt: "2026-03-09T11:00:00.000Z" })),
+    ).toBe("2026-03-09T11:00:00.000Z");
   });
 
   it("counts a turn completion as activity for auto-settled threads", () => {
-    // The message came in before the other thread's, but its turn finished
-    // after: completion time is the real "work ended" moment.
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({ id: "message-only", latestUserMessageAt: "2026-03-09T10:04:00.000Z" }),
-      settled({
-        id: "completed-later",
-        latestUserMessageAt: "2026-03-09T10:00:00.000Z",
-        latestTurn: makeLatestTurn({ completedAt: "2026-03-09T10:30:00.000Z" }),
-      }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["completed-later", "message-only"]);
+    // The turn finished after the message came in: completion time is the
+    // real "work ended" moment.
+    expect(
+      resolveSettledTimestamp(
+        settled({
+          latestUserMessageAt: "2026-03-09T10:00:00.000Z",
+          latestTurn: makeLatestTurn({ completedAt: "2026-03-09T10:30:00.000Z" }),
+        }),
+      ),
+    ).toBe("2026-03-09T10:30:00.000Z");
   });
 
-  it("breaks timestamp ties by id so the order is stable", () => {
-    const sorted = sortSettledThreadsForSidebarV2([
-      settled({ id: "b", settledAt: "2026-03-09T10:00:00.000Z" }),
-      settled({ id: "a", settledAt: "2026-03-09T10:00:00.000Z" }),
-    ]);
-
-    expect(sorted.map((thread) => thread.id)).toEqual(["a", "b"]);
+  it("nets out to updatedAt when a thread has no recorded activity", () => {
+    expect(resolveSettledTimestamp(settled({}))).toBe("2026-03-09T09:00:00.000Z");
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -457,20 +457,6 @@ export function firstValidTimestamp(
   return null;
 }
 
-// v2 sort: static creation order, newest thread on top. Activity NEVER
-// reorders the list — a row holds its position from open until settled, so
-// the screen only moves at lifecycle transitions. Status (including pending
-// approval) is carried by each card's edge strip, not by position.
-export function sortThreadsForSidebarV2<
-  T extends { readonly id: string; readonly createdAt: string },
->(threads: readonly T[]): T[] {
-  return [...threads].toSorted(
-    (left, right) =>
-      parseTimestampMs(right.createdAt) - parseTimestampMs(left.createdAt) ||
-      left.id.localeCompare(right.id),
-  );
-}
-
 type SettledTimestampInput = Pick<
   SidebarThreadSummary,
   "settledAt" | "latestUserMessageAt" | "latestTurn" | "updatedAt"
@@ -500,20 +486,6 @@ export function resolveSettledTimestamp(thread: SettledTimestampInput): string |
     }
   }
   return latest ?? firstValidTimestamp(thread.updatedAt);
-}
-
-// Settled rows are history, so they order by when the work ENDED, not when
-// the thread was created or last touched.
-export function sortSettledThreadsForSidebarV2<
-  T extends SettledTimestampInput & { readonly id: string },
->(threads: readonly T[]): T[] {
-  const timestampMs = (thread: T) => {
-    const timestamp = resolveSettledTimestamp(thread);
-    return timestamp === null ? 0 : Date.parse(timestamp);
-  };
-  return [...threads].toSorted(
-    (left, right) => timestampMs(right) - timestampMs(left) || left.id.localeCompare(right.id),
-  );
 }
 
 /** The timestamp a working thread's elapsed label counts from: the running

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1837,7 +1837,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         if (!confirmed) return;
       }
 
-      const deletedThreadKeys = new Set(threadKeys);
+      const deletedThreadKeys = new Set<string>();
       for (const { threadRef } of selectedThreadEntries) {
         const result = await deleteThread(threadRef, {
           deletedThreadKeys,
@@ -1855,6 +1855,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           }
           return;
         }
+        deletedThreadKeys.add(scopedThreadKey(threadRef));
       }
       removeFromSelection(threadKeys);
     },

--- a/apps/web/src/components/SidebarV2.logic.test.ts
+++ b/apps/web/src/components/SidebarV2.logic.test.ts
@@ -67,10 +67,7 @@ describe("buildSidebarWorktreeGroups", () => {
     const { activeGroups } = buildSidebarWorktreeGroups(classifyAll([newer, older]));
     expect(activeGroups).toHaveLength(1);
     expect(activeGroups[0]!.threads.map((thread) => thread.id)).toEqual([older.id, newer.id]);
-    expect(activeGroups[0]!.memberKeys).toEqual([
-      sidebarThreadKey(older),
-      sidebarThreadKey(newer),
-    ]);
+    expect(activeGroups[0]!.memberKeys).toEqual([sidebarThreadKey(older), sidebarThreadKey(newer)]);
   });
 
   it("groups local-checkout threads (null worktreePath) per project, not per thread", () => {

--- a/apps/web/src/components/SidebarV2.logic.test.ts
+++ b/apps/web/src/components/SidebarV2.logic.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE } from "../types";
+import {
+  buildSidebarWorktreeGroups,
+  pickWorktreeGroupRepresentative,
+  pickWorktreeGroupTimeLabelThread,
+  resolveWorktreeGroupLiveStatus,
+  sidebarThreadKey,
+  type SidebarThreadClassification,
+} from "./SidebarV2.logic";
+
+const environmentId = EnvironmentId.make("environment-local");
+
+function makeShell(overrides: Partial<EnvironmentThreadShell> = {}): EnvironmentThreadShell {
+  return {
+    id: ThreadId.make("thread-1"),
+    environmentId,
+    projectId: ProjectId.make("project-1"),
+    title: "Thread",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5.4",
+    },
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-03-09T10:00:00.000Z",
+    updatedAt: "2026-03-09T10:00:00.000Z",
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    snoozedUntil: null,
+    snoozedAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  } as EnvironmentThreadShell;
+}
+
+function classifyAll(
+  threads: EnvironmentThreadShell[],
+  classification: SidebarThreadClassification = "active",
+) {
+  return threads.map((thread) => ({ thread, classification }));
+}
+
+describe("buildSidebarWorktreeGroups", () => {
+  it("groups threads sharing a worktree path into one card, oldest member first", () => {
+    const older = makeShell({
+      id: ThreadId.make("thread-older"),
+      worktreePath: "/wt/feature",
+      createdAt: "2026-03-09T10:00:00.000Z",
+    });
+    const newer = makeShell({
+      id: ThreadId.make("thread-newer"),
+      worktreePath: "/wt/feature",
+      createdAt: "2026-03-09T11:00:00.000Z",
+    });
+    const { activeGroups } = buildSidebarWorktreeGroups(classifyAll([newer, older]));
+    expect(activeGroups).toHaveLength(1);
+    expect(activeGroups[0]!.threads.map((thread) => thread.id)).toEqual([older.id, newer.id]);
+    expect(activeGroups[0]!.memberKeys).toEqual([
+      sidebarThreadKey(older),
+      sidebarThreadKey(newer),
+    ]);
+  });
+
+  it("groups local-checkout threads (null worktreePath) per project, not per thread", () => {
+    const localA = makeShell({ id: ThreadId.make("thread-a") });
+    const localB = makeShell({ id: ThreadId.make("thread-b") });
+    const otherProject = makeShell({
+      id: ThreadId.make("thread-c"),
+      projectId: ProjectId.make("project-2"),
+    });
+    const { activeGroups } = buildSidebarWorktreeGroups(
+      classifyAll([localA, localB, otherProject]),
+    );
+    expect(activeGroups).toHaveLength(2);
+    const sizes = activeGroups.map((group) => group.threads.length).toSorted();
+    expect(sizes).toEqual([1, 2]);
+  });
+
+  it("keeps distinct worktrees as distinct cards", () => {
+    const first = makeShell({ id: ThreadId.make("thread-a"), worktreePath: "/wt/one" });
+    const second = makeShell({ id: ThreadId.make("thread-b"), worktreePath: "/wt/two" });
+    const { activeGroups } = buildSidebarWorktreeGroups(classifyAll([first, second]));
+    expect(activeGroups).toHaveLength(2);
+  });
+
+  it("classifies the group by its most-alive member: any active member keeps the card active", () => {
+    const settled = makeShell({ id: ThreadId.make("thread-settled"), worktreePath: "/wt/x" });
+    const active = makeShell({ id: ThreadId.make("thread-active"), worktreePath: "/wt/x" });
+    const { activeGroups, settledGroups } = buildSidebarWorktreeGroups([
+      { thread: settled, classification: "settled" },
+      { thread: active, classification: "active" },
+    ]);
+    expect(activeGroups).toHaveLength(1);
+    expect(settledGroups).toHaveLength(0);
+    expect(activeGroups[0]!.threads).toHaveLength(2);
+  });
+
+  it("shelves a group as snoozed when members are snoozed and none active", () => {
+    const snoozed = makeShell({
+      id: ThreadId.make("thread-snoozed"),
+      worktreePath: "/wt/x",
+      snoozedUntil: "2026-03-10T10:00:00.000Z",
+    });
+    const settled = makeShell({ id: ThreadId.make("thread-settled"), worktreePath: "/wt/x" });
+    const { activeGroups, snoozedGroups, settledGroups } = buildSidebarWorktreeGroups([
+      { thread: snoozed, classification: "snoozed" },
+      { thread: settled, classification: "settled" },
+    ]);
+    expect(activeGroups).toHaveLength(0);
+    expect(snoozedGroups).toHaveLength(1);
+    expect(settledGroups).toHaveLength(0);
+  });
+
+  it("shelves a group as settled only when every member settled", () => {
+    const first = makeShell({
+      id: ThreadId.make("thread-a"),
+      worktreePath: "/wt/x",
+      settledAt: "2026-03-09T12:00:00.000Z",
+    });
+    const second = makeShell({
+      id: ThreadId.make("thread-b"),
+      worktreePath: "/wt/x",
+      settledAt: "2026-03-09T13:00:00.000Z",
+    });
+    const { settledGroups } = buildSidebarWorktreeGroups(classifyAll([first, second], "settled"));
+    expect(settledGroups).toHaveLength(1);
+    expect(settledGroups[0]!.threads).toHaveLength(2);
+  });
+
+  it("orders cards statically by their newest member, newest worktree on top", () => {
+    const oldWorktree = makeShell({
+      id: ThreadId.make("thread-old"),
+      worktreePath: "/wt/old",
+      createdAt: "2026-03-09T09:00:00.000Z",
+    });
+    const busyWorktreeOldMember = makeShell({
+      id: ThreadId.make("thread-busy-old"),
+      worktreePath: "/wt/busy",
+      createdAt: "2026-03-09T08:00:00.000Z",
+    });
+    const busyWorktreeNewMember = makeShell({
+      id: ThreadId.make("thread-busy-new"),
+      worktreePath: "/wt/busy",
+      createdAt: "2026-03-09T12:00:00.000Z",
+    });
+    const { activeGroups } = buildSidebarWorktreeGroups(
+      classifyAll([oldWorktree, busyWorktreeOldMember, busyWorktreeNewMember]),
+    );
+    expect(activeGroups.map((group) => group.threads[0]!.worktreePath)).toEqual([
+      "/wt/busy",
+      "/wt/old",
+    ]);
+  });
+});
+
+describe("pickWorktreeGroupRepresentative", () => {
+  it("prefers the route thread when it is a member", () => {
+    const first = makeShell({ id: ThreadId.make("thread-a"), worktreePath: "/wt/x" });
+    const second = makeShell({ id: ThreadId.make("thread-b"), worktreePath: "/wt/x" });
+    const { activeGroups } = buildSidebarWorktreeGroups(classifyAll([first, second]));
+    const representative = pickWorktreeGroupRepresentative(
+      activeGroups[0]!,
+      sidebarThreadKey(first),
+    );
+    expect(representative.id).toBe(first.id);
+  });
+
+  it("uses the most recently settled member for settled groups", () => {
+    const earlier = makeShell({
+      id: ThreadId.make("thread-a"),
+      worktreePath: "/wt/x",
+      settledAt: "2026-03-09T12:00:00.000Z",
+    });
+    const later = makeShell({
+      id: ThreadId.make("thread-b"),
+      worktreePath: "/wt/x",
+      settledAt: "2026-03-09T15:00:00.000Z",
+    });
+    const { settledGroups } = buildSidebarWorktreeGroups(classifyAll([earlier, later], "settled"));
+    expect(pickWorktreeGroupRepresentative(settledGroups[0]!, null).id).toBe(later.id);
+  });
+
+  it("uses the soonest-waking snoozed member for snoozed groups", () => {
+    const wakesLater = makeShell({
+      id: ThreadId.make("thread-a"),
+      worktreePath: "/wt/x",
+      snoozedUntil: "2026-03-11T10:00:00.000Z",
+    });
+    const wakesSooner = makeShell({
+      id: ThreadId.make("thread-b"),
+      worktreePath: "/wt/x",
+      snoozedUntil: "2026-03-10T10:00:00.000Z",
+    });
+    const { snoozedGroups } = buildSidebarWorktreeGroups(
+      classifyAll([wakesLater, wakesSooner], "snoozed"),
+    );
+    expect(pickWorktreeGroupRepresentative(snoozedGroups[0]!, null).id).toBe(wakesSooner.id);
+  });
+});
+
+describe("resolveWorktreeGroupLiveStatus", () => {
+  const running = (startedAt: string) =>
+    makeShell({
+      id: ThreadId.make(`thread-run-${startedAt}`),
+      session: {
+        status: "running",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        providerName: "Codex",
+        updatedAt: startedAt,
+      } as EnvironmentThreadShell["session"],
+      latestTurn: {
+        requestedAt: startedAt,
+        startedAt,
+        completedAt: null,
+      } as EnvironmentThreadShell["latestTurn"],
+    });
+
+  it("returns null when every member is at rest", () => {
+    expect(resolveWorktreeGroupLiveStatus([makeShell(), makeShell()])).toBeNull();
+  });
+
+  it("ranks approval above working", () => {
+    const status = resolveWorktreeGroupLiveStatus([
+      running("2026-03-09T10:00:00.000Z"),
+      makeShell({ id: ThreadId.make("thread-approval"), hasPendingApprovals: true }),
+    ]);
+    expect(status?.kind).toBe("approval");
+  });
+
+  it("counts working from the earliest in-flight member", () => {
+    const status = resolveWorktreeGroupLiveStatus([
+      running("2026-03-09T11:00:00.000Z"),
+      running("2026-03-09T10:00:00.000Z"),
+    ]);
+    expect(status?.kind).toBe("working");
+    expect(status?.workingStartedAt).toBe("2026-03-09T10:00:00.000Z");
+  });
+});
+
+describe("pickWorktreeGroupTimeLabelThread", () => {
+  it("returns the member with the latest activity", () => {
+    const stale = makeShell({
+      id: ThreadId.make("thread-stale"),
+      updatedAt: "2026-03-09T10:00:00.000Z",
+    });
+    const fresh = makeShell({
+      id: ThreadId.make("thread-fresh"),
+      latestUserMessageAt: "2026-03-09T12:00:00.000Z",
+    });
+    expect(pickWorktreeGroupTimeLabelThread([stale, fresh]).id).toBe(fresh.id);
+  });
+});

--- a/apps/web/src/components/SidebarV2.logic.ts
+++ b/apps/web/src/components/SidebarV2.logic.ts
@@ -3,7 +3,6 @@ import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/model
 
 import { threadWorktreeScopeKey } from "../worktreeScope";
 import {
-  firstValidTimestamp,
   firstValidTimestampMs,
   parseTimestampMs,
   resolveSettledTimestamp,
@@ -224,20 +223,4 @@ export function pickWorktreeGroupTimeLabelThread(
     const threadMs = firstValidTimestampMs(thread.latestUserMessageAt, thread.updatedAt);
     return threadMs >= latestMs ? thread : latest;
   });
-}
-
-/** ISO timestamp used by tests/debug displays for a group's settled label. */
-export function resolveWorktreeGroupSettledTimestamp(group: SidebarWorktreeGroup): string | null {
-  let best: string | null = null;
-  let bestMs = Number.NEGATIVE_INFINITY;
-  for (const thread of group.threads) {
-    const timestamp = firstValidTimestamp(resolveSettledTimestamp(thread));
-    if (timestamp === null) continue;
-    const ms = parseTimestampMs(timestamp);
-    if (ms > bestMs) {
-      best = timestamp;
-      bestMs = ms;
-    }
-  }
-  return best;
 }

--- a/apps/web/src/components/SidebarV2.logic.ts
+++ b/apps/web/src/components/SidebarV2.logic.ts
@@ -1,0 +1,243 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+
+import { threadWorktreeScopeKey } from "../worktreeScope";
+import {
+  firstValidTimestamp,
+  firstValidTimestampMs,
+  parseTimestampMs,
+  resolveSettledTimestamp,
+  resolveSidebarV2Status,
+  resolveWorkingStartedAt,
+} from "./Sidebar.logic";
+
+export type SidebarWorktreeSection = "active" | "snoozed" | "settled";
+
+export type SidebarThreadClassification = "active" | "snoozed" | "settled";
+
+/** One sidebar row/card: every visible thread sharing a checkout (git
+    worktree, or the project workspace root for local-mode threads). */
+export interface SidebarWorktreeGroup {
+  readonly key: string;
+  readonly section: SidebarWorktreeSection;
+  /** Members in creation order (oldest first) — the in-card row order. */
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+  /** Member classifications aligned with `threads`. */
+  readonly classifications: ReadonlyArray<SidebarThreadClassification>;
+  /** Scoped thread keys aligned with `threads` (stable identity for memo props). */
+  readonly memberKeys: ReadonlyArray<string>;
+}
+
+export function sidebarThreadKey(thread: EnvironmentThreadShell): string {
+  return scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+}
+
+function groupSettledTimestampMs(group: SidebarWorktreeGroup): number {
+  let latest = 0;
+  for (const thread of group.threads) {
+    const timestamp = resolveSettledTimestamp(thread);
+    if (timestamp !== null) latest = Math.max(latest, parseTimestampMs(timestamp));
+  }
+  return latest;
+}
+
+function groupSoonestWakeMs(group: SidebarWorktreeGroup): number {
+  let soonest = Number.POSITIVE_INFINITY;
+  for (const [index, thread] of group.threads.entries()) {
+    if (group.classifications[index] !== "snoozed") continue;
+    soonest = Math.min(soonest, firstValidTimestampMs(thread.snoozedUntil ?? null));
+  }
+  return soonest;
+}
+
+function groupNewestCreatedAtMs(group: SidebarWorktreeGroup): number {
+  let newest = 0;
+  for (const thread of group.threads) {
+    newest = Math.max(newest, parseTimestampMs(thread.createdAt));
+  }
+  return newest;
+}
+
+/**
+ * Group per-thread classifications into worktree rows. A worktree with any
+ * active member is a full card (settled/snoozed members ride along inside
+ * it); with none active it collapses to the snoozed shelf when any member
+ * is snoozed, else to the settled tail. Sorting mirrors the per-thread
+ * rules: cards hold static creation order (newest worktree on top),
+ * snoozed groups order by soonest wake, settled groups by most recent
+ * wrap-up.
+ */
+export function buildSidebarWorktreeGroups(
+  classified: ReadonlyArray<{
+    readonly thread: EnvironmentThreadShell;
+    readonly classification: SidebarThreadClassification;
+  }>,
+): {
+  activeGroups: SidebarWorktreeGroup[];
+  snoozedGroups: SidebarWorktreeGroup[];
+  settledGroups: SidebarWorktreeGroup[];
+} {
+  const byKey = new Map<
+    string,
+    { threads: EnvironmentThreadShell[]; classifications: SidebarThreadClassification[] }
+  >();
+  for (const { thread, classification } of classified) {
+    const key = threadWorktreeScopeKey(thread);
+    const entry = byKey.get(key) ?? { threads: [], classifications: [] };
+    entry.threads.push(thread);
+    entry.classifications.push(classification);
+    byKey.set(key, entry);
+  }
+
+  const activeGroups: SidebarWorktreeGroup[] = [];
+  const snoozedGroups: SidebarWorktreeGroup[] = [];
+  const settledGroups: SidebarWorktreeGroup[] = [];
+  for (const [key, entry] of byKey) {
+    const order = entry.threads
+      .map((_, index) => index)
+      .toSorted(
+        (left, right) =>
+          parseTimestampMs(entry.threads[left]!.createdAt) -
+            parseTimestampMs(entry.threads[right]!.createdAt) ||
+          entry.threads[left]!.id.localeCompare(entry.threads[right]!.id),
+      );
+    const threads = order.map((index) => entry.threads[index]!);
+    const classifications = order.map((index) => entry.classifications[index]!);
+    const memberKeys = threads.map(sidebarThreadKey);
+    const section: SidebarWorktreeSection = classifications.includes("active")
+      ? "active"
+      : classifications.includes("snoozed")
+        ? "snoozed"
+        : "settled";
+    const group: SidebarWorktreeGroup = { key, section, threads, classifications, memberKeys };
+    if (section === "active") activeGroups.push(group);
+    else if (section === "snoozed") snoozedGroups.push(group);
+    else settledGroups.push(group);
+  }
+
+  activeGroups.sort(
+    (left, right) =>
+      groupNewestCreatedAtMs(right) - groupNewestCreatedAtMs(left) ||
+      left.key.localeCompare(right.key),
+  );
+  snoozedGroups.sort(
+    (left, right) =>
+      groupSoonestWakeMs(left) - groupSoonestWakeMs(right) || left.key.localeCompare(right.key),
+  );
+  settledGroups.sort(
+    (left, right) =>
+      groupSettledTimestampMs(right) - groupSettledTimestampMs(left) ||
+      left.key.localeCompare(right.key),
+  );
+  return { activeGroups, snoozedGroups, settledGroups };
+}
+
+/**
+ * The thread a collapsed (slim) group row stands in for: the route thread
+ * when it's a member (so highlight and pull-into-view keep pointing at what
+ * the user has open), otherwise the member matching the shelf's own sort
+ * story — soonest wake for snoozed groups, most recent wrap-up for settled
+ * ones, newest member for cards.
+ */
+export function pickWorktreeGroupRepresentative(
+  group: SidebarWorktreeGroup,
+  routeThreadKey: string | null,
+): EnvironmentThreadShell {
+  if (routeThreadKey !== null) {
+    const routeMember = group.threads.find((thread) => sidebarThreadKey(thread) === routeThreadKey);
+    if (routeMember !== undefined) return routeMember;
+  }
+  if (group.section === "snoozed") {
+    let best: EnvironmentThreadShell | null = null;
+    let bestWake = Number.POSITIVE_INFINITY;
+    for (const [index, thread] of group.threads.entries()) {
+      if (group.classifications[index] !== "snoozed") continue;
+      const wake = firstValidTimestampMs(thread.snoozedUntil ?? null);
+      if (wake < bestWake || best === null) {
+        best = thread;
+        bestWake = wake;
+      }
+    }
+    if (best !== null) return best;
+  }
+  if (group.section === "settled") {
+    let best: EnvironmentThreadShell | null = null;
+    let bestMs = Number.NEGATIVE_INFINITY;
+    for (const thread of group.threads) {
+      const timestamp = resolveSettledTimestamp(thread);
+      const ms = timestamp === null ? 0 : parseTimestampMs(timestamp);
+      if (ms > bestMs || best === null) {
+        best = thread;
+        bestMs = ms;
+      }
+    }
+    if (best !== null) return best;
+  }
+  return group.threads.reduce((newest, thread) =>
+    parseTimestampMs(thread.createdAt) >= parseTimestampMs(newest.createdAt) ? thread : newest,
+  );
+}
+
+/** Card-level live status: what the worktree as a whole is doing, ranked by
+    how urgently it needs the user (act now > answer > in motion > broken).
+    Per-thread Done/Woke signals stay on the member rows — this is only the
+    shells-derived aggregate for the card's top-right slot. */
+export function resolveWorktreeGroupLiveStatus(
+  threads: ReadonlyArray<EnvironmentThreadShell>,
+): { kind: "approval" | "input" | "working" | "failed"; workingStartedAt: string | null } | null {
+  let hasApproval = false;
+  let hasInput = false;
+  let hasFailed = false;
+  let hasWorking = false;
+  let workingStartedAt: string | null = null;
+  let workingStartedAtMs = Number.POSITIVE_INFINITY;
+  for (const thread of threads) {
+    const status = resolveSidebarV2Status(thread);
+    if (status === "approval") hasApproval = true;
+    else if (status === "input") hasInput = true;
+    else if (status === "failed") hasFailed = true;
+    else if (status === "working") {
+      hasWorking = true;
+      const startedAt = resolveWorkingStartedAt(thread);
+      const startedMs = startedAt === null ? Number.NaN : Date.parse(startedAt);
+      // Earliest running start wins: the card counts the oldest in-flight
+      // work, not the most recently kicked-off member.
+      if (!Number.isNaN(startedMs) && startedMs < workingStartedAtMs) {
+        workingStartedAt = startedAt;
+        workingStartedAtMs = startedMs;
+      }
+    }
+  }
+  if (hasApproval) return { kind: "approval", workingStartedAt: null };
+  if (hasInput) return { kind: "input", workingStartedAt: null };
+  if (hasWorking) return { kind: "working", workingStartedAt };
+  if (hasFailed) return { kind: "failed", workingStartedAt: null };
+  return null;
+}
+
+/** The member whose latest activity stamps the card's resting time label. */
+export function pickWorktreeGroupTimeLabelThread(
+  threads: ReadonlyArray<EnvironmentThreadShell>,
+): EnvironmentThreadShell {
+  return threads.reduce((latest, thread) => {
+    const latestMs = firstValidTimestampMs(latest.latestUserMessageAt, latest.updatedAt);
+    const threadMs = firstValidTimestampMs(thread.latestUserMessageAt, thread.updatedAt);
+    return threadMs >= latestMs ? thread : latest;
+  });
+}
+
+/** ISO timestamp used by tests/debug displays for a group's settled label. */
+export function resolveWorktreeGroupSettledTimestamp(group: SidebarWorktreeGroup): string | null {
+  let best: string | null = null;
+  let bestMs = Number.NEGATIVE_INFINITY;
+  for (const thread of group.threads) {
+    const timestamp = firstValidTimestamp(resolveSettledTimestamp(thread));
+    if (timestamp === null) continue;
+    const ms = parseTimestampMs(timestamp);
+    if (ms > bestMs) {
+      best = timestamp;
+      bestMs = ms;
+    }
+  }
+  return best;
+}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -93,8 +93,8 @@ import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
-import { useRunningTerminalsForThreads } from "../state/terminalSessions";
-import { useDiscoveredPortsForThreads } from "../portDiscoveryState";
+import { useThreadRunningTerminalIds } from "../state/terminalSessions";
+import { useThreadDiscoveredPorts } from "../portDiscoveryState";
 import { useWorktreeCanonicalThreadRef } from "../worktreeScope";
 import { previewEnvironment } from "../state/preview";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
@@ -471,14 +471,16 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
         })
       : null,
   );
+  const checkoutBranch =
+    thread.worktreePath === null ? (gitStatus.data?.refName ?? thread.branch) : thread.branch;
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
     activeWorktreePath: thread.worktreePath,
-    activeThreadBranch: thread.branch,
+    activeThreadBranch: checkoutBranch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
   const pr = resolveThreadPr({
-    threadBranch: thread.branch,
+    threadBranch: checkoutBranch,
     gitStatus: gitStatus.data,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
@@ -1078,22 +1080,17 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
   const isActiveCard = activeMember !== null;
   const environmentId = newest.environmentId;
   const canonicalThreadRef = useWorktreeCanonicalThreadRef(newestRef);
-  const threadIds = useMemo(
-    () => [
-      ...new Set([
-        ...threads.map((thread) => thread.id),
-        ...(canonicalThreadRef ? [canonicalThreadRef.threadId] : []),
-      ]),
-    ],
-    [canonicalThreadRef, threads],
-  );
 
-  // Worktree-level activity: any member thread's terminal with a running
-  // subprocess, and any dev server discovered on a member's terminal. These
-  // sit inline with the repository row because terminals and dev servers
-  // belong to the checkout, not to an individual thread.
-  const runningTerminals = useRunningTerminalsForThreads({ environmentId, threadIds });
-  const discoveredPorts = useDiscoveredPortsForThreads({ environmentId, threadIds });
+  // Checkout-owned resources use one deterministic server key, so cards can
+  // select activity directly instead of rescanning every member thread.
+  const runningTerminalIds = useThreadRunningTerminalIds({
+    environmentId,
+    threadId: canonicalThreadRef?.threadId ?? null,
+  });
+  const discoveredPorts = useThreadDiscoveredPorts({
+    environmentId,
+    threadId: canonicalThreadRef?.threadId ?? null,
+  });
   const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
   const handleOpenDiscoveredPort = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -1132,10 +1129,10 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
   // keeps the selector referentially stable while letting the card derive
   // per-member unread/woke without a hook per member.
   const visitedSignature = useUiStateStore((state) =>
-    memberKeys.map((key) => state.threadLastVisitedAtById[key] ?? "").join(" "),
+    memberKeys.map((key) => state.threadLastVisitedAtById[key] ?? "").join("\u0000"),
   );
   const { anyUnread, anyWoke, wokeAtByKey } = useMemo(() => {
-    const visited = visitedSignature.split(" ");
+    const visited = visitedSignature.split("\u0000");
     let anyUnread = false;
     let anyWoke = false;
     const wokeAtByKey = new Map<string, string | null>();
@@ -1334,7 +1331,7 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
                 {props.projectTitle}
               </span>
             ) : null}
-            {runningTerminals.length > 0 ? (
+            {runningTerminalIds.length > 0 ? (
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -2495,6 +2492,7 @@ export default function SidebarV2() {
         }
       }
       const expandedThreads = [...expandedByKey.values()];
+      const lifecycleCount = expandedThreads.length;
       // Snooze (N) is offered when every affected thread can actually take
       // it — a mixed batch with blocked-on-you work would half-apply.
       const selectionNow = new Date().toISOString();
@@ -2507,12 +2505,12 @@ export default function SidebarV2() {
       const clicked = await settlePromise(() =>
         api.contextMenu.show(
           [
-            { id: "settle", label: `Settle (${count})` },
+            { id: "settle", label: `Settle (${lifecycleCount})` },
             ...(canSnoozeSelection
               ? [
                   {
                     id: "snooze",
-                    label: `Snooze (${count})`,
+                    label: `Snooze (${lifecycleCount})`,
                     children: snoozePresets.map((preset) => ({
                       id: `snooze:${preset.id}`,
                       label: `${preset.label} (${preset.whenLabel})`,

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -391,7 +391,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   wokeAt: string | null;
   isActive: boolean;
   jumpLabel: string | null;
-  currentEnvironmentId: string | null;
   environmentLabel: string | null;
   projectCwd: string | null;
   projectTitle: string | null;
@@ -1069,14 +1068,9 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
     () => scopeThreadRef(newest.environmentId, newest.id),
     [newest.environmentId, newest.id],
   );
-  const activeMember =
-    props.activeThreadKey === null
-      ? null
-      : (threads.find(
-          (thread) =>
-            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) ===
-            props.activeThreadKey,
-        ) ?? null);
+  const activeMemberIndex =
+    props.activeThreadKey === null ? -1 : memberKeys.indexOf(props.activeThreadKey);
+  const activeMember = activeMemberIndex === -1 ? null : threads[activeMemberIndex]!;
   const isActiveCard = activeMember !== null;
   const environmentId = newest.environmentId;
   const canonicalThreadRef = useWorktreeCanonicalThreadRef(newestRef);
@@ -3080,7 +3074,6 @@ export default function SidebarV2() {
                       wokeAt={threadWokeAt(representative, { now: snoozeNow })}
                       isActive={routeThreadKey === threadKey}
                       jumpLabel={showJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null}
-                      currentEnvironmentId={primaryEnvironmentId}
                       environmentLabel={
                         environmentLabelById.get(representative.environmentId) ?? null
                       }

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -1,6 +1,7 @@
 import { autoAnimate } from "@formkit/auto-animate";
 import { useAtomValue } from "@effect/atom-react";
 import {
+  canSettle,
   canSnooze,
   effectiveSettled,
   effectiveSnoozed,
@@ -26,12 +27,14 @@ import {
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
+  Globe2Icon,
   EllipsisIcon,
   MessageSquareIcon,
   PlusIcon,
   SearchIcon,
   ServerIcon,
   SquarePenIcon,
+  TerminalIcon,
   Trash2Icon,
   Undo2Icon,
 } from "lucide-react";
@@ -90,6 +93,9 @@ import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
+import { useRunningTerminalsForThreads } from "../state/terminalSessions";
+import { useDiscoveredPortsForThreads } from "../portDiscoveryState";
+import { previewEnvironment } from "../state/preview";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
@@ -113,13 +119,20 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
-  resolveWorkingStartedAt,
   shouldNavigateAfterProjectRemoval,
   sortLogicalProjectsForSidebar,
-  sortSettledThreadsForSidebarV2,
-  sortThreadsForSidebarV2,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
+import { openDiscoveredPort } from "./preview/openDiscoveredPort";
+import {
+  buildSidebarWorktreeGroups,
+  pickWorktreeGroupRepresentative,
+  pickWorktreeGroupTimeLabelThread,
+  resolveWorktreeGroupLiveStatus,
+  sidebarThreadKey,
+  type SidebarThreadClassification,
+  type SidebarWorktreeGroup,
+} from "./SidebarV2.logic";
 import {
   prStatusIndicator,
   resolveThreadPr,
@@ -359,12 +372,12 @@ function SnoozePopoverButton(props: {
   );
 }
 
+// Slim shelf row: one row per parked WORKTREE (snoozed or settled group).
+// `thread` is the group's representative member (route thread when it's a
+// member); lifecycle actions act on the whole group via the parent.
 const SidebarV2Row = memo(function SidebarV2Row(props: {
   thread: SidebarThreadSummary;
-  variant: "card" | "slim";
-  // Slim rows are either settled (action: un-settle) or merely quiet
-  // (seen Ready threads — action: settle).
-  variantAction: "settle" | "unsettle" | "unsnooze";
+  variantAction: "unsettle" | "unsnooze";
   // False on environments whose server predates thread.settle/unsettle:
   // the lifecycle affordances hide entirely rather than fail on click.
   settlementSupported: boolean;
@@ -382,6 +395,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   projectCwd: string | null;
   projectTitle: string | null;
   providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
+  // Every member thread key in the row's worktree group: the row owns the
+  // group's single VCS subscription, and the partition needs the PR state
+  // under each member's key for effectiveSettled.
+  changeRequestThreadKeys: ReadonlyArray<string>;
   onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
   onThreadActivate: (threadRef: ScopedThreadRef) => void;
   onStartRename: (threadRef: ScopedThreadRef, title: string) => void;
@@ -391,9 +408,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   isRenaming: boolean;
   renamingTitle: string;
   onContextMenu: (threadRef: ScopedThreadRef, position: { x: number; y: number }) => void;
-  onSettle: (threadRef: ScopedThreadRef) => void;
   onUnsettle: (threadRef: ScopedThreadRef) => void;
-  onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
   onUnsnooze: (threadRef: ScopedThreadRef) => void;
   onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
 }) {
@@ -404,8 +419,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     onCommitRename,
     onContextMenu,
     onRenameTitleChange,
-    onSettle,
-    onSnooze,
     onStartRename,
     onThreadActivate,
     onThreadClick,
@@ -413,7 +426,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     onUnsnooze,
     renamingTitle,
     thread,
-    variant,
     variantAction,
   } = props;
   const threadRef = useMemo(
@@ -448,48 +460,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   const isInFlight = status === "working" || status === "approval" || status === "input";
   const shouldRecede =
     (status === "ready" || isInFlight) && !isUnread && !isWoke && !props.isActive && !isSelected;
-  // Status hues follow the system-wide convention set by sidebar v1 and the
-  // mobile Live Activity/widgets (amber approval, indigo input, sky working)
-  // so a thread reads the same color everywhere it surfaces.
-  const topStatus =
-    status === "working"
-      ? {
-          label: "Working",
-          icon: "working" as const,
-          className:
-            "animate-sidebar-working-text text-sky-600 motion-reduce:animate-none dark:text-sky-400",
-        }
-      : status === "approval"
-        ? {
-            label: "Approval",
-            icon: null,
-            className: "text-amber-700 dark:text-amber-300",
-          }
-        : status === "input"
-          ? {
-              label: "Input",
-              icon: null,
-              className: "text-indigo-600 dark:text-indigo-300",
-            }
-          : status === "failed"
-            ? {
-                label: "Failed",
-                icon: null,
-                className: "text-red-700 dark:text-red-300",
-              }
-            : isWoke
-              ? {
-                  label: "Woke",
-                  icon: "woke" as const,
-                  className: "text-amber-700 dark:text-amber-300",
-                }
-              : isUnread
-                ? {
-                    label: "Done",
-                    icon: "done" as const,
-                    className: "text-emerald-700 dark:text-emerald-300",
-                  }
-                : null;
 
   const gitCwd = thread.worktreePath ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(
@@ -513,11 +483,15 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const settledPrHoverClass = pr ? settledPrHoverColorClass(pr.state) : undefined;
   // Report the PR state up: the parent partitions rows with effectiveSettled,
-  // and a merged/closed PR auto-settles a thread — data only rows have.
+  // and a merged/closed PR auto-settles a thread — data only rows have. The
+  // worktree's PR state applies to every member thread of the group.
   const prState = pr?.state ?? null;
+  const { changeRequestThreadKeys } = props;
   useEffect(() => {
-    onChangeRequestState(threadKey, prState);
-  }, [onChangeRequestState, prState, threadKey]);
+    for (const memberKey of changeRequestThreadKeys) {
+      onChangeRequestState(memberKey, prState);
+    }
+  }, [changeRequestThreadKeys, onChangeRequestState, prState]);
 
   const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
   const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
@@ -528,9 +502,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
   const modelLabel = selectedModel
     ? getTriggerDisplayModelLabel(selectedModel)
     : thread.modelSelection.model;
-
-  const isRemote =
-    props.currentEnvironmentId !== null && thread.environmentId !== props.currentEnvironmentId;
 
   const detailsTooltip = (
     <SidebarV2ThreadTooltip
@@ -602,14 +573,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       onCommitRename(threadRef, renamingTitle, thread.title);
     }
   }, [onCommitRename, renamingTitle, thread.title, threadRef]);
-  const handleSettleClick = useCallback(
-    (event: ReactMouseEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      onSettle(threadRef);
-    },
-    [onSettle, threadRef],
-  );
   const handleUnsettleClick = useCallback(
     (event: ReactMouseEvent) => {
       event.preventDefault();
@@ -626,28 +589,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
     },
     [onUnsnooze, threadRef],
   );
-  const handleSnoozePreset = useCallback(
-    (preset: SnoozePreset) => {
-      onSnooze(threadRef, preset);
-    },
-    [onSnooze, threadRef],
-  );
-  // While the snooze popover is open the pointer leaves the row, which
-  // would fade the hover actions out from under the open menu; pin them.
-  const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
-  // Snooze is offered only where it can succeed: capability-gated and never
-  // on blocked-on-you work or queued turns (the server rejects both).
-  const showSnoozeButton =
-    props.snoozeSupported && canSnooze(thread, { now: new Date().toISOString() });
-  // If the thread becomes blocked while the popover is open, the button
-  // unmounts without firing onOpenChange(false). Deriving the flag keeps a
-  // stale true from permanently hiding the status label / pinning the
-  // hover actions, and the effect clears the raw state so the popover
-  // doesn't resurrect if the button later remounts.
-  const snoozeMenuOpen = snoozeMenuOpenRaw && showSnoozeButton;
-  useEffect(() => {
-    if (!showSnoozeButton) setSnoozeMenuOpen(false);
-  }, [showSnoozeButton]);
   const handlePrClick = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
       if (pr?.url) openPrLink(event, pr.url);
@@ -692,25 +633,12 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       className={cn(
         "min-w-0 flex-1 text-sm",
         shouldRecede ? "font-normal" : "font-medium",
-        variant === "card"
-          ? cn(
-              "truncate",
-              isUnread || isWoke
-                ? "text-foreground"
-                : shouldRecede
-                  ? "text-muted-foreground/80"
-                  : status === "failed"
-                    ? "text-foreground/95"
-                    : "text-foreground/90",
-            )
-          : cn(
-              "truncate group-hover/v2-row:text-foreground",
-              props.isActive || isWoke
-                ? "text-foreground"
-                : isUnread
-                  ? "text-muted-foreground"
-                  : "text-muted-foreground/70",
-            ),
+        "truncate group-hover/v2-row:text-foreground",
+        props.isActive || isWoke
+          ? "text-foreground"
+          : isUnread
+            ? "text-muted-foreground"
+            : "text-muted-foreground/70",
       )}
     >
       {thread.title}
@@ -724,7 +652,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
         onClick={handlePrClick}
         className={cn(
           "shrink-0 font-mono text-xs hover:underline",
-          variant === "slim" && variantAction === "unsettle"
+          variantAction === "unsettle"
             ? props.isActive
               ? "text-muted-foreground/70"
               : cn("text-muted-foreground/35 transition-colors", settledPrHoverClass)
@@ -736,9 +664,8 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       </button>
     ) : null;
 
-  if (variant === "slim") {
-    return (
-      <li
+  return (
+    <li
         data-thread-item
         className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
       >
@@ -816,7 +743,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                     <AlarmClockOffIcon className="size-3" />
                   </button>
                 )
-              ) : !props.settlementSupported ? null : variantAction === "unsettle" ? (
+              ) : !props.settlementSupported ? null : (
                 <button
                   type="button"
                   aria-label="Un-settle thread"
@@ -825,15 +752,6 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
                 >
                   <Undo2Icon className="mb-px size-3.5" />
                 </button>
-              ) : (
-                <button
-                  type="button"
-                  aria-label="Settle thread"
-                  onClick={handleSettleClick}
-                  className="absolute inset-y-0 right-0 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/v2-row:opacity-100"
-                >
-                  <CheckIcon className="size-3" />
-                </button>
               )}
             </span>
             {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
@@ -841,160 +759,9 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
           {detailsTooltip}
         </Tooltip>
       </li>
-    );
-  }
-
-  const diff = latestTurnDiff(thread);
-
-  return (
-    <li
-      data-thread-item
-      className="list-none py-0.5 [content-visibility:auto] [contain-intrinsic-size:auto_96px]"
-    >
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <div
-              role="button"
-              tabIndex={0}
-              data-testid="sidebar-v2-row-card"
-              className={rowSurfaceClassName}
-              onClick={handleClick}
-              onDoubleClick={handleDoubleClick}
-              onKeyDown={handleKeyDown}
-              onContextMenu={handleContextMenu}
-            />
-          }
-        >
-          <div className="relative z-10 h-[4.875rem] px-2.5 py-2">
-            <div className="flex h-5 min-w-0 items-center gap-1.5">
-              <ProjectFavicon
-                environmentId={thread.environmentId}
-                cwd={props.projectCwd ?? ""}
-                className="size-4 shrink-0"
-              />
-              {props.projectTitle ? (
-                <span
-                  className={cn(
-                    "min-w-0 flex-1 truncate text-xs text-muted-foreground/85",
-                    shouldRecede ? "font-normal" : "font-medium",
-                  )}
-                >
-                  {props.projectTitle}
-                </span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {/* The visible state owns this slot's width: status at rest,
-                  actions on hover/focus or while the popover is open. Keeping
-                  the hidden state out of flow lets the project label reclaim
-                  space without either state overlapping it. */}
-              <span className="group/v2-status-slot relative ml-auto flex h-5 min-w-8 shrink-0 items-stretch justify-end text-xs">
-                <span
-                  className={cn(
-                    "self-center justify-self-end tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-status-slot:absolute group-focus-within/v2-status-slot:right-0 group-hover/v2-row:absolute group-hover/v2-row:right-0 group-hover/v2-row:opacity-0",
-                    snoozeMenuOpen && "absolute right-0 opacity-0",
-                  )}
-                >
-                  {topStatus ? (
-                    <span
-                      className={cn(
-                        "inline-flex items-center gap-1 font-medium",
-                        topStatus.className,
-                      )}
-                    >
-                      {topStatus.icon === "working" ? (
-                        <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
-                      ) : topStatus.icon === "done" ? (
-                        <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
-                      ) : topStatus.icon === "woke" ? (
-                        <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
-                      ) : null}
-                      {/* The label alone is the live region: a role="status"
-                          wrapper around the ticking duration would make
-                          screen readers announce every second. */}
-                      <span role="status">{topStatus.label}</span>
-                      {status === "working" ? (
-                        <span aria-hidden>
-                          <WorkingDuration startedAt={resolveWorkingStartedAt(thread)} />
-                        </span>
-                      ) : null}
-                    </span>
-                  ) : (
-                    threadTimeLabel(thread)
-                  )}
-                </span>
-                {props.settlementSupported || showSnoozeButton ? (
-                  <span
-                    className={cn(
-                      "absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity focus-within:static focus-within:opacity-100 group-hover/v2-row:static group-hover/v2-row:opacity-100",
-                      snoozeMenuOpen && "static opacity-100",
-                    )}
-                  >
-                    {showSnoozeButton ? (
-                      <SnoozePopoverButton
-                        open={snoozeMenuOpen}
-                        onOpenChange={setSnoozeMenuOpen}
-                        onSnooze={handleSnoozePreset}
-                      />
-                    ) : null}
-                    {props.settlementSupported ? (
-                      <button
-                        type="button"
-                        aria-label="Settle thread"
-                        onClick={handleSettleClick}
-                        className="-mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground"
-                      >
-                        <CheckIcon className="size-3.5" />
-                        Settle
-                      </button>
-                    ) : null}
-                  </span>
-                ) : null}
-              </span>
-            </div>
-            <div className="mt-1 flex min-w-0">{title}</div>
-            <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
-              {thread.branch ? (
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap">{thread.branch}</span>
-              ) : (
-                <span className="flex-1" />
-              )}
-              {prBadge}
-              {diff ? (
-                <span className="shrink-0 font-mono">
-                  <span className="text-emerald-600 dark:text-emerald-400">+{diff.insertions}</span>{" "}
-                  <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
-                </span>
-              ) : null}
-              <span
-                aria-hidden
-                className="pointer-events-none ml-auto inline-flex shrink-0 items-center gap-1"
-              >
-                {isRemote ? (
-                  <span className="inline-flex shrink-0 items-center text-sidebar-muted-foreground/70">
-                    <ServerIcon aria-hidden className="size-3.5" />
-                  </span>
-                ) : null}
-                {driverKind ? (
-                  <span className="inline-flex shrink-0 items-center opacity-60">
-                    <ProviderInstanceIcon
-                      driverKind={driverKind}
-                      displayName={thread.session?.providerName ?? modelInstanceId}
-                      iconClassName="size-3.5"
-                    />
-                  </span>
-                ) : null}
-              </span>
-            </div>
-          </div>
-          {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
-        </TooltipTrigger>
-        {detailsTooltip}
-      </Tooltip>
-    </li>
   );
 });
+
 
 function latestTurnDiff(
   thread: SidebarThreadSummary,
@@ -1004,6 +771,716 @@ function latestTurnDiff(
   void thread;
   return null;
 }
+
+// One clickable line inside a worktree card: the thread's summary text is
+// the navigation target, with the thread's own status signal and provider
+// logo trailing it (threads in one worktree can run different providers).
+const SidebarV2CardThreadRow = memo(function SidebarV2CardThreadRow(props: {
+  thread: SidebarThreadSummary;
+  isActive: boolean;
+  wokeAt: string | null;
+  jumpLabel: string | null;
+  projectTitle: string | null;
+  projectCwd: string | null;
+  environmentLabel: string | null;
+  branchMismatch: { threadBranch: string; currentBranch: string } | null;
+  providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
+  isRenaming: boolean;
+  renamingTitle: string;
+  onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
+  onThreadActivate: (threadRef: ScopedThreadRef) => void;
+  onStartRename: (threadRef: ScopedThreadRef, title: string) => void;
+  onRenameTitleChange: (title: string) => void;
+  onCommitRename: (threadRef: ScopedThreadRef, title: string, originalTitle: string) => void;
+  onCancelRename: () => void;
+  onContextMenu: (threadRef: ScopedThreadRef, position: { x: number; y: number }) => void;
+}) {
+  const {
+    isRenaming,
+    onCancelRename,
+    onCommitRename,
+    onContextMenu,
+    onRenameTitleChange,
+    onStartRename,
+    onThreadActivate,
+    onThreadClick,
+    renamingTitle,
+    thread,
+  } = props;
+  const threadRef = useMemo(
+    () => scopeThreadRef(thread.environmentId, thread.id),
+    [thread.environmentId, thread.id],
+  );
+  const threadKey = scopedThreadKey(threadRef);
+  const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
+
+  const isUnread = hasUnseenCompletion({ ...thread, lastVisitedAt });
+  const status = resolveSidebarV2Status(thread);
+  const lastVisitedDate = lastVisitedAt === undefined ? null : parseTimestampDate(lastVisitedAt);
+  const wokeAtDate = props.wokeAt === null ? null : parseTimestampDate(props.wokeAt);
+  const isWoke = wokeAtDate !== null && (lastVisitedDate === null || lastVisitedDate < wokeAtDate);
+  const rowRecedes =
+    (status === "ready" || status === "working" || status === "approval" || status === "input") &&
+    !isUnread &&
+    !isWoke &&
+    !props.isActive &&
+    !isSelected;
+
+  const modelInstanceId = thread.session?.providerInstanceId ?? thread.modelSelection.instanceId;
+  const providerEntry = props.providerEntryByInstanceId.get(modelInstanceId) ?? null;
+  const driverKind = providerEntry?.driverKind ?? null;
+  const selectedModel = providerEntry?.models.find(
+    (model) => model.slug === thread.modelSelection.model,
+  );
+  const modelLabel = selectedModel
+    ? getTriggerDisplayModelLabel(selectedModel)
+    : thread.modelSelection.model;
+
+  const handleClick = useCallback(
+    (event: ReactMouseEvent) => {
+      event.stopPropagation();
+      onThreadClick(event, threadRef);
+    },
+    [onThreadClick, threadRef],
+  );
+  const handleContextMenu = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onContextMenu(threadRef, { x: event.clientX, y: event.clientY });
+    },
+    [onContextMenu, threadRef],
+  );
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent) => {
+      if (event.target !== event.currentTarget) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      event.stopPropagation();
+      onThreadActivate(threadRef);
+    },
+    [onThreadActivate, threadRef],
+  );
+  const handleDoubleClick = useCallback(
+    (event: ReactMouseEvent) => {
+      event.stopPropagation();
+      if (isRenaming || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+      if ((event.target as HTMLElement).closest("button, a, input")) return;
+      event.preventDefault();
+      onStartRename(threadRef, thread.title);
+    },
+    [isRenaming, onStartRename, thread.title, threadRef],
+  );
+  const renameCommittedRef = useRef(false);
+  useEffect(() => {
+    if (isRenaming) renameCommittedRef.current = false;
+  }, [isRenaming]);
+  const handleRenameKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      if (event.key === "Enter") {
+        event.preventDefault();
+        renameCommittedRef.current = true;
+        onCommitRename(threadRef, renamingTitle, thread.title);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        renameCommittedRef.current = true;
+        onCancelRename();
+      }
+    },
+    [onCancelRename, onCommitRename, renamingTitle, thread.title, threadRef],
+  );
+  const handleRenameBlur = useCallback(() => {
+    if (!renameCommittedRef.current) {
+      onCommitRename(threadRef, renamingTitle, thread.title);
+    }
+  }, [onCommitRename, renamingTitle, thread.title, threadRef]);
+
+  // Per-thread signal, most-urgent first — the card's top row carries the
+  // aggregate, this glyph says which member it's about.
+  const statusGlyph =
+    status === "approval" ? (
+      <span
+        role="status"
+        aria-label="Pending approval"
+        className="size-1.5 shrink-0 rounded-full bg-amber-500"
+      />
+    ) : status === "input" ? (
+      <span
+        role="status"
+        aria-label="Awaiting input"
+        className="size-1.5 shrink-0 rounded-full bg-indigo-500"
+      />
+    ) : status === "working" ? (
+      <CircleDashedIcon
+        role="status"
+        aria-label="Working"
+        className="size-3 shrink-0 animate-status-pulse text-sky-600 motion-reduce:animate-none dark:text-sky-400"
+      />
+    ) : status === "failed" ? (
+      <CircleAlertIcon
+        role="status"
+        aria-label="Failed"
+        className="size-3 shrink-0 text-red-600 dark:text-red-400"
+      />
+    ) : isWoke ? (
+      <AlarmClockIcon
+        role="status"
+        aria-label="Woke from snooze"
+        className="size-3 shrink-0 text-amber-700 dark:text-amber-300"
+      />
+    ) : isUnread ? (
+      <span
+        role="status"
+        aria-label="Done, unread"
+        className="size-1.5 shrink-0 rounded-full bg-emerald-500"
+      />
+    ) : null;
+
+  const title = isRenaming ? (
+    <input
+      autoFocus
+      value={renamingTitle}
+      aria-label="Thread title"
+      onChange={(event) => onRenameTitleChange(event.target.value)}
+      onFocus={(event) => event.currentTarget.select()}
+      onKeyDown={handleRenameKeyDown}
+      onBlur={handleRenameBlur}
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      className="min-w-0 flex-1 rounded-sm border border-input bg-card px-1 text-sm font-medium text-card-foreground outline-none focus:border-foreground"
+    />
+  ) : (
+    <span
+      className={cn(
+        "min-w-0 flex-1 truncate text-sm",
+        isUnread || isWoke || props.isActive
+          ? "font-medium text-foreground"
+          : status === "failed"
+            ? "font-medium text-foreground/95"
+            : rowRecedes
+              ? "font-normal text-muted-foreground/80 group-hover/v2-thread:text-foreground"
+              : "font-medium text-foreground/90",
+      )}
+    >
+      {thread.title}
+    </span>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div
+            role="button"
+            tabIndex={0}
+            data-testid="sidebar-v2-card-thread"
+            className={cn(
+              "group/v2-thread relative -mx-1 flex h-6 min-w-0 cursor-pointer items-center gap-1.5 rounded-[5px] px-1 text-left outline-none select-none",
+              isSelected
+                ? "bg-sidebar-row-selected"
+                : props.isActive
+                  ? "bg-sidebar-row-hover"
+                  : "hover:bg-sidebar-row-hover",
+            )}
+            onClick={handleClick}
+            onDoubleClick={handleDoubleClick}
+            onKeyDown={handleKeyDown}
+            onContextMenu={handleContextMenu}
+          />
+        }
+      >
+        {title}
+        {statusGlyph}
+        {driverKind ? (
+          <span className="inline-flex shrink-0 items-center opacity-60">
+            <ProviderInstanceIcon
+              driverKind={driverKind}
+              displayName={thread.session?.providerName ?? modelInstanceId}
+              iconClassName="size-3.5"
+            />
+          </span>
+        ) : null}
+        {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
+      </TooltipTrigger>
+      <SidebarV2ThreadTooltip
+        thread={thread}
+        projectTitle={props.projectTitle}
+        projectCwd={props.projectCwd}
+        environmentLabel={props.environmentLabel}
+        driverKind={driverKind}
+        modelInstanceId={modelInstanceId}
+        modelLabel={modelLabel}
+        branchMismatch={props.branchMismatch}
+      />
+    </Tooltip>
+  );
+});
+
+// A worktree's card: repository identity, activity indicators and lifecycle
+// actions live at the card (worktree) level; each member thread renders as
+// its own clickable row inside.
+const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
+  groupKey: string;
+  threads: ReadonlyArray<SidebarThreadSummary>;
+  memberKeys: ReadonlyArray<string>;
+  // Route thread key when it belongs to this worktree, else null.
+  activeThreadKey: string | null;
+  settlementSupported: boolean;
+  snoozeSupported: boolean;
+  snoozeNow: string;
+  currentEnvironmentId: string | null;
+  environmentLabel: string | null;
+  projectCwd: string | null;
+  projectTitle: string | null;
+  providerEntryByInstanceId: ReadonlyMap<string, ProviderInstanceEntry>;
+  // Null while jump hints are hidden so the common case keeps memo identity.
+  jumpLabelByKey: ReadonlyMap<string, string> | null;
+  renamingThreadKey: string | null;
+  renamingTitle: string;
+  onThreadClick: (event: ReactMouseEvent, threadRef: ScopedThreadRef) => void;
+  onThreadActivate: (threadRef: ScopedThreadRef) => void;
+  onStartRename: (threadRef: ScopedThreadRef, title: string) => void;
+  onRenameTitleChange: (title: string) => void;
+  onCommitRename: (threadRef: ScopedThreadRef, title: string, originalTitle: string) => void;
+  onCancelRename: () => void;
+  onContextMenu: (threadRef: ScopedThreadRef, position: { x: number; y: number }) => void;
+  onSettle: (threadRef: ScopedThreadRef) => void;
+  onSnooze: (threadRef: ScopedThreadRef, preset: SnoozePreset) => void;
+  onChangeRequestState: (threadKey: string, state: "open" | "closed" | "merged" | null) => void;
+}) {
+  const {
+    memberKeys,
+    onChangeRequestState,
+    onContextMenu,
+    onSettle,
+    onSnooze,
+    onThreadActivate,
+    onThreadClick,
+    threads,
+  } = props;
+  const newest = threads[threads.length - 1]!;
+  const newestRef = useMemo(
+    () => scopeThreadRef(newest.environmentId, newest.id),
+    [newest.environmentId, newest.id],
+  );
+  const activeMember =
+    props.activeThreadKey === null
+      ? null
+      : (threads.find(
+          (thread) =>
+            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) ===
+            props.activeThreadKey,
+        ) ?? null);
+  const isActiveCard = activeMember !== null;
+  const environmentId = newest.environmentId;
+  const threadIds = useMemo(() => threads.map((thread) => thread.id), [threads]);
+
+  // Worktree-level activity: any member thread's terminal with a running
+  // subprocess, and any dev server discovered on a member's terminal. These
+  // sit inline with the repository row because terminals and dev servers
+  // belong to the checkout, not to an individual thread.
+  const runningTerminals = useRunningTerminalsForThreads({ environmentId, threadIds });
+  const discoveredPorts = useDiscoveredPortsForThreads({ environmentId, threadIds });
+  const openPreview = useAtomCommand(previewEnvironment.open, { reportFailure: false });
+  const handleOpenDiscoveredPort = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      const port = discoveredPorts[0];
+      if (!port) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const targetRef =
+        activeMember === null
+          ? newestRef
+          : scopeThreadRef(activeMember.environmentId, activeMember.id);
+      onThreadActivate(targetRef);
+      void (async () => {
+        const result = await openDiscoveredPort({ threadRef: targetRef, port, openPreview });
+        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+          return;
+        }
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to open preview",
+            description:
+              error instanceof Error ? error.message : "The preview could not be opened.",
+          }),
+        );
+      })();
+    },
+    [activeMember, discoveredPorts, newestRef, onThreadActivate, openPreview],
+  );
+
+  const anySelected = useThreadSelectionStore((state) =>
+    memberKeys.some((key) => state.selectedThreadKeys.has(key)),
+  );
+  // One subscription for all members' visited stamps: a joined signature
+  // keeps the selector referentially stable while letting the card derive
+  // per-member unread/woke without a hook per member.
+  const visitedSignature = useUiStateStore((state) =>
+    memberKeys.map((key) => state.threadLastVisitedAtById[key] ?? "").join(" "),
+  );
+  const { anyUnread, anyWoke, wokeAtByKey } = useMemo(() => {
+    const visited = visitedSignature.split(" ");
+    let anyUnread = false;
+    let anyWoke = false;
+    const wokeAtByKey = new Map<string, string | null>();
+    threads.forEach((thread, index) => {
+      const lastVisitedAt = visited[index] === "" ? undefined : visited[index];
+      if (hasUnseenCompletion({ ...thread, lastVisitedAt })) anyUnread = true;
+      const wokeAt = threadWokeAt(thread, { now: props.snoozeNow });
+      wokeAtByKey.set(memberKeys[index]!, wokeAt);
+      if (wokeAt !== null) {
+        const lastVisitedDate = lastVisitedAt == null ? null : parseTimestampDate(lastVisitedAt);
+        const wokeDate = parseTimestampDate(wokeAt);
+        if (wokeDate !== null && (lastVisitedDate === null || lastVisitedDate < wokeDate)) {
+          anyWoke = true;
+        }
+      }
+    });
+    return { anyUnread, anyWoke, wokeAtByKey };
+  }, [memberKeys, props.snoozeNow, threads, visitedSignature]);
+
+  const liveStatus = resolveWorktreeGroupLiveStatus(threads);
+  const isInFlight = liveStatus !== null && liveStatus.kind !== "failed";
+  const shouldRecede =
+    (liveStatus === null || isInFlight) && !anyUnread && !anyWoke && !isActiveCard && !anySelected;
+  const topStatus =
+    liveStatus?.kind === "working"
+      ? {
+          label: "Working",
+          icon: "working" as const,
+          className:
+            "animate-sidebar-working-text text-sky-600 motion-reduce:animate-none dark:text-sky-400",
+        }
+      : liveStatus?.kind === "approval"
+        ? { label: "Approval", icon: null, className: "text-amber-700 dark:text-amber-300" }
+        : liveStatus?.kind === "input"
+          ? { label: "Input", icon: null, className: "text-indigo-600 dark:text-indigo-300" }
+          : liveStatus?.kind === "failed"
+            ? { label: "Failed", icon: null, className: "text-red-700 dark:text-red-300" }
+            : anyWoke
+              ? {
+                  label: "Woke",
+                  icon: "woke" as const,
+                  className: "text-amber-700 dark:text-amber-300",
+                }
+              : anyUnread
+                ? {
+                    label: "Done",
+                    icon: "done" as const,
+                    className: "text-emerald-700 dark:text-emerald-300",
+                  }
+                : null;
+
+  // The worktree's VCS state is card-level: one status subscription per
+  // checkout, PR state fanned out to every member key for the partition.
+  const worktreePath = threads.find((thread) => thread.worktreePath !== null)?.worktreePath ?? null;
+  const gitCwd = worktreePath ?? props.projectCwd;
+  const gitStatus = useEnvironmentQuery(
+    (newest.branch != null || worktreePath !== null) && gitCwd !== null
+      ? vcsEnvironment.status({
+          environmentId,
+          input: { cwd: gitCwd },
+        })
+      : null,
+  );
+  const branchMismatch = resolveLocalCheckoutBranchMismatch({
+    effectiveEnvMode: worktreePath === null ? "local" : "worktree",
+    activeWorktreePath: worktreePath,
+    activeThreadBranch: newest.branch,
+    currentGitBranch: gitStatus.data?.refName ?? null,
+  });
+  const pr = resolveThreadPr({
+    threadBranch: newest.branch,
+    gitStatus: gitStatus.data,
+    hasDedicatedWorktree: worktreePath !== null,
+  });
+  const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
+  const prState = pr?.state ?? null;
+  useEffect(() => {
+    for (const memberKey of memberKeys) {
+      onChangeRequestState(memberKey, prState);
+    }
+  }, [memberKeys, onChangeRequestState, prState]);
+  const openPrLink = useOpenPrLink();
+  const handlePrClick = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      event.stopPropagation();
+      if (pr?.url) openPrLink(event, pr.url);
+    },
+    [openPrLink, pr],
+  );
+
+  const handleCardClick = useCallback(
+    (event: ReactMouseEvent) => {
+      if (isTrailingDoubleClick(event.detail)) return;
+      onThreadClick(event, newestRef);
+    },
+    [newestRef, onThreadClick],
+  );
+  const handleCardContextMenu = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      onContextMenu(newestRef, { x: event.clientX, y: event.clientY });
+    },
+    [newestRef, onContextMenu],
+  );
+  const handleCardKeyDown = useCallback(
+    (event: ReactKeyboardEvent) => {
+      if (event.target !== event.currentTarget) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      onThreadActivate(newestRef);
+    },
+    [newestRef, onThreadActivate],
+  );
+  const handleSettleClick = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onSettle(newestRef);
+    },
+    [newestRef, onSettle],
+  );
+  const handleSnoozePreset = useCallback(
+    (preset: SnoozePreset) => {
+      onSnooze(newestRef, preset);
+    },
+    [newestRef, onSnooze],
+  );
+  // While the snooze popover is open the pointer leaves the card, which
+  // would fade the hover actions out from under the open menu; pin them.
+  const [snoozeMenuOpenRaw, setSnoozeMenuOpen] = useState(false);
+  // Snooze acts on the whole worktree, so it's offered only when every
+  // member can take it — a half-applied snooze would leave the card in
+  // place and read as a failed click.
+  const snoozeNowIso = new Date().toISOString();
+  const showSnoozeButton =
+    props.snoozeSupported && threads.every((thread) => canSnooze(thread, { now: snoozeNowIso }));
+  const snoozeMenuOpen = snoozeMenuOpenRaw && showSnoozeButton;
+  useEffect(() => {
+    if (!showSnoozeButton) setSnoozeMenuOpen(false);
+  }, [showSnoozeButton]);
+
+  const isRemote =
+    props.currentEnvironmentId !== null && environmentId !== props.currentEnvironmentId;
+  const diff = latestTurnDiff(newest);
+  const timeLabelThread = pickWorktreeGroupTimeLabelThread(threads);
+
+  const cardSurfaceClassName = cn(
+    "group/v2-row relative w-full cursor-pointer overflow-hidden rounded-md text-left outline-none select-none",
+    isActiveCard
+      ? "bg-sidebar-row-active text-sidebar-foreground"
+      : anySelected
+        ? "bg-sidebar-row-selected text-sidebar-foreground"
+        : shouldRecede
+          ? "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+          : "bg-transparent text-sidebar-foreground hover:bg-sidebar-row-hover",
+    isInFlight && !isActiveCard && !anySelected && "opacity-70 transition-opacity hover:opacity-100",
+  );
+
+  return (
+    <li
+      data-thread-item
+      className="list-none py-0.5 [content-visibility:auto]"
+      style={{ containIntrinsicSize: `auto ${96 + (threads.length - 1) * 24}px` }}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        data-testid="sidebar-v2-row-card"
+        data-worktree-key={props.groupKey}
+        className={cardSurfaceClassName}
+        onClick={handleCardClick}
+        onKeyDown={handleCardKeyDown}
+        onContextMenu={handleCardContextMenu}
+      >
+        <div className="relative z-10 px-2.5 py-2">
+          <div className="flex h-5 min-w-0 items-center gap-1.5">
+            <ProjectFavicon
+              environmentId={environmentId}
+              cwd={props.projectCwd ?? ""}
+              className="size-4 shrink-0"
+            />
+            {props.projectTitle ? (
+              <span
+                className={cn(
+                  "min-w-0 truncate text-xs text-muted-foreground/85",
+                  shouldRecede ? "font-normal" : "font-medium",
+                )}
+              >
+                {props.projectTitle}
+              </span>
+            ) : null}
+            {runningTerminals.length > 0 ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      role="img"
+                      aria-label="Terminal process running"
+                      data-testid="sidebar-v2-worktree-terminal-indicator"
+                      className="inline-flex shrink-0 items-center justify-center text-teal-600 dark:text-teal-300/90"
+                    />
+                  }
+                >
+                  <TerminalIcon className="size-3 animate-status-pulse" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">Terminal process running</TooltipPopup>
+              </Tooltip>
+            ) : null}
+            {discoveredPorts.length > 0 ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label={`Open localhost:${discoveredPorts[0]?.port ?? ""}`}
+                      data-testid="sidebar-v2-worktree-devserver-indicator"
+                      className="inline-flex shrink-0 cursor-pointer items-center justify-center text-emerald-600 outline-hidden focus-visible:ring-1 focus-visible:ring-ring dark:text-emerald-400"
+                      onClick={handleOpenDiscoveredPort}
+                    />
+                  }
+                >
+                  <Globe2Icon className="size-3" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">
+                  Open localhost:{discoveredPorts[0]?.port}
+                  {discoveredPorts.length > 1 ? ` (+${discoveredPorts.length - 1})` : ""}
+                </TooltipPopup>
+              </Tooltip>
+            ) : null}
+            <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
+              <span
+                className={cn(
+                  "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
+                  snoozeMenuOpen && "opacity-0",
+                )}
+              >
+                {topStatus ? (
+                  <span
+                    className={cn("inline-flex items-center gap-1 font-medium", topStatus.className)}
+                  >
+                    {topStatus.icon === "working" ? (
+                      <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
+                    ) : topStatus.icon === "done" ? (
+                      <CircleCheckIcon aria-hidden className="size-4 shrink-0" />
+                    ) : topStatus.icon === "woke" ? (
+                      <AlarmClockIcon aria-hidden className="size-4 shrink-0" />
+                    ) : null}
+                    {/* The label alone is the live region: a role="status"
+                        wrapper around the ticking duration would make
+                        screen readers announce every second. */}
+                    <span role="status">{topStatus.label}</span>
+                    {liveStatus?.kind === "working" ? (
+                      <span aria-hidden>
+                        <WorkingDuration startedAt={liveStatus.workingStartedAt} />
+                      </span>
+                    ) : null}
+                  </span>
+                ) : (
+                  threadTimeLabel(timeLabelThread)
+                )}
+              </span>
+              {props.settlementSupported || showSnoozeButton ? (
+                <span
+                  className={cn(
+                    "absolute inset-y-0 right-0 flex items-stretch gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
+                    snoozeMenuOpen && "opacity-100",
+                  )}
+                >
+                  {showSnoozeButton ? (
+                    <SnoozePopoverButton
+                      open={snoozeMenuOpen}
+                      onOpenChange={setSnoozeMenuOpen}
+                      onSnooze={handleSnoozePreset}
+                    />
+                  ) : null}
+                  {props.settlementSupported ? (
+                    <button
+                      type="button"
+                      aria-label="Settle worktree"
+                      onClick={handleSettleClick}
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      <CheckIcon className="size-3" />
+                      Settle
+                    </button>
+                  ) : null}
+                </span>
+              ) : null}
+            </span>
+          </div>
+          <div className="mt-1 flex flex-col gap-px">
+            {threads.map((thread, index) => {
+              const memberKey = memberKeys[index]!;
+              return (
+                <SidebarV2CardThreadRow
+                  key={memberKey}
+                  thread={thread}
+                  isActive={props.activeThreadKey === memberKey}
+                  wokeAt={wokeAtByKey.get(memberKey) ?? null}
+                  jumpLabel={props.jumpLabelByKey?.get(memberKey) ?? null}
+                  projectTitle={props.projectTitle}
+                  projectCwd={props.projectCwd}
+                  environmentLabel={props.environmentLabel}
+                  branchMismatch={branchMismatch}
+                  providerEntryByInstanceId={props.providerEntryByInstanceId}
+                  isRenaming={props.renamingThreadKey === memberKey}
+                  renamingTitle={props.renamingThreadKey === memberKey ? props.renamingTitle : ""}
+                  onThreadClick={onThreadClick}
+                  onThreadActivate={onThreadActivate}
+                  onStartRename={props.onStartRename}
+                  onRenameTitleChange={props.onRenameTitleChange}
+                  onCommitRename={props.onCommitRename}
+                  onCancelRename={props.onCancelRename}
+                  onContextMenu={onContextMenu}
+                />
+              );
+            })}
+          </div>
+          <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
+            {newest.branch ? (
+              <span className="min-w-0 flex-1 truncate whitespace-nowrap">{newest.branch}</span>
+            ) : (
+              <span className="flex-1" />
+            )}
+            {prStatus && pr ? (
+              <button
+                type="button"
+                onClick={handlePrClick}
+                className={cn("shrink-0 font-mono text-xs hover:underline", prStatus.colorClass)}
+                aria-label={prStatus.tooltip}
+              >
+                #{pr.number}
+              </button>
+            ) : null}
+            {diff ? (
+              <span className="shrink-0 font-mono">
+                <span className="text-emerald-600 dark:text-emerald-400">+{diff.insertions}</span>{" "}
+                <span className="text-red-600 dark:text-red-400">−{diff.deletions}</span>
+              </span>
+            ) : null}
+            {isRemote ? (
+              <span
+                aria-hidden
+                className="pointer-events-none ml-auto inline-flex shrink-0 items-center text-sidebar-muted-foreground/70"
+              >
+                <ServerIcon aria-hidden className="size-3.5" />
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+});
 
 export default function SidebarV2() {
   const projects = useProjects();
@@ -1375,68 +1852,79 @@ export default function SidebarV2() {
   // merging, no optimistic holds. Archived threads remain hidden here —
   // archive keeps its original "remove from sidebar" meaning.
   const serverConfigs = useAtomValue(environmentServerConfigsAtom);
-  const { activeThreads, snoozedThreads, settledThreads, snoozeNow } = useMemo(() => {
-    const now = `${nowMinute}:00.000Z`;
-    // Snooze classification uses a REAL clock, not the quantized minute:
-    // wake times are second-precise and a woken thread must not linger on
-    // the shelf for the rest of the minute. snoozeWakeTick re-runs this
-    // memo exactly at the next wake boundary.
-    void snoozeWakeTick;
-    const preciseNow = new Date().toISOString();
-    const visible = threads.filter(
-      (thread) =>
-        thread.archivedAt === null &&
-        (scopedProjectKeys === null ||
-          scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
-    );
-    const active: EnvironmentThreadShell[] = [];
-    const snoozed: EnvironmentThreadShell[] = [];
-    const settled: EnvironmentThreadShell[] = [];
-    for (const thread of visible) {
-      // Threads on servers without the settlement capability (old server,
-      // or descriptor not loaded yet) never classify as settled: the user
-      // could neither un-settle nor pin them, so auto-settling them would
-      // strand rows in a tail with no working affordances.
-      const supportsSettlement =
-        serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement === true;
-      const supportsSnooze =
-        serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
-      const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-      const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
-      // Snooze outranks settled classification: an explicitly snoozed thread
-      // belongs to the shelf even if it would also auto-settle (the shelf's
-      // wake time is a stronger statement about when it matters again).
-      if (supportsSnooze && effectiveSnoozed(thread, { now: preciseNow })) {
-        snoozed.push(thread);
-      } else if (
-        supportsSettlement &&
-        effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
-      ) {
-        settled.push(thread);
-      } else {
-        active.push(thread);
+  const { activeGroups, snoozedGroups, settledGroups, snoozedThreads, settledThreads, snoozeNow } =
+    useMemo(() => {
+      const now = `${nowMinute}:00.000Z`;
+      // Snooze classification uses a REAL clock, not the quantized minute:
+      // wake times are second-precise and a woken thread must not linger on
+      // the shelf for the rest of the minute. snoozeWakeTick re-runs this
+      // memo exactly at the next wake boundary.
+      void snoozeWakeTick;
+      const preciseNow = new Date().toISOString();
+      const visible = threads.filter(
+        (thread) =>
+          thread.archivedAt === null &&
+          (scopedProjectKeys === null ||
+            scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
+      );
+      const classified: Array<{
+        thread: EnvironmentThreadShell;
+        classification: SidebarThreadClassification;
+      }> = [];
+      const snoozed: EnvironmentThreadShell[] = [];
+      const settled: EnvironmentThreadShell[] = [];
+      for (const thread of visible) {
+        // Threads on servers without the settlement capability (old server,
+        // or descriptor not loaded yet) never classify as settled: the user
+        // could neither un-settle nor pin them, so auto-settling them would
+        // strand rows in a tail with no working affordances.
+        const supportsSettlement =
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSettlement ===
+          true;
+        const supportsSnooze =
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
+        const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+        const changeRequestState = changeRequestStateByKey.get(threadKey) ?? null;
+        // Snooze outranks settled classification: an explicitly snoozed thread
+        // belongs to the shelf even if it would also auto-settle (the shelf's
+        // wake time is a stronger statement about when it matters again).
+        if (supportsSnooze && effectiveSnoozed(thread, { now: preciseNow })) {
+          snoozed.push(thread);
+          classified.push({ thread, classification: "snoozed" });
+        } else if (
+          supportsSettlement &&
+          effectiveSettled(thread, { now, autoSettleAfterDays, changeRequestState })
+        ) {
+          settled.push(thread);
+          classified.push({ thread, classification: "settled" });
+        } else {
+          classified.push({ thread, classification: "active" });
+        }
       }
-    }
-    return {
-      activeThreads: sortThreadsForSidebarV2(active),
-      // Soonest wake first: "what comes back next" is the shelf's question.
-      snoozedThreads: snoozed.toSorted(
-        (left, right) =>
-          firstValidTimestampMs(left.snoozedUntil ?? null) -
-          firstValidTimestampMs(right.snoozedUntil ?? null),
-      ),
-      settledThreads: sortSettledThreadsForSidebarV2(settled),
-      snoozeNow: preciseNow,
-    };
-  }, [
-    autoSettleAfterDays,
-    changeRequestStateByKey,
-    nowMinute,
-    scopedProjectKeys,
-    serverConfigs,
-    snoozeWakeTick,
-    threads,
-  ]);
+      // Rows are WORKTREES: threads sharing a checkout collapse into one
+      // card (any active member) or one shelf row (all parked).
+      const groups = buildSidebarWorktreeGroups(classified);
+      return {
+        ...groups,
+        // Soonest wake first: "what comes back next" is the shelf's question
+        // (and entry 0 is the wake-timer boundary below).
+        snoozedThreads: snoozed.toSorted(
+          (left, right) =>
+            firstValidTimestampMs(left.snoozedUntil ?? null) -
+            firstValidTimestampMs(right.snoozedUntil ?? null),
+        ),
+        settledThreads: settled,
+        snoozeNow: preciseNow,
+      };
+    }, [
+      autoSettleAfterDays,
+      changeRequestStateByKey,
+      nowMinute,
+      scopedProjectKeys,
+      serverConfigs,
+      snoozeWakeTick,
+      threads,
+    ]);
 
   // Arm a timeout for the earliest upcoming wake so the shelf empties the
   // moment a snooze expires instead of on the next minute tick. Sorted
@@ -1467,62 +1955,69 @@ export default function SidebarV2() {
     lastSettledResetKeyRef.current = settledResetKey;
     setSettledVisibleCount(SETTLED_TAIL_INITIAL_COUNT);
   }
-  const visibleSettledThreads = useMemo(() => {
-    if (settledThreads.length <= settledVisibleCount) return settledThreads;
-    const visible = settledThreads.slice(0, settledVisibleCount);
+  const groupContainsRouteThread = useCallback(
+    (group: SidebarWorktreeGroup) =>
+      routeThreadKey !== null && group.memberKeys.includes(routeThreadKey),
+    [routeThreadKey],
+  );
+  const visibleSettledGroups = useMemo(() => {
+    if (settledGroups.length <= settledVisibleCount) return settledGroups;
+    const visible = settledGroups.slice(0, settledVisibleCount);
     // The open thread must never hide under "Show more": navigating into a
-    // deep settled thread (search, deep link) pulls its row into the visible
-    // tail so the highlight and the un-settle affordance stay reachable.
-    if (routeThreadKey !== null) {
-      const routeThread = settledThreads
-        .slice(settledVisibleCount)
-        .find(
-          (thread) =>
-            scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
-        );
-      if (routeThread !== undefined) visible.push(routeThread);
-    }
+    // deep settled thread (search, deep link) pulls its worktree's row into
+    // the visible tail so the highlight and the un-settle affordance stay
+    // reachable.
+    const routeGroup = settledGroups.slice(settledVisibleCount).find(groupContainsRouteThread);
+    if (routeGroup !== undefined) visible.push(routeGroup);
     return visible;
-  }, [routeThreadKey, settledThreads, settledVisibleCount]);
-  const hiddenSettledCount = settledThreads.length - visibleSettledThreads.length;
+  }, [groupContainsRouteThread, settledGroups, settledVisibleCount]);
+  const hiddenSettledCount = settledGroups.length - visibleSettledGroups.length;
   const showMoreSettled = useCallback(
     () => setSettledVisibleCount((count) => count + SETTLED_TAIL_PAGE_COUNT),
     [],
   );
   const [settledShelfExpanded, setSettledShelfExpanded] = useState(true);
   const toggleSettledShelf = useCallback(() => setSettledShelfExpanded((value) => !value), []);
-  const renderedSettledThreads = useMemo(() => {
-    if (settledShelfExpanded) return visibleSettledThreads;
-    if (routeThreadKey === null) return [];
-    const routeThread = visibleSettledThreads.find(
-      (thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
-    );
-    return routeThread === undefined ? [] : [routeThread];
-  }, [routeThreadKey, settledShelfExpanded, visibleSettledThreads]);
+  const renderedSettledGroups = useMemo(() => {
+    if (settledShelfExpanded) return visibleSettledGroups;
+    const routeGroup = visibleSettledGroups.find(groupContainsRouteThread);
+    return routeGroup === undefined ? [] : [routeGroup];
+  }, [groupContainsRouteThread, settledShelfExpanded, visibleSettledGroups]);
 
   // The snoozed shelf is collapsed by default: out of the way, never gone.
-  // Collapsed threads don't render (and so don't participate in jump
+  // Collapsed rows don't render (and so don't participate in jump
   // shortcuts or multi-select), matching the settled tail's paging model.
   const [snoozedShelfExpanded, setSnoozedShelfExpanded] = useState(false);
   const toggleSnoozedShelf = useCallback(() => setSnoozedShelfExpanded((value) => !value), []);
-  const visibleSnoozedThreads = useMemo(() => {
-    if (snoozedShelfExpanded) return snoozedThreads;
+  const visibleSnoozedGroups = useMemo(() => {
+    if (snoozedShelfExpanded) return snoozedGroups;
     // The open thread must never vanish behind the collapsed shelf: a
     // snoozed thread reached by route (deep link, open before snoozing
-    // elsewhere) keeps its row — with highlight and wake affordance — same
-    // exception the settled tail's "Show more" makes.
-    if (routeThreadKey === null) return [];
-    const routeThread = snoozedThreads.find(
-      (thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
-    );
-    return routeThread === undefined ? [] : [routeThread];
-  }, [routeThreadKey, snoozedShelfExpanded, snoozedThreads]);
+    // elsewhere) keeps its worktree's row — with highlight and wake
+    // affordance — same exception the settled tail's "Show more" makes.
+    const routeGroup = snoozedGroups.find(groupContainsRouteThread);
+    return routeGroup === undefined ? [] : [routeGroup];
+  }, [groupContainsRouteThread, snoozedShelfExpanded, snoozedGroups]);
 
+  // Shelf rows stand in for their whole group; the representative prefers
+  // the route thread so highlight and navigation stay honest.
+  const snoozedRepThreads = useMemo(
+    () => visibleSnoozedGroups.map((group) => pickWorktreeGroupRepresentative(group, routeThreadKey)),
+    [routeThreadKey, visibleSnoozedGroups],
+  );
+  const settledRepThreads = useMemo(
+    () => renderedSettledGroups.map((group) => pickWorktreeGroupRepresentative(group, routeThreadKey)),
+    [renderedSettledGroups, routeThreadKey],
+  );
+  // The flat jump/selection spine: card members in visual order, then the
+  // shelf representatives. Hidden group members are not navigable rows.
   const orderedThreads = useMemo(
-    () => [...activeThreads, ...visibleSnoozedThreads, ...renderedSettledThreads],
-    [activeThreads, visibleSnoozedThreads, renderedSettledThreads],
+    () => [
+      ...activeGroups.flatMap((group) => group.threads),
+      ...snoozedRepThreads,
+      ...settledRepThreads,
+    ],
+    [activeGroups, snoozedRepThreads, settledRepThreads],
   );
   const orderedThreadKeys = useMemo(
     () =>
@@ -1552,6 +2047,20 @@ export default function SidebarV2() {
   // event and defeat row memoization during streaming.
   const threadByKeyRef = useRef(threadByKey);
   threadByKeyRef.current = threadByKey;
+  // Every member key of every group (including members hidden behind a
+  // collapsed shelf): lifecycle actions expand a clicked thread to its
+  // whole worktree through this map.
+  const groupByThreadKey = useMemo(() => {
+    const map = new Map<string, SidebarWorktreeGroup>();
+    for (const group of [...activeGroups, ...snoozedGroups, ...settledGroups]) {
+      for (const memberKey of group.memberKeys) {
+        map.set(memberKey, group);
+      }
+    }
+    return map;
+  }, [activeGroups, snoozedGroups, settledGroups]);
+  const groupByThreadKeyRef = useRef(groupByThreadKey);
+  groupByThreadKeyRef.current = groupByThreadKey;
   // handleNewThread is inherently unstable (depends on the projects list);
   // a ref keeps it out of attemptSettle's dependency array.
   const handleNewThreadRef = useRef(newThreadContext.handleNewThread);
@@ -1703,132 +2212,239 @@ export default function SidebarV2() {
     [navigateToThread, router],
   );
 
-  const attemptSettle = useCallback(
-    (threadRef: ScopedThreadRef, opts: { coSettlingKeys?: ReadonlySet<string> } = {}) => {
+  // Lifecycle actions act on the WORKTREE: a clicked thread expands to its
+  // whole group (falling back to just itself when it isn't in any group,
+  // e.g. a row that vanished mid-flight).
+  const resolveWorktreeThreads = useCallback(
+    (threadRef: ScopedThreadRef): ReadonlyArray<SidebarThreadSummary> => {
+      const threadKey = scopedThreadKey(threadRef);
+      const group = groupByThreadKeyRef.current.get(threadKey);
+      if (group) return group.threads;
+      const shell = threadByKeyRef.current.get(threadKey);
+      return shell ? [shell] : [];
+    },
+    [],
+  );
+  const attemptSettleThreads = useCallback(
+    (
+      groupThreads: ReadonlyArray<SidebarThreadSummary>,
+      opts: { coParkingKeys?: ReadonlySet<string> } = {},
+    ) => {
       void (async () => {
-        const threadKey = scopedThreadKey(threadRef);
-        if (settlingThreadKeysRef.current.has(threadKey)) return;
-        settlingThreadKeysRef.current.add(threadKey);
+        const now = new Date().toISOString();
+        const pending = groupThreads.filter((thread) => {
+          const threadKey = sidebarThreadKey(thread);
+          return (
+            !settlingThreadKeysRef.current.has(threadKey) &&
+            !settledThreadKeysRef.current.has(threadKey) &&
+            thread.settledOverride !== "settled"
+          );
+        });
+        if (pending.length === 0) return;
+        // Prefer members the server will accept; when none qualify, send
+        // the first anyway so the user sees the server's reason.
+        const settleable = pending.filter((thread) => canSettle(thread, { now }));
+        const targets = settleable.length > 0 ? settleable : [pending[0]!];
+        const targetKeys = targets.map(sidebarThreadKey);
+        for (const key of targetKeys) settlingThreadKeysRef.current.add(key);
         try {
-          const navigateAfterSettle = planForwardNavigation(threadKey, opts.coSettlingKeys);
-          const result = await settleThread(threadRef);
-          if (result._tag === "Failure") {
-            // Never navigate away from a thread that did not settle.
-            if (!isAtomCommandInterrupted(result)) {
-              const error = squashAtomCommandFailure(result);
-              toastManager.add(
-                stackedThreadToast({
-                  type: "error",
-                  title: "Failed to settle thread",
-                  description: error instanceof Error ? error.message : "An error occurred.",
-                }),
-              );
+          // Forward navigation must skip everything leaving in this batch —
+          // the whole worktree plus any co-parking selection.
+          const allParkingKeys = new Set([
+            ...(opts.coParkingKeys ?? []),
+            ...groupThreads.map(sidebarThreadKey),
+          ]);
+          const routeKey = targetKeys.find((key) => key === routeThreadKeyRef.current) ?? null;
+          const navigateAfterSettle =
+            routeKey === null ? null : planForwardNavigation(routeKey, allParkingKeys);
+          let routeSettled = false;
+          for (const target of targets) {
+            const result = await settleThread(scopeThreadRef(target.environmentId, target.id));
+            if (result._tag === "Failure") {
+              // Never navigate away from a thread that did not settle.
+              if (!isAtomCommandInterrupted(result)) {
+                const error = squashAtomCommandFailure(result);
+                toastManager.add(
+                  stackedThreadToast({
+                    type: "error",
+                    title: "Failed to settle thread",
+                    description: error instanceof Error ? error.message : "An error occurred.",
+                  }),
+                );
+              }
+            } else if (sidebarThreadKey(target) === routeKey) {
+              routeSettled = true;
             }
-            return;
           }
           // Only move forward if the user is still on the settled thread —
           // a navigation made during the await wins over ours.
-          if (routeThreadKeyRef.current === threadKey) {
+          if (routeSettled && routeThreadKeyRef.current === routeKey) {
             navigateAfterSettle?.();
           }
         } finally {
-          settlingThreadKeysRef.current.delete(threadKey);
+          for (const key of targetKeys) settlingThreadKeysRef.current.delete(key);
         }
       })();
     },
     [planForwardNavigation, settleThread],
   );
-  const attemptUnsettle = useCallback(
+  const attemptSettle = useCallback(
     (threadRef: ScopedThreadRef) => {
+      attemptSettleThreads(resolveWorktreeThreads(threadRef));
+    },
+    [attemptSettleThreads, resolveWorktreeThreads],
+  );
+  const attemptUnsettleThreads = useCallback(
+    (groupThreads: ReadonlyArray<SidebarThreadSummary>) => {
       void (async () => {
-        const result = await unsettleThread(threadRef);
-        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Failed to un-settle thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            }),
-          );
+        // Un-settle every parked member; already-active members are no-ops
+        // skipped client-side.
+        const settledMembers = groupThreads.filter((thread) =>
+          settledThreadKeysRef.current.has(sidebarThreadKey(thread)),
+        );
+        const targets = settledMembers.length > 0 ? settledMembers : groupThreads.slice(0, 1);
+        for (const target of targets) {
+          const result = await unsettleThread(scopeThreadRef(target.environmentId, target.id));
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Failed to un-settle thread",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
         }
       })();
     },
     [unsettleThread],
   );
-  const attemptUnsnooze = useCallback(
+  const attemptUnsettle = useCallback(
     (threadRef: ScopedThreadRef) => {
+      attemptUnsettleThreads(resolveWorktreeThreads(threadRef));
+    },
+    [attemptUnsettleThreads, resolveWorktreeThreads],
+  );
+  const attemptUnsnoozeRefs = useCallback(
+    (threadRefs: ReadonlyArray<ScopedThreadRef>) => {
       void (async () => {
-        const result = await unsnoozeThread(threadRef);
-        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Failed to wake thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            }),
-          );
+        for (const threadRef of threadRefs) {
+          const result = await unsnoozeThread(threadRef);
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Failed to wake thread",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
         }
       })();
     },
     [unsnoozeThread],
   );
+  const attemptUnsnooze = useCallback(
+    (threadRef: ScopedThreadRef) => {
+      const groupThreads = resolveWorktreeThreads(threadRef);
+      const snoozedMembers = groupThreads.filter((thread) =>
+        snoozedThreadKeysRef.current.has(sidebarThreadKey(thread)),
+      );
+      const targets = (snoozedMembers.length > 0 ? snoozedMembers : groupThreads).map((thread) =>
+        scopeThreadRef(thread.environmentId, thread.id),
+      );
+      attemptUnsnoozeRefs(targets.length > 0 ? targets : [threadRef]);
+    },
+    [attemptUnsnoozeRefs, resolveWorktreeThreads],
+  );
   // One snooze per thread at a time — same double-dispatch guard as settle.
   const snoozingThreadKeysRef = useRef(new Set<string>());
-  const attemptSnooze = useCallback(
+  const attemptSnoozeThreads = useCallback(
     (
-      threadRef: ScopedThreadRef,
+      groupThreads: ReadonlyArray<SidebarThreadSummary>,
       preset: SnoozePreset,
-      opts: { coSnoozingKeys?: ReadonlySet<string> } = {},
+      opts: { coParkingKeys?: ReadonlySet<string> } = {},
     ) => {
       void (async () => {
-        const threadKey = scopedThreadKey(threadRef);
-        if (snoozingThreadKeysRef.current.has(threadKey)) return;
-        snoozingThreadKeysRef.current.add(threadKey);
+        const now = new Date().toISOString();
+        const targets = groupThreads.filter((thread) => {
+          const threadKey = sidebarThreadKey(thread);
+          return (
+            !snoozingThreadKeysRef.current.has(threadKey) &&
+            !snoozedThreadKeysRef.current.has(threadKey) &&
+            canSnooze(thread, { now })
+          );
+        });
+        if (targets.length === 0) return;
+        const targetKeys = targets.map(sidebarThreadKey);
+        for (const key of targetKeys) snoozingThreadKeysRef.current.add(key);
         try {
           // Snoozing the open thread moves you forward, same as settle —
-          // both park the thread you're done with for now.
-          const navigateAfterSnooze = planForwardNavigation(threadKey, opts.coSnoozingKeys);
-          const result = await snoozeThread(threadRef, preset.snoozedUntil);
-          if (result._tag === "Failure") {
-            // Never navigate away from a thread that did not snooze.
-            if (!isAtomCommandInterrupted(result)) {
-              const error = squashAtomCommandFailure(result);
-              toastManager.add(
-                stackedThreadToast({
-                  type: "error",
-                  title: "Failed to snooze thread",
-                  description: error instanceof Error ? error.message : "An error occurred.",
-                }),
-              );
+          // both park the worktree you're done with for now.
+          const allParkingKeys = new Set([
+            ...(opts.coParkingKeys ?? []),
+            ...groupThreads.map(sidebarThreadKey),
+          ]);
+          const routeKey = targetKeys.find((key) => key === routeThreadKeyRef.current) ?? null;
+          const navigateAfterSnooze =
+            routeKey === null ? null : planForwardNavigation(routeKey, allParkingKeys);
+          const snoozedRefs: ScopedThreadRef[] = [];
+          let routeSnoozed = false;
+          for (const target of targets) {
+            const targetRef = scopeThreadRef(target.environmentId, target.id);
+            const result = await snoozeThread(targetRef, preset.snoozedUntil);
+            if (result._tag === "Failure") {
+              // Never navigate away from a thread that did not snooze.
+              if (!isAtomCommandInterrupted(result)) {
+                const error = squashAtomCommandFailure(result);
+                toastManager.add(
+                  stackedThreadToast({
+                    type: "error",
+                    title: "Failed to snooze thread",
+                    description: error instanceof Error ? error.message : "An error occurred.",
+                  }),
+                );
+              }
+            } else {
+              snoozedRefs.push(targetRef);
+              if (sidebarThreadKey(target) === routeKey) routeSnoozed = true;
             }
-            return;
           }
-          // Snooze hides the row, so the toast is the only confirmation —
-          // and the Undo is the escape hatch for a mis-click.
-          toastManager.add(
-            stackedThreadToast({
-              type: "success",
-              title: `Snoozed until ${snoozeWakeDescription(preset.snoozedUntil, new Date())}`,
-              timeout: 5_000,
-              actionProps: {
-                children: "Undo",
-                onClick: () => attemptUnsnooze(threadRef),
-              },
-            }),
-          );
+          if (snoozedRefs.length > 0) {
+            // Snooze hides the worktree's card, so the toast is the only
+            // confirmation — one per worktree, not per member — and the
+            // Undo is the escape hatch for a mis-click.
+            toastManager.add(
+              stackedThreadToast({
+                type: "success",
+                title: `Snoozed until ${snoozeWakeDescription(preset.snoozedUntil, new Date())}`,
+                timeout: 5_000,
+                actionProps: {
+                  children: "Undo",
+                  onClick: () => attemptUnsnoozeRefs(snoozedRefs),
+                },
+              }),
+            );
+          }
           // Only move forward if the user is still on the snoozed thread —
           // a navigation made during the await wins over ours.
-          if (routeThreadKeyRef.current === threadKey) {
+          if (routeSnoozed && routeThreadKeyRef.current === routeKey) {
             navigateAfterSnooze?.();
           }
         } finally {
-          snoozingThreadKeysRef.current.delete(threadKey);
+          for (const key of targetKeys) snoozingThreadKeysRef.current.delete(key);
         }
       })();
     },
-    [attemptUnsnooze, planForwardNavigation, snoozeThread],
+    [attemptUnsnoozeRefs, planForwardNavigation, snoozeThread],
+  );
+  const attemptSnooze = useCallback(
+    (threadRef: ScopedThreadRef, preset: SnoozePreset) => {
+      attemptSnoozeThreads(resolveWorktreeThreads(threadRef), preset);
+    },
+    [attemptSnoozeThreads, resolveWorktreeThreads],
   );
 
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
@@ -1845,14 +2461,22 @@ export default function SidebarV2() {
       );
       if (threadKeys.length === 0) return;
       const count = threadKeys.length;
-      // Snooze (N) is offered when every selected thread can actually take
-      // it — a mixed selection with blocked-on-you work would half-apply.
-      const selectionNow = new Date().toISOString();
-      const snoozableThreads = threadKeys.flatMap((threadKey) => {
+      // Lifecycle actions park WORKTREES: the selection expands to every
+      // member of every selected thread's group before settling/snoozing.
+      const expandedByKey = new Map<string, SidebarThreadSummary>();
+      for (const threadKey of threadKeys) {
         const thread = threadByKeyRef.current.get(threadKey);
-        return thread ? [thread] : [];
-      });
-      const canSnoozeSelection = snoozableThreads.every(
+        if (!thread) continue;
+        const groupThreads = groupByThreadKeyRef.current.get(threadKey)?.threads ?? [thread];
+        for (const member of groupThreads) {
+          expandedByKey.set(sidebarThreadKey(member), member);
+        }
+      }
+      const expandedThreads = [...expandedByKey.values()];
+      // Snooze (N) is offered when every affected thread can actually take
+      // it — a mixed batch with blocked-on-you work would half-apply.
+      const selectionNow = new Date().toISOString();
+      const canSnoozeSelection = expandedThreads.every(
         (thread) =>
           serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true &&
           canSnooze(thread, { now: selectionNow }),
@@ -1886,29 +2510,18 @@ export default function SidebarV2() {
           (candidate) => `snooze:${candidate.id}` === clicked.value,
         );
         if (preset) {
-          // Post-snooze navigation must skip threads snoozing in this same
-          // batch — they are all leaving the card block together.
-          const coSnoozingKeys = new Set(threadKeys);
-          for (const thread of snoozableThreads) {
-            attemptSnooze(scopeThreadRef(thread.environmentId, thread.id), preset, {
-              coSnoozingKeys,
-            });
-          }
+          // One batch: post-snooze navigation skips everything leaving
+          // together, and the whole batch gets a single Undo toast.
+          attemptSnoozeThreads(expandedThreads, preset);
           clearSelection();
         }
         return;
       }
       if (clicked.value === "settle") {
-        // Post-settle navigation must skip threads settling in this same
-        // batch — they are all leaving the card block together. Rows that
-        // are already explicitly settled are skipped: nothing to do on a
-        // valid mixed selection.
-        const coSettlingKeys = new Set(threadKeys);
-        for (const threadKey of threadKeys) {
-          const thread = threadByKeyRef.current.get(threadKey);
-          if (!thread || thread.settledOverride === "settled") continue;
-          attemptSettle(scopeThreadRef(thread.environmentId, thread.id), { coSettlingKeys });
-        }
+        // One batch: post-settle navigation must skip threads settling in
+        // this same batch — they are all leaving the card block together.
+        // Already-settled members are skipped inside the handler.
+        attemptSettleThreads(expandedThreads);
         clearSelection();
         return;
       }
@@ -1961,8 +2574,8 @@ export default function SidebarV2() {
       removeFromSelection(threadKeys);
     },
     [
-      attemptSettle,
-      attemptSnooze,
+      attemptSettleThreads,
+      attemptSnoozeThreads,
       clearSelection,
       confirmThreadDelete,
       deleteThread,
@@ -1996,6 +2609,16 @@ export default function SidebarV2() {
           serverConfigs.get(thread.environmentId)?.environment.capabilities.threadSnooze === true;
         const isSettled = settledThreadKeysRef.current.has(threadKey);
         const isSnoozed = snoozedThreadKeysRef.current.has(threadKey);
+        // Lifecycle items act on the thread's whole worktree; the labels
+        // say so as soon as more than one thread shares it.
+        const groupThreads = groupByThreadKeyRef.current.get(threadKey)?.threads ?? [thread];
+        const isMultiThreadWorktree = groupThreads.length > 1;
+        const settleLabel = isMultiThreadWorktree
+          ? `Settle worktree (${groupThreads.length} threads)`
+          : "Settle thread";
+        const unsettleLabel = isMultiThreadWorktree ? "Un-settle worktree" : "Un-settle thread";
+        const wakeLabel = isMultiThreadWorktree ? "Wake worktree" : "Wake thread";
+        const menuNow = new Date().toISOString();
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date());
         const clicked = await settlePromise(() =>
@@ -2012,18 +2635,22 @@ export default function SidebarV2() {
               ...(supportsSettlement
                 ? [
                     isSettled
-                      ? { id: "unsettle", label: "Un-settle thread" }
-                      : { id: "settle", label: "Settle thread" },
+                      ? { id: "unsettle", label: unsettleLabel }
+                      : { id: "settle", label: settleLabel },
                   ]
                 : []),
               ...(supportsSnooze
                 ? [
                     isSnoozed
-                      ? { id: "unsnooze", label: "Wake thread" }
+                      ? { id: "unsnooze", label: wakeLabel }
                       : {
                           id: "snooze",
-                          label: "Snooze",
-                          disabled: !canSnooze(thread, { now: new Date().toISOString() }),
+                          label: isMultiThreadWorktree
+                            ? `Snooze worktree (${groupThreads.length} threads)`
+                            : "Snooze",
+                          disabled: !groupThreads.every((member) =>
+                            canSnooze(member, { now: menuNow }),
+                          ),
                           children: snoozePresets.map((preset) => ({
                             id: `snooze:${preset.id}`,
                             label: `${preset.label} (${preset.whenLabel})`,
@@ -2390,71 +3017,65 @@ export default function SidebarV2() {
           >
             <ul ref={attachListAutoAnimateRef} role="list" className="flex flex-col gap-px">
               {(() => {
-                const renderThreadRow = (
-                  thread: EnvironmentThreadShell,
-                  section: "active" | "snoozed" | "settled",
+                // Shelf rows collapse a whole WORKTREE to one slim line; the
+                // representative thread carries title/branch/tooltip and the
+                // lifecycle actions expand back to the group.
+                const renderShelfRow = (
+                  group: SidebarWorktreeGroup,
+                  section: "snoozed" | "settled",
+                  representative: EnvironmentThreadShell,
                 ) => {
-                  const threadKey = scopedThreadKey(
-                    scopeThreadRef(thread.environmentId, thread.id),
-                  );
-                  // Settled and snoozed are the ONLY things that collapse a
-                  // row: every other thread is a full card. Density comes
-                  // from users (or the auto rules) actually parking work,
-                  // not from the sidebar second-guessing what still matters.
-                  const isCard = section === "active";
-                  const rowVariant = isCard ? "card" : "slim";
+                  const threadKey = sidebarThreadKey(representative);
                   return (
                     <SidebarV2Row
-                      // Keyed per variant on purpose: when a thread settles,
+                      // Keyed per form on purpose: when a worktree settles,
                       // the card fades out in place and the slim row fades
                       // in at its settled position instead of one element
                       // FLIP-sliding through every row in between (rows here
                       // are translucent, so a crossing row reads as text
                       // painted over text).
-                      key={`${threadKey}:${rowVariant}`}
-                      thread={thread}
-                      variant={rowVariant}
+                      key={`${group.key}:slim`}
+                      thread={representative}
                       // Snoozed rows wake; settled rows un-settle (explicit
                       // settles clear the override, auto-settled rows get
-                      // pinned active); cards settle.
-                      variantAction={
-                        section === "snoozed"
-                          ? "unsnooze"
-                          : section === "settled"
-                            ? "unsettle"
-                            : "settle"
-                      }
+                      // pinned active) — both act on the whole worktree.
+                      variantAction={section === "snoozed" ? "unsnooze" : "unsettle"}
                       settlementSupported={
-                        serverConfigs.get(thread.environmentId)?.environment.capabilities
+                        serverConfigs.get(representative.environmentId)?.environment.capabilities
                           .threadSettlement === true
                       }
                       snoozeSupported={
-                        serverConfigs.get(thread.environmentId)?.environment.capabilities
+                        serverConfigs.get(representative.environmentId)?.environment.capabilities
                           .threadSnooze === true
                       }
                       snoozeWakeLabelText={
-                        section === "snoozed" && thread.snoozedUntil != null
-                          ? snoozeWakeLabel(thread.snoozedUntil, new Date())
+                        section === "snoozed" && representative.snoozedUntil != null
+                          ? snoozeWakeLabel(representative.snoozedUntil, new Date())
                           : null
                       }
                       // All sections: a woken thread can classify straight
                       // into the settled tail (PR merged while snoozed), and
                       // the wake signal must survive the trip. Still-snoozed
                       // rows resolve to null on their own.
-                      wokeAt={threadWokeAt(thread, { now: snoozeNow })}
+                      wokeAt={threadWokeAt(representative, { now: snoozeNow })}
                       isActive={routeThreadKey === threadKey}
                       jumpLabel={showJumpHints ? (jumpLabelByKey.get(threadKey) ?? null) : null}
                       currentEnvironmentId={primaryEnvironmentId}
-                      environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
+                      environmentLabel={
+                        environmentLabelById.get(representative.environmentId) ?? null
+                      }
                       projectCwd={
-                        projectCwdByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null
+                        projectCwdByKey.get(
+                          `${representative.environmentId}:${representative.projectId}`,
+                        ) ?? null
                       }
                       projectTitle={
                         projectDisplayNameByKey.get(
-                          `${thread.environmentId}:${thread.projectId}`,
+                          `${representative.environmentId}:${representative.projectId}`,
                         ) ?? null
                       }
                       providerEntryByInstanceId={providerEntryByInstanceId}
+                      changeRequestThreadKeys={group.memberKeys}
                       onThreadClick={handleThreadClick}
                       onThreadActivate={navigateToThread}
                       onStartRename={startThreadRename}
@@ -2464,23 +3085,66 @@ export default function SidebarV2() {
                       isRenaming={renamingThreadKey === threadKey}
                       renamingTitle={renamingThreadKey === threadKey ? renamingTitle : ""}
                       onContextMenu={handleThreadContextMenu}
-                      onSettle={attemptSettle}
                       onUnsettle={attemptUnsettle}
-                      onSnooze={attemptSnooze}
                       onUnsnooze={attemptUnsnooze}
                       onChangeRequestState={handleChangeRequestState}
                     />
                   );
                 };
-                const items: ReactNode[] = activeThreads.map((thread) =>
-                  renderThreadRow(thread, "active"),
-                );
+                const items: ReactNode[] = activeGroups.map((group) => {
+                  const newest = group.threads[group.threads.length - 1]!;
+                  const projectLookupKey = `${newest.environmentId}:${newest.projectId}` as const;
+                  const activeThreadKey =
+                    routeThreadKey !== null && group.memberKeys.includes(routeThreadKey)
+                      ? routeThreadKey
+                      : null;
+                  const renamingInGroup =
+                    renamingThreadKey !== null && group.memberKeys.includes(renamingThreadKey)
+                      ? renamingThreadKey
+                      : null;
+                  return (
+                    <SidebarV2WorktreeCard
+                      key={`${group.key}:card`}
+                      groupKey={group.key}
+                      threads={group.threads}
+                      memberKeys={group.memberKeys}
+                      activeThreadKey={activeThreadKey}
+                      settlementSupported={
+                        serverConfigs.get(newest.environmentId)?.environment.capabilities
+                          .threadSettlement === true
+                      }
+                      snoozeSupported={
+                        serverConfigs.get(newest.environmentId)?.environment.capabilities
+                          .threadSnooze === true
+                      }
+                      snoozeNow={snoozeNow}
+                      currentEnvironmentId={primaryEnvironmentId}
+                      environmentLabel={environmentLabelById.get(newest.environmentId) ?? null}
+                      projectCwd={projectCwdByKey.get(projectLookupKey) ?? null}
+                      projectTitle={projectDisplayNameByKey.get(projectLookupKey) ?? null}
+                      providerEntryByInstanceId={providerEntryByInstanceId}
+                      jumpLabelByKey={showJumpHints ? jumpLabelByKey : null}
+                      renamingThreadKey={renamingInGroup}
+                      renamingTitle={renamingInGroup !== null ? renamingTitle : ""}
+                      onThreadClick={handleThreadClick}
+                      onThreadActivate={navigateToThread}
+                      onStartRename={startThreadRename}
+                      onRenameTitleChange={setRenamingTitle}
+                      onCommitRename={commitThreadRename}
+                      onCancelRename={cancelThreadRename}
+                      onContextMenu={handleThreadContextMenu}
+                      onSettle={attemptSettle}
+                      onSnooze={attemptSnooze}
+                      onChangeRequestState={handleChangeRequestState}
+                    />
+                  );
+                });
                 // Snoozed shelf: between the inbox and Settled — out of the
                 // way, never gone. The header always renders while anything
                 // is snoozed (the count is the whole footprint when
                 // collapsed); rows only when expanded. Vanishes entirely at
                 // count 0.
-                if (snoozedThreads.length > 0) {
+                if (snoozedGroups.length > 0) {
                   items.push(
                     <li key="snoozed-shelf-header" data-thread-selection-safe className="list-none">
                       <button
@@ -2491,7 +3155,7 @@ export default function SidebarV2() {
                         className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
                       >
                         <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
-                          {snoozedShelfExpanded ? "Snoozed" : `Snoozed (${snoozedThreads.length})`}
+                          {snoozedShelfExpanded ? "Snoozed" : `Snoozed (${snoozedGroups.length})`}
                         </span>
                         <span className="h-px flex-1 bg-blue-500/20 dark:bg-blue-400/15" />
                         <ChevronDownIcon
@@ -2504,11 +3168,11 @@ export default function SidebarV2() {
                       </button>
                     </li>,
                   );
-                  for (const thread of visibleSnoozedThreads) {
-                    items.push(renderThreadRow(thread, "snoozed"));
-                  }
+                  visibleSnoozedGroups.forEach((group, index) => {
+                    items.push(renderShelfRow(group, "snoozed", snoozedRepThreads[index]!));
+                  });
                 }
-                if (settledThreads.length > 0) {
+                if (settledGroups.length > 0) {
                   items.push(
                     <li key="settled-shelf-header" data-thread-selection-safe className="list-none">
                       <button
@@ -2519,7 +3183,7 @@ export default function SidebarV2() {
                         className="mb-1 mt-3 flex w-full cursor-pointer items-center gap-2 px-2.5 text-left"
                       >
                         <span className="text-xs font-medium text-muted-foreground/50">
-                          {settledShelfExpanded ? "Settled" : `Settled (${settledThreads.length})`}
+                          {settledShelfExpanded ? "Settled" : `Settled (${settledGroups.length})`}
                         </span>
                         <span className="h-px flex-1 bg-sidebar-border/60" />
                         <ChevronDownIcon
@@ -2533,9 +3197,9 @@ export default function SidebarV2() {
                     </li>,
                   );
                 }
-                for (const thread of renderedSettledThreads) {
-                  items.push(renderThreadRow(thread, "settled"));
-                }
+                renderedSettledGroups.forEach((group, index) => {
+                  items.push(renderShelfRow(group, "settled", settledRepThreads[index]!));
+                });
                 return items;
               })()}
               {settledShelfExpanded && hiddenSettledCount > 0 ? (
@@ -2552,7 +3216,7 @@ export default function SidebarV2() {
               ) : null}
             </ul>
           </TooltipProvider>
-          {activeThreads.length + snoozedThreads.length + settledThreads.length === 0 ? (
+          {activeGroups.length + snoozedGroups.length + settledGroups.length === 0 ? (
             <div className="flex flex-col items-center gap-2 px-2 py-6 text-center text-xs text-muted-foreground/60">
               {projects.length === 0 ? (
                 <>

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -95,6 +95,7 @@ import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments"
 import { useProjects, useThreadShells } from "../state/entities";
 import { useRunningTerminalsForThreads } from "../state/terminalSessions";
 import { useDiscoveredPortsForThreads } from "../portDiscoveryState";
+import { useWorktreeCanonicalThreadRef } from "../worktreeScope";
 import { previewEnvironment } from "../state/preview";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
@@ -666,102 +667,101 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
 
   return (
     <li
-        data-thread-item
-        className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
-      >
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <div
-                role="button"
-                tabIndex={0}
-                data-testid="sidebar-v2-row-slim"
-                className={cn(rowSurfaceClassName, "flex h-9 items-center gap-2.5 px-2.5")}
-                onClick={handleClick}
-                onDoubleClick={handleDoubleClick}
-                onKeyDown={handleKeyDown}
-                onContextMenu={handleContextMenu}
-              />
-            }
-          >
-            {/* Settled history recedes: dimmed favicon at rest, restored on
+      data-thread-item
+      className="list-none [content-visibility:auto] [contain-intrinsic-size:auto_34px]"
+    >
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div
+              role="button"
+              tabIndex={0}
+              data-testid="sidebar-v2-row-slim"
+              className={cn(rowSurfaceClassName, "flex h-9 items-center gap-2.5 px-2.5")}
+              onClick={handleClick}
+              onDoubleClick={handleDoubleClick}
+              onKeyDown={handleKeyDown}
+              onContextMenu={handleContextMenu}
+            />
+          }
+        >
+          {/* Settled history recedes: dimmed favicon at rest, restored on
               hover so the tail stays scannable when you're hunting. */}
-            <span
-              className={cn(
-                "shrink-0 transition-opacity",
-                !props.isActive &&
-                  "opacity-40 grayscale group-hover/v2-row:opacity-100 group-hover/v2-row:grayscale-0",
-              )}
-            >
-              <ProjectFavicon
-                environmentId={thread.environmentId}
-                cwd={props.projectCwd ?? ""}
-                className="size-4"
-                fallbackIcon={MessageSquareIcon}
-              />
-            </span>
-            {title}
-            {/* The PR badge stays outside the hover-fading slot: it must
+          <span
+            className={cn(
+              "shrink-0 transition-opacity",
+              !props.isActive &&
+                "opacity-40 grayscale group-hover/v2-row:opacity-100 group-hover/v2-row:grayscale-0",
+            )}
+          >
+            <ProjectFavicon
+              environmentId={thread.environmentId}
+              cwd={props.projectCwd ?? ""}
+              className="size-4"
+              fallbackIcon={MessageSquareIcon}
+            />
+          </span>
+          {title}
+          {/* The PR badge stays outside the hover-fading slot: it must
               remain visible AND clickable while the row is hovered. Only
               the time/jump label yields to the settle affordance. */}
-            {prBadge}
-            <span className="relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end">
-              <span className="inline-flex justify-end tabular-nums text-muted-foreground/55 transition-opacity group-hover/v2-row:opacity-0">
-                {variantAction === "unsnooze" && props.snoozeWakeLabelText !== null ? (
-                  // Snoozed rows show when they come BACK, not when they were
-                  // last touched — the return ticket is the row's whole story.
-                  <span className="text-xs text-blue-600 tabular-nums dark:text-blue-400">
-                    {props.snoozeWakeLabelText}
-                  </span>
-                ) : isWoke ? (
-                  // A wake can land straight in the settled tail (e.g. PR
-                  // merged while snoozed); the signal must survive the trip.
-                  <span
-                    role="status"
-                    aria-label="Woke from snooze"
-                    className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-300"
-                  >
-                    <AlarmClockIcon aria-hidden className="size-3" />
-                    Woke
-                  </span>
-                ) : (
-                  <span className="text-xs">
-                    {variantAction === "unsettle"
-                      ? settledTimeLabel(thread)
-                      : threadTimeLabel(thread)}
-                  </span>
-                )}
-              </span>
-              {variantAction === "unsnooze" ? (
-                !props.snoozeSupported ? null : (
-                  <button
-                    type="button"
-                    aria-label="Wake thread now"
-                    onClick={handleUnsnoozeClick}
-                    className="absolute inset-y-0 right-0 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/v2-row:opacity-100"
-                  >
-                    <AlarmClockOffIcon className="size-3" />
-                  </button>
-                )
-              ) : !props.settlementSupported ? null : (
-                <button
-                  type="button"
-                  aria-label="Un-settle thread"
-                  onClick={handleUnsettleClick}
-                  className="absolute inset-y-0 right-0 -mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/v2-row:opacity-100"
+          {prBadge}
+          <span className="relative ml-auto flex h-6 min-w-8 shrink-0 items-center justify-end">
+            <span className="inline-flex justify-end tabular-nums text-muted-foreground/55 transition-opacity group-hover/v2-row:opacity-0">
+              {variantAction === "unsnooze" && props.snoozeWakeLabelText !== null ? (
+                // Snoozed rows show when they come BACK, not when they were
+                // last touched — the return ticket is the row's whole story.
+                <span className="text-xs text-blue-600 tabular-nums dark:text-blue-400">
+                  {props.snoozeWakeLabelText}
+                </span>
+              ) : isWoke ? (
+                // A wake can land straight in the settled tail (e.g. PR
+                // merged while snoozed); the signal must survive the trip.
+                <span
+                  role="status"
+                  aria-label="Woke from snooze"
+                  className="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-300"
                 >
-                  <Undo2Icon className="mb-px size-3.5" />
-                </button>
+                  <AlarmClockIcon aria-hidden className="size-3" />
+                  Woke
+                </span>
+              ) : (
+                <span className="text-xs">
+                  {variantAction === "unsettle"
+                    ? settledTimeLabel(thread)
+                    : threadTimeLabel(thread)}
+                </span>
               )}
             </span>
-            {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
-          </TooltipTrigger>
-          {detailsTooltip}
-        </Tooltip>
-      </li>
+            {variantAction === "unsnooze" ? (
+              !props.snoozeSupported ? null : (
+                <button
+                  type="button"
+                  aria-label="Wake thread now"
+                  onClick={handleUnsnoozeClick}
+                  className="absolute inset-y-0 right-0 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-2 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/v2-row:opacity-100"
+                >
+                  <AlarmClockOffIcon className="size-3" />
+                </button>
+              )
+            ) : !props.settlementSupported ? null : (
+              <button
+                type="button"
+                aria-label="Un-settle thread"
+                onClick={handleUnsettleClick}
+                className="absolute inset-y-0 right-0 -mr-1 inline-flex cursor-pointer items-center gap-1 rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/v2-row:opacity-100"
+              >
+                <Undo2Icon className="mb-px size-3.5" />
+              </button>
+            )}
+          </span>
+          {props.jumpLabel ? <JumpHintBadge label={props.jumpLabel} /> : null}
+        </TooltipTrigger>
+        {detailsTooltip}
+      </Tooltip>
+    </li>
   );
 });
-
 
 function latestTurnDiff(
   thread: SidebarThreadSummary,
@@ -1077,7 +1077,16 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
         ) ?? null);
   const isActiveCard = activeMember !== null;
   const environmentId = newest.environmentId;
-  const threadIds = useMemo(() => threads.map((thread) => thread.id), [threads]);
+  const canonicalThreadRef = useWorktreeCanonicalThreadRef(newestRef);
+  const threadIds = useMemo(
+    () => [
+      ...new Set([
+        ...threads.map((thread) => thread.id),
+        ...(canonicalThreadRef ? [canonicalThreadRef.threadId] : []),
+      ]),
+    ],
+    [canonicalThreadRef, threads],
+  );
 
   // Worktree-level activity: any member thread's terminal with a running
   // subprocess, and any dev server discovered on a member's terminal. These
@@ -1183,23 +1192,24 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
   const worktreePath = threads.find((thread) => thread.worktreePath !== null)?.worktreePath ?? null;
   const gitCwd = worktreePath ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(
-    (newest.branch != null || worktreePath !== null) && gitCwd !== null
+    gitCwd !== null
       ? vcsEnvironment.status({
           environmentId,
           input: { cwd: gitCwd },
         })
       : null,
   );
+  const checkoutBranch =
+    worktreePath === null ? (gitStatus.data?.refName ?? newest.branch) : newest.branch;
   const branchMismatch = resolveLocalCheckoutBranchMismatch({
     effectiveEnvMode: worktreePath === null ? "local" : "worktree",
     activeWorktreePath: worktreePath,
-    activeThreadBranch: newest.branch,
+    activeThreadBranch: checkoutBranch,
     currentGitBranch: gitStatus.data?.refName ?? null,
   });
   const pr = resolveThreadPr({
-    threadBranch: newest.branch,
+    threadBranch: checkoutBranch,
     gitStatus: gitStatus.data,
-    hasDedicatedWorktree: worktreePath !== null,
   });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const prState = pr?.state ?? null;
@@ -1261,6 +1271,9 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
   // member can take it — a half-applied snooze would leave the card in
   // place and read as a failed click.
   const snoozeNowIso = new Date().toISOString();
+  const showSettleButton =
+    props.settlementSupported &&
+    threads.every((thread) => canSettle(thread, { now: snoozeNowIso }));
   const showSnoozeButton =
     props.snoozeSupported && threads.every((thread) => canSnooze(thread, { now: snoozeNowIso }));
   const snoozeMenuOpen = snoozeMenuOpenRaw && showSnoozeButton;
@@ -1282,7 +1295,10 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
         : shouldRecede
           ? "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
           : "bg-transparent text-sidebar-foreground hover:bg-sidebar-row-hover",
-    isInFlight && !isActiveCard && !anySelected && "opacity-70 transition-opacity hover:opacity-100",
+    isInFlight &&
+      !isActiveCard &&
+      !anySelected &&
+      "opacity-70 transition-opacity hover:opacity-100",
   );
 
   return (
@@ -1365,7 +1381,10 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
               >
                 {topStatus ? (
                   <span
-                    className={cn("inline-flex items-center gap-1 font-medium", topStatus.className)}
+                    className={cn(
+                      "inline-flex items-center gap-1 font-medium",
+                      topStatus.className,
+                    )}
                   >
                     {topStatus.icon === "working" ? (
                       <CircleDashedIcon aria-hidden className="size-4 shrink-0" />
@@ -1388,7 +1407,7 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
                   threadTimeLabel(timeLabelThread)
                 )}
               </span>
-              {props.settlementSupported || showSnoozeButton ? (
+              {showSettleButton || showSnoozeButton ? (
                 <span
                   className={cn(
                     "absolute inset-y-0 right-0 flex items-stretch gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/v2-row:opacity-100",
@@ -1402,7 +1421,7 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
                       onSnooze={handleSnoozePreset}
                     />
                   ) : null}
-                  {props.settlementSupported ? (
+                  {showSettleButton ? (
                     <button
                       type="button"
                       aria-label="Settle worktree"
@@ -1446,8 +1465,8 @@ const SidebarV2WorktreeCard = memo(function SidebarV2WorktreeCard(props: {
             })}
           </div>
           <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground/75">
-            {newest.branch ? (
-              <span className="min-w-0 flex-1 truncate whitespace-nowrap">{newest.branch}</span>
+            {checkoutBranch ? (
+              <span className="min-w-0 flex-1 truncate whitespace-nowrap">{checkoutBranch}</span>
             ) : (
               <span className="flex-1" />
             )}
@@ -2002,11 +2021,13 @@ export default function SidebarV2() {
   // Shelf rows stand in for their whole group; the representative prefers
   // the route thread so highlight and navigation stay honest.
   const snoozedRepThreads = useMemo(
-    () => visibleSnoozedGroups.map((group) => pickWorktreeGroupRepresentative(group, routeThreadKey)),
+    () =>
+      visibleSnoozedGroups.map((group) => pickWorktreeGroupRepresentative(group, routeThreadKey)),
     [routeThreadKey, visibleSnoozedGroups],
   );
   const settledRepThreads = useMemo(
-    () => renderedSettledGroups.map((group) => pickWorktreeGroupRepresentative(group, routeThreadKey)),
+    () =>
+      renderedSettledGroups.map((group) => pickWorktreeGroupRepresentative(group, routeThreadKey)),
     [renderedSettledGroups, routeThreadKey],
   );
   // The flat jump/selection spine: card members in visual order, then the
@@ -2241,10 +2262,11 @@ export default function SidebarV2() {
           );
         });
         if (pending.length === 0) return;
-        // Prefer members the server will accept; when none qualify, send
-        // the first anyway so the user sees the server's reason.
-        const settleable = pending.filter((thread) => canSettle(thread, { now }));
-        const targets = settleable.length > 0 ? settleable : [pending[0]!];
+        // A worktree-level action is all-or-nothing. If any member is blocked,
+        // send only that member so the server's reason reaches the user without
+        // partially settling its siblings.
+        const blocked = pending.find((thread) => !canSettle(thread, { now }));
+        const targets = blocked ? [blocked] : pending;
         const targetKeys = targets.map(sidebarThreadKey);
         for (const key of targetKeys) settlingThreadKeysRef.current.add(key);
         try {

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -31,7 +31,6 @@ import {
 } from "~/previewStateStore";
 import { usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
 import { resolveWorktreeCanonicalThreadRef } from "~/worktreeScope";
-import { useRightPanelStore } from "~/rightPanelStore";
 import { resolveBrowserNavigationTarget } from "~/browser/browserTargetResolver";
 import {
   readActiveBrowserRecordingTargets,

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -30,6 +30,8 @@ import {
   updatePreviewServerSnapshot,
 } from "~/previewStateStore";
 import { usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
+import { resolveWorktreeCanonicalThreadRef } from "~/worktreeScope";
+import { useRightPanelStore } from "~/rightPanelStore";
 import { resolveBrowserNavigationTarget } from "~/browser/browserTargetResolver";
 import {
   readActiveBrowserRecordingTargets,
@@ -301,10 +303,13 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
 
   const handleRequest = useCallback(
     async (request: PreviewAutomationRequest): Promise<unknown> => {
-      const threadRef: ScopedThreadRef = {
+      // Preview sessions are worktree-scoped: an automation request from any
+      // thread in a checkout drives the worktree's shared session via its
+      // canonical thread id.
+      const threadRef: ScopedThreadRef = resolveWorktreeCanonicalThreadRef({
         environmentId,
         threadId: request.threadId,
-      };
+      });
       let tabId = request.tabId ?? null;
       try {
         let state = readThreadPreviewState(threadRef);
@@ -312,7 +317,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
         if (needsSessionSync) {
           const listTarget = {
             environmentId,
-            input: { threadId: request.threadId },
+            input: { threadId: threadRef.threadId },
           } as const;
           registry.refresh(previewEnvironment.list(listTarget));
           const result = await listPreviews(listTarget);
@@ -327,7 +332,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           requestId: request.requestId,
           operation: request.operation,
           environmentId,
-          threadId: request.threadId,
+          threadId: threadRef.threadId,
           tabId,
           bridgeAvailable: Boolean(previewBridge),
         };
@@ -378,7 +383,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               const result = await open({
                 environmentId,
                 input: {
-                  threadId: request.threadId,
+                  threadId: threadRef.threadId,
                   ...(resolvedInputUrl ? { url: resolvedInputUrl } : {}),
                 },
               });
@@ -502,7 +507,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               const result = await resize({
                 environmentId,
                 input: {
-                  threadId: request.threadId,
+                  threadId: threadRef.threadId,
                   tabId: ready.tabId,
                   viewport: setting,
                 },
@@ -528,7 +533,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                   requestId: request.requestId,
                   operation: request.operation,
                   environmentId,
-                  threadId: request.threadId,
+                  threadId: threadRef.threadId,
                 },
               );
             } catch (cause) {
@@ -548,7 +553,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                   const rollback = await resize({
                     environmentId,
                     input: {
-                      threadId: request.threadId,
+                      threadId: threadRef.threadId,
                       tabId: ready.tabId,
                       viewport: applied.previousSetting,
                     },
@@ -654,7 +659,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 new PreviewAutomationRecordingNotActiveError({
                   requestId: request.requestId,
                   environmentId,
-                  threadId: request.threadId,
+                  threadId: threadRef.threadId,
                   tabId,
                 }),
               );
@@ -667,7 +672,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           requestId: request.requestId,
           operation: request.operation,
           environmentId,
-          threadId: request.threadId,
+          threadId: threadRef.threadId,
           tabId,
           cause,
         });

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -25,6 +25,16 @@ vi.mock("~/state/session", () => ({
   readPreparedConnection: mocks.readPreparedConnection,
 }));
 
+// worktreeScope pulls the full entities/server atom graph into the module
+// graph; identity stubs keep this suite's narrow mocks sufficient.
+vi.mock("~/worktreeScope", () => ({
+  useWorktreeCanonicalThreadRef: (ref: unknown) => ref,
+  useWorktreeScopeKeyForThreadRef: (ref: unknown) =>
+    ref === null ? null : JSON.stringify(ref),
+  resolveWorktreeCanonicalThreadRef: (ref: unknown) => ref,
+  resolveWorktreeScopeKeyForThreadRef: (ref: unknown) => JSON.stringify(ref),
+}));
+
 vi.mock("~/composerDraftStore", () => ({
   useComposerDraftStore: (
     select: (store: { addPreviewAnnotation: () => void; addImage: () => void }) => unknown,

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -29,8 +29,7 @@ vi.mock("~/state/session", () => ({
 // graph; identity stubs keep this suite's narrow mocks sufficient.
 vi.mock("~/worktreeScope", () => ({
   useWorktreeCanonicalThreadRef: (ref: unknown) => ref,
-  useWorktreeScopeKeyForThreadRef: (ref: unknown) =>
-    ref === null ? null : JSON.stringify(ref),
+  useWorktreeScopeKeyForThreadRef: (ref: unknown) => (ref === null ? null : JSON.stringify(ref)),
   resolveWorktreeCanonicalThreadRef: (ref: unknown) => ref,
   resolveWorktreeScopeKeyForThreadRef: (ref: unknown) => JSON.stringify(ref),
 }));

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -24,6 +24,7 @@ import { previewEnvironment } from "~/state/preview";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
 import { useRightPanelStore } from "~/rightPanelStore";
+import { useWorktreeCanonicalThreadRef } from "~/worktreeScope";
 
 import { previewBridge } from "./previewBridge";
 import { subscribePreviewAction } from "./previewActionBus";
@@ -82,6 +83,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   const addImage = useComposerDraftStore((store) => store.addImage);
   const environment = useEnvironment(threadRef.environmentId);
   const environmentHttpBaseUrl = useEnvironmentHttpBaseUrl(threadRef.environmentId);
+  const canonicalThreadRef = useWorktreeCanonicalThreadRef(threadRef) ?? threadRef;
   const open = useAtomCommand(previewEnvironment.open);
   const resize = useAtomCommand(previewEnvironment.resize, "preview viewport resize");
 
@@ -96,13 +98,13 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
 
   const tabId = requestedTabId ?? previewState.activeTabId;
   const runtimeTabId = tabId
-    ? previewRuntimeTabId(threadRef, previewState.serverEpoch, tabId)
+    ? previewRuntimeTabId(canonicalThreadRef, previewState.serverEpoch, tabId)
     : null;
   const recordingRuntimeTabId =
     tabId && runtimeTabId
       ? activeRecordingTabIds.has(runtimeTabId)
         ? runtimeTabId
-        : findActiveBrowserRecordingRuntimeTabId(threadRef, tabId)
+        : findActiveBrowserRecordingRuntimeTabId(canonicalThreadRef, tabId)
       : null;
   const snapshot = tabId ? (previewState.sessions[tabId] ?? null) : null;
   const desktopOverlay = tabId ? (previewState.desktopByTabId[tabId] ?? null) : null;

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -11,6 +11,7 @@ import { toastManager } from "~/components/ui/toast";
 import { useThreadPreviewState } from "~/previewStateStore";
 import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
 import { useRightPanelStore } from "~/rightPanelStore";
+import { useWorktreeCanonicalThreadRef } from "~/worktreeScope";
 
 import { previewBridge } from "./previewBridge";
 import {
@@ -49,8 +50,9 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
     selectThreadPreviewMiniPlayer(state.byThreadKey, threadRef),
   );
   const previewState = useThreadPreviewState(threadRef);
+  const canonicalThreadRef = useWorktreeCanonicalThreadRef(threadRef) ?? threadRef;
   const snapshot = previewState.sessions[tabId] ?? null;
-  const runtimeTabId = previewRuntimeTabId(threadRef, previewState.serverEpoch, tabId);
+  const runtimeTabId = previewRuntimeTabId(canonicalThreadRef, previewState.serverEpoch, tabId);
   const desktopOverlay = previewState.desktopByTabId[tabId] ?? null;
   const position = miniPlayer?.tabId === tabId ? miniPlayer.position : null;
   const size =

--- a/apps/web/src/components/preview/closePreviewSession.ts
+++ b/apps/web/src/components/preview/closePreviewSession.ts
@@ -7,6 +7,7 @@ import type {
 } from "@t3tools/contracts";
 
 import { beginPreviewSessionClose, cancelPreviewSessionClose } from "~/previewStateStore";
+import { resolveWorktreeCanonicalThreadRef } from "~/worktreeScope";
 
 interface ClosePreviewSessionInput<E> {
   readonly closePreview: (input: {
@@ -26,9 +27,12 @@ export async function closePreviewSession<E>(
   input: ClosePreviewSessionInput<E>,
 ): Promise<AtomCommandResult<void, E>> {
   beginPreviewSessionClose(input.threadRef, input.tabId);
+  // Preview sessions are worktree-scoped: close through the worktree's
+  // canonical thread id, matching how the session was opened.
+  const canonicalRef = resolveWorktreeCanonicalThreadRef(input.threadRef);
   const result = await input.closePreview({
-    environmentId: input.threadRef.environmentId,
-    input: { threadId: input.threadRef.threadId, tabId: input.tabId },
+    environmentId: canonicalRef.environmentId,
+    input: { threadId: canonicalRef.threadId, tabId: input.tabId },
   });
   if (result._tag === "Failure") {
     cancelPreviewSessionClose(input.threadRef, input.snapshot, input.tabId);

--- a/apps/web/src/components/preview/openPreviewSession.ts
+++ b/apps/web/src/components/preview/openPreviewSession.ts
@@ -7,6 +7,7 @@ import type {
 import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
 
 import { applyPreviewServerSnapshot, rememberPreviewUrl } from "~/previewStateStore";
+import { resolveWorktreeCanonicalThreadRef } from "~/worktreeScope";
 
 interface OpenPreviewSessionInput<E> {
   openPreview: (input: {
@@ -20,10 +21,13 @@ interface OpenPreviewSessionInput<E> {
 export async function openPreviewSession<E>(
   input: OpenPreviewSessionInput<E>,
 ): Promise<AtomCommandResult<PreviewSessionSnapshot, E>> {
+  // Preview sessions are worktree-scoped: the wire call uses the worktree's
+  // canonical thread id so sibling threads share one set of tabs.
+  const canonicalRef = resolveWorktreeCanonicalThreadRef(input.threadRef);
   const result = await input.openPreview({
-    environmentId: input.threadRef.environmentId,
+    environmentId: canonicalRef.environmentId,
     input: {
-      threadId: input.threadRef.threadId,
+      threadId: canonicalRef.threadId,
       ...(input.url === undefined ? {} : { url: input.url }),
     },
   });

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -5,6 +5,7 @@ import * as Schema from "effect/Schema";
 
 import type { OpenPreviewMutation } from "~/browser/openFileInPreview";
 import { applyPreviewServerSnapshot, isPreviewSupportedInRuntime } from "~/previewStateStore";
+import { resolveWorktreeCanonicalThreadRef } from "~/worktreeScope";
 import { useRightPanelStore } from "~/rightPanelStore";
 
 const terminalLinkErrorContext = {
@@ -81,9 +82,12 @@ export async function openTerminalLinkInPreview<E>(
   }
 
   if (choice === "open-in-preview") {
+    // Preview sessions are worktree-scoped: open through the worktree's
+    // canonical thread id so sibling threads share one set of tabs.
+    const canonicalRef = resolveWorktreeCanonicalThreadRef(input.threadRef);
     const result = await input.openPreview({
-      environmentId: input.threadRef.environmentId,
-      input: { threadId: input.threadRef.threadId, url: input.url },
+      environmentId: canonicalRef.environmentId,
+      input: { threadId: canonicalRef.threadId, url: input.url },
     });
     if (result._tag === "Failure") {
       if (isAtomCommandInterrupted(result)) {

--- a/apps/web/src/components/preview/usePreviewSession.ts
+++ b/apps/web/src/components/preview/usePreviewSession.ts
@@ -12,6 +12,7 @@ import {
   reconcilePreviewServerSessions,
 } from "~/previewStateStore";
 import { previewEnvironment } from "~/state/preview";
+import { useWorktreeCanonicalThreadRef } from "~/worktreeScope";
 
 class PreviewSessionThreadKeyParseError extends Schema.TaggedErrorClass<PreviewSessionThreadKeyParseError>()(
   "PreviewSessionThreadKeyParseError",
@@ -79,5 +80,9 @@ const previewSessionSyncAtom = Atom.family((threadKey: string) => {
 });
 
 export function usePreviewSession(threadRef: ScopedThreadRef): void {
-  useAtomValue(previewSessionSyncAtom(scopedThreadKey(threadRef)));
+  // Preview sessions are worktree-scoped: every thread in a checkout syncs
+  // through the worktree's canonical thread id, so the same tabs stay
+  // attached as the user jumps between sibling threads.
+  const canonicalRef = useWorktreeCanonicalThreadRef(threadRef);
+  useAtomValue(previewSessionSyncAtom(scopedThreadKey(canonicalRef ?? threadRef)));
 }

--- a/apps/web/src/diffPanelStore.test.ts
+++ b/apps/web/src/diffPanelStore.test.ts
@@ -79,4 +79,16 @@ describe("diffPanelStore", () => {
       revealRequestId: 1,
     });
   });
+
+  it("falls back to checkout changes when a sibling has no turn diffs", () => {
+    useDiffPanelStore
+      .getState()
+      .selectTurn(THREAD_REF, TurnId.make("turn-from-sibling"), "src/app.ts");
+
+    useDiffPanelStore.getState().reconcileTurnSelection(THREAD_REF, []);
+
+    expect(
+      selectThreadDiffPanelSelection(useDiffPanelStore.getState().byThreadKey, THREAD_REF),
+    ).toEqual({ kind: "branch", baseRef: null });
+  });
 });

--- a/apps/web/src/diffPanelStore.test.ts
+++ b/apps/web/src/diffPanelStore.test.ts
@@ -64,7 +64,7 @@ describe("diffPanelStore", () => {
     ).toEqual({ kind: "branch", baseRef: "origin/main" });
   });
 
-  it("reconciles a missing turn selection to the latest available turn", () => {
+  it("reconciles to the latest turn without retaining a sibling's file path", () => {
     const missingTurnId = TurnId.make("turn-missing");
     const latestTurnId = TurnId.make("turn-latest");
     useDiffPanelStore.getState().selectTurn(THREAD_REF, missingTurnId, "src/app.ts");
@@ -75,7 +75,7 @@ describe("diffPanelStore", () => {
     ).toEqual({
       kind: "turn",
       turnId: latestTurnId,
-      filePath: "src/app.ts",
+      filePath: null,
       revealRequestId: 1,
     });
   });

--- a/apps/web/src/diffPanelStore.ts
+++ b/apps/web/src/diffPanelStore.ts
@@ -116,7 +116,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
                       kind: "branch",
                       baseRef: migratedBaseRefs.record[threadKey] ?? null,
                     }
-                  : { ...previous, turnId: latestTurnId },
+                  : { ...previous, turnId: latestTurnId, filePath: null },
             },
             branchBaseRefByThreadKey: migratedBaseRefs.record,
           };

--- a/apps/web/src/diffPanelStore.ts
+++ b/apps/web/src/diffPanelStore.ts
@@ -1,9 +1,13 @@
-import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { ScopedThreadRef, TurnId } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { resolveStorage } from "./lib/storage";
+import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
+
+// Diff selections belong to the CHECKOUT, not the thread: every thread
+// sharing a worktree sees the same diff scope and base ref.
+const diffScopeKey = resolveWorktreeScopeKeyForThreadRef;
 
 export type DiffPanelSelection =
   | { kind: "branch"; baseRef: string | null }
@@ -35,7 +39,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
       branchBaseRefByThreadKey: {},
       selectGitScope: (ref, scope) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const threadKey = diffScopeKey(ref);
           const previous = state.byThreadKey[threadKey];
           const previousBaseRef =
             previous?.kind === "branch"
@@ -57,7 +61,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
         }),
       selectBranchBaseRef: (ref, baseRef) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const threadKey = diffScopeKey(ref);
           const normalizedBaseRef = normalizeBaseRef(baseRef);
           return {
             byThreadKey: {
@@ -72,7 +76,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
         }),
       selectTurn: (ref, turnId, filePath) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const threadKey = diffScopeKey(ref);
           const previous = state.byThreadKey[threadKey];
           return {
             byThreadKey: {
@@ -88,7 +92,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
         }),
       reconcileTurnSelection: (ref, availableTurnIds) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const threadKey = diffScopeKey(ref);
           const previous = state.byThreadKey[threadKey];
           const latestTurnId = availableTurnIds[0];
           if (
@@ -107,7 +111,7 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
         }),
       removeThread: (ref) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const threadKey = diffScopeKey(ref);
           if (!(threadKey in state.byThreadKey) && !(threadKey in state.branchBaseRefByThreadKey)) {
             return state;
           }
@@ -119,7 +123,16 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
     }),
     {
       name: "t3code:diff-panel-state:v1",
-      version: 1,
+      // v2 re-keyed entries from thread keys to worktree scope keys; older
+      // thread-keyed entries can never match again, so they are dropped.
+      version: 2,
+      migrate: (persistedState, version) =>
+        version < 2 || !persistedState || typeof persistedState !== "object"
+          ? { byThreadKey: {}, branchBaseRefByThreadKey: {} }
+          : (persistedState as {
+              byThreadKey: Record<string, DiffPanelSelection>;
+              branchBaseRefByThreadKey: Record<string, string | null>;
+            }),
       storage: createJSONStorage(() =>
         resolveStorage(typeof window !== "undefined" ? window.localStorage : undefined),
       ),
@@ -138,7 +151,7 @@ export function selectThreadDiffPanelSelection(
 ): DiffPanelSelection {
   if (!ref) return DEFAULT_SELECTION;
   return (
-    byThreadKey[scopedThreadKey(ref)] ??
+    byThreadKey[diffScopeKey(ref)] ??
     (hasWorkingTreeChanges ? DEFAULT_WORKING_TREE_SELECTION : DEFAULT_SELECTION)
   );
 }

--- a/apps/web/src/diffPanelStore.ts
+++ b/apps/web/src/diffPanelStore.ts
@@ -3,11 +3,7 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { resolveStorage } from "./lib/storage";
-import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
-
-// Diff selections belong to the CHECKOUT, not the thread: every thread
-// sharing a worktree sees the same diff scope and base ref.
-const diffScopeKey = resolveWorktreeScopeKeyForThreadRef;
+import { migrateWorktreeScopedRecord, readWorktreeScopedRecordValue } from "./worktreeScope";
 
 export type DiffPanelSelection =
   | { kind: "branch"; baseRef: string | null }
@@ -39,15 +35,17 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
       branchBaseRefByThreadKey: {},
       selectGitScope: (ref, scope) =>
         set((state) => {
-          const threadKey = diffScopeKey(ref);
-          const previous = state.byThreadKey[threadKey];
+          const migratedSelections = migrateWorktreeScopedRecord(state.byThreadKey, ref);
+          const migratedBaseRefs = migrateWorktreeScopedRecord(state.branchBaseRefByThreadKey, ref);
+          const threadKey = migratedSelections.key;
+          const previous = migratedSelections.record[threadKey];
           const previousBaseRef =
             previous?.kind === "branch"
               ? previous.baseRef
-              : (state.branchBaseRefByThreadKey[threadKey] ?? null);
+              : (migratedBaseRefs.record[threadKey] ?? null);
           return {
             byThreadKey: {
-              ...state.byThreadKey,
+              ...migratedSelections.record,
               [threadKey]:
                 scope === "branch"
                   ? { kind: "branch", baseRef: previousBaseRef }
@@ -55,32 +53,35 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
             },
             branchBaseRefByThreadKey:
               previous?.kind === "branch"
-                ? { ...state.branchBaseRefByThreadKey, [threadKey]: previous.baseRef }
-                : state.branchBaseRefByThreadKey,
+                ? { ...migratedBaseRefs.record, [threadKey]: previous.baseRef }
+                : migratedBaseRefs.record,
           };
         }),
       selectBranchBaseRef: (ref, baseRef) =>
         set((state) => {
-          const threadKey = diffScopeKey(ref);
+          const migratedSelections = migrateWorktreeScopedRecord(state.byThreadKey, ref);
+          const migratedBaseRefs = migrateWorktreeScopedRecord(state.branchBaseRefByThreadKey, ref);
+          const threadKey = migratedSelections.key;
           const normalizedBaseRef = normalizeBaseRef(baseRef);
           return {
             byThreadKey: {
-              ...state.byThreadKey,
+              ...migratedSelections.record,
               [threadKey]: { kind: "branch", baseRef: normalizedBaseRef },
             },
             branchBaseRefByThreadKey: {
-              ...state.branchBaseRefByThreadKey,
+              ...migratedBaseRefs.record,
               [threadKey]: normalizedBaseRef,
             },
           };
         }),
       selectTurn: (ref, turnId, filePath) =>
         set((state) => {
-          const threadKey = diffScopeKey(ref);
-          const previous = state.byThreadKey[threadKey];
+          const migrated = migrateWorktreeScopedRecord(state.byThreadKey, ref);
+          const threadKey = migrated.key;
+          const previous = migrated.record[threadKey];
           return {
             byThreadKey: {
-              ...state.byThreadKey,
+              ...migrated.record,
               [threadKey]: {
                 kind: "turn",
                 turnId,
@@ -92,32 +93,48 @@ export const useDiffPanelStore = create<DiffPanelStoreState>()(
         }),
       reconcileTurnSelection: (ref, availableTurnIds) =>
         set((state) => {
-          const threadKey = diffScopeKey(ref);
-          const previous = state.byThreadKey[threadKey];
+          const migratedSelections = migrateWorktreeScopedRecord(state.byThreadKey, ref);
+          const migratedBaseRefs = migrateWorktreeScopedRecord(state.branchBaseRefByThreadKey, ref);
+          const threadKey = migratedSelections.key;
+          const previous = migratedSelections.record[threadKey];
           const latestTurnId = availableTurnIds[0];
-          if (
-            previous?.kind !== "turn" ||
-            latestTurnId === undefined ||
-            availableTurnIds.includes(previous.turnId)
-          ) {
-            return state;
+          if (previous?.kind !== "turn" || availableTurnIds.includes(previous.turnId)) {
+            return migratedSelections.record === state.byThreadKey &&
+              migratedBaseRefs.record === state.branchBaseRefByThreadKey
+              ? state
+              : {
+                  byThreadKey: migratedSelections.record,
+                  branchBaseRefByThreadKey: migratedBaseRefs.record,
+                };
           }
           return {
             byThreadKey: {
-              ...state.byThreadKey,
-              [threadKey]: { ...previous, turnId: latestTurnId },
+              ...migratedSelections.record,
+              [threadKey]:
+                latestTurnId === undefined
+                  ? {
+                      kind: "branch",
+                      baseRef: migratedBaseRefs.record[threadKey] ?? null,
+                    }
+                  : { ...previous, turnId: latestTurnId },
             },
+            branchBaseRefByThreadKey: migratedBaseRefs.record,
           };
         }),
       removeThread: (ref) =>
         set((state) => {
-          const threadKey = diffScopeKey(ref);
-          if (!(threadKey in state.byThreadKey) && !(threadKey in state.branchBaseRefByThreadKey)) {
+          const migratedSelections = migrateWorktreeScopedRecord(state.byThreadKey, ref);
+          const migratedBaseRefs = migrateWorktreeScopedRecord(state.branchBaseRefByThreadKey, ref);
+          const threadKey = migratedSelections.key;
+          if (
+            !(threadKey in migratedSelections.record) &&
+            !(threadKey in migratedBaseRefs.record)
+          ) {
             return state;
           }
-          const { [threadKey]: _removed, ...byThreadKey } = state.byThreadKey;
+          const { [threadKey]: _removed, ...byThreadKey } = migratedSelections.record;
           const { [threadKey]: _removedBaseRef, ...branchBaseRefByThreadKey } =
-            state.branchBaseRefByThreadKey;
+            migratedBaseRefs.record;
           return { byThreadKey, branchBaseRefByThreadKey };
         }),
     }),
@@ -151,7 +168,7 @@ export function selectThreadDiffPanelSelection(
 ): DiffPanelSelection {
   if (!ref) return DEFAULT_SELECTION;
   return (
-    byThreadKey[diffScopeKey(ref)] ??
+    readWorktreeScopedRecordValue(byThreadKey, ref) ??
     (hasWorkingTreeChanges ? DEFAULT_WORKING_TREE_SELECTION : DEFAULT_SELECTION)
   );
 }

--- a/apps/web/src/hooks/useThreadActions.test.ts
+++ b/apps/web/src/hooks/useThreadActions.test.ts
@@ -1,7 +1,7 @@
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { ThreadArchiveBlockedError } from "./useThreadActions";
+import { isFinalWorktreeThreadAfterDelete, ThreadArchiveBlockedError } from "./useThreadActions";
 
 describe("ThreadArchiveBlockedError", () => {
   it("keeps the blocked thread context with the fixed message", () => {
@@ -15,5 +15,20 @@ describe("ThreadArchiveBlockedError", () => {
       threadId: "thread-1",
     });
     expect(error.message).toBe("Cannot archive a running thread.");
+  });
+});
+
+describe("isFinalWorktreeThreadAfterDelete", () => {
+  const first = ThreadId.make("thread-1");
+  const final = ThreadId.make("thread-2");
+
+  it("waits until every sibling was actually deleted", () => {
+    expect(isFinalWorktreeThreadAfterDelete(first, [first, final], new Set())).toBe(false);
+    expect(isFinalWorktreeThreadAfterDelete(final, [first, final], new Set([first]))).toBe(true);
+  });
+
+  it("does not treat an intended but uncompleted sibling delete as cleanup authority", () => {
+    expect(isFinalWorktreeThreadAfterDelete(first, [first, final], new Set([final]))).toBe(true);
+    expect(isFinalWorktreeThreadAfterDelete(first, [first, final], new Set())).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -28,12 +28,9 @@ import {
   readThreadShell,
 } from "../state/entities";
 import { useTerminalUiStateStore } from "../terminalUiStateStore";
+import { useRightPanelStore } from "../rightPanelStore";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
-import {
-  forgetWorktreeCanonicalOwnerByScopeKey,
-  resolveWorktreeCanonicalThreadRef,
-  threadWorktreeScopeKey,
-} from "../worktreeScope";
+import { resolveWorktreeCanonicalThreadRef, threadWorktreeScopeKey } from "../worktreeScope";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { useClientSettings } from "./useSettings";
@@ -99,6 +96,16 @@ export class ThreadSnoozeBlockedError extends Schema.TaggedErrorClass<ThreadSnoo
   }
 }
 
+export function isFinalWorktreeThreadAfterDelete(
+  threadId: ThreadId,
+  worktreeThreadIds: ReadonlyArray<ThreadId>,
+  alreadyDeletedThreadIds: ReadonlySet<ThreadId>,
+): boolean {
+  return worktreeThreadIds.every(
+    (candidateId) => candidateId === threadId || alreadyDeletedThreadIds.has(candidateId),
+  );
+}
+
 export function useThreadActions() {
   const closeTerminal = useAtomCommand(terminalEnvironment.close);
   const archiveThreadMutation = useAtomCommand(threadEnvironment.archive, {
@@ -137,6 +144,9 @@ export function useThreadActions() {
   );
   const clearTerminalUiStateForKey = useTerminalUiStateStore(
     (state) => state.clearTerminalUiStateForKey,
+  );
+  const removeTerminalSurfacesForKey = useRightPanelStore(
+    (state) => state.removeTerminalSurfacesForKey,
   );
   const router = useRouter();
   const handleNewThread = useNewThreadHandler();
@@ -206,6 +216,7 @@ export function useThreadActions() {
           input: { threadId: canonicalThreadRef.threadId },
         });
         clearTerminalUiStateForKey(worktreeScopeKey);
+        removeTerminalSurfacesForKey(worktreeScopeKey);
       }
 
       if (shouldNavigateToDraft) {
@@ -225,6 +236,7 @@ export function useThreadActions() {
       clearTerminalUiStateForKey,
       closeTerminal,
       getCurrentRouteThreadRef,
+      removeTerminalSurfacesForKey,
       resolveThreadTarget,
     ],
   );
@@ -283,17 +295,11 @@ export function useThreadActions() {
       const worktreeThreads = threads.filter(
         (entry) => threadWorktreeScopeKey(entry) === worktreeScopeKey,
       );
-      const deletingWorktreeThreadIds = worktreeThreads
-        .filter((entry) => entry.id === threadRef.threadId || deletedIds?.has(entry.id) === true)
-        .map((entry) => entry.id)
-        .toSorted();
-      const worktreeHasSurvivingThread = worktreeThreads.some(
-        (entry) =>
-          entry.id !== threadRef.threadId &&
-          (deletedIds === undefined || !deletedIds.has(entry.id)),
+      const shouldCleanUpWorktreeResources = isFinalWorktreeThreadAfterDelete(
+        threadRef.threadId,
+        worktreeThreads.map((entry) => entry.id),
+        deletedIds ?? new Set<ThreadId>(),
       );
-      const shouldCleanUpWorktreeResources =
-        !worktreeHasSurvivingThread && deletingWorktreeThreadIds[0] === threadRef.threadId;
       const canonicalThreadRef = resolveWorktreeCanonicalThreadRef(threadRef);
       const orphanedWorktreePath = getOrphanedWorktreePathForThread(
         survivingThreads,
@@ -329,13 +335,6 @@ export function useThreadActions() {
         });
       }
 
-      if (shouldCleanUpWorktreeResources) {
-        await closeTerminal({
-          environmentId: canonicalThreadRef.environmentId,
-          input: { threadId: canonicalThreadRef.threadId, deleteHistory: true },
-        });
-      }
-
       const deletedThreadIds = deletedIds ?? new Set<ThreadId>();
       const currentRouteThreadRef = getCurrentRouteThreadRef();
       const shouldNavigateToFallback =
@@ -354,17 +353,20 @@ export function useThreadActions() {
       if (deleteResult._tag === "Failure") {
         return deleteResult;
       }
+      if (shouldCleanUpWorktreeResources) {
+        await closeTerminal({
+          environmentId: canonicalThreadRef.environmentId,
+          input: { threadId: canonicalThreadRef.threadId, deleteHistory: true },
+        });
+        clearTerminalUiStateForKey(worktreeScopeKey);
+        removeTerminalSurfacesForKey(worktreeScopeKey);
+      }
       refreshArchivedThreadsForEnvironment(threadRef.environmentId);
       clearComposerDraftForThread(threadRef);
       clearProjectDraftThreadById(
         scopeProjectRef(threadRef.environmentId, thread.projectId),
         threadRef,
       );
-      if (shouldCleanUpWorktreeResources) {
-        clearTerminalUiStateForKey(worktreeScopeKey);
-        forgetWorktreeCanonicalOwnerByScopeKey(worktreeScopeKey);
-      }
-
       if (shouldNavigateToFallback) {
         if (fallbackThreadId) {
           const fallbackThread = readThreadShell(
@@ -454,6 +456,7 @@ export function useThreadActions() {
       deleteThreadMutation,
       getCurrentRouteThreadRef,
       refreshVcsStatus,
+      removeTerminalSurfacesForKey,
       removeWorktree,
       router,
       resolveThreadTarget,

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -29,6 +29,11 @@ import {
 } from "../state/entities";
 import { useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
+import {
+  forgetWorktreeCanonicalOwnerByScopeKey,
+  resolveWorktreeCanonicalThreadRef,
+  threadWorktreeScopeKey,
+} from "../worktreeScope";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { useClientSettings } from "./useSettings";
@@ -130,7 +135,9 @@ export function useThreadActions() {
   const clearProjectDraftThreadById = useComposerDraftStore(
     (store) => store.clearProjectDraftThreadById,
   );
-  const clearTerminalUiState = useTerminalUiStateStore((state) => state.clearTerminalUiState);
+  const clearTerminalUiStateForKey = useTerminalUiStateStore(
+    (state) => state.clearTerminalUiStateForKey,
+  );
   const router = useRouter();
   const handleNewThread = useNewThreadHandler();
   // Keep a ref so archiveThread can call handleNewThread without appearing in
@@ -172,6 +179,15 @@ export function useThreadActions() {
       }
 
       const currentRouteThreadRef = getCurrentRouteThreadRef();
+      const worktreeScopeKey = threadWorktreeScopeKey(thread);
+      const worktreeHasOtherActiveThread = readEnvironmentThreadRefs(threadRef.environmentId).some(
+        (candidateRef) => {
+          if (candidateRef.threadId === threadRef.threadId) return false;
+          const candidate = readThreadShell(candidateRef);
+          return candidate !== null && threadWorktreeScopeKey(candidate) === worktreeScopeKey;
+        },
+      );
+      const canonicalThreadRef = resolveWorktreeCanonicalThreadRef(threadRef);
       const shouldNavigateToDraft =
         currentRouteThreadRef?.threadId === threadRef.threadId &&
         currentRouteThreadRef.environmentId === threadRef.environmentId;
@@ -184,6 +200,13 @@ export function useThreadActions() {
       }
       refreshArchivedThreadsForEnvironment(threadRef.environmentId);
       opts.onArchived?.();
+      if (!worktreeHasOtherActiveThread) {
+        await closeTerminal({
+          environmentId: canonicalThreadRef.environmentId,
+          input: { threadId: canonicalThreadRef.threadId },
+        });
+        clearTerminalUiStateForKey(worktreeScopeKey);
+      }
 
       if (shouldNavigateToDraft) {
         const navigationResult = await settlePromise(() =>
@@ -197,7 +220,13 @@ export function useThreadActions() {
 
       return archiveResult;
     },
-    [archiveThreadMutation, getCurrentRouteThreadRef, resolveThreadTarget],
+    [
+      archiveThreadMutation,
+      clearTerminalUiStateForKey,
+      closeTerminal,
+      getCurrentRouteThreadRef,
+      resolveThreadTarget,
+    ],
   );
 
   const unarchiveThread = useCallback(
@@ -250,6 +279,22 @@ export function useThreadActions() {
         deletedIds && deletedIds.size > 0
           ? threads.filter((entry) => entry.id === threadRef.threadId || !deletedIds.has(entry.id))
           : threads;
+      const worktreeScopeKey = threadWorktreeScopeKey(thread);
+      const worktreeThreads = threads.filter(
+        (entry) => threadWorktreeScopeKey(entry) === worktreeScopeKey,
+      );
+      const deletingWorktreeThreadIds = worktreeThreads
+        .filter((entry) => entry.id === threadRef.threadId || deletedIds?.has(entry.id) === true)
+        .map((entry) => entry.id)
+        .toSorted();
+      const worktreeHasSurvivingThread = worktreeThreads.some(
+        (entry) =>
+          entry.id !== threadRef.threadId &&
+          (deletedIds === undefined || !deletedIds.has(entry.id)),
+      );
+      const shouldCleanUpWorktreeResources =
+        !worktreeHasSurvivingThread && deletingWorktreeThreadIds[0] === threadRef.threadId;
+      const canonicalThreadRef = resolveWorktreeCanonicalThreadRef(threadRef);
       const orphanedWorktreePath = getOrphanedWorktreePathForThread(
         survivingThreads,
         threadRef.threadId,
@@ -284,10 +329,12 @@ export function useThreadActions() {
         });
       }
 
-      await closeTerminal({
-        environmentId: threadRef.environmentId,
-        input: { threadId: threadRef.threadId, deleteHistory: true },
-      });
+      if (shouldCleanUpWorktreeResources) {
+        await closeTerminal({
+          environmentId: canonicalThreadRef.environmentId,
+          input: { threadId: canonicalThreadRef.threadId, deleteHistory: true },
+        });
+      }
 
       const deletedThreadIds = deletedIds ?? new Set<ThreadId>();
       const currentRouteThreadRef = getCurrentRouteThreadRef();
@@ -313,7 +360,10 @@ export function useThreadActions() {
         scopeProjectRef(threadRef.environmentId, thread.projectId),
         threadRef,
       );
-      clearTerminalUiState(threadRef);
+      if (shouldCleanUpWorktreeResources) {
+        clearTerminalUiStateForKey(worktreeScopeKey);
+        forgetWorktreeCanonicalOwnerByScopeKey(worktreeScopeKey);
+      }
 
       if (shouldNavigateToFallback) {
         if (fallbackThreadId) {
@@ -399,7 +449,7 @@ export function useThreadActions() {
     [
       clearComposerDraftForThread,
       clearProjectDraftThreadById,
-      clearTerminalUiState,
+      clearTerminalUiStateForKey,
       closeTerminal,
       deleteThreadMutation,
       getCurrentRouteThreadRef,

--- a/apps/web/src/portDiscoveryState.ts
+++ b/apps/web/src/portDiscoveryState.ts
@@ -5,6 +5,26 @@ import { previewEnvironment } from "./state/preview";
 import { useEnvironmentQuery } from "./state/query";
 
 const EMPTY_PORTS: ReadonlyArray<DiscoveredLocalServer> = Object.freeze([]);
+const portIndexCache = new WeakMap<
+  ReadonlyArray<DiscoveredLocalServer>,
+  ReadonlyMap<string, ReadonlyArray<DiscoveredLocalServer>>
+>();
+
+function indexDiscoveredPorts(
+  ports: ReadonlyArray<DiscoveredLocalServer>,
+): ReadonlyMap<string, ReadonlyArray<DiscoveredLocalServer>> {
+  const cached = portIndexCache.get(ports);
+  if (cached) return cached;
+  const byThreadId = new Map<string, DiscoveredLocalServer[]>();
+  for (const port of ports) {
+    if (port.terminal === null) continue;
+    const existing = byThreadId.get(port.terminal.threadId);
+    if (existing) existing.push(port);
+    else byThreadId.set(port.terminal.threadId, [port]);
+  }
+  portIndexCache.set(ports, byThreadId);
+  return byThreadId;
+}
 
 export function useDiscoveredPorts(
   environmentId: EnvironmentId | null,
@@ -25,7 +45,7 @@ export function useThreadDiscoveredPorts(input: {
   return useMemo(
     () =>
       input.threadId
-        ? ports.filter((port) => port.terminal?.threadId === input.threadId)
+        ? (indexDiscoveredPorts(ports).get(input.threadId) ?? EMPTY_PORTS)
         : EMPTY_PORTS,
     [input.threadId, ports],
   );

--- a/apps/web/src/portDiscoveryState.ts
+++ b/apps/web/src/portDiscoveryState.ts
@@ -51,25 +51,6 @@ export function useThreadDiscoveredPorts(input: {
   );
 }
 
-/** Discovered dev servers owned by any of the given threads (e.g. every
-    thread sharing a worktree). */
-export function useDiscoveredPortsForThreads(input: {
-  readonly environmentId: EnvironmentId | null;
-  readonly threadIds: ReadonlyArray<ThreadId>;
-}): ReadonlyArray<DiscoveredLocalServer> {
-  const ports = useDiscoveredPorts(input.environmentId);
-  return useMemo(() => {
-    if (input.threadIds.length === 0) {
-      return EMPTY_PORTS;
-    }
-    const threadIds = new Set<ThreadId>(input.threadIds);
-    const matched = ports.filter(
-      (port) => port.terminal !== null && threadIds.has(port.terminal.threadId),
-    );
-    return matched.length > 0 ? matched : EMPTY_PORTS;
-  }, [input.threadIds, ports]);
-}
-
 export function useTerminalDiscoveredPorts(input: {
   readonly environmentId: EnvironmentId | null;
   readonly threadId: ThreadId | null;

--- a/apps/web/src/portDiscoveryState.ts
+++ b/apps/web/src/portDiscoveryState.ts
@@ -31,6 +31,25 @@ export function useThreadDiscoveredPorts(input: {
   );
 }
 
+/** Discovered dev servers owned by any of the given threads (e.g. every
+    thread sharing a worktree). */
+export function useDiscoveredPortsForThreads(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly threadIds: ReadonlyArray<ThreadId>;
+}): ReadonlyArray<DiscoveredLocalServer> {
+  const ports = useDiscoveredPorts(input.environmentId);
+  return useMemo(() => {
+    if (input.threadIds.length === 0) {
+      return EMPTY_PORTS;
+    }
+    const threadIds = new Set<ThreadId>(input.threadIds);
+    const matched = ports.filter(
+      (port) => port.terminal !== null && threadIds.has(port.terminal.threadId),
+    );
+    return matched.length > 0 ? matched : EMPTY_PORTS;
+  }, [input.threadIds, ports]);
+}
+
 export function useTerminalDiscoveredPorts(input: {
   readonly environmentId: EnvironmentId | null;
   readonly threadId: ThreadId | null;

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -133,10 +133,13 @@ function migratePreviewState(ref: ScopedThreadRef): string {
   const fallbackAtom = previewStateAtom(fallbackKey);
   const fallbackState = appAtomRegistry.get(fallbackAtom);
   if (fallbackState === EMPTY_THREAD_PREVIEW_STATE) return primaryKey;
-  appAtomRegistry.set(previewStateAtom(primaryKey), fallbackState);
+  const primaryAtom = previewStateAtom(primaryKey);
+  const primaryState = appAtomRegistry.get(primaryAtom);
+  const migratedState = primaryState === EMPTY_THREAD_PREVIEW_STATE ? fallbackState : primaryState;
+  appAtomRegistry.set(primaryAtom, migratedState);
   appAtomRegistry.set(fallbackAtom, EMPTY_THREAD_PREVIEW_STATE);
   syncActivePreviewThread(fallbackKey, ref, EMPTY_THREAD_PREVIEW_STATE);
-  syncActivePreviewThread(primaryKey, ref, fallbackState);
+  syncActivePreviewThread(primaryKey, ref, migratedState);
   changedPreviewThreadKeys.delete(fallbackKey);
   changedPreviewThreadKeys.add(primaryKey);
   return primaryKey;

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -18,11 +18,7 @@ import { Atom } from "effect/unstable/reactivity";
 
 import { PREVIEW_RECENT_URL_LIMIT } from "./components/preview/previewConstants";
 import { appAtomRegistry } from "./rpc/atomRegistry";
-import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
-
-// Preview tabs belong to the CHECKOUT, not the thread: every thread sharing
-// a worktree sees the same browser tabs, active tab, and recent URLs.
-const previewScopeKey = resolveWorktreeScopeKeyForThreadRef;
+import { resolveWorktreeCanonicalThreadRef, worktreeStateKeysForThreadRef } from "./worktreeScope";
 
 export interface DesktopPreviewOverlay {
   hasWebContents: boolean;
@@ -76,42 +72,81 @@ export const previewStateAtom = Atom.family((threadKey: string) =>
 // Only the Electron browser host needs a cross-thread view. Keep that index
 // separate so thread-local readers never subscribe to unrelated previews.
 interface ActivePreviewThreadIndex {
-  readonly keys: ReadonlySet<string>;
+  readonly threadRefByScopeKey: ReadonlyMap<string, ScopedThreadRef>;
 }
 
 const activePreviewThreadKeysAtom = Atom.make<ActivePreviewThreadIndex>({
-  keys: new Set<string>(),
+  threadRefByScopeKey: new Map<string, ScopedThreadRef>(),
 }).pipe(Atom.keepAlive, Atom.withLabel("preview:active-thread-keys"));
 
 const activePreviewSessionsAtom = Atom.make((get) => {
-  const byThreadKey: Record<string, ThreadPreviewState> = {};
-  for (const threadKey of get(activePreviewThreadKeysAtom).keys) {
-    const state = get(previewStateAtom(threadKey));
+  const sessions: Array<{ threadRef: ScopedThreadRef; state: ThreadPreviewState }> = [];
+  for (const [scopeKey, threadRef] of get(activePreviewThreadKeysAtom).threadRefByScopeKey) {
+    const state = get(previewStateAtom(scopeKey));
     if (Object.keys(state.sessions).length > 0) {
-      byThreadKey[threadKey] = state;
+      sessions.push({ threadRef, state });
     }
   }
-  return byThreadKey;
+  return sessions;
 }).pipe(Atom.withLabel("preview:active-sessions"));
 
 const changedPreviewThreadKeys = new Set<string>();
 
-function syncActivePreviewThread(threadKey: string, state: ThreadPreviewState): void {
+function syncActivePreviewThread(
+  threadKey: string,
+  ref: ScopedThreadRef,
+  state: ThreadPreviewState,
+): void {
   const active = Object.keys(state.sessions).length > 0;
+  const canonicalRef = resolveWorktreeCanonicalThreadRef(ref);
   appAtomRegistry.update(activePreviewThreadKeysAtom, (current) => {
-    if (current.keys.has(threadKey) === active) return current;
-    const next = new Set(current.keys);
-    if (active) next.add(threadKey);
+    const existing = current.threadRefByScopeKey.get(threadKey);
+    if (
+      active &&
+      existing?.environmentId === canonicalRef.environmentId &&
+      existing.threadId === canonicalRef.threadId
+    ) {
+      return current;
+    }
+    if (!active && existing === undefined) return current;
+    const next = new Map(current.threadRefByScopeKey);
+    if (active) next.set(threadKey, canonicalRef);
     else next.delete(threadKey);
-    return { keys: next };
+    return { threadRefByScopeKey: next };
   });
+}
+
+function previewStateAtomForRead(ref: ScopedThreadRef) {
+  const { primaryKey, fallbackKey } = worktreeStateKeysForThreadRef(ref);
+  const primaryAtom = previewStateAtom(primaryKey);
+  if (primaryKey === fallbackKey) return primaryAtom;
+  const fallbackAtom = previewStateAtom(fallbackKey);
+  return appAtomRegistry.get(primaryAtom) === EMPTY_THREAD_PREVIEW_STATE &&
+    appAtomRegistry.get(fallbackAtom) !== EMPTY_THREAD_PREVIEW_STATE
+    ? fallbackAtom
+    : primaryAtom;
+}
+
+function migratePreviewState(ref: ScopedThreadRef): string {
+  const { primaryKey, fallbackKey } = worktreeStateKeysForThreadRef(ref);
+  if (primaryKey === fallbackKey) return primaryKey;
+  const fallbackAtom = previewStateAtom(fallbackKey);
+  const fallbackState = appAtomRegistry.get(fallbackAtom);
+  if (fallbackState === EMPTY_THREAD_PREVIEW_STATE) return primaryKey;
+  appAtomRegistry.set(previewStateAtom(primaryKey), fallbackState);
+  appAtomRegistry.set(fallbackAtom, EMPTY_THREAD_PREVIEW_STATE);
+  syncActivePreviewThread(fallbackKey, ref, EMPTY_THREAD_PREVIEW_STATE);
+  syncActivePreviewThread(primaryKey, ref, fallbackState);
+  changedPreviewThreadKeys.delete(fallbackKey);
+  changedPreviewThreadKeys.add(primaryKey);
+  return primaryKey;
 }
 
 function updateThreadPreviewState(
   ref: ScopedThreadRef,
   update: (current: ThreadPreviewState) => ThreadPreviewState,
 ): void {
-  const threadKey = previewScopeKey(ref);
+  const threadKey = migratePreviewState(ref);
   const atom = previewStateAtom(threadKey);
   let nextState = appAtomRegistry.get(atom);
   const changed = appAtomRegistry.modify(atom, (current) => {
@@ -120,7 +155,7 @@ function updateThreadPreviewState(
   });
   if (!changed) return;
   changedPreviewThreadKeys.add(threadKey);
-  syncActivePreviewThread(threadKey, nextState);
+  syncActivePreviewThread(threadKey, ref, nextState);
 }
 
 const dedupeRecentUrls = (existing: string[], url: string): string[] => {
@@ -162,23 +197,26 @@ const removeSession = (current: ThreadPreviewState, tabId: string): ThreadPrevie
 };
 
 export function useThreadPreviewState(ref: ScopedThreadRef | null | undefined): ThreadPreviewState {
-  const atom = ref ? previewStateAtom(previewScopeKey(ref)) : emptyPreviewStateAtom;
+  const atom = ref ? previewStateAtomForRead(ref) : emptyPreviewStateAtom;
   return useAtomValue(atom);
 }
 
-export function useActivePreviewSessions(): Record<string, ThreadPreviewState> {
+export function useActivePreviewSessions(): ReadonlyArray<{
+  threadRef: ScopedThreadRef;
+  state: ThreadPreviewState;
+}> {
   return useAtomValue(activePreviewSessionsAtom);
 }
 
 export function readThreadPreviewState(ref: ScopedThreadRef): ThreadPreviewState {
-  return appAtomRegistry.get(previewStateAtom(previewScopeKey(ref)));
+  return appAtomRegistry.get(previewStateAtomForRead(ref));
 }
 
 export function subscribeThreadPreviewState(
   ref: ScopedThreadRef,
   listener: (state: ThreadPreviewState, previous: ThreadPreviewState) => void,
 ): () => void {
-  const atom = previewStateAtom(previewScopeKey(ref));
+  const atom = previewStateAtomForRead(ref);
   let previous = appAtomRegistry.get(atom);
   return appAtomRegistry.subscribe(atom, (state) => {
     const prior = previous;
@@ -447,10 +485,12 @@ export function rememberPreviewUrl(ref: ScopedThreadRef, url: string): void {
 }
 
 export function removePreviewThread(ref: ScopedThreadRef): void {
-  const threadKey = previewScopeKey(ref);
-  appAtomRegistry.set(previewStateAtom(threadKey), EMPTY_THREAD_PREVIEW_STATE);
-  syncActivePreviewThread(threadKey, EMPTY_THREAD_PREVIEW_STATE);
-  changedPreviewThreadKeys.delete(threadKey);
+  const { primaryKey, fallbackKey } = worktreeStateKeysForThreadRef(ref);
+  for (const threadKey of new Set([primaryKey, fallbackKey])) {
+    appAtomRegistry.set(previewStateAtom(threadKey), EMPTY_THREAD_PREVIEW_STATE);
+    syncActivePreviewThread(threadKey, ref, EMPTY_THREAD_PREVIEW_STATE);
+    changedPreviewThreadKeys.delete(threadKey);
+  }
 }
 
 export function isPreviewSupportedInRuntime(): boolean {
@@ -463,7 +503,9 @@ export function resetPreviewStateForTests(): void {
     appAtomRegistry.set(previewStateAtom(threadKey), EMPTY_THREAD_PREVIEW_STATE);
   }
   changedPreviewThreadKeys.clear();
-  appAtomRegistry.set(activePreviewThreadKeysAtom, { keys: new Set<string>() });
+  appAtomRegistry.set(activePreviewThreadKeysAtom, {
+    threadRefByScopeKey: new Map<string, ScopedThreadRef>(),
+  });
 }
 
 export const __testing = {

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -1,12 +1,12 @@
 /**
- * Per-thread preview UI state.
+ * Per-worktree preview UI state.
  *
- * Each thread owns an independent atom. Most consumers read exactly one
- * thread; the desktop browser host uses the aggregate session atom because it
- * is the one place that must enumerate every live preview tab.
+ * Each worktree (checkout) owns an independent atom; callers pass a thread
+ * ref that resolves to its worktree scope key. Most consumers read exactly
+ * one worktree; the desktop browser host uses the aggregate session atom
+ * because it is the one place that must enumerate every live preview tab.
  */
 import { useAtomValue } from "@effect/atom-react";
-import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import {
   type DesktopPreviewColorScheme,
   type PreviewEvent,
@@ -18,6 +18,11 @@ import { Atom } from "effect/unstable/reactivity";
 
 import { PREVIEW_RECENT_URL_LIMIT } from "./components/preview/previewConstants";
 import { appAtomRegistry } from "./rpc/atomRegistry";
+import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
+
+// Preview tabs belong to the CHECKOUT, not the thread: every thread sharing
+// a worktree sees the same browser tabs, active tab, and recent URLs.
+const previewScopeKey = resolveWorktreeScopeKeyForThreadRef;
 
 export interface DesktopPreviewOverlay {
   hasWebContents: boolean;
@@ -106,7 +111,7 @@ function updateThreadPreviewState(
   ref: ScopedThreadRef,
   update: (current: ThreadPreviewState) => ThreadPreviewState,
 ): void {
-  const threadKey = scopedThreadKey(ref);
+  const threadKey = previewScopeKey(ref);
   const atom = previewStateAtom(threadKey);
   let nextState = appAtomRegistry.get(atom);
   const changed = appAtomRegistry.modify(atom, (current) => {
@@ -157,7 +162,7 @@ const removeSession = (current: ThreadPreviewState, tabId: string): ThreadPrevie
 };
 
 export function useThreadPreviewState(ref: ScopedThreadRef | null | undefined): ThreadPreviewState {
-  const atom = ref ? previewStateAtom(scopedThreadKey(ref)) : emptyPreviewStateAtom;
+  const atom = ref ? previewStateAtom(previewScopeKey(ref)) : emptyPreviewStateAtom;
   return useAtomValue(atom);
 }
 
@@ -166,14 +171,14 @@ export function useActivePreviewSessions(): Record<string, ThreadPreviewState> {
 }
 
 export function readThreadPreviewState(ref: ScopedThreadRef): ThreadPreviewState {
-  return appAtomRegistry.get(previewStateAtom(scopedThreadKey(ref)));
+  return appAtomRegistry.get(previewStateAtom(previewScopeKey(ref)));
 }
 
 export function subscribeThreadPreviewState(
   ref: ScopedThreadRef,
   listener: (state: ThreadPreviewState, previous: ThreadPreviewState) => void,
 ): () => void {
-  const atom = previewStateAtom(scopedThreadKey(ref));
+  const atom = previewStateAtom(previewScopeKey(ref));
   let previous = appAtomRegistry.get(atom);
   return appAtomRegistry.subscribe(atom, (state) => {
     const prior = previous;
@@ -442,7 +447,7 @@ export function rememberPreviewUrl(ref: ScopedThreadRef, url: string): void {
 }
 
 export function removePreviewThread(ref: ScopedThreadRef): void {
-  const threadKey = scopedThreadKey(ref);
+  const threadKey = previewScopeKey(ref);
   appAtomRegistry.set(previewStateAtom(threadKey), EMPTY_THREAD_PREVIEW_STATE);
   syncActivePreviewThread(threadKey, EMPTY_THREAD_PREVIEW_STATE);
   changedPreviewThreadKeys.delete(threadKey);

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -1,8 +1,9 @@
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { type EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
+  filterRightPanelStateForThread,
   migratePersistedRightPanelState,
   selectActiveRightPanel,
   selectActiveRightPanelSurface,
@@ -12,6 +13,7 @@ import {
 
 const refA = scopeThreadRef("env-1" as EnvironmentId, ThreadId.make("thread-A"));
 const refB = scopeThreadRef("env-1" as EnvironmentId, ThreadId.make("thread-B"));
+const refAPlanId = `plan:${scopedThreadKey(refA)}`;
 
 beforeEach(() => {
   useRightPanelStore.setState({ byThreadKey: {} });
@@ -127,7 +129,7 @@ describe("rightPanelStore", () => {
       activeSurfaceId: "diff",
       surfaces: [
         { id: "diff", kind: "diff" },
-        { id: "plan", kind: "plan" },
+        { id: refAPlanId, kind: "plan", threadKey: scopedThreadKey(refA) },
       ],
     });
   });
@@ -214,8 +216,8 @@ describe("rightPanelStore", () => {
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
       isOpen: true,
-      activeSurfaceId: "plan",
-      surfaces: [{ id: "plan", kind: "plan" }],
+      activeSurfaceId: refAPlanId,
+      surfaces: [{ id: refAPlanId, kind: "plan", threadKey: scopedThreadKey(refA) }],
     });
 
     useRightPanelStore.getState().openFile(refB, "conductor.json");
@@ -228,13 +230,13 @@ describe("rightPanelStore", () => {
   });
 
   it("close hides the panel without clearing its selected surface", () => {
-    useRightPanelStore.getState().open(refA, "plan");
+    useRightPanelStore.getState().open(refA, "diff");
     useRightPanelStore.getState().close(refA);
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBeNull();
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
       isOpen: false,
-      activeSurfaceId: "plan",
-      surfaces: [{ id: "plan", kind: "plan" }],
+      activeSurfaceId: "diff",
+      surfaces: [{ id: "diff", kind: "diff" }],
     });
   });
 
@@ -266,6 +268,28 @@ describe("rightPanelStore", () => {
     useRightPanelStore.getState().toggle(refA, "preview");
     useRightPanelStore.getState().toggle(refA, "plan");
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBe("plan");
+  });
+
+  it("hides another conversation's plan while retaining shared checkout surfaces", () => {
+    const state = {
+      isOpen: true,
+      activeSurfaceId: refAPlanId,
+      surfaces: [
+        { id: "diff" as const, kind: "diff" as const },
+        {
+          id: refAPlanId as `plan:${string}`,
+          kind: "plan" as const,
+          threadKey: scopedThreadKey(refA),
+        },
+      ],
+    };
+
+    expect(filterRightPanelStateForThread(state, scopedThreadKey(refB))).toEqual({
+      isOpen: true,
+      activeSurfaceId: "diff",
+      surfaces: [{ id: "diff", kind: "diff" }],
+    });
+    expect(filterRightPanelStateForThread(state, scopedThreadKey(refA))).toBe(state);
   });
 
   it("removeThread clears persisted state", () => {
@@ -314,6 +338,19 @@ describe("rightPanelStore", () => {
       },
     ]);
     expect(state.activeSurfaceId).toBe("terminal:term-2");
+  });
+
+  it("removes terminal surfaces without discarding other checkout panels", () => {
+    useRightPanelStore.getState().open(refA, "diff");
+    useRightPanelStore.getState().openTerminal(refA, "term-1");
+
+    useRightPanelStore.getState().removeTerminalSurfacesForKey(scopedThreadKey(refA));
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: "diff",
+      surfaces: [{ id: "diff", kind: "diff" }],
+    });
   });
 
   it("tracks split panes and the active pane within a terminal surface", () => {

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -16,9 +16,7 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { resolveStorage } from "./lib/storage";
-import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
-
-const panelScopeKey = resolveWorktreeScopeKeyForThreadRef;
+import { migrateWorktreeScopedRecord, readWorktreeScopedRecordValue } from "./worktreeScope";
 
 export const RIGHT_PANEL_KINDS = ["plan", "diff", "files", "file", "preview", "terminal"] as const;
 export type RightPanelKind = (typeof RIGHT_PANEL_KINDS)[number];
@@ -140,18 +138,20 @@ const upsertSurface = (
 
 const updateThread = (
   byThreadKey: Record<string, ThreadRightPanelState>,
-  threadKey: string,
+  ref: ScopedThreadRef,
   updater: (current: ThreadRightPanelState) => ThreadRightPanelState,
 ): Record<string, ThreadRightPanelState> => {
-  const current = byThreadKey[threadKey] ?? EMPTY_THREAD_STATE;
+  const migrated = migrateWorktreeScopedRecord(byThreadKey, ref);
+  const threadKey = migrated.key;
+  const current = migrated.record[threadKey] ?? EMPTY_THREAD_STATE;
   const next = updater(current);
   if (!next.isOpen && next.activeSurfaceId === null && next.surfaces.length === 0) {
-    if (!(threadKey in byThreadKey)) return byThreadKey;
-    const { [threadKey]: _removed, ...rest } = byThreadKey;
+    if (!(threadKey in migrated.record)) return migrated.record;
+    const { [threadKey]: _removed, ...rest } = migrated.record;
     return rest;
   }
-  if (next === current) return byThreadKey;
-  return { ...byThreadKey, [threadKey]: next };
+  if (next === current) return migrated.record;
+  return { ...migrated.record, [threadKey]: next };
 };
 
 function normalizeRevealLine(line: number | undefined): number | null {
@@ -247,7 +247,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
       byThreadKey: {},
       open: (ref, kind) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             if (kind === "preview") {
               const existing = current.surfaces.find((surface) => surface.kind === "preview");
               return upsertSurface(current, existing ?? browserSurface(null));
@@ -257,7 +257,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       openBrowser: (ref, tabId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const surface = browserSurface(tabId);
             const withoutPlaceholder = tabId
               ? current.surfaces.filter((entry) => entry.id !== "browser:new")
@@ -267,7 +267,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       openFile: (ref, relativePath, line) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const withoutStandaloneExplorer = current.surfaces.filter(
               (surface) => surface.kind !== "files",
             );
@@ -294,13 +294,13 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       openTerminal: (ref, terminalId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
             upsertSurface(current, terminalSurface(terminalId)),
           ),
         })),
       splitTerminal: (ref, surfaceId, terminalId, direction = "horizontal") =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => ({
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => ({
             ...current,
             isOpen: true,
             activeSurfaceId: surfaceId,
@@ -320,7 +320,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       activateTerminal: (ref, surfaceId, terminalId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => ({
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => ({
             ...current,
             activeSurfaceId: surfaceId,
             surfaces: current.surfaces.map((surface) =>
@@ -334,7 +334,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeTerminal: (ref, surfaceId, terminalId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const surface = current.surfaces.find(
               (entry) => entry.id === surfaceId && entry.kind === "terminal",
             );
@@ -373,7 +373,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       activateSurface: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
             current.surfaces.some((surface) => surface.id === surfaceId)
               ? { ...current, isOpen: true, activeSurfaceId: surfaceId }
               : current,
@@ -381,7 +381,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeSurface: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0) return current;
             const surfaces = current.surfaces.filter((surface) => surface.id !== surfaceId);
@@ -399,7 +399,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeOtherSurfaces: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const surface = current.surfaces.find((entry) => entry.id === surfaceId);
             if (!surface || current.surfaces.length === 1) return current;
             return {
@@ -412,7 +412,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeSurfacesToRight: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0 || index === current.surfaces.length - 1) return current;
             const surfaces = current.surfaces.slice(0, index + 1);
@@ -428,7 +428,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeAllSurfaces: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
             current.surfaces.length === 0
               ? current
               : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
@@ -436,7 +436,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       reconcileBrowserSurfaces: (ref, tabIds) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const validIds = new Set(tabIds.map((tabId) => `browser:${tabId}`));
             const nonBrowser = current.surfaces.filter((surface) => surface.kind !== "preview");
             const existingBrowser = current.surfaces.filter(
@@ -465,7 +465,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       reconcileFileSurfaces: (ref, workspaceAvailable) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             if (workspaceAvailable) return current;
             const surfaces = current.surfaces.filter(
               (surface) => surface.kind !== "files" && surface.kind !== "file",
@@ -486,26 +486,26 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       show: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
             current.isOpen ? current : { ...current, isOpen: true },
           ),
         })),
       close: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
             current.isOpen ? { ...current, isOpen: false } : current,
           ),
         })),
       toggleVisibility: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => ({
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => ({
             ...current,
             isOpen: !current.isOpen,
           })),
         })),
       toggle: (ref, kind) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const active = current.surfaces.find(
               (surface) => surface.id === current.activeSurfaceId,
             );
@@ -521,9 +521,9 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       removeThread: (ref) =>
         set((state) => {
-          const threadKey = panelScopeKey(ref);
-          if (!(threadKey in state.byThreadKey)) return state;
-          const { [threadKey]: _removed, ...rest } = state.byThreadKey;
+          const migrated = migrateWorktreeScopedRecord(state.byThreadKey, ref);
+          if (!(migrated.key in migrated.record)) return state;
+          const { [migrated.key]: _removed, ...rest } = migrated.record;
           return { byThreadKey: rest };
         }),
     }),
@@ -548,7 +548,7 @@ export function selectThreadRightPanelState(
   ref: ScopedThreadRef | null | undefined,
 ): ThreadRightPanelState {
   if (!ref) return EMPTY_THREAD_STATE;
-  return byThreadKey[panelScopeKey(ref)] ?? EMPTY_THREAD_STATE;
+  return readWorktreeScopedRecordValue(byThreadKey, ref) ?? EMPTY_THREAD_STATE;
 }
 
 export function selectActiveRightPanel(

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -1,18 +1,24 @@
 /**
- * Thread-scoped right-panel surface state.
+ * Worktree-scoped right-panel surface state.
  *
  * This is intentionally a shallow workspace model: it owns an ordered set of
  * surface descriptors and the active surface, while each feature continues to
  * own its durable resource state. Browser surfaces point at preview tab ids,
  * terminal surfaces point at terminal session ids, file surfaces point at
  * workspace paths, and diff/plan/files remain singleton surfaces.
+ *
+ * Callers still hand in a thread ref, but the state keys by the thread's
+ * WORKTREE: every thread sharing a checkout sees the same panel layout, so
+ * switching between sibling threads never swaps the open surfaces.
  */
-import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { ScopedThreadRef } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { resolveStorage } from "./lib/storage";
+import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
+
+const panelScopeKey = resolveWorktreeScopeKeyForThreadRef;
 
 export const RIGHT_PANEL_KINDS = ["plan", "diff", "files", "file", "preview", "terminal"] as const;
 export type RightPanelKind = (typeof RIGHT_PANEL_KINDS)[number];
@@ -40,7 +46,7 @@ export type RightPanelSurface =
   | { id: "plan"; kind: "plan" };
 
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
-const RIGHT_PANEL_STORAGE_VERSION = 7;
+const RIGHT_PANEL_STORAGE_VERSION = 8;
 
 export interface ThreadRightPanelState {
   isOpen: boolean;
@@ -241,7 +247,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
       byThreadKey: {},
       open: (ref, kind) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             if (kind === "preview") {
               const existing = current.surfaces.find((surface) => surface.kind === "preview");
               return upsertSurface(current, existing ?? browserSurface(null));
@@ -251,7 +257,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       openBrowser: (ref, tabId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const surface = browserSurface(tabId);
             const withoutPlaceholder = tabId
               ? current.surfaces.filter((entry) => entry.id !== "browser:new")
@@ -261,7 +267,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       openFile: (ref, relativePath, line) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const withoutStandaloneExplorer = current.surfaces.filter(
               (surface) => surface.kind !== "files",
             );
@@ -288,13 +294,13 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       openTerminal: (ref, terminalId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
             upsertSurface(current, terminalSurface(terminalId)),
           ),
         })),
       splitTerminal: (ref, surfaceId, terminalId, direction = "horizontal") =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => ({
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => ({
             ...current,
             isOpen: true,
             activeSurfaceId: surfaceId,
@@ -314,7 +320,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       activateTerminal: (ref, surfaceId, terminalId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => ({
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => ({
             ...current,
             activeSurfaceId: surfaceId,
             surfaces: current.surfaces.map((surface) =>
@@ -328,7 +334,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeTerminal: (ref, surfaceId, terminalId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const surface = current.surfaces.find(
               (entry) => entry.id === surfaceId && entry.kind === "terminal",
             );
@@ -367,7 +373,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       activateSurface: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
             current.surfaces.some((surface) => surface.id === surfaceId)
               ? { ...current, isOpen: true, activeSurfaceId: surfaceId }
               : current,
@@ -375,7 +381,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeSurface: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0) return current;
             const surfaces = current.surfaces.filter((surface) => surface.id !== surfaceId);
@@ -393,7 +399,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeOtherSurfaces: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const surface = current.surfaces.find((entry) => entry.id === surfaceId);
             if (!surface || current.surfaces.length === 1) return current;
             return {
@@ -406,7 +412,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeSurfacesToRight: (ref, surfaceId) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0 || index === current.surfaces.length - 1) return current;
             const surfaces = current.surfaces.slice(0, index + 1);
@@ -422,7 +428,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeAllSurfaces: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
             current.surfaces.length === 0
               ? current
               : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
@@ -430,7 +436,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       reconcileBrowserSurfaces: (ref, tabIds) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const validIds = new Set(tabIds.map((tabId) => `browser:${tabId}`));
             const nonBrowser = current.surfaces.filter((surface) => surface.kind !== "preview");
             const existingBrowser = current.surfaces.filter(
@@ -459,7 +465,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       reconcileFileSurfaces: (ref, workspaceAvailable) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             if (workspaceAvailable) return current;
             const surfaces = current.surfaces.filter(
               (surface) => surface.kind !== "files" && surface.kind !== "file",
@@ -480,26 +486,26 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       show: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
             current.isOpen ? current : { ...current, isOpen: true },
           ),
         })),
       close: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) =>
             current.isOpen ? { ...current, isOpen: false } : current,
           ),
         })),
       toggleVisibility: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => ({
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => ({
             ...current,
             isOpen: !current.isOpen,
           })),
         })),
       toggle: (ref, kind) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) => {
+          byThreadKey: updateThread(state.byThreadKey, panelScopeKey(ref), (current) => {
             const active = current.surfaces.find(
               (surface) => surface.id === current.activeSurfaceId,
             );
@@ -515,7 +521,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       removeThread: (ref) =>
         set((state) => {
-          const threadKey = scopedThreadKey(ref);
+          const threadKey = panelScopeKey(ref);
           if (!(threadKey in state.byThreadKey)) return state;
           const { [threadKey]: _removed, ...rest } = state.byThreadKey;
           return { byThreadKey: rest };
@@ -528,7 +534,11 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         resolveStorage(typeof window !== "undefined" ? window.localStorage : undefined),
       ),
       partialize: (state) => ({ byThreadKey: state.byThreadKey }),
-      migrate: migratePersistedRightPanelState,
+      // v8 re-keyed entries from thread keys to worktree scope keys; older
+      // thread-keyed entries can never match again, so they are dropped
+      // rather than left as unreachable garbage.
+      migrate: (persistedState, version) =>
+        version < 8 ? { byThreadKey: {} } : migratePersistedRightPanelState(persistedState),
     },
   ),
 );
@@ -538,7 +548,7 @@ export function selectThreadRightPanelState(
   ref: ScopedThreadRef | null | undefined,
 ): ThreadRightPanelState {
   if (!ref) return EMPTY_THREAD_STATE;
-  return byThreadKey[scopedThreadKey(ref)] ?? EMPTY_THREAD_STATE;
+  return byThreadKey[panelScopeKey(ref)] ?? EMPTY_THREAD_STATE;
 }
 
 export function selectActiveRightPanel(

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -5,12 +5,15 @@
  * surface descriptors and the active surface, while each feature continues to
  * own its durable resource state. Browser surfaces point at preview tab ids,
  * terminal surfaces point at terminal session ids, file surfaces point at
- * workspace paths, and diff/plan/files remain singleton surfaces.
+ * workspace paths, and diff/files remain checkout singletons. Plan surfaces
+ * carry their conversation owner so sibling threads never display each
+ * other's plan.
  *
  * Callers still hand in a thread ref, but the state keys by the thread's
  * WORKTREE: every thread sharing a checkout sees the same panel layout, so
  * switching between sibling threads never swaps the open surfaces.
  */
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { ScopedThreadRef } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -41,10 +44,10 @@ export type RightPanelSurface =
       revealLine: number | null;
       revealRequestId: number;
     }
-  | { id: "plan"; kind: "plan" };
+  | { id: `plan:${string}`; kind: "plan"; threadKey: string };
 
 const RIGHT_PANEL_STORAGE_KEY = "t3code:right-panel-state:v2";
-const RIGHT_PANEL_STORAGE_VERSION = 8;
+const RIGHT_PANEL_STORAGE_VERSION = 9;
 
 export interface ThreadRightPanelState {
   isOpen: boolean;
@@ -66,6 +69,8 @@ interface RightPanelStoreState {
   ) => void;
   activateTerminal: (ref: ScopedThreadRef, surfaceId: string, terminalId: string) => void;
   closeTerminal: (ref: ScopedThreadRef, surfaceId: string, terminalId: string) => void;
+  removeTerminalSurfaces: (ref: ScopedThreadRef) => void;
+  removeTerminalSurfacesForKey: (threadKey: string) => void;
   activateSurface: (ref: ScopedThreadRef, surfaceId: string) => void;
   closeSurface: (ref: ScopedThreadRef, surfaceId: string) => void;
   closeOtherSurfaces: (ref: ScopedThreadRef, surfaceId: string) => void;
@@ -88,6 +93,7 @@ const EMPTY_THREAD_STATE: ThreadRightPanelState = {
 
 const singletonSurface = (
   kind: Exclude<RightPanelKind, "file" | "preview" | "terminal">,
+  ref: ScopedThreadRef,
 ): RightPanelSurface => {
   switch (kind) {
     case "diff":
@@ -95,7 +101,11 @@ const singletonSurface = (
     case "files":
       return { id: "files", kind };
     case "plan":
-      return { id: "plan", kind };
+      return {
+        id: `plan:${scopedThreadKey(ref)}`,
+        kind,
+        threadKey: scopedThreadKey(ref),
+      };
   }
 };
 
@@ -123,6 +133,18 @@ const terminalSurface = (terminalId: string): RightPanelSurface => ({
   terminalIds: [terminalId],
   activeTerminalId: terminalId,
 });
+
+const withoutTerminalSurfaces = (current: ThreadRightPanelState): ThreadRightPanelState => {
+  const surfaces = current.surfaces.filter((surface) => surface.kind !== "terminal");
+  if (surfaces.length === current.surfaces.length) return current;
+  const activeStillExists = surfaces.some((surface) => surface.id === current.activeSurfaceId);
+  return {
+    ...current,
+    isOpen: surfaces.length > 0 && current.isOpen,
+    surfaces,
+    activeSurfaceId: activeStillExists ? current.activeSurfaceId : (surfaces.at(-1)?.id ?? null),
+  };
+};
 
 const upsertSurface = (
   current: ThreadRightPanelState,
@@ -252,7 +274,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               const existing = current.surfaces.find((surface) => surface.kind === "preview");
               return upsertSurface(current, existing ?? browserSurface(null));
             }
-            return upsertSurface(current, singletonSurface(kind));
+            return upsertSurface(current, singletonSurface(kind, ref));
           }),
         })),
       openBrowser: (ref, tabId) =>
@@ -371,6 +393,22 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             };
           }),
         })),
+      removeTerminalSurfaces: (ref) =>
+        set((state) => ({
+          byThreadKey: updateThread(state.byThreadKey, ref, withoutTerminalSurfaces),
+        })),
+      removeTerminalSurfacesForKey: (threadKey) =>
+        set((state) => {
+          const current = state.byThreadKey[threadKey];
+          if (current === undefined) return state;
+          const next = withoutTerminalSurfaces(current);
+          if (next === current) return state;
+          if (!next.isOpen && next.activeSurfaceId === null && next.surfaces.length === 0) {
+            const { [threadKey]: _removed, ...byThreadKey } = state.byThreadKey;
+            return { byThreadKey };
+          }
+          return { byThreadKey: { ...state.byThreadKey, [threadKey]: next } };
+        }),
       activateSurface: (ref, surfaceId) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
@@ -402,10 +440,14 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
             const surface = current.surfaces.find((entry) => entry.id === surfaceId);
             if (!surface || current.surfaces.length === 1) return current;
+            const currentThreadKey = scopedThreadKey(ref);
+            const foreignPlans = current.surfaces.filter(
+              (entry) => entry.kind === "plan" && entry.threadKey !== currentThreadKey,
+            );
             return {
               ...current,
               isOpen: true,
-              surfaces: [surface],
+              surfaces: [...foreignPlans, ...(foreignPlans.includes(surface) ? [] : [surface])],
               activeSurfaceId: surface.id,
             };
           }),
@@ -413,9 +455,20 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
       closeSurfacesToRight: (ref, surfaceId) =>
         set((state) => ({
           byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
-            const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
-            if (index < 0 || index === current.surfaces.length - 1) return current;
-            const surfaces = current.surfaces.slice(0, index + 1);
+            const currentThreadKey = scopedThreadKey(ref);
+            const visible = current.surfaces.filter(
+              (surface) => surface.kind !== "plan" || surface.threadKey === currentThreadKey,
+            );
+            const index = visible.findIndex((surface) => surface.id === surfaceId);
+            if (index < 0 || index === visible.length - 1) return current;
+            const keptVisibleIds = new Set(
+              visible.slice(0, index + 1).map((surface) => surface.id),
+            );
+            const surfaces = current.surfaces.filter(
+              (surface) =>
+                (surface.kind === "plan" && surface.threadKey !== currentThreadKey) ||
+                keptVisibleIds.has(surface.id),
+            );
             const activeStillExists = surfaces.some(
               (surface) => surface.id === current.activeSurfaceId,
             );
@@ -428,11 +481,23 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       closeAllSurfaces: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
-            current.surfaces.length === 0
-              ? current
-              : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
-          ),
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
+            const currentThreadKey = scopedThreadKey(ref);
+            const foreignPlans = current.surfaces.filter(
+              (surface) => surface.kind === "plan" && surface.threadKey !== currentThreadKey,
+            );
+            if (foreignPlans.length === current.surfaces.length) return current;
+            return {
+              ...current,
+              isOpen: foreignPlans.length > 0 && current.isOpen,
+              surfaces: foreignPlans,
+              activeSurfaceId: foreignPlans.some(
+                (surface) => surface.id === current.activeSurfaceId,
+              )
+                ? current.activeSurfaceId
+                : (foreignPlans.at(-1)?.id ?? null),
+            };
+          }),
         })),
       reconcileBrowserSurfaces: (ref, tabIds) =>
         set((state) => ({
@@ -492,9 +557,19 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         })),
       close: (ref) =>
         set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, ref, (current) =>
-            current.isOpen ? { ...current, isOpen: false } : current,
-          ),
+          byThreadKey: updateThread(state.byThreadKey, ref, (current) => {
+            const planId = `plan:${scopedThreadKey(ref)}`;
+            if (current.activeSurfaceId !== planId) {
+              return current.isOpen ? { ...current, isOpen: false } : current;
+            }
+            const surfaces = current.surfaces.filter((surface) => surface.id !== planId);
+            return {
+              ...current,
+              isOpen: surfaces.length > 0,
+              surfaces,
+              activeSurfaceId: surfaces.at(-1)?.id ?? null,
+            };
+          }),
         })),
       toggleVisibility: (ref) =>
         set((state) => ({
@@ -516,7 +591,18 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               const existing = current.surfaces.find((surface) => surface.kind === "preview");
               return upsertSurface(current, existing ?? browserSurface(null));
             }
-            return upsertSurface(current, singletonSurface(kind));
+            const surface = singletonSurface(kind, ref);
+            if (current.isOpen && current.activeSurfaceId === surface.id) {
+              if (surface.kind !== "plan") return { ...current, isOpen: false };
+              const surfaces = current.surfaces.filter((entry) => entry.id !== surface.id);
+              return {
+                ...current,
+                isOpen: surfaces.length > 0,
+                surfaces,
+                activeSurfaceId: surfaces.at(-1)?.id ?? null,
+              };
+            }
+            return upsertSurface(current, surface);
           }),
         })),
       removeThread: (ref) =>
@@ -534,21 +620,62 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         resolveStorage(typeof window !== "undefined" ? window.localStorage : undefined),
       ),
       partialize: (state) => ({ byThreadKey: state.byThreadKey }),
-      // v8 re-keyed entries from thread keys to worktree scope keys; older
+      // v9 makes plan surfaces conversation-owned within shared worktree
+      // records. Older state cannot identify which sibling owned a plan.
       // thread-keyed entries can never match again, so they are dropped
       // rather than left as unreachable garbage.
       migrate: (persistedState, version) =>
-        version < 8 ? { byThreadKey: {} } : migratePersistedRightPanelState(persistedState),
+        version < 9 ? { byThreadKey: {} } : migratePersistedRightPanelState(persistedState),
     },
   ),
 );
+
+const filteredRightPanelStateCache = new WeakMap<
+  ThreadRightPanelState,
+  Map<string, ThreadRightPanelState>
+>();
+
+export function filterRightPanelStateForThread(
+  state: ThreadRightPanelState,
+  threadKey: string,
+): ThreadRightPanelState {
+  const hasForeignPlan = state.surfaces.some(
+    (surface) => surface.kind === "plan" && surface.threadKey !== threadKey,
+  );
+  const ownPlanIsActive = state.surfaces.some(
+    (surface) =>
+      surface.kind === "plan" &&
+      surface.threadKey === threadKey &&
+      surface.id === state.activeSurfaceId,
+  );
+  if (!hasForeignPlan && (state.isOpen || !ownPlanIsActive)) return state;
+
+  let cachedByThread = filteredRightPanelStateCache.get(state);
+  const cached = cachedByThread?.get(threadKey);
+  if (cached !== undefined) return cached;
+
+  const surfaces = state.surfaces.filter(
+    (surface) => surface.kind !== "plan" || surface.threadKey === threadKey,
+  );
+  const activeStillExists = surfaces.some((surface) => surface.id === state.activeSurfaceId);
+  const filtered: ThreadRightPanelState = {
+    isOpen: surfaces.length > 0 && (state.isOpen || ownPlanIsActive),
+    surfaces,
+    activeSurfaceId: activeStillExists ? state.activeSurfaceId : (surfaces.at(-1)?.id ?? null),
+  };
+  cachedByThread ??= new Map<string, ThreadRightPanelState>();
+  cachedByThread.set(threadKey, filtered);
+  filteredRightPanelStateCache.set(state, cachedByThread);
+  return filtered;
+}
 
 export function selectThreadRightPanelState(
   byThreadKey: Record<string, ThreadRightPanelState>,
   ref: ScopedThreadRef | null | undefined,
 ): ThreadRightPanelState {
   if (!ref) return EMPTY_THREAD_STATE;
-  return readWorktreeScopedRecordValue(byThreadKey, ref) ?? EMPTY_THREAD_STATE;
+  const state = readWorktreeScopedRecordValue(byThreadKey, ref) ?? EMPTY_THREAD_STATE;
+  return filterRightPanelStateForThread(state, scopedThreadKey(ref));
 }
 
 export function selectActiveRightPanel(

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -69,7 +69,6 @@ interface RightPanelStoreState {
   ) => void;
   activateTerminal: (ref: ScopedThreadRef, surfaceId: string, terminalId: string) => void;
   closeTerminal: (ref: ScopedThreadRef, surfaceId: string, terminalId: string) => void;
-  removeTerminalSurfaces: (ref: ScopedThreadRef) => void;
   removeTerminalSurfacesForKey: (threadKey: string) => void;
   activateSurface: (ref: ScopedThreadRef, surfaceId: string) => void;
   closeSurface: (ref: ScopedThreadRef, surfaceId: string) => void;
@@ -393,10 +392,6 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             };
           }),
         })),
-      removeTerminalSurfaces: (ref) =>
-        set((state) => ({
-          byThreadKey: updateThread(state.byThreadKey, ref, withoutTerminalSurfaces),
-        })),
       removeTerminalSurfacesForKey: (threadKey) =>
         set((state) => {
           const current = state.byThreadKey[threadKey];
@@ -620,10 +615,10 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
         resolveStorage(typeof window !== "undefined" ? window.localStorage : undefined),
       ),
       partialize: (state) => ({ byThreadKey: state.byThreadKey }),
-      // v9 makes plan surfaces conversation-owned within shared worktree
-      // records. Older state cannot identify which sibling owned a plan.
-      // thread-keyed entries can never match again, so they are dropped
-      // rather than left as unreachable garbage.
+      // v9 keys records by worktree scope and makes plan surfaces
+      // conversation-owned. Older state is thread-keyed (it can never match a
+      // worktree key) and cannot say which sibling owned a plan, so it is
+      // dropped rather than left as unreachable garbage.
       migrate: (persistedState, version) =>
         version < 9 ? { byThreadKey: {} } : migratePersistedRightPanelState(persistedState),
     },

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,5 +1,6 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { useEffect, useMemo } from "react";
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
@@ -80,6 +81,34 @@ function ChatRouteGlobalShortcuts() {
       if (command === "chat.newLocal") {
         event.preventDefault();
         event.stopPropagation();
+        void startNewThreadFromContext({
+          activeDraftThread,
+          activeThread: activeThread ?? undefined,
+          defaultProjectRef,
+          handleNewThread,
+        });
+        return;
+      }
+
+      if (command === "chat.newInWorktree") {
+        event.preventDefault();
+        event.stopPropagation();
+        // Same action as the sidebar card's "New thread on {branch}" menu
+        // item: the new thread joins the active thread's checkout (its git
+        // worktree, or its branch on the local checkout). With no active
+        // checkout to join, fall back to the default contextual create.
+        if (activeThread && (activeThread.worktreePath !== null || activeThread.branch !== null)) {
+          void handleNewThread(
+            scopeProjectRef(activeThread.environmentId, activeThread.projectId),
+            {
+              branch: activeThread.branch,
+              worktreePath: activeThread.worktreePath,
+              envMode: activeThread.worktreePath !== null ? "worktree" : "local",
+              startFromOrigin: false,
+            },
+          );
+          return;
+        }
         void startNewThreadFromContext({
           activeDraftThread,
           activeThread: activeThread ?? undefined,

--- a/apps/web/src/state/terminalSessions.ts
+++ b/apps/web/src/state/terminalSessions.ts
@@ -6,11 +6,59 @@ import {
   type KnownTerminalSession,
   type TerminalSessionState,
 } from "@t3tools/client-runtime/state/terminal";
-import { ThreadId, type EnvironmentId, type TerminalAttachInput } from "@t3tools/contracts";
+import {
+  ThreadId,
+  type EnvironmentId,
+  type TerminalAttachInput,
+  type TerminalSummary,
+} from "@t3tools/contracts";
 import { useMemo } from "react";
 
 import { useEnvironmentQuery } from "./query";
 import { terminalEnvironment } from "./terminal";
+
+const EMPTY_TERMINAL_SUMMARIES: ReadonlyArray<TerminalSummary> = Object.freeze([]);
+const EMPTY_KNOWN_TERMINAL_SESSIONS: ReadonlyArray<KnownTerminalSession> = Object.freeze([]);
+const knownTerminalSessionIndexCache = new WeakMap<
+  ReadonlyArray<TerminalSummary>,
+  {
+    readonly environmentId: EnvironmentId;
+    readonly all: ReadonlyArray<KnownTerminalSession>;
+    readonly byThreadId: ReadonlyMap<string, ReadonlyArray<KnownTerminalSession>>;
+  }
+>();
+
+function indexKnownTerminalSessions(
+  environmentId: EnvironmentId,
+  summaries: ReadonlyArray<TerminalSummary>,
+) {
+  const cached = knownTerminalSessionIndexCache.get(summaries);
+  if (cached?.environmentId === environmentId) return cached;
+
+  const all = summaries
+    .map((summary) => ({
+      target: {
+        environmentId,
+        threadId: ThreadId.make(summary.threadId),
+        terminalId: summary.terminalId,
+      },
+      state: combineTerminalSessionState(summary, EMPTY_TERMINAL_BUFFER_STATE),
+    }))
+    .sort((left, right) =>
+      left.target.terminalId.localeCompare(right.target.terminalId, undefined, {
+        numeric: true,
+      }),
+    );
+  const byThreadId = new Map<string, KnownTerminalSession[]>();
+  for (const session of all) {
+    const existing = byThreadId.get(session.target.threadId);
+    if (existing) existing.push(session);
+    else byThreadId.set(session.target.threadId, [session]);
+  }
+  const indexed = { environmentId, all, byThreadId };
+  knownTerminalSessionIndexCache.set(summaries, indexed);
+  return indexed;
+}
 
 export function useAttachedTerminalSession(input: {
   readonly environmentId: EnvironmentId | null;
@@ -62,23 +110,15 @@ export function useKnownTerminalSessions(input: {
   );
   return useMemo(() => {
     if (input.environmentId === null) {
-      return [];
+      return EMPTY_KNOWN_TERMINAL_SESSIONS;
     }
-    return (metadata.data ?? [])
-      .filter((summary) => input.threadId === null || summary.threadId === input.threadId)
-      .map((summary) => ({
-        target: {
-          environmentId: input.environmentId!,
-          threadId: ThreadId.make(summary.threadId),
-          terminalId: summary.terminalId,
-        },
-        state: combineTerminalSessionState(summary, EMPTY_TERMINAL_BUFFER_STATE),
-      }))
-      .sort((left, right) =>
-        left.target.terminalId.localeCompare(right.target.terminalId, undefined, {
-          numeric: true,
-        }),
-      );
+    const index = indexKnownTerminalSessions(
+      input.environmentId,
+      metadata.data ?? EMPTY_TERMINAL_SUMMARIES,
+    );
+    return input.threadId === null
+      ? index.all
+      : (index.byThreadId.get(input.threadId) ?? EMPTY_KNOWN_TERMINAL_SESSIONS);
   }, [input.environmentId, input.threadId, metadata.data]);
 }
 

--- a/apps/web/src/state/terminalSessions.ts
+++ b/apps/web/src/state/terminalSessions.ts
@@ -128,30 +128,3 @@ export function useThreadRunningTerminalIds(input: {
 }): ReadonlyArray<string> {
   return selectRunningSubprocessTerminalIds(useKnownTerminalSessions(input));
 }
-
-/** Running-subprocess terminals across a set of threads (e.g. every thread
-    sharing a worktree). Terminal ids are only unique per thread, so results
-    are (threadId, terminalId) pairs. */
-export function useRunningTerminalsForThreads(input: {
-  readonly environmentId: EnvironmentId | null;
-  readonly threadIds: ReadonlyArray<ThreadId>;
-}): ReadonlyArray<{ readonly threadId: ThreadId; readonly terminalId: string }> {
-  const sessions = useKnownTerminalSessions({
-    environmentId: input.environmentId,
-    threadId: null,
-  });
-  return useMemo(() => {
-    if (input.threadIds.length === 0) {
-      return [];
-    }
-    const threadIds = new Set<string>(input.threadIds);
-    return sessions
-      .filter(
-        (session) => threadIds.has(session.target.threadId) && session.state.hasRunningSubprocess,
-      )
-      .map((session) => ({
-        threadId: session.target.threadId,
-        terminalId: session.target.terminalId,
-      }));
-  }, [input.threadIds, sessions]);
-}

--- a/apps/web/src/state/terminalSessions.ts
+++ b/apps/web/src/state/terminalSessions.ts
@@ -88,3 +88,30 @@ export function useThreadRunningTerminalIds(input: {
 }): ReadonlyArray<string> {
   return selectRunningSubprocessTerminalIds(useKnownTerminalSessions(input));
 }
+
+/** Running-subprocess terminals across a set of threads (e.g. every thread
+    sharing a worktree). Terminal ids are only unique per thread, so results
+    are (threadId, terminalId) pairs. */
+export function useRunningTerminalsForThreads(input: {
+  readonly environmentId: EnvironmentId | null;
+  readonly threadIds: ReadonlyArray<ThreadId>;
+}): ReadonlyArray<{ readonly threadId: ThreadId; readonly terminalId: string }> {
+  const sessions = useKnownTerminalSessions({
+    environmentId: input.environmentId,
+    threadId: null,
+  });
+  return useMemo(() => {
+    if (input.threadIds.length === 0) {
+      return [];
+    }
+    const threadIds = new Set<string>(input.threadIds);
+    return sessions
+      .filter(
+        (session) => threadIds.has(session.target.threadId) && session.state.hasRunningSubprocess,
+      )
+      .map((session) => ({
+        threadId: session.target.threadId,
+        terminalId: session.target.terminalId,
+      }));
+  }, [input.threadIds, sessions]);
+}

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -284,11 +284,11 @@ describe("terminalUiStateStore actions", () => {
     ).toEqual(["term-2", "term-1"]);
   });
 
-  it("is a no-op when clearing terminal UI state for a thread with no state", () => {
+  it("is a no-op when clearing terminal UI state for a key with no state", () => {
     const store = useTerminalUiStateStore.getState();
     const before = useTerminalUiStateStore.getState();
 
-    store.clearTerminalUiState(THREAD_REF);
+    store.clearTerminalUiStateForKey(scopedThreadKey(THREAD_REF));
 
     expect(useTerminalUiStateStore.getState()).toBe(before);
   });

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -173,19 +173,11 @@ describe("terminalUiStateStore actions", () => {
     ).toEqual(["env-b-terminal"]);
   });
 
-  it("drops persisted entries whose thread keys are not valid scoped keys", () => {
+  it("drops pre-v5 persisted entries (thread-keyed state predates worktree scoping)", () => {
     const migrated = migratePersistedTerminalUiStateStoreState(
       {
         terminalStateByThreadKey: {
           [scopedThreadKey(THREAD_REF)]: {
-            terminalOpen: true,
-            terminalHeight: 320,
-            terminalIds: ["term-1"],
-            activeTerminalId: "term-1",
-            terminalGroups: [{ id: "group-term-1", terminalIds: ["term-1"] }],
-            activeTerminalGroupId: "group-term-1",
-          },
-          "legacy-thread-id": {
             terminalOpen: true,
             terminalHeight: 320,
             terminalIds: ["term-1"],
@@ -198,18 +190,25 @@ describe("terminalUiStateStore actions", () => {
       2,
     );
 
-    expect(migrated).toEqual({
-      terminalUiStateByThreadKey: {
-        [scopedThreadKey(THREAD_REF)]: {
-          terminalOpen: true,
-          terminalHeight: 320,
-          terminalIds: ["term-1"],
-          activeTerminalId: "term-1",
-          terminalGroups: [{ id: "group-term-1", terminalIds: ["term-1"] }],
-          activeTerminalGroupId: "group-term-1",
-        },
-      },
-    });
+    expect(migrated).toEqual({ terminalUiStateByThreadKey: {} });
+  });
+
+  it("passes v5 worktree-keyed entries through unchanged", () => {
+    const worktreeKey = "environment-a:project-1:/tmp/worktrees/feature";
+    const entry = {
+      terminalOpen: true,
+      terminalHeight: 320,
+      terminalIds: ["term-1"],
+      activeTerminalId: "term-1",
+      terminalGroups: [{ id: "group-term-1", terminalIds: ["term-1"] }],
+      activeTerminalGroupId: "group-term-1",
+    };
+    const migrated = migratePersistedTerminalUiStateStoreState(
+      { terminalUiStateByThreadKey: { [worktreeKey]: entry } },
+      5,
+    );
+
+    expect(migrated).toEqual({ terminalUiStateByThreadKey: { [worktreeKey]: entry } });
   });
 
   it("resets to default and clears persisted entry when closing the last terminal", () => {

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -586,7 +586,6 @@ interface TerminalUiStateStoreState {
   setActiveTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   closeTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   reconcileTerminalIds: (threadRef: ScopedThreadRef, nextIds: string[]) => void;
-  clearTerminalUiState: (threadRef: ScopedThreadRef) => void;
   clearTerminalUiStateForKey: (threadKey: string) => void;
   removeTerminalUiState: (threadRef: ScopedThreadRef) => void;
   removeOrphanedTerminalUiStates: (activeThreadKeys: Set<string>) => void;
@@ -707,33 +706,6 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               state,
               nextIds.filter((terminalId) => !suppressedIds.has(terminalId)),
             );
-          }),
-        clearTerminalUiState: (threadRef) =>
-          set((state) => {
-            const threadKey = terminalThreadKey(threadRef);
-            const nextTerminalUiStateByThreadKey = updateTerminalUiStateByThreadKey(
-              state.terminalUiStateByThreadKey,
-              threadRef,
-              () => createDefaultThreadTerminalUiState(),
-            );
-            const migratedSuppressedTerminalIds = migrateWorktreeScopedRecord(
-              state.suppressedTerminalIdsByThreadKey,
-              threadRef,
-            ).record;
-            const hadSuppressedTerminalIds = migratedSuppressedTerminalIds[threadKey] !== undefined;
-            if (
-              nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
-              !hadSuppressedTerminalIds
-            ) {
-              return state;
-            }
-            return {
-              terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
-              suppressedTerminalIdsByThreadKey: removeRecordEntry(
-                migratedSuppressedTerminalIds,
-                threadKey,
-              ),
-            };
           }),
         clearTerminalUiStateForKey: (threadKey) =>
           set((state) => {

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -19,7 +19,11 @@ import {
   MAX_TERMINALS_PER_GROUP,
   type ThreadTerminalGroup,
 } from "./types";
-import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
+import {
+  migrateWorktreeScopedRecord,
+  readWorktreeScopedRecordValue,
+  resolveWorktreeScopeKeyForThreadRef,
+} from "./worktreeScope";
 
 interface ThreadTerminalUiState {
   terminalOpen: boolean;
@@ -487,7 +491,8 @@ export function selectThreadTerminalUiState(
     return getDefaultThreadTerminalUiState();
   }
   return (
-    terminalUiStateByThreadKey[terminalThreadKey(threadRef)] ?? getDefaultThreadTerminalUiState()
+    readWorktreeScopedRecordValue(terminalUiStateByThreadKey, threadRef) ??
+    getDefaultThreadTerminalUiState()
   );
 }
 
@@ -500,23 +505,24 @@ function updateTerminalUiStateByThreadKey(
     return terminalUiStateByThreadKey;
   }
 
-  const threadKey = terminalThreadKey(threadRef);
-  const current = selectThreadTerminalUiState(terminalUiStateByThreadKey, threadRef);
+  const migrated = migrateWorktreeScopedRecord(terminalUiStateByThreadKey, threadRef);
+  const threadKey = migrated.key;
+  const current = migrated.record[threadKey] ?? getDefaultThreadTerminalUiState();
   const next = updater(current);
   if (next === current) {
-    return terminalUiStateByThreadKey;
+    return migrated.record;
   }
 
   if (isDefaultThreadTerminalUiState(next)) {
-    if (terminalUiStateByThreadKey[threadKey] === undefined) {
-      return terminalUiStateByThreadKey;
+    if (migrated.record[threadKey] === undefined) {
+      return migrated.record;
     }
-    const { [threadKey]: _removed, ...rest } = terminalUiStateByThreadKey;
+    const { [threadKey]: _removed, ...rest } = migrated.record;
     return rest;
   }
 
   return {
-    ...terminalUiStateByThreadKey,
+    ...migrated.record,
     [threadKey]: next,
   };
 }
@@ -531,15 +537,16 @@ function updateSuppressedTerminalId(
   if (normalizedTerminalId.length === 0) {
     return suppressedTerminalIdsByThreadKey;
   }
-  const threadKey = terminalThreadKey(threadRef);
-  const currentIds = suppressedTerminalIdsByThreadKey[threadKey] ?? [];
+  const migrated = migrateWorktreeScopedRecord(suppressedTerminalIdsByThreadKey, threadRef);
+  const threadKey = migrated.key;
+  const currentIds = migrated.record[threadKey] ?? [];
   const currentlySuppressed = currentIds.includes(normalizedTerminalId);
   if (currentlySuppressed === suppressed) {
-    return suppressedTerminalIdsByThreadKey;
+    return migrated.record;
   }
   if (suppressed) {
     return {
-      ...suppressedTerminalIdsByThreadKey,
+      ...migrated.record,
       [threadKey]: [...currentIds, normalizedTerminalId],
     };
   }
@@ -547,11 +554,11 @@ function updateSuppressedTerminalId(
   const remainingIds = currentIds.filter((id) => id !== normalizedTerminalId);
   if (remainingIds.length > 0) {
     return {
-      ...suppressedTerminalIdsByThreadKey,
+      ...migrated.record,
       [threadKey]: remainingIds,
     };
   }
-  return removeRecordEntry(suppressedTerminalIdsByThreadKey, threadKey);
+  return removeRecordEntry(migrated.record, threadKey);
 }
 
 function removeRecordEntry<T>(record: Record<string, T>, key: string): Record<string, T> {
@@ -580,6 +587,7 @@ interface TerminalUiStateStoreState {
   closeTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   reconcileTerminalIds: (threadRef: ScopedThreadRef, nextIds: string[]) => void;
   clearTerminalUiState: (threadRef: ScopedThreadRef) => void;
+  clearTerminalUiStateForKey: (threadKey: string) => void;
   removeTerminalUiState: (threadRef: ScopedThreadRef) => void;
   removeOrphanedTerminalUiStates: (activeThreadKeys: Set<string>) => void;
 }
@@ -596,8 +604,8 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
         suppression?: { terminalId: string; suppressed: boolean },
       ) => {
         set((state) => {
-          const threadKey = terminalThreadKey(threadRef);
-          const suppressedTerminalIds = state.suppressedTerminalIdsByThreadKey[threadKey] ?? [];
+          const suppressedTerminalIds =
+            readWorktreeScopedRecordValue(state.suppressedTerminalIdsByThreadKey, threadRef) ?? [];
           const nextTerminalUiStateByThreadKey = updateTerminalUiStateByThreadKey(
             state.terminalUiStateByThreadKey,
             threadRef,
@@ -708,8 +716,11 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
               threadRef,
               () => createDefaultThreadTerminalUiState(),
             );
-            const hadSuppressedTerminalIds =
-              state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
+            const migratedSuppressedTerminalIds = migrateWorktreeScopedRecord(
+              state.suppressedTerminalIdsByThreadKey,
+              threadRef,
+            ).record;
+            const hadSuppressedTerminalIds = migratedSuppressedTerminalIds[threadKey] !== undefined;
             if (
               nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
               !hadSuppressedTerminalIds
@@ -719,6 +730,23 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             return {
               terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
               suppressedTerminalIdsByThreadKey: removeRecordEntry(
+                migratedSuppressedTerminalIds,
+                threadKey,
+              ),
+            };
+          }),
+        clearTerminalUiStateForKey: (threadKey) =>
+          set((state) => {
+            const hadTerminalUiState = state.terminalUiStateByThreadKey[threadKey] !== undefined;
+            const hadSuppressedTerminalIds =
+              state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
+            if (!hadTerminalUiState && !hadSuppressedTerminalIds) return state;
+            return {
+              terminalUiStateByThreadKey: removeRecordEntry(
+                state.terminalUiStateByThreadKey,
+                threadKey,
+              ),
+              suppressedTerminalIdsByThreadKey: removeRecordEntry(
                 state.suppressedTerminalIdsByThreadKey,
                 threadKey,
               ),
@@ -727,19 +755,23 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
         removeTerminalUiState: (threadRef) =>
           set((state) => {
             const threadKey = terminalThreadKey(threadRef);
-            const hadTerminalUiState = state.terminalUiStateByThreadKey[threadKey] !== undefined;
-            const hadSuppressedTerminalIds =
-              state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
+            const migratedTerminalUiState = migrateWorktreeScopedRecord(
+              state.terminalUiStateByThreadKey,
+              threadRef,
+            ).record;
+            const migratedSuppressedTerminalIds = migrateWorktreeScopedRecord(
+              state.suppressedTerminalIdsByThreadKey,
+              threadRef,
+            ).record;
+            const hadTerminalUiState = migratedTerminalUiState[threadKey] !== undefined;
+            const hadSuppressedTerminalIds = migratedSuppressedTerminalIds[threadKey] !== undefined;
             if (!hadTerminalUiState && !hadSuppressedTerminalIds) {
               return state;
             }
             return {
-              terminalUiStateByThreadKey: removeRecordEntry(
-                state.terminalUiStateByThreadKey,
-                threadKey,
-              ),
+              terminalUiStateByThreadKey: removeRecordEntry(migratedTerminalUiState, threadKey),
               suppressedTerminalIdsByThreadKey: removeRecordEntry(
-                state.suppressedTerminalIdsByThreadKey,
+                migratedSuppressedTerminalIds,
                 threadKey,
               ),
             };

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -1,11 +1,14 @@
 /**
- * Single Zustand store for terminal UI state keyed by scoped thread identity.
+ * Single Zustand store for terminal UI state keyed by WORKTREE identity.
+ *
+ * Callers pass a thread ref; the store resolves it to the thread's worktree
+ * scope key so every thread sharing a checkout shares one drawer layout
+ * (open state, height, terminal ids, splits).
  *
  * Terminal UI transition helpers are intentionally private to keep the public
  * API constrained to store actions/selectors.
  */
 
-import { parseScopedThreadKey, scopedThreadKey } from "@t3tools/client-runtime/environment";
 import { type ScopedThreadRef } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -16,6 +19,7 @@ import {
   MAX_TERMINALS_PER_GROUP,
   type ThreadTerminalGroup,
 } from "./types";
+import { resolveWorktreeScopeKeyForThreadRef } from "./worktreeScope";
 
 interface ThreadTerminalUiState {
   terminalOpen: boolean;
@@ -36,20 +40,18 @@ interface PersistedTerminalUiStateStoreState {
 
 export function migratePersistedTerminalUiStateStoreState(
   persistedState: unknown,
-  _version: number,
+  version: number,
 ): PersistedTerminalUiStateStoreState {
-  if (!persistedState || typeof persistedState !== "object") {
+  // v5 re-keyed entries from thread keys to worktree scope keys; older
+  // thread-keyed entries can never match again, so they are dropped rather
+  // than left as unreachable garbage.
+  if (version < 5 || !persistedState || typeof persistedState !== "object") {
     return { terminalUiStateByThreadKey: {} };
   }
 
   const candidate = persistedState as PersistedTerminalUiStateStoreState;
-  const persistedUiStateByThreadKey =
+  const terminalUiStateByThreadKey =
     candidate.terminalUiStateByThreadKey ?? candidate.terminalStateByThreadKey ?? {};
-  const terminalUiStateByThreadKey = Object.fromEntries(
-    Object.entries(persistedUiStateByThreadKey).filter(([threadKey]) =>
-      parseScopedThreadKey(threadKey),
-    ),
-  );
 
   return { terminalUiStateByThreadKey };
 }
@@ -240,7 +242,7 @@ function isValidTerminalId(terminalId: string): boolean {
 }
 
 function terminalThreadKey(threadRef: ScopedThreadRef): string {
-  return scopedThreadKey(threadRef);
+  return resolveWorktreeScopeKeyForThreadRef(threadRef);
 }
 
 function copyTerminalGroups(groups: ThreadTerminalGroup[]): ThreadTerminalGroup[] {
@@ -770,7 +772,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
     },
     {
       name: TERMINAL_UI_STATE_STORAGE_KEY,
-      version: 4,
+      version: 5,
       storage: createJSONStorage(createTerminalUiStateStorage),
       migrate: migratePersistedTerminalUiStateStoreState,
       partialize: (state) => ({

--- a/apps/web/src/worktreeCleanup.test.ts
+++ b/apps/web/src/worktreeCleanup.test.ts
@@ -83,6 +83,23 @@ describe("getOrphanedWorktreePathForThread", () => {
     const result = getOrphanedWorktreePathForThread(threads, ThreadId.make("thread-1"));
     expect(result).toBe("/tmp/repo/worktrees/feature-a");
   });
+
+  it("treats surrounding whitespace as part of the filesystem path", () => {
+    const threads = [
+      makeThread({
+        id: ThreadId.make("thread-1"),
+        worktreePath: "/tmp/repo/worktrees/feature-a",
+      }),
+      makeThread({
+        id: ThreadId.make("thread-2"),
+        worktreePath: "/tmp/repo/worktrees/feature-a ",
+      }),
+    ];
+
+    expect(getOrphanedWorktreePathForThread(threads, ThreadId.make("thread-1"))).toBe(
+      "/tmp/repo/worktrees/feature-a",
+    );
+  });
 });
 
 describe("formatWorktreePathForDisplay", () => {

--- a/apps/web/src/worktreeCleanup.ts
+++ b/apps/web/src/worktreeCleanup.ts
@@ -1,11 +1,7 @@
 import type { ThreadShell } from "./types";
 
 function normalizeWorktreePath(path: string | null): string | null {
-  const trimmed = path?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed;
+  return path && path.length > 0 ? path : null;
 }
 
 export function getOrphanedWorktreePathForThread(

--- a/apps/web/src/worktreeScope.test.ts
+++ b/apps/web/src/worktreeScope.test.ts
@@ -1,4 +1,5 @@
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { worktreeResourceThreadId } from "@t3tools/shared/worktreeResource";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
@@ -8,6 +9,9 @@ import {
   migrateWorktreeScopedRecordKeys,
   resolveWorktreeCanonicalThreadRef,
   resolveWorktreeScopeKeyForThreadRef,
+  threadWorktreeScopeKey,
+  worktreeCanonicalThreadRefsByScopeKey,
+  worktreeRepresentativeThreadRefsByScopeKey,
   worktreeScopeKey,
 } from "./worktreeScope";
 
@@ -84,6 +88,32 @@ describe("worktreeScope", () => {
       worktreeScopeKey(environmentId, projectId, worktreePath),
     );
     expect(resolveWorktreeCanonicalThreadRef(threadRef).threadId).toBe(
+      worktreeResourceThreadId(projectId, worktreePath),
+    );
+  });
+
+  it("keeps a real thread ref available for checkout-scoped UI metadata", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const projectId = ProjectId.make("project-1");
+    const worktreePath = "/repo/worktree";
+    const first = {
+      environmentId,
+      id: ThreadId.make("thread-1"),
+      projectId,
+      worktreePath,
+    } as EnvironmentThreadShell;
+    const second = {
+      environmentId,
+      id: ThreadId.make("thread-2"),
+      projectId,
+      worktreePath,
+    } as EnvironmentThreadShell;
+    const scopeKey = threadWorktreeScopeKey(first);
+
+    expect(worktreeRepresentativeThreadRefsByScopeKey([first, second]).get(scopeKey)).toEqual(
+      scopeThreadRef(environmentId, first.id),
+    );
+    expect(worktreeCanonicalThreadRefsByScopeKey([first, second]).get(scopeKey)?.threadId).toBe(
       worktreeResourceThreadId(projectId, worktreePath),
     );
   });

--- a/apps/web/src/worktreeScope.test.ts
+++ b/apps/web/src/worktreeScope.test.ts
@@ -1,0 +1,48 @@
+import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  migrateWorktreeScopedRecordKeys,
+  selectStableCanonicalThreadId,
+  worktreeScopeKey,
+} from "./worktreeScope";
+
+describe("worktreeScope", () => {
+  it("preserves whitespace that is part of a filesystem path", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const projectId = ProjectId.make("project-1");
+
+    expect(worktreeScopeKey(environmentId, projectId, "/repo/worktree")).not.toBe(
+      worktreeScopeKey(environmentId, projectId, "/repo/worktree "),
+    );
+  });
+
+  it("migrates draft-scoped state when the worktree shell materializes", () => {
+    const fallbackKey = "environment-1:thread-1";
+    const primaryKey = "environment-1:project-1:/repo/worktree";
+    const draftState = { isOpen: true };
+
+    const migrated = migrateWorktreeScopedRecordKeys(
+      { [fallbackKey]: draftState },
+      primaryKey,
+      fallbackKey,
+    );
+
+    expect(migrated).toEqual({
+      key: primaryKey,
+      record: { [primaryKey]: draftState },
+    });
+  });
+
+  it("retains a remembered canonical owner after it leaves the candidate set", () => {
+    const rememberedThreadId = ThreadId.make("thread-oldest");
+    const remainingThreadId = ThreadId.make("thread-sibling");
+
+    expect(
+      selectStableCanonicalThreadId(
+        [{ id: remainingThreadId, createdAt: "2026-01-02T00:00:00.000Z" }],
+        rememberedThreadId,
+      ),
+    ).toBe(rememberedThreadId);
+  });
+});

--- a/apps/web/src/worktreeScope.test.ts
+++ b/apps/web/src/worktreeScope.test.ts
@@ -1,13 +1,25 @@
+import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import { worktreeResourceThreadId } from "@t3tools/shared/worktreeResource";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
 
+import { DraftId, useComposerDraftStore } from "./composerDraftStore";
 import {
   migrateWorktreeScopedRecordKeys,
-  selectStableCanonicalThreadId,
+  resolveWorktreeCanonicalThreadRef,
+  resolveWorktreeScopeKeyForThreadRef,
   worktreeScopeKey,
 } from "./worktreeScope";
 
 describe("worktreeScope", () => {
+  beforeEach(() => {
+    useComposerDraftStore.setState({
+      draftsByThreadKey: {},
+      draftThreadsByThreadKey: {},
+      logicalProjectDraftThreadKeyByLogicalProjectKey: {},
+    });
+  });
+
   it("preserves whitespace that is part of a filesystem path", () => {
     const environmentId = EnvironmentId.make("environment-1");
     const projectId = ProjectId.make("project-1");
@@ -34,15 +46,45 @@ describe("worktreeScope", () => {
     });
   });
 
-  it("retains a remembered canonical owner after it leaves the candidate set", () => {
-    const rememberedThreadId = ThreadId.make("thread-oldest");
-    const remainingThreadId = ThreadId.make("thread-sibling");
+  it("keeps established worktree state when stale draft state also exists", () => {
+    const fallbackKey = "environment-1:thread-1";
+    const primaryKey = "environment-1:project-1:/repo/worktree";
+    const worktreeState = { isOpen: true };
 
     expect(
-      selectStableCanonicalThreadId(
-        [{ id: remainingThreadId, createdAt: "2026-01-02T00:00:00.000Z" }],
-        rememberedThreadId,
+      migrateWorktreeScopedRecordKeys(
+        {
+          [primaryKey]: worktreeState,
+          [fallbackKey]: { isOpen: false },
+        },
+        primaryKey,
+        fallbackKey,
       ),
-    ).toBe(rememberedThreadId);
+    ).toEqual({
+      key: primaryKey,
+      record: { [primaryKey]: worktreeState },
+    });
+  });
+
+  it("uses the final checkout scope and resource owner before a draft is sent", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const projectId = ProjectId.make("project-1");
+    const threadId = ThreadId.make("thread-1");
+    const threadRef = scopeThreadRef(environmentId, threadId);
+    const worktreePath = "/repo/worktree";
+
+    useComposerDraftStore
+      .getState()
+      .setProjectDraftThreadId(scopeProjectRef(environmentId, projectId), DraftId.make("draft-1"), {
+        threadId,
+        worktreePath,
+      });
+
+    expect(resolveWorktreeScopeKeyForThreadRef(threadRef)).toBe(
+      worktreeScopeKey(environmentId, projectId, worktreePath),
+    );
+    expect(resolveWorktreeCanonicalThreadRef(threadRef).threadId).toBe(
+      worktreeResourceThreadId(projectId, worktreePath),
+    );
   });
 });

--- a/apps/web/src/worktreeScope.ts
+++ b/apps/web/src/worktreeScope.ts
@@ -1,75 +1,17 @@
 import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import {
-  ThreadId,
-  type EnvironmentId,
-  type ProjectId,
-  type ScopedThreadRef,
-} from "@t3tools/contracts";
+import type { EnvironmentId, ProjectId, ScopedThreadRef } from "@t3tools/contracts";
+import { worktreeResourceThreadId } from "@t3tools/shared/worktreeResource";
 import { useMemo } from "react";
 
-import {
-  readEnvironmentThreadRefs,
-  readThreadShell,
-  useThreadShell,
-  useThreadShells,
-} from "./state/entities";
+import { useComposerDraftStore } from "./composerDraftStore";
+import { readThreadShell, useThreadShell } from "./state/entities";
 
 /** Threads without a worktree share the project's workspace-root checkout. */
 const LOCAL_CHECKOUT_SEGMENT = "local";
-const CANONICAL_OWNER_STORAGE_KEY = "t3code:worktree-canonical-owners:v1";
-
-let canonicalOwnerThreadIdByScopeKey: Map<string, string> | null = null;
 
 function normalizeWorktreePath(worktreePath: string | null | undefined): string | null {
   return worktreePath && worktreePath.length > 0 ? worktreePath : null;
-}
-
-function readCanonicalOwners(): Map<string, string> {
-  if (canonicalOwnerThreadIdByScopeKey !== null) {
-    return canonicalOwnerThreadIdByScopeKey;
-  }
-  const owners = new Map<string, string>();
-  if (typeof window !== "undefined") {
-    try {
-      const serialized = window.localStorage.getItem(CANONICAL_OWNER_STORAGE_KEY);
-      if (serialized !== null) {
-        const parsed: unknown = JSON.parse(serialized);
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          for (const [scopeKey, threadId] of Object.entries(parsed)) {
-            if (typeof threadId === "string" && threadId.length > 0) {
-              owners.set(scopeKey, threadId);
-            }
-          }
-        }
-      }
-    } catch {
-      // Corrupt or unavailable storage should only reset canonical ownership.
-    }
-  }
-  canonicalOwnerThreadIdByScopeKey = owners;
-  return owners;
-}
-
-function persistCanonicalOwners(owners: ReadonlyMap<string, string>): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(
-      CANONICAL_OWNER_STORAGE_KEY,
-      JSON.stringify(Object.fromEntries(owners)),
-    );
-  } catch {
-    // Resource ownership still remains stable for this renderer session.
-  }
-}
-
-function rememberCanonicalOwner(scopeKey: string, threadId: string): string {
-  const owners = readCanonicalOwners();
-  const existing = owners.get(scopeKey);
-  if (existing !== undefined) return existing;
-  owners.set(scopeKey, threadId);
-  persistCanonicalOwners(owners);
-  return threadId;
 }
 
 /** Identity of the checkout a thread runs in. There is no server-side worktree
@@ -93,7 +35,7 @@ export function threadWorktreeScopeKey(
     key when the shell is unknown (drafts, shells not yet bootstrapped) so state
     degrades to thread-scoped instead of colliding. */
 export function resolveWorktreeScopeKeyForThreadRef(ref: ScopedThreadRef): string {
-  const shell = readThreadShell(ref);
+  const shell = readThreadShell(ref) ?? useComposerDraftStore.getState().getDraftThreadByRef(ref);
   return shell === null ? scopedThreadKey(ref) : threadWorktreeScopeKey(shell);
 }
 
@@ -131,87 +73,34 @@ export function migrateWorktreeScopedRecordKeys<T>(
   if (primaryKey === fallbackKey || record[fallbackKey] === undefined) {
     return { key: primaryKey, record };
   }
-  const fallbackValue = record[fallbackKey]!;
   const { [fallbackKey]: _fallback, ...remaining } = record;
   return {
     key: primaryKey,
-    record: { ...remaining, [primaryKey]: fallbackValue },
+    record:
+      record[primaryKey] === undefined
+        ? { ...remaining, [primaryKey]: record[fallbackKey]! }
+        : remaining,
   };
 }
 
-function compareCanonicalCandidates(
-  left: Pick<EnvironmentThreadShell, "createdAt" | "id">,
-  right: Pick<EnvironmentThreadShell, "createdAt" | "id">,
-): number {
-  const leftCreatedAt = Date.parse(left.createdAt);
-  const rightCreatedAt = Date.parse(right.createdAt);
-  if (Number.isFinite(leftCreatedAt) && Number.isFinite(rightCreatedAt)) {
-    if (leftCreatedAt !== rightCreatedAt) {
-      return leftCreatedAt - rightCreatedAt;
-    }
-  } else if (Number.isFinite(leftCreatedAt)) {
-    return -1;
-  } else if (Number.isFinite(rightCreatedAt)) {
-    return 1;
-  }
-  return left.id.localeCompare(right.id);
-}
-
-export function selectStableCanonicalThreadId(
-  candidates: ReadonlyArray<Pick<EnvironmentThreadShell, "createdAt" | "id">>,
-  rememberedThreadId?: string,
-): string | null {
-  if (rememberedThreadId !== undefined) return rememberedThreadId;
-  return candidates.toSorted(compareCanonicalCandidates)[0]?.id ?? null;
-}
-
-function selectCanonicalShell(
+function resolveCanonicalRef(
   ref: ScopedThreadRef,
-  shell: EnvironmentThreadShell | null,
-  candidates: Iterable<EnvironmentThreadShell | null>,
+  shell: Pick<EnvironmentThreadShell, "projectId" | "worktreePath"> | null,
 ): ScopedThreadRef {
-  if (shell === null) {
-    return ref;
-  }
-  const scopeKey = threadWorktreeScopeKey(shell);
-  const rememberedThreadId = readCanonicalOwners().get(scopeKey);
-  if (rememberedThreadId !== undefined) {
-    return scopeThreadRef(ref.environmentId, ThreadId.make(rememberedThreadId));
-  }
-  // Archived threads stay eligible on purpose: the canonical ref must not
-  // shift (orphaning the worktree's terminal/preview sessions) just because
-  // the oldest thread was archived while siblings remain.
-  const matchingCandidates: EnvironmentThreadShell[] = [];
-  for (const candidate of candidates) {
-    if (candidate === null || candidate.environmentId !== ref.environmentId) {
-      continue;
-    }
-    if (threadWorktreeScopeKey(candidate) !== scopeKey) {
-      continue;
-    }
-    matchingCandidates.push(candidate);
-  }
-  const selectedThreadId = selectStableCanonicalThreadId(matchingCandidates) ?? shell.id;
-  const ownerThreadId = rememberCanonicalOwner(scopeKey, selectedThreadId);
-  return scopeThreadRef(shell.environmentId, ThreadId.make(ownerThreadId));
+  return shell === null
+    ? ref
+    : scopeThreadRef(
+        ref.environmentId,
+        worktreeResourceThreadId(shell.projectId, shell.worktreePath),
+      );
 }
 
 /** Stable thread ref used to scope wire calls (terminal/preview RPCs) for a
-    worktree: the oldest thread that ever ran in the checkout. Server sessions
-    stay keyed by threadId, so every thread in a worktree must agree on the
-    thread id it uses for those calls. */
+    worktree. The synthetic owner is deterministic from project + checkout, so
+    every client agrees even when conversations are archived or deleted. */
 export function resolveWorktreeCanonicalThreadRef(ref: ScopedThreadRef): ScopedThreadRef {
-  const shell = readThreadShell(ref);
-  if (shell === null) {
-    return ref;
-  }
-  return selectCanonicalShell(
-    ref,
-    shell,
-    readEnvironmentThreadRefs(ref.environmentId).map((candidateRef) =>
-      readThreadShell(candidateRef),
-    ),
-  );
+  const shell = readThreadShell(ref) ?? useComposerDraftStore.getState().getDraftThreadByRef(ref);
+  return resolveCanonicalRef(ref, shell);
 }
 
 /** Canonical wire-call thread ref for every worktree scope key present in
@@ -221,51 +110,45 @@ export function resolveWorktreeCanonicalThreadRef(ref: ScopedThreadRef): ScopedT
 export function worktreeCanonicalThreadRefsByScopeKey(
   shells: ReadonlyArray<EnvironmentThreadShell>,
 ): Map<string, ScopedThreadRef> {
-  const bestByKey = new Map<string, EnvironmentThreadShell>();
+  const refsByKey = new Map<string, ScopedThreadRef>();
   for (const shell of shells) {
     const key = threadWorktreeScopeKey(shell);
-    const existing = bestByKey.get(key);
-    if (existing === undefined || compareCanonicalCandidates(shell, existing) < 0) {
-      bestByKey.set(key, shell);
+    if (!refsByKey.has(key)) {
+      refsByKey.set(
+        key,
+        scopeThreadRef(
+          shell.environmentId,
+          worktreeResourceThreadId(shell.projectId, shell.worktreePath),
+        ),
+      );
     }
   }
-  return new Map(
-    [...bestByKey].map(([key, shell]) => [
-      key,
-      scopeThreadRef(shell.environmentId, ThreadId.make(rememberCanonicalOwner(key, shell.id))),
-    ]),
-  );
-}
-
-export function forgetWorktreeCanonicalOwner(ref: ScopedThreadRef): void {
-  const shell = readThreadShell(ref);
-  if (shell === null) return;
-  forgetWorktreeCanonicalOwnerByScopeKey(threadWorktreeScopeKey(shell));
-}
-
-export function forgetWorktreeCanonicalOwnerByScopeKey(scopeKey: string): void {
-  const owners = readCanonicalOwners();
-  if (!owners.delete(scopeKey)) return;
-  persistCanonicalOwners(owners);
+  return refsByKey;
 }
 
 /** Reactive twin of resolveWorktreeScopeKeyForThreadRef. */
 export function useWorktreeScopeKeyForThreadRef(ref: ScopedThreadRef | null): string | null {
   const shell = useThreadShell(ref);
+  const draft = useComposerDraftStore((state) =>
+    ref === null ? null : state.getDraftThreadByRef(ref),
+  );
   if (ref === null) {
     return null;
   }
-  return shell === null ? scopedThreadKey(ref) : threadWorktreeScopeKey(shell);
+  const scope = shell ?? draft;
+  return scope === null ? scopedThreadKey(ref) : threadWorktreeScopeKey(scope);
 }
 
 /** Reactive twin of resolveWorktreeCanonicalThreadRef. */
 export function useWorktreeCanonicalThreadRef(ref: ScopedThreadRef | null): ScopedThreadRef | null {
   const shell = useThreadShell(ref);
-  const shells = useThreadShells();
+  const draft = useComposerDraftStore((state) =>
+    ref === null ? null : state.getDraftThreadByRef(ref),
+  );
   return useMemo(() => {
     if (ref === null) {
       return null;
     }
-    return selectCanonicalShell(ref, shell, shells);
-  }, [ref, shell, shells]);
+    return resolveCanonicalRef(ref, shell ?? draft);
+  }, [draft, ref, shell]);
 }

--- a/apps/web/src/worktreeScope.ts
+++ b/apps/web/src/worktreeScope.ts
@@ -1,0 +1,148 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
+import type { EnvironmentId, ProjectId, ScopedThreadRef } from "@t3tools/contracts";
+import { useMemo } from "react";
+
+import {
+  readEnvironmentThreadRefs,
+  readThreadShell,
+  useThreadShell,
+  useThreadShells,
+} from "./state/entities";
+
+/** Threads without a worktree share the project's workspace-root checkout. */
+const LOCAL_CHECKOUT_SEGMENT = "local";
+
+function normalizeWorktreePath(worktreePath: string | null | undefined): string | null {
+  const trimmed = worktreePath?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+/** Identity of the checkout a thread runs in. There is no server-side worktree
+    entity, so this key is composed client-side: threads with the same key share
+    a working directory (either a git worktree or the project workspace root). */
+export function worktreeScopeKey(
+  environmentId: EnvironmentId,
+  projectId: ProjectId,
+  worktreePath: string | null | undefined,
+): string {
+  return `${environmentId}:${projectId}:${normalizeWorktreePath(worktreePath) ?? LOCAL_CHECKOUT_SEGMENT}`;
+}
+
+export function threadWorktreeScopeKey(
+  shell: Pick<EnvironmentThreadShell, "environmentId" | "projectId" | "worktreePath">,
+): string {
+  return worktreeScopeKey(shell.environmentId, shell.projectId, shell.worktreePath);
+}
+
+/** Worktree scope key for a thread ref, falling back to the plain scoped thread
+    key when the shell is unknown (drafts, shells not yet bootstrapped) so state
+    degrades to thread-scoped instead of colliding. */
+export function resolveWorktreeScopeKeyForThreadRef(ref: ScopedThreadRef): string {
+  const shell = readThreadShell(ref);
+  return shell === null ? scopedThreadKey(ref) : threadWorktreeScopeKey(shell);
+}
+
+function compareCanonicalCandidates(
+  left: EnvironmentThreadShell,
+  right: EnvironmentThreadShell,
+): number {
+  const leftCreatedAt = Date.parse(left.createdAt);
+  const rightCreatedAt = Date.parse(right.createdAt);
+  if (Number.isFinite(leftCreatedAt) && Number.isFinite(rightCreatedAt)) {
+    if (leftCreatedAt !== rightCreatedAt) {
+      return leftCreatedAt - rightCreatedAt;
+    }
+  } else if (Number.isFinite(leftCreatedAt)) {
+    return -1;
+  } else if (Number.isFinite(rightCreatedAt)) {
+    return 1;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function selectCanonicalShell(
+  ref: ScopedThreadRef,
+  shell: EnvironmentThreadShell | null,
+  candidates: Iterable<EnvironmentThreadShell | null>,
+): ScopedThreadRef {
+  if (shell === null) {
+    return ref;
+  }
+  const scopeKey = threadWorktreeScopeKey(shell);
+  // Archived threads stay eligible on purpose: the canonical ref must not
+  // shift (orphaning the worktree's terminal/preview sessions) just because
+  // the oldest thread was archived while siblings remain.
+  let canonical: EnvironmentThreadShell | null = null;
+  for (const candidate of candidates) {
+    if (candidate === null || candidate.environmentId !== ref.environmentId) {
+      continue;
+    }
+    if (threadWorktreeScopeKey(candidate) !== scopeKey) {
+      continue;
+    }
+    if (canonical === null || compareCanonicalCandidates(candidate, canonical) < 0) {
+      canonical = candidate;
+    }
+  }
+  return canonical === null ? ref : scopeThreadRef(canonical.environmentId, canonical.id);
+}
+
+/** Stable thread ref used to scope wire calls (terminal/preview RPCs) for a
+    worktree: the oldest thread that ever ran in the checkout. Server sessions
+    stay keyed by threadId, so every thread in a worktree must agree on the
+    thread id it uses for those calls. */
+export function resolveWorktreeCanonicalThreadRef(ref: ScopedThreadRef): ScopedThreadRef {
+  const shell = readThreadShell(ref);
+  if (shell === null) {
+    return ref;
+  }
+  return selectCanonicalShell(
+    ref,
+    shell,
+    readEnvironmentThreadRefs(ref.environmentId).map((candidateRef) =>
+      readThreadShell(candidateRef),
+    ),
+  );
+}
+
+/** Canonical wire-call thread ref for every worktree scope key present in
+    `shells`. Bulk twin of resolveWorktreeCanonicalThreadRef for callers that
+    need to resolve many scope keys reactively (e.g. mounted terminal
+    drawers). */
+export function worktreeCanonicalThreadRefsByScopeKey(
+  shells: ReadonlyArray<EnvironmentThreadShell>,
+): Map<string, ScopedThreadRef> {
+  const bestByKey = new Map<string, EnvironmentThreadShell>();
+  for (const shell of shells) {
+    const key = threadWorktreeScopeKey(shell);
+    const existing = bestByKey.get(key);
+    if (existing === undefined || compareCanonicalCandidates(shell, existing) < 0) {
+      bestByKey.set(key, shell);
+    }
+  }
+  return new Map(
+    [...bestByKey].map(([key, shell]) => [key, scopeThreadRef(shell.environmentId, shell.id)]),
+  );
+}
+
+/** Reactive twin of resolveWorktreeScopeKeyForThreadRef. */
+export function useWorktreeScopeKeyForThreadRef(ref: ScopedThreadRef | null): string | null {
+  const shell = useThreadShell(ref);
+  if (ref === null) {
+    return null;
+  }
+  return shell === null ? scopedThreadKey(ref) : threadWorktreeScopeKey(shell);
+}
+
+/** Reactive twin of resolveWorktreeCanonicalThreadRef. */
+export function useWorktreeCanonicalThreadRef(ref: ScopedThreadRef | null): ScopedThreadRef | null {
+  const shell = useThreadShell(ref);
+  const shells = useThreadShells();
+  return useMemo(() => {
+    if (ref === null) {
+      return null;
+    }
+    return selectCanonicalShell(ref, shell, shells);
+  }, [ref, shell, shells]);
+}

--- a/apps/web/src/worktreeScope.ts
+++ b/apps/web/src/worktreeScope.ts
@@ -126,6 +126,24 @@ export function worktreeCanonicalThreadRefsByScopeKey(
   return refsByKey;
 }
 
+/**
+ * Real thread refs used when mounted checkout-scoped UI still needs thread and
+ * project metadata. Wire resources use the synthetic refs above, but those refs
+ * intentionally have no matching thread shell.
+ */
+export function worktreeRepresentativeThreadRefsByScopeKey(
+  shells: ReadonlyArray<EnvironmentThreadShell>,
+): Map<string, ScopedThreadRef> {
+  const refsByKey = new Map<string, ScopedThreadRef>();
+  for (const shell of shells) {
+    const key = threadWorktreeScopeKey(shell);
+    if (!refsByKey.has(key)) {
+      refsByKey.set(key, scopeThreadRef(shell.environmentId, shell.id));
+    }
+  }
+  return refsByKey;
+}
+
 /** Reactive twin of resolveWorktreeScopeKeyForThreadRef. */
 export function useWorktreeScopeKeyForThreadRef(ref: ScopedThreadRef | null): string | null {
   const shell = useThreadShell(ref);

--- a/apps/web/src/worktreeScope.ts
+++ b/apps/web/src/worktreeScope.ts
@@ -1,6 +1,11 @@
 import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import type { EnvironmentId, ProjectId, ScopedThreadRef } from "@t3tools/contracts";
+import {
+  ThreadId,
+  type EnvironmentId,
+  type ProjectId,
+  type ScopedThreadRef,
+} from "@t3tools/contracts";
 import { useMemo } from "react";
 
 import {
@@ -12,10 +17,59 @@ import {
 
 /** Threads without a worktree share the project's workspace-root checkout. */
 const LOCAL_CHECKOUT_SEGMENT = "local";
+const CANONICAL_OWNER_STORAGE_KEY = "t3code:worktree-canonical-owners:v1";
+
+let canonicalOwnerThreadIdByScopeKey: Map<string, string> | null = null;
 
 function normalizeWorktreePath(worktreePath: string | null | undefined): string | null {
-  const trimmed = worktreePath?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : null;
+  return worktreePath && worktreePath.length > 0 ? worktreePath : null;
+}
+
+function readCanonicalOwners(): Map<string, string> {
+  if (canonicalOwnerThreadIdByScopeKey !== null) {
+    return canonicalOwnerThreadIdByScopeKey;
+  }
+  const owners = new Map<string, string>();
+  if (typeof window !== "undefined") {
+    try {
+      const serialized = window.localStorage.getItem(CANONICAL_OWNER_STORAGE_KEY);
+      if (serialized !== null) {
+        const parsed: unknown = JSON.parse(serialized);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          for (const [scopeKey, threadId] of Object.entries(parsed)) {
+            if (typeof threadId === "string" && threadId.length > 0) {
+              owners.set(scopeKey, threadId);
+            }
+          }
+        }
+      }
+    } catch {
+      // Corrupt or unavailable storage should only reset canonical ownership.
+    }
+  }
+  canonicalOwnerThreadIdByScopeKey = owners;
+  return owners;
+}
+
+function persistCanonicalOwners(owners: ReadonlyMap<string, string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CANONICAL_OWNER_STORAGE_KEY,
+      JSON.stringify(Object.fromEntries(owners)),
+    );
+  } catch {
+    // Resource ownership still remains stable for this renderer session.
+  }
+}
+
+function rememberCanonicalOwner(scopeKey: string, threadId: string): string {
+  const owners = readCanonicalOwners();
+  const existing = owners.get(scopeKey);
+  if (existing !== undefined) return existing;
+  owners.set(scopeKey, threadId);
+  persistCanonicalOwners(owners);
+  return threadId;
 }
 
 /** Identity of the checkout a thread runs in. There is no server-side worktree
@@ -43,9 +97,51 @@ export function resolveWorktreeScopeKeyForThreadRef(ref: ScopedThreadRef): strin
   return shell === null ? scopedThreadKey(ref) : threadWorktreeScopeKey(shell);
 }
 
+export function worktreeStateKeysForThreadRef(ref: ScopedThreadRef): {
+  primaryKey: string;
+  fallbackKey: string;
+} {
+  return {
+    primaryKey: resolveWorktreeScopeKeyForThreadRef(ref),
+    fallbackKey: scopedThreadKey(ref),
+  };
+}
+
+export function readWorktreeScopedRecordValue<T>(
+  record: Readonly<Record<string, T>>,
+  ref: ScopedThreadRef,
+): T | undefined {
+  const { primaryKey, fallbackKey } = worktreeStateKeysForThreadRef(ref);
+  return record[primaryKey] ?? record[fallbackKey];
+}
+
+export function migrateWorktreeScopedRecord<T>(
+  record: Record<string, T>,
+  ref: ScopedThreadRef,
+): { key: string; record: Record<string, T> } {
+  const { primaryKey, fallbackKey } = worktreeStateKeysForThreadRef(ref);
+  return migrateWorktreeScopedRecordKeys(record, primaryKey, fallbackKey);
+}
+
+export function migrateWorktreeScopedRecordKeys<T>(
+  record: Record<string, T>,
+  primaryKey: string,
+  fallbackKey: string,
+): { key: string; record: Record<string, T> } {
+  if (primaryKey === fallbackKey || record[fallbackKey] === undefined) {
+    return { key: primaryKey, record };
+  }
+  const fallbackValue = record[fallbackKey]!;
+  const { [fallbackKey]: _fallback, ...remaining } = record;
+  return {
+    key: primaryKey,
+    record: { ...remaining, [primaryKey]: fallbackValue },
+  };
+}
+
 function compareCanonicalCandidates(
-  left: EnvironmentThreadShell,
-  right: EnvironmentThreadShell,
+  left: Pick<EnvironmentThreadShell, "createdAt" | "id">,
+  right: Pick<EnvironmentThreadShell, "createdAt" | "id">,
 ): number {
   const leftCreatedAt = Date.parse(left.createdAt);
   const rightCreatedAt = Date.parse(right.createdAt);
@@ -61,6 +157,14 @@ function compareCanonicalCandidates(
   return left.id.localeCompare(right.id);
 }
 
+export function selectStableCanonicalThreadId(
+  candidates: ReadonlyArray<Pick<EnvironmentThreadShell, "createdAt" | "id">>,
+  rememberedThreadId?: string,
+): string | null {
+  if (rememberedThreadId !== undefined) return rememberedThreadId;
+  return candidates.toSorted(compareCanonicalCandidates)[0]?.id ?? null;
+}
+
 function selectCanonicalShell(
   ref: ScopedThreadRef,
   shell: EnvironmentThreadShell | null,
@@ -70,10 +174,14 @@ function selectCanonicalShell(
     return ref;
   }
   const scopeKey = threadWorktreeScopeKey(shell);
+  const rememberedThreadId = readCanonicalOwners().get(scopeKey);
+  if (rememberedThreadId !== undefined) {
+    return scopeThreadRef(ref.environmentId, ThreadId.make(rememberedThreadId));
+  }
   // Archived threads stay eligible on purpose: the canonical ref must not
   // shift (orphaning the worktree's terminal/preview sessions) just because
   // the oldest thread was archived while siblings remain.
-  let canonical: EnvironmentThreadShell | null = null;
+  const matchingCandidates: EnvironmentThreadShell[] = [];
   for (const candidate of candidates) {
     if (candidate === null || candidate.environmentId !== ref.environmentId) {
       continue;
@@ -81,11 +189,11 @@ function selectCanonicalShell(
     if (threadWorktreeScopeKey(candidate) !== scopeKey) {
       continue;
     }
-    if (canonical === null || compareCanonicalCandidates(candidate, canonical) < 0) {
-      canonical = candidate;
-    }
+    matchingCandidates.push(candidate);
   }
-  return canonical === null ? ref : scopeThreadRef(canonical.environmentId, canonical.id);
+  const selectedThreadId = selectStableCanonicalThreadId(matchingCandidates) ?? shell.id;
+  const ownerThreadId = rememberCanonicalOwner(scopeKey, selectedThreadId);
+  return scopeThreadRef(shell.environmentId, ThreadId.make(ownerThreadId));
 }
 
 /** Stable thread ref used to scope wire calls (terminal/preview RPCs) for a
@@ -122,8 +230,23 @@ export function worktreeCanonicalThreadRefsByScopeKey(
     }
   }
   return new Map(
-    [...bestByKey].map(([key, shell]) => [key, scopeThreadRef(shell.environmentId, shell.id)]),
+    [...bestByKey].map(([key, shell]) => [
+      key,
+      scopeThreadRef(shell.environmentId, ThreadId.make(rememberCanonicalOwner(key, shell.id))),
+    ]),
   );
+}
+
+export function forgetWorktreeCanonicalOwner(ref: ScopedThreadRef): void {
+  const shell = readThreadShell(ref);
+  if (shell === null) return;
+  forgetWorktreeCanonicalOwnerByScopeKey(threadWorktreeScopeKey(shell));
+}
+
+export function forgetWorktreeCanonicalOwnerByScopeKey(scopeKey: string): void {
+  const owners = readCanonicalOwners();
+  if (!owners.delete(scopeKey)) return;
+  persistCanonicalOwners(owners);
 }
 
 /** Reactive twin of resolveWorktreeScopeKeyForThreadRef. */

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
   - [Remote access](./user/remote-access.md)
   - [Keeping T3 Code in sync](./user/server-updates.md)
   - [Keybindings](./user/keybindings.md)
+  - [Threads in the same checkout](./user/worktree-scoped-threads.md)
 - [T3 Connect](./cloud/t3-connect-clerk.md)
 - [Integrations](./integrations/source-control-providers.md)
 - [Mobile](./mobile/app.md)

--- a/docs/reference/encyclopedia.md
+++ b/docs/reference/encyclopedia.md
@@ -26,6 +26,15 @@ The root filesystem path for a project. In [the orchestration model][1], it is t
 
 A Git worktree used as an isolated workspace for a thread. If a thread has a `worktreePath` in [the contracts][1], it runs there instead of in the main working tree. Git operations live in [GitCore.ts][3].
 
+#### Checkout scope
+
+The project checkout shared by one or more threads. It is either a Git worktree
+or the project's main workspace root. Checkout-owned resources such as
+terminals, previews, open files, and Git diff state remain available while the
+user switches between sibling conversations. Messages, turns, approvals, and
+plans remain thread-owned. See
+[Threads in the same checkout](../user/worktree-scoped-threads.md).
+
 ### Thread timeline
 
 #### Thread

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -65,6 +65,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `preview.resetZoom`: reset the preview zoom to 100% (in focused preview context by default)
 - `commandPalette.toggle`: open or close the global command palette
 - `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
+- `chat.newInWorktree`: create another conversation in the current checkout (default `mod+t`)
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
 - `editor.openFavorite`: open current project/worktree in the last-used editor
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)

--- a/docs/user/worktree-scoped-threads.md
+++ b/docs/user/worktree-scoped-threads.md
@@ -1,0 +1,24 @@
+# Threads in the same checkout
+
+The sidebar groups active threads by checkout. Threads that use the same Git
+worktree appear in one card, and threads that use a project's main checkout
+share a card as well.
+
+Each conversation keeps its own messages, turns, approvals, and plan. Resources
+that belong to the checkout are shared across the card:
+
+- terminal sessions and terminal layout
+- preview tabs
+- open files and Git diff state
+- the checkout's current branch and pull request
+
+Switching between sibling threads therefore keeps a running dev server, browser
+preview, and workspace panels in place. Archiving or deleting one sibling does
+not stop those resources while another sibling remains. Removing the final
+thread closes the checkout-owned terminal resources.
+
+Use `chat.newInWorktree` (default: `mod+t`) to start another conversation in the
+current checkout. `chat.new` keeps the active thread's branch/worktree setup,
+while `chat.newLocal` follows the configured default for a new environment.
+
+See [Keybindings](./keybindings.md) to customize these shortcuts.

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -66,6 +66,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "composer.stash",
   "chat.new",
   "chat.newLocal",
+  "chat.newInWorktree",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -206,6 +206,10 @@
     "./devProxy": {
       "types": "./src/devProxy.ts",
       "import": "./src/devProxy.ts"
+    },
+    "./worktreeResource": {
+      "types": "./src/worktreeResource.ts",
+      "import": "./src/worktreeResource.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -39,6 +39,9 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  // "New thread on {branch}": joins the active thread's worktree/branch
+  // instead of creating a fresh checkout.
+  { key: "mod+t", command: "chat.newInWorktree", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },

--- a/packages/shared/src/worktreeResource.test.ts
+++ b/packages/shared/src/worktreeResource.test.ts
@@ -1,0 +1,24 @@
+import { ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { worktreeResourceThreadId } from "./worktreeResource.ts";
+
+describe("worktreeResourceThreadId", () => {
+  const projectId = ProjectId.make("project-1");
+
+  it("is stable for every client viewing the same checkout", () => {
+    expect(worktreeResourceThreadId(projectId, "/repo/worktree")).toBe(
+      worktreeResourceThreadId(projectId, "/repo/worktree"),
+    );
+  });
+
+  it("keeps whitespace-bearing paths distinct", () => {
+    expect(worktreeResourceThreadId(projectId, "/repo/worktree")).not.toBe(
+      worktreeResourceThreadId(projectId, "/repo/worktree "),
+    );
+  });
+
+  it("uses one owner for blank and local-checkout paths", () => {
+    expect(worktreeResourceThreadId(projectId, null)).toBe(worktreeResourceThreadId(projectId, ""));
+  });
+});

--- a/packages/shared/src/worktreeResource.ts
+++ b/packages/shared/src/worktreeResource.ts
@@ -1,0 +1,21 @@
+import { ThreadId, type ProjectId } from "@t3tools/contracts";
+
+const LOCAL_CHECKOUT_SEGMENT = "local";
+
+/**
+ * Stable server-side owner for resources shared by every thread in a checkout.
+ *
+ * Environments are separate server processes, so project + checkout identity is
+ * sufficient and gives every connected client the same owner without storing
+ * renderer-local election state.
+ */
+export function worktreeResourceThreadId(
+  projectId: ProjectId,
+  worktreePath: string | null | undefined,
+): ThreadId {
+  const checkoutSegment =
+    worktreePath && worktreePath.length > 0
+      ? encodeURIComponent(worktreePath)
+      : LOCAL_CHECKOUT_SEGMENT;
+  return ThreadId.make(`worktree:${projectId}:${checkoutSegment}`);
+}


### PR DESCRIPTION
## Demo
#### Video Demo: https://cap.so/s/re2f8y944mb8vfr

<img width="1500" height="950" alt="t3-sidebar-1-worktree-cards-overview" src="https://github.com/user-attachments/assets/3d12d4d6-cd52-4f1d-9cf3-e85511456f45" />
<img width="1500" height="950" alt="t3-sidebar-2-worktree-level-settle-snooze" src="https://github.com/user-attachments/assets/99331816-05ef-4e31-a085-4f082ad33235" />
<img width="1500" height="950" alt="t3-sidebar-3-worktree-activity-indicators" src="https://github.com/user-attachments/assets/1f27e766-0234-428c-8c5d-545737d994c5" />
<img width="1500" height="950" alt="t3-sidebar-4-panes-persist-across-threads" src="https://github.com/user-attachments/assets/bafaba06-e33a-4812-b243-006a5d7b5ccd" />


## What

Sidebar v2 rows now represent a **worktree** instead of a thread, and the right-panel surfaces follow the checkout rather than the thread.

### Sidebar

- Threads sharing a checkout collapse into **one card**. Each thread's summary is its own clickable row, carrying **that thread's provider logo** — threads in one worktree can run different providers.
- Branch, PR badge, diff stats and the repository row stay at the **worktree** level. Single-thread worktrees look essentially as they do today.
- **Settle / snooze** (and un-settle / wake) act on every thread in the worktree, from the hover actions, the context menu (labelled `Settle worktree (N threads)` when it applies to more than one) and multi-select. A snoozed worktree gets one Undo toast, not one per thread.
- The v1 **activity indicators are back**: pulsing terminal icon and emerald dev-server globe, inline with the repository row — that is the worktree level, which is where terminals and dev servers actually live.
- Settled and snoozed shelves collapse a whole worktree to a single row.

### Panes

Terminal, browser, diff and files are keyed to the worktree, so switching between sibling threads keeps the same terminal session (including a running dev server), the same browser tabs, and the same diff/files state. They change only when the checkout does.

### Keybinding

New `chat.newInWorktree`, default <kbd>⌘T</kbd>: the keyboard equivalent of a card's "New thread on {branch}" action. Falls back to a normal new thread when there is no checkout to join.

## How

There is no worktree entity in the data model — a worktree is only `thread.worktreePath` — so identity is composed client-side in `apps/web/src/worktreeScope.ts` as `environment + project + worktreePath`, with a null path meaning the project's local checkout.

Server terminal and preview sessions stay keyed by `threadId` on the wire, so every thread in a worktree routes those calls through a stable **canonical thread ref** (the oldest thread ever in the checkout; archived threads stay eligible so the ref cannot shift out from under live sessions).

`rightPanelStore`, `terminalUiStateStore`, `diffPanelStore` and `previewStateStore` still take a `ScopedThreadRef` publicly but key internally by worktree scope key.

## Notes for reviewers

- **Persisted state is dropped on upgrade.** Right-panel (v7→v8), terminal UI (v4→v5) and diff-panel (v1→v2) migrations discard old thread-keyed entries — they can never match a worktree key again, and leaving them would be unreachable garbage.
- **One server change** (`apps/server/src/ws.ts`): archiving a thread no longer closes its terminals while another non-archived thread shares the same checkout. Without this, archiving one thread kills a dev server its siblings are still using. Covered by a new test.
- **Known trade-offs:** terminals opened by an older client under a non-canonical sibling thread will not appear in the worktree drawer; multiple local-checkout (non-worktree) threads in one project now share a card and one set of panes, which follows from "panes belong to the checkout".

## Testing

- `pnpm typecheck` clean in `apps/web`, `apps/server`, `packages/contracts`, `packages/shared`
- `pnpm test` in `apps/web`: 1527 passing, including 14 new unit tests for the worktree grouping/bucketing/ordering logic
- `pnpm test` in `apps/server`: passing, including a new test for the shared-worktree archive guard. One unrelated `GitManager` commit-hook test fails on my machine on a clean checkout too — pre-existing, not from this change.
- Verified manually against a seeded local instance: multi-thread cards, per-thread provider logos, worktree-level settle/snooze, live terminal + dev-server indicators, and terminal/dev-server persistence across sibling-thread navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat UX, multiple persisted client stores (migrations discard prior layout), and server archive/terminal cleanup; behavior is covered by new unit and server tests but regressions could affect live dev servers and multi-thread workflows.
> 
> **Overview**
> Sidebar v2 **rows are now worktrees**, not threads: siblings sharing a checkout collapse into one **card** (per-thread summary lines inside) or one **slim shelf row** when snoozed/settled. Settle, snooze, wake, and multi-select lifecycle actions apply to **all threads in the worktree**, with worktree-level terminal/dev-server indicators on the card header.
> 
> **Panes and wire traffic follow the checkout.** New `worktreeScope` helpers derive a worktree scope key and a **canonical thread ref** so terminals, previews, diff/files, and right-panel surfaces stay shared when switching between sibling threads; `ChatView` and preview open paths route server calls through that canonical id. Persisted right-panel, terminal UI, and diff-panel store versions are bumped and **old thread-keyed entries are dropped** on upgrade.
> 
> On the server, **thread archive** no longer calls `terminalManager.close` for the archived thread alone—it skips close while another live thread shares the same project/checkout, and otherwise closes using `worktreeResourceThreadId` (tests updated/added in `server.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5a02963fdfe4b2006ae1789dce5b80be05908a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group sidebar V2 threads by worktree and scope terminal, preview, and right panel state to the checkout
> - Introduces a worktree grouping concept so threads sharing the same checkout are treated as a unit; the sidebar now renders one card per worktree (active) or one slim row per worktree (snoozed/settled) instead of one row per thread.
> - Adds [`worktreeScope.ts`](https://github.com/pingdotgg/t3code/pull/4521/files#diff-b4224b980c6a19935dbd2600e64fd31a4d04c5055183c0d6a740e399cd5e7855) with helpers to derive stable worktree scope keys and canonical thread refs, and migrates keyed records from draft/thread scope to worktree scope on first write.
> - Terminal sessions, preview tabs, diff panel selections, and right panel state are all re-keyed by worktree scope; sibling threads within the same checkout share server-side sessions rather than each owning separate ones.
> - Adds `worktreeResourceThreadId` in [`packages/shared/src/worktreeResource.ts`](https://github.com/pingdotgg/t3code/pull/4521/files#diff-e3b16f20112573e49cbf66a9498c81ca344e6f507fccb2eb99eb7b7022e03c99) to compute a stable checkout-owned thread ID used as the canonical target for terminal/preview RPCs.
> - Adds the `chat.newInWorktree` command (default `mod+t`) to create a new thread in the active thread's checkout.
> - On thread archive/delete, terminals are only closed when no other live thread shares the same checkout, and the close targets the checkout's canonical owner ID.
> - Risk: persisted state for right panel (pre-v9), diff panel (pre-v2), and terminal UI (pre-v5) is dropped on load rather than migrated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f5a029.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->