### PR TITLE
Allow custom environment names

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1457,7 +1457,12 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
-          <Button size="xs" variant="outline" onClick={() => onRename(environment)}>
+          <Button
+            size="xs"
+            variant="outline"
+            disabled={removingEnvironmentId === environmentId}
+            onClick={() => onRename(environment)}
+          >
             Rename
           </Button>
           {isWslEnvironment ? (

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -38,6 +38,7 @@ import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
 
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
+import { useClientSettings, useUpdateClientSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
@@ -1340,6 +1341,7 @@ type SavedBackendListRowProps = {
   environment: EnvironmentPresentation;
   removingEnvironmentId: EnvironmentId | null;
   onConnect: (environmentId: EnvironmentId) => void;
+  onRename: (environment: EnvironmentPresentation) => void;
   onRemove: (environmentId: EnvironmentId) => void;
 };
 
@@ -1347,6 +1349,7 @@ function SavedBackendListRow({
   environment,
   removingEnvironmentId,
   onConnect,
+  onRename,
   onRemove,
 }: SavedBackendListRowProps) {
   const environmentId = environment.environmentId;
@@ -1389,14 +1392,12 @@ function SavedBackendListRow({
     [copyTraceIdToClipboard],
   );
   const versionMismatch = resolveServerConfigVersionMismatch(environment.serverConfig);
-  const sshTarget =
-    environment.entry.target._tag === "SshConnectionTarget" &&
-    Option.isSome(environment.entry.profile) &&
-    environment.entry.profile.value._tag === "SshConnectionProfile"
-      ? environment.entry.profile.value.target
-      : null;
   const metadataBits = [
-    sshTarget ? `SSH ${formatDesktopSshTarget(sshTarget)}` : null,
+    environment.displayUrl
+      ? environment.entry.target._tag === "SshConnectionTarget"
+        ? `SSH ${environment.displayUrl}`
+        : environment.displayUrl
+      : null,
     environment.relayManaged ? "T3 Connect" : null,
   ].filter((value): value is string => value !== null);
 
@@ -1456,6 +1457,9 @@ function SavedBackendListRow({
           ) : null}
         </div>
         <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
+          <Button size="xs" variant="outline" onClick={() => onRename(environment)}>
+            Rename
+          </Button>
           {isWslEnvironment ? (
             <Tooltip>
               <TooltipTrigger
@@ -1713,6 +1717,8 @@ export function ConnectionsSettings() {
   const desktopBridge = window.desktopBridge;
   const { environments } = useEnvironments();
   const primaryEnvironment = usePrimaryEnvironment();
+  const environmentDisplayNames = useClientSettings((settings) => settings.environmentDisplayNames);
+  const updateClientSettings = useUpdateClientSettings();
   const connectPairing = useAtomCommand(connectPairingAtom, { reportFailure: false });
   const connectSshEnvironment = useAtomCommand(connectSshEnvironmentAtom, {
     reportFailure: false,
@@ -1796,6 +1802,9 @@ export function ConnectionsSettings() {
   const [isAddingSavedBackend, setIsAddingSavedBackend] = useState(false);
   const [removingSavedEnvironmentId, setRemovingSavedEnvironmentId] =
     useState<EnvironmentId | null>(null);
+  const [renameEnvironmentTarget, setRenameEnvironmentTarget] =
+    useState<EnvironmentPresentation | null>(null);
+  const [renameEnvironmentValue, setRenameEnvironmentValue] = useState("");
   const [isUpdatingDesktopServerExposure, setIsUpdatingDesktopServerExposure] = useState(false);
   const [isDesktopServerExposureDialogOpen, setIsDesktopServerExposureDialogOpen] = useState(false);
   const [isUpdatingTailscaleServe, setIsUpdatingTailscaleServe] = useState(false);
@@ -2121,7 +2130,7 @@ export function ConnectionsSettings() {
         return;
       }
 
-      const result = await connectSshEnvironment({ target, label: "" });
+      const result = await connectSshEnvironment({ target, label: target.alias });
       if (result._tag === "Failure") {
         if (!isAtomCommandInterrupted(result)) {
           setSavedBackendError(formatDesktopSshConnectionError(squashAtomCommandFailure(result)));
@@ -2227,6 +2236,41 @@ export function ConnectionsSettings() {
     },
     [retryEnvironment],
   );
+
+  const handleStartRenameEnvironment = useCallback(
+    (environment: EnvironmentPresentation) => {
+      setRenameEnvironmentTarget(environment);
+      setRenameEnvironmentValue(environmentDisplayNames[environment.environmentId] ?? "");
+    },
+    [environmentDisplayNames],
+  );
+
+  const handleCloseRenameEnvironment = useCallback(() => {
+    setRenameEnvironmentTarget(null);
+    setRenameEnvironmentValue("");
+  }, []);
+
+  const handleSaveRenameEnvironment = useCallback(() => {
+    if (!renameEnvironmentTarget) {
+      return;
+    }
+    const environmentId = renameEnvironmentTarget.environmentId;
+    const displayName = renameEnvironmentValue.trim();
+    const nextDisplayNames = { ...environmentDisplayNames };
+    if (displayName === "") {
+      delete nextDisplayNames[environmentId];
+    } else {
+      nextDisplayNames[environmentId] = displayName;
+    }
+    updateClientSettings({ environmentDisplayNames: nextDisplayNames });
+    handleCloseRenameEnvironment();
+  }, [
+    environmentDisplayNames,
+    handleCloseRenameEnvironment,
+    renameEnvironmentTarget,
+    renameEnvironmentValue,
+    updateClientSettings,
+  ]);
 
   const handleRemoveSavedBackend = useCallback(
     async (environmentId: EnvironmentId) => {
@@ -3385,6 +3429,7 @@ export function ConnectionsSettings() {
             environment={environment}
             removingEnvironmentId={removingSavedEnvironmentId}
             onConnect={handleConnectSavedBackend}
+            onRename={handleStartRenameEnvironment}
             onRemove={handleRemoveSavedBackend}
           />
         ))}
@@ -3393,6 +3438,52 @@ export function ConnectionsSettings() {
           savedEnvironments={savedEnvironments}
         />
       </SettingsSection>
+      <Dialog
+        open={renameEnvironmentTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleCloseRenameEnvironment();
+          }
+        }}
+      >
+        <DialogPopup className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename environment</DialogTitle>
+            <DialogDescription>
+              Set an optional name for this client. Leave it empty to use the environment’s default
+              name.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <label className="grid gap-1.5">
+              <span className="text-xs font-medium text-foreground">Display name</span>
+              <Input
+                autoFocus
+                value={renameEnvironmentValue}
+                placeholder={renameEnvironmentTarget?.defaultLabel}
+                onChange={(event) => setRenameEnvironmentValue(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    handleSaveRenameEnvironment();
+                  }
+                }}
+              />
+            </label>
+            {renameEnvironmentTarget?.displayUrl ? (
+              <p className="truncate text-xs text-muted-foreground">
+                {renameEnvironmentTarget.displayUrl}
+              </p>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCloseRenameEnvironment}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveRenameEnvironment}>Save</Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -27,7 +27,7 @@ import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import { ensureLocalApi } from "~/localApi";
 import * as Struct from "effect/Struct";
 import { primaryServerSettingsAtom, serverEnvironment } from "~/state/server";
-import { usePrimaryEnvironment } from "~/state/environments";
+import { primaryEnvironmentIdAtom } from "~/state/primaryEnvironment";
 import { useAtomCommand } from "~/state/use-atom-command";
 
 const CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE = "[CLIENT_SETTINGS]";
@@ -278,7 +278,7 @@ export function useUpdateEnvironmentSettings(environmentId: EnvironmentId) {
 }
 
 export function useUpdatePrimarySettings() {
-  return useUpdateSettingsTarget(usePrimaryEnvironment()?.environmentId ?? null);
+  return useUpdateSettingsTarget(useAtomValue(primaryEnvironmentIdAtom));
 }
 
 export function useUpdateClientSettings() {

--- a/apps/web/src/state/environments.ts
+++ b/apps/web/src/state/environments.ts
@@ -9,6 +9,7 @@ import * as Option from "effect/Option";
 import { useMemo } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
+import { useClientSettings } from "../hooks/useSettings";
 import { environmentPresentations, useEnvironmentPresentation } from "./presentation";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { useEnvironmentQuery } from "./query";
@@ -18,6 +19,7 @@ import { usePreparedConnection } from "./session";
 export interface EnvironmentPresentation extends BaseEnvironmentPresentation {
   readonly environmentId: EnvironmentId;
   readonly label: string;
+  readonly defaultLabel: string;
   readonly displayUrl: string | null;
   readonly relayManaged: boolean;
 }
@@ -25,11 +27,14 @@ export interface EnvironmentPresentation extends BaseEnvironmentPresentation {
 function projectEnvironmentPresentation(
   environmentId: EnvironmentId,
   presentation: BaseEnvironmentPresentation,
+  environmentDisplayNames: Readonly<Record<string, string>>,
 ): EnvironmentPresentation {
+  const defaultLabel = presentation.entry.target.label;
   return {
     ...presentation,
     environmentId,
-    label: presentation.entry.target.label,
+    label: environmentDisplayNames[environmentId] ?? defaultLabel,
+    defaultLabel,
     displayUrl: connectionCatalogDisplayUrl(presentation.entry),
     relayManaged: presentation.entry.target._tag === "RelayConnectionTarget",
   };
@@ -39,13 +44,14 @@ export function useEnvironments() {
   const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
   const networkStatus = useAtomValue(environmentCatalog.networkStatusValueAtom);
   const presentationById = useAtomValue(environmentPresentations.presentationsAtom);
+  const environmentDisplayNames = useClientSettings((settings) => settings.environmentDisplayNames);
 
   const environments = useMemo(
     () =>
       [...presentationById.entries()].map(([environmentId, presentation]) =>
-        projectEnvironmentPresentation(environmentId, presentation),
+        projectEnvironmentPresentation(environmentId, presentation, environmentDisplayNames),
       ),
-    [presentationById],
+    [environmentDisplayNames, presentationById],
   );
 
   return {
@@ -64,12 +70,13 @@ export function useEnvironment(
   environmentId: EnvironmentId | null,
 ): EnvironmentPresentation | null {
   const { presentation } = useEnvironmentPresentation(environmentId);
+  const environmentDisplayNames = useClientSettings((settings) => settings.environmentDisplayNames);
   return useMemo(
     () =>
       environmentId === null || presentation === null
         ? null
-        : projectEnvironmentPresentation(environmentId, presentation),
-    [environmentId, presentation],
+        : projectEnvironmentPresentation(environmentId, presentation, environmentDisplayNames),
+    [environmentDisplayNames, environmentId, presentation],
   );
 }
 

--- a/packages/client-runtime/src/connection/presentation.test.ts
+++ b/packages/client-runtime/src/connection/presentation.test.ts
@@ -2,10 +2,15 @@ import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Option from "effect/Option";
 
-import { BearerConnectionProfile, type ConnectionCatalogEntry } from "./catalog.ts";
+import {
+  BearerConnectionProfile,
+  type ConnectionCatalogEntry,
+  SshConnectionProfile,
+} from "./catalog.ts";
 import {
   BearerConnectionTarget,
   ConnectionTransientError,
+  SshConnectionTarget,
   type SupervisorConnectionState,
 } from "./model.ts";
 import {
@@ -53,6 +58,32 @@ function supervisorState(overrides: Partial<SupervisorConnectionState>): Supervi
 describe("connection presentation", () => {
   it("preserves profile display information without exposing credentials", () => {
     expect(connectionCatalogDisplayUrl(ENTRY)).toBe("https://environment.example.test");
+  });
+
+  it("formats SSH display information without a missing username and preserves the port", () => {
+    const target = new SshConnectionTarget({
+      environmentId: EnvironmentId.make("environment-ssh"),
+      label: "SSH environment",
+      connectionId: "connection-ssh",
+    });
+    const entry: ConnectionCatalogEntry = {
+      target,
+      profile: Option.some(
+        new SshConnectionProfile({
+          connectionId: target.connectionId,
+          environmentId: target.environmentId,
+          label: target.label,
+          target: {
+            alias: "devbox",
+            hostname: "devbox.example.test",
+            username: null,
+            port: 2222,
+          },
+        }),
+      ),
+    };
+
+    expect(connectionCatalogDisplayUrl(entry)).toBe("devbox.example.test:2222");
   });
 
   it("distinguishes initial connection, reconnect, and retry errors", () => {

--- a/packages/client-runtime/src/connection/presentation.ts
+++ b/packages/client-runtime/src/connection/presentation.ts
@@ -100,9 +100,12 @@ export function connectionCatalogDisplayUrl(entry: ConnectionCatalogEntry): stri
         ? entry.profile.value.httpBaseUrl
         : null;
     case "SshConnectionTarget":
-      return Option.isSome(entry.profile) && entry.profile.value._tag === "SshConnectionProfile"
-        ? `${entry.profile.value.target.username}@${entry.profile.value.target.hostname}`
-        : null;
+      if (Option.isNone(entry.profile) || entry.profile.value._tag !== "SshConnectionProfile") {
+        return null;
+      }
+      const { hostname, port, username } = entry.profile.value.target;
+      const authority = username ? `${username}@${hostname}` : hostname;
+      return port ? `${authority}:${port}` : authority;
   }
 }
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as Schema from "effect/Schema";
 
+import { EnvironmentId } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
@@ -30,6 +31,30 @@ describe("ClientSettings word wrap", () => {
     expect(decoded.wordWrap).toBe(true);
     expect(decoded).not.toHaveProperty("chatWordWrap");
     expect(decoded).not.toHaveProperty("diffWordWrap");
+  });
+});
+
+describe("ClientSettings environment display names", () => {
+  const environmentId = EnvironmentId.make("environment-1");
+
+  it("defaults to no client-local overrides", () => {
+    expect(decodeClientSettings({}).environmentDisplayNames).toEqual({});
+  });
+
+  it("trims saved overrides", () => {
+    expect(
+      decodeClientSettings({
+        environmentDisplayNames: { [environmentId]: "  Workstation  " },
+      }).environmentDisplayNames,
+    ).toEqual({ [environmentId]: "Workstation" });
+  });
+
+  it("rejects empty overrides", () => {
+    expect(() =>
+      decodeClientSettingsPatch({
+        environmentDisplayNames: { [environmentId]: "   " },
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,7 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Duration from "effect/Duration";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
-import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
+import { EnvironmentId, TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { DEFAULT_TEXT_GENERATION_MODEL, ProviderOptionSelections } from "./model.ts";
 import { ModelSelection } from "./orchestration.ts";
 import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.ts";
@@ -67,6 +67,9 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed([])),
   ),
   diffIgnoreWhitespace: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  environmentDisplayNames: Schema.Record(EnvironmentId, TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
   ),
@@ -605,6 +608,7 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
+  environmentDisplayNames: Schema.optionalKey(Schema.Record(EnvironmentId, TrimmedNonEmptyString)),
   glassOpacity: Schema.optionalKey(GlassOpacity),
   favorites: Schema.optionalKey(
     Schema.Array(


### PR DESCRIPTION
## What Changed

- Add optional, client-local environment display names keyed by environment ID.
- Add a Rename action to saved environment rows; clearing the field restores the server-reported label.
- Resolve custom names through the shared web environment presentation so pickers, sidebars, and thread indicators use the same name.
- Preserve SSH aliases when adding manual SSH connections.
- Show the connection URL beneath saved environment names for additional disambiguation.

## Why

Different remote machines commonly report the same hostname, making saved connections and environment pickers indistinguishable. Custom names provide an opt-in per-client override without changing environment identity or server configuration.

## UI Changes

Settings → Connections now exposes a Rename action on each saved environment. The dialog makes the override explicitly client-local and allows clearing it to return to the live server default. Browser verification covered pairing a remote, renaming it, persistence after reload, clearing the override, and the URL subtitle.

## Checklist

- [x] `vp run --filter @t3tools/contracts test -- src/settings.test.ts`
- [x] `vp run --filter @t3tools/web test -- src/clientPersistenceStorage.test.ts src/localApi.test.ts`
- [x] `vp check` (passes with existing repository warnings)
- [ ] `vp run typecheck` (blocked by pre-existing web type errors and the isolated checkout missing `@astrojs/check`; changed contracts typecheck passes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to client-local persistence and UI labeling; no server config or auth changes, with schema validation on saved names.
> 
> **Overview**
> Adds **optional per-environment display names** stored in client settings (`environmentDisplayNames`) so saved connections and environment pickers can be distinguished without changing server identity.
> 
> **Connections** gets a **Rename** flow on each saved remote row: a dialog saves a trimmed override or clears it to fall back to the server default; rows show the connection **URL** via shared `displayUrl` metadata instead of ad hoc SSH formatting.
> 
> **Environment presentation** now resolves `label` from client overrides (with `defaultLabel` preserved) everywhere `useEnvironments` / `useEnvironment` run, so sidebars and pickers stay consistent.
> 
> Also fixes **SSH presentation**: manual SSH adds use the target **alias** as the initial label, and `connectionCatalogDisplayUrl` omits a missing username and appends **port** when set. `useUpdatePrimarySettings` reads the primary environment id from `primaryEnvironmentIdAtom` instead of the presentation hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e10a60709587d23937448ac9f0e69a8770197e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow custom per-environment display names in connection settings
> - Adds a Rename action to saved environment rows in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/4538/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9), opening a dialog to set a client-local display name stored in `ClientSettings.environmentDisplayNames`.
> - Extends [settings.ts](https://github.com/pingdotgg/t3code/pull/4538/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) with an `environmentDisplayNames` field (keyed by `EnvironmentId`, trimmed non-empty strings) and a matching patch field; defaults to `{}`.
> - Updates `projectEnvironmentPresentation` in [environments.ts](https://github.com/pingdotgg/t3code/pull/4538/files#diff-44037206277bcac2d6451bcc25329659407c1d314bc246e46e1025cbb6f6c222) to apply overrides from client settings, exposing both `label` (possibly overridden) and `defaultLabel`.
> - Fixes SSH display URLs in [presentation.ts](https://github.com/pingdotgg/t3code/pull/4538/files#diff-696aa7c2bcbe229bb02c6650bd93c240a3bf10020da226e64d7158f5dd4da6b3) to omit the username when absent (previously rendered as `null@host`) and include the port when set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e10a60.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->