### PR TITLE
fix(marketing): detect CPU arch for macOS download button instead of hardcoding arm64

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -393,11 +393,10 @@ const mobileEndorsementRows = [
         if (uad?.getHighEntropyValues) {
           const values = await uad.getHighEntropyValues(["architecture"]);
           if (values.architecture === "x86") arch = "x64";
-        } else if (/Intel|i\d86/i.test(ua)) {
-          arch = "x64";
         }
       } catch {
-        if (/Intel|i\d86/i.test(ua)) arch = "x64";
+        // UA-based fallback is unreliable — all macOS UAs report "Intel Mac OS X",
+        // even on Apple Silicon. Default to arm64 (majority of modern Macs).
       }
       return { os: "mac", label: "Download for macOS", arch };
     }

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -383,11 +383,23 @@ const mobileEndorsementRows = [
 
   type Platform = { os: "mac" | "win" | "linux"; label: string; arch?: string };
 
-  function detectPlatform(): Platform | null {
+  async function detectPlatform(): Promise<Platform | null> {
     const ua = navigator.userAgent;
     if (/Win/i.test(ua)) return { os: "win", label: "Download for Windows" };
     if (/Mac/i.test(ua)) {
-      return { os: "mac", label: "Download for macOS", arch: "arm64" };
+      let arch = "arm64";
+      try {
+        const uad = (navigator as { userAgentData?: { getHighEntropyValues: (hints: string[]) => Promise<{ architecture?: string }> } }).userAgentData;
+        if (uad?.getHighEntropyValues) {
+          const values = await uad.getHighEntropyValues(["architecture"]);
+          if (values.architecture === "x86") arch = "x64";
+        } else if (/Intel|i\d86/i.test(ua)) {
+          arch = "x64";
+        }
+      } catch {
+        if (/Intel|i\d86/i.test(ua)) arch = "x64";
+      }
+      return { os: "mac", label: "Download for macOS", arch };
     }
     if (/Linux/i.test(ua)) return { os: "linux", label: "Download for Linux" };
     return null;
@@ -415,7 +427,7 @@ const mobileEndorsementRows = [
     const ctaLabel = document.getElementById("cta-download-label");
     const kbd = document.getElementById("pr-button-kbd");
 
-    const platform = detectPlatform();
+    const platform = await detectPlatform();
     if (!platform) return;
     document.documentElement.dataset.platform = platform.os;
     if (label) label.textContent = platform.label;


### PR DESCRIPTION
## What Changed

Changed `detectPlatform()` in `apps/marketing/src/pages/index.astro` from hardcoding `arch: "arm64"` for all Mac users to detecting the actual CPU architecture.

- Uses `navigator.userAgentData.getHighEntropyValues(["architecture"])` (Chrome/Edge) for reliable detection
- Falls back to user-agent heuristics for Intel patterns
- Defaults to `"arm64"` when detection is unavailable (same as before)

## Why

The "Download for macOS" button on the landing page always linked to the arm64 DMG for every Mac visitor, even Intel Mac users who cannot run arm64 binaries. This caused installation failures for Intel users and potentially confusing behavior for Apple Silicon users when the download resolution failed.

Fixes #4358

## UI Changes

No visual changes to the page. The button looks identical — it just links to the correct architecture-specific DMG based on the user's CPU.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, client-only change on the marketing homepage download script with graceful fallback to arm64 when architecture cannot be read.
> 
> **Overview**
> The marketing landing page **macOS download links** no longer always resolve to the **arm64** DMG. `detectPlatform` is now **async** and, for Mac visitors, reads CPU architecture via `navigator.userAgentData.getHighEntropyValues(["architecture"])` when the browser supports it, mapping **x86** to **x64** and otherwise keeping **arm64** as the default (including when detection is unavailable).
> 
> `init` **awaits** platform detection before setting `data-platform`, labels, and the release asset URL used by `pickAsset` for arch-specific DMG filenames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f346d7711d6bfdd4db7242d6c0b06979898dcb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect CPU architecture for macOS download button instead of hardcoding arm64
> Previously, macOS users were always served the arm64 download link. `detectPlatform` in [index.astro](https://github.com/pingdotgg/t3code/pull/4532/files#diff-44a2946e1eacc7096aee1ba8a172800aa7d94150585e21ff8486d94f4776677a) now calls `navigator.userAgentData.getHighEntropyValues(["architecture"])` to detect Intel vs Apple Silicon, returning `x64` for Intel Macs and defaulting to `arm64` otherwise. The function is now async, wrapped in a try/catch for browsers that don't support UA-CH.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f346d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->