### PR TITLE
fix(desktop): surface Tailscale Serve setup failures with admin link

### DIFF
--- a/apps/desktop/src/app/DesktopLifecycle.relaunch.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.relaunch.test.ts
@@ -1,0 +1,64 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { resolveDesktopRelaunchOptions } from "./resolveDesktopRelaunchOptions.ts";
+
+describe("resolveDesktopRelaunchOptions", () => {
+  it.effect("relaunches the outer AppImage path instead of the temporary mount binary", () =>
+    Effect.sync(() => {
+      const options = resolveDesktopRelaunchOptions({
+        appImagePath: "/home/user/T3-Code-0.0.28-x86_64.AppImage",
+        execPath: "/tmp/.mount_t3_codXXXX/t3-code",
+        argv: ["/tmp/.mount_t3_codXXXX/t3-code", "--some-internal-flag"],
+      });
+
+      assert.deepEqual(options, {
+        execPath: "/home/user/T3-Code-0.0.28-x86_64.AppImage",
+        args: [],
+      });
+    }),
+  );
+
+  it.effect("trims APPIMAGE and ignores empty values", () =>
+    Effect.sync(() => {
+      assert.deepEqual(
+        resolveDesktopRelaunchOptions({
+          appImagePath: "  /opt/T3-Code.AppImage  ",
+          execPath: "/tmp/.mount/app",
+          argv: ["/tmp/.mount/app"],
+        }),
+        {
+          execPath: "/opt/T3-Code.AppImage",
+          args: [],
+        },
+      );
+
+      assert.deepEqual(
+        resolveDesktopRelaunchOptions({
+          appImagePath: "   ",
+          execPath: "/usr/bin/t3-code",
+          argv: ["/usr/bin/t3-code", "--flag"],
+        }),
+        {
+          execPath: "/usr/bin/t3-code",
+          args: ["--flag"],
+        },
+      );
+    }),
+  );
+
+  it.effect("preserves packaged non-AppImage exec path and argv", () =>
+    Effect.sync(() => {
+      const options = resolveDesktopRelaunchOptions({
+        appImagePath: null,
+        execPath: "/Applications/T3 Code.app/Contents/MacOS/T3 Code",
+        argv: ["/Applications/T3 Code.app/Contents/MacOS/T3 Code", "--inspect"],
+      });
+
+      assert.deepEqual(options, {
+        execPath: "/Applications/T3 Code.app/Contents/MacOS/T3 Code",
+        args: ["--inspect"],
+      });
+    }),
+  );
+});

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -14,6 +14,7 @@ import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
+import { resolveDesktopRelaunchOptions } from "./resolveDesktopRelaunchOptions.ts";
 
 export class DesktopLifecycleRelaunchError extends Schema.TaggedErrorClass<DesktopLifecycleRelaunchError>()(
   "DesktopLifecycleRelaunchError",
@@ -26,6 +27,8 @@ export class DesktopLifecycleRelaunchError extends Schema.TaggedErrorClass<Deskt
     return `Desktop relaunch failed for reason "${this.reason}".`;
   }
 }
+
+export { resolveDesktopRelaunchOptions } from "./resolveDesktopRelaunchOptions.ts";
 
 export type DesktopLifecycleRuntimeServices =
   | DesktopEnvironment.DesktopEnvironment
@@ -154,10 +157,19 @@ export const make = DesktopLifecycle.of({
         yield* electronApp.exit(75);
         return;
       }
-      yield* electronApp.relaunch({
+      const relaunchOptions = resolveDesktopRelaunchOptions({
+        // AppImage runtime injects APPIMAGE; see resolveDesktopRelaunchOptions.
+        appImagePath: process.env.APPIMAGE,
         execPath: process.execPath,
-        args: process.argv.slice(1),
+        argv: process.argv,
       });
+      yield* logLifecycleInfo("desktop relaunch exec", {
+        reason,
+        execPath: relaunchOptions.execPath,
+        argumentCount: relaunchOptions.args?.length ?? 0,
+        isAppImage: Boolean(process.env.APPIMAGE?.trim()),
+      });
+      yield* electronApp.relaunch(relaunchOptions);
       yield* electronApp.exit(0);
     }).pipe(
       Effect.catchCause((cause) => {

--- a/apps/desktop/src/app/resolveDesktopRelaunchOptions.ts
+++ b/apps/desktop/src/app/resolveDesktopRelaunchOptions.ts
@@ -1,0 +1,31 @@
+export interface DesktopRelaunchOptions {
+  readonly execPath: string;
+  readonly args: string[];
+}
+
+/**
+ * Resolve Electron relaunch options for the current packaging mode.
+ *
+ * AppImage mounts the payload under a temporary directory and sets `APPIMAGE`
+ * to the outer `.AppImage` path. `process.execPath` / `process.argv` point at
+ * the mount, which is unmounted when the process exits — so relaunching with
+ * those paths exits and never comes back. Prefer `$APPIMAGE` with empty args.
+ */
+export function resolveDesktopRelaunchOptions(input: {
+  readonly appImagePath?: string | null | undefined;
+  readonly execPath: string;
+  readonly argv: readonly string[];
+}): DesktopRelaunchOptions {
+  const appImagePath = input.appImagePath?.trim();
+  if (appImagePath) {
+    return {
+      execPath: appImagePath,
+      args: [],
+    };
+  }
+
+  return {
+    execPath: input.execPath,
+    args: input.argv.slice(1),
+  };
+}

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -330,6 +330,39 @@ describe("DesktopServerExposure", () => {
       applyWslWindowsFallbackInMemory: Effect.die("unexpected WSL Windows fallback"),
     } satisfies DesktopAppSettings.DesktopAppSettings["Service"]);
 
+    const tailscaleCommands: Array<{
+      readonly command: string;
+      readonly args: ReadonlyArray<string>;
+    }> = [];
+    const recordingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as {
+          readonly command: string;
+          readonly args: ReadonlyArray<string>;
+        };
+        tailscaleCommands.push({
+          command: childProcess.command,
+          args: childProcess.args,
+        });
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode("{}")),
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
     return withHarness(
       lanNetworkInterfaces,
       Effect.gen(function* () {
@@ -369,9 +402,22 @@ describe("DesktopServerExposure", () => {
           "Failed to persist desktop Tailscale Serve settings (enabled: true, port: 8443).",
         );
         assert.notInclude(tailscaleError.message, diskFailure.message);
+
+        // Preflight turned Serve on; persistence failure must roll it back so we
+        // do not leave HTTPS exposure active while settings still say disabled.
+        assert.deepEqual(tailscaleCommands, [
+          {
+            command: "tailscale",
+            args: ["serve", "--bg", "--https=8443", "http://127.0.0.1:4173"],
+          },
+          {
+            command: "tailscale",
+            args: ["serve", "--https=8443", "off"],
+          },
+        ]);
       }),
       {},
-      undefined,
+      recordingSpawner,
       settingsLayer,
     );
   });

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -209,7 +209,7 @@ describe("DesktopServerExposure", () => {
     ),
   );
 
-  it.effect("persists tailscale serve preferences atomically and reports no-op updates", () =>
+  it.effect("persists tailscale serve preferences atomically after a successful preflight", () =>
     withHarness(
       emptyNetworkInterfaces,
       Effect.gen(function* () {
@@ -227,11 +227,14 @@ describe("DesktopServerExposure", () => {
         assert.equal(changed.state.tailscaleServeEnabled, true);
         assert.equal(changed.state.tailscaleServePort, 8443);
 
-        const unchanged = yield* serverExposure.setTailscaleServeEnabled({
+        // Re-enabling still relaunches so the child server re-binds Serve to
+        // its listen port, even when the preference document is unchanged.
+        const reenabled = yield* serverExposure.setTailscaleServeEnabled({
           enabled: true,
           port: 8443,
         });
-        assert.equal(unchanged.requiresRelaunch, false);
+        assert.equal(reenabled.requiresRelaunch, true);
+        assert.equal(reenabled.state.tailscaleServeEnabled, true);
 
         const persisted = yield* settings.get;
         assert.equal(persisted.tailscaleServeEnabled, true);
@@ -239,6 +242,72 @@ describe("DesktopServerExposure", () => {
       }),
     ),
   );
+
+  it.effect("fails enablement with CLI guidance when Tailscale Serve is not available", () => {
+    const configureUrl = "https://login.tailscale.com/f/serve?node=nExampleNodeIdForTests";
+    const failingSpawner = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make((command) => {
+        const childProcess = command as unknown as {
+          readonly command: string;
+          readonly args: ReadonlyArray<string>;
+        };
+        const isServe = childProcess.args[0] === "serve";
+        const stderr = isServe
+          ? [
+              "Serve is not enabled on your tailnet.",
+              "To enable, visit:",
+              "",
+              `         ${configureUrl}`,
+            ].join("\n")
+          : "";
+        return Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(isServe ? 1 : 0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            unref: Effect.succeed(Effect.void),
+            stdin: Sink.drain,
+            stdout: Stream.make(encoder.encode(isServe ? "" : "{}")),
+            stderr: Stream.make(encoder.encode(stderr)),
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+          }),
+        );
+      }),
+    );
+
+    return withHarness(
+      emptyNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+
+        yield* settings.load;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const error = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: true, port: 443 })
+          .pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopServerExposure.DesktopTailscaleServeConfigureError);
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureSetTailscaleServeError(error));
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(error));
+        assert.equal(error.configureUrl, configureUrl);
+        assert.equal(
+          error.message,
+          `Serve is not enabled on your tailnet. To enable, visit: ${configureUrl}`,
+        );
+
+        const persisted = yield* settings.get;
+        assert.equal(persisted.tailscaleServeEnabled, false);
+      }),
+      {},
+      failingSpawner,
+    );
+  });
 
   it.effect("preserves persistence request context and the settings failure chain", () => {
     const diskFailure = new Error("disk exploded");

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -295,9 +295,16 @@ describe("DesktopServerExposure", () => {
         assert.instanceOf(error, DesktopServerExposure.DesktopTailscaleServeConfigureError);
         assert.isTrue(DesktopServerExposure.isDesktopServerExposureSetTailscaleServeError(error));
         assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(error));
+        assert.equal(error.detail, "Serve is not enabled on your tailnet.");
         assert.equal(error.configureUrl, configureUrl);
+        assert.equal(error.cause?._tag, "TailscaleCommandExitError");
         assert.equal(
           error.message,
+          `Serve is not enabled on your tailnet. To enable, visit: ${configureUrl}`,
+        );
+        // Wrapper message is structural; underlying CLI error remains on cause.
+        assert.equal(
+          error.cause?.message,
           `Serve is not enabled on your tailnet. To enable, visit: ${configureUrl}`,
         );
 

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -10,6 +10,7 @@ import {
   type DesktopServerExposureState,
 } from "@t3tools/contracts";
 import {
+  disableTailscaleServe,
   ensureTailscaleServe,
   formatTailscaleServeUserMessage,
   readTailscaleStatus,
@@ -525,7 +526,10 @@ export const make = Effect.gen(function* () {
 
       // Preflight Serve configuration before persisting so Enable can fail loudly
       // with the same CLI guidance (including the admin setup URL) instead of a
-      // silent restart that leaves the toggle unchecked.
+      // silent restart that leaves the toggle unchecked. If settings write fails
+      // after Serve is already active, roll Serve back so we do not leave
+      // unintended network exposure with UI/settings still showing disabled.
+      let preflightedServePort: number | null = null;
       if (input.enabled) {
         const current = yield* Ref.get(stateRef);
         const servePort = input.port ?? current.tailscaleServePort;
@@ -558,6 +562,7 @@ export const make = Effect.gen(function* () {
             });
           }),
         );
+        preflightedServePort = servePort;
       }
 
       const result = yield* desktopSettings
@@ -573,6 +578,18 @@ export const make = Effect.gen(function* () {
                 port: input.port ?? null,
                 cause,
               }),
+          ),
+          Effect.tapError(() =>
+            preflightedServePort === null
+              ? Effect.void
+              : disableTailscaleServe({ servePort: preflightedServePort }).pipe(
+                  Effect.provideService(
+                    ChildProcessSpawner.ChildProcessSpawner,
+                    childProcessSpawner,
+                  ),
+                  // Best-effort: still surface the original persistence failure.
+                  Effect.ignore,
+                ),
           ),
         );
 

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -9,7 +9,11 @@ import {
   type DesktopServerExposureMode,
   type DesktopServerExposureState,
 } from "@t3tools/contracts";
-import { readTailscaleStatus } from "@t3tools/tailscale";
+import {
+  ensureTailscaleServe,
+  formatTailscaleServeUserMessage,
+  readTailscaleStatus,
+} from "@t3tools/tailscale";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -239,6 +243,21 @@ export class DesktopTailscaleServePersistenceError extends Schema.TaggedErrorCla
   }
 }
 
+export class DesktopTailscaleServeConfigureError extends Schema.TaggedErrorClass<DesktopTailscaleServeConfigureError>()(
+  "DesktopTailscaleServeConfigureError",
+  {
+    enabled: Schema.Boolean,
+    port: Schema.NullOr(Schema.Number),
+    localPort: Schema.Number,
+    reason: Schema.String,
+    configureUrl: Schema.NullOr(Schema.String),
+  },
+) {
+  override get message(): string {
+    return this.reason;
+  }
+}
+
 export const DesktopServerExposureSetModeError = Schema.Union([
   DesktopServerExposureNoNetworkAddressError,
   DesktopServerExposureModePersistenceError,
@@ -246,10 +265,21 @@ export const DesktopServerExposureSetModeError = Schema.Union([
 export type DesktopServerExposureSetModeError = typeof DesktopServerExposureSetModeError.Type;
 export const isDesktopServerExposureSetModeError = Schema.is(DesktopServerExposureSetModeError);
 
+export const DesktopServerExposureSetTailscaleServeError = Schema.Union([
+  DesktopTailscaleServePersistenceError,
+  DesktopTailscaleServeConfigureError,
+]);
+export type DesktopServerExposureSetTailscaleServeError =
+  typeof DesktopServerExposureSetTailscaleServeError.Type;
+export const isDesktopServerExposureSetTailscaleServeError = Schema.is(
+  DesktopServerExposureSetTailscaleServeError,
+);
+
 export const DesktopServerExposureError = Schema.Union([
   DesktopServerExposureNoNetworkAddressError,
   DesktopServerExposureModePersistenceError,
   DesktopTailscaleServePersistenceError,
+  DesktopTailscaleServeConfigureError,
 ]);
 export type DesktopServerExposureError = typeof DesktopServerExposureError.Type;
 export const isDesktopServerExposureError = Schema.is(DesktopServerExposureError);
@@ -281,7 +311,7 @@ export class DesktopServerExposure extends Context.Service<
     readonly setTailscaleServeEnabled: (input: {
       readonly enabled: boolean;
       readonly port?: number;
-    }) => Effect.Effect<DesktopServerExposureChange, DesktopTailscaleServePersistenceError>;
+    }) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposureSetTailscaleServeError>;
     readonly getAdvertisedEndpoints: Effect.Effect<readonly AdvertisedEndpoint[]>;
   }
 >()("@t3tools/desktop/backend/DesktopServerExposure") {}
@@ -492,6 +522,44 @@ export const make = Effect.gen(function* () {
         enabled: input.enabled,
         ...(input.port === undefined ? {} : { port: input.port }),
       });
+
+      // Preflight Serve configuration before persisting so Enable can fail loudly
+      // with the same CLI guidance (including the admin setup URL) instead of a
+      // silent restart that leaves the toggle unchecked.
+      if (input.enabled) {
+        const current = yield* Ref.get(stateRef);
+        const servePort = input.port ?? current.tailscaleServePort;
+        const localPort = current.port;
+        if (localPort <= 0) {
+          return yield* new DesktopTailscaleServeConfigureError({
+            enabled: true,
+            port: servePort,
+            localPort,
+            reason: "Local backend is not ready yet. Try again in a moment.",
+            configureUrl: null,
+          });
+        }
+
+        yield* ensureTailscaleServe({
+          localPort,
+          servePort,
+          localHost: "127.0.0.1",
+        }).pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+          Effect.mapError((cause) => {
+            const configureUrl =
+              cause._tag === "TailscaleCommandExitError" ? (cause.configureUrl ?? null) : null;
+            return new DesktopTailscaleServeConfigureError({
+              enabled: true,
+              port: servePort,
+              localPort,
+              reason: formatTailscaleServeUserMessage(cause),
+              configureUrl,
+            });
+          }),
+        );
+      }
+
       const result = yield* desktopSettings
         .setTailscaleServe({
           enabled: input.enabled,
@@ -516,7 +584,9 @@ export const make = Effect.gen(function* () {
 
       return {
         state: toContractState(nextState),
-        requiresRelaunch: result.changed,
+        // Always relaunch after a successful enable preflight so the child
+        // server re-binds Serve to its current listen port (which may change).
+        requiresRelaunch: result.changed || input.enabled,
       };
     },
   );

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -12,8 +12,8 @@ import {
 import {
   disableTailscaleServe,
   ensureTailscaleServe,
-  formatTailscaleServeUserMessage,
   readTailscaleStatus,
+  TailscaleCommandError,
 } from "@t3tools/tailscale";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -250,12 +250,34 @@ export class DesktopTailscaleServeConfigureError extends Schema.TaggedErrorClass
     enabled: Schema.Boolean,
     port: Schema.NullOr(Schema.Number),
     localPort: Schema.Number,
-    reason: Schema.String,
+    /**
+     * Safe CLI summary extracted from known `tailscale serve` patterns.
+     * Never raw stderr; optional when this is a pure validation failure.
+     */
+    detail: Schema.optionalKey(Schema.String),
+    /** Admin URL from the CLI (`login.tailscale.com/f/serve...`) when present. */
     configureUrl: Schema.NullOr(Schema.String),
+    /** Immediate CLI failure when configuration was attempted; absent for validation-only errors. */
+    cause: Schema.optionalKey(TailscaleCommandError),
   },
 ) {
   override get message(): string {
-    return this.reason;
+    // Derive only from structural attributes — never cause.message.
+    if (this.localPort <= 0 && this.cause === undefined) {
+      return "Local backend is not ready yet. Try again in a moment.";
+    }
+    const parts: string[] = [];
+    if (this.detail !== undefined) {
+      parts.push(this.detail);
+    } else {
+      parts.push(
+        `Failed to configure Tailscale Serve for the local backend on port ${this.localPort}.`,
+      );
+    }
+    if (this.configureUrl !== null) {
+      parts.push(`To enable, visit: ${this.configureUrl}`);
+    }
+    return parts.join(" ");
   }
 }
 
@@ -539,7 +561,6 @@ export const make = Effect.gen(function* () {
             enabled: true,
             port: servePort,
             localPort,
-            reason: "Local backend is not ready yet. Try again in a moment.",
             configureUrl: null,
           });
         }
@@ -551,14 +572,19 @@ export const make = Effect.gen(function* () {
         }).pipe(
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
           Effect.mapError((cause) => {
+            // Lift only safe structural diagnostics from the CLI error; keep the
+            // full TailscaleCommandError as cause for the error chain/stack.
+            const exitDetail =
+              cause._tag === "TailscaleCommandExitError" ? cause.detail : undefined;
             const configureUrl =
               cause._tag === "TailscaleCommandExitError" ? (cause.configureUrl ?? null) : null;
             return new DesktopTailscaleServeConfigureError({
               enabled: true,
               port: servePort,
               localPort,
-              reason: formatTailscaleServeUserMessage(cause),
+              ...(exitDetail === undefined ? {} : { detail: exitDetail }),
               configureUrl,
+              cause,
             });
           }),
         );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -93,7 +93,11 @@ import {
 import { orchestrationHttpApiLayer } from "./orchestration/http.ts";
 import * as NetService from "@t3tools/shared/Net";
 import * as RelayClient from "@t3tools/shared/relayClient";
-import { disableTailscaleServe, ensureTailscaleServe } from "@t3tools/tailscale";
+import {
+  disableTailscaleServe,
+  ensureTailscaleServe,
+  formatTailscaleServeUserMessage,
+} from "@t3tools/tailscale";
 
 // Effect's default preemptive shutdown waits 20s before finalizing request scopes.
 // T3's primary transport is long-lived WebSocket RPC, whose Effect scope finalizer
@@ -430,6 +434,7 @@ export const makeServerLayer = Layer.unwrap(
                 Effect.catch((cause) =>
                   Effect.logWarning("Failed to configure Tailscale Serve", {
                     cause,
+                    message: formatTailscaleServeUserMessage(cause),
                     localPort,
                     servePort: config.tailscaleServePort,
                   }).pipe(Effect.as(null)),

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -137,6 +137,26 @@ import { CloudEnvironmentConnectRows } from "../cloud/CloudEnvironmentConnectLis
 import { ITEM_ROW_CLASSNAME, ITEM_ROW_INNER_CLASSNAME } from "./itemRows";
 
 const DEFAULT_TAILSCALE_SERVE_PORT = 443;
+
+/** Matches the admin URL Tailscale CLI prints when Serve is disabled on the tailnet. */
+const TAILSCALE_SERVE_CONFIGURE_URL_PATTERN =
+  /https:\/\/login\.tailscale\.com\/f\/serve\?[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+/i;
+
+function extractTailscaleServeConfigureUrl(text: string): string | null {
+  const match = text.match(TAILSCALE_SERVE_CONFIGURE_URL_PATTERN);
+  if (!match?.[0] || match[0].length > 500) {
+    return null;
+  }
+  try {
+    const parsed = new URL(match[0]);
+    if (parsed.protocol !== "https:") return null;
+    if (parsed.hostname !== "login.tailscale.com") return null;
+    if (!parsed.pathname.startsWith("/f/serve")) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
 const EMPTY_ADVERTISED_ENDPOINTS: ReadonlyArray<AdvertisedEndpoint> = [];
 const EMPTY_DISCOVERED_SSH_HOSTS: ReadonlyArray<DesktopDiscoveredSshHost> = [];
 
@@ -1984,11 +2004,25 @@ export function ConnectionsSettings() {
       const message =
         error instanceof Error ? error.message : "Failed to configure Tailscale HTTPS.";
       setDesktopServerExposureMutationError(message);
+      const configureUrl = extractTailscaleServeConfigureUrl(message);
       toastManager.add(
         stackedThreadToast({
           type: "error",
           title: "Could not set up Tailscale HTTPS",
           description: message,
+          actionVariant: "outline",
+          ...(configureUrl
+            ? {
+                actionProps: {
+                  children: "Open setup",
+                  onClick: () => {
+                    void desktopBridge.openExternal(configureUrl).catch(() => {
+                      window.open(configureUrl, "_blank", "noopener,noreferrer");
+                    });
+                  },
+                },
+              }
+            : {}),
         }),
       );
     } finally {

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -13,6 +13,9 @@ import {
   buildTailscaleHttpsBaseUrl,
   disableTailscaleServe,
   ensureTailscaleServe,
+  extractTailscaleServeConfigureUrl,
+  extractTailscaleServeDiagnostics,
+  formatTailscaleServeUserMessage,
   isTailscaleIpv4Address,
   parseTailscaleMagicDnsName,
   parseTailscaleStatus,
@@ -253,8 +256,69 @@ describe("tailscale", () => {
       assert.notProperty(error, "command");
       assert.notProperty(error, "stderr");
       assert.notInclude(error.message, "tskey-auth-secret-token-value");
+      assert.equal(error.detail, undefined);
+      assert.equal(error.configureUrl, undefined);
     });
   });
+
+  it.effect("surfaces Tailscale Serve-not-enabled diagnostics without raw stderr", () => {
+    const configureUrl = "https://login.tailscale.com/f/serve?node=nExampleNodeIdForTests";
+    const stderr = [
+      "Serve is not enabled on your tailnet.",
+      "To enable, visit:",
+      "",
+      `         ${configureUrl}`,
+      "",
+      "tskey-auth-secret-token-value",
+    ].join("\n");
+    const layer = mockSpawnerLayer(() => ({
+      code: 1,
+      stderr,
+    }));
+
+    return Effect.gen(function* () {
+      const error = yield* ensureTailscaleServe({ localPort: 13773, servePort: 443 }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
+      );
+
+      assert.instanceOf(error, TailscaleCommandExitError);
+      assert.equal(error.detail, "Serve is not enabled on your tailnet.");
+      assert.equal(error.configureUrl, configureUrl);
+      assert.equal(
+        error.message,
+        `Serve is not enabled on your tailnet. To enable, visit: ${configureUrl}`,
+      );
+      assert.equal(formatTailscaleServeUserMessage(error), error.message);
+      assert.notInclude(error.message, "tskey-auth-secret-token-value");
+      assert.notProperty(error, "stderr");
+    });
+  });
+
+  it.effect("extracts only Tailscale Serve configure URLs from CLI text", () =>
+    Effect.sync(() => {
+      const configureUrl = "https://login.tailscale.com/f/serve?node=abc123";
+      assert.equal(extractTailscaleServeConfigureUrl(`visit ${configureUrl} please`), configureUrl);
+      assert.equal(
+        extractTailscaleServeConfigureUrl("https://evil.example/f/serve?node=abc123"),
+        null,
+      );
+      const disabled = extractTailscaleServeDiagnostics(
+        "Serve is not enabled on your tailnet.\nTo enable, visit:\n\n  " + configureUrl,
+      );
+      assert.equal(disabled.detail, "Serve is not enabled on your tailnet.");
+      assert.equal(disabled.configureUrl, configureUrl);
+
+      const tlsUnsupported = extractTailscaleServeDiagnostics(
+        "500 Internal Server Error: your Tailscale account does not support getting TLS certs",
+      );
+      assert.equal(
+        tlsUnsupported.detail,
+        "This Tailscale account does not support getting TLS certificates required for HTTPS Serve.",
+      );
+      assert.equal(tlsUnsupported.configureUrl, null);
+    }),
+  );
 
   it.effect("disables tailscale serve through the process spawner service", () => {
     const commands: {

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -54,11 +54,109 @@ export class TailscaleCommandExitError extends Schema.TaggedErrorClass<Tailscale
     exitCode: Schema.Number,
     stdoutLength: Schema.optional(Schema.Number),
     stderrLength: Schema.Number,
+    /**
+     * Safe, human-readable summary derived from known CLI patterns.
+     * Never contains raw stderr (which may include secrets).
+     */
+    detail: Schema.optionalKey(Schema.String),
+    /**
+     * Admin URL from the CLI to enable Serve/HTTPS when the tailnet blocks it.
+     * Restricted to `https://login.tailscale.com/f/serve...`.
+     */
+    configureUrl: Schema.optionalKey(Schema.String),
   },
 ) {
   override get message(): string {
-    return `tailscale ${this.subcommand} exited with code ${this.exitCode}.`;
+    return formatTailscaleCommandExitMessage({
+      subcommand: this.subcommand,
+      exitCode: this.exitCode,
+      detail: this.detail,
+      configureUrl: this.configureUrl,
+    });
   }
+}
+
+/** Admin console URL Tailscale prints when Serve/HTTPS is not enabled for the tailnet. */
+const TAILSCALE_SERVE_CONFIGURE_URL_PATTERN =
+  /https:\/\/login\.tailscale\.com\/f\/serve\?[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+/i;
+
+export interface TailscaleServeDiagnostics {
+  readonly detail: string | null;
+  readonly configureUrl: string | null;
+}
+
+/**
+ * Extract a Tailscale Serve enablement URL from CLI text.
+ * Only accepts `https://login.tailscale.com/f/serve...` URLs.
+ */
+export function extractTailscaleServeConfigureUrl(text: string): string | null {
+  const match = text.match(TAILSCALE_SERVE_CONFIGURE_URL_PATTERN);
+  if (!match?.[0] || match[0].length > 500) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(match[0]);
+    if (parsed.protocol !== "https:") return null;
+    if (parsed.hostname !== "login.tailscale.com") return null;
+    if (!parsed.pathname.startsWith("/f/serve")) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive safe, user-facing diagnostics from `tailscale serve` stderr.
+ * Does not return raw stderr — tokens and other secrets must not leak.
+ */
+export function extractTailscaleServeDiagnostics(stderr: string): TailscaleServeDiagnostics {
+  const configureUrl = extractTailscaleServeConfigureUrl(stderr);
+
+  if (/Serve is not enabled on your tailnet/i.test(stderr)) {
+    return {
+      detail: "Serve is not enabled on your tailnet.",
+      configureUrl,
+    };
+  }
+
+  if (/does not support getting TLS certs/i.test(stderr)) {
+    return {
+      detail:
+        "This Tailscale account does not support getting TLS certificates required for HTTPS Serve.",
+      configureUrl,
+    };
+  }
+
+  if (/HTTPS is not enabled/i.test(stderr)) {
+    return {
+      detail: "HTTPS is not enabled for this tailnet.",
+      configureUrl,
+    };
+  }
+
+  return { detail: null, configureUrl };
+}
+
+export function formatTailscaleCommandExitMessage(input: {
+  readonly subcommand: "status" | "serve";
+  readonly exitCode: number;
+  readonly detail?: string | undefined;
+  readonly configureUrl?: string | undefined;
+}): string {
+  if (input.detail || input.configureUrl) {
+    const parts: string[] = [];
+    if (input.detail) {
+      parts.push(input.detail);
+    } else {
+      parts.push(`tailscale ${input.subcommand} exited with code ${input.exitCode}.`);
+    }
+    if (input.configureUrl) {
+      parts.push(`To enable, visit: ${input.configureUrl}`);
+    }
+    return parts.join(" ");
+  }
+  return `tailscale ${input.subcommand} exited with code ${input.exitCode}.`;
 }
 
 export class TailscaleCommandTimeoutError extends Schema.TaggedErrorClass<TailscaleCommandTimeoutError>()(
@@ -81,6 +179,20 @@ export const TailscaleCommandError = Schema.Union([
   TailscaleCommandTimeoutError,
 ]);
 export type TailscaleCommandError = typeof TailscaleCommandError.Type;
+
+/** User-facing message for any Tailscale CLI failure while configuring Serve. */
+export function formatTailscaleServeUserMessage(error: TailscaleCommandError): string {
+  switch (error._tag) {
+    case "TailscaleCommandSpawnError":
+      return "Could not run the tailscale CLI. Is Tailscale installed and on PATH?";
+    case "TailscaleCommandOutputError":
+      return "Could not read output from the tailscale CLI.";
+    case "TailscaleCommandTimeoutError":
+      return "The tailscale CLI timed out while configuring Serve.";
+    case "TailscaleCommandExitError":
+      return error.message;
+  }
+}
 
 export class TailscaleStatusParseError extends Schema.TaggedErrorClass<TailscaleStatusParseError>()(
   "TailscaleStatusParseError",
@@ -271,10 +383,13 @@ const runTailscaleCommand = (
         Effect.mapError((cause) => new TailscaleCommandOutputError({ ...commandContext, cause })),
       );
       if (exitCode !== 0) {
+        const diagnostics = extractTailscaleServeDiagnostics(stderr);
         return yield* new TailscaleCommandExitError({
           ...commandContext,
           exitCode,
           stderrLength: stderr.length,
+          ...(diagnostics.detail ? { detail: diagnostics.detail } : {}),
+          ...(diagnostics.configureUrl ? { configureUrl: diagnostics.configureUrl } : {}),
         });
       }
     }).pipe(


### PR DESCRIPTION
## Summary

- Preflight `tailscale serve` when enabling Tailscale HTTPS in the desktop app, so setup failures fail the Enable action instead of silently restarting with an unchecked toggle.
- Extract safe CLI diagnostics (including the `login.tailscale.com/f/serve` configure URL) without leaking raw stderr secrets.
- Show an error toast with the CLI-style message and an **Open setup** action that opens the admin URL.

## Problem

Enable persisted `tailscaleServeEnabled: true` and relaunched the app, but the child server swallowed `tailscale serve` failures as warnings. The UI toggle is driven by HTTPS probe success, so it stayed off with no user-visible error. Locally this was:

```text
Serve is not enabled on your tailnet.
To enable, visit:
  https://login.tailscale.com/f/serve?node=...
```

## Test plan

- [x] `vp run --filter @t3tools/tailscale test`
- [x] `DesktopServerExposure` unit tests (including Serve-not-enabled preflight failure)
- [x] typecheck for tailscale, desktop, server, web
- [ ] Manual: with Serve disabled on the tailnet, open Settings → Connections → Tailscale HTTPS → Enable → confirm toast shows the error text and **Open setup** opens the Tailscale admin URL
- [ ] Manual: after enabling Serve in the admin console, Enable succeeds, app relaunches, toggle becomes checked when HTTPS is reachable

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Tailscale Serve setup failures with admin link and structured errors
> - When `setTailscaleServeEnabled` fails, a new `DesktopTailscaleServeConfigureError` is thrown with a user-readable reason and optional `configureUrl` extracted from sanitized CLI output (never raw stderr).
> - The failure toast in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/4552/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) now includes an action button to open the Tailscale Admin Serve URL in the browser when one is present in the error.
> - New utilities in [tailscale.ts](https://github.com/pingdotgg/t3code/pull/4552/files#diff-580f62662917cf32d498487b66719be157805c6a8b3cd04d84bb278fef541e43) (`extractTailscaleServeDiagnostics`, `formatTailscaleServeUserMessage`, `extractTailscaleServeConfigureUrl`) parse and sanitize CLI errors into structured diagnostics and human-readable messages.
> - Behavioral Change: `setTailscaleServeEnabled` now performs a preflight `ensureTailscaleServe` check before persisting settings, and always returns `requiresRelaunch=true` on successful enable even when settings are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4a0919b. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->