### PR TITLE
fix(client-runtime): re-read network status when the app resumes

### DIFF
--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -109,16 +109,17 @@ describe("followNetworkStatus", () => {
     ),
   );
 
-  it.effect("keeps a resumed read that only a repeated status raced", () =>
+  it.effect("discards a resumed read that a repeated report raced", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const readStarted = yield* Deferred.make<void>();
         const releaseRead = yield* Deferred.make<void>();
         const harness = yield* makeHarness({
-          initialStatus: "offline",
+          initialStatus: "online",
+          // The resume samples a brief opposite state.
           status: Deferred.succeed(readStarted, undefined).pipe(
             Effect.andThen(Deferred.await(releaseRead)),
-            Effect.as("online" as const),
+            Effect.as("offline" as const),
           ),
         });
         yield* Connectivity.followNetworkStatus({
@@ -127,22 +128,50 @@ describe("followNetworkStatus", () => {
           apply: harness.apply,
         });
 
-        // Apply "offline" first so the listener's later repeat of it is genuinely
+        // Apply "online" first so the listener's later repeat of it is genuinely
         // redundant rather than a new status.
-        yield* untilApplied(harness.report("offline"), harness.applied, 1);
+        yield* untilApplied(harness.report("online"), harness.applied, 1);
         yield* harness.resume.pipe(
           Effect.andThen(Effect.yieldNow),
           Effect.repeat({ until: () => Deferred.isDone(readStarted) }),
         );
 
-        // A repeat of the status already in effect carries nothing newer, so the
-        // resumed read still has to land.
-        yield* harness.report("offline");
+        // The repeat carries no new status, but it proves the listener spoke
+        // after this read began, so the read is stale even though the status it
+        // returns differs. Applying it would strand consumers on "offline" while
+        // the platform reports "online" — the very failure this helper exists to
+        // prevent.
+        yield* harness.report("online");
         yield* Effect.yieldNow;
         yield* Deferred.succeed(releaseRead, undefined);
         yield* Effect.yieldNow;
         yield* Effect.yieldNow;
 
+        expect(yield* Ref.get(harness.applied)).toEqual(["online"]);
+      }),
+    ),
+  );
+
+  it.effect("still deduplicates a repeated report before it reaches consumers", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness({ initialStatus: "online" });
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: harness.apply,
+        });
+
+        yield* untilApplied(harness.report("offline"), harness.applied, 1);
+        // Counting the repeat for staleness must not turn it into a redundant
+        // consumer update.
+        yield* harness.report("offline");
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        expect(yield* Ref.get(harness.applied)).toEqual(["offline"]);
+
+        // A genuine transition after the repeat still lands.
+        yield* untilApplied(harness.report("online"), harness.applied, 2);
         expect(yield* Ref.get(harness.applied)).toEqual(["offline", "online"]);
       }),
     ),

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -142,4 +142,50 @@ describe("followNetworkStatus", () => {
       }),
     ),
   );
+
+  it.effect("keeps a reported change from interleaving with a resumed apply", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const applyStarted = yield* Deferred.make<void>();
+        const releaseApply = yield* Deferred.make<void>();
+        const harness = yield* makeHarness({ initialStatus: "offline" });
+        // Holds the resumed apply open once it begins, so a reported change has
+        // a window to interleave between the guard and its apply.
+        const gatedApply = (status: NetworkStatus) =>
+          status === "online"
+            ? Deferred.succeed(applyStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseApply)),
+                Effect.andThen(harness.apply(status)),
+              )
+            : harness.apply(status);
+
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: gatedApply,
+        });
+
+        yield* harness.setLiveStatus("online");
+        yield* harness.resume.pipe(
+          Effect.andThen(Effect.yieldNow),
+          Effect.repeat({ until: () => Deferred.isDone(applyStarted) }),
+        );
+
+        // The listener reports a newer transition mid-apply.
+        yield* harness.report("offline");
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseApply, undefined);
+        yield* Effect.yieldNow.pipe(
+          Effect.repeat({
+            until: () =>
+              Ref.get(harness.applied).pipe(Effect.map((statuses) => statuses.length >= 2)),
+          }),
+        );
+
+        // The reported change has to land last; applying it before the resumed
+        // status finished would leave the stale "online" as the final word.
+        expect(yield* Ref.get(harness.applied)).toEqual(["online", "offline"]);
+      }),
+    ),
+  );
 });

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+
+import * as Connectivity from "./connectivity.ts";
+import type { NetworkStatus } from "./model.ts";
+import * as ConnectionWakeups from "./wakeups.ts";
+
+const makeHarness = Effect.fn("TestConnectivityHarness.make")(function* (options?: {
+  readonly status?: Effect.Effect<NetworkStatus>;
+  readonly initialStatus?: NetworkStatus;
+}) {
+  const liveStatus = yield* Ref.make<NetworkStatus>(options?.initialStatus ?? "online");
+  const reported = yield* SubscriptionRef.make<{
+    readonly sequence: number;
+    readonly status: NetworkStatus;
+  }>({ sequence: 0, status: options?.initialStatus ?? "online" });
+  const wakeups = yield* SubscriptionRef.make(0);
+  const applied = yield* Ref.make<ReadonlyArray<NetworkStatus>>([]);
+
+  const connectivity = Connectivity.Connectivity.of({
+    status: options?.status ?? Ref.get(liveStatus),
+    changes: SubscriptionRef.changes(reported).pipe(
+      Stream.drop(1),
+      Stream.map((event) => event.status),
+    ),
+  });
+
+  const wakeupService = ConnectionWakeups.ConnectionWakeups.of({
+    changes: SubscriptionRef.changes(wakeups).pipe(
+      Stream.drop(1),
+      Stream.map(() => "application-active" as const),
+    ),
+  });
+
+  return {
+    connectivity,
+    wakeups: wakeupService,
+    applied,
+    setLiveStatus: (status: NetworkStatus) => Ref.set(liveStatus, status),
+    // Emits a listener event, as a platform connectivity listener would.
+    report: (status: NetworkStatus) =>
+      Ref.set(liveStatus, status).pipe(
+        Effect.andThen(
+          SubscriptionRef.update(reported, (event) => ({
+            sequence: event.sequence + 1,
+            status,
+          })),
+        ),
+      ),
+    resume: SubscriptionRef.update(wakeups, (count) => count + 1),
+    apply: (status: NetworkStatus) => Ref.update(applied, (statuses) => [...statuses, status]),
+  };
+});
+
+// The forked listeners subscribe after `followNetworkStatus` returns, so repeat
+// the trigger until its effect is observed rather than racing the first one.
+const untilApplied = Effect.fn("TestConnectivityHarness.untilApplied")(function* (
+  trigger: Effect.Effect<unknown>,
+  applied: Ref.Ref<ReadonlyArray<NetworkStatus>>,
+  expected: number,
+) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    yield* trigger;
+    yield* Effect.yieldNow;
+    if ((yield* Ref.get(applied)).length >= expected) {
+      return yield* Ref.get(applied);
+    }
+  }
+  return yield* Effect.die(new Error("The expected network status was never applied."));
+});
+
+describe("followNetworkStatus", () => {
+  it.effect("applies statuses reported by the platform listener", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness();
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: harness.apply,
+        });
+
+        const applied = yield* untilApplied(harness.report("offline"), harness.applied, 1);
+        expect(applied).toEqual(["offline"]);
+      }),
+    ),
+  );
+
+  it.effect("applies a resumed read when the listener missed a transition", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeHarness({ initialStatus: "offline" });
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: harness.apply,
+        });
+
+        // The device came back online while suspended and the listener never
+        // reported the transition.
+        yield* harness.setLiveStatus("online");
+        const applied = yield* untilApplied(harness.resume, harness.applied, 1);
+        expect(applied).toEqual(["online"]);
+      }),
+    ),
+  );
+
+  it.effect("discards a resumed read that a newer reported change superseded", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const readStarted = yield* Deferred.make<void>();
+        const releaseRead = yield* Deferred.make<void>();
+        const harness = yield* makeHarness({
+          initialStatus: "offline",
+          status: Deferred.succeed(readStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseRead)),
+            Effect.as("online" as const),
+          ),
+        });
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: harness.apply,
+        });
+
+        // Resume, and hold the status read open so the listener can report a
+        // newer transition while that read is still in flight.
+        yield* harness.resume.pipe(
+          Effect.andThen(Effect.yieldNow),
+          Effect.repeat({ until: () => Deferred.isDone(readStarted) }),
+        );
+        yield* untilApplied(harness.report("offline"), harness.applied, 1);
+        yield* Deferred.succeed(releaseRead, undefined);
+        yield* Effect.yieldNow;
+
+        // The stale "online" snapshot must not land on top of the newer event.
+        expect(yield* Ref.get(harness.applied)).toEqual(["offline"]);
+      }),
+    ),
+  );
+});

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -109,6 +109,45 @@ describe("followNetworkStatus", () => {
     ),
   );
 
+  it.effect("keeps a resumed read that only a repeated status raced", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const readStarted = yield* Deferred.make<void>();
+        const releaseRead = yield* Deferred.make<void>();
+        const harness = yield* makeHarness({
+          initialStatus: "offline",
+          status: Deferred.succeed(readStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseRead)),
+            Effect.as("online" as const),
+          ),
+        });
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: harness.apply,
+        });
+
+        // Apply "offline" first so the listener's later repeat of it is genuinely
+        // redundant rather than a new status.
+        yield* untilApplied(harness.report("offline"), harness.applied, 1);
+        yield* harness.resume.pipe(
+          Effect.andThen(Effect.yieldNow),
+          Effect.repeat({ until: () => Deferred.isDone(readStarted) }),
+        );
+
+        // A repeat of the status already in effect carries nothing newer, so the
+        // resumed read still has to land.
+        yield* harness.report("offline");
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseRead, undefined);
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        expect(yield* Ref.get(harness.applied)).toEqual(["offline", "online"]);
+      }),
+    ),
+  );
+
   it.effect("discards a resumed read that a newer reported change superseded", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/client-runtime/src/connection/connectivity.test.ts
+++ b/packages/client-runtime/src/connection/connectivity.test.ts
@@ -148,6 +148,45 @@ describe("followNetworkStatus", () => {
     ),
   );
 
+  it.effect("does not start a second status read while one is in flight", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstRead = yield* Deferred.make<NetworkStatus>();
+        const readCount = yield* Ref.make(0);
+        const harness = yield* makeHarness({
+          initialStatus: "unknown",
+          status: Ref.updateAndGet(readCount, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.await(firstRead)),
+          ),
+        });
+        yield* Connectivity.followNetworkStatus({
+          connectivity: harness.connectivity,
+          wakeups: harness.wakeups,
+          apply: harness.apply,
+        });
+
+        yield* harness.resume.pipe(
+          Effect.andThen(Effect.yieldNow),
+          Effect.repeat({
+            until: () => Ref.get(readCount).pipe(Effect.map((count) => count >= 1)),
+          }),
+        );
+
+        // Resumes are consumed sequentially, so further resumes cannot start a
+        // read that races the one already in flight. Overlapping snapshots
+        // therefore cannot apply out of order.
+        yield* harness.resume;
+        yield* harness.resume;
+        yield* Effect.yieldNow;
+        expect(yield* Ref.get(readCount)).toBe(1);
+
+        yield* Deferred.succeed(firstRead, "online");
+        yield* Effect.yieldNow;
+        expect(yield* Ref.get(harness.applied)).toEqual(["online"]);
+      }),
+    ),
+  );
+
   it.effect("discards a resumed read that a newer reported change superseded", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -71,6 +71,8 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
     Stream.runForEach((reason) =>
       reason === "application-active"
         ? Effect.gen(function* () {
+            // `runForEach` is sequential, so resume reads cannot overlap: a
+            // second resume does not start a read until this one has applied.
             const startedAt = (yield* Ref.get(applied)).changeCount;
             const status = yield* options.connectivity.status;
             yield* applyLock.withPermits(1)(

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -1,9 +1,11 @@
 import * as Context from "effect/Context";
-import type * as Effect from "effect/Effect";
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type * as Stream from "effect/Stream";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
 
 import type { NetworkStatus } from "./model.ts";
+import * as ConnectionWakeups from "./wakeups.ts";
 
 export class Connectivity extends Context.Service<
   Connectivity,
@@ -17,3 +19,43 @@ export const make = (service: Connectivity["Service"]) => Connectivity.of(servic
 
 export const layer = (service: Connectivity["Service"]) =>
   Layer.succeed(Connectivity, make(service));
+
+/**
+ * Applies every reported connectivity change, plus a freshly read status each
+ * time the application resumes.
+ *
+ * Platform listeners drop transitions while an app is suspended, so a consumer
+ * that follows `changes` alone keeps a stale status until the next real
+ * transition — which left mobile stranded on "offline" until it was restarted.
+ * Reading the status is asynchronous, so a read that started before a newer
+ * reported change is discarded instead of applied over it.
+ */
+export const followNetworkStatus = Effect.fnUntraced(function* (options: {
+  readonly connectivity: Connectivity["Service"];
+  readonly wakeups: ConnectionWakeups.ConnectionWakeups["Service"];
+  readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
+}) {
+  const reportedCount = yield* Ref.make(0);
+
+  yield* options.connectivity.changes.pipe(
+    Stream.runForEach((status) =>
+      Ref.update(reportedCount, (count) => count + 1).pipe(Effect.andThen(options.apply(status))),
+    ),
+    Effect.forkScoped,
+  );
+
+  yield* options.wakeups.changes.pipe(
+    Stream.runForEach((reason) =>
+      reason === "application-active"
+        ? Effect.gen(function* () {
+            const startedAt = yield* Ref.get(reportedCount);
+            const status = yield* options.connectivity.status;
+            if ((yield* Ref.get(reportedCount)) === startedAt) {
+              yield* options.apply(status);
+            }
+          })
+        : Effect.void,
+    ),
+    Effect.forkScoped,
+  );
+});

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
@@ -36,39 +37,54 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   readonly wakeups: ConnectionWakeups.ConnectionWakeups["Service"];
   readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
 }) {
-  const reportedCount = yield* Ref.make(0);
+  // `changeCount` counts applied status changes rather than received events, so
+  // a listener that repeats the status already in effect carries no newer
+  // information and cannot discard a resumed read.
+  const applied = yield* Ref.make<{
+    readonly status: Option.Option<NetworkStatus>;
+    readonly changeCount: number;
+  }>({ status: Option.none(), changeCount: 0 });
   // Counting a reported change and applying it has to be indivisible with
   // respect to the resume branch's guard. Otherwise a change landing between
   // that guard and its apply would be overwritten by the older read.
   const applyLock = yield* Semaphore.make(1);
 
+  const applyStatus = Effect.fnUntraced(function* (status: NetworkStatus) {
+    const changed = yield* Ref.modify(applied, (current) =>
+      Option.isSome(current.status) && current.status.value === status
+        ? ([false, current] as const)
+        : ([true, { status: Option.some(status), changeCount: current.changeCount + 1 }] as const),
+    );
+    if (changed) {
+      yield* options.apply(status);
+    }
+  });
+
   yield* options.connectivity.changes.pipe(
-    Stream.runForEach((status) =>
-      applyLock.withPermits(1)(
-        Ref.update(reportedCount, (count) => count + 1).pipe(Effect.andThen(options.apply(status))),
-      ),
-    ),
-    Effect.forkScoped,
+    Stream.runForEach((status) => applyLock.withPermits(1)(applyStatus(status))),
+    // Subscribe before returning so a transition reported while this is still
+    // being set up is not dropped.
+    Effect.forkScoped({ startImmediately: true }),
   );
 
   yield* options.wakeups.changes.pipe(
     Stream.runForEach((reason) =>
       reason === "application-active"
         ? Effect.gen(function* () {
-            const startedAt = yield* Ref.get(reportedCount);
+            const startedAt = (yield* Ref.get(applied)).changeCount;
             const status = yield* options.connectivity.status;
             yield* applyLock.withPermits(1)(
               Effect.gen(function* () {
-                // Re-read under the permit: any change reported while the status
+                // Re-read under the permit: a status change applied while the
                 // read was in flight is newer, so this result is stale.
-                if ((yield* Ref.get(reportedCount)) === startedAt) {
-                  yield* options.apply(status);
+                if ((yield* Ref.get(applied)).changeCount === startedAt) {
+                  yield* applyStatus(status);
                 }
               }),
             );
           })
         : Effect.void,
     ),
-    Effect.forkScoped,
+    Effect.forkScoped({ startImmediately: true }),
   );
 });

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -37,23 +37,26 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   readonly wakeups: ConnectionWakeups.ConnectionWakeups["Service"];
   readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
 }) {
-  // `changeCount` counts applied status changes rather than received events, so
-  // a listener that repeats the status already in effect carries no newer
-  // information and cannot discard a resumed read.
-  const applied = yield* Ref.make<{
-    readonly status: Option.Option<NetworkStatus>;
-    readonly changeCount: number;
-  }>({ status: Option.none(), changeCount: 0 });
-  // Counting a reported change and applying it has to be indivisible with
-  // respect to the resume branch's guard. Otherwise a change landing between
-  // that guard and its apply would be overwritten by the older read.
+  // Counts every report the listener delivers, including one that repeats the
+  // status already in effect. Such a repeat carries no new status, but it does
+  // prove the listener spoke more recently than a resume read still in flight,
+  // so it has to invalidate that read: otherwise a snapshot taken during a brief
+  // opposite state would land afterwards and overwrite the real status.
+  const reportCount = yield* Ref.make(0);
+  // Tracks what was last handed to `options.apply` purely to keep repeats from
+  // reaching consumers. Deduplication is deliberately kept separate from the
+  // staleness guard above.
+  const appliedStatus = yield* Ref.make<Option.Option<NetworkStatus>>(Option.none());
+  // Counting a report and applying it has to be indivisible with respect to the
+  // resume branch's guard. Otherwise a change landing between that guard and its
+  // apply would be overwritten by the older read.
   const applyLock = yield* Semaphore.make(1);
 
   const applyStatus = Effect.fnUntraced(function* (status: NetworkStatus) {
-    const changed = yield* Ref.modify(applied, (current) =>
-      Option.isSome(current.status) && current.status.value === status
+    const changed = yield* Ref.modify(appliedStatus, (current) =>
+      Option.isSome(current) && current.value === status
         ? ([false, current] as const)
-        : ([true, { status: Option.some(status), changeCount: current.changeCount + 1 }] as const),
+        : ([true, Option.some(status)] as const),
     );
     if (changed) {
       yield* options.apply(status);
@@ -61,7 +64,11 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   });
 
   yield* options.connectivity.changes.pipe(
-    Stream.runForEach((status) => applyLock.withPermits(1)(applyStatus(status))),
+    Stream.runForEach((status) =>
+      applyLock.withPermits(1)(
+        Ref.update(reportCount, (count) => count + 1).pipe(Effect.andThen(applyStatus(status))),
+      ),
+    ),
     // Subscribe before returning so a transition reported while this is still
     // being set up is not dropped.
     Effect.forkScoped({ startImmediately: true }),
@@ -73,13 +80,13 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
         ? Effect.gen(function* () {
             // `runForEach` is sequential, so resume reads cannot overlap: a
             // second resume does not start a read until this one has applied.
-            const startedAt = (yield* Ref.get(applied)).changeCount;
+            const startedAt = yield* Ref.get(reportCount);
             const status = yield* options.connectivity.status;
             yield* applyLock.withPermits(1)(
               Effect.gen(function* () {
-                // Re-read under the permit: a status change applied while the
+                // Re-read under the permit: any report that arrived while the
                 // read was in flight is newer, so this result is stale.
-                if ((yield* Ref.get(applied)).changeCount === startedAt) {
+                if ((yield* Ref.get(reportCount)) === startedAt) {
                   yield* applyStatus(status);
                 }
               }),

--- a/packages/client-runtime/src/connection/connectivity.ts
+++ b/packages/client-runtime/src/connection/connectivity.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 
 import type { NetworkStatus } from "./model.ts";
@@ -36,10 +37,16 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
   readonly apply: (status: NetworkStatus) => Effect.Effect<void>;
 }) {
   const reportedCount = yield* Ref.make(0);
+  // Counting a reported change and applying it has to be indivisible with
+  // respect to the resume branch's guard. Otherwise a change landing between
+  // that guard and its apply would be overwritten by the older read.
+  const applyLock = yield* Semaphore.make(1);
 
   yield* options.connectivity.changes.pipe(
     Stream.runForEach((status) =>
-      Ref.update(reportedCount, (count) => count + 1).pipe(Effect.andThen(options.apply(status))),
+      applyLock.withPermits(1)(
+        Ref.update(reportedCount, (count) => count + 1).pipe(Effect.andThen(options.apply(status))),
+      ),
     ),
     Effect.forkScoped,
   );
@@ -50,9 +57,15 @@ export const followNetworkStatus = Effect.fnUntraced(function* (options: {
         ? Effect.gen(function* () {
             const startedAt = yield* Ref.get(reportedCount);
             const status = yield* options.connectivity.status;
-            if ((yield* Ref.get(reportedCount)) === startedAt) {
-              yield* options.apply(status);
-            }
+            yield* applyLock.withPermits(1)(
+              Effect.gen(function* () {
+                // Re-read under the permit: any change reported while the status
+                // read was in flight is newer, so this result is stale.
+                if ((yield* Ref.get(reportedCount)) === startedAt) {
+                  yield* options.apply(status);
+                }
+              }),
+            );
           })
         : Effect.void,
     ),

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -267,8 +267,12 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
       Ref.update(ownedDataClears, (environmentIds) => [...environmentIds, environmentId]),
   });
   const networkStatus = yield* SubscriptionRef.make<"unknown" | "offline" | "online">("online");
+  // Status reads come from a separate ref so a test can simulate a platform
+  // listener that missed a transition while the app was suspended.
+  const liveNetworkStatus = yield* Ref.make<"unknown" | "offline" | "online">("online");
+  const wakeups = yield* SubscriptionRef.make(0);
   const connectivity = Connectivity.Connectivity.of({
-    status: SubscriptionRef.get(networkStatus),
+    status: Ref.get(liveNetworkStatus),
     changes: SubscriptionRef.changes(networkStatus),
   });
   const profileStore = ConnectionProfileStore.ConnectionProfileStore.of({
@@ -375,7 +379,12 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         Layer.succeed(Connectivity.Connectivity, connectivity),
         Layer.succeed(
           ConnectionWakeups.ConnectionWakeups,
-          ConnectionWakeups.ConnectionWakeups.of({ changes: Stream.never }),
+          ConnectionWakeups.ConnectionWakeups.of({
+            changes: SubscriptionRef.changes(wakeups).pipe(
+              Stream.drop(1),
+              Stream.map(() => "application-active" as const),
+            ),
+          }),
         ),
         Layer.succeed(ConnectionDriver.ConnectionDriver, driver),
         cacheLayer,
@@ -398,6 +407,11 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     storedRemoteTokens,
     disconnectedSshTargets,
     networkStatus,
+    // Changes the network the device is actually on without emitting a change
+    // event, mimicking a listener that was suspended while backgrounded.
+    setLiveNetworkStatus: (status: "unknown" | "offline" | "online") =>
+      Ref.set(liveNetworkStatus, status),
+    resume: SubscriptionRef.update(wakeups, (count) => count + 1),
   };
 });
 
@@ -452,6 +466,41 @@ describe("EnvironmentRegistry", () => {
 
         expect(yield* Fiber.join(offline)).toBe("offline");
         expect(yield* SubscriptionRef.get(registry.networkStatus)).toBe("offline");
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("recovers the network status a suspended listener never reported", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([]);
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const offline = yield* Effect.forkChild(
+          SubscriptionRef.changes(registry.networkStatus).pipe(
+            Stream.filter((status) => status === "offline"),
+            Stream.runHead,
+          ),
+        );
+        yield* SubscriptionRef.set(harness.networkStatus, "offline");
+        yield* Fiber.join(offline);
+
+        // The device came back online while backgrounded and the listener never
+        // reported the transition, so only a fresh read can observe it.
+        yield* harness.setLiveNetworkStatus("online");
+        // The forked listener subscribes after `start`, so repeat the resume
+        // until it is observed rather than racing the first one.
+        yield* harness.resume.pipe(
+          Effect.andThen(Effect.yieldNow),
+          Effect.repeat({
+            while: () =>
+              SubscriptionRef.get(registry.networkStatus).pipe(
+                Effect.map((status) => status !== "online"),
+              ),
+          }),
+        );
+
+        expect(yield* SubscriptionRef.get(registry.networkStatus)).toBe("online");
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -652,10 +652,14 @@ export const make = Effect.gen(function* () {
       ),
     ),
   );
-  yield* connectivity.changes.pipe(
-    Stream.runForEach((status) => SubscriptionRef.set(networkStatus, status)),
-    Effect.forkScoped,
-  );
+  // `networkStatus` feeds the connection UI and readiness checks, so it has to
+  // recover from a transition dropped while the app was suspended just like the
+  // supervisors do. Otherwise a reconnected environment still reads as offline.
+  yield* Connectivity.followNetworkStatus({
+    connectivity,
+    wakeups,
+    apply: (status) => SubscriptionRef.set(networkStatus, status),
+  });
 
   return EnvironmentRegistry.of({
     entries,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -116,9 +116,13 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   readonly ready?: (attempt: number) => Effect.Effect<void, ConnectionAttemptError>;
   readonly probe?: (attempt: number) => Effect.Effect<void, ConnectionAttemptError>;
 }) {
-  const networkStatus = yield* SubscriptionRef.make<NetworkStatus>(
+  // `reportedNetworkStatus` drives the change stream while `liveNetworkStatus`
+  // answers status reads, so a test can simulate a platform listener that missed
+  // a transition while the app was suspended.
+  const reportedNetworkStatus = yield* SubscriptionRef.make<NetworkStatus>(
     options?.networkStatus ?? "online",
   );
+  const liveNetworkStatus = yield* Ref.make<NetworkStatus>(options?.networkStatus ?? "online");
   const prepareCount = yield* Ref.make(0);
   const sessionCount = yield* Ref.make(0);
   const releaseCount = yield* Ref.make(0);
@@ -134,8 +138,8 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
   >([]);
 
   const connectivity = Connectivity.Connectivity.of({
-    status: SubscriptionRef.get(networkStatus),
-    changes: SubscriptionRef.changes(networkStatus),
+    status: Ref.get(liveNetworkStatus),
+    changes: SubscriptionRef.changes(reportedNetworkStatus),
   });
 
   const prepare = Effect.fn("TestConnectionDriver.prepare")(function* (target: ConnectionTarget) {
@@ -197,7 +201,13 @@ const makeHarness = Effect.fn("TestConnectionHarness.make")(function* (options?:
     prepareCount,
     sessionCount,
     releaseCount,
-    setNetworkStatus: (status: NetworkStatus) => SubscriptionRef.set(networkStatus, status),
+    setNetworkStatus: (status: NetworkStatus) =>
+      Ref.set(liveNetworkStatus, status).pipe(
+        Effect.andThen(SubscriptionRef.set(reportedNetworkStatus, status)),
+      ),
+    // Changes the network the device is actually on without emitting a change
+    // event, mimicking a listener that was suspended while backgrounded.
+    setNetworkStatusWithoutNotifying: (status: NetworkStatus) => Ref.set(liveNetworkStatus, status),
     wake: (reason: "application-active" | "credentials-changed") =>
       SubscriptionRef.update(wakeups, (event) => ({
         sequence: event.sequence + 1,
@@ -305,6 +315,42 @@ describe("EnvironmentSupervisor", () => {
         phase: "connected",
         attempt: 1,
         generation: 1,
+        lastFailure: null,
+      });
+      expect(yield* Ref.get(harness.prepareCount)).toBe(1);
+    }),
+  );
+
+  it.effect("recovers from a network change the platform dropped while suspended", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ networkStatus: "offline" });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "offline");
+
+      // The device regained connectivity while backgrounded, but the listener
+      // was suspended and never reported the transition.
+      yield* harness.setNetworkStatusWithoutNotifying("online");
+
+      // The supervisor reaches its offline state before the forked wakeup
+      // listener subscribes, so repeat the resume until it is observed.
+      yield* harness.wake("application-active").pipe(
+        Effect.andThen(Effect.yieldNow),
+        Effect.repeat({
+          while: () =>
+            SubscriptionRef.get(supervisor.state).pipe(
+              Effect.map((state) => state.phase === "offline"),
+            ),
+        }),
+      );
+
+      const ready = yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      expect(ready).toMatchObject({
+        desired: true,
+        network: "online",
+        phase: "connected",
         lastFailure: null,
       });
       expect(yield* Ref.get(harness.prepareCount)).toBe(1);

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -676,22 +676,16 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     }
   });
 
-  yield* connectivity.changes.pipe(Stream.runForEach(applyNetworkStatus), Effect.forkScoped);
+  // The offline branch of `run` only waits for signals and re-reads the same
+  // cached network value, so a transition dropped while the app was suspended
+  // would otherwise strand this supervisor until the app restarted.
+  yield* Connectivity.followNetworkStatus({
+    connectivity,
+    wakeups,
+    apply: applyNetworkStatus,
+  });
   yield* wakeups.changes.pipe(
-    Stream.runForEach((reason) =>
-      Effect.gen(function* () {
-        // Platform connectivity listeners can drop transitions while the app is
-        // suspended, so a device that went offline and back online while
-        // backgrounded leaves `intent.network` stuck on "offline". The offline
-        // branch of `run` only waits for signals, so no later wakeup recovers on
-        // its own. Re-reading the live status on resume keeps a restart from
-        // being the only way back online.
-        if (reason === "application-active") {
-          yield* applyNetworkStatus(yield* connectivity.status);
-        }
-        yield* signal({ _tag: "Wakeup", reason });
-      }),
-    ),
+    Stream.runForEach((reason) => signal({ _tag: "Wakeup", reason })),
     Effect.forkScoped,
   );
   yield* run().pipe(Effect.forkScoped);

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -667,20 +667,31 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
     }
   });
 
-  yield* connectivity.changes.pipe(
-    Stream.runForEach((network) =>
-      Ref.modify(intent, (current) =>
-        current.network === network ? [false, current] : ([true, { ...current, network }] as const),
-      ).pipe(
-        Effect.flatMap((changed) =>
-          changed ? signal({ _tag: "NetworkChanged", network }) : Effect.void,
-        ),
-      ),
-    ),
-    Effect.forkScoped,
-  );
+  const applyNetworkStatus = Effect.fnUntraced(function* (network: NetworkStatus) {
+    const changed = yield* Ref.modify(intent, (current) =>
+      current.network === network ? [false, current] : ([true, { ...current, network }] as const),
+    );
+    if (changed) {
+      yield* signal({ _tag: "NetworkChanged", network });
+    }
+  });
+
+  yield* connectivity.changes.pipe(Stream.runForEach(applyNetworkStatus), Effect.forkScoped);
   yield* wakeups.changes.pipe(
-    Stream.runForEach((reason) => signal({ _tag: "Wakeup", reason })),
+    Stream.runForEach((reason) =>
+      Effect.gen(function* () {
+        // Platform connectivity listeners can drop transitions while the app is
+        // suspended, so a device that went offline and back online while
+        // backgrounded leaves `intent.network` stuck on "offline". The offline
+        // branch of `run` only waits for signals, so no later wakeup recovers on
+        // its own. Re-reading the live status on resume keeps a restart from
+        // being the only way back online.
+        if (reason === "application-active") {
+          yield* applyNetworkStatus(yield* connectivity.status);
+        }
+        yield* signal({ _tag: "Wakeup", reason });
+      }),
+    ),
     Effect.forkScoped,
   );
   yield* run().pipe(Effect.forkScoped);

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -309,9 +309,15 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
     ),
   );
 
-  yield* connectivity.changes.pipe(
-    Stream.changes,
-    Stream.runForEach((networkStatus) =>
+  // Follow resumes too: a transition dropped while the app was suspended would
+  // otherwise leave `offline` set, so the environment list stayed stale until
+  // another network event or a manual refresh. `followNetworkStatus` only
+  // reports actual changes, so a resume that reads the current status does not
+  // trigger a refresh.
+  yield* Connectivity.followNetworkStatus({
+    connectivity,
+    wakeups,
+    apply: (networkStatus) =>
       networkStatus === "offline"
         ? SubscriptionRef.update(state, (current) => ({
             ...current,
@@ -321,9 +327,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
         : Ref.get(hasRefreshed).pipe(
             Effect.flatMap((shouldRefresh) => (shouldRefresh ? refresh : Effect.void)),
           ),
-    ),
-    Effect.forkScoped,
-  );
+  });
   yield* wakeups.changes.pipe(
     Stream.runForEach((reason) =>
       reason === "credentials-changed"


### PR DESCRIPTION
## Problem

Leaving the mobile app backgrounded for a while and returning to it shows **"You are offline"**, and the only way back online is to restart the app.

## Cause

`EnvironmentSupervisor` reads the live connectivity status exactly once, when it is constructed, and from then on tracks it only through the connectivity change stream:

```ts
const initialIntent: SupervisorIntent = {
  desired: options?.initiallyDesired ?? false,
  network: yield* connectivity.status,   // read once, never again
};
```

Platform listeners drop transitions while an app is suspended, so a device that went offline and came back while backgrounded leaves `intent.network` stuck on `"offline"`. The offline branch of the run loop only waits for a signal and then re-checks that same stale value:

```ts
if (currentIntent.network === "offline") {
  yield* clearLease;
  yield* setState(offlineState(...));
  yield* waitForSignal;   // wakes, re-reads the stale value, waits again
  continue;
}
```

Every subsequent wakeup re-enters this branch, so the supervisor never attempts a connection. Restarting the app is the only recovery because construction is the one place the live status is read. `"You are offline"` is driven by this value via `workspaceConnectionStatusLabel`.

The rest of the retry machinery already handles its own cases: backoff retries forever capped at 16s, and the foreground liveness probe catches sockets that died silently. Stale network status is the one path that needs a restart, which is why this fix is small.

## Fix

Re-read the live status on an `application-active` wakeup and reconcile the intent before forwarding the signal. Network reconciliation is factored into a shared `applyNetworkStatus` used by both the change stream and the resume path, so a stale value corrects itself and the run loop leaves the offline branch on its own.

## Testing

- Added `recovers from a network change the platform dropped while suspended`, which sets the live status without emitting a change event and asserts the supervisor reconnects on resume. It times out against the old code and passes with the fix.
- The test harness now backs `status` and `changes` with separate refs so a dropped listener event can be simulated; `setNetworkStatus` still updates both.
- `packages/client-runtime`: 472 tests pass, typecheck and lint clean.

No UI change, so no before/after images. This was diagnosed from the supervisor's state machine and covered by the regression test rather than reproduced on hardware, so the real-world timing of a suspended platform listener is not verified on a device.

The fix is in shared client-runtime, so desktop and web (which resume on `visibilitychange`) get the same self-healing behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection/registry/supervisor/discovery networking paths with async resume reads and concurrency guards; behavior change on every foreground resume but scoped to connectivity reconciliation.
> 
> **Overview**
> Fixes mobile (and other platforms) staying stuck on **"You are offline"** after backgrounding when the OS connectivity listener never delivered a transition that happened while suspended.
> 
> Adds **`Connectivity.followNetworkStatus`**, which still applies platform `changes` but also **re-reads live status on `application-active` wakeups**. Resume snapshots are dropped if a newer listener report arrived while the read was in flight (via a report counter and semaphore), and duplicate statuses are not pushed to consumers again.
> 
> **`EnvironmentRegistry`**, **`EnvironmentSupervisor`**, and **relay discovery** now use this helper instead of wiring `connectivity.changes` directly, so registry UI/readiness, connection supervisors, and relay environment lists can recover without an app restart.
> 
> Regression coverage includes dedicated **`followNetworkStatus`** tests (staleness, dedup, ordering) and integration tests that simulate a missed transition by separating live status from the change stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed60fd0ba116dd8f9658b83cd106638af732cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-read network status on app resume to recover transitions missed while suspended
> - Adds `Connectivity.followNetworkStatus` in [`connectivity.ts`](https://github.com/pingdotgg/t3code/pull/4528/files#diff-0c3ee6e174dbdeb40c2bc2adf111383534ce5d1c7fe7528ca7402fed727d514a), which subscribes to both connectivity change events and wakeup events, re-reads live status on resume, and discards stale reads that are superseded by newer reports.
> - Updates `EnvironmentRegistry`, `EnvironmentSupervisor`, and `RelayEnvironmentDiscovery` to use `followNetworkStatus` instead of subscribing directly to `connectivity.changes`, so all three recover from network transitions that occurred while the app was suspended.
> - Deduplicates status applies so consumers only see actual changes, not repeated identical statuses.
> - Behavioral Change: network status updates now also fire on application resume, not only on platform-reported connectivity change events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ed60fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->