### PR TITLE
fix(web): preserve virtualized diff scrolling

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -866,7 +866,11 @@ export default function DiffPanel({
                 <AnnotatableCodeView
                   viewerRef={codeViewRef}
                   key={collapseScopeKey ?? reviewSectionId}
-                  className="diff-render-surface h-full min-h-0 overflow-auto [&>div>div:last-child]:top-0! [&>div>div:last-child]:bottom-auto!"
+                  className={cn(
+                    "diff-render-surface h-full min-h-0 overflow-auto",
+                    allDiffFilesCollapsed &&
+                      "[&>div>div:last-child]:top-0! [&>div>div:last-child]:bottom-auto!",
+                  )}
                   files={codeViewFiles}
                   sectionId={reviewSectionId}
                   sectionTitle={reviewSectionTitle}


### PR DESCRIPTION
Fixes #4525

## What Changed

Conditionally apply the existing `top: 0` and `bottom: auto` overrides when all diff files are collapsed.

## Why

Commit 38cfc25e5 made the override unconditional. This prevents the virtualizer from positioning expanded diff content and causes scrolling to drift.

Removing the override entirely restores a gap above the all-collapsed file list, so keeping it conditional preserves both behaviours.

## UI Changes

Before: expanded diffs drift behind the scrollbar as files are traversed.

After: expanded diffs follow the virtualizer while collapsed file headers remain aligned below the toolbar.

Collapsed Spacing Video:

https://github.com/user-attachments/assets/e3f55128-e190-4a29-8d4f-5b7e33df4df0

Virtual Scroll Video:

https://github.com/user-attachments/assets/75841766-cbef-40e3-a454-50383e102efa

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A: interaction-only; see videos)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional class change in DiffPanel UI styling with no auth, data, or API impact.
> 
> **Overview**
> Fixes **virtualized diff scrolling** in the diff panel by only applying the virtualizer `top`/`bottom` CSS overrides when **all diff files are collapsed**.
> 
> `AnnotatableCodeView` previously always included `[&>div>div:last-child]:top-0!` and `bottom-auto!`, which broke the virtualizer’s positioning for expanded files and caused scroll drift. Those classes are now added via `cn()` only when `allDiffFilesCollapsed` is true, so expanded diffs scroll correctly while the all-collapsed header layout stays aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71f197d8a6d3bcd5974970c0dcbb921f18ee2a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix diff render surface scroll position in non-collapsed state
> The CSS overrides `top:0` and `bottom:auto` on the last child of `AnnotatableCodeView` in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/4526/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) were always applied, breaking scroll behavior when diff files are expanded. They are now conditional on `allDiffFilesCollapsed`, restoring correct virtualized scroll positioning in the non-collapsed state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b71f197.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->