### PR TITLE
Configure providers per environment

### DIFF
--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -4,12 +4,13 @@ import { Radio as RadioPrimitive } from "@base-ui/react/radio";
 import { CheckIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
+  type EnvironmentId,
   ProviderInstanceId,
   ProviderDriverKind,
   type ProviderInstanceConfig,
 } from "@t3tools/contracts";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
@@ -115,13 +116,20 @@ function validateInstanceId(id: string, existing: ReadonlySet<string>): string |
 }
 
 interface AddProviderInstanceDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  readonly open: boolean;
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly onOpenChange: (open: boolean) => void;
 }
 
-export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderInstanceDialogProps) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+export function AddProviderInstanceDialog({
+  open,
+  environmentId,
+  environmentLabel,
+  onOpenChange,
+}: AddProviderInstanceDialogProps) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
 
   const [wizardStep, setWizardStep] = useState(0);
   const [driver, setDriver] = useState<ProviderDriverKind>(DEFAULT_DRIVER_KIND);
@@ -208,7 +216,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
       toastManager.add({
         type: "success",
         title: "Provider instance added",
-        description: `${driverOption.label} instance '${instanceId}' was added.`,
+        description: `${driverOption.label} instance '${instanceId}' was added to ${environmentLabel}.`,
       });
       onOpenChange(false);
     } catch (error) {
@@ -227,8 +235,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
           <DialogHeader>
             <DialogTitle>Add provider instance</DialogTitle>
             <DialogDescription>
-              Configure an additional provider instance — for example, a second Codex install
-              pointed at a different workspace.
+              Configure an additional provider instance on {environmentLabel}.
             </DialogDescription>
             <AddProviderInstanceWizardSteps
               currentStep={wizardStep}

--- a/apps/web/src/components/settings/ProviderEnvironmentSelector.tsx
+++ b/apps/web/src/components/settings/ProviderEnvironmentSelector.tsx
@@ -1,0 +1,77 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { CloudIcon, MonitorIcon } from "lucide-react";
+import { useMemo } from "react";
+
+import type { EnvironmentPresentation } from "../../state/environments";
+import {
+  Select,
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+interface ProviderEnvironmentSelectorProps {
+  readonly environmentId: EnvironmentId;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
+}
+
+export function ProviderEnvironmentSelector({
+  environmentId,
+  environments,
+  primaryEnvironmentId,
+  onEnvironmentChange,
+}: ProviderEnvironmentSelectorProps) {
+  const selectedEnvironment =
+    environments.find((environment) => environment.environmentId === environmentId) ?? null;
+  const items = useMemo(
+    () =>
+      environments.map((environment) => ({
+        value: environment.environmentId,
+        label: environment.label,
+      })),
+    [environments],
+  );
+
+  return (
+    <Select
+      value={environmentId}
+      items={items}
+      onValueChange={(value) => onEnvironmentChange(value as EnvironmentId)}
+    >
+      <SelectTrigger
+        size="sm"
+        className="w-36 sm:w-52"
+        aria-label="Configure providers on environment"
+      >
+        {environmentId === primaryEnvironmentId ? (
+          <MonitorIcon className="size-3.5" />
+        ) : (
+          <CloudIcon className="size-3.5" />
+        )}
+        <SelectValue>{selectedEnvironment?.label ?? "Select environment"}</SelectValue>
+      </SelectTrigger>
+      <SelectPopup align="end" alignItemWithTrigger={false}>
+        <SelectGroup>
+          <SelectGroupLabel>Configure providers on</SelectGroupLabel>
+          {environments.map((environment) => (
+            <SelectItem key={environment.environmentId} value={environment.environmentId}>
+              <span className="inline-flex items-center gap-1.5">
+                {environment.environmentId === primaryEnvironmentId ? (
+                  <MonitorIcon className="size-3.5" />
+                ) : (
+                  <CloudIcon className="size-3.5" />
+                )}
+                {environment.label}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectPopup>
+    </Select>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceId,
   type ProviderInstanceConfig,
@@ -10,7 +11,68 @@ import {
   formatDiagnosticsDescription,
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
+  resolveProviderSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
+
+const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000001");
+const REMOTE_ENVIRONMENT_ID = EnvironmentId.make("00000000-0000-4000-8000-000000000002");
+
+describe("provider settings environment selection", () => {
+  it("preserves an explicit selected environment", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
+        selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: LOCAL_ENVIRONMENT_ID,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("defaults to the primary environment in managed mode", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [REMOTE_ENVIRONMENT_ID, LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(LOCAL_ENVIRONMENT_ID);
+  });
+
+  it("defaults to the active remote environment in client-only mode", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID, REMOTE_ENVIRONMENT_ID],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(REMOTE_ENVIRONMENT_ID);
+  });
+
+  it("falls back when the selected environment is no longer available", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [LOCAL_ENVIRONMENT_ID],
+        selectedEnvironmentId: REMOTE_ENVIRONMENT_ID,
+        primaryEnvironmentId: LOCAL_ENVIRONMENT_ID,
+        activeEnvironmentId: REMOTE_ENVIRONMENT_ID,
+      }),
+    ).toBe(LOCAL_ENVIRONMENT_ID);
+  });
+
+  it("returns null when no environments are available", () => {
+    expect(
+      resolveProviderSettingsEnvironmentId({
+        availableEnvironmentIds: [],
+        selectedEnvironmentId: null,
+        primaryEnvironmentId: null,
+        activeEnvironmentId: null,
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("project grouping toggle", () => {
   it("enables repository grouping and disables into separate projects", () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,4 +1,5 @@
 import type {
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
@@ -7,6 +8,29 @@ import type {
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+
+export function resolveProviderSettingsEnvironmentId(input: {
+  readonly availableEnvironmentIds: ReadonlyArray<EnvironmentId>;
+  readonly selectedEnvironmentId: EnvironmentId | null;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly activeEnvironmentId: EnvironmentId | null;
+}): EnvironmentId | null {
+  const availableIds = new Set(input.availableEnvironmentIds);
+  const candidates = [
+    input.selectedEnvironmentId,
+    input.primaryEnvironmentId,
+    input.activeEnvironmentId,
+    input.availableEnvironmentIds[0] ?? null,
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate !== null && availableIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1407,8 +1407,6 @@ function ProviderSettingsEnvironmentPanel({
   const deleteProviderInstance = (id: ProviderInstanceId) => {
     updateSettings({
       providerInstances: withoutProviderInstanceKey(settings.providerInstances, id),
-      providerModelPreferences: withoutProviderInstanceKey(settings.providerModelPreferences, id),
-      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], id),
     });
   };
 
@@ -1471,11 +1469,6 @@ function ProviderSettingsEnvironmentPanel({
         [driverKind]: defaultLegacyProvider,
       } as typeof settings.providers,
       providerInstances: withoutProviderInstanceKey(settings.providerInstances, defaultInstanceId),
-      providerModelPreferences: withoutProviderInstanceKey(
-        settings.providerModelPreferences,
-        defaultInstanceId,
-      ),
-      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], defaultInstanceId),
     });
   };
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -6,6 +6,7 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   defaultInstanceIdForDriver,
   type DesktopUpdateChannel,
+  type EnvironmentId,
   PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
   type ProviderInstanceConfig,
@@ -43,7 +44,12 @@ import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useTheme } from "../../hooks/useTheme";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  useEnvironmentSettings,
+  usePrimarySettings,
+  useUpdateEnvironmentSettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -61,8 +67,12 @@ import {
   primaryServerProvidersAtom,
   serverEnvironment,
 } from "../../state/server";
-import { usePrimaryEnvironment } from "../../state/environments";
-import { useProjects } from "../../state/entities";
+import {
+  type EnvironmentPresentation,
+  useEnvironments,
+  usePrimaryEnvironmentId,
+} from "../../state/environments";
+import { useActiveEnvironmentId, useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel, getRelativeTimeState } from "../../timestampFormat";
 import { Button } from "../ui/button";
@@ -80,6 +90,7 @@ import {
   type ProviderUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
+import { ProviderEnvironmentSelector } from "./ProviderEnvironmentSelector";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   buildProviderInstanceUpdatePatch,
@@ -88,6 +99,7 @@ import {
   projectGroupingModeFromToggle,
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
+  resolveProviderSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -1097,10 +1109,74 @@ export function GeneralSettingsPanel() {
 }
 
 export function ProviderSettingsPanel() {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const primaryEnvironment = usePrimaryEnvironment();
+  const { isReady, environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<EnvironmentId | null>(null);
+  const environmentId = resolveProviderSettingsEnvironmentId({
+    availableEnvironmentIds: environments.map((environment) => environment.environmentId),
+    selectedEnvironmentId,
+    primaryEnvironmentId,
+    activeEnvironmentId,
+  });
+  const environment =
+    environmentId === null
+      ? null
+      : (environments.find((candidate) => candidate.environmentId === environmentId) ?? null);
+
+  if (environmentId === null || environment === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Providers">
+          <SettingsRow
+            title={isReady ? "No connected environments" : "Loading environments"}
+            description={
+              isReady
+                ? "Connect an environment before configuring its provider accounts."
+                : "Waiting for available environments."
+            }
+            control={
+              isReady ? (
+                <Button render={<Link to="/settings/connections" />} size="xs" variant="outline">
+                  Open connections
+                </Button>
+              ) : null
+            }
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
+
+  return (
+    <ProviderSettingsEnvironmentPanel
+      key={environmentId}
+      environmentId={environmentId}
+      environmentLabel={environment.label}
+      environments={environments}
+      primaryEnvironmentId={primaryEnvironmentId}
+      onEnvironmentChange={setSelectedEnvironmentId}
+    />
+  );
+}
+
+function ProviderSettingsEnvironmentPanel({
+  environmentId,
+  environmentLabel,
+  environments,
+  primaryEnvironmentId,
+  onEnvironmentChange,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string;
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+  readonly primaryEnvironmentId: EnvironmentId | null;
+  readonly onEnvironmentChange: (environmentId: EnvironmentId) => void;
+}) {
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
+  const serverSettings = useAtomValue(serverEnvironment.settingsValueAtom(environmentId));
+  const serverProviders = useAtomValue(serverEnvironment.providersValueAtom(environmentId)) ?? [];
   const refreshServerProviders = useAtomCommand(serverEnvironment.refreshProviders, {
     reportFailure: false,
   });
@@ -1114,6 +1190,15 @@ export function ProviderSettingsPanel() {
   >(() => new Set());
   const [openInstanceDetails, setOpenInstanceDetails] = useState<Record<string, boolean>>({});
   const refreshingRef = useRef(false);
+
+  const environmentSelector = (
+    <ProviderEnvironmentSelector
+      environmentId={environmentId}
+      environments={environments}
+      primaryEnvironmentId={primaryEnvironmentId}
+      onEnvironmentChange={onEnvironmentChange}
+    />
+  );
 
   const providerUpdateCandidates = useMemo(
     () => collectProviderUpdateCandidates(serverProviders),
@@ -1145,14 +1230,9 @@ export function ProviderSettingsPanel() {
     if (refreshingRef.current) return;
     refreshingRef.current = true;
     setIsRefreshingProviders(true);
-    if (!primaryEnvironment) {
-      refreshingRef.current = false;
-      setIsRefreshingProviders(false);
-      return;
-    }
     void (async () => {
       const result = await refreshServerProviders({
-        environmentId: primaryEnvironment.environmentId,
+        environmentId,
         input: {},
       });
       refreshingRef.current = false;
@@ -1160,16 +1240,15 @@ export function ProviderSettingsPanel() {
       if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
         console.warn("Failed to refresh providers", {
           operation: "refresh-providers",
-          environmentId: primaryEnvironment.environmentId,
+          environmentId,
           ...safeErrorLogAttributes(squashAtomCommandFailure(result)),
         });
       }
     })();
-  }, [primaryEnvironment, refreshServerProviders]);
+  }, [environmentId, refreshServerProviders]);
 
   const runProviderUpdate = useCallback(
     async (candidate: ProviderUpdateCandidate) => {
-      if (!primaryEnvironment) return;
       let started = false;
       setUpdatingProviderDrivers((previous) => {
         if (previous.has(candidate.driver)) {
@@ -1185,7 +1264,7 @@ export function ProviderSettingsPanel() {
       }
 
       const result = await updateProvider({
-        environmentId: primaryEnvironment.environmentId,
+        environmentId,
         input: {
           provider: candidate.driver,
           instanceId: candidate.instanceId,
@@ -1213,8 +1292,21 @@ export function ProviderSettingsPanel() {
         return next;
       });
     },
-    [primaryEnvironment, updateProvider],
+    [environmentId, updateProvider],
   );
+
+  if (serverSettings === null) {
+    return (
+      <SettingsPageContainer>
+        <SettingsSection title="Providers" headerAction={environmentSelector}>
+          <SettingsRow
+            title={`Connecting to ${environmentLabel}`}
+            description="Provider settings will be available when this environment connects."
+          />
+        </SettingsSection>
+      </SettingsPageContainer>
+    );
+  }
 
   interface InstanceRow {
     readonly instanceId: ProviderInstanceId;
@@ -1393,6 +1485,7 @@ export function ProviderSettingsPanel() {
         title="Providers"
         headerAction={
           <div className="flex items-center gap-1.5">
+            {environmentSelector}
             <ProviderLastChecked lastCheckedAt={lastCheckedAt} />
             <Tooltip>
               <TooltipTrigger
@@ -1535,7 +1628,12 @@ export function ProviderSettingsPanel() {
       </SettingsSection>
 
       {isAddInstanceDialogOpen ? (
-        <AddProviderInstanceDialog open onOpenChange={setIsAddInstanceDialogOpen} />
+        <AddProviderInstanceDialog
+          open
+          environmentId={environmentId}
+          environmentLabel={environmentLabel}
+          onOpenChange={setIsAddInstanceDialogOpen}
+        />
       ) : null}
     </SettingsPageContainer>
   );


### PR DESCRIPTION
## What Changed

- Added an environment selector to Provider settings.
- Routed provider configuration, status refreshes, updates, and new instances to the selected environment.
- Defaulted managed deployments to the primary environment and client-only deployments to the active/first available environment.
- Added safe loading and no-environment states plus focused environment-selection tests.

## Why

Provider settings were implicitly tied to the primary server. In client-only mode, or when multiple T3 environments are connected, that made it impossible to see which machine owned an account configuration and could route updates to the wrong target.

## UI Changes

| Before | After |
| --- | --- |
| ![Provider settings before](https://raw.githubusercontent.com/colonelpanic8/t3code/0b426998677b830e3491c21e99b69b59f6a8ff49/provider-settings-before.png) | ![Environment-scoped provider settings](https://raw.githubusercontent.com/colonelpanic8/t3code/0b426998677b830e3491c21e99b69b59f6a8ff49/provider-settings-after.png) |

<details>
<summary>Mobile-width verification</summary>

![Environment-scoped provider settings at 390px](https://raw.githubusercontent.com/colonelpanic8/t3code/0b426998677b830e3491c21e99b69b59f6a8ff49/provider-settings-after-mobile.png)

</details>

The real add-instance flow was exercised against the selected environment. The resulting provider instance was persisted to that environment and the confirmation toast named the target environment.

## Checklist

- [x] `vp check`
- [x] `vp test run src/components/settings/SettingsPanels.logic.test.ts src/hooks/useSettings.test.ts --project unit` (13 tests)
- [x] Type-aware lint and type checking for the five changed files
- [x] Integrated desktop and 390px web verification with zero browser errors or warnings
- [ ] `vp run typecheck` — blocked by pre-existing `@effect/vitest` export errors in `oxlint-plugin-t3code`; clean `origin/main` fails with the same errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where provider accounts are read and written across environments, which could mis-route updates if selection logic is wrong; the reduced cleanup on delete/reset may leave orphaned model prefs or favorites for removed instances.
> 
> **Overview**
> Provider settings are no longer tied to the primary server only. The Providers panel adds an **environment selector** so reads, edits, refreshes, and one-click provider updates target the chosen connected environment, with loading and “no environments” empty states.
> 
> **`resolveProviderSettingsEnvironmentId`** picks the effective environment: explicit selection, then primary (managed), then active/first available (client-only), with fallback when a stale selection disappears. **`AddProviderInstanceDialog`** now requires `environmentId` / `environmentLabel` and persists new instances via per-environment settings; success copy names the environment.
> 
> Deleting a custom instance or resetting a default provider **only** updates `providerInstances` (and legacy `providers` on reset)—it no longer strips `providerModelPreferences` or `favorites` in the same patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be176c3b75a382db6143cce59ebc9aba6613c2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope provider settings and instance management to a selected environment
> - Provider settings are now resolved and displayed per environment using a new `ProviderSettingsEnvironmentPanel` component in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/4548/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18), replacing the previous primary-settings-only approach.
> - A new `ProviderEnvironmentSelector` component in [ProviderEnvironmentSelector.tsx](https://github.com/pingdotgg/t3code/pull/4548/files#diff-fec018fe618fe7ffc607592c213309710e4c7b4831b390b3806a987808222a6f) lets users switch the active environment for provider configuration.
> - Environment resolution logic is extracted into `resolveProviderSettingsEnvironmentId` in [SettingsPanels.logic.ts](https://github.com/pingdotgg/t3code/pull/4548/files#diff-bad687287a18d0a58c30735640fef99f0f90283727a66f89de22cffd8cb302c4), which handles fallback to primary or active environment when no explicit selection exists.
> - `AddProviderInstanceDialog` now accepts `environmentId` and `environmentLabel` props and stores new instances against the selected environment.
> - Behavioral Change: Deleting provider instances or reverting default providers no longer automatically removes favorites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be176c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->