### PR TITLE
fix(web): open Windows markdown file links

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -66,7 +66,9 @@ import {
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
-  normalizeMarkdownLinkDestination,
+  extractMarkdownLinkDestinationAtOffsets,
+  normalizeMarkdownFileLinkHref,
+  preserveMarkdownFileLinkHref,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
 } from "../markdown-links";
@@ -826,11 +828,6 @@ function extractMarkdownLinkHrefs(text: string): string[] {
   return hrefs;
 }
 
-function normalizeMarkdownLinkHrefKey(href: string): string {
-  const normalizedHref = normalizeMarkdownLinkDestination(href);
-  return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
-}
-
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";
 
 /** Hosts whose favicon request already failed this session — skip straight to the globe. */
@@ -1272,7 +1269,7 @@ function ChatMarkdown({
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
     for (const href of extractMarkdownLinkHrefs(text)) {
-      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
+      const normalizedHref = normalizeMarkdownFileLinkHref(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
       if (meta) {
@@ -1285,9 +1282,13 @@ function ChatMarkdown({
     const filePaths = [...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath);
     return buildFileLinkParentSuffixByPath(filePaths);
   }, [markdownFileLinkMetaByHref]);
-  const markdownUrlTransform = useCallback((href: string) => {
-    return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
-  }, []);
+  const markdownUrlTransform = useCallback(
+    (href: string) =>
+      rewriteMarkdownFileUriHref(href) ??
+      preserveMarkdownFileLinkHref(href, cwd) ??
+      defaultUrlTransform(href),
+    [cwd],
+  );
   // Re-emit highlighted content as markdown so copying out of the rendered
   // view keeps links, emphasis, lists, and code fences intact.
   const handleCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
@@ -1384,8 +1385,22 @@ function ChatMarkdown({
         );
       },
       a({ node, href, children, ...props }) {
-        const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const normalizedHref = href ? normalizeMarkdownFileLinkHref(href) : "";
+        const sourceHref = extractMarkdownLinkDestinationAtOffsets(
+          text,
+          node?.position?.start.offset,
+          node?.position?.end.offset,
+        );
+        const normalizedSourceHref = sourceHref ? normalizeMarkdownFileLinkHref(sourceHref) : "";
+        const fileLinkMeta =
+          (normalizedHref
+            ? (markdownFileLinkMetaByHref.get(normalizedHref) ??
+              resolveMarkdownFileLinkMeta(normalizedHref, cwd))
+            : null) ??
+          (normalizedSourceHref
+            ? (markdownFileLinkMetaByHref.get(normalizedSourceHref) ??
+              resolveMarkdownFileLinkMeta(normalizedSourceHref, cwd))
+            : null);
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1475,7 +1490,7 @@ function ChatMarkdown({
             workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
             line={fileLinkMeta.line}
             label={labelParts.join(" · ")}
-            copyMarkdown={`[${fileLinkMeta.basename}](${normalizedHref})`}
+            copyMarkdown={`[${fileLinkMeta.basename}](${normalizedSourceHref || normalizedHref})`}
             theme={resolvedTheme}
             threadRef={threadRef}
             onOpen={openInPreferredEditor}
@@ -1527,6 +1542,7 @@ function ChatMarkdown({
     }),
     [
       diffThemeName,
+      cwd,
       fileLinkParentSuffixByPath,
       isStreaming,
       markdownFileLinkMetaByHref,

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  extractMarkdownLinkDestinationAtOffsets,
+  normalizeMarkdownFileLinkHref,
+  preserveMarkdownFileLinkHref,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
@@ -125,5 +128,66 @@ describe("resolveMarkdownFileLinkTarget", () => {
 
   it("does not treat app routes as file links", () => {
     expect(resolveMarkdownFileLinkTarget("/chat/settings")).toBeNull();
+  });
+});
+
+describe("markdown file href compatibility", () => {
+  it("recovers a raw Windows destination from a parsed link node range", () => {
+    const markdown = "Created [markdown-links.ts](C:\\Users\\aydri\\repo\\src\\markdown-links.ts).";
+    const startOffset = markdown.indexOf("[");
+    const endOffset = markdown.indexOf(").") + 1;
+
+    expect(extractMarkdownLinkDestinationAtOffsets(markdown, startOffset, endOffset)).toBe(
+      "C:\\Users\\aydri\\repo\\src\\markdown-links.ts",
+    );
+  });
+
+  it("recovers an angle-wrapped destination containing spaces", () => {
+    const markdown = 'See [report](<C:/Users/Test User/repo/report.md> "Report").';
+    const startOffset = markdown.indexOf("[");
+    const endOffset = markdown.indexOf(").") + 1;
+
+    expect(extractMarkdownLinkDestinationAtOffsets(markdown, startOffset, endOffset)).toBe(
+      "<C:/Users/Test User/repo/report.md>",
+    );
+  });
+
+  it("preserves windows file destinations that React Markdown would otherwise sanitize", () => {
+    const href = String.raw`C:\Users\aydri\Documents\GitHub\t3code\AVA_HANDOFF.md`;
+
+    expect(preserveMarkdownFileLinkHref(href)).toBe(href);
+  });
+
+  it("preserves workspace file destinations containing spaces", () => {
+    expect(
+      preserveMarkdownFileLinkHref(
+        "C:/Users/Test User/repo/AVA_HANDOFF.md",
+        "C:/Users/Test User/repo",
+      ),
+    ).toBe("C:/Users/Test User/repo/AVA_HANDOFF.md");
+  });
+
+  it("does not bypass normal URL sanitization for external schemes", () => {
+    expect(preserveMarkdownFileLinkHref("javascript:report.md", "/repo")).toBeNull();
+  });
+
+  it("resolves the encoded href received by the rendered anchor", () => {
+    expect(
+      resolveMarkdownFileLinkMeta(
+        "C:%5CUsers%5Caydri%5CDocuments%5CGitHub%5Ct3code%5CAVA_HANDOFF.md",
+        String.raw`C:\Users\aydri\Documents\GitHub\t3code`,
+      ),
+    ).toMatchObject({
+      basename: "AVA_HANDOFF.md",
+      workspaceRelativePath: "AVA_HANDOFF.md",
+    });
+  });
+
+  it("normalizes file URI aliases before matching known file metadata", () => {
+    expect(
+      normalizeMarkdownFileLinkHref(
+        "file:///C:/Users/aydri/Documents/GitHub/t3code/AVA_HANDOFF.md#L12",
+      ),
+    ).toBe("C:/Users/aydri/Documents/GitHub/t3code/AVA_HANDOFF.md#L12");
   });
 });

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -92,6 +92,62 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   return `${target.path}${target.hash}`;
 }
 
+export function normalizeMarkdownFileLinkHref(href: string): string {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
+}
+
+export function extractMarkdownLinkDestinationAtOffsets(
+  markdown: string,
+  startOffset: number | undefined,
+  endOffset: number | undefined,
+): string | null {
+  if (
+    !Number.isSafeInteger(startOffset) ||
+    !Number.isSafeInteger(endOffset) ||
+    startOffset === undefined ||
+    endOffset === undefined ||
+    startOffset < 0 ||
+    endOffset <= startOffset ||
+    endOffset > markdown.length
+  ) {
+    return null;
+  }
+
+  const source = markdown.slice(startOffset, endOffset);
+  const destinationMarker = source.lastIndexOf("](");
+  if (destinationMarker < 0 || !source.endsWith(")")) return null;
+
+  const destinationSource = source.slice(destinationMarker + 2, -1).trimStart();
+  if (destinationSource.startsWith("<")) {
+    const closingBracket = destinationSource.indexOf(">");
+    return closingBracket > 0 ? destinationSource.slice(0, closingBracket + 1) : null;
+  }
+
+  let nestedParentheses = 0;
+  for (let index = 0; index < destinationSource.length; index += 1) {
+    const character = destinationSource[index];
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (character === "(") {
+      nestedParentheses += 1;
+      continue;
+    }
+    if (character === ")") {
+      if (nestedParentheses === 0) return destinationSource.slice(0, index);
+      nestedParentheses -= 1;
+      continue;
+    }
+    if (/\s/.test(character ?? "") && nestedParentheses === 0) {
+      return destinationSource.slice(0, index);
+    }
+  }
+
+  return destinationSource || null;
+}
+
 function looksLikePosixFilesystemPath(path: string): boolean {
   if (!path.startsWith("/")) return false;
   if (POSIX_FILE_ROOT_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;
@@ -168,6 +224,11 @@ export function resolveMarkdownFileLinkTarget(
 
   if (!cwd) return null;
   return resolvePathLinkTarget(pathWithPosition, cwd);
+}
+
+export function preserveMarkdownFileLinkHref(href: string, cwd?: string): string | null {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  return resolveMarkdownFileLinkTarget(normalizedHref, cwd) ? normalizedHref : null;
 }
 
 function basenameOfPath(path: string): string {


### PR DESCRIPTION
## What Changed

- Preserve recognized filesystem paths through Markdown URL sanitization.
- Recover raw Windows file destinations when React Markdown strips backslashes.
- Render these references using T3 Code's existing file-link chip and file panel.
- Add coverage for Windows paths, encoded paths, paths containing spaces, and unsafe schemes.

## Why

Codex can emit file links using Windows paths, for example:

```md
[AVA_HANDOFF.md]
(C:\Users\name\project\AVA_HANDOFF.md)
```

React Markdown can sanitize or alter these destinations before the anchor renderer receives them. The result is a blue link that has no href and does nothing when clicked.

This change recovers and validates the original filesystem destination, then routes it through T3 Code's existing file-reference UI.

External URL schemes continue to use the normal URL sanitizer.

## UI Changes

Before: sometimes, the filename would appear as an inert blue link.
<img width="223" height="40" alt="image" src="https://github.com/user-attachments/assets/6214a544-2d51-44fa-9ff5-8f579fe2face" />

After: it renders as T3 Code's native file chip and opens the file in the right-side panel.
<img width="221" height="43" alt="image" src="https://github.com/user-attachments/assets/eb86a924-bb73-44f4-825c-3aaaf90bb580" />

## Verification

- `vp test run src/markdown-links.test.ts --project unit` — 24 tests passed
- `vp run typecheck`
- Focused lint
- Verified the Windows-style link opens the correct file in an isolated T3 Code environment

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [ ] I included a video for animation/interaction changes — not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat markdown link parsing and sanitization; external URLs still use the default sanitizer and unsafe schemes are explicitly rejected in tests.
> 
> **Overview**
> Fixes **inert blue links** when chat markdown uses Windows-style file paths (e.g. `C:\Users\...\file.md`) that React Markdown sanitizes or mangles before rendering.
> 
> **`markdown-links`** adds helpers to keep recognized filesystem paths through URL sanitization (`preserveMarkdownFileLinkHref`), normalize file href keys (`normalizeMarkdownFileLinkHref`), and **re-read the raw destination** from the source markdown via AST offsets (`extractMarkdownLinkDestinationAtOffsets`) when the parsed `href` loses backslashes or encoding.
> 
> **`ChatMarkdown`** wires `urlTransform` to preserve validated file paths (still falling back to `defaultUrlTransform` for real URLs), resolves file-link metadata from both sanitized and recovered hrefs, and uses the source destination for copy-to-clipboard markdown. File links continue to render as the native file chip and open in the side panel.
> 
> New unit tests cover Windows paths, spaces, angle-bracket destinations, encoded hrefs, and rejection of unsafe schemes like `javascript:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165116bd6f48ea2dbeaa7a8cfbbfa411c46e07cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown file link resolution for Windows paths in `ChatMarkdown`
> - Adds `extractMarkdownLinkDestinationAtOffsets` to [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/4545/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to recover raw link destinations (including Windows-style paths and space-containing paths) from parsed node offsets.
> - Adds `preserveMarkdownFileLinkHref` and `normalizeMarkdownFileLinkHref` to normalize and validate file link hrefs against the workspace or filesystem before React Markdown sanitizes them.
> - Updates [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/4545/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to resolve file link metadata using both the sanitized href and the raw source destination, so Windows paths and space-containing paths are matched correctly.
> - Behavioral Change: the URL transform now bypasses React Markdown's default sanitization for hrefs that resolve to workspace or filesystem targets; external schemes remain sanitized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 165116b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->