### PR TITLE
fix(server): poll with real ticks instead of bare yields in CursorAdapter tests

### DIFF
--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -108,7 +108,7 @@ async function waitForFileContent(filePath: string, attempts = 40) {
         return raw;
       }
     } catch {}
-    await Effect.runPromise(Effect.yieldNow);
+    await Effect.runPromise(Effect.sleep("25 millis"));
   }
   throw new Error(`Timed out waiting for file content at ${filePath}`);
 }
@@ -124,7 +124,9 @@ function waitForJsonLogMatch(
       if (requests.some(predicate)) {
         return requests;
       }
-      yield* Effect.yieldNow;
+      // The mock ACP process runs on the real clock, so TestClock.adjust just
+      // provides the scheduler hops for its stdio responses to land.
+      yield* TestClock.adjust("25 millis");
     }
     return yield* Effect.promise(() => readJsonLines(filePath));
   });


### PR DESCRIPTION
## What Changed

`waitForFileContent` and `waitForJsonLogMatch` in `apps/server/src/provider/Layers/CursorAdapter.test.ts` now poll with a real delay (`Effect.sleep("25 millis")` / `TestClock.adjust("25 millis")`) between attempts instead of a bare `Effect.yieldNow`.

## Why

CI run [30140499630](https://github.com/pingdotgg/t3code/actions/runs/30140499630) failed on `main` in the "cancels pending ACP approvals and marks the turn cancelled when interrupted" test with `AssertionError: expected false to be true`. The commit that CI run built only touched `apps/web/src/components/chat/TraitsPicker.tsx`, so this was a pre-existing flake unrelated to that change.

Both helpers busy-poll a log file written by a real ACP mock child process (an actual subprocess, not a stub). With no real wall-clock delay between the 40 poll attempts, all attempts could be exhausted before the child process was scheduled and had written its response under CI load, so the assertion would see an incomplete log.

Sibling test files in the same directory (`CursorProvider.test.ts`, `GrokAdapter.test.ts`) already establish the correct pattern for this exact cross-process situation: sleep briefly between polls. This PR aligns `CursorAdapter.test.ts` with that convention. Since this suite runs under a virtual `TestClock` (via `it.layer`), the fix uses `TestClock.adjust` for the generator that runs directly on the test's own fiber (matching an existing local precedent in the same file around line 288-302), and plain `Effect.sleep` for the other helper, which is a bare async function that runs its own fresh, live `Effect.runPromise` per iteration.

Verified locally: `vp test run CursorAdapter.test.ts` passes 18/18 consistently across repeated runs. `vp lint` and a scoped `vp run typecheck` in `apps/server` are clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A — no UI change)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing changes with no production code impact.
> 
> **Overview**
> Fixes flaky **CursorAdapter** integration tests that poll log files written by a real mock ACP subprocess.
> 
> `waitForFileContent` now waits **25ms** between read attempts via `Effect.sleep` instead of `Effect.yieldNow`. `waitForJsonLogMatch` uses **`TestClock.adjust("25 millis")`** between polls (with a short comment that the mock process uses the real clock), matching the pattern already used elsewhere in this test file and sibling adapter tests.
> 
> This gives the child process time to write under CI load so helpers like the cancel-approval assertion do not time out with incomplete logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c397a3461e96a5ecc6be318dfe7640c0e914d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix polling in `CursorAdapter` tests to use real ticks instead of bare yields
> - In `waitForFileContent`, replaces a bare scheduler yield between poll attempts with a 25ms sleep, introducing real elapsed time between read checks.
> - In `waitForJsonLogMatch`, replaces the yield with `TestClock.adjust("25 millis")` and adds a comment explaining why the mock process requires real-clock advancement.
> - Behavioral Change: poll helpers now consume real or simulated time between attempts rather than yielding immediately, which may affect test timing and throughput.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67c397a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->