### PR TITLE
Fix Sidebar V2 status overlap after snooze dismissal

### DIFF
--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -882,7 +882,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
               <span className="relative ml-auto flex h-5 min-w-8 shrink-0 items-center justify-end pl-1 text-xs">
                 <span
                   className={cn(
-                    "tabular-nums text-muted-foreground/65 transition-opacity group-hover/v2-row:opacity-0",
+                    "tabular-nums text-muted-foreground/65 transition-opacity group-focus-within/v2-row:opacity-0 group-hover/v2-row:opacity-0",
                     snoozeMenuOpen && "opacity-0",
                   )}
                 >


### PR DESCRIPTION
## What changed

Hide the Sidebar V2 status/time layer while the row retains focus, matching the existing focus behavior of the snooze and settle actions.

## Why

Dismissing the snooze popover can leave focus on its trigger. The action layer stays visible through `focus-within`, but the `Woke` label previously became visible again as soon as the menu closed and the pointer left the row, so both layers overlapped.

Fixes #4537.

## Validation

- `vp check apps/web/src/components/SidebarV2.tsx`
- Isolated web pass in Chromium with a seeded `Woke` row:
  - Before: focused snooze trigger with the pointer outside the row rendered both layers at `opacity: 1`.
  - After: the status layer renders at `opacity: 0` while the action layer remains at `opacity: 1`.

The original interaction is shown in the recording attached to #4537.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix status text overlap in SidebarV2 rows after snooze dismissal
> Adds `group-focus-within/v2-row:opacity-0` to the status text element in [SidebarV2.tsx](https://github.com/pingdotgg/t3code/pull/4541/files#diff-87e093a89032045fe7c876d3d324b60251f65a65d07e96e2a0c8eb92cb759d6c) so it hides on focus-within, matching the existing hover and snooze-open behavior. This prevents the status text from overlapping other row content when a row retains focus after the snooze menu is dismissed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b81c6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->