### PR TITLE
feat: auto reasoning effort with bounded limits and per-message model attribution

### DIFF
--- a/apps/mobile/src/lib/providerOptions.test.ts
+++ b/apps/mobile/src/lib/providerOptions.test.ts
@@ -46,6 +46,7 @@ describe("mobile provider options", () => {
         title: "Reasoning",
         subtitle: "Medium",
         subactions: [
+          { title: "Auto", state: undefined },
           { title: "Medium (default)", state: "on" },
           { title: "High", state: undefined },
         ],
@@ -75,6 +76,69 @@ describe("mobile provider options", () => {
       { id: "reasoningEffort", value: "medium" },
       { id: "serviceTier", value: "priority" },
     ]);
+  });
+
+  it("reveals the auto effort limits only once auto is selected", () => {
+    const manual = resolveProviderOptionDescriptors({
+      capabilities: CODEX_CAPABILITIES,
+      selections: [{ id: "reasoningEffort", value: "high" }],
+    });
+    expect(buildProviderOptionMenuActions(manual).map((action) => action.title)).toEqual([
+      "Reasoning",
+      "Service Tier",
+    ]);
+
+    const auto = resolveProviderOptionDescriptors({
+      capabilities: CODEX_CAPABILITIES,
+      selections: [{ id: "reasoningEffort", value: "auto" }],
+    });
+    expect(buildProviderOptionMenuActions(auto).map((action) => action.title)).toEqual([
+      "Reasoning",
+      "Minimum",
+      "Maximum",
+      "Service Tier",
+    ]);
+    expect(providerOptionsConfigurationLabel(auto)).toBe("Auto · Standard");
+  });
+
+  it("keeps the auto limits from contradicting each other", () => {
+    const descriptors = resolveProviderOptionDescriptors({
+      capabilities: CODEX_CAPABILITIES,
+      selections: [
+        { id: "reasoningEffort", value: "auto" },
+        { id: "reasoningEffortAutoCeiling", value: "medium" },
+        { id: "reasoningEffortAutoFloor", value: "medium" },
+      ],
+    });
+    const minimumHigh = buildProviderOptionMenuActions(descriptors)
+      .find((action) => action.title === "Minimum")
+      ?.subactions?.find((subaction) => subaction.title === "High");
+
+    expect(minimumHigh?.id).toBeDefined();
+    expect(applyProviderOptionMenuEvent(descriptors, minimumHigh!.id!)).toEqual([
+      { id: "reasoningEffort", value: "auto" },
+      { id: "reasoningEffortAutoFloor", value: "high" },
+      { id: "reasoningEffortAutoCeiling", value: "high" },
+      { id: "serviceTier", value: "default" },
+    ]);
+  });
+
+  it("keeps stored auto limits out of the menu after switching back to a manual effort", () => {
+    const descriptors = resolveProviderOptionDescriptors({
+      capabilities: CODEX_CAPABILITIES,
+      selections: [
+        { id: "reasoningEffort", value: "high" },
+        { id: "reasoningEffortAutoCeiling", value: "high" },
+      ],
+    });
+
+    expect(buildProviderOptionMenuActions(descriptors).map((action) => action.title)).toEqual([
+      "Reasoning",
+      "Service Tier",
+    ]);
+    // The stored limit still round-trips so re-enabling Auto keeps the choice.
+    expect(applyProviderOptionMenuEvent(descriptors, "provider-option:bogus")).toBeNull();
+    expect(providerOptionsConfigurationLabel(descriptors)).toBe("High · Standard");
   });
 
   it("treats an unspecified boolean capability as off", () => {

--- a/apps/mobile/src/lib/providerOptions.ts
+++ b/apps/mobile/src/lib/providerOptions.ts
@@ -5,10 +5,16 @@ import type {
 } from "@t3tools/contracts";
 import type { MenuAction } from "@react-native-menu/menu";
 import {
+  AUTO_EFFORT_VALUE,
+  getAutoEffortAwareDescriptors,
+  isAutoEffortBoundDescriptor,
+  isEffortOptionDescriptor,
+  reconcileAutoEffortLimitDescriptors,
+} from "@t3tools/shared/autoEffort";
+import {
   buildProviderOptionSelectionsFromDescriptors,
   getProviderOptionCurrentLabel,
   getProviderOptionCurrentValue,
-  getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
 
 const PROVIDER_OPTION_EVENT_PREFIX = "provider-option:";
@@ -52,16 +58,29 @@ export function resolveProviderOptionDescriptors(input: {
   if (!input.capabilities) {
     return [];
   }
-  return getProviderOptionDescriptors({
+  return getAutoEffortAwareDescriptors({
     caps: input.capabilities,
     selections: input.selections,
   });
 }
 
+function isAutoEffortSelected(descriptors: ReadonlyArray<ProviderOptionDescriptor>): boolean {
+  const effortDescriptor = descriptors.find(isEffortOptionDescriptor);
+  return (
+    effortDescriptor !== undefined &&
+    getProviderOptionCurrentValue(effortDescriptor) === AUTO_EFFORT_VALUE
+  );
+}
+
 export function buildProviderOptionMenuActions(
   descriptors: ReadonlyArray<ProviderOptionDescriptor>,
 ): ReadonlyArray<MenuAction> {
-  return descriptors.map((descriptor) => {
+  // The limits only mean something while Auto is picked, so they stay out of the
+  // menu otherwise even when previously configured limits are still stored.
+  const visible = isAutoEffortSelected(descriptors)
+    ? descriptors
+    : descriptors.filter((descriptor) => !isAutoEffortBoundDescriptor(descriptor));
+  return visible.map((descriptor) => {
     const currentValue =
       descriptor.type === "boolean"
         ? (descriptor.currentValue ?? false)
@@ -100,6 +119,10 @@ export function providerOptionsConfigurationLabel(
     if (descriptor.type === "boolean") {
       return descriptor.currentValue ? [descriptor.label] : [];
     }
+    // The auto limits are configuration for Auto, not traits of their own.
+    if (isAutoEffortBoundDescriptor(descriptor)) {
+      return [];
+    }
     const label = getProviderOptionCurrentLabel(descriptor);
     return label ? [label] : [];
   });
@@ -137,5 +160,9 @@ export function applyProviderOptionMenuEvent(
       : candidate,
   ) as ReadonlyArray<ProviderOptionDescriptor>;
 
-  return buildProviderOptionSelectionsFromDescriptors(nextDescriptors) ?? [];
+  return (
+    buildProviderOptionSelectionsFromDescriptors(
+      reconcileAutoEffortLimitDescriptors(nextDescriptors, descriptor.id),
+    ) ?? []
+  );
 }

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -54,6 +54,7 @@ import { RuntimeReceiptBusTest } from "../src/orchestration/Layers/RuntimeReceip
 import { OrchestrationReactorLive } from "../src/orchestration/Layers/OrchestrationReactor.ts";
 import { ProviderCommandReactorLive } from "../src/orchestration/Layers/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionLive } from "../src/orchestration/Layers/ProviderRuntimeIngestion.ts";
+import { TurnResponderLive } from "../src/orchestration/Layers/TurnResponder.ts";
 import {
   OrchestrationEngineService,
   type OrchestrationEngineShape,
@@ -305,6 +306,7 @@ export const makeOrchestrationIntegrationHarness = (
       checkpointStoreLayer,
       providerLayer,
       RuntimeReceiptBusTest,
+      TurnResponderLive,
     );
     const serverSettingsLayer = ServerSettingsService.layerTest();
     const runtimeIngestionLayer = ProviderRuntimeIngestionLive.pipe(

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -365,6 +365,13 @@ function createTextGeneration(
             }),
         ),
       ),
+    selectReasoningEffort: () =>
+      Effect.fail(
+        new TextGenerationError({
+          operation: "selectReasoningEffort",
+          detail: "git tests never review reasoning effort",
+        }),
+      ),
   };
 }
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -910,6 +910,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             text: nextText,
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
             isStreaming: event.payload.streaming,
+            ...(event.payload.responder !== undefined
+              ? { responder: event.payload.responder }
+              : previousMessage?.responder !== undefined
+                ? { responder: previousMessage.responder }
+                : {}),
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,
             updatedAt: event.payload.updatedAt,
           });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -22,6 +22,7 @@ import {
   type OrchestrationThreadActivity,
   type OrchestrationThreadShell,
   ModelSelection,
+  OrchestrationMessageResponder,
   ProjectId,
   ThreadId,
 } from "@t3tools/contracts";
@@ -72,6 +73,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    responder: Schema.NullOr(Schema.fromJsonString(OrchestrationMessageResponder)),
   }),
 );
 const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
@@ -429,6 +431,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          responder_json AS "responder",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
@@ -796,6 +799,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          responder_json AS "responder",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
@@ -1068,6 +1072,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   ...(row.attachments !== null ? { attachments: row.attachments } : {}),
                   turnId: row.turnId,
                   streaming: row.isStreaming === 1,
+                  ...(row.responder !== null ? { responder: row.responder } : {}),
                   createdAt: row.createdAt,
                   updatedAt: row.updatedAt,
                 });
@@ -2029,6 +2034,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             text: row.text,
             turnId: row.turnId,
             streaming: row.isStreaming === 1,
+            ...(row.responder !== null ? { responder: row.responder } : {}),
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
           };

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -448,7 +448,7 @@ describe("ProviderCommandReactor", () => {
       generateBranchName,
       generateThreadTitle,
       selectReasoningEffort,
-      recordedResponder: () => turnResponder.get(ThreadId.make("thread-1")),
+      recordedResponder: () => turnResponder.get({ threadId: ThreadId.make("thread-1") }),
       runtimeSessions,
       stateDir,
       drain,
@@ -665,6 +665,64 @@ describe("ProviderCommandReactor", () => {
         expect(request.modelSelection?.options).toContainEqual({
           id: "reasoningEffort",
           value: "medium",
+        });
+      }),
+    );
+
+    effectIt.effect("keeps handling other events while the reviewer is still deciding", () =>
+      Effect.gen(function* () {
+        const harness = yield* createAutoEffortHarness();
+        const releaseReview = yield* Deferred.make<void>();
+        harness.selectReasoningEffort.mockReturnValue(
+          Deferred.await(releaseReview).pipe(
+            Effect.as({ effort: "low", reason: "Released by the test." }),
+          ),
+        );
+
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-auto-effort-slow-review"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-auto-effort-slow-review"),
+            role: "user",
+            text: "think about it",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        yield* Effect.promise(() =>
+          waitFor(() => harness.selectReasoningEffort.mock.calls.length === 1),
+        );
+
+        // The reviewer holds this turn, but the queue behind it must keep moving.
+        yield* harness.engine.dispatch({
+          type: "thread.session.stop",
+          commandId: CommandId.make("cmd-session-stop-during-review"),
+          threadId: ThreadId.make("thread-1"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        yield* Effect.promise(() =>
+          waitFor(async () => {
+            const readModel = await harness.readModel();
+            return (
+              readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"))?.session
+                ?.status === "stopped"
+            );
+          }),
+        );
+        expect(harness.sendTurn).not.toHaveBeenCalled();
+
+        yield* Deferred.succeed(releaseReview, undefined);
+        yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
+        const request = harness.sendTurn.mock.calls[0]?.[0] as {
+          modelSelection?: ModelSelection;
+        };
+        expect(request.modelSelection?.options).toContainEqual({
+          id: "reasoningEffort",
+          value: "low",
         });
       }),
     );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -10,7 +10,8 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
 } from "@t3tools/contracts";
-import { createModelSelection } from "@t3tools/shared/model";
+import type { ServerProviderModel } from "@t3tools/contracts";
+import { createModelCapabilities, createModelSelection } from "@t3tools/shared/model";
 import {
   ApprovalRequestId,
   CommandId,
@@ -53,6 +54,8 @@ import {
   providerErrorLabelFromInstanceHint,
   ProviderCommandReactorLive,
 } from "./ProviderCommandReactor.ts";
+import { TurnResponderLive } from "./TurnResponder.ts";
+import { TurnResponder } from "../Services/TurnResponder.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -91,7 +94,7 @@ async function waitFor(
 
 describe("ProviderCommandReactor", () => {
   let runtime: ManagedRuntime.ManagedRuntime<
-    OrchestrationEngineService | ProviderCommandReactor | ProjectionSnapshotQuery,
+    OrchestrationEngineService | ProviderCommandReactor | ProjectionSnapshotQuery | TurnResponder,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -144,6 +147,7 @@ describe("ProviderCommandReactor", () => {
   async function createHarness(input?: {
     readonly baseDir?: string;
     readonly threadModelSelection?: ModelSelection;
+    readonly providerModels?: ReadonlyArray<ServerProviderModel>;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
     readonly startSessionEffect?: (
@@ -294,9 +298,18 @@ describe("ProviderCommandReactor", () => {
         }),
       ),
     );
+    const selectReasoningEffort = vi.fn<TextGenerationShape["selectReasoningEffort"]>((_) =>
+      Effect.fail(
+        new TextGenerationError({
+          operation: "selectReasoningEffort",
+          detail: "disabled in test harness",
+        }),
+      ),
+    );
     const providerSnapshots = [
       {
         instanceId: modelSelection.instanceId,
+        models: input?.providerModels ?? [],
         ...(input?.requiresNewThreadForModelChange === true
           ? { requiresNewThreadForModelChange: true }
           : {}),
@@ -376,8 +389,10 @@ describe("ProviderCommandReactor", () => {
         Layer.mock(TextGeneration, {
           generateBranchName,
           generateThreadTitle,
+          selectReasoningEffort,
         }),
       ),
+      Layer.provideMerge(TurnResponderLive),
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
@@ -387,6 +402,7 @@ describe("ProviderCommandReactor", () => {
     const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
     const snapshotQuery = await runtime.runPromise(Effect.service(ProjectionSnapshotQuery));
     const reactor = await runtime.runPromise(Effect.service(ProviderCommandReactor));
+    const turnResponder = await runtime.runPromise(Effect.service(TurnResponder));
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
     const drain = () => Effect.runPromise(reactor.drain);
@@ -431,6 +447,8 @@ describe("ProviderCommandReactor", () => {
       refreshStatus,
       generateBranchName,
       generateThreadTitle,
+      selectReasoningEffort,
+      recordedResponder: () => turnResponder.get(ThreadId.make("thread-1")),
       runtimeSessions,
       stateDir,
       drain,
@@ -475,6 +493,201 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  describe("auto reasoning effort", () => {
+    const AUTO_EFFORT_MODEL: ServerProviderModel = {
+      slug: "gpt-5-codex",
+      name: "GPT-5 Codex",
+      isCustom: false,
+      capabilities: createModelCapabilities({
+        optionDescriptors: [
+          {
+            id: "reasoningEffort",
+            label: "Reasoning",
+            type: "select",
+            options: [
+              { id: "low", label: "Low" },
+              { id: "medium", label: "Medium" },
+              { id: "high", label: "High", isDefault: true },
+              { id: "xhigh", label: "Extra High" },
+            ],
+          },
+        ],
+      }),
+    };
+
+    const autoModelSelection = (
+      options: ReadonlyArray<{ id: string; value: string }>,
+    ): ModelSelection =>
+      createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", options);
+
+    const createAutoEffortHarness = (
+      options: ReadonlyArray<{ id: string; value: string }> = [
+        { id: "reasoningEffort", value: "auto" },
+        { id: "reasoningEffortAutoCeiling", value: "xhigh" },
+        { id: "reasoningEffortAutoFloor", value: "low" },
+      ],
+    ) =>
+      Effect.promise(() =>
+        createHarness({
+          threadModelSelection: autoModelSelection(options),
+          providerModels: [AUTO_EFFORT_MODEL],
+        }),
+      );
+
+    const startAutoTurn = (
+      harness: Awaited<ReturnType<typeof createHarness>>,
+      input: { readonly commandId: string; readonly messageId: string; readonly text: string },
+    ) =>
+      Effect.gen(function* () {
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(input.commandId),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId(input.messageId),
+            role: "user",
+            text: input.text,
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+        yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
+        return harness.sendTurn.mock.calls[0]?.[0] as { modelSelection?: ModelSelection };
+      });
+
+    effectIt.effect("sends the effort the reviewer picked instead of auto", () =>
+      Effect.gen(function* () {
+        const harness = yield* createAutoEffortHarness();
+        harness.selectReasoningEffort.mockReturnValue(
+          Effect.succeed({ effort: "low", reason: "Single-line rename." }),
+        );
+
+        const request = yield* startAutoTurn(harness, {
+          commandId: "cmd-turn-start-auto-effort",
+          messageId: "user-message-auto-effort",
+          text: "rename this variable",
+        });
+
+        expect(harness.selectReasoningEffort.mock.calls[0]?.[0]).toMatchObject({
+          message: "rename this variable",
+          allowedEfforts: [
+            { id: "low", label: "Low" },
+            { id: "medium", label: "Medium" },
+            { id: "high", label: "High" },
+            { id: "xhigh", label: "Extra High" },
+          ],
+          // The reviewer runs on the thread's own provider at its cheapest
+          // effort, not on the configured text-generation provider.
+          modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
+            { id: "reasoningEffort", value: "low" },
+          ]),
+        });
+        expect(request.modelSelection?.options).toEqual([
+          { id: "reasoningEffort", value: "low" },
+          { id: "reasoningEffortAutoCeiling", value: "xhigh" },
+          { id: "reasoningEffortAutoFloor", value: "low" },
+        ]);
+        // Messages this turn produces are labeled with the resolved effort.
+        const responder = yield* harness.recordedResponder();
+        expect(responder?.autoEffort).toBe(true);
+        expect(responder?.modelSelection.options).toContainEqual({
+          id: "reasoningEffort",
+          value: "low",
+        });
+      }),
+    );
+
+    effectIt.effect("caps the reviewer at the configured limit", () =>
+      Effect.gen(function* () {
+        const harness = yield* createAutoEffortHarness([
+          { id: "reasoningEffort", value: "auto" },
+          { id: "reasoningEffortAutoCeiling", value: "medium" },
+        ]);
+        harness.selectReasoningEffort.mockReturnValue(
+          Effect.succeed({ effort: "xhigh", reason: "Looks like a big refactor." }),
+        );
+
+        const request = yield* startAutoTurn(harness, {
+          commandId: "cmd-turn-start-auto-effort-clamped",
+          messageId: "user-message-auto-effort-clamped",
+          text: "refactor the world",
+        });
+
+        expect(harness.selectReasoningEffort.mock.calls[0]?.[0]?.allowedEfforts).toEqual([
+          { id: "low", label: "Low" },
+          { id: "medium", label: "Medium" },
+        ]);
+        expect(request.modelSelection?.options).toEqual([
+          { id: "reasoningEffort", value: "medium" },
+          { id: "reasoningEffortAutoCeiling", value: "medium" },
+        ]);
+      }),
+    );
+
+    effectIt.effect("starts the turn with the default effort when the reviewer fails", () =>
+      Effect.gen(function* () {
+        const harness = yield* createAutoEffortHarness();
+
+        const request = yield* startAutoTurn(harness, {
+          commandId: "cmd-turn-start-auto-effort-failure",
+          messageId: "user-message-auto-effort-failure",
+          text: "do the thing",
+        });
+
+        expect(harness.selectReasoningEffort).toHaveBeenCalledTimes(1);
+        expect(request.modelSelection?.options).toEqual([
+          { id: "reasoningEffort", value: "high" },
+          { id: "reasoningEffortAutoCeiling", value: "xhigh" },
+          { id: "reasoningEffortAutoFloor", value: "low" },
+        ]);
+      }),
+    );
+
+    effectIt.effect("skips the reviewer when the limits pin auto to one effort", () =>
+      Effect.gen(function* () {
+        const harness = yield* createAutoEffortHarness([
+          { id: "reasoningEffort", value: "auto" },
+          { id: "reasoningEffortAutoCeiling", value: "medium" },
+          { id: "reasoningEffortAutoFloor", value: "medium" },
+        ]);
+
+        const request = yield* startAutoTurn(harness, {
+          commandId: "cmd-turn-start-auto-effort-pinned",
+          messageId: "user-message-auto-effort-pinned",
+          text: "do the thing",
+        });
+
+        expect(harness.selectReasoningEffort).not.toHaveBeenCalled();
+        expect(request.modelSelection?.options).toContainEqual({
+          id: "reasoningEffort",
+          value: "medium",
+        });
+      }),
+    );
+
+    effectIt.effect("leaves manual effort selections alone", () =>
+      Effect.gen(function* () {
+        const harness = yield* createAutoEffortHarness([{ id: "reasoningEffort", value: "high" }]);
+
+        const request = yield* startAutoTurn(harness, {
+          commandId: "cmd-turn-start-manual-effort",
+          messageId: "user-message-manual-effort",
+          text: "do the thing",
+        });
+
+        expect(harness.selectReasoningEffort).not.toHaveBeenCalled();
+        expect(request.modelSelection).toBeUndefined();
+        const responder = yield* harness.recordedResponder();
+        expect(responder?.autoEffort).toBeUndefined();
+        expect(responder?.modelSelection.options).toEqual([
+          { id: "reasoningEffort", value: "high" },
+        ]);
+      }),
+    );
   });
 
   effectIt.effect("projects starting before a slow provider session finishes", () =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2,8 +2,10 @@ import {
   type ChatAttachment,
   CommandId,
   EventId,
+  type MessageId,
   type ModelSelection,
   type OrchestrationEvent,
+  type OrchestrationMessage,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -12,7 +14,14 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
+import {
+  type AutoEffortState,
+  autoEffortAllowedChoices,
+  resolveAutoEffortSelection,
+  resolveAutoEffortState,
+} from "@t3tools/shared/autoEffort";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { createModelSelection } from "@t3tools/shared/model";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -29,11 +38,15 @@ import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
-import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
+import {
+  type ReasoningEffortConversationEntry,
+  TextGeneration,
+} from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+import { TurnResponder } from "../Services/TurnResponder.ts";
 import {
   ProviderCommandReactor,
   type ProviderCommandReactorShape,
@@ -85,6 +98,14 @@ const turnStartKeyForEvent = (event: ProviderIntentEvent): string =>
 
 const HANDLED_TURN_START_KEY_MAX = 10_000;
 const HANDLED_TURN_START_KEY_TTL = Duration.minutes(30);
+/**
+ * The auto-effort reviewer runs before the turn starts, so a stuck CLI would
+ * stall the whole turn. Give up well before the provider's own timeout and use
+ * the clamped default effort instead.
+ */
+const AUTO_EFFORT_REVIEW_TIMEOUT = Duration.seconds(45);
+/** How many earlier messages the reviewer sees as thread context. */
+const AUTO_EFFORT_CONTEXT_MESSAGES = 6;
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 const DEFAULT_THREAD_TITLE = "New thread";
 
@@ -100,6 +121,27 @@ export function providerErrorLabelFromInstanceHint(input: {
 }): string {
   return providerErrorLabel(
     input.instanceId ?? input.modelSelectionInstanceId ?? input.sessionProvider,
+  );
+}
+
+/**
+ * Model selection for the auto-effort reviewer.
+ *
+ * The reviewer runs on the thread's own provider instance and model, so a thread
+ * that works can always be reviewed — pointing it at the configured
+ * text-generation provider instead would fail whenever that CLI is not
+ * installed. It runs at the cheapest effort the model offers because sizing one
+ * request is a classification, not the work itself.
+ */
+export function buildAutoEffortReviewerSelection(
+  modelSelection: ModelSelection,
+  state: Pick<AutoEffortState, "descriptorId" | "ladder">,
+): ModelSelection {
+  const cheapest = state.ladder[0]?.id;
+  return createModelSelection(
+    modelSelection.instanceId,
+    modelSelection.model,
+    cheapest !== undefined ? [{ id: state.descriptorId, value: cheapest }] : [],
   );
 }
 
@@ -163,6 +205,27 @@ function stalePendingRequestDetail(
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
 }
 
+/**
+ * Thread context handed to the auto-effort reviewer: the turns before the new
+ * request, oldest last-first trimmed to the most recent few, so the reviewer can
+ * judge the incremental work rather than re-reading the whole thread.
+ */
+export function buildAutoEffortConversationContext(input: {
+  readonly messages: ReadonlyArray<OrchestrationMessage>;
+  readonly currentMessageId: MessageId;
+  readonly limit?: number;
+}): ReadonlyArray<ReasoningEffortConversationEntry> {
+  const currentIndex = input.messages.findIndex((entry) => entry.id === input.currentMessageId);
+  const earlier = currentIndex >= 0 ? input.messages.slice(0, currentIndex) : input.messages;
+  return earlier
+    .filter(
+      (entry): entry is OrchestrationMessage & { role: "user" | "assistant" } =>
+        (entry.role === "user" || entry.role === "assistant") && entry.text.trim().length > 0,
+    )
+    .slice(-(input.limit ?? AUTO_EFFORT_CONTEXT_MESSAGES))
+    .map((entry) => ({ role: entry.role, text: entry.text }));
+}
+
 function buildGeneratedWorktreeBranchName(raw: string): string {
   const normalized = raw
     .trim()
@@ -195,6 +258,7 @@ const make = Effect.gen(function* () {
   const gitWorkflow = yield* GitWorkflowService;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const textGeneration = yield* TextGeneration;
+  const turnResponder = yield* TurnResponder;
   const serverSettingsService = yield* ServerSettingsService;
   const serverCommandId = (tag: string) =>
     crypto.randomUUIDv4.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
@@ -768,6 +832,109 @@ const make = Effect.gen(function* () {
     },
   );
 
+  const resolveModelCapabilities = Effect.fnUntraced(function* (modelSelection: ModelSelection) {
+    const providers = yield* providerRegistry.getProviders;
+    return (
+      providers
+        .find((candidate) => candidate.instanceId === modelSelection.instanceId)
+        ?.models.find((model) => model.slug === modelSelection.model)?.capabilities ?? null
+    );
+  });
+
+  const reviewReasoningEffort = Effect.fnUntraced(function* (input: {
+    readonly threadId: ThreadId;
+    readonly cwd: string;
+    readonly messageText: string;
+    readonly attachments?: ReadonlyArray<ChatAttachment>;
+    readonly conversation: ReadonlyArray<ReasoningEffortConversationEntry>;
+    readonly allowedEfforts: ReadonlyArray<{ readonly id: string; readonly label: string }>;
+    readonly modelSelection: ModelSelection;
+  }) {
+    return yield* textGeneration
+      .selectReasoningEffort({
+        cwd: input.cwd,
+        message: input.messageText,
+        ...(input.conversation.length > 0 ? { conversation: input.conversation } : {}),
+        ...(input.attachments !== undefined && input.attachments.length > 0
+          ? { attachments: input.attachments }
+          : {}),
+        allowedEfforts: input.allowedEfforts,
+        modelSelection: input.modelSelection,
+      })
+      .pipe(
+        Effect.timeoutOption(AUTO_EFFORT_REVIEW_TIMEOUT),
+        Effect.map(Option.getOrNull),
+        // A missing or broken reviewer must never block a turn: the caller
+        // falls back to the clamped default effort.
+        Effect.catchCause((cause) =>
+          Effect.logWarning("provider command reactor failed to review reasoning effort", {
+            threadId: input.threadId,
+            cause: Cause.pretty(cause),
+          }).pipe(Effect.as(null)),
+        ),
+      );
+  });
+
+  /**
+   * Replace an `auto` reasoning effort with a concrete one for this turn.
+   *
+   * Returns `undefined` when the thread is not on auto effort, which tells the
+   * caller to leave the requested model selection untouched.
+   */
+  const resolveAutoEffortForTurn = Effect.fn("resolveAutoEffortForTurn")(function* (input: {
+    readonly threadId: ThreadId;
+    readonly modelSelection: ModelSelection;
+    readonly cwd: string;
+    readonly messageText: string;
+    readonly attachments?: ReadonlyArray<ChatAttachment>;
+    readonly conversation: ReadonlyArray<ReasoningEffortConversationEntry>;
+  }) {
+    const caps = yield* resolveModelCapabilities(input.modelSelection);
+    const state = resolveAutoEffortState({ caps, selections: input.modelSelection.options });
+    if (!state?.active) {
+      return undefined;
+    }
+
+    const allowedEfforts = autoEffortAllowedChoices(state).map((option) => ({
+      id: option.id,
+      label: option.label,
+    }));
+    // A one-rung window has nothing to decide, so skip the reviewer spend.
+    const reviewed =
+      allowedEfforts.length < 2
+        ? null
+        : yield* reviewReasoningEffort({
+            threadId: input.threadId,
+            cwd: input.cwd,
+            messageText: input.messageText,
+            ...(input.attachments !== undefined ? { attachments: input.attachments } : {}),
+            conversation: input.conversation,
+            allowedEfforts,
+            modelSelection: buildAutoEffortReviewerSelection(input.modelSelection, state),
+          });
+
+    const resolved = resolveAutoEffortSelection({
+      modelSelection: input.modelSelection,
+      caps,
+      requestedEffort: reviewed?.effort ?? null,
+    });
+    if (!resolved) {
+      return undefined;
+    }
+
+    yield* Effect.logDebug("auto effort resolved for turn", {
+      threadId: input.threadId,
+      effort: resolved.effort,
+      ceiling: resolved.ceiling,
+      floor: resolved.floor,
+      requestedEffort: resolved.requested,
+      clampedToLimit: resolved.clamped,
+      reason: reviewed?.reason ?? null,
+    });
+
+    return resolved.modelSelection;
+  });
+
   const processTurnStartRequested = Effect.fn("processTurnStartRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
   ) {
@@ -794,15 +961,16 @@ const make = Effect.gen(function* () {
       return;
     }
 
+    const project = yield* resolveProject(thread.projectId);
+    const generationCwd =
+      resolveThreadWorkspaceCwd({
+        thread,
+        projects: project ? [project] : [],
+      }) ?? process.cwd();
+
     const isFirstUserMessageTurn =
       thread.messages.filter((entry) => entry.role === "user").length === 1;
     if (isFirstUserMessageTurn) {
-      const project = yield* resolveProject(thread.projectId);
-      const generationCwd =
-        resolveThreadWorkspaceCwd({
-          thread,
-          projects: project ? [project] : [],
-        }) ?? process.cwd();
       const generationInput = {
         messageText: message.text,
         ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
@@ -861,13 +1029,26 @@ const make = Effect.gen(function* () {
         ),
       );
 
+    // Auto effort resolves before the session is configured so both the session
+    // and the turn agree on the effort the reviewer picked.
+    const autoEffortModelSelection = yield* resolveAutoEffortForTurn({
+      threadId: event.payload.threadId,
+      modelSelection: event.payload.modelSelection ?? thread.modelSelection,
+      cwd: generationCwd,
+      messageText: message.text,
+      ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+      conversation: buildAutoEffortConversationContext({
+        messages: thread.messages,
+        currentMessageId: event.payload.messageId,
+      }),
+    });
+    const modelSelectionForTurn = autoEffortModelSelection ?? event.payload.modelSelection;
+
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
-      ...(event.payload.modelSelection !== undefined
-        ? { modelSelection: event.payload.modelSelection }
-        : {}),
+      ...(modelSelectionForTurn !== undefined ? { modelSelection: modelSelectionForTurn } : {}),
       interactionMode: event.payload.interactionMode,
       createdAt: event.payload.createdAt,
     }).pipe(
@@ -878,6 +1059,16 @@ const make = Effect.gen(function* () {
     if (Option.isNone(sendTurnRequest)) {
       return;
     }
+
+    // Label the messages this turn produces: the composer can change model or
+    // effort between turns, and auto effort is only resolved here.
+    yield* turnResponder.record({
+      threadId: event.payload.threadId,
+      responder: {
+        modelSelection: sendTurnRequest.value.modelSelection ?? thread.modelSelection,
+        ...(autoEffortModelSelection !== undefined ? { autoEffort: true } : {}),
+      },
+    });
 
     yield* providerService
       .sendTurn(sendTurnRequest.value)

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -31,8 +31,9 @@ import * as Equal from "effect/Equal";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { type DrainableWorker, makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
@@ -70,6 +71,36 @@ type ProviderIntentEvent = Extract<
   }
 >;
 
+type TurnStartRequestedEvent = Extract<
+  ProviderIntentEvent,
+  { type: "thread.turn-start-requested" }
+>;
+
+/**
+ * Everything the second half of a turn start needs, captured before the
+ * auto-effort reviewer runs.
+ */
+interface TurnStartWork {
+  readonly event: TurnStartRequestedEvent;
+  readonly messageText: string;
+  readonly attachments: ReadonlyArray<ChatAttachment> | undefined;
+  /** Thread default, used to label messages when the turn carries no selection. */
+  readonly threadModelSelection: ModelSelection;
+  /** Set only when the auto-effort reviewer resolved an effort for this turn. */
+  readonly autoEffortModelSelection: ModelSelection | undefined;
+}
+
+/**
+ * Queue items for the reactor's single worker.
+ *
+ * Turn starts come back around as their own item: the auto-effort reviewer runs
+ * off the queue, and the turn resumes on the worker once it answers so every
+ * provider mutation still happens on one fiber, in order.
+ */
+type ReactorWorkItem =
+  | { readonly kind: "event"; readonly event: ProviderIntentEvent }
+  | { readonly kind: "turn-start"; readonly work: TurnStartWork };
+
 function toNonEmptyProviderInput(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   return normalized && normalized.length > 0 ? normalized : undefined;
@@ -100,8 +131,8 @@ const HANDLED_TURN_START_KEY_MAX = 10_000;
 const HANDLED_TURN_START_KEY_TTL = Duration.minutes(30);
 /**
  * The auto-effort reviewer runs before the turn starts, so a stuck CLI would
- * stall the whole turn. Give up well before the provider's own timeout and use
- * the clamped default effort instead.
+ * leave the turn waiting indefinitely. Give up well before the provider's own
+ * timeout and use the clamped default effort instead.
  */
 const AUTO_EFFORT_REVIEW_TIMEOUT = Duration.seconds(45);
 /** How many earlier messages the reviewer sees as thread context. */
@@ -875,6 +906,12 @@ const make = Effect.gen(function* () {
       );
   });
 
+  /** Whether a turn needs the reviewer at all, from capabilities alone. */
+  const isAutoEffortTurn = Effect.fnUntraced(function* (modelSelection: ModelSelection) {
+    const caps = yield* resolveModelCapabilities(modelSelection);
+    return resolveAutoEffortState({ caps, selections: modelSelection.options })?.active === true;
+  });
+
   /**
    * Replace an `auto` reasoning effort with a concrete one for this turn.
    *
@@ -936,7 +973,7 @@ const make = Effect.gen(function* () {
   });
 
   const processTurnStartRequested = Effect.fn("processTurnStartRequested")(function* (
-    event: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
+    event: TurnStartRequestedEvent,
   ) {
     const key = turnStartKeyForEvent(event);
     if (yield* hasHandledTurnStartRecently(key)) {
@@ -993,6 +1030,55 @@ const make = Effect.gen(function* () {
       }
     }
 
+    const work = {
+      event,
+      messageText: message.text,
+      attachments: message.attachments,
+      threadModelSelection: thread.modelSelection,
+    };
+
+    // The reviewer is a provider CLI call, so it runs off the queue: leaving it
+    // here would hold every other thread's events behind one slow review.
+    if (!(yield* isAutoEffortTurn(event.payload.modelSelection ?? thread.modelSelection))) {
+      return yield* startTurn({ ...work, autoEffortModelSelection: undefined });
+    }
+
+    yield* worker.fork(
+      resolveAutoEffortForTurn({
+        threadId: event.payload.threadId,
+        modelSelection: event.payload.modelSelection ?? thread.modelSelection,
+        cwd: generationCwd,
+        messageText: message.text,
+        ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+        conversation: buildAutoEffortConversationContext({
+          messages: thread.messages,
+          currentMessageId: event.payload.messageId,
+        }),
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("provider command reactor failed to resolve auto effort", {
+            threadId: event.payload.threadId,
+            cause: Cause.pretty(cause),
+          }).pipe(Effect.as(undefined)),
+        ),
+        // Back onto the worker: the session and the turn are configured there,
+        // one thread at a time.
+        Effect.flatMap((autoEffortModelSelection) =>
+          worker.enqueue({ kind: "turn-start", work: { ...work, autoEffortModelSelection } }),
+        ),
+      ),
+    );
+  });
+
+  /**
+   * Configure the session and send the turn, with the effort auto effort picked.
+   *
+   * Runs on the worker so provider mutations for a thread stay ordered, even
+   * though the reviewer that precedes it does not.
+   */
+  const startTurn = Effect.fn("startTurn")(function* (work: TurnStartWork) {
+    const event = work.event;
+
     const handleTurnStartFailure = (cause: Cause.Cause<unknown>) => {
       if (Cause.hasInterruptsOnly(cause)) {
         return Effect.void;
@@ -1029,25 +1115,12 @@ const make = Effect.gen(function* () {
         ),
       );
 
-    // Auto effort resolves before the session is configured so both the session
-    // and the turn agree on the effort the reviewer picked.
-    const autoEffortModelSelection = yield* resolveAutoEffortForTurn({
-      threadId: event.payload.threadId,
-      modelSelection: event.payload.modelSelection ?? thread.modelSelection,
-      cwd: generationCwd,
-      messageText: message.text,
-      ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
-      conversation: buildAutoEffortConversationContext({
-        messages: thread.messages,
-        currentMessageId: event.payload.messageId,
-      }),
-    });
-    const modelSelectionForTurn = autoEffortModelSelection ?? event.payload.modelSelection;
+    const modelSelectionForTurn = work.autoEffortModelSelection ?? event.payload.modelSelection;
 
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
-      messageText: message.text,
-      ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+      messageText: work.messageText,
+      ...(work.attachments !== undefined ? { attachments: work.attachments } : {}),
       ...(modelSelectionForTurn !== undefined ? { modelSelection: modelSelectionForTurn } : {}),
       interactionMode: event.payload.interactionMode,
       createdAt: event.payload.createdAt,
@@ -1065,8 +1138,8 @@ const make = Effect.gen(function* () {
     yield* turnResponder.record({
       threadId: event.payload.threadId,
       responder: {
-        modelSelection: sendTurnRequest.value.modelSelection ?? thread.modelSelection,
-        ...(autoEffortModelSelection !== undefined ? { autoEffort: true } : {}),
+        modelSelection: sendTurnRequest.value.modelSelection ?? work.threadModelSelection,
+        ...(work.autoEffortModelSelection !== undefined ? { autoEffort: true } : {}),
       },
     });
 
@@ -1260,20 +1333,21 @@ const make = Effect.gen(function* () {
     }
   });
 
-  const processDomainEventSafely = (event: ProviderIntentEvent) =>
-    processDomainEvent(event).pipe(
+  const processWorkItemSafely = (item: ReactorWorkItem) =>
+    (item.kind === "turn-start" ? startTurn(item.work) : processDomainEvent(item.event)).pipe(
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {
           return Effect.failCause(cause);
         }
         return Effect.logWarning("provider command reactor failed to process event", {
-          eventType: event.type,
+          eventType: item.kind === "turn-start" ? item.work.event.type : item.event.type,
           cause: Cause.pretty(cause),
         });
       }),
     );
 
-  const worker = yield* makeDrainableWorker(processDomainEventSafely);
+  const worker: DrainableWorker<ReactorWorkItem, never, Scope.Scope> =
+    yield* makeDrainableWorker(processWorkItemSafely);
 
   const start: ProviderCommandReactorShape["start"] = Effect.fn("start")(function* () {
     const processEvent = Effect.fn("processEvent")(function* (event: OrchestrationEvent) {
@@ -1285,7 +1359,7 @@ const make = Effect.gen(function* () {
         event.type === "thread.user-input-response-requested" ||
         event.type === "thread.session-stop-requested"
       ) {
-        return yield* worker.enqueue(event);
+        return yield* worker.enqueue({ kind: "event", event });
       }
     });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1016,6 +1016,91 @@ describe("ProviderRuntimeIngestion", () => {
     ]);
   });
 
+  it("labels a straggling completion with its own turn's model, not the newest turn's", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const responderFor = (effort: string): OrchestrationMessageResponder => ({
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5-codex",
+        options: [{ id: "reasoningEffort", value: effort }],
+      },
+      autoEffort: true,
+    });
+
+    await harness.recordResponder(responderFor("low"));
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-first-turn-started"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-first"),
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-first-turn-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-first"),
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    await harness.recordResponder(responderFor("xhigh"));
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-second-turn-started"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-second"),
+    });
+    await harness.drain();
+
+    // Arrives while the second turn owns the thread, but belongs to the first.
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-straggler-delta"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-first"),
+      itemId: asItemId("item-straggler"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "late",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-straggler-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-first"),
+      itemId: asItemId("item-straggler"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-straggler" && !message.streaming,
+      ),
+    );
+    const message = thread.messages.find(
+      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-straggler",
+    );
+    expect(message?.responder?.modelSelection.options).toEqual([
+      { id: "reasoningEffort", value: "low" },
+    ]);
+  });
+
   it("uses assistant item completion detail when no assistant deltas were streamed", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
   MessageId,
+  type OrchestrationMessageResponder,
   ProjectId,
   ProviderItemId,
   type ServerSettings,
@@ -45,6 +46,8 @@ import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { ProviderRuntimeIngestionLive } from "./ProviderRuntimeIngestion.ts";
+import { TurnResponderLive } from "./TurnResponder.ts";
+import { TurnResponder } from "../Services/TurnResponder.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
@@ -192,7 +195,10 @@ async function waitForThread(
 
 describe("ProviderRuntimeIngestion", () => {
   let runtime: ManagedRuntime.ManagedRuntime<
-    OrchestrationEngineService | ProviderRuntimeIngestionService | ProjectionSnapshotQuery,
+    | OrchestrationEngineService
+    | ProviderRuntimeIngestionService
+    | ProjectionSnapshotQuery
+    | TurnResponder,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -240,6 +246,7 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(makeTestServerSettingsLayer(options?.serverSettings)),
+      Layer.provideMerge(TurnResponderLive),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -315,6 +322,14 @@ describe("ProviderRuntimeIngestion", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       emit: provider.emit,
       setProviderSession: provider.setSession,
+      recordResponder: (responder: OrchestrationMessageResponder) =>
+        runtime!.runPromise(
+          Effect.service(TurnResponder).pipe(
+            Effect.flatMap((service) =>
+              service.record({ threadId: ThreadId.make("thread-1"), responder }),
+            ),
+          ),
+        ),
       drain,
     };
   }
@@ -944,6 +959,61 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(message?.text).toBe("hello world");
     expect(message?.streaming).toBe(false);
+  });
+
+  it("labels a finalized assistant message with the model the turn ran on", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    await harness.recordResponder({
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5-codex",
+        options: [{ id: "reasoningEffort", value: "xhigh" }],
+      },
+      autoEffort: true,
+    });
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-responder-delta"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-responder"),
+      itemId: asItemId("item-responder"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "done",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-responder-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-responder"),
+      itemId: asItemId("item-responder"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-responder" && !message.streaming,
+      ),
+    );
+    const message = thread.messages.find(
+      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-responder",
+    );
+    expect(message?.responder?.modelSelection.model).toBe("gpt-5-codex");
+    expect(message?.responder?.autoEffort).toBe(true);
+    expect(message?.responder?.modelSelection.options).toEqual([
+      { id: "reasoningEffort", value: "xhigh" },
+    ]);
   });
 
   it("uses assistant item completion detail when no assistant deltas were streamed", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -33,6 +33,7 @@ import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/Projectio
 import { isGitRepository } from "../../git/Utils.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+import { TurnResponder } from "../Services/TurnResponder.ts";
 import {
   ProviderRuntimeIngestionService,
   type ProviderRuntimeIngestionShape,
@@ -692,6 +693,7 @@ const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
   const projectionTurnRepository = yield* ProjectionTurnRepository;
+  const turnResponder = yield* TurnResponder;
   const serverSettingsService = yield* ServerSettingsService;
   const providerCommandId = (event: ProviderRuntimeEvent, tag: string) =>
     crypto.randomUUIDv4.pipe(
@@ -1031,12 +1033,14 @@ const make = Effect.gen(function* () {
       }
 
       if (input.hasProjectedMessage || hasRenderableText) {
+        const responder = yield* turnResponder.get(input.threadId);
         yield* orchestrationEngine.dispatch({
           type: "thread.message.assistant.complete",
           commandId: yield* providerCommandId(input.event, input.commandTag),
           threadId: input.threadId,
           messageId: input.messageId,
           ...(input.turnId ? { turnId: input.turnId } : {}),
+          ...(responder !== undefined ? { responder } : {}),
           createdAt: input.createdAt,
         });
       }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1033,7 +1033,10 @@ const make = Effect.gen(function* () {
       }
 
       if (input.hasProjectedMessage || hasRenderableText) {
-        const responder = yield* turnResponder.get(input.threadId);
+        const responder = yield* turnResponder.get({
+          threadId: input.threadId,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+        });
         yield* orchestrationEngine.dispatch({
           type: "thread.message.assistant.complete",
           commandId: yield* providerCommandId(input.event, input.commandTag),
@@ -1416,6 +1419,13 @@ const make = Effect.gen(function* () {
                 : (thread.session?.lastError ?? null);
 
         if (shouldApplyThreadLifecycle) {
+          // The reactor parked this turn's model selection before the provider
+          // named the turn; claim it now so later completions can be labelled
+          // per turn instead of per thread.
+          if (event.type === "turn.started" && eventTurnId !== undefined) {
+            yield* turnResponder.bind({ threadId: thread.id, turnId: eventTurnId });
+          }
+
           if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
             yield* markSourceProposedPlanImplemented(
               acceptedTurnStartedSourcePlan.sourceThreadId,

--- a/apps/server/src/orchestration/Layers/TurnResponder.ts
+++ b/apps/server/src/orchestration/Layers/TurnResponder.ts
@@ -1,0 +1,29 @@
+/**
+ * TurnResponder layer.
+ *
+ * @module TurnResponder
+ */
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+import type { OrchestrationMessageResponder, ThreadId } from "@t3tools/contracts";
+import { TurnResponder, type TurnResponderShape } from "../Services/TurnResponder.ts";
+
+const makeTurnResponder = Effect.gen(function* () {
+  const respondersRef = yield* Ref.make(new Map<ThreadId, OrchestrationMessageResponder>());
+
+  return {
+    record: ({ threadId, responder }) =>
+      Ref.update(respondersRef, (responders) => new Map(responders).set(threadId, responder)),
+    get: (threadId) => Ref.get(respondersRef).pipe(Effect.map((map) => map.get(threadId))),
+    forget: (threadId) =>
+      Ref.update(respondersRef, (responders) => {
+        const next = new Map(responders);
+        next.delete(threadId);
+        return next;
+      }),
+  } satisfies TurnResponderShape;
+});
+
+export const TurnResponderLive = Layer.effect(TurnResponder, makeTurnResponder);

--- a/apps/server/src/orchestration/Layers/TurnResponder.ts
+++ b/apps/server/src/orchestration/Layers/TurnResponder.ts
@@ -7,22 +7,75 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 
-import type { OrchestrationMessageResponder, ThreadId } from "@t3tools/contracts";
+import type { OrchestrationMessageResponder, ThreadId, TurnId } from "@t3tools/contracts";
 import { TurnResponder, type TurnResponderShape } from "../Services/TurnResponder.ts";
 
+interface BoundTurn {
+  readonly turnId: TurnId;
+  readonly responder: OrchestrationMessageResponder;
+}
+
+interface ThreadResponders {
+  /** Recorded by the reactor, not yet claimed by a provider turn. */
+  readonly pending: OrchestrationMessageResponder | undefined;
+  /** Newest last. */
+  readonly turns: ReadonlyArray<BoundTurn>;
+}
+
+/**
+ * Bound turns kept per thread. Completions can straggle in after the next turn
+ * starts, so a couple of turns of history is enough to label them correctly
+ * without holding every turn a long-lived thread ever ran.
+ */
+const TURN_HISTORY_LIMIT = 4;
+
+const EMPTY_THREAD_RESPONDERS: ThreadResponders = { pending: undefined, turns: [] };
+
 const makeTurnResponder = Effect.gen(function* () {
-  const respondersRef = yield* Ref.make(new Map<ThreadId, OrchestrationMessageResponder>());
+  const respondersRef = yield* Ref.make(new Map<ThreadId, ThreadResponders>());
+
+  const update = (threadId: ThreadId, change: (state: ThreadResponders) => ThreadResponders) =>
+    Ref.update(respondersRef, (byThread) =>
+      new Map(byThread).set(threadId, change(byThread.get(threadId) ?? EMPTY_THREAD_RESPONDERS)),
+    );
 
   return {
     record: ({ threadId, responder }) =>
-      Ref.update(respondersRef, (responders) => new Map(responders).set(threadId, responder)),
-    get: (threadId) => Ref.get(respondersRef).pipe(Effect.map((map) => map.get(threadId))),
-    forget: (threadId) =>
-      Ref.update(respondersRef, (responders) => {
-        const next = new Map(responders);
-        next.delete(threadId);
-        return next;
-      }),
+      update(threadId, (state) => ({ ...state, pending: responder })),
+
+    bind: ({ threadId, turnId }) =>
+      update(threadId, (state) =>
+        state.pending === undefined
+          ? state
+          : {
+              pending: undefined,
+              turns: [...state.turns, { turnId, responder: state.pending }].slice(
+                -TURN_HISTORY_LIMIT,
+              ),
+            },
+      ),
+
+    get: ({ threadId, turnId }) =>
+      Ref.get(respondersRef).pipe(
+        Effect.map((byThread) => {
+          const state = byThread.get(threadId);
+          if (!state) {
+            return undefined;
+          }
+          if (turnId === undefined) {
+            return state.pending ?? state.turns.at(-1)?.responder;
+          }
+          const bound = state.turns.find((turn) => turn.turnId === turnId);
+          if (bound) {
+            return bound.responder;
+          }
+          // Nothing bound yet means the provider never reported a turn id we
+          // could bind, so the parked selection is still the only candidate.
+          // Once any turn is bound, an unknown turn id is a turn we did not
+          // start and must not borrow another turn's label.
+          return state.turns.length === 0 ? state.pending : undefined;
+        }),
+      ),
   } satisfies TurnResponderShape;
 });
 

--- a/apps/server/src/orchestration/Services/TurnResponder.ts
+++ b/apps/server/src/orchestration/Services/TurnResponder.ts
@@ -7,22 +7,40 @@
  * so the reactor parks that selection here and `ProviderRuntimeIngestion` reads
  * it back when an assistant message completes.
  *
+ * A turn has no id until the provider reports one, so the reactor parks the
+ * selection per thread and ingestion binds it to the turn the provider started.
+ * Reads are then scoped by turn: a straggling completion for a superseded turn
+ * must not be labelled with the model a newer turn is running on.
+ *
  * State is per-thread and in memory: it exists only to label messages produced
- * by the current turn. A restart mid-turn simply leaves that message unlabeled.
+ * by recent turns. A restart mid-turn simply leaves that message unlabeled.
  *
  * @module TurnResponder
  */
-import type { OrchestrationMessageResponder, ThreadId } from "@t3tools/contracts";
+import type { OrchestrationMessageResponder, ThreadId, TurnId } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 
 export interface TurnResponderShape {
+  /** Park the selection a turn is starting with, before its turn id exists. */
   readonly record: (input: {
     readonly threadId: ThreadId;
     readonly responder: OrchestrationMessageResponder;
   }) => Effect.Effect<void>;
-  readonly get: (threadId: ThreadId) => Effect.Effect<OrchestrationMessageResponder | undefined>;
-  readonly forget: (threadId: ThreadId) => Effect.Effect<void>;
+  /** Attach the parked selection to the turn the provider reported starting. */
+  readonly bind: (input: {
+    readonly threadId: ThreadId;
+    readonly turnId: TurnId;
+  }) => Effect.Effect<void>;
+  /**
+   * Selection a turn ran on. Falls back to the parked selection only while no
+   * turn on the thread has been bound, which is how providers that never report
+   * a usable turn id still get their messages labelled.
+   */
+  readonly get: (input: {
+    readonly threadId: ThreadId;
+    readonly turnId?: TurnId | undefined;
+  }) => Effect.Effect<OrchestrationMessageResponder | undefined>;
 }
 
 export class TurnResponder extends Context.Service<TurnResponder, TurnResponderShape>()(

--- a/apps/server/src/orchestration/Services/TurnResponder.ts
+++ b/apps/server/src/orchestration/Services/TurnResponder.ts
@@ -1,0 +1,30 @@
+/**
+ * TurnResponder - which model an in-flight turn is running on.
+ *
+ * `ProviderCommandReactor` is the only place that knows the model selection a
+ * turn actually starts with, including the concrete effort the auto-effort
+ * reviewer picked. Provider runtime events arrive later, on a different path,
+ * so the reactor parks that selection here and `ProviderRuntimeIngestion` reads
+ * it back when an assistant message completes.
+ *
+ * State is per-thread and in memory: it exists only to label messages produced
+ * by the current turn. A restart mid-turn simply leaves that message unlabeled.
+ *
+ * @module TurnResponder
+ */
+import type { OrchestrationMessageResponder, ThreadId } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+export interface TurnResponderShape {
+  readonly record: (input: {
+    readonly threadId: ThreadId;
+    readonly responder: OrchestrationMessageResponder;
+  }) => Effect.Effect<void>;
+  readonly get: (threadId: ThreadId) => Effect.Effect<OrchestrationMessageResponder | undefined>;
+  readonly forget: (threadId: ThreadId) => Effect.Effect<void>;
+}
+
+export class TurnResponder extends Context.Service<TurnResponder, TurnResponderShape>()(
+  "t3/orchestration/Services/TurnResponder",
+) {}

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1039,6 +1039,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           text: "",
           turnId: command.turnId ?? null,
           streaming: false,
+          ...(command.responder !== undefined ? { responder: command.responder } : {}),
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Struct from "effect/Struct";
-import { ChatAttachment } from "@t3tools/contracts";
+import { ChatAttachment, OrchestrationMessageResponder } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -21,6 +21,7 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
   Struct.assign({
     isStreaming: Schema.Number,
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
+    responder: Schema.NullOr(Schema.fromJsonString(OrchestrationMessageResponder)),
   }),
 );
 
@@ -37,6 +38,7 @@ function toProjectionThreadMessage(
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...(row.attachments !== null ? { attachments: row.attachments } : {}),
+    ...(row.responder !== null ? { responder: row.responder } : {}),
   };
 }
 
@@ -48,6 +50,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
     execute: (row) => {
       const nextAttachmentsJson =
         row.attachments !== undefined ? JSON.stringify(row.attachments) : null;
+      const nextResponderJson = row.responder !== undefined ? JSON.stringify(row.responder) : null;
       return sql`
         INSERT INTO projection_thread_messages (
           message_id,
@@ -57,6 +60,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json,
           is_streaming,
+          responder_json,
           created_at,
           updated_at
         )
@@ -75,6 +79,14 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
             )
           ),
           ${row.isStreaming ? 1 : 0},
+          COALESCE(
+            ${nextResponderJson},
+            (
+              SELECT responder_json
+              FROM projection_thread_messages
+              WHERE message_id = ${row.messageId}
+            )
+          ),
           ${row.createdAt},
           ${row.updatedAt}
         )
@@ -89,6 +101,10 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
             projection_thread_messages.attachments_json
           ),
           is_streaming = excluded.is_streaming,
+          responder_json = COALESCE(
+            excluded.responder_json,
+            projection_thread_messages.responder_json
+          ),
           created_at = excluded.created_at,
           updated_at = excluded.updated_at
       `;
@@ -108,6 +124,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          responder_json AS "responder",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages
@@ -129,6 +146,7 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
           text,
           attachments_json AS "attachments",
           is_streaming AS "isStreaming",
+          responder_json AS "responder",
           created_at AS "createdAt",
           updated_at AS "updatedAt"
         FROM projection_thread_messages

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -47,6 +47,7 @@ import Migration0031 from "./Migrations/031_AuthAuthorizationScopes.ts";
 import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
 import Migration0033 from "./Migrations/033_ProjectionThreadsSettled.ts";
 import Migration0034 from "./Migrations/034_ProjectionThreadsSnoozed.ts";
+import Migration0035 from "./Migrations/035_ProjectionThreadMessageResponder.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -93,6 +94,7 @@ export const migrationEntries = [
   [32, "AuthPairingProofKeyThumbprint", Migration0032],
   [33, "ProjectionThreadsSettled", Migration0033],
   [34, "ProjectionThreadsSnoozed", Migration0034],
+  [35, "ProjectionThreadMessageResponder", Migration0035],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/035_ProjectionThreadMessageResponder.ts
+++ b/apps/server/src/persistence/Migrations/035_ProjectionThreadMessageResponder.ts
@@ -1,0 +1,11 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as Effect from "effect/Effect";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE projection_thread_messages
+    ADD COLUMN responder_json TEXT
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -9,6 +9,7 @@
 import {
   ChatAttachment,
   MessageId,
+  OrchestrationMessageResponder,
   OrchestrationMessageRole,
   ThreadId,
   TurnId,
@@ -29,6 +30,7 @@ export const ProjectionThreadMessage = Schema.Struct({
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   isStreaming: Schema.Boolean,
+  responder: Schema.optional(OrchestrationMessageResponder),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -37,6 +37,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
+import { withoutAutoEffortValue } from "@t3tools/shared/autoEffort";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { getCodexServiceTierOptionValue } from "../../codexModelOptions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
@@ -1538,7 +1539,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     const session = yield* requireSession(input.threadId);
     const reasoningEffort =
       input.modelSelection?.instanceId === boundInstanceId
-        ? getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
+        ? withoutAutoEffortValue(
+            getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort"),
+          )
         : undefined;
     const serviceTier =
       input.modelSelection?.instanceId === boundInstanceId

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -23,6 +23,7 @@ import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { withoutAutoEffortValue } from "@t3tools/shared/autoEffort";
 import {
   createModelCapabilities,
   getProviderOptionBooleanSelectionValue,
@@ -494,7 +495,7 @@ export function resolveCursorAcpConfigUpdates(
 
   const reasoningOption = findCursorEffortConfigOption(configOptions);
   const requestedReasoning = normalizeCursorReasoningValue(
-    getProviderOptionStringSelectionValue(selections, "reasoning"),
+    withoutAutoEffortValue(getProviderOptionStringSelectionValue(selections, "reasoning")),
   );
   if (reasoningOption && requestedReasoning) {
     const value = findCursorSelectOptionValue(reasoningOption, (option) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -47,6 +47,7 @@ import { OrchestrationReactorLive } from "./orchestration/Layers/OrchestrationRe
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus.ts";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion.ts";
 import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor.ts";
+import { TurnResponderLive } from "./orchestration/Layers/TurnResponder.ts";
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
@@ -166,6 +167,7 @@ const ReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(ThreadDeletionReactorLive),
   Layer.provideMerge(AgentAwarenessRelay.layer.pipe(Layer.provide(ServerSecretStore.layer))),
   Layer.provideMerge(RuntimeReceiptBusLive),
+  Layer.provideMerge(TurnResponderLive),
 );
 
 const ProviderSessionDirectoryLayerLive = ProviderSessionDirectoryLive.pipe(

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -23,12 +23,14 @@ import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
   buildPrContentPrompt,
+  buildReasoningEffortPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
 import {
   normalizeCliError,
   sanitizeCommitSubject,
   sanitizePrTitle,
+  sanitizeReasoningEffort,
   sanitizeThreadTitle,
   toJsonSchemaObject,
 } from "./TextGenerationUtils.ts";
@@ -85,7 +87,8 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle",
+      | "generateThreadTitle"
+      | "selectReasoningEffort",
     value: unknown,
     detail: string,
   ): Effect.Effect<string, TextGenerationError> =>
@@ -115,7 +118,8 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle";
+      | "generateThreadTitle"
+      | "selectReasoningEffort";
     cwd: string;
     prompt: string;
     outputSchemaJson: S;
@@ -355,10 +359,34 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       };
     });
 
+  const selectReasoningEffort: TextGeneration.TextGeneration["Service"]["selectReasoningEffort"] =
+    Effect.fn("ClaudeTextGeneration.selectReasoningEffort")(function* (input) {
+      const { prompt, outputSchema } = buildReasoningEffortPrompt({
+        message: input.message,
+        conversation: input.conversation,
+        allowedEfforts: input.allowedEfforts,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runClaudeJson({
+        operation: "selectReasoningEffort",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        effort: sanitizeReasoningEffort(generated.effort),
+        reason: generated.reason.trim(),
+      };
+    });
+
   return {
     generateCommitMessage,
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    selectReasoningEffort,
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -21,15 +21,18 @@ import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
   buildPrContentPrompt,
+  buildReasoningEffortPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
 import {
   normalizeCliError,
   sanitizeCommitSubject,
   sanitizePrTitle,
+  sanitizeReasoningEffort,
   sanitizeThreadTitle,
   toJsonSchemaObject,
 } from "./TextGenerationUtils.ts";
+import { withoutAutoEffortValue } from "@t3tools/shared/autoEffort";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { getCodexServiceTierOptionValue } from "../codexModelOptions.ts";
 
@@ -98,7 +101,8 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle",
+      | "generateThreadTitle"
+      | "selectReasoningEffort",
     value: unknown,
   ): Effect.Effect<string, TextGenerationError> =>
     encodeJsonString(value).pipe(
@@ -117,7 +121,8 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle",
+      | "generateThreadTitle"
+      | "selectReasoningEffort",
     attachments: TextGeneration.BranchNameGenerationInput["attachments"],
   ): Effect.fn.Return<MaterializedImageAttachments, TextGenerationError> {
     if (!attachments || attachments.length === 0) {
@@ -159,7 +164,8 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle";
+      | "generateThreadTitle"
+      | "selectReasoningEffort";
     cwd: string;
     prompt: string;
     outputSchemaJson: S;
@@ -177,8 +183,9 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
     const runCodexCommand = Effect.fn("runCodexJson.runCodexCommand")(function* () {
       const launchArgs = resolveCodexLaunchArgs(codexConfig.launchArgs, resolvedEnvironment);
       const reasoningEffort =
-        getModelSelectionStringOptionValue(modelSelection, "reasoningEffort") ??
-        CODEX_GIT_TEXT_GENERATION_REASONING_EFFORT;
+        withoutAutoEffortValue(
+          getModelSelectionStringOptionValue(modelSelection, "reasoningEffort"),
+        ) ?? CODEX_GIT_TEXT_GENERATION_REASONING_EFFORT;
       const serviceTier = getCodexServiceTierOptionValue(modelSelection);
       const spawnCommand = yield* resolveSpawnCommand(
         codexConfig.binaryPath || "codex",
@@ -398,10 +405,34 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       } satisfies TextGeneration.ThreadTitleGenerationResult;
     });
 
+  const selectReasoningEffort: TextGeneration.TextGeneration["Service"]["selectReasoningEffort"] =
+    Effect.fn("CodexTextGeneration.selectReasoningEffort")(function* (input) {
+      const { prompt, outputSchema } = buildReasoningEffortPrompt({
+        message: input.message,
+        conversation: input.conversation,
+        allowedEfforts: input.allowedEfforts,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runCodexJson({
+        operation: "selectReasoningEffort",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        effort: sanitizeReasoningEffort(generated.effort),
+        reason: generated.reason.trim(),
+      } satisfies TextGeneration.ReasoningEffortSelectionResult;
+    });
+
   return {
     generateCommitMessage,
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    selectReasoningEffort,
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -407,6 +407,10 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
 
   const selectReasoningEffort: TextGeneration.TextGeneration["Service"]["selectReasoningEffort"] =
     Effect.fn("CodexTextGeneration.selectReasoningEffort")(function* (input) {
+      const { imagePaths } = yield* materializeImageAttachments(
+        "selectReasoningEffort",
+        input.attachments,
+      );
       const { prompt, outputSchema } = buildReasoningEffortPrompt({
         message: input.message,
         conversation: input.conversation,
@@ -419,6 +423,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
         cwd: input.cwd,
         prompt,
         outputSchemaJson: outputSchema,
+        imagePaths,
         modelSelection: input.modelSelection,
       });
 

--- a/apps/server/src/textGeneration/CursorTextGeneration.ts
+++ b/apps/server/src/textGeneration/CursorTextGeneration.ts
@@ -15,11 +15,13 @@ import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
   buildPrContentPrompt,
+  buildReasoningEffortPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
 import {
   sanitizeCommitSubject,
   sanitizePrTitle,
+  sanitizeReasoningEffort,
   sanitizeThreadTitle,
 } from "./TextGenerationUtils.ts";
 import {
@@ -54,7 +56,8 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle";
+      | "generateThreadTitle"
+      | "selectReasoningEffort";
     cwd: string;
     prompt: string;
     outputSchemaJson: S;
@@ -255,10 +258,34 @@ export const makeCursorTextGeneration = Effect.fn("makeCursorTextGeneration")(fu
       } satisfies TextGeneration.ThreadTitleGenerationResult;
     });
 
+  const selectReasoningEffort: TextGeneration.TextGeneration["Service"]["selectReasoningEffort"] =
+    Effect.fn("CursorTextGeneration.selectReasoningEffort")(function* (input) {
+      const { prompt, outputSchema } = buildReasoningEffortPrompt({
+        message: input.message,
+        conversation: input.conversation,
+        allowedEfforts: input.allowedEfforts,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runCursorJson({
+        operation: "selectReasoningEffort",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        effort: sanitizeReasoningEffort(generated.effort),
+        reason: generated.reason.trim(),
+      } satisfies TextGeneration.ReasoningEffortSelectionResult;
+    });
+
   return {
     generateCommitMessage,
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    selectReasoningEffort,
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/GrokTextGeneration.ts
+++ b/apps/server/src/textGeneration/GrokTextGeneration.ts
@@ -16,11 +16,13 @@ import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
   buildPrContentPrompt,
+  buildReasoningEffortPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
 import {
   sanitizeCommitSubject,
   sanitizePrTitle,
+  sanitizeReasoningEffort,
   sanitizeThreadTitle,
 } from "./TextGenerationUtils.ts";
 import {
@@ -52,7 +54,8 @@ export const makeGrokTextGeneration = Effect.fn("makeGrokTextGeneration")(functi
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle";
+      | "generateThreadTitle"
+      | "selectReasoningEffort";
     cwd: string;
     prompt: string;
     outputSchemaJson: S;
@@ -247,10 +250,34 @@ export const makeGrokTextGeneration = Effect.fn("makeGrokTextGeneration")(functi
       } satisfies TextGeneration.ThreadTitleGenerationResult;
     });
 
+  const selectReasoningEffort: TextGeneration.TextGeneration["Service"]["selectReasoningEffort"] =
+    Effect.fn("GrokTextGeneration.selectReasoningEffort")(function* (input) {
+      const { prompt, outputSchema } = buildReasoningEffortPrompt({
+        message: input.message,
+        conversation: input.conversation,
+        allowedEfforts: input.allowedEfforts,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runGrokJson({
+        operation: "selectReasoningEffort",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        effort: sanitizeReasoningEffort(generated.effort),
+        reason: generated.reason.trim(),
+      } satisfies TextGeneration.ReasoningEffortSelectionResult;
+    });
+
   return {
     generateCommitMessage,
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    selectReasoningEffort,
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -22,12 +22,14 @@ import {
   buildBranchNamePrompt,
   buildCommitMessagePrompt,
   buildPrContentPrompt,
+  buildReasoningEffortPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
 import * as TextGeneration from "./TextGeneration.ts";
 import {
   sanitizeCommitSubject,
   sanitizePrTitle,
+  sanitizeReasoningEffort,
   sanitizeThreadTitle,
 } from "./TextGenerationUtils.ts";
 import * as OpenCodeRuntime from "../provider/opencodeRuntime.ts";
@@ -39,6 +41,7 @@ const OpenCodeTextGenerationOperation = Schema.Literals([
   "generatePrContent",
   "generateBranchName",
   "generateThreadTitle",
+  "selectReasoningEffort",
 ]);
 
 type OpenCodeTextGenerationOperation = typeof OpenCodeTextGenerationOperation.Type;
@@ -253,7 +256,8 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
-      | "generateThreadTitle";
+      | "generateThreadTitle"
+      | "selectReasoningEffort";
   }) =>
     sharedServerMutex.withPermit(
       Effect.gen(function* () {
@@ -611,10 +615,34 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
       };
     });
 
+  const selectReasoningEffort: TextGeneration.TextGeneration["Service"]["selectReasoningEffort"] =
+    Effect.fn("OpenCodeTextGeneration.selectReasoningEffort")(function* (input) {
+      const { prompt, outputSchema } = buildReasoningEffortPrompt({
+        message: input.message,
+        conversation: input.conversation,
+        allowedEfforts: input.allowedEfforts,
+        attachments: input.attachments,
+      });
+      const generated = yield* runOpenCodeJson({
+        operation: "selectReasoningEffort",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+        attachments: input.attachments,
+      });
+
+      return {
+        effort: sanitizeReasoningEffort(generated.effort),
+        reason: generated.reason.trim(),
+      };
+    });
+
   return {
     generateCommitMessage,
     generatePrContent,
     generateBranchName,
     generateThreadTitle,
+    selectReasoningEffort,
   } satisfies TextGeneration.TextGeneration["Service"];
 });

--- a/apps/server/src/textGeneration/TextGeneration.test.ts
+++ b/apps/server/src/textGeneration/TextGeneration.test.ts
@@ -21,6 +21,8 @@ const makeStubTextGeneration = (
     generatePrContent: () => Effect.die("generatePrContent stub not configured for this test"),
     generateBranchName: () => Effect.die("generateBranchName stub not configured for this test"),
     generateThreadTitle: () => Effect.die("generateThreadTitle stub not configured for this test"),
+    selectReasoningEffort: () =>
+      Effect.die("selectReasoningEffort stub not configured for this test"),
     ...overrides,
   });
 

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -67,6 +67,33 @@ export interface ThreadTitleGenerationResult {
   title: string;
 }
 
+export interface ReasoningEffortConversationEntry {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+}
+
+export interface ReasoningEffortSelectionInput {
+  cwd: string;
+  /** The prompt whose difficulty is being judged. */
+  message: string;
+  /** Earlier turns of the same thread, oldest first. */
+  conversation?: ReadonlyArray<ReasoningEffortConversationEntry> | undefined;
+  attachments?: ReadonlyArray<ChatAttachment> | undefined;
+  /**
+   * Efforts the reviewer may pick, cheapest first. Callers pass the window
+   * allowed by the user's auto-effort limits, so the reviewer never sees an
+   * option it is not permitted to choose.
+   */
+  allowedEfforts: ReadonlyArray<{ readonly id: string; readonly label: string }>;
+  /** What model and provider to use for the review. */
+  modelSelection: ModelSelection;
+}
+
+export interface ReasoningEffortSelectionResult {
+  effort: string;
+  reason: string;
+}
+
 export interface TextGenerationService {
   generateCommitMessage(
     input: CommitMessageGenerationInput,
@@ -74,6 +101,9 @@ export interface TextGenerationService {
   generatePrContent(input: PrContentGenerationInput): Promise<PrContentGenerationResult>;
   generateBranchName(input: BranchNameGenerationInput): Promise<BranchNameGenerationResult>;
   generateThreadTitle(input: ThreadTitleGenerationInput): Promise<ThreadTitleGenerationResult>;
+  selectReasoningEffort(
+    input: ReasoningEffortSelectionInput,
+  ): Promise<ReasoningEffortSelectionResult>;
 }
 
 /**
@@ -109,6 +139,14 @@ export class TextGeneration extends Context.Service<
     readonly generateThreadTitle: (
       input: ThreadTitleGenerationInput,
     ) => Effect.Effect<ThreadTitleGenerationResult, TextGenerationError>;
+
+    /**
+     * Judge how much reasoning effort a prompt deserves, choosing from the
+     * efforts the caller allows. Backs the composer's auto effort mode.
+     */
+    readonly selectReasoningEffort: (
+      input: ReasoningEffortSelectionInput,
+    ) => Effect.Effect<ReasoningEffortSelectionResult, TextGenerationError>;
   }
 >()("t3/textGeneration/TextGeneration") {}
 
@@ -119,7 +157,8 @@ type TextGenerationOp =
   | "generateCommitMessage"
   | "generatePrContent"
   | "generateBranchName"
-  | "generateThreadTitle";
+  | "generateThreadTitle"
+  | "selectReasoningEffort";
 
 const resolveInstance = (
   registry: ProviderInstanceRegistry.ProviderInstanceRegistry["Service"],
@@ -158,6 +197,10 @@ export const makeTextGenerationFromRegistry = (
     generateThreadTitle: (input) =>
       resolveInstance(registry, "generateThreadTitle", input.modelSelection.instanceId).pipe(
         Effect.flatMap((textGeneration) => textGeneration.generateThreadTitle(input)),
+      ),
+    selectReasoningEffort: (input) =>
+      resolveInstance(registry, "selectReasoningEffort", input.modelSelection.instanceId).pipe(
+        Effect.flatMap((textGeneration) => textGeneration.selectReasoningEffort(input)),
       ),
   });
 

--- a/apps/server/src/textGeneration/TextGenerationPrompts.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.ts
@@ -196,6 +196,99 @@ export interface ThreadTitlePromptInput {
   policy?: TextGenerationPolicy | undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Reasoning effort
+// ---------------------------------------------------------------------------
+
+export interface ReasoningEffortChoicePromptInput {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface ReasoningEffortConversationEntry {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+}
+
+export interface ReasoningEffortPromptInput {
+  /** The prompt whose difficulty is being judged. */
+  message: string;
+  /** Earlier turns of the same thread, oldest first. */
+  conversation?: ReadonlyArray<ReasoningEffortConversationEntry> | undefined;
+  /** Efforts the reviewer may pick, cheapest first, already clamped to the user's limits. */
+  allowedEfforts: ReadonlyArray<ReasoningEffortChoicePromptInput>;
+  attachments?: ReadonlyArray<ChatAttachment> | undefined;
+}
+
+/** Cap per-message context so a long thread cannot dominate the reviewer prompt. */
+const REASONING_EFFORT_MESSAGE_LIMIT = 1_200;
+
+function formatConversationEntry(entry: ReasoningEffortConversationEntry): string {
+  const speaker = entry.role === "user" ? "User" : "Assistant";
+  return `${speaker}: ${limitSection(entry.text.trim(), REASONING_EFFORT_MESSAGE_LIMIT)}`;
+}
+
+export function buildReasoningEffortPrompt(input: ReasoningEffortPromptInput) {
+  const allowed = input.allowedEfforts;
+  const cheapest = allowed[0];
+  const costliest = allowed.at(-1);
+  const conversation = input.conversation ?? [];
+  const attachmentLines = (input.attachments ?? []).map(
+    (attachment) => `- ${attachment.name} (${attachment.mimeType}, ${attachment.sizeBytes} bytes)`,
+  );
+
+  const promptSections = [
+    "You size the reasoning effort a coding agent should spend on one request.",
+    "Return a JSON object with keys: effort, reason.",
+    "Rules:",
+    `- effort must be exactly one of: ${allowed.map((option) => option.id).join(", ")}`,
+    ...(cheapest
+      ? [
+          `- pick ${cheapest.id} for trivial work: reading a file, a one-line edit, a factual question, a rename, a restated instruction`,
+        ]
+      : []),
+    ...(costliest && costliest.id !== cheapest?.id
+      ? [
+          `- pick ${costliest.id} only for genuinely hard work: cross-cutting refactors, debugging with unclear root cause, concurrency or protocol design, ambiguous requirements needing exploration`,
+        ]
+      : []),
+    "- judge the work the request implies, not how politely or verbosely it is written",
+    "- a long message that only pastes logs or context is not automatically hard",
+    "- when the thread already established the context, weigh only the incremental work the new request adds",
+    "- prefer the cheaper option when two are defensible",
+    "- reason must be one short sentence naming the deciding factor",
+    "",
+    "Effort levels, cheapest first:",
+    ...allowed.map((option) => `- ${option.id} (${option.label})`),
+  ];
+
+  if (conversation.length > 0) {
+    promptSections.push(
+      "",
+      "Earlier messages in this thread (oldest first):",
+      conversation.map(formatConversationEntry).join("\n"),
+    );
+  }
+
+  promptSections.push("", "New request:", limitSection(input.message, 8_000));
+
+  if (attachmentLines.length > 0) {
+    promptSections.push(
+      "",
+      "Attachment metadata:",
+      limitSection(attachmentLines.join("\n"), 4_000),
+    );
+  }
+
+  return {
+    prompt: promptSections.join("\n"),
+    outputSchema: Schema.Struct({
+      effort: Schema.String,
+      reason: Schema.String,
+    }),
+  };
+}
+
 export function buildThreadTitlePrompt(input: ThreadTitlePromptInput) {
   const prompt = buildPromptFromMessage({
     instruction: "You write concise thread titles for coding conversations.",

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -63,6 +63,22 @@ export function sanitizeThreadTitle(raw: string): string {
   return `${normalized.slice(0, 47).trimEnd()}...`;
 }
 
+/**
+ * Normalise a reviewer's raw effort choice to a bare option id.
+ *
+ * Models answer with things like `"High"` or `"effort: xhigh"`; callers still
+ * clamp the result, so this only has to strip the decoration.
+ */
+export function sanitizeReasoningEffort(raw: string): string {
+  return (
+    raw
+      .trim()
+      .toLowerCase()
+      .replace(/^effort\s*[:=]\s*/, "")
+      .replace(/[^a-z0-9_-]/g, "") || ""
+  );
+}
+
 /** CLI name to human-readable label, e.g. "codex" → "Codex CLI (`codex`)" */
 function cliLabel(cliName: string): string {
   const capitalized = cliName.charAt(0).toUpperCase() + cliName.slice(1);

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1,4 +1,10 @@
-import { CheckpointRef, EnvironmentId, MessageId, TurnId } from "@t3tools/contracts";
+import {
+  CheckpointRef,
+  EnvironmentId,
+  MessageId,
+  ProviderInstanceId,
+  TurnId,
+} from "@t3tools/contracts";
 import { createRef, type ReactNode, type Ref } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vite-plus/test";
@@ -120,6 +126,40 @@ function MockFileDiff(props: {
 
 vi.mock("@pierre/diffs/react", () => {
   return { FileDiff: MockFileDiff };
+});
+
+// Assistant rows read the thread environment's provider snapshot to label the
+// model behind a response.
+vi.mock("../../state/server", async () => {
+  const { Atom } = await import("effect/unstable/reactivity");
+  const configAtom = Atom.make(() => ({
+    providers: [
+      {
+        instanceId: "codex",
+        models: [
+          {
+            slug: "gpt-5-codex",
+            name: "GPT-5 Codex",
+            isCustom: false,
+            capabilities: {
+              optionDescriptors: [
+                {
+                  id: "reasoningEffort",
+                  label: "Reasoning",
+                  type: "select",
+                  options: [
+                    { id: "low", label: "Low" },
+                    { id: "high", label: "High", isDefault: true },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  }));
+  return { serverEnvironment: { configValueAtom: () => configAtom } };
 });
 
 function matchMedia() {
@@ -294,6 +334,80 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Collapse all folders"');
     expect(markup).toContain('aria-label="Open diff"');
     expect(markup).toContain("1 changed file");
+  });
+
+  it("names the model and resolved auto effort behind an assistant response", () => {
+    const turnId = TurnId.make("turn-responder");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-assistant-responder",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-assistant-responder"),
+              role: "assistant",
+              text: "Shipped it.",
+              turnId,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+              responder: {
+                modelSelection: {
+                  instanceId: ProviderInstanceId.make("codex"),
+                  model: "gpt-5-codex",
+                  options: [{ id: "reasoningEffort", value: "high" }],
+                },
+                autoEffort: true,
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("GPT-5 Codex");
+    expect(markup).toContain("Auto (High)");
+  });
+
+  it("names the model and effort behind an assistant response", () => {
+    const turnId = TurnId.make("turn-responder");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-assistant-responder",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-assistant-responder"),
+              role: "assistant",
+              text: "Done.",
+              turnId,
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+              responder: {
+                modelSelection: {
+                  instanceId: ProviderInstanceId.make("claudeAgent"),
+                  model: "claude-opus-5",
+                  options: [{ id: "effort", value: "low" }],
+                },
+                autoEffort: true,
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    // The provider snapshot is unavailable in this render, so the slug and raw
+    // effort value stand in for their labels.
+    expect(markup).toContain("claude-opus-5");
+    expect(markup).toContain("Auto");
   });
 
   it("uses LegendList isNearEnd when deciding whether the live edge is visible", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1,12 +1,16 @@
 import {
   type EnvironmentId,
   type MessageId,
+  type OrchestrationMessageResponder,
   type ScopedThreadRef,
+  type ServerProvider,
   type ServerProviderSkill,
   type TurnId,
 } from "@t3tools/contracts";
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import { resolveChatListAnchoredEndSpace } from "@t3tools/shared/chatList";
+import { describeMessageResponder } from "@t3tools/shared/messageResponder";
+import { useAtomValue } from "@effect/atom-react";
 import {
   createContext,
   Fragment,
@@ -64,6 +68,7 @@ import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
 import { shouldAutoExpandChangedFiles } from "./changedFilesPresentation";
 import { MessageCopyButton } from "./MessageCopyButton";
+import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
@@ -96,6 +101,7 @@ import {
   type ParsedPreviewAnnotation,
 } from "~/lib/previewAnnotation";
 import { cn } from "~/lib/utils";
+import { serverEnvironment } from "../../state/server";
 import { useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { formatChatTimestampTooltip, formatShortTimestamp } from "../../timestampFormat";
@@ -150,6 +156,7 @@ const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FADE_HEADER = <div className="h-10 sm:h-12" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const EMPTY_TIMELINE_PROVIDERS: ReadonlyArray<ServerProvider> = [];
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -1036,19 +1043,22 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           onOpenTurnDiff={ctx.onOpenTurnDiff}
         />
         {row.showAssistantMeta ? (
-          <div className="mt-1.5 flex items-center gap-2 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover/assistant:opacity-100">
+          <div className="mt-1.5 flex min-w-0 items-center gap-1.5 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover/assistant:opacity-100">
             <AssistantCopyButton row={row} />
             {!row.message.streaming && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={<p className="text-muted-foreground text-xs tabular-nums" />}
-                >
-                  {formatShortTimestamp(row.message.updatedAt, ctx.timestampFormat)}
-                </TooltipTrigger>
-                <TooltipPopup>
-                  {formatChatTimestampTooltip(row.message.updatedAt, ctx.timestampFormat)}
-                </TooltipPopup>
-              </Tooltip>
+              <>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={<p className="text-muted-foreground text-xs tabular-nums" />}
+                  >
+                    {formatShortTimestamp(row.message.updatedAt, ctx.timestampFormat)}
+                  </TooltipTrigger>
+                  <TooltipPopup>
+                    {formatChatTimestampTooltip(row.message.updatedAt, ctx.timestampFormat)}
+                  </TooltipPopup>
+                </Tooltip>
+                <AssistantResponderMeta responder={row.message.responder} />
+              </>
             )}
           </div>
         ) : null}
@@ -1069,6 +1079,44 @@ function AssistantCopyButton({ row }: { row: Extract<TimelineRow, { kind: "messa
   }
 
   return <MessageCopyButton text={assistantCopyState.text ?? ""} variant="ghost" />;
+}
+
+/** Which model and effort produced this response, revealed with the hover row. */
+function AssistantResponderMeta({
+  responder,
+}: {
+  responder: OrchestrationMessageResponder | undefined;
+}) {
+  const ctx = use(TimelineRowCtx);
+  const serverConfig = useAtomValue(
+    serverEnvironment.configValueAtom(ctx.activeThreadEnvironmentId),
+  );
+  const display = describeMessageResponder({
+    responder,
+    providers: serverConfig?.providers ?? EMPTY_TIMELINE_PROVIDERS,
+  });
+
+  if (!display) {
+    return null;
+  }
+
+  return (
+    <p className="flex min-w-0 items-center gap-1.5 text-muted-foreground text-xs">
+      <span aria-hidden="true">·</span>
+      {display.driver !== null ? (
+        <ProviderInstanceIcon
+          driverKind={display.driver}
+          displayName={display.providerName}
+          accentColor={display.accentColor}
+          className="size-3.5"
+          iconClassName="size-3.5"
+        />
+      ) : null}
+      <span className="truncate">
+        {display.effort !== null ? `${display.model} ${display.effort}` : display.model}
+      </span>
+    </p>
+  );
 }
 
 function ProposedPlanTimelineRow({

--- a/apps/web/src/components/chat/TraitsPicker.test.ts
+++ b/apps/web/src/components/chat/TraitsPicker.test.ts
@@ -97,6 +97,32 @@ describe("buildTraitsTriggerDisplay", () => {
     expect(display([unresolved], false)).toEqual({ label: "", showFastModeIcon: false });
   });
 
+  it("labels auto effort as Auto and keeps the other traits alongside it", () => {
+    const autoEffort = selectDescriptor(
+      "effort",
+      [
+        { id: "auto", label: "Auto" },
+        { id: "high", label: "High" },
+        { id: "max", label: "Max" },
+      ],
+      "auto",
+    );
+    const ceiling = selectDescriptor(
+      "effortAutoCeiling",
+      [
+        { id: "high", label: "High" },
+        { id: "max", label: "Max" },
+      ],
+      "high",
+    );
+    const floor = selectDescriptor("effortAutoFloor", [{ id: "high", label: "High" }], "high");
+
+    expect(display([autoEffort, floor, ceiling, CONTEXT_WINDOW], false)).toEqual({
+      label: "Auto · 1M",
+      showFastModeIcon: false,
+    });
+  });
+
   it("still renders the prompt-controlled ultrathink label alongside the bolt", () => {
     expect(
       buildTraitsTriggerDisplay({

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -7,11 +7,21 @@ import {
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import {
+  AUTO_EFFORT_LABEL,
+  AUTO_EFFORT_VALUE,
+  autoEffortCeilingOptionId,
+  autoEffortFloorOptionId,
+  autoEffortManualDefault,
+  getAutoEffortAwareDescriptors,
+  isAutoEffortBoundDescriptor,
+  isEffortOptionDescriptor,
+  reconcileAutoEffortLimitDescriptors,
+} from "@t3tools/shared/autoEffort";
+import {
   applyClaudePromptEffortPrefix,
   buildProviderOptionSelectionsFromDescriptors,
   getProviderOptionCurrentLabel,
   getProviderOptionCurrentValue,
-  getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
 } from "@t3tools/shared/model";
 import { memo, useCallback, useState } from "react";
@@ -20,11 +30,15 @@ import { ChevronDownIcon, ZapIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
 import {
   Menu,
+  MenuCheckboxItem,
   MenuGroup,
   MenuPopup,
   MenuRadioGroup,
   MenuRadioItem,
   MenuSeparator as MenuDivider,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
   MenuTrigger,
 } from "../ui/menu";
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
@@ -55,6 +69,66 @@ function DefaultBadge() {
     >
       Default
     </Badge>
+  );
+}
+
+/**
+ * Chevron next to the Auto switch that opens the auto-effort window settings.
+ * These live in a submenu because they are second-order controls: the common
+ * action is picking Auto, not retuning its bounds.
+ */
+function AutoEffortSettingsSubmenu({
+  descriptors,
+  onChange,
+}: {
+  descriptors: ReadonlyArray<Extract<ProviderOptionDescriptor, { type: "select" }>>;
+  onChange: (
+    descriptor: Extract<ProviderOptionDescriptor, { type: "select" }>,
+    value: string,
+  ) => void;
+}) {
+  return (
+    <MenuSub>
+      <MenuSubTrigger
+        aria-label="Auto effort settings"
+        className="min-h-8 shrink-0 gap-0 px-1 sm:min-h-7"
+      />
+      <MenuSubPopup align="start" className="min-w-40">
+        {descriptors.map((descriptor, index) => (
+          <div key={descriptor.id}>
+            {index > 0 ? <MenuDivider /> : null}
+            <MenuGroup>
+              <div className="px-2 pt-1.5 pb-1 font-medium text-muted-foreground text-xs">
+                {descriptor.label}
+              </div>
+              {descriptor.description ? (
+                <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">
+                  {descriptor.description}
+                </div>
+              ) : null}
+              <MenuRadioGroup
+                value={getDescriptorStringValue(descriptor) ?? ""}
+                onValueChange={(value) => onChange(descriptor, value)}
+              >
+                {descriptor.options.map((option) => (
+                  <MenuRadioItem key={option.id} value={option.id} hideIndicator>
+                    <span className="min-w-0 truncate">
+                      {option.label}
+                      {option.isDefault ? (
+                        <>
+                          {" "}
+                          <DefaultBadge />
+                        </>
+                      ) : null}
+                    </span>
+                  </MenuRadioItem>
+                ))}
+              </MenuRadioGroup>
+            </MenuGroup>
+          </div>
+        ))}
+      </MenuSubPopup>
+    </MenuSub>
   );
 }
 
@@ -97,14 +171,30 @@ function getSelectedTraits(
   allowPromptInjectedEffort: boolean,
 ) {
   const caps = getProviderModelCapabilities(models, model, provider);
-  const descriptors = getProviderOptionDescriptors({
+  const descriptors = getAutoEffortAwareDescriptors({
     caps,
     selections: modelOptions,
   });
+  // The auto ceiling/floor selects belong under the effort group, not in the
+  // flat list of provider options.
   const selectDescriptors = descriptors.filter(
     (descriptor): descriptor is Extract<ProviderOptionDescriptor, { type: "select" }> =>
-      descriptor.type === "select",
+      descriptor.type === "select" && !isAutoEffortBoundDescriptor(descriptor),
   );
+  const effortDescriptor = descriptors.find(isEffortOptionDescriptor) ?? null;
+  const autoEffortActive =
+    effortDescriptor !== null &&
+    getProviderOptionCurrentValue(effortDescriptor) === AUTO_EFFORT_VALUE;
+  // Ordered so the limits submenu always reads minimum then maximum.
+  const autoEffortBoundDescriptors = effortDescriptor
+    ? [
+        autoEffortFloorOptionId(effortDescriptor.id),
+        autoEffortCeilingOptionId(effortDescriptor.id),
+      ].flatMap((boundId) => {
+        const descriptor = descriptors.find((candidate) => candidate.id === boundId);
+        return descriptor?.type === "select" ? [descriptor] : [];
+      })
+    : [];
   const booleanDescriptors = descriptors.filter(
     (descriptor): descriptor is Extract<ProviderOptionDescriptor, { type: "boolean" }> =>
       descriptor.type === "boolean",
@@ -146,6 +236,9 @@ function getSelectedTraits(
     descriptors,
     selectDescriptors,
     booleanDescriptors,
+    effortDescriptor,
+    autoEffortActive,
+    autoEffortBoundDescriptors,
     primarySelectDescriptor,
     contextWindowDescriptor,
     agentDescriptor,
@@ -254,6 +347,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     descriptors,
     selectDescriptors,
     booleanDescriptors,
+    effortDescriptor,
+    autoEffortActive,
+    autoEffortBoundDescriptors,
     primarySelectDescriptor,
     ultrathinkPromptControlled,
     ultrathinkInBodyText,
@@ -288,7 +384,21 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       const stripped = prompt.replace(/^Ultrathink:\s*/i, "");
       onPromptChange(stripped);
     }
-    updateDescriptors(replaceDescriptorCurrentValue(descriptors, descriptor.id, value));
+    updateDescriptors(
+      reconcileAutoEffortLimitDescriptors(
+        replaceDescriptorCurrentValue(descriptors, descriptor.id, value),
+        descriptor.id,
+      ),
+    );
+  };
+
+  const handleAutoEffortToggle = (enabled: boolean) => {
+    if (!effortDescriptor) return;
+    const nextValue = enabled
+      ? AUTO_EFFORT_VALUE
+      : (autoEffortManualDefault(effortDescriptor) ?? effortDescriptor.options[1]?.id);
+    if (!nextValue) return;
+    handleSelectChange(effortDescriptor, nextValue);
   };
 
   if (!hasAnyControls) {
@@ -302,6 +412,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
             ? "ultrathink"
             : (getDescriptorStringValue(descriptor) ?? "");
+        const isEffortGroup =
+          descriptor.id === effortDescriptor?.id &&
+          descriptor.options.some((option) => option.id === AUTO_EFFORT_VALUE);
 
         return (
           <div key={descriptor.id}>
@@ -316,31 +429,61 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                   option.
                 </div>
               ) : null}
-              <MenuRadioGroup
-                value={selectedValue}
-                onValueChange={(value) => handleSelectChange(descriptor, value)}
-              >
-                {descriptor.options.map((option) => (
-                  <MenuRadioItem
-                    key={option.id}
-                    value={option.id}
-                    hideIndicator
-                    disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
-                  >
-                    <span className="flex w-full min-w-0 items-center justify-between gap-3">
-                      <span className="min-w-0 truncate">
-                        {option.label}
-                        {option.isDefault ? (
-                          <>
-                            {" "}
-                            <DefaultBadge />
-                          </>
-                        ) : null}
-                      </span>
-                    </span>
-                  </MenuRadioItem>
-                ))}
-              </MenuRadioGroup>
+              {isEffortGroup ? (
+                <div className="flex items-center gap-0.5">
+                  <span className="min-w-0 flex-1">
+                    <MenuCheckboxItem
+                      variant="switch"
+                      checked={autoEffortActive}
+                      closeOnClick={false}
+                      onCheckedChange={handleAutoEffortToggle}
+                      disabled={ultrathinkInBodyText}
+                    >
+                      <span className="min-w-0 truncate">{AUTO_EFFORT_LABEL}</span>
+                    </MenuCheckboxItem>
+                  </span>
+                  {autoEffortActive && autoEffortBoundDescriptors.length > 0 ? (
+                    <AutoEffortSettingsSubmenu
+                      descriptors={autoEffortBoundDescriptors}
+                      onChange={handleSelectChange}
+                    />
+                  ) : null}
+                </div>
+              ) : null}
+              {/* Auto owns the whole group while it is on: the manual rungs are
+                  what Auto is choosing between, so showing them would imply a
+                  second, competing selection. */}
+              {autoEffortActive && isEffortGroup ? null : (
+                <MenuRadioGroup
+                  value={selectedValue}
+                  onValueChange={(value) => handleSelectChange(descriptor, value)}
+                >
+                  {descriptor.options
+                    .filter((option) => option.id !== AUTO_EFFORT_VALUE)
+                    .map((option) => (
+                      <MenuRadioItem
+                        key={option.id}
+                        value={option.id}
+                        hideIndicator
+                        disabled={
+                          ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id
+                        }
+                      >
+                        <span className="flex w-full min-w-0 items-center justify-between gap-3">
+                          <span className="min-w-0 truncate">
+                            {option.label}
+                            {option.isDefault ? (
+                              <>
+                                {" "}
+                                <DefaultBadge />
+                              </>
+                            ) : null}
+                          </span>
+                        </span>
+                      </MenuRadioItem>
+                    ))}
+                </MenuRadioGroup>
+              )}
             </MenuGroup>
           </div>
         );
@@ -397,6 +540,10 @@ export function buildTraitsTriggerDisplay(input: {
   for (const descriptor of input.descriptors) {
     if (descriptor.id === "fastMode" && descriptor.type === "boolean") {
       hasFastMode = true;
+      continue;
+    }
+    // The auto limits are configuration for Auto, not traits of their own.
+    if (isAutoEffortBoundDescriptor(descriptor)) {
       continue;
     }
     const label =

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -89,6 +89,25 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("carries an auto effort selection and its limits through dispatch", () => {
+    const state = getComposerProviderState({
+      provider: PROVIDER,
+      model: MODEL,
+      models: modelWith([
+        selectDescriptor("effort", [
+          { id: "low", label: "Low" },
+          { id: "medium", label: "Medium" },
+          { id: "high", label: "High", isDefault: true },
+        ]),
+      ]),
+      modelOptions: selections(["effort", "auto"], ["effortAutoCeiling", "medium"]),
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(
+      selections(["effort", "auto"], ["effortAutoFloor", "low"], ["effortAutoCeiling", "medium"]),
+    );
+  });
+
   it("lets selections override defaults and propagates them through dispatch", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -5,10 +5,10 @@ import {
   type ScopedThreadRef,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import { getAutoEffortAwareDescriptors } from "@t3tools/shared/autoEffort";
 import {
   buildProviderOptionSelectionsFromDescriptors,
   getProviderOptionCurrentValue,
-  getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
 } from "@t3tools/shared/model";
 import type { ReactNode } from "react";
@@ -55,7 +55,7 @@ export function getComposerPromptInjectionState(prompt: string): ComposerPromptI
 export function getComposerProviderState(input: ComposerProviderStateInput): ComposerProviderState {
   const { provider, model, models, modelOptions, promptInjectionState = "none" } = input;
   const caps = getProviderModelCapabilities(models, model, provider);
-  const descriptors = getProviderOptionDescriptors({ caps, selections: modelOptions });
+  const descriptors = getAutoEffortAwareDescriptors({ caps, selections: modelOptions });
   const primarySelectDescriptor = descriptors.find(
     (descriptor): descriptor is Extract<(typeof descriptors)[number], { type: "select" }> =>
       descriptor.type === "select",

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -235,6 +235,7 @@ export function applyThreadDetailEvent(
           : {}),
         turnId: event.payload.turnId,
         streaming: event.payload.streaming,
+        ...(event.payload.responder !== undefined ? { responder: event.payload.responder } : {}),
         createdAt: event.payload.createdAt,
         updatedAt: event.payload.updatedAt,
       };
@@ -257,6 +258,7 @@ export function applyThreadDetailEvent(
                   ...(message.attachments !== undefined
                     ? { attachments: message.attachments }
                     : {}),
+                  ...(message.responder !== undefined ? { responder: message.responder } : {}),
                 },
           )
         : Arr.append(thread.messages, message);

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -225,6 +225,17 @@ export type OrchestrationProject = typeof OrchestrationProject.Type;
 export const OrchestrationMessageRole = Schema.Literals(["user", "assistant", "system"]);
 export type OrchestrationMessageRole = typeof OrchestrationMessageRole.Type;
 
+/**
+ * Which model produced an assistant message, recorded per message because a
+ * thread can switch model or effort between turns.
+ */
+export const OrchestrationMessageResponder = Schema.Struct({
+  modelSelection: ModelSelection,
+  /** True when the effort in `modelSelection` was picked by the auto reviewer. */
+  autoEffort: Schema.optional(Schema.Boolean),
+});
+export type OrchestrationMessageResponder = typeof OrchestrationMessageResponder.Type;
+
 export const OrchestrationMessage = Schema.Struct({
   id: MessageId,
   role: OrchestrationMessageRole,
@@ -232,6 +243,7 @@ export const OrchestrationMessage = Schema.Struct({
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
+  responder: Schema.optional(OrchestrationMessageResponder),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });
@@ -819,6 +831,7 @@ const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
   turnId: Schema.optional(TurnId),
+  responder: Schema.optional(OrchestrationMessageResponder),
   createdAt: IsoDateTime,
 });
 
@@ -1028,6 +1041,9 @@ export const ThreadMessageSentPayload = Schema.Struct({
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.NullOr(TurnId),
   streaming: Schema.Boolean,
+  // Only set when an assistant message completes: streaming deltas would repeat
+  // it on every event for no gain.
+  responder: Schema.optional(OrchestrationMessageResponder),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,14 @@
       "types": "./src/model.ts",
       "import": "./src/model.ts"
     },
+    "./autoEffort": {
+      "types": "./src/autoEffort.ts",
+      "import": "./src/autoEffort.ts"
+    },
+    "./messageResponder": {
+      "types": "./src/messageResponder.ts",
+      "import": "./src/messageResponder.ts"
+    },
     "./advertisedEndpoint": {
       "types": "./src/advertisedEndpoint.ts",
       "import": "./src/advertisedEndpoint.ts"

--- a/packages/shared/src/DrainableWorker.ts
+++ b/packages/shared/src/DrainableWorker.ts
@@ -13,7 +13,7 @@ import * as Effect from "effect/Effect";
 import * as TxQueue from "effect/TxQueue";
 import * as TxRef from "effect/TxRef";
 
-export interface DrainableWorker<A> {
+export interface DrainableWorker<A, E = never, R = never> {
   /**
    * Enqueue a work item and track it for `drain()`.
    *
@@ -23,7 +23,19 @@ export interface DrainableWorker<A> {
   readonly enqueue: (item: A) => Effect.Effect<void>;
 
   /**
-   * Resolves when the queue is empty and the worker is idle (not processing).
+   * Run work off the queue, without blocking it, while still counting toward
+   * `drain()`.
+   *
+   * For slow work that only one item depends on: keeping it in `process` would
+   * hold every other queued item behind it. The forked fiber lives as long as
+   * the worker, and failures surface as fiber failures, so work passed here
+   * should handle its own errors.
+   */
+  readonly fork: (work: Effect.Effect<void, E, R>) => Effect.Effect<void, never, R>;
+
+  /**
+   * Resolves when the queue is empty, the worker is idle (not processing), and
+   * no forked work is outstanding.
    */
   readonly drain: Effect.Effect<void>;
 }
@@ -39,10 +51,13 @@ export interface DrainableWorker<A> {
  */
 export const makeDrainableWorker = <A, E, R>(
   process: (item: A) => Effect.Effect<void, E, R>,
-): Effect.Effect<DrainableWorker<A>, never, Scope.Scope | R> =>
+): Effect.Effect<DrainableWorker<A, E, R>, never, Scope.Scope | R> =>
   Effect.gen(function* () {
     const queue = yield* Effect.acquireRelease(TxQueue.unbounded<A>(), TxQueue.shutdown);
     const outstanding = yield* TxRef.make(0);
+    // Forked work outlives the enqueue path that started it, so it belongs to
+    // the worker's scope rather than to whichever fiber called `fork`.
+    const workerScope = yield* Effect.scope;
 
     yield* TxQueue.take(queue).pipe(
       Effect.tap((a) =>
@@ -66,5 +81,19 @@ export const makeDrainableWorker = <A, E, R>(
         Effect.tx,
       );
 
-    return { enqueue, drain } satisfies DrainableWorker<A>;
+    const fork: DrainableWorker<A, E, R>["fork"] = (work) =>
+      TxRef.update(outstanding, (n) => n + 1).pipe(
+        Effect.andThen(
+          Effect.forkIn(
+            Effect.ensuring(
+              work,
+              TxRef.update(outstanding, (n) => n - 1),
+            ),
+            workerScope,
+          ),
+        ),
+        Effect.asVoid,
+      );
+
+    return { enqueue, fork, drain } satisfies DrainableWorker<A, E, R>;
   });

--- a/packages/shared/src/autoEffort.test.ts
+++ b/packages/shared/src/autoEffort.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, it } from "vite-plus/test";
+import { ProviderInstanceId, type ModelCapabilities } from "@t3tools/contracts";
+
+import {
+  AUTO_EFFORT_VALUE,
+  autoEffortAllowedChoices,
+  autoEffortCeilingOptionId,
+  autoEffortFloorOptionId,
+  autoEffortManualDefault,
+  clampAutoEffort,
+  getAutoEffortAwareDescriptors,
+  isAutoEffortActive,
+  reconcileAutoEffortLimitDescriptors,
+  resolveAutoEffortBounds,
+  resolveAutoEffortSelection,
+  resolveAutoEffortState,
+  withoutAutoEffortValue,
+} from "./autoEffort.ts";
+import {
+  buildProviderOptionSelectionsFromDescriptors,
+  createModelCapabilities,
+  createModelSelection,
+} from "./model.ts";
+
+/** Codex-shaped capabilities, deliberately declared out of cheapest-first order. */
+const codexCaps: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [
+    {
+      id: "reasoningEffort",
+      label: "Reasoning",
+      type: "select",
+      options: [
+        { id: "xhigh", label: "Extra High" },
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+        { id: "medium", label: "Medium" },
+      ],
+    },
+    {
+      id: "serviceTier",
+      label: "Service Tier",
+      type: "select",
+      options: [{ id: "default", label: "Standard", isDefault: true }],
+    },
+  ],
+});
+
+const claudeCaps: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [
+    {
+      id: "effort",
+      label: "Reasoning",
+      type: "select",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+        { id: "max", label: "Max" },
+        { id: "ultrathink", label: "Ultrathink" },
+      ],
+      promptInjectedValues: ["ultrathink"],
+    },
+  ],
+});
+
+const singleEffortCaps: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [
+    {
+      id: "reasoningEffort",
+      label: "Reasoning",
+      type: "select",
+      options: [{ id: "high", label: "High", isDefault: true }],
+    },
+  ],
+});
+
+const autoSelection = (options: ReadonlyArray<{ id: string; value: string }>) =>
+  createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.6-sol", options);
+
+describe("auto effort state", () => {
+  it("orders the ladder cheapest first regardless of provider declaration order", () => {
+    const state = resolveAutoEffortState({ caps: codexCaps });
+
+    expect(state?.ladder.map((option) => option.id)).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+
+  it("excludes prompt-injected efforts from the ladder", () => {
+    const state = resolveAutoEffortState({ caps: claudeCaps });
+
+    expect(state?.ladder.map((option) => option.id)).toEqual(["low", "high", "max"]);
+  });
+
+  it("defaults the ceiling to the model default so enabling auto cannot spend more", () => {
+    const state = resolveAutoEffortState({ caps: codexCaps });
+
+    expect(state?.ceiling).toBe("high");
+    expect(state?.floor).toBe("low");
+    expect(state?.fallback).toBe("high");
+  });
+
+  it("reads stored ceiling and floor selections", () => {
+    const bounds = resolveAutoEffortBounds({
+      descriptor: {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "low", label: "Low" },
+          { id: "medium", label: "Medium" },
+          { id: "high", label: "High", isDefault: true },
+          { id: "xhigh", label: "Extra High" },
+        ],
+      },
+      selections: [
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+        { id: autoEffortFloorOptionId("reasoningEffort"), value: "medium" },
+      ],
+    });
+
+    expect(bounds).toEqual({ ceiling: "xhigh", floor: "medium" });
+  });
+
+  it("treats an inverted range as unordered instead of failing", () => {
+    const bounds = resolveAutoEffortBounds({
+      descriptor: {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+        ],
+      },
+      selections: [
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "low" },
+        { id: autoEffortFloorOptionId("reasoningEffort"), value: "high" },
+      ],
+    });
+
+    expect(bounds).toEqual({ ceiling: "high", floor: "low" });
+  });
+
+  it("declines auto for models with a single effort rung", () => {
+    expect(resolveAutoEffortState({ caps: singleEffortCaps })).toBeNull();
+  });
+
+  it("declines auto for models without an effort select", () => {
+    expect(
+      resolveAutoEffortState({
+        caps: createModelCapabilities({
+          optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it("lands on the provider default when auto is switched off", () => {
+    const codexEffort = codexCaps.optionDescriptors?.[0];
+    expect(codexEffort?.type === "select" ? autoEffortManualDefault(codexEffort) : undefined).toBe(
+      "high",
+    );
+  });
+
+  it("reports auto as active only when the effort selection is auto", () => {
+    expect(
+      isAutoEffortActive({
+        caps: codexCaps,
+        selections: [{ id: "reasoningEffort", value: AUTO_EFFORT_VALUE }],
+      }),
+    ).toBe(true);
+    expect(
+      isAutoEffortActive({
+        caps: codexCaps,
+        selections: [{ id: "reasoningEffort", value: "high" }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("clamping", () => {
+  const state = resolveAutoEffortState({
+    caps: codexCaps,
+    selections: [
+      { id: autoEffortCeilingOptionId("reasoningEffort"), value: "high" },
+      { id: autoEffortFloorOptionId("reasoningEffort"), value: "medium" },
+    ],
+  });
+
+  it("keeps values inside the window", () => {
+    expect(clampAutoEffort(state!, "high")).toBe("high");
+    expect(clampAutoEffort(state!, "medium")).toBe("medium");
+  });
+
+  it("caps values above the ceiling", () => {
+    expect(clampAutoEffort(state!, "xhigh")).toBe("high");
+  });
+
+  it("raises values below the floor", () => {
+    expect(clampAutoEffort(state!, "low")).toBe("medium");
+  });
+
+  it("falls back to the ceiling for unknown values", () => {
+    expect(clampAutoEffort(state!, "turbo")).toBe("high");
+    expect(clampAutoEffort(state!, null)).toBe("high");
+  });
+
+  it("offers only the efforts inside the window", () => {
+    expect(autoEffortAllowedChoices(state!).map((option) => option.id)).toEqual(["medium", "high"]);
+  });
+
+  it("collapses to a single choice when the window is one rung wide", () => {
+    const pinned = resolveAutoEffortState({
+      caps: codexCaps,
+      selections: [
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "low" },
+        { id: autoEffortFloorOptionId("reasoningEffort"), value: "low" },
+      ],
+    });
+
+    expect(autoEffortAllowedChoices(pinned!).map((option) => option.id)).toEqual(["low"]);
+  });
+});
+
+describe("auto-effort-aware descriptors", () => {
+  it("offers auto without adding limit selects until auto is used", () => {
+    const descriptors = getAutoEffortAwareDescriptors({ caps: codexCaps });
+
+    expect(descriptors.map((descriptor) => descriptor.id)).toEqual([
+      "reasoningEffort",
+      "serviceTier",
+    ]);
+    const effort = descriptors[0];
+    expect(effort?.type === "select" && effort.options[0]?.id).toBe(AUTO_EFFORT_VALUE);
+  });
+
+  it("adds the auto limits once auto is selected", () => {
+    const descriptors = getAutoEffortAwareDescriptors({
+      caps: codexCaps,
+      selections: [{ id: "reasoningEffort", value: AUTO_EFFORT_VALUE }],
+    });
+
+    expect(descriptors.map((descriptor) => descriptor.id)).toEqual([
+      "reasoningEffort",
+      autoEffortFloorOptionId("reasoningEffort"),
+      autoEffortCeilingOptionId("reasoningEffort"),
+      "serviceTier",
+    ]);
+    expect(
+      descriptors
+        .filter((descriptor) => descriptor.id.startsWith("reasoningEffortAuto"))
+        .map((descriptor) => descriptor.label),
+    ).toEqual(["Minimum", "Maximum"]);
+  });
+
+  it("keeps configured limits after switching back to a manual effort", () => {
+    const descriptors = getAutoEffortAwareDescriptors({
+      caps: codexCaps,
+      selections: [
+        { id: "reasoningEffort", value: "high" },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+      ],
+    });
+
+    expect(
+      descriptors.find(
+        (descriptor) => descriptor.id === autoEffortCeilingOptionId("reasoningEffort"),
+      )?.currentValue,
+    ).toBe("xhigh");
+  });
+
+  it("keeps a stored auto selection instead of falling back to the provider default", () => {
+    const descriptors = getAutoEffortAwareDescriptors({
+      caps: codexCaps,
+      selections: [{ id: "reasoningEffort", value: AUTO_EFFORT_VALUE }],
+    });
+
+    expect(descriptors[0]?.currentValue).toBe(AUTO_EFFORT_VALUE);
+  });
+
+  it("round-trips auto and its bounds through selection persistence", () => {
+    const descriptors = getAutoEffortAwareDescriptors({
+      caps: codexCaps,
+      selections: [
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+      ],
+    });
+
+    expect(buildProviderOptionSelectionsFromDescriptors(descriptors)).toEqual([
+      { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+      { id: autoEffortFloorOptionId("reasoningEffort"), value: "low" },
+      { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+      { id: "serviceTier", value: "default" },
+    ]);
+  });
+
+  it("leaves capabilities without an effort select untouched", () => {
+    const caps = createModelCapabilities({
+      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
+    });
+
+    expect(getAutoEffortAwareDescriptors({ caps }).map((descriptor) => descriptor.id)).toEqual([
+      "fastMode",
+    ]);
+  });
+});
+
+describe("limit reconciliation", () => {
+  const limitDescriptors = (ceiling: string, floor: string) =>
+    getAutoEffortAwareDescriptors({
+      caps: codexCaps,
+      selections: [
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: ceiling },
+        { id: autoEffortFloorOptionId("reasoningEffort"), value: floor },
+      ],
+    });
+
+  const valuesAfterChange = (input: {
+    ceiling: string;
+    floor: string;
+    changedId: string;
+  }): { ceiling: unknown; floor: unknown } => {
+    const reconciled = reconcileAutoEffortLimitDescriptors(
+      limitDescriptors(input.ceiling, input.floor),
+      input.changedId,
+    );
+    const find = (id: string) => reconciled.find((descriptor) => descriptor.id === id);
+    return {
+      ceiling: find(autoEffortCeilingOptionId("reasoningEffort"))?.currentValue,
+      floor: find(autoEffortFloorOptionId("reasoningEffort"))?.currentValue,
+    };
+  };
+
+  it("drags the maximum up when the minimum is raised past it", () => {
+    expect(
+      valuesAfterChange({
+        ceiling: "high",
+        floor: "xhigh",
+        changedId: autoEffortFloorOptionId("reasoningEffort"),
+      }),
+    ).toEqual({ ceiling: "xhigh", floor: "xhigh" });
+  });
+
+  it("drags the minimum down when the maximum is lowered past it", () => {
+    expect(
+      valuesAfterChange({
+        ceiling: "low",
+        floor: "high",
+        changedId: autoEffortCeilingOptionId("reasoningEffort"),
+      }),
+    ).toEqual({ ceiling: "low", floor: "low" });
+  });
+
+  it("leaves a consistent window alone", () => {
+    expect(
+      valuesAfterChange({
+        ceiling: "high",
+        floor: "low",
+        changedId: autoEffortFloorOptionId("reasoningEffort"),
+      }),
+    ).toEqual({ ceiling: "high", floor: "low" });
+  });
+
+  it("ignores changes to descriptors that are not limits", () => {
+    const descriptors = limitDescriptors("high", "xhigh");
+
+    expect(reconcileAutoEffortLimitDescriptors(descriptors, "serviceTier")).toBe(descriptors);
+  });
+});
+
+describe("resolving a selection for a turn", () => {
+  it("replaces auto with the reviewer's choice", () => {
+    const resolved = resolveAutoEffortSelection({
+      modelSelection: autoSelection([
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+        { id: "serviceTier", value: "default" },
+      ]),
+      caps: codexCaps,
+      requestedEffort: "medium",
+    });
+
+    expect(resolved?.effort).toBe("medium");
+    expect(resolved?.clamped).toBe(false);
+    expect(resolved?.modelSelection.options).toEqual([
+      { id: "reasoningEffort", value: "medium" },
+      { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+      { id: "serviceTier", value: "default" },
+    ]);
+  });
+
+  it("clamps a reviewer choice above the ceiling and reports it", () => {
+    const resolved = resolveAutoEffortSelection({
+      modelSelection: autoSelection([
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "high" },
+      ]),
+      caps: codexCaps,
+      requestedEffort: "xhigh",
+    });
+
+    expect(resolved?.effort).toBe("high");
+    expect(resolved?.requested).toBe("xhigh");
+    expect(resolved?.clamped).toBe(true);
+  });
+
+  it("uses the clamped default when no reviewer choice is available", () => {
+    const resolved = resolveAutoEffortSelection({
+      modelSelection: autoSelection([
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortFloorOptionId("reasoningEffort"), value: "xhigh" },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+      ]),
+      caps: codexCaps,
+      requestedEffort: null,
+    });
+
+    expect(resolved?.effort).toBe("xhigh");
+    expect(resolved?.requested).toBeNull();
+  });
+
+  it("falls back to the provider default, clamped to the window, without a reviewer", () => {
+    const resolved = resolveAutoEffortSelection({
+      modelSelection: autoSelection([
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "medium" },
+      ]),
+      caps: codexCaps,
+      requestedEffort: null,
+    });
+
+    // codexCaps defaults to high, which the medium ceiling caps.
+    expect(resolved?.effort).toBe("medium");
+  });
+
+  it("passes through selections that are not on auto", () => {
+    expect(
+      resolveAutoEffortSelection({
+        modelSelection: autoSelection([{ id: "reasoningEffort", value: "high" }]),
+        caps: codexCaps,
+        requestedEffort: "low",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("auto value guard", () => {
+  it("hides auto from provider-bound effort reads", () => {
+    expect(withoutAutoEffortValue(AUTO_EFFORT_VALUE)).toBeUndefined();
+    expect(withoutAutoEffortValue("high")).toBe("high");
+    expect(withoutAutoEffortValue(undefined)).toBeUndefined();
+  });
+});

--- a/packages/shared/src/autoEffort.test.ts
+++ b/packages/shared/src/autoEffort.test.ts
@@ -419,6 +419,23 @@ describe("resolving a selection for a turn", () => {
     expect(resolved?.requested).toBeNull();
   });
 
+  it("falls back to the clamped default when the reviewer answers off the ladder", () => {
+    const resolved = resolveAutoEffortSelection({
+      modelSelection: autoSelection([
+        { id: "reasoningEffort", value: AUTO_EFFORT_VALUE },
+        { id: autoEffortFloorOptionId("reasoningEffort"), value: "low" },
+        { id: autoEffortCeilingOptionId("reasoningEffort"), value: "xhigh" },
+      ]),
+      caps: codexCaps,
+      requestedEffort: "turbo",
+    });
+
+    // Nonsense must not read as "above the ceiling" and spend xhigh.
+    expect(resolved?.effort).toBe("high");
+    expect(resolved?.requested).toBe("turbo");
+    expect(resolved?.clamped).toBe(false);
+  });
+
   it("falls back to the provider default, clamped to the window, without a reviewer", () => {
     const resolved = resolveAutoEffortSelection({
       modelSelection: autoSelection([

--- a/packages/shared/src/autoEffort.ts
+++ b/packages/shared/src/autoEffort.ts
@@ -1,0 +1,566 @@
+/**
+ * Auto reasoning effort: shared, provider-agnostic logic.
+ *
+ * Providers expose reasoning effort as a `select` provider option
+ * (`reasoningEffort` for Codex, `effort` for Claude, `reasoning` for Cursor).
+ * Auto effort adds one synthetic `auto` choice to that select plus two limits —
+ * a maximum and a minimum — so the user delegates the per-prompt decision to a
+ * reviewer model while keeping a hard spend limit.
+ *
+ * Everything here is pure so the server (resolving a turn's effort), the web
+ * composer, and the mobile composer share one definition of the effort ladder,
+ * the bounds, and the clamping rules.
+ *
+ * @module autoEffort
+ */
+import type {
+  ModelCapabilities,
+  ModelSelection,
+  ProviderOptionChoice,
+  ProviderOptionDescriptor,
+  ProviderOptionSelection,
+  SelectProviderOptionDescriptor,
+} from "@t3tools/contracts";
+
+import {
+  getProviderOptionCurrentValue,
+  getProviderOptionDescriptors,
+  getProviderOptionStringSelectionValue,
+} from "./model.ts";
+
+/** Synthetic effort value that delegates the choice to the reviewer model. */
+export const AUTO_EFFORT_VALUE = "auto";
+
+export const AUTO_EFFORT_LABEL = "Auto";
+
+/** Option id suffixes for the auto-effort limits derived from an effort select. */
+const CEILING_SUFFIX = "AutoCeiling";
+const FLOOR_SUFFIX = "AutoFloor";
+
+/**
+ * Provider option ids that carry reasoning effort. Auto effort is offered for
+ * these and only these, so unrelated selects (service tier, context window,
+ * agent) keep their plain behavior.
+ */
+const EFFORT_DESCRIPTOR_IDS: ReadonlySet<string> = new Set([
+  "reasoningEffort",
+  "effort",
+  "reasoning",
+]);
+
+/**
+ * Canonical ordering of known effort values, cheapest first. Providers list
+ * their efforts in arbitrary order, and the ceiling/floor comparison needs a
+ * total order, so unknown values sort after all known ones by declaration
+ * order.
+ */
+const EFFORT_RANKS: Readonly<Record<string, number>> = {
+  none: 0,
+  minimal: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  xhigh: 5,
+  max: 6,
+  ultra: 7,
+  ultracode: 8,
+};
+
+const UNKNOWN_EFFORT_RANK_BASE = 100;
+
+export interface AutoEffortBounds {
+  /** Highest effort the reviewer may pick. */
+  readonly ceiling: string;
+  /** Lowest effort the reviewer may pick. */
+  readonly floor: string;
+}
+
+export interface AutoEffortState extends AutoEffortBounds {
+  /** Id of the provider's effort select (e.g. `reasoningEffort`). */
+  readonly descriptorId: string;
+  /** Label of the provider's effort select (e.g. `Reasoning`). */
+  readonly descriptorLabel: string;
+  /** True when the effort select is currently set to `auto`. */
+  readonly active: boolean;
+  /** Selectable efforts, cheapest first, with prompt-injected values removed. */
+  readonly ladder: ReadonlyArray<ProviderOptionChoice>;
+  /** Effort to use when the reviewer is unavailable or returns nonsense. */
+  readonly fallback: string;
+}
+
+export function autoEffortCeilingOptionId(descriptorId: string): string {
+  return `${descriptorId}${CEILING_SUFFIX}`;
+}
+
+export function autoEffortFloorOptionId(descriptorId: string): string {
+  return `${descriptorId}${FLOOR_SUFFIX}`;
+}
+
+export function isAutoEffortBoundOptionId(optionId: string): boolean {
+  return optionId.endsWith(CEILING_SUFFIX) || optionId.endsWith(FLOOR_SUFFIX);
+}
+
+export function isEffortOptionDescriptor(
+  descriptor: ProviderOptionDescriptor | null | undefined,
+): descriptor is SelectProviderOptionDescriptor {
+  return (
+    descriptor !== null &&
+    descriptor !== undefined &&
+    descriptor.type === "select" &&
+    EFFORT_DESCRIPTOR_IDS.has(descriptor.id)
+  );
+}
+
+function effortRank(optionId: string, declarationIndex: number): number {
+  return EFFORT_RANKS[optionId] ?? UNKNOWN_EFFORT_RANK_BASE + declarationIndex;
+}
+
+/**
+ * Selectable efforts for a descriptor, cheapest first.
+ *
+ * Prompt-injected values (Claude's `ultrathink`) are excluded: they are applied
+ * by rewriting the prompt text rather than by sending an option, so the
+ * reviewer must not be able to pick them.
+ */
+export function autoEffortLadder(
+  descriptor: SelectProviderOptionDescriptor,
+): ReadonlyArray<ProviderOptionChoice> {
+  const promptInjected = new Set(descriptor.promptInjectedValues ?? []);
+  return descriptor.options
+    .map((option, index) => ({ option, index }))
+    .filter(({ option }) => option.id !== AUTO_EFFORT_VALUE && !promptInjected.has(option.id))
+    .sort((left, right) => {
+      const delta =
+        effortRank(left.option.id, left.index) - effortRank(right.option.id, right.index);
+      return delta !== 0 ? delta : left.index - right.index;
+    })
+    .map(({ option }) => option);
+}
+
+function isLadderRankAtMost(
+  ladder: ReadonlyArray<ProviderOptionChoice>,
+  candidate: string,
+  limit: string,
+): boolean {
+  return ladderIndex(ladder, candidate) <= ladderIndex(ladder, limit);
+}
+
+function ladderIndex(ladder: ReadonlyArray<ProviderOptionChoice>, optionId: string): number {
+  return ladder.findIndex((option) => option.id === optionId);
+}
+
+function defaultCeiling(
+  descriptor: SelectProviderOptionDescriptor,
+  ladder: ReadonlyArray<ProviderOptionChoice>,
+): string | undefined {
+  // The model's own default is the token-safe ceiling: turning Auto on can then
+  // only spend less than a manual default-effort turn until the user raises it.
+  const providerDefault = providerDefaultEffort(descriptor);
+  if (providerDefault && ladderIndex(ladder, providerDefault) >= 0) {
+    return providerDefault;
+  }
+  return ladder.at(-1)?.id;
+}
+
+function resolveBoundValue(input: {
+  readonly ladder: ReadonlyArray<ProviderOptionChoice>;
+  readonly raw: string | undefined;
+  readonly fallback: string | undefined;
+}): string | undefined {
+  const raw = input.raw?.trim();
+  if (raw && ladderIndex(input.ladder, raw) >= 0) {
+    return raw;
+  }
+  return input.fallback;
+}
+
+/**
+ * Ceiling/floor for one effort descriptor, resolved from stored selections and
+ * ordered so the ceiling is never below the floor.
+ */
+export function resolveAutoEffortBounds(input: {
+  readonly descriptor: SelectProviderOptionDescriptor;
+  readonly selections?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+}): AutoEffortBounds | null {
+  const ladder = autoEffortLadder(input.descriptor);
+  if (ladder.length === 0) {
+    return null;
+  }
+  const ceiling = resolveBoundValue({
+    ladder,
+    raw: getProviderOptionStringSelectionValue(
+      input.selections,
+      autoEffortCeilingOptionId(input.descriptor.id),
+    ),
+    fallback: defaultCeiling(input.descriptor, ladder),
+  });
+  const floor = resolveBoundValue({
+    ladder,
+    raw: getProviderOptionStringSelectionValue(
+      input.selections,
+      autoEffortFloorOptionId(input.descriptor.id),
+    ),
+    fallback: ladder[0]?.id,
+  });
+  if (!ceiling || !floor) {
+    return null;
+  }
+  // A floor above the ceiling is user error, not a reason to fail: treat the
+  // pair as an unordered range so the reviewer still gets a usable window.
+  return isLadderRankAtMost(ladder, floor, ceiling)
+    ? { ceiling, floor }
+    : { ceiling: floor, floor: ceiling };
+}
+
+/** Clamp any candidate effort into the configured window. */
+export function clampAutoEffort(
+  state: Pick<AutoEffortState, "ladder" | "ceiling" | "floor">,
+  candidate: string | null | undefined,
+): string {
+  const trimmed = candidate?.trim();
+  const index = trimmed ? ladderIndex(state.ladder, trimmed) : -1;
+  const ceilingIndex = ladderIndex(state.ladder, state.ceiling);
+  const floorIndex = ladderIndex(state.ladder, state.floor);
+  if (index < 0) {
+    return state.ceiling;
+  }
+  if (index > ceilingIndex) {
+    return state.ceiling;
+  }
+  if (index < floorIndex) {
+    return state.floor;
+  }
+  return trimmed as string;
+}
+
+function effortDescriptorFrom(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
+): SelectProviderOptionDescriptor | undefined {
+  return descriptors.find(isEffortOptionDescriptor);
+}
+
+/**
+ * Full auto-effort state for a capability set, or `null` when the model has no
+ * effort select (nothing to automate).
+ */
+export function resolveAutoEffortState(input: {
+  readonly caps: ModelCapabilities | null | undefined;
+  readonly selections?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+}): AutoEffortState | null {
+  if (!input.caps) {
+    return null;
+  }
+  const descriptor = effortDescriptorFrom(input.caps.optionDescriptors ?? []);
+  if (!descriptor) {
+    return null;
+  }
+  const ladder = autoEffortLadder(descriptor);
+  // A single rung leaves nothing for the reviewer to decide between.
+  if (ladder.length < 2) {
+    return null;
+  }
+  const bounds = resolveAutoEffortBounds({ descriptor, selections: input.selections });
+  if (!bounds) {
+    return null;
+  }
+  const active =
+    getProviderOptionStringSelectionValue(input.selections, descriptor.id) === AUTO_EFFORT_VALUE;
+
+  return {
+    descriptorId: descriptor.id,
+    descriptorLabel: descriptor.label,
+    active,
+    ladder,
+    ...bounds,
+    // The provider's own default is the fallback; it is clamped so a reviewer
+    // outage can never spend above the ceiling.
+    fallback: clampAutoEffort({ ladder, ...bounds }, providerDefaultEffort(descriptor)),
+  };
+}
+
+/** The effort the provider itself defaults to, when it advertises one. */
+function providerDefaultEffort(descriptor: SelectProviderOptionDescriptor): string | undefined {
+  return descriptor.options.find((option) => option.isDefault)?.id;
+}
+
+/**
+ * Efforts inside the configured window, cheapest first. This is what the
+ * reviewer is allowed to choose from.
+ */
+export function autoEffortAllowedChoices(
+  state: Pick<AutoEffortState, "ladder" | "ceiling" | "floor">,
+): ReadonlyArray<ProviderOptionChoice> {
+  const floorIndex = ladderIndex(state.ladder, state.floor);
+  const ceilingIndex = ladderIndex(state.ladder, state.ceiling);
+  if (floorIndex < 0 || ceilingIndex < 0) {
+    return state.ladder;
+  }
+  return state.ladder.slice(floorIndex, ceilingIndex + 1);
+}
+
+export function isAutoEffortActive(input: {
+  readonly caps: ModelCapabilities | null | undefined;
+  readonly selections?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+}): boolean {
+  return resolveAutoEffortState(input)?.active === true;
+}
+
+/**
+ * `auto` is a T3 Code concept; no provider CLI understands it. Read effort
+ * values through this so a stale or unresolved `auto` degrades to "provider
+ * default" instead of being forwarded verbatim.
+ */
+export function withoutAutoEffortValue(value: string | undefined): string | undefined {
+  return value === AUTO_EFFORT_VALUE ? undefined : value;
+}
+
+function augmentEffortDescriptor(
+  descriptor: SelectProviderOptionDescriptor,
+): SelectProviderOptionDescriptor {
+  return {
+    ...descriptor,
+    options: [
+      {
+        id: AUTO_EFFORT_VALUE,
+        label: AUTO_EFFORT_LABEL,
+        description: "A reviewer model picks the effort for each prompt, within your limits.",
+      },
+      ...descriptor.options,
+    ],
+  };
+}
+
+function buildBoundDescriptor(input: {
+  readonly id: string;
+  readonly label: string;
+  readonly ladder: ReadonlyArray<ProviderOptionChoice>;
+  readonly defaultValue: string;
+}): SelectProviderOptionDescriptor {
+  return {
+    id: input.id,
+    label: input.label,
+    type: "select",
+    options: input.ladder.map((option) =>
+      option.id === input.defaultValue
+        ? { id: option.id, label: option.label, isDefault: true }
+        : { id: option.id, label: option.label },
+    ),
+  };
+}
+
+/**
+ * Capabilities with the synthetic auto choice folded into the effort select,
+ * and optionally with its two bound selects appended.
+ *
+ * The bounds are conditional so a user who never touches auto effort does not
+ * accumulate ceiling/floor selections in every stored model selection.
+ */
+export function withAutoEffortCapabilities(
+  caps: ModelCapabilities | null | undefined,
+  options?: { readonly includeBounds?: boolean },
+): ModelCapabilities | null | undefined {
+  if (!caps) {
+    return caps;
+  }
+  const descriptors = caps.optionDescriptors ?? [];
+  const descriptor = effortDescriptorFrom(descriptors);
+  if (!descriptor) {
+    return caps;
+  }
+  const ladder = autoEffortLadder(descriptor);
+  if (ladder.length < 2) {
+    return caps;
+  }
+  const ceiling = defaultCeiling(descriptor, ladder) ?? ladder[ladder.length - 1]!.id;
+  const floor = ladder[0]!.id;
+  const boundDescriptors =
+    options?.includeBounds === true
+      ? [
+          buildBoundDescriptor({
+            id: autoEffortFloorOptionId(descriptor.id),
+            label: "Minimum",
+            ladder,
+            defaultValue: floor,
+          }),
+          buildBoundDescriptor({
+            id: autoEffortCeilingOptionId(descriptor.id),
+            label: "Maximum",
+            ladder,
+            defaultValue: ceiling,
+          }),
+        ]
+      : [];
+
+  return {
+    optionDescriptors: descriptors.flatMap((candidate) =>
+      candidate.id === descriptor.id && isEffortOptionDescriptor(candidate)
+        ? [augmentEffortDescriptor(candidate), ...boundDescriptors]
+        : [candidate],
+    ),
+  };
+}
+
+/**
+ * Provider option descriptors for composer surfaces: identical to
+ * `getProviderOptionDescriptors` except that auto effort is selectable, and its
+ * limits are included once the user has engaged with auto effort at all.
+ */
+export function getAutoEffortAwareDescriptors(input: {
+  readonly caps: ModelCapabilities | null | undefined;
+  readonly selections?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+}): ReadonlyArray<ProviderOptionDescriptor> {
+  const caps = withAutoEffortCapabilities(input.caps, {
+    includeBounds: hasAutoEffortFootprint(input.caps, input.selections),
+  });
+  if (!caps) {
+    return [];
+  }
+  return getProviderOptionDescriptors({ caps, selections: input.selections });
+}
+
+/**
+ * True once auto effort is in play for a selection: either it is currently
+ * selected, or limits were configured earlier and must survive a temporary
+ * switch back to a manual effort.
+ */
+function hasAutoEffortFootprint(
+  caps: ModelCapabilities | null | undefined,
+  selections: ReadonlyArray<ProviderOptionSelection> | null | undefined,
+): boolean {
+  const descriptor = effortDescriptorFrom(caps?.optionDescriptors ?? []);
+  if (!descriptor) {
+    return false;
+  }
+  if (getProviderOptionStringSelectionValue(selections, descriptor.id) === AUTO_EFFORT_VALUE) {
+    return true;
+  }
+  const limitIds = new Set([
+    autoEffortCeilingOptionId(descriptor.id),
+    autoEffortFloorOptionId(descriptor.id),
+  ]);
+  return (selections ?? []).some((selection) => limitIds.has(selection.id));
+}
+
+/** True for the maximum/minimum descriptors synthesized for auto effort. */
+export function isAutoEffortBoundDescriptor(descriptor: ProviderOptionDescriptor): boolean {
+  return descriptor.type === "select" && isAutoEffortBoundOptionId(descriptor.id);
+}
+
+/**
+ * Effort to select when the user switches Auto off: the provider's own default,
+ * so turning Auto off lands on the same effort a fresh thread would use.
+ */
+export function autoEffortManualDefault(
+  descriptor: SelectProviderOptionDescriptor,
+): string | undefined {
+  return defaultCeiling(descriptor, autoEffortLadder(descriptor));
+}
+
+/**
+ * Push the sibling limit out of the way after one limit changes.
+ *
+ * The maximum and the minimum describe one window, so raising the minimum above
+ * the maximum has to drag the maximum up with it (and vice versa) — otherwise
+ * the menu shows a window that reads backwards.
+ */
+export function reconcileAutoEffortLimitDescriptors(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
+  changedId: string,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  const effortDescriptor = effortDescriptorFrom(descriptors);
+  if (!effortDescriptor) {
+    return descriptors;
+  }
+  const ceilingId = autoEffortCeilingOptionId(effortDescriptor.id);
+  const floorId = autoEffortFloorOptionId(effortDescriptor.id);
+  if (changedId !== ceilingId && changedId !== floorId) {
+    return descriptors;
+  }
+  const siblingId = changedId === ceilingId ? floorId : ceilingId;
+  const ladder = autoEffortLadder(effortDescriptor);
+  const changedValue = descriptorValue(descriptors, changedId);
+  const siblingValue = descriptorValue(descriptors, siblingId);
+  if (changedValue === undefined || siblingValue === undefined) {
+    return descriptors;
+  }
+  const changedIndex = ladderIndex(ladder, changedValue);
+  const siblingIndex = ladderIndex(ladder, siblingValue);
+  if (changedIndex < 0 || siblingIndex < 0) {
+    return descriptors;
+  }
+  const contradicts =
+    changedId === ceilingId ? siblingIndex > changedIndex : siblingIndex < changedIndex;
+  if (!contradicts) {
+    return descriptors;
+  }
+  return descriptors.map((descriptor) =>
+    descriptor.id === siblingId && descriptor.type === "select"
+      ? { ...descriptor, currentValue: changedValue }
+      : descriptor,
+  );
+}
+
+function descriptorValue(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
+  descriptorId: string,
+): string | undefined {
+  const value = getProviderOptionCurrentValue(
+    descriptors.find((descriptor) => descriptor.id === descriptorId),
+  );
+  return typeof value === "string" ? value : undefined;
+}
+
+export function isAutoEffortSelectedInDescriptors(
+  descriptors: ReadonlyArray<ProviderOptionDescriptor>,
+): boolean {
+  const descriptor = effortDescriptorFrom(descriptors);
+  return descriptor ? getProviderOptionCurrentValue(descriptor) === AUTO_EFFORT_VALUE : false;
+}
+
+export interface ResolvedAutoEffort {
+  /** Effort actually sent to the provider. */
+  readonly effort: string;
+  /** Raw reviewer choice before clamping, when a reviewer ran. */
+  readonly requested: string | null;
+  /** True when clamping overrode the reviewer's choice. */
+  readonly clamped: boolean;
+  readonly ceiling: string;
+  readonly floor: string;
+  /** Selection with `auto` replaced by the resolved effort. */
+  readonly modelSelection: ModelSelection;
+}
+
+/**
+ * Replace an `auto` effort selection with a concrete effort.
+ *
+ * Returns `null` when auto is not active, which is the signal for callers to
+ * pass the selection through untouched.
+ */
+export function resolveAutoEffortSelection(input: {
+  readonly modelSelection: ModelSelection;
+  readonly caps: ModelCapabilities | null | undefined;
+  /** Reviewer's choice; `null`/invalid falls back to the clamped default. */
+  readonly requestedEffort: string | null | undefined;
+}): ResolvedAutoEffort | null {
+  const state = resolveAutoEffortState({
+    caps: input.caps,
+    selections: input.modelSelection.options,
+  });
+  if (!state || !state.active) {
+    return null;
+  }
+  const requested = input.requestedEffort?.trim() || null;
+  const effort = requested === null ? state.fallback : clampAutoEffort(state, requested);
+  const options = (input.modelSelection.options ?? []).map((selection) =>
+    selection.id === state.descriptorId ? { id: selection.id, value: effort } : selection,
+  );
+
+  return {
+    effort,
+    requested,
+    clamped: requested !== null && requested !== effort,
+    ceiling: state.ceiling,
+    floor: state.floor,
+    modelSelection: { ...input.modelSelection, options },
+  };
+}

--- a/packages/shared/src/autoEffort.ts
+++ b/packages/shared/src/autoEffort.ts
@@ -550,7 +550,11 @@ export function resolveAutoEffortSelection(input: {
     return null;
   }
   const requested = input.requestedEffort?.trim() || null;
-  const effort = requested === null ? state.fallback : clampAutoEffort(state, requested);
+  // Only an effort the model actually offers counts as a choice. Clamping an
+  // off-ladder answer would read it as "above the ceiling" and spend the
+  // maximum, so anything else is treated as no answer at all.
+  const chosen = requested !== null && ladderIndex(state.ladder, requested) >= 0 ? requested : null;
+  const effort = chosen === null ? state.fallback : clampAutoEffort(state, chosen);
   const options = (input.modelSelection.options ?? []).map((selection) =>
     selection.id === state.descriptorId ? { id: selection.id, value: effort } : selection,
   );
@@ -558,7 +562,7 @@ export function resolveAutoEffortSelection(input: {
   return {
     effort,
     requested,
-    clamped: requested !== null && requested !== effort,
+    clamped: chosen !== null && chosen !== effort,
     ceiling: state.ceiling,
     floor: state.floor,
     modelSelection: { ...input.modelSelection, options },

--- a/packages/shared/src/messageResponder.test.ts
+++ b/packages/shared/src/messageResponder.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+
+import { describeMessageResponder, type MessageResponderProvider } from "./messageResponder.ts";
+import { createModelCapabilities, createModelSelection } from "./model.ts";
+
+const codexModel: ServerProviderModel = {
+  slug: "gpt-5.3-codex",
+  name: "GPT-5.3 Codex",
+  isCustom: false,
+  capabilities: createModelCapabilities({
+    optionDescriptors: [
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+          { id: "xhigh", label: "Extra High" },
+        ],
+      },
+    ],
+  }),
+};
+
+const providers: ReadonlyArray<MessageResponderProvider> = [
+  {
+    instanceId: "codex",
+    driver: ProviderDriverKind.make("codex"),
+    displayName: "Codex",
+    models: [codexModel],
+  },
+];
+
+function responderFor(options: ReadonlyArray<{ id: string; value: string }>) {
+  return {
+    modelSelection: createModelSelection(
+      ProviderInstanceId.make("codex"),
+      codexModel.slug,
+      options,
+    ),
+  };
+}
+
+describe("describeMessageResponder", () => {
+  it("labels the model, its effort, and the provider behind it", () => {
+    const display = describeMessageResponder({
+      responder: responderFor([{ id: "reasoningEffort", value: "xhigh" }]),
+      providers,
+    });
+
+    expect(display).toEqual({
+      model: "GPT-5.3 Codex",
+      effort: "Extra High",
+      driver: "codex",
+      providerName: "Codex",
+      accentColor: undefined,
+    });
+  });
+
+  it("names the resolved effort behind auto", () => {
+    const display = describeMessageResponder({
+      responder: {
+        ...responderFor([{ id: "reasoningEffort", value: "high" }]),
+        autoEffort: true,
+      },
+      providers,
+    });
+
+    expect(display?.effort).toBe("Auto (High)");
+  });
+
+  it("falls back to the model slug for models the server no longer reports", () => {
+    const display = describeMessageResponder({
+      responder: responderFor([{ id: "reasoningEffort", value: "high" }]),
+      providers: [],
+    });
+
+    expect(display).toEqual({
+      model: "gpt-5.3-codex",
+      effort: null,
+      driver: null,
+      providerName: "codex",
+      accentColor: undefined,
+    });
+  });
+
+  it("omits the effort for models without one", () => {
+    const display = describeMessageResponder({
+      responder: responderFor([]),
+      providers,
+    });
+
+    expect(display?.model).toBe("GPT-5.3 Codex");
+    expect(display?.effort).toBeNull();
+  });
+
+  it("returns nothing for messages recorded before responders were tracked", () => {
+    expect(describeMessageResponder({ responder: undefined, providers })).toBeNull();
+  });
+});

--- a/packages/shared/src/messageResponder.ts
+++ b/packages/shared/src/messageResponder.ts
@@ -1,0 +1,92 @@
+/**
+ * Labels for the model behind an assistant message.
+ *
+ * A thread can change model and effort between turns, so each assistant message
+ * records what produced it. This turns that record into display strings, using
+ * the live provider snapshot for model names and effort labels.
+ *
+ * @module messageResponder
+ */
+import type {
+  ModelSelection,
+  OrchestrationMessageResponder,
+  ProviderDriverKind,
+  ServerProviderModel,
+} from "@t3tools/contracts";
+
+import { AUTO_EFFORT_LABEL, isEffortOptionDescriptor } from "./autoEffort.ts";
+import { getProviderOptionDescriptors, getProviderOptionStringSelectionValue } from "./model.ts";
+
+export interface MessageResponderProvider {
+  readonly instanceId: string;
+  readonly driver: ProviderDriverKind;
+  readonly displayName?: string | undefined;
+  readonly accentColor?: string | undefined;
+  readonly models: ReadonlyArray<ServerProviderModel>;
+}
+
+export interface MessageResponderDisplay {
+  /** Model display name, falling back to its slug. */
+  readonly model: string;
+  /** Effort label, or `Auto (High)` when the reviewer picked it. */
+  readonly effort: string | null;
+  /** Driver behind the message, for the provider logo. Null once uninstalled. */
+  readonly driver: ProviderDriverKind | null;
+  readonly providerName: string;
+  readonly accentColor: string | undefined;
+}
+
+function effortLabel(
+  model: ServerProviderModel | undefined,
+  modelSelection: ModelSelection,
+): string | null {
+  const caps = model?.capabilities;
+  if (!caps) {
+    return null;
+  }
+  for (const descriptor of getProviderOptionDescriptors({ caps })) {
+    if (!isEffortOptionDescriptor(descriptor)) {
+      continue;
+    }
+    const value = getProviderOptionStringSelectionValue(modelSelection.options, descriptor.id);
+    if (value === undefined) {
+      return null;
+    }
+    return descriptor.options.find((option) => option.id === value)?.label ?? value;
+  }
+  return null;
+}
+
+/**
+ * Describe the model and effort an assistant message was produced with.
+ *
+ * Returns `null` for messages recorded before this was tracked, so callers can
+ * skip rendering rather than show a placeholder.
+ */
+export function describeMessageResponder(input: {
+  readonly responder: OrchestrationMessageResponder | null | undefined;
+  readonly providers: ReadonlyArray<MessageResponderProvider>;
+}): MessageResponderDisplay | null {
+  const responder = input.responder;
+  if (!responder) {
+    return null;
+  }
+  const { modelSelection } = responder;
+  const provider = input.providers.find(
+    (candidate) => candidate.instanceId === modelSelection.instanceId,
+  );
+  const model = provider?.models.find((candidate) => candidate.slug === modelSelection.model);
+  const effort = effortLabel(model, modelSelection);
+  return {
+    model: model?.name ?? modelSelection.model,
+    effort:
+      responder.autoEffort === true
+        ? effort === null
+          ? AUTO_EFFORT_LABEL
+          : `${AUTO_EFFORT_LABEL} (${effort})`
+        : effort,
+    driver: provider?.driver ?? null,
+    providerName: provider?.displayName ?? modelSelection.instanceId,
+    accentColor: provider?.accentColor,
+  };
+}


### PR DESCRIPTION
## What Changed

**Auto reasoning effort.** `Auto` becomes a choice in the composer's effort control, alongside the fixed levels. When it is on, the reviewer model already used for command approvals reads the prompt plus thread context and picks the effort for that turn, clamped between a user-set **Minimum** and **Maximum**. The control is a toggle with a submenu holding those two limits; picking a minimum above the current maximum raises the maximum to match (and vice versa) so the range cannot contradict itself. If the reviewer fails or times out, the provider's own default effort is used, clamped to the same bounds. `auto` is never forwarded to a provider CLI.

The reviewer runs on the thread's own provider at its cheapest effort, not the globally configured text-generation model, so this works on Cursor, Codex, Claude, and the rest without extra setup.

**Per-message model attribution.** Since model and effort can now differ between turns in one thread, each assistant message records the selection that produced it, and the existing hover meta row (copy button, timestamp) gains the provider logo, model name, and effort — `GPT-5.6 Sol Auto (Low)` when the reviewer picked it, or just the effort when set manually.

Where the pieces live:

- `packages/shared/autoEffort` — effort descriptor derivation, bound clamping, and limit reconciliation, shared by web and mobile.
- `packages/shared/messageResponder` — turns a recorded selection into display strings using the live provider snapshot.
- `apps/server` — `TurnResponder` holds the resolved selection for the active turn; `ProviderCommandReactor` records it at turn start and `ProviderRuntimeIngestion` attaches it when an assistant message completes.
- Persistence — migration `035` adds `responder_json` to `projection_thread_messages`; the projection pipeline, snapshot query, and thread reducer carry it to clients.

## Why

Choosing an effort per prompt is manual busywork with a real cost in both directions: a trivial rename burns a high-effort turn, and a hard design question gets short-changed because the picker was left on low. Letting a cheap reviewer pass make that call per turn removes the fiddling, and the minimum/maximum bounds keep token spend predictable instead of handing the decision over unconditionally — that ceiling is the reason this is safe to leave on.

Attribution is the necessary companion. Once effort (and model) can vary per turn inside one thread, a response on its own no longer tells you what produced it, which makes both trusting a good answer and diagnosing a bad one guesswork.

Note on rollout: assistant messages written before migration `035` have no recorded selection, so the hover row simply omits the label for them rather than showing a placeholder. No backfill is possible since the information was never captured.

## UI Changes

Two surfaces change, both in the composer/timeline:

1. The effort control renders `Auto · <context>` with a toggle and a submenu for Minimum/Maximum.
2. The assistant hover row gains provider logo + model + effort, e.g. `GPT-5.6 Sol Auto (Low)`.

I verified both live in an isolated dev environment rather than only in tests: with `Auto` enabled on Cursor's GPT-5.6 Sol, a trivial prompt had the reviewer resolve `Low`, and the hover row rendered `GPT-5.6 Sol Auto (Low)` (hidden until hover, as before). Happy to attach screenshots/video on request.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

On the first box, being straight with you: this is not small. It is two related features (~2.6k lines) because the attribution row is what makes variable effort legible. If you would consider it in smaller pieces, or not at all, say so and I will split it into the auto-effort change and the attribution change, or close it.

## Verification

- `vp test run` over the changed scope — 163 tests passing: `packages/shared/{autoEffort,messageResponder}`, `apps/web/src/components/chat/{TraitsPicker,MessagesTimeline,composerProviderState}`, `apps/mobile/src/lib/providerOptions`, `apps/server/src/orchestration/Layers/{ProviderCommandReactor,ProviderRuntimeIngestion}`, `apps/server/src/textGeneration/TextGeneration`.
- `vp check` (format + lint) clean on all changed files; `typecheck` clean for contracts, shared, client-runtime, server, web, and mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large orchestration change (~2.6k LOC): turn-start path now depends on an extra LLM call and new in-memory state; mis-binding or projection gaps could mislabel messages, though failures degrade to default effort rather than blocking turns.
> 
> **Overview**
> **Auto reasoning effort** adds an `auto` choice on effort selects (web traits picker, mobile provider menu) with optional **Minimum** / **Maximum** limits, shared via `@t3tools/shared/autoEffort`. On turn start, `ProviderCommandReactor` runs `TextGeneration.selectReasoningEffort` on the thread’s provider at cheapest effort (off the worker queue via `DrainableWorker.fork`), clamps to bounds, and sends a concrete effort—`auto` is stripped before Codex/Cursor adapters. Reviewer failure/timeout falls back to a clamped default; a one-rung window skips the reviewer.
> 
> **Per-message attribution** introduces in-memory `TurnResponder` (record at send, bind on `turn.started`, read on assistant complete), `OrchestrationMessageResponder` on messages/events, migration **035** (`responder_json`), and timeline hover UI via `describeMessageResponder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2cf36161c18134c8c11a15991607f3e7c1643bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto reasoning effort selection with per-turn bounds and per-message model attribution
> - Adds an `auto` reasoning effort mode where a lightweight LLM reviewer (`selectReasoningEffort`) picks a concrete effort level per turn from a configured ladder, clamped by optional floor and ceiling bounds set in the traits picker.
> - Introduces a new `TurnResponder` service that records which model selection and effort produced each assistant turn, binding the responder to the provider turn id before ingestion finalizes the message.
> - Persists responder metadata (`responder_json`) in `projection_thread_messages` via migration 035 and threads it through projection snapshots, the thread reducer, and `thread.message-sent` events.
> - Renders the resolved model name, effort label, and optional provider icon in the assistant message hover row in the web UI; shows `Auto` when effort was auto-selected.
> - Extends `DrainableWorker` with a `fork` method so auto-effort review can run off the queue without blocking event processing while still being counted toward drain.
> - Risk: auto-effort adds a provider CLI call per turn before dispatching; timeouts and failures fall back to a clamped default rather than blocking, but latency before turn start increases when auto effort is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2cf361.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->