### PR TITLE
Fix missing space before GitHub releases link

### DIFF
--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -60,7 +60,7 @@ import { RELEASES_URL } from "../lib/releases";
   </div>
 
   <p class="releases-link">
-    Looking for older versions? Check the
+    Looking for older versions? Check the{" "}
     <a href="https://github.com/pingdotgg/t3code/releases" target="_blank" rel="noopener noreferrer">
       GitHub releases page<span aria-hidden="true"> &#8599;</span>
     </a>


### PR DESCRIPTION
## What Changed

Added explicit whitespace before the GitHub releases link on the download page.

## Why

The template boundary removed the expected space between the surrounding text and the link, rendering the sentence as `Check theGitHub releases page`. The explicit whitespace keeps the copy readable without changing layout or behavior.

## UI Changes

| Before | After |
| --- | --- |
| `Check theGitHub releases page` | `Check the GitHub releases page` |

## Validation

- `vp run --filter @t3tools/marketing typecheck`
- `vp run --filter @t3tools/marketing build`
- Verified the rendered `/download` page in the controlled browser; the text now reads “Looking for older versions? Check the GitHub releases page”.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing space before GitHub releases link on download page
> Adds an explicit `{' '}` space literal in [download.astro](https://github.com/pingdotgg/t3code/pull/4540/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926) between the text 'Check the' and the 'GitHub releases page' anchor to fix a rendering issue where the two were visually joined.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59cf597.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->