### PR TITLE
Fix woke status overlap after snooze menu closes

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -879,10 +879,10 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               ) : (
                 <span className="flex-1" />
               )}
-              <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
+              <span className="group/actions relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
                 <span
                   className={cn(
-                    "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
+                    "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0 group-focus-within/actions:opacity-0",
                     snoozeMenuOpen && "opacity-0",
                   )}
                 >


### PR DESCRIPTION
## Summary

- keep the thread status hidden while focused row actions remain visible
- prevent `Woke` and `Settle` from overlapping after dismissing the snooze menu

## Root cause

Closing the popover leaves focus on the snooze trigger. The action container stayed visible through `focus-within`, while the status label was only hidden for hover or an open menu.

## Testing

- `pnpm --dir apps/web exec vp test run src/components/Sidebar.snooze.test.ts --project unit` (7 tests)
- `pnpm --filter @t3tools/web typecheck`
- targeted lint and format checks for `SidebarV2.tsx`
- isolated web verification of the reported flow: after outside-click dismissal, actions remained at opacity `1` and `Woke` resolved to opacity `0`

Fixes #4537

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix status text overlap when snooze menu closes in sidebar
> The woke status text in `SidebarV2Row` was remaining visible while the snooze menu was open, causing an overlap. Adds a `group/actions` class to the actions container in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4539/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) and hides the status text via `group-focus-within/actions:opacity-0` when focus is within the actions group, matching the existing hover-based hide behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e15a12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two Tailwind classes on the sidebar card row; no logic or API changes.
> 
> **Overview**
> Fixes **Woke** (and other top status labels) overlapping **Settle** on sidebar v2 card rows after the snooze popover is dismissed with an outside click.
> 
> The row actions area is now a `group/actions` container, and the status/time slot uses `group-focus-within/actions:opacity-0` so it stays hidden whenever focus remains inside that actions group—not only on row hover or while `snoozeMenuOpen` is true. That matches the existing behavior where closing the menu leaves focus on the snooze trigger and keeps the action buttons visible via `focus-within`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e15a12fbdaca4f4d365459f47e4a924adb8a2a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->