### PR TITLE
fix: discover project-level Claude skills for the picker in the desktop app

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -54,6 +54,7 @@ import {
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
 import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -216,6 +217,15 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        // Workspace-scoped discovery for the `$` picker: the snapshot scans
+        // against the server process cwd, which is unrelated to the active
+        // project in the desktop app. Transports call this with the
+        // project's own path instead.
+        discoverSkills: (projectCwd: string) =>
+          discoverClaudeSkills(effectiveConfig, projectCwd, processEnv).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, path),
+          ),
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -188,6 +188,54 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
+  it.effect("scopes project skills to the workspace passed in, not the process cwd", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-skills-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const projectAlpha = path.join(tempDir, "project-alpha");
+      const projectBeta = path.join(tempDir, "project-beta");
+
+      yield* writeSkill(
+        path.join(configDir, "skills"),
+        "shared",
+        ["---", "name: shared", "description: User-scoped.", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(projectAlpha, ".claude", "skills"),
+        "alpha-deploy",
+        ["---", "name: alpha-deploy", "---"].join("\n"),
+      );
+      yield* writeSkill(
+        path.join(projectBeta, ".claude", "skills"),
+        "beta-release",
+        ["---", "name: beta-release", "---"].join("\n"),
+      );
+
+      // The desktop app runs the server from a cwd unrelated to any project;
+      // discovery keyed by each project's own path must return that
+      // project's skills without leaking the other project's set.
+      const alphaSkills = yield* discoverClaudeSkills({ homePath: configDir }, projectAlpha);
+      const betaSkills = yield* discoverClaudeSkills({ homePath: configDir }, projectBeta);
+
+      assert.deepEqual(
+        alphaSkills.map((skill) => [skill.name, skill.scope]),
+        [
+          ["alpha-deploy", "project"],
+          ["shared", "user"],
+        ],
+      );
+      assert.deepEqual(
+        betaSkills.map((skill) => [skill.name, skill.scope]),
+        [
+          ["beta-release", "project"],
+          ["shared", "user"],
+        ],
+      );
+    }),
+  );
+
   it.effect("returns an empty list when no skill roots exist", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,6 +25,7 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
@@ -71,6 +72,17 @@ export interface ProviderInstance {
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  /**
+   * Best-effort skill discovery resolved against a specific workspace root.
+   * The snapshot's `skills` are scanned against the server process cwd,
+   * which only matches the user's repository in the `npx t3`-inside-a-repo
+   * flow; transports call this with the active project's path so the `$`
+   * picker sees that project's skills. Absent when the driver has no
+   * workspace-scoped skill discovery — callers then fall back to the
+   * snapshot's `skills`. Must never fail; unreadable roots yield fewer
+   * skills, not errors.
+   */
+  readonly discoverSkills?: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -82,6 +82,8 @@ import { OrchestrationListenerCallbackError } from "./orchestration/Errors.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
+import type { ProviderInstance } from "./provider/ProviderDriver.ts";
+import * as ProviderInstanceRegistry from "./provider/Services/ProviderInstanceRegistry.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -323,6 +325,9 @@ const buildAppUnderTest = (options?: {
   layers?: {
     keybindings?: Partial<Keybindings.Keybindings["Service"]>;
     providerRegistry?: Partial<ProviderRegistry.ProviderRegistry["Service"]>;
+    providerInstanceRegistry?: Partial<
+      ProviderInstanceRegistry.ProviderInstanceRegistry["Service"]
+    >;
     serverSettings?: Partial<ServerSettings.ServerSettingsService["Service"]>;
     externalLauncher?: Partial<ExternalLauncher.ExternalLauncher["Service"]>;
     vcsDriver?: Partial<VcsDriver.VcsDriver["Service"]>;
@@ -544,18 +549,27 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(ProviderRegistry.ProviderRegistry)({
-          getProviders: Effect.succeed([]),
-          refresh: () => Effect.succeed([]),
-          refreshInstance: () => Effect.succeed([]),
-          getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
-            Effect.succeed(
-              makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
-            ),
-          setProviderMaintenanceActionState: () => Effect.succeed([]),
-          streamChanges: Stream.empty,
-          ...options?.layers?.providerRegistry,
-        }),
+        Layer.mergeAll(
+          Layer.mock(ProviderRegistry.ProviderRegistry)({
+            getProviders: Effect.succeed([]),
+            refresh: () => Effect.succeed([]),
+            refreshInstance: () => Effect.succeed([]),
+            getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+              Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
+              ),
+            setProviderMaintenanceActionState: () => Effect.succeed([]),
+            streamChanges: Stream.empty,
+            ...options?.layers?.providerRegistry,
+          }),
+          Layer.mock(ProviderInstanceRegistry.ProviderInstanceRegistry)({
+            getInstance: () => Effect.succeed(undefined),
+            listInstances: Effect.succeed([]),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.empty,
+            ...options?.layers?.providerInstanceRegistry,
+          }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ServerSettings.ServerSettingsService)({
@@ -4454,6 +4468,68 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         truncated: false,
       });
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
+  it.effect(
+    "routes websocket rpc server.discoverProviderSkills against the requested workspace",
+    () =>
+      Effect.gen(function* () {
+        const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
+        const requestedCwds: Array<string> = [];
+        // The handler only reaches for `discoverSkills`; the rest of the
+        // instance is irrelevant to this route.
+        const fakeInstance = {
+          discoverSkills: (cwd: string) => {
+            requestedCwds.push(cwd);
+            return Effect.succeed([
+              {
+                name: "deploy",
+                path: `${cwd}/.claude/skills/deploy/SKILL.md`,
+                enabled: true,
+                scope: "project",
+              },
+            ]);
+          },
+        } as unknown as ProviderInstance;
+
+        yield* buildAppUnderTest({
+          layers: {
+            providerInstanceRegistry: {
+              getInstance: (instanceId) =>
+                Effect.succeed(instanceId === claudeInstanceId ? fakeInstance : undefined),
+            },
+          },
+        });
+
+        const wsUrl = yield* getWsServerUrl("/ws");
+        const response = yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            Effect.all({
+              discovered: client[WS_METHODS.serverDiscoverProviderSkills]({
+                instanceId: claudeInstanceId,
+                cwd: "/projects/alpha",
+              }),
+              // Instances without workspace discovery (or unknown ids) answer
+              // `skills: null` so clients keep the snapshot's skills.
+              unsupported: client[WS_METHODS.serverDiscoverProviderSkills]({
+                instanceId: ProviderInstanceId.make("codex"),
+                cwd: "/projects/alpha",
+              }),
+            }),
+          ),
+        );
+
+        assert.deepEqual(requestedCwds, ["/projects/alpha"]);
+        assert.deepEqual(response.discovered.skills, [
+          {
+            name: "deploy",
+            path: "/projects/alpha/.claude/skills/deploy/SKILL.md",
+            enabled: true,
+            scope: "project",
+          },
+        ]);
+        assert.isNull(response.unsupported.skills);
+      }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
   it.effect("routes websocket rpc projects.searchEntries excludes gitignored files", () =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -76,6 +76,7 @@ import {
   observeRpcStream as instrumentRpcStream,
   observeRpcStreamEffect as instrumentRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
+import * as ProviderInstanceRegistry from "./provider/Services/ProviderInstanceRegistry.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
@@ -297,6 +298,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.serverGetConfig, AuthOrchestrationReadScope],
   [WS_METHODS.serverRefreshProviders, AuthOrchestrationOperateScope],
   [WS_METHODS.serverUpdateProvider, AuthOrchestrationOperateScope],
+  [WS_METHODS.serverDiscoverProviderSkills, AuthOrchestrationReadScope],
   [WS_METHODS.serverUpdateServer, AuthOrchestrationOperateScope],
   [WS_METHODS.serverUpsertKeybinding, AuthOrchestrationOperateScope],
   [WS_METHODS.serverRemoveKeybinding, AuthOrchestrationOperateScope],
@@ -419,6 +421,7 @@ const makeWsRpcLayer = (
       const previewManager = yield* PreviewManager.PreviewManager;
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
+      const providerInstanceRegistry = yield* ProviderInstanceRegistry.ProviderInstanceRegistry;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
       const config = yield* ServerConfig.ServerConfig;
@@ -1478,6 +1481,21 @@ const makeWsRpcLayer = (
             {
               "rpc.aggregate": "server",
             },
+          ),
+        [WS_METHODS.serverDiscoverProviderSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverDiscoverProviderSkills,
+            Effect.gen(function* () {
+              const instance = yield* providerInstanceRegistry.getInstance(input.instanceId);
+              // `skills: null` tells the client this driver has no
+              // workspace-scoped discovery, so it keeps using the snapshot's
+              // skills instead of treating the result as "no skills here".
+              if (!instance?.discoverSkills) {
+                return { skills: null };
+              }
+              return { skills: yield* instance.discoverSkills(input.cwd) };
+            }),
+            { "rpc.aggregate": "server" },
           ),
         [WS_METHODS.serverUpdateServer]: (input) =>
           observeRpcEffect(WS_METHODS.serverUpdateServer, serverSelfUpdate.update(input), {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -151,6 +151,7 @@ import { cn, randomHex } from "~/lib/utils";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
+import { useWorkspaceProviderSkills } from "~/state/queries";
 import { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   buildProjectScript,
@@ -2354,6 +2355,14 @@ function ChatViewContent(props: ChatViewProps) {
     const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
+  // Skills resolved against the active workspace (project path / worktree)
+  // rather than the server process cwd baked into the snapshot.
+  const workspaceProviderSkills = useWorkspaceProviderSkills({
+    environmentId,
+    instanceId: activeProviderStatus?.instanceId ?? null,
+    cwd: gitCwd,
+    snapshotSkills: activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS,
+  });
   const providerStatusBannerKey = getProviderStatusBannerKey(activeProviderStatus);
   const [dismissedProviderStatusBannerKey, setDismissedProviderStatusBannerKey] = useState<
     string | null
@@ -5698,7 +5707,7 @@ function ChatViewContent(props: ChatViewProps) {
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
                 workspaceRoot={activeWorkspaceRoot}
-                skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
+                skills={workspaceProviderSkills}
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 onAnchorSizeChanged={onTimelineAnchorSizeChanged}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -9,6 +9,7 @@ import type {
   RuntimeMode,
   ScopedThreadRef,
   ServerProvider,
+  ServerProviderSkill,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -62,6 +63,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { useWorkspaceProviderSkills } from "../../state/queries";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -92,6 +94,8 @@ import { buildExpandedImagePreview, type ExpandedImagePreview } from "./Expanded
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
+
+const EMPTY_PROVIDER_SKILLS: ReadonlyArray<ServerProviderSkill> = [];
 
 function ComposerCommandMenuLayer(props: { anchor: HTMLElement | null; children: ReactNode }) {
   const [position, setPosition] = useState<{
@@ -864,6 +868,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () => selectedProviderEntry?.models ?? [],
     [selectedProviderEntry],
   );
+  // Skills resolved against the active workspace (project path / worktree)
+  // rather than the server process cwd baked into the snapshot.
+  const workspaceProviderSkills = useWorkspaceProviderSkills({
+    environmentId,
+    instanceId: selectedProviderEntry ? selectedInstanceId : null,
+    cwd: gitCwd,
+    snapshotSkills: selectedProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS,
+  });
 
   const composerPromptInjectionState = useMemo(
     () => getComposerPromptInjectionState(prompt),
@@ -1071,22 +1083,26 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(workspaceProviderSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
-  }, [composerTrigger, selectedProvider, selectedProviderStatus, workspaceEntries.entries]);
+  }, [
+    composerTrigger,
+    selectedProvider,
+    selectedProviderStatus,
+    workspaceEntries.entries,
+    workspaceProviderSkills,
+  ]);
 
   const composerMenuOpen = Boolean(composerTrigger);
   const composerMenuSearchKey = composerTrigger
@@ -2559,7 +2575,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     ? composerTerminalContexts
                     : []
                 }
-                skills={selectedProviderStatus?.skills ?? []}
+                skills={workspaceProviderSkills}
                 {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                 onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                 onChange={onPromptChange}

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -7,6 +7,8 @@ import { type VcsRefTarget } from "@t3tools/client-runtime/state/vcs";
 import type {
   EnvironmentId,
   OrchestrationThread,
+  ProviderInstanceId,
+  ServerProviderSkill,
   ThreadId,
   VcsListRefsResult,
   VcsRef,
@@ -20,6 +22,7 @@ import { appAtomRegistry } from "../rpc/atomRegistry";
 import { orchestrationEnvironment } from "./orchestration";
 import { projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
+import { serverEnvironment } from "./server";
 import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 
@@ -212,6 +215,35 @@ export function useComposerPathSearch(target: ComposerPathSearchTarget) {
     isPending: normalizedTarget.query !== debouncedTarget.query || result.isPending,
     refresh: result.refresh,
   };
+}
+
+/**
+ * Provider skills resolved against the active workspace, for the `$` picker
+ * and inline skill rendering.
+ *
+ * The provider snapshot's `skills` are discovered against the server process
+ * cwd, which only matches the user's repository in the `npx t3`-inside-a-repo
+ * flow — in the desktop app that cwd is unrelated to the project open in the
+ * sidebar, so project-scoped skills never showed up there. This asks the
+ * server to re-run discovery against the workspace's own path and falls back
+ * to the snapshot list while loading, on error (older servers without the
+ * RPC), or when the driver has no workspace-scoped discovery (`skills: null`).
+ */
+export function useWorkspaceProviderSkills(input: {
+  readonly environmentId: EnvironmentId;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly cwd: string | null;
+  readonly snapshotSkills: ReadonlyArray<ServerProviderSkill>;
+}): ReadonlyArray<ServerProviderSkill> {
+  const result = useEnvironmentQuery(
+    input.instanceId !== null && input.cwd !== null
+      ? serverEnvironment.discoverProviderSkills({
+          environmentId: input.environmentId,
+          input: { instanceId: input.instanceId, cwd: input.cwd },
+        })
+      : null,
+  );
+  return result.data?.skills ?? input.snapshotSkills;
 }
 
 export function useCheckpointDiff(

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -307,6 +307,12 @@ export function createServerEnvironmentAtoms<R, E>(
           Stream.mapAccum(Option.none<ServerLifecycleWelcomePayload>, projectServerWelcome),
         ),
     }),
+    discoverProviderSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:discover-provider-skills",
+      tag: WS_METHODS.serverDiscoverProviderSkills,
+      staleTimeMs: 15_000,
+      idleTtlMs: 5 * 60_000,
+    }),
     refreshProviders: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:refresh-providers",
       tag: WS_METHODS.serverRefreshProviders,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -116,6 +116,8 @@ import {
 import {
   ServerConfigStreamEvent,
   ServerConfig,
+  ServerProviderDiscoverSkillsInput,
+  ServerProviderDiscoverSkillsResult,
   ServerProviderUpdateError,
   ServerProviderUpdateInput,
   ServerLifecycleStreamEvent,
@@ -208,6 +210,7 @@ export const WS_METHODS = {
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
   serverUpdateProvider: "server.updateProvider",
+  serverDiscoverProviderSkills: "server.discoverProviderSkills",
   serverUpdateServer: "server.updateServer",
   serverUpsertKeybinding: "server.upsertKeybinding",
   serverRemoveKeybinding: "server.removeKeybinding",
@@ -281,6 +284,12 @@ export const WsServerUpdateProviderRpc = Rpc.make(WS_METHODS.serverUpdateProvide
   payload: ServerProviderUpdateInput,
   success: ServerProviderUpdatedPayload,
   error: Schema.Union([ServerProviderUpdateError, EnvironmentAuthorizationError]),
+});
+
+export const WsServerDiscoverProviderSkillsRpc = Rpc.make(WS_METHODS.serverDiscoverProviderSkills, {
+  payload: ServerProviderDiscoverSkillsInput,
+  success: ServerProviderDiscoverSkillsResult,
+  error: EnvironmentAuthorizationError,
 });
 
 export const WsServerUpdateServerRpc = Rpc.make(WS_METHODS.serverUpdateServer, {
@@ -703,6 +712,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
   WsServerUpdateProviderRpc,
+  WsServerDiscoverProviderSkillsRpc,
   WsServerUpdateServerRpc,
   WsServerUpsertKeybindingRpc,
   WsServerRemoveKeybindingRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -575,6 +575,21 @@ export class ServerProviderUpdateError extends Schema.TaggedErrorClass<ServerPro
   }
 }
 
+export const ServerProviderDiscoverSkillsInput = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  /** Workspace root to resolve project-scoped skills against — the active
+      project's repository path (or worktree), not the server process cwd. */
+  cwd: TrimmedNonEmptyString,
+});
+export type ServerProviderDiscoverSkillsInput = typeof ServerProviderDiscoverSkillsInput.Type;
+
+export const ServerProviderDiscoverSkillsResult = Schema.Struct({
+  /** `null` when the instance's driver has no workspace skill discovery —
+      consumers fall back to the snapshot's `skills` in that case. */
+  skills: Schema.NullOr(Schema.Array(ServerProviderSkill)),
+});
+export type ServerProviderDiscoverSkillsResult = typeof ServerProviderDiscoverSkillsResult.Type;
+
 export const ServerSelfUpdateInput = Schema.Struct({
   /** Exact npm version of the `t3` package to install (never a dist-tag, so
       the server and the acknowledging client agree on what was requested). */


### PR DESCRIPTION
## What

Project-level Claude Code skills (`<project>/.claude/skills/`) now show up in the `$` picker and `/` autocomplete for projects added via the UI in the desktop app. Previously only user-level skills (`~/.claude/skills/`) appeared there, even though project skills executed fine when invoked inside a thread.

Fixes #4544 (open packaged-desktop reproduction), fixes #2048, fixes #2416 (original report: #1283). Reproduced on `0.0.29-nightly.20260725.899`, i.e. after #4414 landed.

## Why #4414 didn't cover the desktop app

`discoverClaudeSkills` (added in #4414) is correct in itself, but it receives `ServerConfig.cwd` — the working directory of the T3 server process. That is only ever the user's repository in the `npx t3`-launched-from-inside-a-repo flow. In the desktop app the server cwd is unrelated to whatever project is open in the sidebar, so the project-scope scan silently found nothing. The snapshot is also global rather than per project, so even with a correct path, one project's skills would leak into every other project's picker.

## How

- New `server.discoverProviderSkills` RPC (`{ instanceId, cwd }` → `{ skills | null }`) that re-runs skill discovery against the active project's own path (or worktree). `skills: null` means "this driver has no workspace-scoped discovery", so clients can distinguish that from "this project has no skills".
- `ProviderInstance` gains an optional `discoverSkills(cwd)` capability. The Claude driver implements it as a closure over its instance config, reusing `discoverClaudeSkills` unchanged — the existing project-wins-on-collision rule and best-effort semantics apply as-is.
- The web app resolves picker/timeline skills through a `useWorkspaceProviderSkills` hook keyed by the thread's workspace (project path or worktree), falling back to the snapshot's skills while loading, on older servers without the RPC, or for drivers that answer `null`.

The `npx t3` flow is unchanged: the snapshot still scans the server cwd, and the per-workspace call returns the same result there.

## Codex

The Codex driver has the same server-cwd assumption (#3040): its snapshot probe passes `process.cwd()` to the app-server `skills/list` call (`CodexProvider.ts`). Not touched here — Codex discovery goes through the app-server JSON-RPC client rather than the filesystem and deserves its own tests. The new per-instance `discoverSkills` capability is the seam to fix it separately.

## Testing

- `ClaudeSkills.test.ts`: new case covering two projects with different skill sets discovered against their own paths (not the process cwd), each seeing only its own project skills plus shared user skills — 7/7 passing.
- `server.test.ts`: new end-to-end WebSocket RPC test verifying the requested cwd reaches discovery and that instances without the capability answer `skills: null` — all 20 ws routing tests passing.
- Typecheck, oxlint, and formatting clean across `contracts`, `client-runtime`, `server`, and `web`.
- Manually verified in the desktop app: project skills appear in the `$` picker for a sidebar-added project whose path differs from the server cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-scoped RPC and UI wiring with graceful fallbacks; no auth or persistence changes. Filesystem discovery is best-effort as before.
> 
> **Overview**
> **Project-level Claude skills** now show in the `$` picker and composer when the desktop app’s open project path differs from the server process cwd.
> 
> Adds **`server.discoverProviderSkills`** (`instanceId` + workspace `cwd` → `skills` or `skills: null`). **`ProviderInstance`** gains optional **`discoverSkills(cwd)`**; the Claude driver implements it via existing **`discoverClaudeSkills`**. The web app uses **`useWorkspaceProviderSkills`** (keyed by active project/worktree) in **ChatView** and **ChatComposer**, falling back to snapshot skills while loading, on older servers, or when the driver returns `null`.
> 
> Tests cover per-project isolation in **`ClaudeSkills.test.ts`** and WebSocket RPC routing in **`server.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce84ea7fae8d248845b343bdcea2f3c1807b7804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->