### PR TITLE
feat(relay): limit managed tunnels per user

### DIFF
--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -143,6 +143,8 @@ function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
       return `Relay could not link the environment (${error.reason}).`;
     case "RelayEnvironmentLinkUnavailableError":
       return `Relay cannot provision the managed endpoint (${error.reason}).`;
+    case "RelayEnvironmentLinkLimitExceededError":
+      return `Relay refused the link: this account already has its maximum of ${error.maxTunnels} managed tunnels. Unlink an environment to free one up.`;
     case "RelayAgentActivityPublishProofExpiredError":
       return "Relay rejected an expired agent activity publish proof.";
     case "RelayAgentActivityPublishProofInvalidError":

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -154,6 +154,8 @@ function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
       return `Relay could not link the environment (${error.reason}).`;
     case "RelayEnvironmentLinkUnavailableError":
       return `Relay cannot provision the managed endpoint (${error.reason}).`;
+    case "RelayEnvironmentLinkLimitExceededError":
+      return `Relay refused the link: this account already has its maximum of ${error.maxTunnels} managed tunnels. Unlink an environment to free one up.`;
     case "RelayAgentActivityPublishProofExpiredError":
       return "Relay rejected an expired agent activity publish proof.";
     case "RelayAgentActivityPublishProofInvalidError":

--- a/infra/relay/src/environments/ManagedEndpointProvider.test.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.test.ts
@@ -9,6 +9,7 @@ import * as Redacted from "effect/Redacted";
 import * as RelayConfiguration from "../Config.ts";
 import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
 import * as ManagedEndpointProvider from "./ManagedEndpointProvider.ts";
+import * as ManagedTunnelLimits from "./ManagedTunnelLimits.ts";
 
 const config = RelayConfiguration.RelayConfiguration.of({
   relayIssuer: "https://relay.example.test",
@@ -200,10 +201,24 @@ function makeAllocations(calls: AllocationCall[] = []) {
   });
 }
 
+function makeTunnelLimits(
+  calls: Array<{ readonly userId: string; readonly environmentId: string }> = [],
+  result: ManagedTunnelLimits.ManagedTunnelLimitExceeded | null = null,
+) {
+  return ManagedTunnelLimits.ManagedTunnelLimits.of({
+    ensureCapacity: (input) =>
+      Effect.suspend(() => {
+        calls.push(input);
+        return result === null ? Effect.void : Effect.fail(result);
+      }),
+  });
+}
+
 function providerLayer(
   tunnelClient = makeTunnelClient(),
   dnsClient = makeDnsClient(),
   allocations = makeAllocations(),
+  tunnelLimits = makeTunnelLimits(),
 ) {
   return ManagedEndpointProvider.layer.pipe(
     Layer.provideMerge(NodeServices.layer),
@@ -213,6 +228,7 @@ function providerLayer(
     Layer.provide(
       Layer.succeed(ManagedEndpointAllocations.ManagedEndpointAllocations, allocations),
     ),
+    Layer.provide(Layer.succeed(ManagedTunnelLimits.ManagedTunnelLimits, tunnelLimits)),
   );
 }
 
@@ -306,6 +322,67 @@ describe("ManagedEndpointProvider", () => {
           makeTunnelClient(tunnelCalls),
           makeDnsClient(dnsCalls),
           makeAllocations(allocationCalls),
+        ),
+      ),
+    );
+  });
+
+  it.effect("checks the managed tunnel limit before reserving an allocation", () => {
+    const limitCalls: Array<{ readonly userId: string; readonly environmentId: string }> = [];
+
+    return Effect.gen(function* () {
+      const provider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
+      yield* provider.provision({
+        userId: "user_ABC",
+        environmentId: "env_ABC",
+        origin: { localHttpHost: "127.0.0.1", localHttpPort: 3773 },
+      });
+
+      expect(limitCalls).toEqual([{ userId: "user_ABC", environmentId: "env_ABC" }]);
+    }).pipe(
+      Effect.provide(
+        providerLayer(
+          makeTunnelClient(),
+          makeDnsClient(),
+          makeAllocations(),
+          makeTunnelLimits(limitCalls),
+        ),
+      ),
+    );
+  });
+
+  it.effect("refuses to provision past the managed tunnel limit without side effects", () => {
+    const tunnelCalls: TunnelCall[] = [];
+    const dnsCalls: DnsCall[] = [];
+    const allocationCalls: AllocationCall[] = [];
+    const exceeded = new ManagedTunnelLimits.ManagedTunnelLimitExceeded({
+      userId: "user_ABC",
+      environmentId: "env_ABC",
+      maxTunnels: 10,
+      activeTunnels: 10,
+    });
+
+    return Effect.gen(function* () {
+      const provider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
+      const error = yield* Effect.flip(
+        provider.provision({
+          userId: "user_ABC",
+          environmentId: "env_ABC",
+          origin: { localHttpHost: "127.0.0.1", localHttpPort: 3773 },
+        }),
+      );
+
+      expect(error).toBe(exceeded);
+      expect(tunnelCalls).toEqual([]);
+      expect(dnsCalls).toEqual([]);
+      expect(allocationCalls).toEqual([]);
+    }).pipe(
+      Effect.provide(
+        providerLayer(
+          makeTunnelClient(tunnelCalls),
+          makeDnsClient(dnsCalls),
+          makeAllocations(allocationCalls),
+          makeTunnelLimits([], exceeded),
         ),
       ),
     );

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -514,18 +514,19 @@ export const make = Effect.gen(function* () {
           environmentId: input.environmentId,
         })
         .pipe(
-          Effect.catchTag("ManagedTunnelLimitPersistenceError", (cause) =>
-            Effect.fail(
-              new ManagedEndpointProvisioningFailed({
-                userId: input.userId,
-                environmentId: input.environmentId,
-                stage: "check-tunnel-limit",
-                hostname: requestedHostname,
-                tunnelName: requestedTunnelName,
-                cause,
-              }),
-            ),
-          ),
+          Effect.catchTags({
+            ManagedTunnelLimitPersistenceError: (cause) =>
+              Effect.fail(
+                new ManagedEndpointProvisioningFailed({
+                  userId: input.userId,
+                  environmentId: input.environmentId,
+                  stage: "check-tunnel-limit",
+                  hostname: requestedHostname,
+                  tunnelName: requestedTunnelName,
+                  cause,
+                }),
+              ),
+          }),
         );
       const allocation = yield* allocations
         .reserve({

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -23,6 +23,7 @@ import {
   managedEndpointTunnelName,
 } from "../deploymentConfig.ts";
 import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
+import * as ManagedTunnelLimits from "./ManagedTunnelLimits.ts";
 
 export class ManagedEndpointProvisioningNotConfigured extends Schema.TaggedErrorClass<ManagedEndpointProvisioningNotConfigured>()(
   "ManagedEndpointProvisioningNotConfigured",
@@ -41,6 +42,7 @@ export class ManagedEndpointProvisioningNotConfigured extends Schema.TaggedError
 
 const ManagedEndpointProvisioningStage = Schema.Literals([
   "derive-environment-hash",
+  "check-tunnel-limit",
   "reserve-allocation",
   "ensure-tunnel",
   "validate-tunnel-response",
@@ -112,7 +114,8 @@ export class ManagedEndpointOriginNotAllowed extends Schema.TaggedErrorClass<Man
 export type ManagedEndpointProviderError =
   | ManagedEndpointProvisioningNotConfigured
   | ManagedEndpointProvisioningFailed
-  | ManagedEndpointOriginNotAllowed;
+  | ManagedEndpointOriginNotAllowed
+  | ManagedTunnelLimits.ManagedTunnelLimitExceeded;
 
 export interface ManagedEndpointProvisioningResult {
   readonly endpoint: RelayManagedEndpoint;
@@ -331,6 +334,7 @@ export const make = Effect.gen(function* () {
   const tunnels = yield* ManagedEndpointTunnelClient;
   const dns = yield* ManagedEndpointDnsClient;
   const allocations = yield* ManagedEndpointAllocations.ManagedEndpointAllocations;
+  const tunnelLimits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
 
   const updateExistingDnsRecords = Effect.fnUntraced(function* (
     records: ReadonlyArray<{ readonly id: string }>,
@@ -504,6 +508,25 @@ export const make = Effect.gen(function* () {
         environmentHash,
       );
       const requestedTunnelName = managedEndpointTunnelName(cf.namespace, environmentHash);
+      yield* tunnelLimits
+        .ensureCapacity({
+          userId: input.userId,
+          environmentId: input.environmentId,
+        })
+        .pipe(
+          Effect.catchTag("ManagedTunnelLimitPersistenceError", (cause) =>
+            Effect.fail(
+              new ManagedEndpointProvisioningFailed({
+                userId: input.userId,
+                environmentId: input.environmentId,
+                stage: "check-tunnel-limit",
+                hostname: requestedHostname,
+                tunnelName: requestedTunnelName,
+                cause,
+              }),
+            ),
+          ),
+        );
       const allocation = yield* allocations
         .reserve({
           userId: input.userId,

--- a/infra/relay/src/environments/ManagedTunnelLimits.test.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as RelayDb from "../db.ts";
+import {
+  relayManagedEndpointAllocations,
+  relayManagedTunnelLimits,
+} from "../persistence/schema.ts";
+import * as ManagedTunnelLimits from "./ManagedTunnelLimits.ts";
+
+const layerWithDb = (db: RelayDb.RelayDb["Service"]) =>
+  ManagedTunnelLimits.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, db)));
+
+function makeFakeDb(input: {
+  readonly overrideRows?: Effect.Effect<ReadonlyArray<{ readonly maxTunnels: number }>, Error>;
+  readonly countRows?: Effect.Effect<ReadonlyArray<{ readonly activeTunnels: number }>, Error>;
+}) {
+  return {
+    select: () => ({
+      from: (table: unknown) => {
+        if (table === relayManagedTunnelLimits) {
+          return {
+            where: () => ({
+              limit: () => input.overrideRows ?? Effect.succeed([]),
+            }),
+          };
+        }
+        expect(table).toBe(relayManagedEndpointAllocations);
+        return {
+          where: () => input.countRows ?? Effect.succeed([{ activeTunnels: 0 }]),
+        };
+      },
+    }),
+  } as unknown as RelayDb.RelayDb["Service"];
+}
+
+describe("ManagedTunnelLimits", () => {
+  it.effect("allows provisioning below the default limit", () => {
+    const fakeDb = makeFakeDb({
+      countRows: Effect.succeed([
+        { activeTunnels: ManagedTunnelLimits.DEFAULT_MANAGED_TUNNEL_LIMIT - 1 },
+      ]),
+    });
+
+    return Effect.gen(function* () {
+      const limits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
+      yield* limits.ensureCapacity({ userId: "user-1", environmentId: "environment-1" });
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
+  it.effect("rejects provisioning at the default limit of 10", () => {
+    const fakeDb = makeFakeDb({
+      countRows: Effect.succeed([{ activeTunnels: 10 }]),
+    });
+
+    return Effect.gen(function* () {
+      const limits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
+      const error = yield* Effect.flip(
+        limits.ensureCapacity({ userId: "user-1", environmentId: "environment-1" }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ManagedTunnelLimitExceeded",
+        userId: "user-1",
+        environmentId: "environment-1",
+        maxTunnels: 10,
+        activeTunnels: 10,
+      });
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
+  it.effect("honors a per-user override above the default", () => {
+    const fakeDb = makeFakeDb({
+      overrideRows: Effect.succeed([{ maxTunnels: 25 }]),
+      countRows: Effect.succeed([{ activeTunnels: 10 }]),
+    });
+
+    return Effect.gen(function* () {
+      const limits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
+      yield* limits.ensureCapacity({ userId: "user-1", environmentId: "environment-1" });
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
+  it.effect("honors a per-user override below the default", () => {
+    const fakeDb = makeFakeDb({
+      overrideRows: Effect.succeed([{ maxTunnels: 1 }]),
+      countRows: Effect.succeed([{ activeTunnels: 1 }]),
+    });
+
+    return Effect.gen(function* () {
+      const limits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
+      const error = yield* Effect.flip(
+        limits.ensureCapacity({ userId: "user-1", environmentId: "environment-1" }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ManagedTunnelLimitExceeded",
+        maxTunnels: 1,
+        activeTunnels: 1,
+      });
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
+  it.effect("retains database failures with operation and user identity", () => {
+    const cause = new Error("database unavailable");
+    const fakeDb = makeFakeDb({
+      overrideRows: Effect.fail(cause),
+    });
+
+    return Effect.gen(function* () {
+      const limits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
+      const error = yield* Effect.flip(
+        limits.ensureCapacity({ userId: "user-1", environmentId: "environment-1" }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ManagedTunnelLimitPersistenceError",
+        operation: "load-limit",
+        userId: "user-1",
+      });
+      expect(error).toHaveProperty("cause", cause);
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+
+  it.effect("retains count failures with operation and user identity", () => {
+    const cause = new Error("database unavailable");
+    const fakeDb = makeFakeDb({
+      countRows: Effect.fail(cause),
+    });
+
+    return Effect.gen(function* () {
+      const limits = yield* ManagedTunnelLimits.ManagedTunnelLimits;
+      const error = yield* Effect.flip(
+        limits.ensureCapacity({ userId: "user-1", environmentId: "environment-1" }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ManagedTunnelLimitPersistenceError",
+        operation: "count-tunnels",
+        userId: "user-1",
+      });
+    }).pipe(Effect.provide(layerWithDb(fakeDb)));
+  });
+});

--- a/infra/relay/src/environments/ManagedTunnelLimits.test.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.test.ts
@@ -49,9 +49,9 @@ describe("ManagedTunnelLimits", () => {
     }).pipe(Effect.provide(layerWithDb(fakeDb)));
   });
 
-  it.effect("rejects provisioning at the default limit of 10", () => {
+  it.effect("rejects provisioning at the default limit of 3", () => {
     const fakeDb = makeFakeDb({
-      countRows: Effect.succeed([{ activeTunnels: 10 }]),
+      countRows: Effect.succeed([{ activeTunnels: 3 }]),
     });
 
     return Effect.gen(function* () {
@@ -64,8 +64,8 @@ describe("ManagedTunnelLimits", () => {
         _tag: "ManagedTunnelLimitExceeded",
         userId: "user-1",
         environmentId: "environment-1",
-        maxTunnels: 10,
-        activeTunnels: 10,
+        maxTunnels: 3,
+        activeTunnels: 3,
       });
     }).pipe(Effect.provide(layerWithDb(fakeDb)));
   });

--- a/infra/relay/src/environments/ManagedTunnelLimits.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.ts
@@ -21,7 +21,7 @@ export class ManagedTunnelLimitPersistenceError extends Schema.TaggedErrorClass<
   {
     operation: Schema.Literals(["load-limit", "count-tunnels"]),
     userId: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {

--- a/infra/relay/src/environments/ManagedTunnelLimits.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.ts
@@ -1,0 +1,114 @@
+import { and, count, eq, ne } from "drizzle-orm";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as RelayDb from "../db.ts";
+import {
+  relayManagedEndpointAllocations,
+  relayManagedTunnelLimits,
+} from "../persistence/schema.ts";
+
+/**
+ * Managed tunnels a user may hold at once unless a row in
+ * `relay_managed_tunnel_limits` overrides it for that user.
+ */
+export const DEFAULT_MANAGED_TUNNEL_LIMIT = 10;
+
+export class ManagedTunnelLimitPersistenceError extends Schema.TaggedErrorClass<ManagedTunnelLimitPersistenceError>()(
+  "ManagedTunnelLimitPersistenceError",
+  {
+    operation: Schema.Literals(["load-limit", "count-tunnels"]),
+    userId: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Managed tunnel limit '${this.operation}' failed for user '${this.userId}'`;
+  }
+}
+
+export class ManagedTunnelLimitExceeded extends Schema.TaggedErrorClass<ManagedTunnelLimitExceeded>()(
+  "ManagedTunnelLimitExceeded",
+  {
+    userId: Schema.String,
+    environmentId: Schema.String,
+    maxTunnels: Schema.Number,
+    activeTunnels: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Managed tunnel limit reached for user '${this.userId}': ${this.activeTunnels} of ${this.maxTunnels} tunnels in use`;
+  }
+}
+
+export class ManagedTunnelLimits extends Context.Service<
+  ManagedTunnelLimits,
+  {
+    readonly ensureCapacity: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+    }) => Effect.Effect<void, ManagedTunnelLimitExceeded | ManagedTunnelLimitPersistenceError>;
+  }
+>()("t3code-relay/environments/ManagedTunnelLimits") {}
+
+export const make = Effect.gen(function* () {
+  const db = yield* RelayDb.RelayDb;
+
+  return ManagedTunnelLimits.of({
+    ensureCapacity: Effect.fn("relay.managed_tunnel_limits.ensure_capacity")(function* (input) {
+      const overrides = yield* db
+        .select({ maxTunnels: relayManagedTunnelLimits.maxTunnels })
+        .from(relayManagedTunnelLimits)
+        .where(eq(relayManagedTunnelLimits.userId, input.userId))
+        .limit(1)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ManagedTunnelLimitPersistenceError({
+                operation: "load-limit",
+                userId: input.userId,
+                cause,
+              }),
+          ),
+        );
+      const maxTunnels = overrides[0]?.maxTunnels ?? DEFAULT_MANAGED_TUNNEL_LIMIT;
+
+      // Allocations already held for this environment are excluded so that
+      // re-linking an environment the user already has a tunnel for stays
+      // idempotent even when the account is at its limit.
+      const counted = yield* db
+        .select({ activeTunnels: count() })
+        .from(relayManagedEndpointAllocations)
+        .where(
+          and(
+            eq(relayManagedEndpointAllocations.userId, input.userId),
+            ne(relayManagedEndpointAllocations.environmentId, input.environmentId),
+          ),
+        )
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ManagedTunnelLimitPersistenceError({
+                operation: "count-tunnels",
+                userId: input.userId,
+                cause,
+              }),
+          ),
+        );
+      const activeTunnels = counted[0]?.activeTunnels ?? 0;
+
+      if (activeTunnels >= maxTunnels) {
+        return yield* new ManagedTunnelLimitExceeded({
+          userId: input.userId,
+          environmentId: input.environmentId,
+          maxTunnels,
+          activeTunnels,
+        });
+      }
+    }),
+  });
+});
+
+export const layer = Layer.effect(ManagedTunnelLimits, make);

--- a/infra/relay/src/environments/ManagedTunnelLimits.ts
+++ b/infra/relay/src/environments/ManagedTunnelLimits.ts
@@ -14,7 +14,7 @@ import {
  * Managed tunnels a user may hold at once unless a row in
  * `relay_managed_tunnel_limits` overrides it for that user.
  */
-export const DEFAULT_MANAGED_TUNNEL_LIMIT = 10;
+export const DEFAULT_MANAGED_TUNNEL_LIMIT = 3;
 
 export class ManagedTunnelLimitPersistenceError extends Schema.TaggedErrorClass<ManagedTunnelLimitPersistenceError>()(
   "ManagedTunnelLimitPersistenceError",

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -43,6 +43,7 @@ import {
   RelayEnvironmentLinkProofExpiredError,
   RelayEnvironmentLinkProofInvalidError,
   RelayEnvironmentLinkUnavailableError,
+  RelayEnvironmentLinkLimitExceededError,
   RelayEnvironmentPrincipal,
   type RelayEnvironmentConnectRequest,
   type RelayDpopAccessTokenScope,
@@ -534,6 +535,12 @@ export const clientApi = HttpApiBuilder.group(
               new RelayEnvironmentLinkProofInvalidError({
                 code: "environment_link_proof_invalid",
                 reason: "origin_not_allowed",
+                traceId,
+              }),
+            ManagedTunnelLimitExceeded: (limitError, traceId) =>
+              new RelayEnvironmentLinkLimitExceededError({
+                code: "environment_link_limit_exceeded",
+                maxTunnels: limitError.maxTunnels,
                 traceId,
               }),
             EnvironmentLinkUpsertPersistenceError: (_error, traceId) =>

--- a/infra/relay/src/persistence/schema.ts
+++ b/infra/relay/src/persistence/schema.ts
@@ -105,6 +105,13 @@ export const relayManagedEndpointAllocations = pgTable(
   ],
 );
 
+export const relayManagedTunnelLimits = pgTable("relay_managed_tunnel_limits", {
+  userId: varchar("user_id", { length: 191 }).primaryKey(),
+  maxTunnels: integer("max_tunnels").notNull(),
+  createdAt: varchar("created_at", { length: 64 }).notNull(),
+  updatedAt: varchar("updated_at", { length: 64 }).notNull(),
+});
+
 export const relayEnvironmentCredentials = pgTable(
   "relay_environment_credentials",
   {

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -55,6 +55,7 @@ import * as EnvironmentConnector from "./environments/EnvironmentConnector.ts";
 import * as EnvironmentLinker from "./environments/EnvironmentLinker.ts";
 import * as EnvironmentPublishSignatures from "./environments/EnvironmentPublishSignatures.ts";
 import * as ManagedEndpointProvider from "./environments/ManagedEndpointProvider.ts";
+import * as ManagedTunnelLimits from "./environments/ManagedTunnelLimits.ts";
 import * as MobileRegistrations from "./agentActivity/MobileRegistrations.ts";
 
 const webcryptoLayer = Layer.succeed(
@@ -205,7 +206,13 @@ export default class Api extends Cloudflare.Worker<Api>()(
       Layer.provideMerge(AgentActivityRows.layer),
       Layer.provideMerge(Devices.layer),
       Layer.provideMerge(EnvironmentCredentials.layer),
-      Layer.provideMerge(Layer.mergeAll(EnvironmentLinks.layer, ManagedEndpointAllocations.layer)),
+      Layer.provideMerge(
+        Layer.mergeAll(
+          EnvironmentLinks.layer,
+          ManagedEndpointAllocations.layer,
+          ManagedTunnelLimits.layer,
+        ),
+      ),
       Layer.provideMerge(LiveActivities.layer),
       Layer.provideMerge(DeliveryAttempts.layer),
       Layer.provideMerge(RelayTokens.layer),

--- a/packages/client-runtime/src/connection/errors.ts
+++ b/packages/client-runtime/src/connection/errors.ts
@@ -45,6 +45,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
       });
     case "RelayEnvironmentConnectNotAuthorizedError":
     case "RelayEnvironmentLinkProofInvalidError":
+    case "RelayEnvironmentLinkLimitExceededError":
       return new ConnectionBlockedError({
         reason: "permission",
         detail: error.message,

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -439,6 +439,20 @@ export class RelayEnvironmentLinkUnavailableError extends Schema.TaggedErrorClas
   }
 }
 
+export class RelayEnvironmentLinkLimitExceededError extends Schema.TaggedErrorClass<RelayEnvironmentLinkLimitExceededError>()(
+  "RelayEnvironmentLinkLimitExceededError",
+  {
+    code: Schema.Literal("environment_link_limit_exceeded"),
+    maxTunnels: Schema.Number,
+    traceId: TrimmedNonEmptyString,
+  },
+  { httpApiStatus: 403 },
+) {
+  override get message(): string {
+    return `Relay managed tunnel limit reached: this account allows at most ${this.maxTunnels} tunnels`;
+  }
+}
+
 export class RelayAgentActivityPublishProofExpiredError extends Schema.TaggedErrorClass<RelayAgentActivityPublishProofExpiredError>()(
   "RelayAgentActivityPublishProofExpiredError",
   {
@@ -489,6 +503,7 @@ export const RelayProtectedError = Schema.Union([
   RelayEnvironmentEndpointTimedOutError,
   RelayEnvironmentLinkFailedError,
   RelayEnvironmentLinkUnavailableError,
+  RelayEnvironmentLinkLimitExceededError,
   RelayAgentActivityPublishProofExpiredError,
   RelayAgentActivityPublishProofInvalidError,
   RelayInternalError,
@@ -502,6 +517,7 @@ const RelayEnvironmentLinkErrors = [
   RelayEnvironmentLinkProofExpiredError,
   RelayEnvironmentLinkProofInvalidError,
   RelayEnvironmentLinkUnavailableError,
+  RelayEnvironmentLinkLimitExceededError,
   RelayEnvironmentLinkFailedError,
   RelayInternalError,
 ] as const;


### PR DESCRIPTION
## Summary

Adds a per-user cap on relay managed tunnels: **3 by default**, overridable per user.

In the relay, a "tunnel" is a managed endpoint — one Cloudflare tunnel per (user, environment) allocation — so the limit counts a user's rows in `relay_managed_endpoint_allocations`.

- **New `ManagedTunnelLimits` service** (`infra/relay/src/environments/ManagedTunnelLimits.ts`): `ensureCapacity` reads a per-user override from the new `relay_managed_tunnel_limits` table (falls back to `DEFAULT_MANAGED_TUNNEL_LIMIT = 3`), counts the user's existing allocations, and fails with `ManagedTunnelLimitExceeded` at the cap.
- **Enforced in `ManagedEndpointProvider.provision`** before the allocation is reserved, so a rejected link creates no tunnel, DNS record, or allocation row. The count excludes the environment being provisioned, so re-linking an environment that already holds a tunnel stays idempotent even for an account at its limit.
- **New contract error** `RelayEnvironmentLinkLimitExceededError` (HTTP 403, code `environment_link_limit_exceeded`, carries `maxTunnels`) returned from `linkEnvironment`, with user-facing handling in the web, mobile, and client-runtime link flows.
- **Schema**: `relay_managed_tunnel_limits` (`user_id` PK, `max_tunnels`). The migration is generated from the schema automatically by the alchemy `Drizzle.Schema` resource on deploy.

## Overriding a user's limit

There is no admin API surface in the relay, so overrides are direct DB rows (e.g. via the PlanetScale console), keyed by Clerk user id:

```sql
INSERT INTO relay_managed_tunnel_limits (user_id, max_tunnels, created_at, updated_at)
VALUES ('user_xyz', 25, '<now-iso>', '<now-iso>');
```

An operator endpoint could be a follow-up if wanted.

## Notes

- The check counts before reserving without a transaction, so two simultaneous first-time links could race one past the cap — kept simple as a soft quota.

## Testing

- `infra/relay`: 195 tests pass, including 8 new ones (`ManagedTunnelLimits.test.ts` covering default limit, over/under overrides, and persistence-error mapping; `ManagedEndpointProvider.test.ts` asserting the check runs before reservation and that a rejection has zero side effects).
- Typecheck + lint clean across `infra/relay`, `@t3tools/contracts`, `@t3tools/client-runtime`, `@t3tools/web`, `@t3tools/mobile`; client-runtime suite (471 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the managed endpoint provisioning path and introduces quota logic on allocation counts; impact is bounded by fail-fast behavior and tests, though concurrent links can still race past the cap without a transaction.
> 
> **Overview**
> Enforces a **per-user quota on relay managed tunnels** (default **3**, overridable via `relay_managed_tunnel_limits`) before any tunnel/DNS/allocation work runs.
> 
> A new **`ManagedTunnelLimits`** service counts a user’s existing `relay_managed_endpoint_allocations` (excluding the environment being linked so re-link stays idempotent) and fails with **`ManagedTunnelLimitExceeded`** when at cap. **`ManagedEndpointProvider.provision`** invokes this in a new **`check-tunnel-limit`** stage ahead of reservation; tests assert a rejection leaves tunnel, DNS, and allocation calls empty.
> 
> Clients see **`RelayEnvironmentLinkLimitExceededError`** (HTTP 403, `environment_link_limit_exceeded`, `maxTunnels`) from **`linkEnvironment`**, with tailored copy on web/mobile and **`ConnectionBlockedError`** (`permission`) in client-runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99bcad7486314e7052066020d7c4e4e0c05735d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit managed tunnels per user in relay environment linking
> - Adds a new `ManagedTunnelLimits` service ([ManagedTunnelLimits.ts](https://github.com/pingdotgg/t3code/pull/4530/files#diff-71a263ab4df8a1efa521271ec89e21e79d7ce7a63d9a3cb438bd797a6a338dc0)) that checks a per-user tunnel cap before provisioning, reading overrides from a new `relay_managed_tunnel_limits` table and counting active allocations.
> - `ManagedEndpointProvider` now calls `ensureCapacity` before reserving an allocation, failing early with `ManagedTunnelLimitExceeded` if the user is at or over their limit.
> - The relay API maps `ManagedTunnelLimitExceeded` to a 403 `RelayEnvironmentLinkLimitExceededError` (defined in [relay.ts](https://github.com/pingdotgg/t3code/pull/4530/files#diff-cb107044ca7f6b82daab8e559dd6407c25ff0c6fdb488cc9e1b58ebd31ed8310)), which includes `maxTunnels`.
> - Mobile and web clients surface a user-facing message when this error is received; the client runtime classifies it as a `ConnectionBlockedError` with reason `permission`.
> - Behavioral Change: `linkEnvironment` now returns 403 for users who have reached their tunnel limit, where it previously had no such cap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99bcad7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
