### PR TITLE
feat(dev): keep worktree dev state isolated on T3 Code dev servers

### DIFF
--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -57,7 +57,7 @@ T3CODE_PORT=<server-port> node apps/server/src/bin.ts auth pairing create \
 
 Use the `Pair URL` from this command once. Derive `<server-port>` and `<web-url>` from the current dev-runner output, including any automatically selected port offset. Setting `T3CODE_PORT` keeps the administrative CLI from probing for an unrelated free port.
 
-Always pass `--dev-url` for a dev-runner environment so the generated pairing URL uses the current web origin. An explicit base directory stores runtime state in `<base-dir>/userdata`; the `<base-dir>/dev` fallback is only used by an implicit dev home. Use `auth pairing list` to inspect active token metadata; it intentionally cannot reveal token secrets.
+Always pass `--dev-url` for a dev-runner environment so the generated pairing URL uses the current web origin. An explicit base directory stores runtime state in `<base-dir>/userdata`; the `<base-dir>/dev` fallback is only used by an implicit dev home. A worktree-local `.t3` counts as explicit, so its state lives in `<worktree>/.t3/userdata`. Use `auth pairing list` to inspect active token metadata; it intentionally cannot reveal token secrets.
 
 ## Inspect or seed SQLite state
 

--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -13,10 +13,12 @@ Use this skill for the web client. For iOS Simulator, Android Emulator, or physi
 2. Choose a base directory that belongs only to the current worktree or test:
    - Use the repository's ignored `.t3` directory for reusable worktree-local state.
    - Use `mktemp -d /tmp/t3code-test.XXXXXX` for disposable state and retain the printed absolute path.
-3. Start the full web stack with `vp run dev --home-dir <base-dir>`.
+3. Start the full web stack with `vp run dev`. In a linked worktree it defaults to that worktree's gitignored `.t3`; pass `--home-dir <base-dir>` only when the test needs a different isolated directory.
 4. Keep the terminal session alive and read the selected server port, web port, base directory, and pairing URL from its output.
 
 Treat a base directory as disposable only when it was created or deliberately selected for the current test. Never delete or directly seed the shared `~/.t3` directory. Prefer starting with a new temporary base directory over clearing state of uncertain ownership.
+
+The worktree-local default deliberately outranks an ambient `T3CODE_HOME`; do not pass the shared home through to a worktree dev server.
 
 The dev runner disables browser auto-open by default. Do not pass `--browser` during automated testing: an automatically opened page can consume the one-time bootstrap token before the controlled browser uses it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@
   - Subagents must not independently launch dev servers or repeat integrated client verification unless their delegated task explicitly requires it.
   - Stop dev servers, watchers, and other long-running verification processes when the focused verification is complete.
 
+## Dev Servers
+
+- In a linked git worktree, dev state defaults to that worktree's gitignored `.t3`. This deliberately outranks an ambient `T3CODE_HOME`, which could otherwise select the installed app's live `~/.t3/userdata` database. An explicit `--home-dir` still wins.
+
 ## Package Roles
 
 - `apps/server`: Node.js WebSocket server. Wraps Codex app-server (JSON-RPC over stdio), serves the React web app, and manages provider sessions.

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -3,7 +3,8 @@
 - `vp run dev` — Starts contracts, server, and web in watch mode.
 - `vp run dev:server` — Starts just the WebSocket server. The server process runs on Bun (`@effect/platform-bun` + `BunPtyAdapter`), but task running uses `vp run`.
 - `vp run dev:web` — Starts just the Vite dev server for the web app.
-- Dev commands implicitly use `~/.t3/dev`, keeping development state separate from `~/.t3/userdata`. An explicit `--home-dir <path>` stores state under `<path>/userdata`; the base directory remains available for caches, worktrees, and other shared data.
+- Dev commands run from a linked **git worktree** default to that worktree's gitignored `.t3`, even when `T3CODE_HOME` is set. Pass `--home-dir <path>` to choose another isolated directory explicitly.
+- From the **main checkout**, dev commands implicitly use `~/.t3/dev`, keeping development state separate from `~/.t3/userdata`. An explicit `--home-dir <path>` stores state under `<path>/userdata`; the base directory remains available for caches, worktrees, and other shared data.
 - Web dev commands do not auto-open a browser. Open the one-time pairing URL printed by the server so the first browser navigation is authenticated. Set `T3CODE_NO_BROWSER=0` only when interactive auto-open is intentional.
 - Pass dev-runner flags directly after the root task name, for example:
   `vp run dev --home-dir /tmp/t3code-dev`

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -3,7 +3,7 @@
 - `vp run dev` — Starts contracts, server, and web in watch mode.
 - `vp run dev:server` — Starts just the WebSocket server. The server process runs on Bun (`@effect/platform-bun` + `BunPtyAdapter`), but task running uses `vp run`.
 - `vp run dev:web` — Starts just the Vite dev server for the web app.
-- Dev commands run from a linked **git worktree** default to that worktree's gitignored `.t3`, even when `T3CODE_HOME` is set. Pass `--home-dir <path>` to choose another isolated directory explicitly.
+- Dev commands run from a linked **git worktree** default to that worktree's gitignored `.t3`, even when `T3CODE_HOME` is set, storing state in `<worktree>/.t3/userdata`. Pass `--home-dir <path>` to choose another isolated directory explicitly. Submodules are not worktrees and keep the normal precedence.
 - From the **main checkout**, dev commands implicitly use `~/.t3/dev`, keeping development state separate from `~/.t3/userdata`. An explicit `--home-dir <path>` stores state under `<path>/userdata`; the base directory remains available for caches, worktrees, and other shared data.
 - Web dev commands do not auto-open a browser. Open the one-time pairing URL printed by the server so the first browser navigation is authenticated. Set `T3CODE_NO_BROWSER=0` only when interactive auto-open is intentional.
 - Pass dev-runner flags directly after the root task name, for example:

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -194,6 +194,10 @@
     "./httpReadiness": {
       "types": "./src/httpReadiness.ts",
       "import": "./src/httpReadiness.ts"
+    },
+    "./devHome": {
+      "types": "./src/devHome.ts",
+      "import": "./src/devHome.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/devHome.test.ts
+++ b/packages/shared/src/devHome.test.ts
@@ -8,12 +8,16 @@ import * as Effect from "effect/Effect";
 
 import { resolveGitWorktreePath, resolveWorktreeT3Home } from "./devHome.ts";
 
-const makeRepo = (kind: "worktree" | "checkout" | "bare") =>
+const makeRepo = (kind: "worktree" | "checkout" | "bare" | "submodule" | "unreadable-git-file") =>
   Effect.acquireRelease(
     Effect.sync(() => {
       const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-devhome-"));
       if (kind === "worktree") {
         NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n");
+      } else if (kind === "submodule") {
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: ../.git/modules/sub\n");
+      } else if (kind === "unreadable-git-file") {
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "not a gitdir pointer\n");
       } else if (kind === "checkout") {
         NodeFS.mkdirSync(NodePath.join(root, ".git"));
       }
@@ -42,6 +46,20 @@ describe("resolveGitWorktreePath", () => {
   it.effect("reports a directory outside a repository", () =>
     Effect.gen(function* () {
       const { nested } = yield* makeRepo("bare");
+      assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports a submodule as not a linked worktree", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("submodule");
+      assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports a .git file without a usable gitdir pointer", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("unreadable-git-file");
       assert.equal(yield* resolveGitWorktreePath(nested), undefined);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );

--- a/packages/shared/src/devHome.test.ts
+++ b/packages/shared/src/devHome.test.ts
@@ -8,12 +8,27 @@ import * as Effect from "effect/Effect";
 
 import { resolveGitWorktreePath, resolveWorktreeT3Home } from "./devHome.ts";
 
-const makeRepo = (kind: "worktree" | "checkout" | "bare" | "submodule" | "unreadable-git-file") =>
+const makeRepo = (
+  kind:
+    | "worktree"
+    | "checkout"
+    | "bare"
+    | "submodule"
+    | "unreadable-git-file"
+    | "bare-repo-worktree"
+    | "custom-common-dir-worktree",
+) =>
   Effect.acquireRelease(
     Effect.sync(() => {
       const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-devhome-"));
       if (kind === "worktree") {
         NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n");
+      } else if (kind === "bare-repo-worktree") {
+        // `git worktree add` from a bare repo: the common dir is `<name>.git`.
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /srv/myrepo.git/worktrees/x\n");
+      } else if (kind === "custom-common-dir-worktree") {
+        // $GIT_COMMON_DIR need not be named `.git` at all.
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /srv/store/worktrees/x\n");
       } else if (kind === "submodule") {
         NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: ../.git/modules/sub\n");
       } else if (kind === "unreadable-git-file") {
@@ -61,6 +76,20 @@ describe("resolveGitWorktreePath", () => {
     Effect.gen(function* () {
       const { nested } = yield* makeRepo("unreadable-git-file");
       assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("finds a worktree of a bare repository", () =>
+    Effect.gen(function* () {
+      const { root, nested } = yield* makeRepo("bare-repo-worktree");
+      assert.equal(yield* resolveGitWorktreePath(nested), NodePath.resolve(root));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("finds a worktree whose common dir is not named .git", () =>
+    Effect.gen(function* () {
+      const { root, nested } = yield* makeRepo("custom-common-dir-worktree");
+      assert.equal(yield* resolveGitWorktreePath(nested), NodePath.resolve(root));
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 });

--- a/packages/shared/src/devHome.test.ts
+++ b/packages/shared/src/devHome.test.ts
@@ -1,0 +1,59 @@
+// @effect-diagnostics nodeBuiltinImport:off - builds real worktree layouts on disk.
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
+
+import { resolveGitWorktreePath, resolveWorktreeT3Home } from "./devHome.ts";
+
+const makeRepo = (kind: "worktree" | "checkout" | "bare") =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-devhome-"));
+      if (kind === "worktree") {
+        NodeFS.writeFileSync(NodePath.join(root, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n");
+      } else if (kind === "checkout") {
+        NodeFS.mkdirSync(NodePath.join(root, ".git"));
+      }
+      const nested = NodePath.join(root, "apps", "web", "src");
+      NodeFS.mkdirSync(nested, { recursive: true });
+      return { root, nested };
+    }),
+    ({ root }) => Effect.sync(() => NodeFS.rmSync(root, { recursive: true, force: true })),
+  );
+
+describe("resolveGitWorktreePath", () => {
+  it.effect("finds a worktree root from a nested directory", () =>
+    Effect.gen(function* () {
+      const { root, nested } = yield* makeRepo("worktree");
+      assert.equal(yield* resolveGitWorktreePath(nested), NodePath.resolve(root));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports a main checkout as not a linked worktree", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("checkout");
+      assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports a directory outside a repository", () =>
+    Effect.gen(function* () {
+      const { nested } = yield* makeRepo("bare");
+      assert.equal(yield* resolveGitWorktreePath(nested), undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});
+
+describe("resolveWorktreeT3Home", () => {
+  it.effect("answers with .t3 before the dev runner creates it", () =>
+    Effect.gen(function* () {
+      const { root, nested } = yield* makeRepo("worktree");
+      const home = yield* resolveWorktreeT3Home(nested);
+      assert.equal(home, NodePath.join(NodePath.resolve(root), ".t3"));
+      assert.isFalse(NodeFS.existsSync(home ?? ""));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/packages/shared/src/devHome.ts
+++ b/packages/shared/src/devHome.ts
@@ -14,9 +14,32 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
 /**
+ * A `.git` file points at the real git directory. A linked worktree's lives
+ * under `<repo>/.git/worktrees/<name>`; a submodule's under
+ * `<super>/.git/modules/<name>`. Both are files, so the pointer — not the
+ * file-vs-directory distinction alone — is what identifies a worktree.
+ */
+const pointsAtLinkedWorktree = (gitFileContents: string, path: Path.Path): boolean => {
+  const gitdir = gitFileContents
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("gitdir:"))
+    ?.slice("gitdir:".length)
+    .trim();
+  if (gitdir === undefined || gitdir.length === 0) {
+    return false;
+  }
+  // Normalize so `.git/worktrees` is matched as path segments rather than as a
+  // substring of some directory that merely happens to be named that way.
+  const segments = path.normalize(gitdir.replaceAll("\\", "/")).split(/[/\\]/);
+  const gitIndex = segments.lastIndexOf(".git");
+  return gitIndex !== -1 && segments[gitIndex + 1] === "worktrees";
+};
+
+/**
  * The path of the linked git worktree containing `cwd`, or undefined when
  * `cwd` is not inside one. Git marks a linked worktree by making `.git` a file
- * (`gitdir: …`) rather than a directory.
+ * whose `gitdir:` points into the repository's `.git/worktrees`.
  *
  * Walks up to the repository root, so running from a subdirectory resolves the
  * same worktree as running from the top.
@@ -30,11 +53,20 @@ export const resolveGitWorktreePath = (
 
     let directory = path.resolve(cwd);
     for (;;) {
-      const info = yield* fileSystem.stat(path.join(directory, ".git")).pipe(Effect.option);
+      const gitPath = path.join(directory, ".git");
+      const info = yield* fileSystem.stat(gitPath).pipe(Effect.option);
       if (Option.isSome(info)) {
         // A directory means the main checkout. Stop either way: nesting one
         // repository inside another does not make the outer one this root.
-        return info.value.type === "File" ? directory : undefined;
+        if (info.value.type !== "File") {
+          return undefined;
+        }
+        // A submodule also has a `.git` file, but it is not a worktree of this
+        // repository and gets no worktree-local home.
+        const contents = yield* fileSystem
+          .readFileString(gitPath)
+          .pipe(Effect.orElseSucceed(() => ""));
+        return pointsAtLinkedWorktree(contents, path) ? directory : undefined;
       }
       const parent = path.dirname(directory);
       if (parent === directory) {

--- a/packages/shared/src/devHome.ts
+++ b/packages/shared/src/devHome.ts
@@ -1,0 +1,62 @@
+/**
+ * Where development state lives, and how to keep it away from the shared
+ * `~/.t3` that a user's installed T3 Code runs against.
+ *
+ * A linked git worktree gets its own (gitignored) `.t3`: feature work in a
+ * throwaway branch must not share a database with the real app, and an ambient
+ * `T3CODE_HOME` counts as an explicit base dir — flipping the state directory
+ * from `<base>/dev` to `<base>/userdata`, the live production database.
+ */
+
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+
+/**
+ * The path of the linked git worktree containing `cwd`, or undefined when
+ * `cwd` is not inside one. Git marks a linked worktree by making `.git` a file
+ * (`gitdir: …`) rather than a directory.
+ *
+ * Walks up to the repository root, so running from a subdirectory resolves the
+ * same worktree as running from the top.
+ */
+export const resolveGitWorktreePath = (
+  cwd: string,
+): Effect.Effect<string | undefined, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    let directory = path.resolve(cwd);
+    for (;;) {
+      const info = yield* fileSystem.stat(path.join(directory, ".git")).pipe(Effect.option);
+      if (Option.isSome(info)) {
+        // A directory means the main checkout. Stop either way: nesting one
+        // repository inside another does not make the outer one this root.
+        return info.value.type === "File" ? directory : undefined;
+      }
+      const parent = path.dirname(directory);
+      if (parent === directory) {
+        return undefined;
+      }
+      directory = parent;
+    }
+  });
+
+/**
+ * The worktree-local data directory for `cwd`, or undefined outside a linked
+ * worktree. Deliberately does not require the directory to exist yet: falling
+ * back because it is missing would send callers at the shared home.
+ */
+export const resolveWorktreeT3Home = (
+  cwd: string,
+): Effect.Effect<string | undefined, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const worktreePath = yield* resolveGitWorktreePath(cwd);
+    if (worktreePath === undefined) {
+      return undefined;
+    }
+    const path = yield* Path.Path;
+    return path.join(worktreePath, ".t3");
+  });

--- a/packages/shared/src/devHome.ts
+++ b/packages/shared/src/devHome.ts
@@ -14,10 +14,15 @@ import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
 /**
- * A `.git` file points at the real git directory. A linked worktree's lives
- * under `<repo>/.git/worktrees/<name>`; a submodule's under
- * `<super>/.git/modules/<name>`. Both are files, so the pointer — not the
+ * A `.git` file points at the real git directory. A linked worktree's lives at
+ * `<common-dir>/worktrees/<name>`; a submodule's at
+ * `<super-git-dir>/modules/<name>`. Both are files, so the pointer — not the
  * file-vs-directory distinction alone — is what identifies a worktree.
+ *
+ * The common dir is not necessarily named `.git`: a worktree of a bare repo
+ * points at `<repo>.git/worktrees/<name>`, and `$GIT_COMMON_DIR` can be
+ * anything. So match on the `worktrees/<name>` tail, which git always uses,
+ * rather than on the name of the directory containing it.
  */
 const pointsAtLinkedWorktree = (gitFileContents: string, path: Path.Path): boolean => {
   const gitdir = gitFileContents
@@ -29,11 +34,15 @@ const pointsAtLinkedWorktree = (gitFileContents: string, path: Path.Path): boole
   if (gitdir === undefined || gitdir.length === 0) {
     return false;
   }
-  // Normalize so `.git/worktrees` is matched as path segments rather than as a
-  // substring of some directory that merely happens to be named that way.
-  const segments = path.normalize(gitdir.replaceAll("\\", "/")).split(/[/\\]/);
-  const gitIndex = segments.lastIndexOf(".git");
-  return gitIndex !== -1 && segments[gitIndex + 1] === "worktrees";
+  // Compare as path segments so a directory merely named `…worktrees…` cannot
+  // match as a substring. Trailing separators normalize away first.
+  const segments = path
+    .normalize(gitdir.replaceAll("\\", "/"))
+    .split(/[/\\]/)
+    .filter((segment) => segment.length > 0);
+  // `<common-dir>/worktrees/<name>`: `worktrees` is the penultimate segment,
+  // and something must precede it. This excludes `<git-dir>/modules/<name>`.
+  return segments.length >= 3 && segments.at(-2) === "worktrees";
 };
 
 /**

--- a/packages/shared/src/hostProcess.ts
+++ b/packages/shared/src/hostProcess.ts
@@ -30,6 +30,13 @@ export const HostProcessEnvironment = Context.Reference<NodeJS.ProcessEnv>(
   },
 );
 
+export const HostProcessWorkingDirectory = Context.Reference<string>(
+  "@t3tools/shared/hostProcess/HostProcessWorkingDirectory",
+  {
+    defaultValue: () => process.cwd(),
+  },
+);
+
 export const HostProcessExecutablePath = Context.Reference<string>(
   "@t3tools/shared/hostProcess/HostProcessExecutablePath",
   {

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -696,6 +696,19 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
         }).pipe(Effect.scoped),
       );
 
+      it.effect("treats a blank --home-dir as unset rather than as a selection", () =>
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const root = yield* makeWorktree;
+          const home = yield* spawnedHome({
+            t3Home: "   ",
+            cwd: root,
+            ambientHome: "/home/user/.t3",
+          });
+          assert.equal(home, path.join(path.resolve(root), ".t3"));
+        }).pipe(Effect.scoped),
+      );
+
       it.effect("prefers the worktree .t3 over an ambient T3CODE_HOME", () =>
         Effect.gen(function* () {
           const path = yield* Path.Path;

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -1,6 +1,14 @@
+// @effect-diagnostics nodeBuiltinImport:off - builds real worktree layouts on disk.
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
 import * as NetService from "@t3tools/shared/Net";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import {
+  HostProcessEnvironment,
+  HostProcessPlatform,
+  HostProcessWorkingDirectory,
+} from "@t3tools/shared/hostProcess";
 import { assert, describe, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
@@ -628,6 +636,101 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
         assert.notProperty(error, "args");
         assert.notInclude(error.message, "secret-token-value");
       });
+    });
+
+    describe("t3 home precedence", () => {
+      const makeWorktree = Effect.acquireRelease(
+        Effect.sync(() => {
+          const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-devrunner-"));
+          NodeFS.writeFileSync(
+            NodePath.join(root, ".git"),
+            "gitdir: /elsewhere/.git/worktrees/x\n",
+          );
+          return root;
+        }),
+        (root) => Effect.sync(() => NodeFS.rmSync(root, { recursive: true, force: true })),
+      );
+
+      const spawnedHome = (input: {
+        readonly t3Home: string | undefined;
+        readonly cwd: string;
+        readonly ambientHome: string | undefined;
+      }) =>
+        Effect.gen(function* () {
+          let captured: Record<string, string | undefined> | undefined;
+          const spawnerLayer = Layer.succeed(
+            ChildProcessSpawner.ChildProcessSpawner,
+            ChildProcessSpawner.make((command) => {
+              captured = (
+                command as {
+                  readonly options?: { readonly env?: Record<string, string | undefined> };
+                }
+              ).options?.env;
+              return Effect.succeed(mockProcess(0));
+            }),
+          );
+
+          yield* runDevRunnerWithInput({ ...devServerInput, t3Home: input.t3Home }).pipe(
+            Effect.provide(Layer.mergeAll(emptyConfigLayer, netServiceLayer, spawnerLayer)),
+            Effect.provideService(HostProcessPlatform, "linux"),
+            Effect.provideService(HostProcessWorkingDirectory, input.cwd),
+            Effect.provideService(
+              HostProcessEnvironment,
+              input.ambientHome === undefined ? {} : { T3CODE_HOME: input.ambientHome },
+            ),
+          );
+
+          return captured?.T3CODE_HOME;
+        });
+
+      it.effect("prefers an explicit --home-dir over the worktree default", () =>
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const root = yield* makeWorktree;
+          const home = yield* spawnedHome({
+            t3Home: "/tmp/explicit-home",
+            cwd: root,
+            ambientHome: "/home/user/.t3",
+          });
+          assert.equal(home, path.resolve("/tmp/explicit-home"));
+        }).pipe(Effect.scoped),
+      );
+
+      it.effect("prefers the worktree .t3 over an ambient T3CODE_HOME", () =>
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const root = yield* makeWorktree;
+          const home = yield* spawnedHome({
+            t3Home: undefined,
+            cwd: root,
+            ambientHome: "/home/user/.t3",
+          });
+          assert.equal(home, path.join(path.resolve(root), ".t3"));
+        }).pipe(Effect.scoped),
+      );
+
+      it.effect("falls back to an ambient T3CODE_HOME outside a worktree", () =>
+        Effect.gen(function* () {
+          const path = yield* Path.Path;
+          const home = yield* spawnedHome({
+            t3Home: undefined,
+            cwd: NodeOS.tmpdir(),
+            ambientHome: "/home/user/.t3",
+          });
+          assert.equal(home, path.resolve("/home/user/.t3"));
+        }),
+      );
+
+      it.effect("leaves the home implicit with no worktree and no ambient value", () =>
+        Effect.gen(function* () {
+          const home = yield* spawnedHome({
+            t3Home: undefined,
+            cwd: NodeOS.tmpdir(),
+            ambientHome: undefined,
+          });
+          assert.equal(home, undefined);
+        }),
+      );
     });
   });
 });

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -512,8 +512,13 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
     // outranks ambient T3CODE_HOME, which otherwise selects the installed
     // app's live userdata database. An explicit --home-dir still wins.
     const worktreeHome = yield* resolveWorktreeT3Home(yield* HostProcessWorkingDirectory);
+    // Trim before choosing: `--home-dir ""` is not a selection, and treating it
+    // as one would skip the worktree default and land on the shared home —
+    // exactly the outcome this precedence exists to prevent.
     const resolvedT3Home =
-      input.t3Home ?? worktreeHome ?? (hostEnvironment.T3CODE_HOME?.trim() || undefined);
+      (input.t3Home?.trim() || undefined) ??
+      worktreeHome ??
+      (hostEnvironment.T3CODE_HOME?.trim() || undefined);
     const env = yield* createDevRunnerEnv({
       mode: input.mode,
       baseEnv: hostEnvironment,

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -5,6 +5,7 @@ import * as NodeOS from "node:os";
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
+import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Config from "effect/Config";
@@ -245,7 +246,9 @@ export function createDevRunnerEnv({
   return Effect.gen(function* () {
     const serverPort = port ?? BASE_SERVER_PORT + serverOffset;
     const webPort = BASE_WEB_PORT + webOffset;
-    const configuredBaseDir = t3Home?.trim() || baseEnv.T3CODE_HOME?.trim() || undefined;
+    // Precedence is resolved by the caller. An unset t3Home here genuinely
+    // means "use the default" rather than inheriting an ambient value.
+    const configuredBaseDir = t3Home?.trim() || undefined;
     const resolvedBaseDir = yield* resolveBaseDir(configuredBaseDir);
     const isDesktopMode = mode === "dev:desktop";
 
@@ -505,12 +508,18 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
     });
 
     const hostEnvironment = yield* HostProcessEnvironment;
+    // A worktree defaults to its own gitignored `.t3`. This deliberately
+    // outranks ambient T3CODE_HOME, which otherwise selects the installed
+    // app's live userdata database. An explicit --home-dir still wins.
+    const worktreeHome = yield* resolveWorktreeT3Home(process.cwd());
+    const resolvedT3Home =
+      input.t3Home ?? worktreeHome ?? (hostEnvironment.T3CODE_HOME?.trim() || undefined);
     const env = yield* createDevRunnerEnv({
       mode: input.mode,
       baseEnv: hostEnvironment,
       serverOffset,
       webOffset,
-      t3Home: input.t3Home,
+      t3Home: resolvedT3Home,
       browser: input.browser,
       autoBootstrapProjectFromCwd: input.autoBootstrapProjectFromCwd,
       logWebSocketEvents: input.logWebSocketEvents,
@@ -592,9 +601,10 @@ const devRunnerCli = Command.make("dev-runner", {
   ),
   t3Home: Flag.string("home-dir").pipe(
     Flag.withDescription(
-      "Explicit T3 Code data directory; runtime state is stored under userdata (equivalent to T3CODE_HOME).",
+      "Explicit T3 Code data directory; runtime state is stored under userdata. Inside a git worktree this defaults to that worktree's own .t3.",
     ),
-    Flag.withFallbackConfig(optionalStringConfig("T3CODE_HOME")),
+    Flag.optional,
+    Flag.map(Option.getOrUndefined),
   ),
   browser: Flag.boolean("browser").pipe(
     Flag.withDescription("Open a browser automatically (disabled by default for web dev)."),

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -6,7 +6,7 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
 import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
-import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessWorkingDirectory } from "@t3tools/shared/hostProcess";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
@@ -511,7 +511,7 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
     // A worktree defaults to its own gitignored `.t3`. This deliberately
     // outranks ambient T3CODE_HOME, which otherwise selects the installed
     // app's live userdata database. An explicit --home-dir still wins.
-    const worktreeHome = yield* resolveWorktreeT3Home(process.cwd());
+    const worktreeHome = yield* resolveWorktreeT3Home(yield* HostProcessWorkingDirectory);
     const resolvedT3Home =
       input.t3Home ?? worktreeHome ?? (hostEnvironment.T3CODE_HOME?.trim() || undefined);
     const env = yield* createDevRunnerEnv({


### PR DESCRIPTION
> [!NOTE]
> **Dev mode overhaul — PR 1 of 3.** The stack moves from [worktree-isolated dev state](https://github.com/pingdotgg/t3code/pull/4555) → [single-origin and Tailscale sharing](https://github.com/pingdotgg/t3code/pull/4556) → [pairing and seed utilities](https://github.com/pingdotgg/t3code/pull/4557). This PR establishes the foundation; #4556 is stacked on it.

## What

- Resolve linked worktree roots and default development state to that worktree’s ignored `.t3` directory.
- Keep an explicit `--home-dir` authoritative while preventing an ambient `T3CODE_HOME` from selecting the installed app’s live data.
- Document and test the resolution rules.

## Why

A dev command launched from a linked worktree could otherwise inherit the shared application home and write development state into the database used by the installed app.

## Impact

This is the foundational slice of the dev-server overhaul. It changes only worktree state isolation and is the base for the two follow-up PRs.

## Verification

- `vp test run packages/shared/src/devHome.test.ts scripts/dev-runner.test.ts` (32 tests)
- targeted lint
- `vp run --filter=@t3tools/shared typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate dev state to the linked git worktree's `.t3` directory by default
> - Adds `resolveGitWorktreePath` and `resolveWorktreeT3Home` utilities in [`packages/shared/src/devHome.ts`](https://github.com/pingdotgg/t3code/pull/4555/files#diff-77ea98aaec3bbe7740817fc180fa324901af50b98efee5617284c8deaaf9a40b) to detect when the process runs inside a linked git worktree and derive its local `.t3` path.
> - Updates [`scripts/dev-runner.ts`](https://github.com/pingdotgg/t3code/pull/4555/files#diff-8ba446fc13205cee91be4164b3936316a911d90cfc2fb690c99c49ea439542bf) to apply a new precedence order: explicit `--home-dir` > worktree-local `<worktree>/.t3` > ambient `T3CODE_HOME`. Blank `--home-dir` is treated as unset.
> - Removes the implicit `T3CODE_HOME` fallback from the `--home-dir` CLI flag; absence of the flag now delegates to the new precedence logic.
> - Updates docs and `AGENTS.md` to document the new precedence rules, including the note that submodules are not worktrees.
> - Behavioral Change: when running inside a linked worktree, the dev server now ignores `T3CODE_HOME` unless `--home-dir` is absent and no worktree `.t3` is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6404fc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which SQLite database dev commands use in worktrees (behavioral shift away from shared/live userdata); logic is well-tested but mis-detection could still point at the wrong home.
> 
> **Overview**
> **Linked git worktrees** now get an isolated dev data directory at `<worktree>/.t3` (userdata under `<worktree>/.t3/userdata`) when you run `vp run dev`, so feature work does not inherit the installed app’s shared home.
> 
> The dev runner resolves home in order: **explicit `--home-dir`** (whitespace-only counts as unset), then **worktree `.t3`**, then **ambient `T3CODE_HOME`**. Worktree detection walks up from cwd, treats a `.git` **file** whose `gitdir:` ends in `worktrees/<name>` as a linked worktree (not main checkout, submodules, or invalid pointers), and is implemented in new `@t3tools/shared/devHome` helpers with tests. `createDevRunnerEnv` no longer merges ambient `T3CODE_HOME` when no explicit base dir is passed; precedence is applied in `runDevRunnerWithInput` using injectable `HostProcessWorkingDirectory`. Agent docs and `test-t3-app` / scripts reference reflect the new default and pairing/SQLite paths for worktree-local state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6404fc1a8e042e3ec079ea749413602e79e7002d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development environments in linked worktrees now use a worktree-local `.t3` directory by default.
  * Added clear precedence for development home selection: explicit `--home-dir`, worktree `.t3`, then ambient configuration.
  * Added a shared development-home export for tooling integrations.

* **Documentation**
  * Clarified development server setup, state storage, isolation, and pairing-token recovery guidance.

* **Tests**
  * Added coverage for worktree detection and development-home precedence across repository layouts and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->