### PR TITLE
feat(web): add manual project visibility

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -13,6 +13,7 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  partitionSidebarProjectsByHiddenState,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -28,6 +29,7 @@ import {
   sortProjectsForSidebar,
   sortScopedProjectsForSidebar,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
+  updateSidebarHiddenProjectKeys,
 } from "./Sidebar.logic";
 import {
   EnvironmentId,
@@ -1422,5 +1424,96 @@ describe("sortLogicalProjectsForSidebar", () => {
         (project) => project.projectKey,
       ),
     ).toEqual(["logical-newer", "logical-older"]);
+  });
+});
+
+describe("partitionSidebarProjectsByHiddenState", () => {
+  const visibleProjectId = ProjectId.make("project-visible");
+  const groupedProjectId = ProjectId.make("project-grouped");
+  const hiddenProjectId = ProjectId.make("project-hidden");
+  const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+  const projects = [
+    {
+      ...makeProject({ id: visibleProjectId, title: "Visible" }),
+      projectKey: "logical-visible",
+      memberProjectRefs: [{ environmentId: localEnvironmentId, projectId: visibleProjectId }],
+    },
+    {
+      ...makeProject({ id: hiddenProjectId, title: "Hidden" }),
+      projectKey: "logical-hidden",
+      memberProjectRefs: [
+        { environmentId: localEnvironmentId, projectId: hiddenProjectId },
+        { environmentId: remoteEnvironmentId, projectId: groupedProjectId },
+      ],
+    },
+  ];
+
+  it("partitions only projects whose every grouped member is hidden", () => {
+    expect(
+      partitionSidebarProjectsByHiddenState({
+        projects,
+        threads: [],
+        hiddenProjectKeys: [
+          `${localEnvironmentId}:${hiddenProjectId}`,
+          `${remoteEnvironmentId}:${groupedProjectId}`,
+        ],
+      }),
+    ).toEqual({
+      visibleProjects: [projects[0]],
+      hiddenProjects: [projects[1]],
+    });
+  });
+
+  it("promotes a hidden project while one of its chats is running", () => {
+    const threads = [
+      makeThread({
+        environmentId: remoteEnvironmentId,
+        projectId: groupedProjectId,
+        archivedAt: null,
+        session: {
+          threadId: ThreadId.make("thread-running"),
+          status: "running",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-03-09T10:11:00.000Z",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          providerName: null,
+          runtimeMode: DEFAULT_RUNTIME_MODE,
+        },
+      }),
+    ];
+
+    expect(
+      partitionSidebarProjectsByHiddenState({
+        projects,
+        threads,
+        hiddenProjectKeys: [
+          `${localEnvironmentId}:${hiddenProjectId}`,
+          `${remoteEnvironmentId}:${groupedProjectId}`,
+        ],
+      }),
+    ).toEqual({ visibleProjects: projects, hiddenProjects: [] });
+  });
+
+  it("updates grouped project keys without disturbing other hidden projects", () => {
+    const otherProjectKey = `${localEnvironmentId}:project-other`;
+    const projectRefs = projects[1]!.memberProjectRefs;
+    const hiddenProjectKeys = updateSidebarHiddenProjectKeys({
+      hiddenProjectKeys: [otherProjectKey],
+      projectRefs,
+      hidden: true,
+    });
+    expect(hiddenProjectKeys).toEqual([
+      otherProjectKey,
+      `${localEnvironmentId}:${hiddenProjectId}`,
+      `${remoteEnvironmentId}:${groupedProjectId}`,
+    ]);
+    expect(
+      updateSidebarHiddenProjectKeys({
+        hiddenProjectKeys,
+        projectRefs,
+        hidden: false,
+      }),
+    ).toEqual([otherProjectKey]);
   });
 });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -43,6 +43,69 @@ type LogicalSidebarProject = SidebarProject & {
   }[];
 };
 
+const sidebarProjectRefKey = (environmentId: string, projectId: string) =>
+  `${environmentId}:${projectId}`;
+
+type SidebarProjectVisibilityThread = {
+  environmentId: string;
+  projectId: string;
+  archivedAt: string | null;
+  session?: {
+    status: string;
+  } | null;
+};
+
+export function partitionSidebarProjectsByHiddenState<
+  TProject extends LogicalSidebarProject,
+  TThread extends SidebarProjectVisibilityThread,
+>(input: {
+  projects: readonly TProject[];
+  threads: readonly TThread[];
+  hiddenProjectKeys: readonly string[];
+}): { visibleProjects: TProject[]; hiddenProjects: TProject[] } {
+  const hiddenProjectKeys = new Set(input.hiddenProjectKeys);
+  const runningProjectKeys = new Set(
+    input.threads
+      .filter(
+        (thread) =>
+          thread.archivedAt === null &&
+          (thread.session?.status === "running" || thread.session?.status === "starting"),
+      )
+      .map((thread) => sidebarProjectRefKey(thread.environmentId, thread.projectId)),
+  );
+  const visibleProjects: TProject[] = [];
+  const hiddenProjects: TProject[] = [];
+
+  for (const project of input.projects) {
+    const projectKeys = project.memberProjectRefs.map((projectRef) =>
+      sidebarProjectRefKey(projectRef.environmentId, projectRef.projectId),
+    );
+    const isHidden =
+      projectKeys.length > 0 &&
+      projectKeys.every((projectKey) => hiddenProjectKeys.has(projectKey));
+    const hasRunningChat = projectKeys.some((projectKey) => runningProjectKeys.has(projectKey));
+    (isHidden && !hasRunningChat ? hiddenProjects : visibleProjects).push(project);
+  }
+
+  return { hiddenProjects, visibleProjects };
+}
+
+export function updateSidebarHiddenProjectKeys(input: {
+  hiddenProjectKeys: readonly string[];
+  projectRefs: readonly { environmentId: string; projectId: string }[];
+  hidden: boolean;
+}): string[] {
+  const projectKeys = input.projectRefs.map((projectRef) =>
+    sidebarProjectRefKey(projectRef.environmentId, projectRef.projectId),
+  );
+  if (input.hidden) {
+    return [...new Set([...input.hiddenProjectKeys, ...projectKeys])];
+  }
+
+  const keysToShow = new Set(projectKeys);
+  return input.hiddenProjectKeys.filter((projectKey) => !keysToShow.has(projectKey));
+}
+
 export type ThreadTraversalDirection = "previous" | "next";
 
 export async function archiveSelectedThreadEntries<

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -75,7 +75,7 @@ import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstra
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { isTerminalFocused } from "../lib/terminalFocus";
-import { isMacPlatform } from "../lib/utils";
+import { cn, isMacPlatform } from "../lib/utils";
 import {
   readThreadShell,
   useProject,
@@ -182,6 +182,8 @@ import {
   orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
+  partitionSidebarProjectsByHiddenState,
+  updateSidebarHiddenProjectKeys,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
 } from "./Sidebar.logic";
@@ -1055,6 +1057,8 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
 
 interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
+  isManuallyHidden: boolean;
+  onSetProjectHidden: (project: SidebarProjectSnapshot, hidden: boolean) => void;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
@@ -1075,6 +1079,8 @@ interface SidebarProjectItemProps {
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
   const {
     project,
+    isManuallyHidden,
+    onSetProjectHidden,
     isThreadListExpanded,
     activeRouteThreadKey,
     newThreadShortcutLabel,
@@ -1586,6 +1592,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         if (!api) return;
 
         const actionHandlers = new Map<string, () => Promise<void> | void>();
+        actionHandlers.set("visibility", () => {
+          onSetProjectHidden(project, !isManuallyHidden);
+        });
         const makeLeaf = (
           action: "rename" | "grouping" | "copy-path" | "delete",
           member: SidebarProjectGroupMember,
@@ -1657,6 +1666,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             buildTargetedItem("rename", "Rename"),
             buildTargetedItem("grouping", "Group into..."),
             buildTargetedItem("copy-path", "Copy Path"),
+            {
+              id: "visibility",
+              label: isManuallyHidden ? "Show" : "Hide",
+            },
             buildTargetedItem("delete", "Remove", {
               destructive: true,
             }),
@@ -1677,6 +1690,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [
       copyPathToClipboard,
       handleRemoveProject,
+      isManuallyHidden,
+      onSetProjectHidden,
       openProjectGroupingDialog,
       openProjectRenameDialog,
       project.groupedProjectCount,
@@ -2732,6 +2747,7 @@ interface SidebarProjectsContentProps {
   desktopUpdateButtonAction: "download" | "install" | "none";
   desktopUpdateButtonDisabled: boolean;
   handleDesktopUpdateButtonClick: () => void;
+  hiddenProjectKeys: readonly string[];
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   threadPreviewCount: SidebarThreadPreviewCount;
@@ -2747,6 +2763,7 @@ interface SidebarProjectsContentProps {
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
+  hiddenProjects: readonly SidebarProjectSnapshot[];
   expandedThreadListsByProject: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
   routeThreadKey: string | null;
@@ -2772,6 +2789,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     desktopUpdateButtonAction,
     desktopUpdateButtonDisabled,
     handleDesktopUpdateButtonClick,
+    hiddenProjectKeys,
     projectSortOrder,
     threadSortOrder,
     threadPreviewCount,
@@ -2787,6 +2805,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     archiveThread,
     deleteThread,
     sortedProjects,
+    hiddenProjects,
     expandedThreadListsByProject,
     activeRouteProjectKey,
     routeThreadKey,
@@ -2808,6 +2827,46 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
       updateSettings({ sidebarProjectSortOrder: sortOrder });
     },
     [updateSettings],
+  );
+  const [hiddenProjectsExpanded, setHiddenProjectsExpanded] = useState(false);
+  const hiddenProjectKeySet = useMemo(() => new Set(hiddenProjectKeys), [hiddenProjectKeys]);
+  const isProjectManuallyHidden = useCallback(
+    (project: SidebarProjectSnapshot) =>
+      project.memberProjectRefs.length > 0 &&
+      project.memberProjectRefs.every((projectRef) =>
+        hiddenProjectKeySet.has(scopedProjectKey(projectRef)),
+      ),
+    [hiddenProjectKeySet],
+  );
+  const handleSetProjectHidden = useCallback(
+    (project: SidebarProjectSnapshot, hidden: boolean) => {
+      updateSettings({
+        sidebarHiddenProjectKeys: updateSidebarHiddenProjectKeys({
+          hiddenProjectKeys,
+          projectRefs: project.memberProjectRefs,
+          hidden,
+        }),
+      });
+    },
+    [hiddenProjectKeys, updateSettings],
+  );
+  const handleHiddenProjectContextMenu = useCallback(
+    (event: React.MouseEvent<HTMLElement>, project: SidebarProjectSnapshot) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void (async () => {
+        const api = readLocalApi();
+        if (!api) return;
+        const clicked = await api.contextMenu.show([{ id: "show", label: "Show" }], {
+          x: event.clientX,
+          y: event.clientY,
+        });
+        if (clicked === "show") {
+          handleSetProjectHidden(project, false);
+        }
+      })();
+    },
+    [handleSetProjectHidden],
   );
   const handleThreadSortOrderChange = useCallback(
     (sortOrder: SidebarThreadSortOrder) => {
@@ -2921,6 +2980,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                     {(dragHandleProps) => (
                       <SidebarProjectItem
                         project={project}
+                        isManuallyHidden={isProjectManuallyHidden(project)}
+                        onSetProjectHidden={handleSetProjectHidden}
                         isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -2953,6 +3014,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               <SidebarProjectListRow
                 key={project.projectKey}
                 project={project}
+                isManuallyHidden={isProjectManuallyHidden(project)}
+                onSetProjectHidden={handleSetProjectHidden}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
@@ -2975,6 +3038,49 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
           </SidebarMenu>
         )}
 
+        {hiddenProjects.length > 0 ? (
+          <div className="mt-3 pt-1">
+            <button
+              type="button"
+              aria-expanded={hiddenProjectsExpanded}
+              className="flex h-7 w-full cursor-pointer items-center gap-2 px-2 text-xs font-medium text-sidebar-muted-foreground/55 hover:text-sidebar-muted-foreground"
+              onClick={() => setHiddenProjectsExpanded((expanded) => !expanded)}
+            >
+              <span aria-hidden className="flex-1 overflow-hidden whitespace-nowrap opacity-50">
+                — — —
+              </span>
+              <span className="shrink-0">hidden ({hiddenProjects.length})</span>
+              <ChevronRightIcon
+                aria-hidden
+                className={cn("size-3 transition-transform", hiddenProjectsExpanded && "rotate-90")}
+              />
+              <span aria-hidden className="flex-1 overflow-hidden whitespace-nowrap opacity-50">
+                — — —
+              </span>
+            </button>
+            {hiddenProjectsExpanded ? (
+              <SidebarMenu className="mt-1">
+                {hiddenProjects.map((project) => (
+                  <SidebarMenuItem key={project.projectKey}>
+                    <button
+                      type="button"
+                      className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm text-sidebar-muted-foreground/65 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
+                      onContextMenu={(event) => handleHiddenProjectContextMenu(event, project)}
+                    >
+                      <ProjectFavicon
+                        environmentId={project.environmentId}
+                        cwd={project.workspaceRoot}
+                        className="size-4 shrink-0 opacity-70"
+                      />
+                      <span className="min-w-0 flex-1 truncate">{project.displayName}</span>
+                    </button>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            ) : null}
+          </div>
+        ) : null}
+
         {projectsLength === 0 && (
           <div className="px-2 pt-4 text-center text-xs text-muted-foreground/60">
             No projects yet
@@ -2996,6 +3102,7 @@ export default function Sidebar() {
   const isOnSettings = pathname.startsWith("/settings");
   const sidebarThreadSortOrder = useClientSettings((s) => s.sidebarThreadSortOrder);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
+  const sidebarHiddenProjectKeys = useClientSettings((s) => s.sidebarHiddenProjectKeys);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
   const updateSettings = useUpdateClientSettings();
@@ -3262,7 +3369,7 @@ export default function Sidebar() {
     () => sidebarThreads.filter((thread) => thread.archivedAt === null),
     [sidebarThreads],
   );
-  const sortedProjects = useMemo(() => {
+  const { visibleProjects: sortedProjects, hiddenProjects } = useMemo(() => {
     const sortableProjects = sidebarProjects.map((project) => ({
       ...project,
       id: project.projectKey,
@@ -3277,7 +3384,7 @@ export default function Sidebar() {
         projectId: (physicalToLogicalKey.get(physicalKey) ?? physicalKey) as ProjectId,
       };
     });
-    return sortProjectsForSidebar(
+    const orderedSidebarProjects = sortProjectsForSidebar(
       sortableProjects,
       sortableThreads,
       sidebarProjectSortOrder,
@@ -3285,8 +3392,15 @@ export default function Sidebar() {
       const resolvedProject = sidebarProjectByKey.get(project.id);
       return resolvedProject ? [resolvedProject] : [];
     });
+    return partitionSidebarProjectsByHiddenState({
+      projects: orderedSidebarProjects,
+      threads: sidebarThreads,
+      hiddenProjectKeys: sidebarHiddenProjectKeys,
+    });
   }, [
+    sidebarHiddenProjectKeys,
     sidebarProjectSortOrder,
+    sidebarThreads,
     physicalToLogicalKey,
     projectPhysicalKeyByScopedRef,
     sidebarProjectByKey,
@@ -3603,6 +3717,7 @@ export default function Sidebar() {
             desktopUpdateButtonAction={desktopUpdateButtonAction}
             desktopUpdateButtonDisabled={desktopUpdateButtonDisabled}
             handleDesktopUpdateButtonClick={handleDesktopUpdateButtonClick}
+            hiddenProjectKeys={sidebarHiddenProjectKeys}
             projectSortOrder={sidebarProjectSortOrder}
             threadSortOrder={sidebarThreadSortOrder}
             threadPreviewCount={sidebarThreadPreviewCount}
@@ -3618,6 +3733,7 @@ export default function Sidebar() {
             archiveThread={archiveThread}
             deleteThread={deleteThread}
             sortedProjects={sortedProjects}
+            hiddenProjects={hiddenProjects}
             expandedThreadListsByProject={expandedThreadListsByProject}
             activeRouteProjectKey={activeRouteProjectKey}
             routeThreadKey={routeThreadKey}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -18,6 +18,7 @@ import {
   AlarmClockOffIcon,
   CheckIcon,
   ChevronDownIcon,
+  ChevronRightIcon,
   CircleAlertIcon,
   CircleCheckIcon,
   CircleDashedIcon,
@@ -106,6 +107,7 @@ import {
   hasUnseenCompletion,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  partitionSidebarProjectsByHiddenState,
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarV2Status,
@@ -114,6 +116,7 @@ import {
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebarV2,
   sortThreadsForSidebarV2,
+  updateSidebarHiddenProjectKeys,
 } from "./Sidebar.logic";
 import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import {
@@ -146,7 +149,7 @@ import {
 } from "./ui/dialog";
 import { Input } from "./ui/input";
 import { Kbd } from "./ui/kbd";
-import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import { Menu, MenuItem, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
 import { SidebarContent, SidebarGroup, SidebarMenuButton, useSidebar } from "./ui/sidebar";
 import { SidebarChromeFooter, SidebarChromeHeader } from "./sidebar/SidebarChrome";
@@ -1004,6 +1007,7 @@ export default function SidebarV2() {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
+  const sidebarHiddenProjectKeys = useClientSettings((s) => s.sidebarHiddenProjectKeys);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const { settleThread, unsettleThread, snoozeThread, unsnoozeThread, deleteThread } =
@@ -1040,6 +1044,7 @@ export default function SidebarV2() {
     null,
   );
   const [projectScopeMenuOpen, setProjectScopeMenuOpen] = useState(false);
+  const [hiddenProjectsExpanded, setHiddenProjectsExpanded] = useState(false);
   const newThreadContext = useHandleNewThread();
   const openAddProjectCommandPalette = useCallback(
     () => openCommandPalette({ open: "add-project" }),
@@ -1103,9 +1108,29 @@ export default function SidebarV2() {
       sidebarProjectSortOrder,
     ],
   );
-  const projectGroups = useMemo(
+  const sortedProjectGroups = useMemo(
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
+  );
+  const { visibleProjects: projectGroups, hiddenProjects } = useMemo(
+    () =>
+      partitionSidebarProjectsByHiddenState({
+        projects: sortedProjectGroups,
+        threads,
+        hiddenProjectKeys: sidebarHiddenProjectKeys,
+      }),
+    [sidebarHiddenProjectKeys, sortedProjectGroups, threads],
+  );
+  const visibleProjectKeys = useMemo(
+    () =>
+      new Set(
+        projectGroups.flatMap((project) =>
+          project.memberProjectRefs.map(
+            (projectRef) => `${projectRef.environmentId}:${projectRef.projectId}`,
+          ),
+        ),
+      ),
+    [projectGroups],
   );
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
   const providerEntryByInstanceId = useMemo(
@@ -1344,6 +1369,54 @@ export default function SidebarV2() {
     [projectGroupingSettings.sidebarProjectGroupingOverrides, updateSettings],
   );
 
+  const hiddenProjectKeySet = useMemo(
+    () => new Set(sidebarHiddenProjectKeys),
+    [sidebarHiddenProjectKeys],
+  );
+  const isProjectManuallyHidden = useCallback(
+    (project: SidebarProjectSnapshot) =>
+      project.memberProjectRefs.length > 0 &&
+      project.memberProjectRefs.every((projectRef) =>
+        hiddenProjectKeySet.has(`${projectRef.environmentId}:${projectRef.projectId}`),
+      ),
+    [hiddenProjectKeySet],
+  );
+  const handleSetProjectHidden = useCallback(
+    (project: SidebarProjectSnapshot, hidden: boolean) => {
+      updateSettings({
+        sidebarHiddenProjectKeys: updateSidebarHiddenProjectKeys({
+          hiddenProjectKeys: sidebarHiddenProjectKeys,
+          projectRefs: project.memberProjectRefs,
+          hidden,
+        }),
+      });
+    },
+    [sidebarHiddenProjectKeys, updateSettings],
+  );
+  const handleProjectVisibilityContextMenu = useCallback(
+    (
+      event: ReactMouseEvent<HTMLElement>,
+      project: SidebarProjectSnapshot,
+      currentHidden: boolean,
+    ) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void (async () => {
+        const api = readLocalApi();
+        if (!api) return;
+        const action = currentHidden ? "show" : "hide";
+        const clicked = await api.contextMenu.show(
+          [{ id: action, label: currentHidden ? "Show" : "Hide" }],
+          { x: event.clientX, y: event.clientY },
+        );
+        if (clicked === action) {
+          handleSetProjectHidden(project, !currentHidden);
+        }
+      })();
+    },
+    [handleSetProjectHidden],
+  );
+
   const handleProjectActions = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>, projectGroup: SidebarProjectSnapshot) => {
       event.preventDefault();
@@ -1370,6 +1443,7 @@ export default function SidebarV2() {
     const visible = threads.filter(
       (thread) =>
         thread.archivedAt === null &&
+        visibleProjectKeys.has(`${thread.environmentId}:${thread.projectId}`) &&
         (scopedProjectKeys === null ||
           scopedProjectKeys.has(`${thread.environmentId}:${thread.projectId}`)),
     );
@@ -1420,6 +1494,7 @@ export default function SidebarV2() {
     serverConfigs,
     snoozeWakeTick,
     threads,
+    visibleProjectKeys,
   ]);
 
   // Arm a timeout for the earliest upcoming wake so the shelf empties the
@@ -2191,7 +2266,7 @@ export default function SidebarV2() {
   // for multi-project setups.
   const handleNewThreadClick = useCallback(() => {
     // One project: nothing to pick, create immediately.
-    if (projectGroups.length <= 1) {
+    if (unsortedProjectGroups.length <= 1) {
       if (isMobile) setOpenMobile(false);
       void startNewThreadFromContext({
         activeDraftThread: newThreadContext.activeDraftThread,
@@ -2203,7 +2278,7 @@ export default function SidebarV2() {
     }
     if (isMobile) setOpenMobile(false);
     openCommandPalette({ open: "new-thread-in" });
-  }, [isMobile, newThreadContext, projectGroups.length, setOpenMobile]);
+  }, [isMobile, newThreadContext, setOpenMobile, unsortedProjectGroups.length]);
 
   const commandPaletteShortcutLabel = shortcutLabelForCommand(keybindings, "commandPalette.toggle");
   // Same resolution as v1: prefer the local-thread binding, fall back to
@@ -2265,7 +2340,7 @@ export default function SidebarV2() {
             </div>
           </div>
         </SidebarGroup>
-        {projectGroups.length > 0 ? (
+        {unsortedProjectGroups.length > 0 ? (
           <SidebarGroup className="px-2 pb-2 pt-0">
             <div className="flex items-center gap-1">
               <Menu open={projectScopeMenuOpen} onOpenChange={setProjectScopeMenuOpen}>
@@ -2309,6 +2384,13 @@ export default function SidebarV2() {
                           key={scopeKey}
                           value={scopeKey}
                           closeOnClick
+                          onContextMenu={(event) =>
+                            handleProjectVisibilityContextMenu(
+                              event,
+                              project,
+                              isProjectManuallyHidden(project),
+                            )
+                          }
                           className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
                         >
                           <ProjectFavicon
@@ -2333,6 +2415,57 @@ export default function SidebarV2() {
                       );
                     })}
                   </MenuRadioGroup>
+                  {hiddenProjects.length > 0 ? (
+                    <>
+                      <MenuItem
+                        closeOnClick={false}
+                        className="h-7 min-h-7 cursor-pointer gap-2 px-1 text-xs font-medium text-muted-foreground/60"
+                        onClick={() => setHiddenProjectsExpanded((expanded) => !expanded)}
+                      >
+                        <span
+                          aria-hidden
+                          className="flex-1 overflow-hidden whitespace-nowrap opacity-50"
+                        >
+                          — — —
+                        </span>
+                        <span className="shrink-0">hidden ({hiddenProjects.length})</span>
+                        <ChevronRightIcon
+                          aria-hidden
+                          className={cn(
+                            "size-3 transition-transform",
+                            hiddenProjectsExpanded && "rotate-90",
+                          )}
+                        />
+                        <span
+                          aria-hidden
+                          className="flex-1 overflow-hidden whitespace-nowrap opacity-50"
+                        >
+                          — — —
+                        </span>
+                      </MenuItem>
+                      {hiddenProjectsExpanded
+                        ? hiddenProjects.map((project) => (
+                            <MenuItem
+                              key={project.projectKey}
+                              closeOnClick={false}
+                              className="h-8 min-h-8 text-muted-foreground/65"
+                              onContextMenu={(event) =>
+                                handleProjectVisibilityContextMenu(event, project, true)
+                              }
+                            >
+                              <ProjectFavicon
+                                environmentId={project.environmentId}
+                                cwd={project.workspaceRoot}
+                                className="size-4 shrink-0 opacity-70"
+                              />
+                              <span className="min-w-0 flex-1 truncate text-sm">
+                                {project.displayName}
+                              </span>
+                            </MenuItem>
+                          ))
+                        : null}
+                    </>
+                  ) : null}
                 </MenuPopup>
               </Menu>
               <Tooltip>

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -68,6 +68,22 @@ describe("ClientSettings sidebar v2", () => {
   });
 });
 
+describe("ClientSettings sidebar project visibility", () => {
+  it("shows every project by default", () => {
+    expect(decodeClientSettings({}).sidebarHiddenProjectKeys).toEqual([]);
+  });
+
+  it("accepts persisted and patched hidden project keys", () => {
+    const sidebarHiddenProjectKeys = ["environment-local:project-one"];
+    expect(decodeClientSettings({ sidebarHiddenProjectKeys }).sidebarHiddenProjectKeys).toEqual(
+      sidebarHiddenProjectKeys,
+    );
+    expect(
+      decodeClientSettingsPatch({ sidebarHiddenProjectKeys }).sidebarHiddenProjectKeys,
+    ).toEqual(sidebarHiddenProjectKeys);
+  });
+});
+
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults to an empty record so legacy configs without the key still decode", () => {
     expect(DEFAULT_SERVER_SETTINGS.providerInstances).toEqual({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -105,6 +105,9 @@ export const ClientSettingsSchema = Schema.Struct({
     TrimmedNonEmptyString,
     SidebarProjectGroupingMode,
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  sidebarHiddenProjectKeys: Schema.Array(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_SORT_ORDER)),
   ),
@@ -600,6 +603,7 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),
   ),
+  sidebarHiddenProjectKeys: Schema.optionalKey(Schema.Array(TrimmedNonEmptyString)),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),


### PR DESCRIPTION
## What Changed

Adds persisted, manual project visibility controls to both sidebar implementations:

- Right-click a visible project and choose **Hide**.
- Expand the `~~~ hidden (N) ~~~` shelf at the bottom and right-click a project to **Show** it again.
- Treat grouped project references as one visibility choice.
- Temporarily promote hidden projects with running or starting chats so active work cannot disappear.
- Keep hidden inactive projects lightweight by avoiding full project rows and per-project thread/detail subscriptions.

The V2 sidebar applies the same behavior in its project picker and filters hidden project threads before row mounting.

## Why

Automatic sorting or hiding made the sidebar feel unpredictable. Explicit per-project control lets users decide what stays out of the active list while still protecting active chats from being hidden.

The collapsed shelf also reduces inactive sidebar work without pretending that all global project summary state can be removed.

## UI Changes

### Demo

![Project visibility Hide/Show flow](https://raw.githubusercontent.com/danieliser/t3code/pr-assets-4554/docs/pr-assets/4554/project-visibility.gif)

### Classic sidebar

| Right-click to hide | Expand the hidden shelf and right-click to show |
| --- | --- |
| ![Classic sidebar Hide action](https://raw.githubusercontent.com/danieliser/t3code/pr-assets-4554/docs/pr-assets/4554/classic-hide.png) | ![Classic hidden-project shelf with Show action](https://raw.githubusercontent.com/danieliser/t3code/pr-assets-4554/docs/pr-assets/4554/classic-hidden-shelf.png) |

### V2 project picker

![V2 project picker with collapsed hidden shelf](https://raw.githubusercontent.com/danieliser/t3code/pr-assets-4554/docs/pr-assets/4554/v2-hidden-shelf.png)

## Validation

- `vp test run packages/contracts/src/settings.test.ts apps/web/src/components/Sidebar.logic.test.ts` — 110 tests passed
- Contracts and web targeted typechecks
- Targeted lint and formatting checks
- Integrated browser verification in classic and V2 sidebars, including hidden-row suppression

Effective non-test diff: 323 changed lines (`size:L`, below XL).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a GIF for the interaction flow