### PR TITLE
fix(marketing): keep Grok mark clear of mobile hero copy

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -704,7 +704,7 @@ const mobileEndorsementRows = [
       height: 44px;
     }
 
-    /* Three stacked on the left, two on the right — keeps the center CTA clear. */
+    /* Three above the headline, two beside the CTA — keeps the copy clear. */
     .hero-float-mark.hf-claude {
       top: 44px;
       left: 10px;
@@ -712,8 +712,8 @@ const mobileEndorsementRows = [
     }
 
     .hero-float-mark.hf-grok {
-      top: 240px;
-      left: 4px;
+      top: 44px;
+      left: calc(50% - 39px);
       right: auto;
       transform: rotate(-4deg);
     }
@@ -741,8 +741,8 @@ const mobileEndorsementRows = [
 
   @media (max-width: 340px) {
     .hero-float-mark.hf-grok {
-      top: 220px;
-      left: 0;
+      top: 57px;
+      left: calc(50% - 26px);
       width: 52px;
       height: 52px;
       border-radius: 14px;


### PR DESCRIPTION
## Summary

- move the Grok mark into the open center position above the mobile hero headline
- preserve the compact centered layout for viewports at or below 340px
- leave desktop positioning unchanged

Fixes #4234

## Before and after

### Mobile (393 × 852)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/NicL9923/t3code/pr-assets-4234/issue-4234/before-mobile.png" alt="Mobile hero before the fix, with the Grok mark overlapping the headline" width="393" /> | <img src="https://raw.githubusercontent.com/NicL9923/t3code/pr-assets-4234/issue-4234/after-mobile.png" alt="Mobile hero after the fix, with the Grok mark above the headline" width="393" /> |

### Desktop (rendered at 1440 × 1000)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/NicL9923/t3code/pr-assets-4234/issue-4234/before-desktop.png" alt="Desktop hero before the fix" width="600" /> | <img src="https://raw.githubusercontent.com/NicL9923/t3code/pr-assets-4234/issue-4234/after-desktop.png" alt="Desktop hero after the fix" width="600" /> |

The screenshots are hosted on the `pr-assets-4234` branch in the fork so review evidence stays out of the product diff.

## Verification

- `pnpm --filter @t3tools/marketing typecheck`
- `pnpm --filter @t3tools/marketing build`
- `git diff --check`
- integrated browser verification at 393 × 852 and 1440 × 1000
- responsive overlap sweep at 320px, 340px, 393px, 430px, and 820px

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only marketing hero layout tweak with no logic, auth, or data changes.
> 
> **Overview**
> On **mobile** (≤820px), the Grok floating harness mark is moved from the left stack beside the headline to **top-center** above the copy (`top: 44px`, `left: calc(50% - 39px)`), matching the updated layout comment (three marks above the headline, two by the CTA).
> 
> For **very narrow** viewports (≤340px), Grok’s compact rule is updated the same way (`top: 57px`, `left: calc(50% - 26px)`) so it stays centered and off the headline. **Desktop and tablet** float positions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0669e7ca2e1b6d2a736f306aa013c58148389c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reposition Grok floating mark to top-center on mobile hero
> On mobile, the `.hf-grok` floating mark was overlapping the hero copy. It is now positioned near the top of the hero and centered horizontally using `calc(50% - 39px)`, moving it away from the headline and CTA. For viewports ≤340px, a separate rule centers it at `calc(50% - 26px)` with a slightly lower top offset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0669e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->