### PR TITLE
feat(dev): dev server pairing and seed utilities

### DIFF
--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -13,7 +13,7 @@ Use this skill for the web client. For iOS Simulator, Android Emulator, or physi
 2. Choose a base directory that belongs only to the current worktree or test:
    - Use the repository's ignored `.t3` directory for reusable worktree-local state.
    - Use `mktemp -d /tmp/t3code-test.XXXXXX` for disposable state and retain the printed absolute path.
-3. Start the full web stack with `vp run dev`. Add `--share` when the user needs to open it from another tailnet device. In a linked worktree it defaults to that worktree's gitignored `.t3`; pass `--home-dir <base-dir>` only when the test needs a different isolated directory.
+3. Start the full web stack with `bun run dev`. Use `bun run dev:share` when the user needs to open it from another tailnet device. In a linked worktree it defaults to that worktree's gitignored `.t3`; pass `--home-dir <base-dir>` only when the test needs a different isolated directory.
 4. Keep the terminal session alive and read the selected server port, web port, base directory, and pairing URL from its output.
 
 Treat a base directory as disposable only when it was created or deliberately selected for the current test. Never delete or directly seed the shared `~/.t3` directory. Prefer starting with a new temporary base directory over clearing state of uncertain ownership.

--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -70,7 +70,7 @@ An explicit base directory stores runtime state in `<base-dir>/userdata`; the `<
 Read [references/sqlite-fixtures.md](references/sqlite-fixtures.md) before changing the database.
 
 - Use `node apps/server/scripts/t3-sqlite-state.ts query` for schema discovery and read-only checks.
-- To populate realistic list and thread data, stop the server and run `bun run dev:seed`, then restart it. This copies recent projections from the shared home while refusing to write to it.
+- To populate realistic list and thread data, stop the server and run `bun run dev:seed`, then restart it. This copies recent projections from the shared home while refusing to write to it. It also refuses to run while a server is still using the target directory, so stop the server first rather than expecting the seed to wait.
 - Stop the dev server before using `node apps/server/scripts/t3-sqlite-state.ts exec`, then restart it with the same base directory.
 - Seed projection tables only for disposable UI fixtures. Use application commands and APIs when testing business behavior or projection correctness.
 - Use the auth CLI, not direct `auth_*` table edits, for pairing and sessions.

--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -92,7 +92,7 @@ If completion is uncertain, keep the environment alive and mention that it is re
 ## Troubleshoot predictably
 
 - If the browser shows an unauthenticated pairing screen, issue a new token instead of retrying the consumed URL.
-- If the pairing URL is no longer visible, create a replacement token with both `--dev-url` and `--base-url`.
-- If the replacement token is rejected, verify that the CLI and server use the identical absolute base directory and web URL.
+- If the pairing URL is no longer visible, run `bun run dev:pair`. Add `-- --base-dir <base-dir>` only when the server was started with `--home-dir`.
+- If the replacement token is rejected, verify that `dev:pair` and the server resolve the same base directory.
 - If the UI shows unexpected data, verify that every command uses the identical explicit base directory before editing anything.
 - If ports move because another instance is running, trust the current dev-runner output rather than assuming ports `13773` and `5733`.

--- a/.agents/skills/test-t3-app/SKILL.md
+++ b/.agents/skills/test-t3-app/SKILL.md
@@ -54,26 +54,23 @@ Treat pairing URLs as secrets. Do not copy them into final responses, screenshot
 
 ## Recover a consumed or expired pairing token
 
-Create another token against the same database and web URL as the running dev server:
+Ask the running server for a fresh pairing URL:
 
 ```bash
-T3CODE_PORT=<server-port> node apps/server/src/bin.ts auth pairing create \
-  --base-dir <base-dir> \
-  --dev-url <web-url> \
-  --base-url <web-url> \
-  --ttl 15m \
-  --label agent-ui-test
+bun run dev:pair
+bun run dev:pair -- --base-dir <base-dir>
 ```
 
-Use the `Pair URL` from this command once. Derive `<server-port>` and `<web-url>` from the current dev-runner output, including any automatically selected port offset. Setting `T3CODE_PORT` keeps the administrative CLI from probing for an unrelated free port.
+It finds the live server state under either the `dev` or `userdata` state directory and reuses the recorded web origin, including a tailnet URL. Pass `--base-dir` only when the server was started with `--home-dir`. Use the printed URL once.
 
-Always pass `--dev-url` for a dev-runner environment so the generated pairing URL uses the current web origin. An explicit base directory stores runtime state in `<base-dir>/userdata`; the `<base-dir>/dev` fallback is only used by an implicit dev home. A worktree-local `.t3` counts as explicit, so its state lives in `<worktree>/.t3/userdata`. Use `auth pairing list` to inspect active token metadata; it intentionally cannot reveal token secrets.
+An explicit base directory stores runtime state in `<base-dir>/userdata`; the `<base-dir>/dev` fallback is only used by an implicit dev home. A worktree-local `.t3` counts as explicit, so its state lives in `<worktree>/.t3/userdata`. Use `auth pairing list` to inspect active token metadata; it intentionally cannot reveal token secrets.
 
 ## Inspect or seed SQLite state
 
 Read [references/sqlite-fixtures.md](references/sqlite-fixtures.md) before changing the database.
 
 - Use `node apps/server/scripts/t3-sqlite-state.ts query` for schema discovery and read-only checks.
+- To populate realistic list and thread data, stop the server and run `bun run dev:seed`, then restart it. This copies recent projections from the shared home while refusing to write to it.
 - Stop the dev server before using `node apps/server/scripts/t3-sqlite-state.ts exec`, then restart it with the same base directory.
 - Seed projection tables only for disposable UI fixtures. Use application commands and APIs when testing business behavior or projection correctness.
 - Use the auth CLI, not direct `auth_*` table edits, for pairing and sessions.

--- a/.agents/skills/test-t3-app/references/sqlite-fixtures.md
+++ b/.agents/skills/test-t3-app/references/sqlite-fixtures.md
@@ -49,6 +49,8 @@ The web UI primarily reads these projection tables:
 - `projection_pending_approvals`
 - `projection_thread_proposed_plans`
 
+`projection_state` holds one cursor row per projector and is not read by the UI, but a fixture that omits it still breaks: `computeSnapshotSequence` returns 0 unless every projector has a row, which makes every shell snapshot advertise sequence 0. Write all of them (`PROJECTOR_NAMES` in `scripts/lib/projection-tables.ts`), at a sequence no higher than the event log actually reaches.
+
 Inspect `PRAGMA table_info(<table>)` and the current migrations under `apps/server/src/persistence/Migrations/` before constructing inserts. Keep identifiers unique, timestamps as ISO strings, JSON columns valid, and related project/thread/turn IDs consistent.
 
 For a substantial current example, inspect `seedDatabase` in `scripts/mobile-showcase-environment.ts`. Adapt its column set to the target database instead of assuming copied SQL remains current.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - In a linked git worktree, dev state defaults to that worktree's gitignored `.t3`. This deliberately outranks an ambient `T3CODE_HOME`, which could otherwise select the installed app's live `~/.t3/userdata` database. An explicit `--home-dir` still wins.
 - Start the web stack with `vp run dev`. Add `--share` when someone needs to open it from another device on the tailnet.
 - Use `vp run dev:pair` to issue a fresh URL for the running server without reconstructing its port or origin.
-- Use `vp run dev:seed` while the server is stopped to populate an isolated database with recent projects and threads from the shared home.
+- Use `vp run dev:seed` while the server is stopped to populate an isolated database with recent projects and threads from the shared home. It refuses to run against a directory a live server is using.
 - Browser dev is single-origin: Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known` to the backend. Do not set `VITE_HTTP_URL` or `VITE_WS_URL` for `dev`/`dev:web`.
 - Worktree paths supply stable preferred port offsets. Read the actual server and web ports from the `[dev-runner]` line because occupied ports can still shift them.
 - Before handing off a `--share` URL, open its origin in a controlled browser and confirm the app loads. A successful curl is insufficient because browsers reject some otherwise reachable ports.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@
 
 - In a linked git worktree, dev state defaults to that worktree's gitignored `.t3`. This deliberately outranks an ambient `T3CODE_HOME`, which could otherwise select the installed app's live `~/.t3/userdata` database. An explicit `--home-dir` still wins.
 - Start the web stack with `vp run dev`. Add `--share` when someone needs to open it from another device on the tailnet.
+- Use `vp run dev:pair` to issue a fresh URL for the running server without reconstructing its port or origin.
+- Use `vp run dev:seed` while the server is stopped to populate an isolated database with recent projects and threads from the shared home.
 - Browser dev is single-origin: Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known` to the backend. Do not set `VITE_HTTP_URL` or `VITE_WS_URL` for `dev`/`dev:web`.
 - Worktree paths supply stable preferred port offsets. Read the actual server and web ports from the `[dev-runner]` line because occupied ports can still shift them.
 - Before handing off a `--share` URL, open its origin in a controlled browser and confirm the app loads. A successful curl is insufficient because browsers reject some otherwise reachable ports.

--- a/apps/server/src/auth/EnvironmentAuth.test.ts
+++ b/apps/server/src/auth/EnvironmentAuth.test.ts
@@ -46,10 +46,8 @@ const makeCookieRequest = (
   ({
     cookies: {
       // Derived, not hardcoded: the name is port-scoped so concurrent servers
-      // on one hostname don't share a cookie. Mode and devUrl mirror
-      // ServerConfig.layerTest, so this resolves to whatever the server reads.
-      [resolveSessionCookieName({ mode: "web", port: TEST_SERVER_PORT, devUrl: undefined })]:
-        sessionToken,
+      // on one hostname don't share a cookie.
+      [resolveSessionCookieName({ port: TEST_SERVER_PORT, devUrl: undefined })]: sessionToken,
     },
     headers: {},
   }) as unknown as Parameters<

--- a/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.test.ts
@@ -34,31 +34,12 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
 
       expect(descriptor.policy).toBe("desktop-managed-local");
       expect(descriptor.bootstrapMethods).toEqual(["desktop-bootstrap"]);
-      // Packaged desktop has no devUrl, but still needs the port scope: it
-      // scans upward from 3773 for a free port and binds 127.0.0.1, so a second
-      // instance shares this one's hostname on a different port.
-      expect(descriptor.sessionCookieName).toBe("t3_session_3773");
+      expect(descriptor.sessionCookieName).toBe("t3_session");
     }).pipe(
       Effect.provide(
         makeEnvironmentAuthPolicyLayer({
           mode: "desktop",
           port: 3773,
-        }),
-      ),
-    ),
-  );
-
-  it.effect("keeps desktop cookies port-scoped on the port a second instance lands on", () =>
-    Effect.gen(function* () {
-      const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
-      const descriptor = yield* policy.getDescriptor();
-
-      expect(descriptor.sessionCookieName).toBe("t3_session_3774");
-    }).pipe(
-      Effect.provide(
-        makeEnvironmentAuthPolicyLayer({
-          mode: "desktop",
-          port: 3774,
         }),
       ),
     ),
@@ -100,7 +81,7 @@ it.layer(NodeServices.layer)("EnvironmentAuthPolicy.layer", (it) => {
     ),
   );
 
-  it.effect("scopes web session cookies by port only in development", () =>
+  it.effect("scopes session cookies by port only in development", () =>
     Effect.gen(function* () {
       const policy = yield* EnvironmentAuthPolicy.EnvironmentAuthPolicy;
       const descriptor = yield* policy.getDescriptor();

--- a/apps/server/src/auth/EnvironmentAuthPolicy.ts
+++ b/apps/server/src/auth/EnvironmentAuthPolicy.ts
@@ -38,11 +38,7 @@ export const make = Effect.gen(function* () {
     policy,
     bootstrapMethods,
     sessionMethods: ["browser-session-cookie", "bearer-access-token", "dpop-access-token"],
-    sessionCookieName: resolveSessionCookieName({
-      mode: config.mode,
-      port: config.port,
-      devUrl: config.devUrl,
-    }),
+    sessionCookieName: resolveSessionCookieName({ port: config.port, devUrl: config.devUrl }),
   };
 
   return EnvironmentAuthPolicy.of({

--- a/apps/server/src/auth/SessionStore.ts
+++ b/apps/server/src/auth/SessionStore.ts
@@ -468,7 +468,6 @@ export const make = Effect.gen(function* () {
   const connectedSessionsRef = yield* Ref.make(new Map<string, number>());
   const changesPubSub = yield* PubSub.unbounded<SessionCredentialChange>();
   const cookieName = resolveSessionCookieName({
-    mode: serverConfig.mode,
     port: serverConfig.port,
     devUrl: serverConfig.devUrl,
   });

--- a/apps/server/src/auth/utils.ts
+++ b/apps/server/src/auth/utils.ts
@@ -11,28 +11,16 @@ import * as Result from "effect/Result";
 const SESSION_COOKIE_NAME = "t3_session";
 
 /**
- * Cookies are scoped by host but *not* by port, so any two servers that can be
- * live on one hostname at once need separate names — otherwise the second
- * clobbers the first's session and both sides see "Invalid session token
- * signature" until someone clears cookies by hand.
- *
- * Two populations qualify, for the same reason but from different causes:
- *
- * - **Dev servers** (`devUrl` set), which run several at a time across worktrees.
- * - **Desktop**, which scans upward from 3773 for a free port and binds
- *   127.0.0.1, so a second instance lands on a different port and the same host.
- *
- * Hosted deployments keep the stable production name: their public port can
- * change between releases, and scoping it would log every user out.
+ * Cookies are scoped by host but *not* by port, so concurrent dev servers on a
+ * hostname need separate names. Hosted deployments keep the stable production
+ * name: their public port can change between releases, and scoping it would log
+ * every user out.
  */
 export function resolveSessionCookieName(input: {
-  readonly mode: "web" | "desktop";
   readonly port: number;
   readonly devUrl: URL | undefined;
 }): string {
-  return input.devUrl === undefined && input.mode !== "desktop"
-    ? SESSION_COOKIE_NAME
-    : `${SESSION_COOKIE_NAME}_${input.port}`;
+  return input.devUrl === undefined ? SESSION_COOKIE_NAME : `${SESSION_COOKIE_NAME}_${input.port}`;
 }
 
 export function base64UrlEncode(input: string | Uint8Array): string {

--- a/apps/server/src/cli/auth.test.ts
+++ b/apps/server/src/cli/auth.test.ts
@@ -1,0 +1,138 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+
+import { persistServerRuntimeState } from "../serverRuntimeState.ts";
+import { findLiveServerRuntimeState } from "./auth.ts";
+
+/** A pid that cannot belong to a live process (above the usual pid_max). */
+const DEAD_PID = 0x7ffffffe;
+
+const writeRuntimeState = Effect.fn(function* (input: {
+  readonly baseDir: string;
+  readonly stateDir: "dev" | "userdata";
+  readonly pid: number;
+  readonly port: number;
+  readonly devUrl?: string;
+}) {
+  const path = yield* Path.Path;
+  yield* persistServerRuntimeState({
+    path: path.join(input.baseDir, input.stateDir, "server-runtime.json"),
+    state: {
+      version: 1,
+      pid: input.pid,
+      port: input.port,
+      origin: `http://127.0.0.1:${String(input.port)}`,
+      ...(input.devUrl ? { devUrl: input.devUrl } : {}),
+      startedAt: "2026-07-20T00:00:00.000Z",
+    },
+  });
+});
+
+const makeBaseDir = Effect.fn(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const baseDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-auth-cli-test-" });
+  return {
+    baseDir,
+    // What the flag heuristic resolves to without --dev-url: the userdata dir.
+    serverRuntimeStatePath: path.join(baseDir, "userdata", "server-runtime.json"),
+  };
+});
+
+describe("findLiveServerRuntimeState", () => {
+  it.effect("prefers the dev server when both state directories are live", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const config = yield* makeBaseDir();
+      // The configured path points at userdata, but this command is about dev.
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "userdata",
+        pid: process.pid,
+        port: 16_601,
+      });
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "dev",
+        pid: process.pid,
+        port: 16_602,
+        devUrl: "http://localhost:8888/",
+      });
+
+      const found = yield* findLiveServerRuntimeState(config);
+
+      const live = Option.getOrThrow(found);
+      assert.equal(live.stateDir, path.join(config.baseDir, "dev"));
+      assert.equal(live.state.devUrl, "http://localhost:8888/");
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("falls back to a live non-dev server when no dev server is running", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const config = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "userdata",
+        pid: process.pid,
+        port: 16_601,
+      });
+
+      const found = yield* findLiveServerRuntimeState(config);
+
+      const live = Option.getOrThrow(found);
+      assert.equal(live.stateDir, path.join(config.baseDir, "userdata"));
+      assert.equal(live.state.port, 16_601);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  // A server killed with SIGKILL never clears its state file.
+  it.effect("ignores state files whose process is gone", () =>
+    Effect.gen(function* () {
+      const config = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "dev",
+        pid: DEAD_PID,
+        port: 16_602,
+        devUrl: "http://localhost:8888/",
+      });
+
+      assert.isTrue(Option.isNone(yield* findLiveServerRuntimeState(config)));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("skips a stale dev server in favor of a live one elsewhere", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const config = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "dev",
+        pid: DEAD_PID,
+        port: 16_602,
+        devUrl: "http://localhost:8888/",
+      });
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "userdata",
+        pid: process.pid,
+        port: 16_601,
+      });
+
+      const live = Option.getOrThrow(yield* findLiveServerRuntimeState(config));
+      assert.equal(live.stateDir, path.join(config.baseDir, "userdata"));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports nothing when no state files exist", () =>
+    Effect.gen(function* () {
+      const config = yield* makeBaseDir();
+      assert.isTrue(Option.isNone(yield* findLiveServerRuntimeState(config)));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/cli/auth.test.ts
+++ b/apps/server/src/cli/auth.test.ts
@@ -71,6 +71,29 @@ describe("findLiveServerRuntimeState", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("prefers a legacy dev state without a dev URL", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const config = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "userdata",
+        pid: process.pid,
+        port: 16_601,
+      });
+      yield* writeRuntimeState({
+        baseDir: config.baseDir,
+        stateDir: "dev",
+        pid: process.pid,
+        port: 16_602,
+      });
+
+      const live = Option.getOrThrow(yield* findLiveServerRuntimeState(config));
+      assert.equal(live.stateDir, path.join(config.baseDir, "dev"));
+      assert.equal(live.state.port, 16_602);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("falls back to a live non-dev server when no dev server is running", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;

--- a/apps/server/src/cli/auth.ts
+++ b/apps/server/src/cli/auth.ts
@@ -171,11 +171,14 @@ export const findLiveServerRuntimeState = Effect.fn("auth.findLiveServerRuntimeS
 
   // `devUrl` is only recorded by a server fronted by a web dev server, so it
   // distinguishes the dev instance from a production-style one when both are
-  // running under the same base directory. This command is about dev, so a dev
-  // server wins regardless of which state directory the flags happened to
-  // resolve to.
+  // running under the same base directory. Older runtime-state files predate
+  // that field, but an implicit dev server still lives in `<base>/dev`, which is
+  // enough to prefer it over a production-style `<base>/userdata` server.
+  const devStateDir = path.join(config.baseDir, "dev");
   return Option.fromNullishOr(
-    live.find((candidate) => candidate.state.devUrl !== undefined) ?? live[0],
+    live.find((candidate) => candidate.state.devUrl !== undefined) ??
+      live.find((candidate) => candidate.stateDir === devStateDir) ??
+      live[0],
   );
 });
 

--- a/apps/server/src/cli/auth.ts
+++ b/apps/server/src/cli/auth.ts
@@ -210,7 +210,16 @@ const pairingUrlCommand = Command.make("url", {
           ? flags
           : { ...flags, baseDir: Option.some(worktreeBaseDir) };
       const config = yield* resolveCliAuthConfig(resolvedFlags, logLevel);
-      const live = yield* findLiveServerRuntimeState(config);
+      // Quieted here rather than only around the issuing layer below: probing
+      // reads both state directories, and a corrupt file in the one *not* in
+      // use logs a Warn to stdout — ahead of the payload, breaking `--json`
+      // for any consumer piping it. The warning is about a file the command
+      // then ignores, so under --json it is noise either way.
+      const live = yield* findLiveServerRuntimeState(config).pipe(
+        Effect.provide(
+          Layer.succeed(References.MinimumLogLevel, flags.json ? "Error" : config.logLevel),
+        ),
+      );
 
       if (Option.isNone(live)) {
         return yield* new NoRunningServerError({ baseDir: config.baseDir });

--- a/apps/server/src/cli/auth.ts
+++ b/apps/server/src/cli/auth.ts
@@ -3,11 +3,14 @@ import {
   AuthSessionId,
   AuthStandardClientScopes,
 } from "@t3tools/contracts";
+import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as References from "effect/References";
+import * as Schema from "effect/Schema";
 import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli";
 
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
@@ -20,11 +23,34 @@ import {
 } from "../cliAuthFormat.ts";
 import * as ServerConfig from "../config.ts";
 import {
+  isPersistedServerRuntimeStateLive,
+  type PersistedServerRuntimeState,
+  readPersistedServerRuntimeState,
+} from "../serverRuntimeState.ts";
+import {
   authLocationFlags,
   type CliAuthLocationFlags,
   DurationFromString,
   resolveCliAuthConfig,
 } from "./config.ts";
+
+class NoRunningServerError extends Schema.TaggedErrorClass<NoRunningServerError>()(
+  "NoRunningServerError",
+  { baseDir: Schema.String },
+) {
+  override get message(): string {
+    return [
+      `No running T3 Code server was found under ${this.baseDir}.`,
+      "Start one with `bun run dev`, or point at another directory with --base-dir.",
+    ].join("\n");
+  }
+}
+
+const environmentAuthLayer = (config: ServerConfig.ServerConfig["Service"], quietLogs: boolean) =>
+  EnvironmentAuth.runtimeLayer.pipe(
+    Layer.provide(ServerConfig.layer(config)),
+    Layer.provide(Layer.succeed(References.MinimumLogLevel, quietLogs ? "Error" : config.logLevel)),
+  );
 
 const runWithEnvironmentAuth = <A, E>(
   flags: CliAuthLocationFlags,
@@ -36,18 +62,10 @@ const runWithEnvironmentAuth = <A, E>(
   Effect.gen(function* () {
     const logLevel = yield* GlobalFlag.LogLevel;
     const config = yield* resolveCliAuthConfig(flags, logLevel);
-    const minimumLogLevel = options?.quietLogs ? "Error" : config.logLevel;
     return yield* Effect.gen(function* () {
       const environmentAuth = yield* EnvironmentAuth.EnvironmentAuth;
       return yield* run(environmentAuth);
-    }).pipe(
-      Effect.provide(
-        Layer.mergeAll(EnvironmentAuth.runtimeLayer).pipe(
-          Layer.provide(ServerConfig.layer(config)),
-          Layer.provide(Layer.succeed(References.MinimumLogLevel, minimumLogLevel)),
-        ),
-      ),
-    );
+    }).pipe(Effect.provide(environmentAuthLayer(config, options?.quietLogs ?? false)));
   });
 
 const ttlFlag = Flag.string("ttl").pipe(
@@ -113,6 +131,115 @@ const pairingCreateCommand = Command.make("create", {
   ),
 );
 
+/**
+ * The state directory is `<base>/dev` for an implicit dev home and
+ * `<base>/userdata` otherwise — a split that depends on flags the caller of
+ * this command should not have to reason about, and which silently mints
+ * tokens into a database the running server never reads when guessed wrong.
+ * So check both, and let the live server decide which one is right.
+ */
+export const findLiveServerRuntimeState = Effect.fn("auth.findLiveServerRuntimeState")(function* (
+  config: Pick<ServerConfig.ServerConfig["Service"], "baseDir" | "serverRuntimeStatePath">,
+) {
+  const path = yield* Path.Path;
+  const candidatePaths = [
+    ...new Set([
+      config.serverRuntimeStatePath,
+      ...(["dev", "userdata"] as const).map((stateDir) =>
+        path.join(config.baseDir, stateDir, "server-runtime.json"),
+      ),
+    ]),
+  ];
+
+  const live: Array<{
+    readonly stateDir: string;
+    readonly state: PersistedServerRuntimeState;
+  }> = [];
+
+  for (const statePath of candidatePaths) {
+    const state = yield* readPersistedServerRuntimeState(statePath);
+    if (Option.isNone(state)) {
+      continue;
+    }
+    // A file left behind by a killed or crashed server describes a port
+    // nothing is listening on. Minting against it produces a token the live
+    // server rejects with `invalid_credential`.
+    if (yield* isPersistedServerRuntimeStateLive(state.value)) {
+      live.push({ stateDir: path.dirname(statePath), state: state.value });
+    }
+  }
+
+  // `devUrl` is only recorded by a server fronted by a web dev server, so it
+  // distinguishes the dev instance from a production-style one when both are
+  // running under the same base directory. This command is about dev, so a dev
+  // server wins regardless of which state directory the flags happened to
+  // resolve to.
+  return Option.fromNullishOr(
+    live.find((candidate) => candidate.state.devUrl !== undefined) ?? live[0],
+  );
+});
+
+/**
+ * `t3 auth pairing url` — print a ready-to-open pairing link for a dev server
+ * that is already running, without having to know its port, its state
+ * directory, or which of those two the `--base-dir`/`--dev-url` combination
+ * happens to select. The running server records all of it in
+ * `server-runtime.json`; this reads that back.
+ *
+ * The startup link printed in the server's own log is usually enough. This is
+ * for when it has been consumed, scrolled away, or the log isn't at hand.
+ */
+const pairingUrlCommand = Command.make("url", {
+  ...authLocationFlags,
+  ttl: ttlFlag,
+  json: jsonFlag,
+}).pipe(
+  Command.withDescription(
+    "Print a pairing URL for the dev server running against this data directory.",
+  ),
+  Command.withHandler((flags) =>
+    Effect.gen(function* () {
+      const logLevel = yield* GlobalFlag.LogLevel;
+      // Run from a worktree, this command means "the dev server I just started
+      // here" — which the dev runner puts in the worktree's own `.t3`. Falling
+      // through to the shared home would mint a credential into the database
+      // the user's installed T3 Code is running against.
+      const worktreeBaseDir = yield* resolveWorktreeT3Home(process.cwd());
+      const resolvedFlags =
+        Option.isSome(flags.baseDir) || worktreeBaseDir === undefined
+          ? flags
+          : { ...flags, baseDir: Option.some(worktreeBaseDir) };
+      const config = yield* resolveCliAuthConfig(resolvedFlags, logLevel);
+      const live = yield* findLiveServerRuntimeState(config);
+
+      if (Option.isNone(live)) {
+        return yield* new NoRunningServerError({ baseDir: config.baseDir });
+      }
+
+      // Issue against the same state directory the server is using, whichever
+      // of the two it turned out to be.
+      const derivedPaths = yield* ServerConfig.deriveServerPaths(config.baseDir, config.devUrl, {
+        stateDir: live.value.stateDir,
+      });
+
+      // Prefer the web origin the user actually opens; a server with no dev URL
+      // serves the app itself, so its own origin is the right target.
+      const baseUrl = live.value.state.devUrl ?? live.value.state.origin;
+
+      return yield* Effect.gen(function* () {
+        const environmentAuth = yield* EnvironmentAuth.EnvironmentAuth;
+        const issued = yield* environmentAuth.createPairingLink({
+          scopes: AuthStandardClientScopes,
+          subject: "one-time-token",
+          ...(Option.isSome(flags.ttl) ? { ttl: flags.ttl.value } : {}),
+          label: "cli-issued pairing url",
+        });
+        yield* Console.log(formatIssuedPairingCredential(issued, { json: flags.json, baseUrl }));
+      }).pipe(Effect.provide(environmentAuthLayer({ ...config, ...derivedPaths }, flags.json)));
+    }),
+  ),
+);
+
 const pairingListCommand = Command.make("list", {
   ...authLocationFlags,
   json: jsonFlag,
@@ -156,7 +283,12 @@ const pairingRevokeCommand = Command.make("revoke", {
 
 const pairingCommand = Command.make("pairing").pipe(
   Command.withDescription("Manage one-time client pairing tokens."),
-  Command.withSubcommands([pairingCreateCommand, pairingListCommand, pairingRevokeCommand]),
+  Command.withSubcommands([
+    pairingCreateCommand,
+    pairingUrlCommand,
+    pairingListCommand,
+    pairingRevokeCommand,
+  ]),
 );
 
 const sessionIssueCommand = Command.make("issue", {

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -47,6 +47,13 @@ export interface ServerDerivedPaths {
 
 export interface DeriveServerPathsOptions {
   readonly baseDirIsExplicit?: boolean;
+  /**
+   * Use this state directory verbatim instead of deriving `dev` vs `userdata`.
+   * For tooling that has already located a running server's state directory and
+   * must target it exactly, rather than re-running the heuristic and risking a
+   * different answer.
+   */
+  readonly stateDir?: string;
 }
 
 /**
@@ -99,10 +106,9 @@ export const deriveServerPaths = Effect.fn(function* (
   options: DeriveServerPathsOptions = {},
 ): Effect.fn.Return<ServerDerivedPaths, never, Path.Path> {
   const { join } = yield* Path.Path;
-  const stateDir = join(
-    baseDir,
-    devUrl !== undefined && !options.baseDirIsExplicit ? "dev" : "userdata",
-  );
+  const stateDir =
+    options.stateDir ??
+    join(baseDir, devUrl !== undefined && !options.baseDirIsExplicit ? "dev" : "userdata");
   const dbPath = join(stateDir, "state.sqlite");
   const attachmentsDir = join(stateDir, "attachments");
   const logsDir = join(stateDir, "logs");

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1329,9 +1329,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         "bearer-access-token",
         "dpop-access-token",
       ]);
-      // Desktop, so port-scoped: instances scan for a free port and share
-      // 127.0.0.1, and cookies are not scoped by port.
-      assert.isTrue(body.auth.sessionCookieName.startsWith("t3_session_"));
+      assert.equal(body.auth.sessionCookieName, "t3_session");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -70,6 +70,30 @@ describe("serverRuntimeState", () => {
         );
       }),
     );
+
+    // `process.kill` reads non-positive pids as signal-group targets rather
+    // than process lookups — 0 is the caller's own group, -1 every permitted
+    // process — so neither throws, and a probe that only catches would call
+    // both "live" no matter what wrote the file.
+    for (const pid of [0, -1]) {
+      it.effect(`reports pid ${String(pid)} as dead rather than signalling a group`, () =>
+        Effect.gen(function* () {
+          assert.isFalse(
+            yield* ServerRuntimeState.isPersistedServerRuntimeStateLive(stateForPid(pid)),
+          );
+        }),
+      );
+    }
+
+    // Out of range for a pid: process.kill throws a TypeError with no errno,
+    // which the EPERM check must not assume the shape of.
+    it.effect("reports an out-of-range pid as dead", () =>
+      Effect.gen(function* () {
+        assert.isFalse(
+          yield* ServerRuntimeState.isPersistedServerRuntimeStateLive(stateForPid(2 ** 40)),
+        );
+      }),
+    );
   });
 
   it.effect("treats a missing runtime state file as absent", () =>

--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -43,6 +43,35 @@ describe("serverRuntimeState", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  // A server killed with SIGKILL never runs its release finalizer, so the file
+  // survives it. Trusting a leftover file points callers at a dead port.
+  describe("isPersistedServerRuntimeStateLive", () => {
+    const stateForPid = (pid: number): ServerRuntimeState.PersistedServerRuntimeState => ({
+      version: 1,
+      pid,
+      port: 4_971,
+      origin: "http://127.0.0.1:4971",
+      startedAt: "2026-06-20T00:00:00.000Z",
+    });
+
+    it.effect("recognizes the current process as live", () =>
+      Effect.gen(function* () {
+        assert.isTrue(
+          yield* ServerRuntimeState.isPersistedServerRuntimeStateLive(stateForPid(process.pid)),
+        );
+      }),
+    );
+
+    it.effect("reports a pid that no longer exists as dead", () =>
+      Effect.gen(function* () {
+        // Above the default pid_max, so it cannot be a live process.
+        assert.isFalse(
+          yield* ServerRuntimeState.isPersistedServerRuntimeStateLive(stateForPid(0x7ffffffe)),
+        );
+      }),
+    );
+  });
+
   it.effect("treats a missing runtime state file as absent", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -10,7 +10,11 @@ import { formatHostForUrl, isWildcardHost } from "./startupAccess.ts";
 
 export const PersistedServerRuntimeState = Schema.Struct({
   version: Schema.Literal(1),
-  pid: Schema.Int,
+  /**
+   * Positive: `process.kill` reads 0 and negatives as signal-group targets, so
+   * a liveness probe on one reports "live" for a process that never existed.
+   */
+  pid: Schema.Int.check(Schema.isGreaterThan(0)),
   host: Schema.optional(Schema.String),
   port: Schema.Int,
   origin: Schema.String,
@@ -108,6 +112,13 @@ export const clearPersistedServerRuntimeState = (path: string) =>
   });
 
 /**
+ * `process.kill` rejects an out-of-range pid with a TypeError rather than an
+ * errno, so the catch below cannot assume either shape.
+ */
+const isErrnoException = (cause: unknown): cause is NodeJS.ErrnoException =>
+  typeof cause === "object" && cause !== null && "code" in cause;
+
+/**
  * Whether the process that wrote a runtime-state file is still alive.
  *
  * The file is removed by a release finalizer, so a server killed with SIGKILL —
@@ -123,12 +134,20 @@ export const isPersistedServerRuntimeStateLive = (
   state: PersistedServerRuntimeState,
 ): Effect.Effect<boolean> =>
   Effect.sync(() => {
+    // `process.kill` reads non-positive pids as signal-group targets rather
+    // than process lookups: 0 signals the caller's own group and -1 every
+    // permitted process, so neither throws and both would report "live"
+    // unconditionally. A server never records one; a corrupt or truncated file
+    // can, and that file would then be believed forever.
+    if (!Number.isSafeInteger(state.pid) || state.pid <= 0) {
+      return false;
+    }
     try {
       process.kill(state.pid, 0);
       return true;
     } catch (cause) {
       // EPERM means the process exists but belongs to another user.
-      return (cause as NodeJS.ErrnoException).code === "EPERM";
+      return isErrnoException(cause) && cause.code === "EPERM";
     }
   });
 

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -14,6 +14,12 @@ export const PersistedServerRuntimeState = Schema.Struct({
   host: Schema.optional(Schema.String),
   port: Schema.Int,
   origin: Schema.String,
+  /**
+   * The web origin users actually open in dev — the Vite server, or the shared
+   * tailnet URL when the dev runner published one. Recorded so tooling can mint
+   * a pairing URL for a running server without being told where it lives.
+   */
+  devUrl: Schema.optional(Schema.String),
   startedAt: Schema.String,
 });
 export type PersistedServerRuntimeState = typeof PersistedServerRuntimeState.Type;
@@ -45,7 +51,7 @@ const runtimeOriginForConfig = (
 };
 
 export const makePersistedServerRuntimeState = (input: {
-  readonly config: Pick<ServerConfig.ServerConfig["Service"], "host">;
+  readonly config: Pick<ServerConfig.ServerConfig["Service"], "host" | "devUrl">;
   readonly port: number;
 }): Effect.Effect<PersistedServerRuntimeState> =>
   Effect.map(DateTime.now, (now) => ({
@@ -54,6 +60,7 @@ export const makePersistedServerRuntimeState = (input: {
     ...(input.config.host ? { host: input.config.host } : {}),
     port: input.port,
     origin: runtimeOriginForConfig(input.config, input.port),
+    ...(input.config.devUrl ? { devUrl: input.config.devUrl.toString() } : {}),
     startedAt: DateTime.formatIso(now),
   }));
 
@@ -98,6 +105,31 @@ export const clearPersistedServerRuntimeState = (path: string) =>
           ),
       }),
     );
+  });
+
+/**
+ * Whether the process that wrote a runtime-state file is still alive.
+ *
+ * The file is removed by a release finalizer, so a server killed with SIGKILL —
+ * or one that crashed — leaves it behind. Treating a leftover file as "the
+ * server is up" points callers at a port nothing is listening on. Signal 0
+ * performs the permission and existence checks without delivering a signal.
+ *
+ * PIDs are reused eventually, so a false positive is possible in principle;
+ * that is acceptable for local dev tooling, where the alternative is an
+ * HTTP probe that has to guess how long to wait for a starting server.
+ */
+export const isPersistedServerRuntimeStateLive = (
+  state: PersistedServerRuntimeState,
+): Effect.Effect<boolean> =>
+  Effect.sync(() => {
+    try {
+      process.kill(state.pid, 0);
+      return true;
+    } catch (cause) {
+      // EPERM means the process exists but belongs to another user.
+      return (cause as NodeJS.ErrnoException).code === "EPERM";
+    }
   });
 
 export const readPersistedServerRuntimeState = (path: string) =>

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -51,7 +51,7 @@ An isolated dev database starts empty. `bun run dev:seed` copies projection data
 
 `dev:seed` refuses to run while a server is using the target directory: it replaces the projections and event log that server is holding open, and it has no way to tell the running process its read model was swapped underneath it. Stop the server, seed, then start it again.
 
-Both source and target follow whichever state directory actually holds a database — `userdata` when present, otherwise `dev` — so a main-checkout `bun run dev`, whose state lives in `~/.t3/dev`, is seedable without naming the directory.
+Both source and target follow whichever state directory actually holds a database, so a main-checkout `bun run dev` — whose state lives in `~/.t3/dev` — is seedable without naming the directory. When a base directory holds both, the more recently written one wins, since that is the database the last server to run had open. The resolved path is printed in the summary.
 
 ## Running multiple dev instances
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -51,6 +51,8 @@ An isolated dev database starts empty. `bun run dev:seed` copies projection data
 
 `dev:seed` refuses to run while a server is using the target directory: it replaces the projections and event log that server is holding open, and it has no way to tell the running process its read model was swapped underneath it. Stop the server, seed, then start it again.
 
+Both source and target follow whichever state directory actually holds a database — `userdata` when present, otherwise `dev` — so a main-checkout `bun run dev`, whose state lives in `~/.t3/dev`, is seedable without naming the directory.
+
 ## Running multiple dev instances
 
 Set `T3CODE_DEV_INSTANCE` to any value to deterministically shift all dev ports together.

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -47,7 +47,9 @@
 
 Worktrees derive a preferred port offset from their path. The runner shifts both ports together when either is occupied or the web port is blocked by browsers, so treat the `[dev-runner]` output as authoritative.
 
-An isolated dev database starts empty. `bun run dev:seed` copies projection data only, clears the target event log, and resets every projector cursor to zero so later events are not skipped or replayed over unrelated projections. Copied sessions are stopped and pending interaction counts are cleared because no live agent accompanies the copy. The copy tolerates source/target migration drift and remains local because it includes real message bodies and host paths.
+An isolated dev database starts empty. `bun run dev:seed` copies projection data only, clears the target event log, and resets every projector cursor to zero so later events are not skipped or replayed over unrelated projections. Because no live agent accompanies the copy, it also settles anything that would otherwise wait on one: sessions are stopped, running turns are interrupted, streaming messages are finished, pending interaction counts are cleared, and orphaned provider bindings are removed. Files backing copied image attachments are copied alongside the rows. The copy tolerates source/target migration drift and remains local because it includes real message bodies and host paths.
+
+`dev:seed` refuses to run while a server is using the target directory: it replaces the projections and event log that server is holding open, and it has no way to tell the running process its read model was swapped underneath it. Stop the server, seed, then start it again.
 
 ## Running multiple dev instances
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -2,6 +2,8 @@
 
 - `vp run dev` — Starts contracts, server, and web in watch mode.
 - `vp run dev --share` — Also publishes the web port over HTTPS on this machine's tailnet. The startup pairing URL is built against the shared origin, and the mapping is removed on exit.
+- `vp run dev:pair` — Prints a fresh pairing URL for the running dev server, using its recorded state directory, port, and web origin. Add `--base-dir <path>` only when the server was started with `--home-dir`.
+- `vp run dev:seed` — Copies recent projects and threads from the shared home into the isolated dev database. Stop the server before running it, then restart. Tune the copy with `--threads` and `--activities`; it refuses to write to the shared home.
 - `vp run dev:server` — Starts just the WebSocket server. The server process runs on Bun (`@effect/platform-bun` + `BunPtyAdapter`), but task running uses `vp run`.
 - `vp run dev:web` — Starts just the Vite dev server for the web app.
 - Dev commands run from a linked **git worktree** default to that worktree's gitignored `.t3`, even when `T3CODE_HOME` is set, storing state in `<worktree>/.t3/userdata`. Pass `--home-dir <path>` to choose another isolated directory explicitly. Submodules are not worktrees and keep the normal precedence.
@@ -44,6 +46,8 @@
 `dev` and `dev:web` leave `VITE_HTTP_URL` and `VITE_WS_URL` unset so the browser resolves the backend from `window.location.origin`. Vite proxies `/api`, `/ws`, `/oauth`, and `/.well-known` to the server, allowing the same bundle to work from localhost or a tailnet hostname.
 
 Worktrees derive a preferred port offset from their path. The runner shifts both ports together when either is occupied or the web port is blocked by browsers, so treat the `[dev-runner]` output as authoritative.
+
+An isolated dev database starts empty. `bun run dev:seed` copies projection data only, clears the target event log, and resets every projector cursor to zero so later events are not skipped or replayed over unrelated projections. Copied sessions are stopped and pending interaction counts are cleared because no live agent accompanies the copy. The copy tolerates source/target migration drift and remains local because it includes real message bodies and host paths.
 
 ## Running multiple dev instances
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -1,9 +1,9 @@
 # Scripts
 
-- `vp run dev` — Starts contracts, server, and web in watch mode.
-- `vp run dev --share` — Also publishes the web port over HTTPS on this machine's tailnet. The startup pairing URL is built against the shared origin, and the mapping is removed on exit.
-- `vp run dev:pair` — Prints a fresh pairing URL for the running dev server, using its recorded state directory, port, and web origin. Add `--base-dir <path>` only when the server was started with `--home-dir`.
-- `vp run dev:seed` — Copies recent projects and threads from the shared home into the isolated dev database. Stop the server before running it, then restart. Tune the copy with `--threads` and `--activities`; it refuses to write to the shared home.
+- `bun run dev` — Starts contracts, server, and web in watch mode.
+- `bun run dev:share` — Also publishes the web port over HTTPS on this machine's tailnet. The startup pairing URL is built against the shared origin, and the mapping is removed on exit.
+- `bun run dev:pair` — Prints a fresh pairing URL for the running dev server, using its recorded state directory, port, and web origin. Add `--base-dir <path>` only when the server was started with `--home-dir`.
+- `bun run dev:seed` — Copies recent projects and threads from the shared home into the isolated dev database. Stop the server before running it, then restart. Tune the copy with `--threads` and `--activities`; it refuses to write to the shared home.
 - `vp run dev:server` — Starts just the WebSocket server. The server process runs on Bun (`@effect/platform-bun` + `BunPtyAdapter`), but task running uses `vp run`.
 - `vp run dev:web` — Starts just the Vite dev server for the web app.
 - Dev commands run from a linked **git worktree** default to that worktree's gitignored `.t3`, even when `T3CODE_HOME` is set, storing state in `<worktree>/.t3/userdata`. Pass `--home-dir <path>` to choose another isolated directory explicitly. Submodules are not worktrees and keep the normal precedence.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "prepare": "effect-tsgo patch && vp config --no-agent",
     "dev": "node scripts/dev-runner.ts dev",
     "dev:share": "node scripts/dev-runner.ts dev --share",
+    "dev:pair": "node apps/server/src/bin.ts auth pairing url",
+    "dev:seed": "node scripts/dev-seed.ts",
     "dev:server": "node scripts/dev-runner.ts dev:server",
     "dev:web": "node scripts/dev-runner.ts dev:web",
     "dev:marketing": "vp run --filter @t3tools/marketing dev",

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -20,12 +20,7 @@ import * as Schema from "effect/Schema";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 
-import {
-  claimDevShareLease,
-  cleanupOwnedDevShare,
-  type DevShareError,
-  shareDevServer,
-} from "./lib/dev-share.ts";
+import { acquireDevShare, cleanupOwnedDevShare, type DevShareError } from "./lib/dev-share.ts";
 import { loadRepoEnv } from "./lib/public-config.ts";
 
 Object.assign(process.env, loadRepoEnv());
@@ -744,12 +739,12 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
         // A tailnet that isn't up shouldn't stop the dev server from starting —
         // warn, and carry on serving locally.
         const shared = yield* Effect.gen(function* () {
-          const lease = yield* claimDevShareLease({
+          const lease = {
             leasePath: path.join(baseDir, "dev-share", `${String(sharedWebPort)}.owner`),
             ownerId: `${String(process.pid)}:${NodeCrypto.randomUUID()}`,
             webPort: sharedWebPort,
-          });
-          return yield* Effect.acquireRelease(shareDevServer({ webPort: sharedWebPort }), () =>
+          };
+          return yield* Effect.acquireRelease(acquireDevShare(lease), () =>
             cleanupOwnedDevShare(lease).pipe(
               Effect.flatMap((result) =>
                 result.status !== "failed"

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -730,12 +730,6 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
         // with creating it. An interrupt landing in between would otherwise
         // leave a mapping pointing at a port nothing is listening on.
         //
-        // Deliberately no ownership tracking beyond that: if a second runner
-        // takes this port during a fast restart, the first's exit can briefly
-        // tear down the new mapping — visible (the URL stops working) and fixed
-        // by re-running --share. A lease protocol closing that window existed
-        // and was removed as more machinery than a dev convenience warrants.
-        //
         // A tailnet that isn't up shouldn't stop the dev server from starting —
         // warn, and carry on serving locally.
         const shared = yield* Effect.gen(function* () {

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as NodeOS from "node:os";
+import * as NodeCrypto from "node:crypto";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -19,7 +20,12 @@ import * as Schema from "effect/Schema";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 
-import { type DevShareError, shareDevServer, unshareDevServer } from "./lib/dev-share.ts";
+import {
+  claimDevShareLease,
+  cleanupOwnedDevShare,
+  type DevShareError,
+  shareDevServer,
+} from "./lib/dev-share.ts";
 import { loadRepoEnv } from "./lib/public-config.ts";
 
 Object.assign(process.env, loadRepoEnv());
@@ -723,6 +729,7 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
           "[dev-runner] --share is not supported for dev:desktop (the renderer is pinned to loopback). Use `dev`, which runs the whole browser stack.",
         );
       } else {
+        const path = yield* Path.Path;
         // acquireRelease, not share-then-addFinalizer: the mapping outlives this
         // process (and reboots), so the cleanup has to be registered atomically
         // with creating it. An interrupt landing in between would otherwise
@@ -736,23 +743,24 @@ export function runDevRunnerWithInput(input: DevRunnerCliInput) {
         //
         // A tailnet that isn't up shouldn't stop the dev server from starting —
         // warn, and carry on serving locally.
-        const shared = yield* Effect.acquireRelease(
-          shareDevServer({ webPort: sharedWebPort }),
-          () =>
-            // Serve config outlives this process, so a cleanup that did not
-            // take leaves a tailnet URL pointing at a port nothing serves.
-            unshareDevServer(sharedWebPort).pipe(
+        const shared = yield* Effect.gen(function* () {
+          const lease = yield* claimDevShareLease({
+            leasePath: path.join(baseDir, "dev-share", `${String(sharedWebPort)}.owner`),
+            ownerId: `${String(process.pid)}:${NodeCrypto.randomUUID()}`,
+            webPort: sharedWebPort,
+          });
+          return yield* Effect.acquireRelease(shareDevServer({ webPort: sharedWebPort }), () =>
+            cleanupOwnedDevShare(lease).pipe(
               Effect.flatMap((result) =>
-                result.cleared
+                result.status !== "failed"
                   ? Effect.void
                   : Effect.logWarning(
-                      `[dev-runner] could not remove the tailnet mapping for port ${String(sharedWebPort)}${
-                        result.explanation ? `: ${result.explanation}` : ""
-                      }. Remove it with \`tailscale serve --https=${String(sharedWebPort)} off\`.`,
+                      `[dev-runner] could not safely clean up the tailnet mapping for port ${String(sharedWebPort)}: ${result.explanation}`,
                     ),
               ),
             ),
-        ).pipe(
+          );
+        }).pipe(
           Effect.tapError((error: DevShareError) =>
             Effect.logWarning(
               `[dev-runner] could not share on the tailnet: ${error.message}${

--- a/scripts/dev-seed-cli.test.ts
+++ b/scripts/dev-seed-cli.test.ts
@@ -5,6 +5,34 @@ import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
+const runDevSeed = (input: {
+  readonly root: string;
+  readonly targetBaseDir: string;
+  readonly t3Home: string;
+}) =>
+  NodeChildProcess.spawnSync(
+    process.execPath,
+    [
+      NodePath.join(import.meta.dirname, "dev-seed.ts"),
+      "--from",
+      NodePath.join(input.root, "source"),
+      "--to",
+      input.targetBaseDir,
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, NO_COLOR: "1", T3CODE_HOME: input.t3Home },
+    },
+  );
+
+const assertSharedHomeRefusal = (result: ReturnType<typeof runDevSeed>) => {
+  assert.notEqual(result.status, 0);
+  assert.include(
+    `${result.stdout}${result.stderr}`,
+    "that database lives in the shared T3 Code home",
+  );
+};
+
 it("refuses to seed a target inside T3CODE_HOME through a symlink", () => {
   const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-dev-seed-cli-"));
   try {
@@ -16,28 +44,33 @@ it("refuses to seed a target inside T3CODE_HOME through a symlink", () => {
     NodeFS.writeFileSync(NodePath.join(sharedStateDir, "state.sqlite"), "must stay untouched");
     NodeFS.symlinkSync(sharedStateDir, NodePath.join(targetBaseDir, "userdata"), "dir");
 
-    const result = NodeChildProcess.spawnSync(
-      process.execPath,
-      [
-        NodePath.join(import.meta.dirname, "dev-seed.ts"),
-        "--from",
-        NodePath.join(root, "source"),
-        "--to",
-        targetBaseDir,
-      ],
-      {
-        encoding: "utf8",
-        env: { ...process.env, NO_COLOR: "1", T3CODE_HOME: sharedHome },
-      },
-    );
+    const result = runDevSeed({ root, targetBaseDir, t3Home: sharedHome });
 
-    assert.notEqual(result.status, 0);
-    assert.include(
-      `${result.stdout}${result.stderr}`,
-      "that database lives in the shared T3 Code home",
-    );
+    assertSharedHomeRefusal(result);
     assert.equal(
       NodeFS.readFileSync(NodePath.join(sharedStateDir, "state.sqlite"), "utf8"),
+      "must stay untouched",
+    );
+  } finally {
+    NodeFS.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+it("refuses targets when T3CODE_HOME resolves to the filesystem root", () => {
+  const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-dev-seed-root-cli-"));
+  try {
+    const sharedHome = NodePath.join(root, "shared");
+    const targetBaseDir = NodePath.join(root, "target");
+    const targetStateDir = NodePath.join(targetBaseDir, "userdata");
+    NodeFS.symlinkSync(NodePath.parse(root).root, sharedHome, "dir");
+    NodeFS.mkdirSync(targetStateDir, { recursive: true });
+    NodeFS.writeFileSync(NodePath.join(targetStateDir, "state.sqlite"), "must stay untouched");
+
+    const result = runDevSeed({ root, targetBaseDir, t3Home: sharedHome });
+
+    assertSharedHomeRefusal(result);
+    assert.equal(
+      NodeFS.readFileSync(NodePath.join(targetStateDir, "state.sqlite"), "utf8"),
       "must stay untouched",
     );
   } finally {

--- a/scripts/dev-seed-cli.test.ts
+++ b/scripts/dev-seed-cli.test.ts
@@ -1,0 +1,46 @@
+// @effect-diagnostics nodeBuiltinImport:off - exercises the executable path guard in a child process.
+import { assert, it } from "@effect/vitest";
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+it("refuses to seed a target inside T3CODE_HOME through a symlink", () => {
+  const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-dev-seed-cli-"));
+  try {
+    const sharedHome = NodePath.join(root, "shared");
+    const sharedStateDir = NodePath.join(sharedHome, "userdata");
+    const targetBaseDir = NodePath.join(root, "target");
+    NodeFS.mkdirSync(sharedStateDir, { recursive: true });
+    NodeFS.mkdirSync(targetBaseDir, { recursive: true });
+    NodeFS.writeFileSync(NodePath.join(sharedStateDir, "state.sqlite"), "must stay untouched");
+    NodeFS.symlinkSync(sharedStateDir, NodePath.join(targetBaseDir, "userdata"), "dir");
+
+    const result = NodeChildProcess.spawnSync(
+      process.execPath,
+      [
+        NodePath.join(import.meta.dirname, "dev-seed.ts"),
+        "--from",
+        NodePath.join(root, "source"),
+        "--to",
+        targetBaseDir,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, NO_COLOR: "1", T3CODE_HOME: sharedHome },
+      },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.include(
+      `${result.stdout}${result.stderr}`,
+      "that database lives in the shared T3 Code home",
+    );
+    assert.equal(
+      NodeFS.readFileSync(NodePath.join(sharedStateDir, "state.sqlite"), "utf8"),
+      "must stay untouched",
+    );
+  } finally {
+    NodeFS.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -81,18 +81,40 @@ class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
  * the seed reported "no database, start the dev server so migrations run" about
  * a server that was already running.
  *
- * Whichever one exists wins; `userdata` breaks the tie, since that is what an
- * explicit `--home-dir` produces.
+ * When both exist, neither is categorically right — a worktree run gets
+ * `userdata` (the dev runner passes an explicit home), a main-checkout run gets
+ * `dev` — so the tie goes to whichever was written most recently, i.e. the one
+ * the last server to run actually opened. The chosen path is printed, so a
+ * wrong guess is visible rather than silent.
  */
 const resolveStateDir = Effect.fn("devSeed.resolveStateDir")(function* (baseDir: string) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+
+  const candidates: Array<{ readonly stateDir: string; readonly modifiedAtMs: number }> = [];
   for (const stateDir of ["userdata", "dev"] as const) {
-    if (yield* fileSystem.exists(path.join(baseDir, stateDir, "state.sqlite"))) {
-      return stateDir;
+    const info = yield* fileSystem
+      .stat(path.join(baseDir, stateDir, "state.sqlite"))
+      .pipe(Effect.option);
+    if (Option.isSome(info)) {
+      candidates.push({
+        stateDir,
+        modifiedAtMs: Option.match(info.value.mtime, {
+          onSome: (mtime) => mtime.getTime(),
+          onNone: () => 0,
+        }),
+      });
     }
   }
-  return "userdata";
+
+  // `userdata` first above, so an equal or missing mtime keeps the old default.
+  return (
+    candidates.reduce<{ readonly stateDir: string; readonly modifiedAtMs: number } | undefined>(
+      (best, candidate) =>
+        best === undefined || candidate.modifiedAtMs > best.modifiedAtMs ? candidate : best,
+      undefined,
+    )?.stateDir ?? "userdata"
+  );
 });
 
 const stateDbPath = (path: Path.Path, baseDir: string, stateDir: string) =>

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -40,7 +40,7 @@ class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
     switch (this.reason) {
       case "shared-home":
         return [
-          `Refusing to seed ${this.detail}: that is the shared T3 Code home.`,
+          `Refusing to seed ${this.detail}: that database lives in the shared T3 Code home.`,
           "This command overwrites projection tables. Run it from a worktree, or pass --to <base-dir>.",
         ].join("\n");
       case "missing-target":
@@ -231,24 +231,6 @@ const devSeedCli = Command.make("dev-seed", {
         return yield* new DevSeedTargetError({ reason: "not-a-worktree", detail: process.cwd() });
       }
 
-      // The whole point is to keep dev data off the real home; overwriting it
-      // here would be the exact accident this command exists to avoid.
-      const [canonicalTarget, canonicalSource, canonicalShared] = yield* Effect.all([
-        fileSystem.realPath(targetBaseDir).pipe(Effect.orElseSucceed(() => targetBaseDir)),
-        fileSystem.realPath(sourceBaseDir).pipe(Effect.orElseSucceed(() => sourceBaseDir)),
-        fileSystem.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
-      ]);
-      if (canonicalTarget === canonicalShared) {
-        return yield* new DevSeedTargetError({ reason: "shared-home", detail: targetBaseDir });
-      }
-      // Seeding a directory from itself is not the data loss it looks like —
-      // the source reads a pre-transaction snapshot, so the copy puts the rows
-      // back. What does not come back is the event log and the cursors, and
-      // anything outside the caps. Nobody means to ask for that.
-      if (canonicalTarget === canonicalSource) {
-        return yield* new DevSeedTargetError({ reason: "same-source", detail: targetBaseDir });
-      }
-
       const [sourceStateDir, targetStateDir] = yield* Effect.all([
         resolveStateDir(sourceBaseDir),
         resolveStateDir(targetBaseDir),
@@ -257,6 +239,30 @@ const devSeedCli = Command.make("dev-seed", {
       const targetDbPath = stateDbPath(path, targetBaseDir, targetStateDir);
       if (!(yield* fileSystem.exists(targetDbPath))) {
         return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
+      }
+
+      // The whole point is to keep dev data off the real home; overwriting it
+      // here would be the exact accident this command exists to avoid.
+      //
+      // Guarded on the canonical *database* paths, not the base directories: a
+      // base can canonicalize to itself while its `userdata` or `dev`
+      // subdirectory is a symlink into the shared home, and comparing bases
+      // then waves through a seed whose actual write target is the real
+      // database. The db path is what gets opened, so it is what gets checked.
+      const [canonicalTargetDb, canonicalSourceDb, canonicalShared] = yield* Effect.all([
+        fileSystem.realPath(targetDbPath).pipe(Effect.orElseSucceed(() => targetDbPath)),
+        fileSystem.realPath(sourceDbPath).pipe(Effect.orElseSucceed(() => sourceDbPath)),
+        fileSystem.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
+      ]);
+      if (canonicalTargetDb.startsWith(`${canonicalShared}${path.sep}`)) {
+        return yield* new DevSeedTargetError({ reason: "shared-home", detail: canonicalTargetDb });
+      }
+      // Seeding a database from itself is not the data loss it looks like —
+      // the source reads a pre-transaction snapshot, so the copy puts the rows
+      // back. What does not come back is the event log and the cursors, and
+      // anything outside the caps. Nobody means to ask for that.
+      if (canonicalTargetDb === canonicalSourceDb) {
+        return yield* new DevSeedTargetError({ reason: "same-source", detail: canonicalTargetDb });
       }
 
       // SQLite locking is not enough on its own: the seed's transaction can take

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -166,16 +166,23 @@ const copyAttachments = Effect.fn("devSeed.copyAttachments")(function* (input: {
     return 0;
   }
 
-  yield* fileSystem.makeDirectory(input.targetDir, { recursive: true });
   // Attachments are decoration on a dev fixture: one unreadable file should
-  // leave the rest of the seed intact rather than fail a completed copy.
-  const copied = yield* Effect.forEach(matches, (entry) =>
-    fileSystem.copyFile(path.join(input.sourceDir, entry), path.join(input.targetDir, entry)).pipe(
-      Effect.as(1),
-      Effect.orElseSucceed(() => 0),
+  // leave the rest of the seed intact rather than fail a completed database
+  // copy. The directory itself is subject to the same rule.
+  return yield* fileSystem.makeDirectory(input.targetDir, { recursive: true }).pipe(
+    Effect.andThen(
+      Effect.forEach(matches, (entry) =>
+        fileSystem
+          .copyFile(path.join(input.sourceDir, entry), path.join(input.targetDir, entry))
+          .pipe(
+            Effect.as(1),
+            Effect.orElseSucceed(() => 0),
+          ),
+      ),
     ),
+    Effect.map((copied) => copied.reduce((total, one) => total + one, 0)),
+    Effect.orElseSucceed(() => 0),
   );
-  return copied.reduce((total, one) => total + one, 0);
 });
 
 const devSeedCli = Command.make("dev-seed", {

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -18,14 +18,17 @@ import { Command, Flag } from "effect/unstable/cli";
 import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
 
 import { DevSeedError, seedDevDatabase } from "./lib/dev-seed.ts";
+import { findRunningServerPid } from "./lib/server-runtime-probe.ts";
 
 const DEFAULT_THREAD_LIMIT = 25;
 const DEFAULT_ACTIVITY_LIMIT = 200;
+/** SQLite's default SQLITE_MAX_VARIABLE_NUMBER; one bound parameter per thread. */
+const MAX_THREAD_LIMIT = 32_766;
 
 class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
   "DevSeedTargetError",
   {
-    reason: Schema.Literals(["shared-home", "missing-target", "not-a-worktree"]),
+    reason: Schema.Literals(["shared-home", "missing-target", "not-a-worktree", "server-running"]),
     detail: Schema.String,
   },
 ) {
@@ -46,12 +49,67 @@ class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
           "Not inside a git worktree, so there is no worktree-local data directory to seed.",
           "Pass --to <base-dir> to choose one explicitly.",
         ].join("\n");
+      case "server-running":
+        return [
+          `A T3 Code server (pid ${this.detail}) is running against this data directory.`,
+          "Seeding replaces its projections and empties its event log while it holds them open,",
+          "which leaves the running server's in-memory read model describing rows that no longer exist.",
+          "Stop it, run the seed, then start it again.",
+        ].join("\n");
     }
   }
 }
 
 const stateDbPath = (path: Path.Path, baseDir: string) =>
   path.join(baseDir, "userdata", "state.sqlite");
+
+/**
+ * Copies the files behind the copied messages' attachment references.
+ *
+ * The rows carry only metadata; the bytes sit in a flat directory beside the
+ * database as `<attachmentId><ext>` (apps/server/src/attachmentStore.ts). Copy
+ * the rows alone and a seeded thread renders an image whose request 404s.
+ *
+ * Matched by directory listing rather than by reconstructing the extension: the
+ * server infers it from mime type and file name at upload, and duplicating that
+ * inference here would rot independently of it.
+ */
+const copyAttachments = Effect.fn("devSeed.copyAttachments")(function* (input: {
+  readonly sourceDir: string;
+  readonly targetDir: string;
+  readonly attachmentIds: ReadonlyArray<string>;
+}) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  if (input.attachmentIds.length === 0) {
+    return 0;
+  }
+
+  const entries = yield* fileSystem
+    .readDirectory(input.sourceDir)
+    .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  const wanted = new Set(input.attachmentIds);
+  const matches = entries.filter((entry) => wanted.has(path.parse(entry).name));
+  if (matches.length === 0) {
+    return 0;
+  }
+
+  yield* fileSystem.makeDirectory(input.targetDir, { recursive: true });
+  // Attachments are decoration on a dev fixture: one unreadable file should
+  // leave the rest of the seed intact rather than fail a completed copy.
+  const copied = yield* Effect.forEach(matches, (entry) =>
+    fileSystem.copyFile(path.join(input.sourceDir, entry), path.join(input.targetDir, entry)).pipe(
+      Effect.as(1),
+      Effect.orElseSucceed(() => 0),
+    ),
+  );
+  return copied.reduce((total, one) => total + one, 0);
+});
 
 const devSeedCli = Command.make("dev-seed", {
   from: Flag.string("from").pipe(
@@ -68,12 +126,17 @@ const devSeedCli = Command.make("dev-seed", {
     Flag.optional,
     Flag.map(Option.getOrUndefined),
   ),
-  // Bounded: SQLite reads a negative LIMIT as "no limit", which would quietly
-  // turn a capped copy into a full-table one.
+  // Bounded below: SQLite reads a negative LIMIT as "no limit", which would
+  // quietly turn a capped copy into a full-table one. Bounded above because
+  // every selected thread becomes one bound parameter in the copy's `IN (...)`,
+  // and SQLite's compiled-in ceiling is 32766 — past it the seed dies with
+  // "too many SQL variables" after the target has already been emptied.
   threads: Flag.integer("threads").pipe(
-    Flag.withSchema(Schema.Int.check(Schema.isGreaterThan(0))),
+    Flag.withSchema(
+      Schema.Int.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(MAX_THREAD_LIMIT)),
+    ),
     Flag.withDescription(
-      `How many recent threads to copy (default ${String(DEFAULT_THREAD_LIMIT)}).`,
+      `How many recent threads to copy (default ${String(DEFAULT_THREAD_LIMIT)}, max ${String(MAX_THREAD_LIMIT)}).`,
     ),
     Flag.withDefault(DEFAULT_THREAD_LIMIT),
   ),
@@ -117,6 +180,19 @@ const devSeedCli = Command.make("dev-seed", {
         return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
       }
 
+      // SQLite locking is not enough on its own: the seed's transaction can take
+      // the write lock between a running server's own writes and commit cleanly.
+      // What it cannot do is tell that server the projections it is holding in
+      // memory, and the event log it is appending to, were both replaced under
+      // it. Its next write then lands on top of a read model it never built.
+      const runningPid = yield* findRunningServerPid(targetBaseDir);
+      if (Option.isSome(runningPid)) {
+        return yield* new DevSeedTargetError({
+          reason: "server-running",
+          detail: String(runningPid.value),
+        });
+      }
+
       const seededAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
       const summary = yield* Effect.try({
         try: () =>
@@ -130,6 +206,12 @@ const devSeedCli = Command.make("dev-seed", {
         catch: (cause) => cause as DevSeedError,
       });
 
+      const copiedAttachments = yield* copyAttachments({
+        sourceDir: path.join(sourceBaseDir, "userdata", "attachments"),
+        targetDir: path.join(targetBaseDir, "userdata", "attachments"),
+        attachmentIds: summary.attachmentIds,
+      });
+
       yield* Console.log(
         [
           `Seeded ${targetDbPath}`,
@@ -139,6 +221,11 @@ const devSeedCli = Command.make("dev-seed", {
           `  messages ${String(summary.messages)}`,
           `  activity ${String(summary.activities)}`,
           `  turns    ${String(summary.turns)}  sessions ${String(summary.sessions)}`,
+          ...(summary.attachmentIds.length > 0
+            ? [
+                `  files    ${String(copiedAttachments)}/${String(summary.attachmentIds.length)} attachment(s)`,
+              ]
+            : []),
           ...(summary.skippedColumns.length > 0
             ? [
                 `  note: skipped ${String(summary.skippedColumns.length)} column(s) absent from the target schema`,

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -245,14 +245,19 @@ const devSeedCli = Command.make("dev-seed", {
       // base can canonicalize to itself while its `userdata` or `dev`
       // subdirectory is a symlink into the shared home, and comparing bases
       // then waves through a seed whose actual write target is the real
-      // database. The directory is canonicalized and the filename re-joined
-      // because the database may not exist yet — realPath fails on a missing
-      // final component, and falling back to the literal path would lose the
-      // symlink resolution in exactly the case where the next error's advice
-      // ("start the dev server") would create the database in the shared home.
+      // database. Resolve the full path first — the file itself can be the
+      // symlink — and fall back to resolving the directory and re-joining the
+      // filename when the file does not exist yet: a nonexistent file cannot
+      // be a link to anything, but its directory still can be, and this is
+      // exactly the case where the missing-target advice ("start the dev
+      // server") would otherwise create the database in the shared home.
       const canonicalDbPath = (databasePath: string) =>
-        fileSystem.realPath(path.dirname(databasePath)).pipe(
-          Effect.map((directory) => path.join(directory, path.basename(databasePath))),
+        fileSystem.realPath(databasePath).pipe(
+          Effect.catch(() =>
+            fileSystem
+              .realPath(path.dirname(databasePath))
+              .pipe(Effect.map((directory) => path.join(directory, path.basename(databasePath)))),
+          ),
           Effect.orElseSucceed(() => databasePath),
         );
       const [canonicalTargetDb, canonicalSourceDb, canonicalShared] = yield* Effect.all([
@@ -263,19 +268,22 @@ const devSeedCli = Command.make("dev-seed", {
       if (canonicalTargetDb.startsWith(`${canonicalShared}${path.sep}`)) {
         return yield* new DevSeedTargetError({ reason: "shared-home", detail: canonicalTargetDb });
       }
+      // After the shared-home refusal: that one must come first because the
+      // missing-target advice below — start a dev server, which creates the
+      // database — is exactly wrong for the shared home. Everywhere else, a
+      // missing database is the more actionable diagnosis, so it outranks
+      // same-source: aliased paths with nothing behind them are a setup
+      // problem, not a self-seed.
+      if (!(yield* fileSystem.exists(targetDbPath))) {
+        return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
+      }
+
       // Seeding a database from itself is not the data loss it looks like —
       // the source reads a pre-transaction snapshot, so the copy puts the rows
       // back. What does not come back is the event log and the cursors, and
       // anything outside the caps. Nobody means to ask for that.
       if (canonicalTargetDb === canonicalSourceDb) {
         return yield* new DevSeedTargetError({ reason: "same-source", detail: canonicalTargetDb });
-      }
-
-      // After the refusals: this error's advice is to start a dev server, which
-      // creates the database — the right next step everywhere the guards above
-      // did not already rule the target out.
-      if (!(yield* fileSystem.exists(targetDbPath))) {
-        return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
       }
 
       // SQLite locking is not enough on its own: the seed's transaction can take

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -237,9 +237,6 @@ const devSeedCli = Command.make("dev-seed", {
       ]);
       const sourceDbPath = stateDbPath(path, sourceBaseDir, sourceStateDir);
       const targetDbPath = stateDbPath(path, targetBaseDir, targetStateDir);
-      if (!(yield* fileSystem.exists(targetDbPath))) {
-        return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
-      }
 
       // The whole point is to keep dev data off the real home; overwriting it
       // here would be the exact accident this command exists to avoid.
@@ -248,10 +245,19 @@ const devSeedCli = Command.make("dev-seed", {
       // base can canonicalize to itself while its `userdata` or `dev`
       // subdirectory is a symlink into the shared home, and comparing bases
       // then waves through a seed whose actual write target is the real
-      // database. The db path is what gets opened, so it is what gets checked.
+      // database. The directory is canonicalized and the filename re-joined
+      // because the database may not exist yet — realPath fails on a missing
+      // final component, and falling back to the literal path would lose the
+      // symlink resolution in exactly the case where the next error's advice
+      // ("start the dev server") would create the database in the shared home.
+      const canonicalDbPath = (databasePath: string) =>
+        fileSystem.realPath(path.dirname(databasePath)).pipe(
+          Effect.map((directory) => path.join(directory, path.basename(databasePath))),
+          Effect.orElseSucceed(() => databasePath),
+        );
       const [canonicalTargetDb, canonicalSourceDb, canonicalShared] = yield* Effect.all([
-        fileSystem.realPath(targetDbPath).pipe(Effect.orElseSucceed(() => targetDbPath)),
-        fileSystem.realPath(sourceDbPath).pipe(Effect.orElseSucceed(() => sourceDbPath)),
+        canonicalDbPath(targetDbPath),
+        canonicalDbPath(sourceDbPath),
         fileSystem.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
       ]);
       if (canonicalTargetDb.startsWith(`${canonicalShared}${path.sep}`)) {
@@ -263,6 +269,13 @@ const devSeedCli = Command.make("dev-seed", {
       // anything outside the caps. Nobody means to ask for that.
       if (canonicalTargetDb === canonicalSourceDb) {
         return yield* new DevSeedTargetError({ reason: "same-source", detail: canonicalTargetDb });
+      }
+
+      // After the refusals: this error's advice is to start a dev server, which
+      // creates the database — the right next step everywhere the guards above
+      // did not already rule the target out.
+      if (!(yield* fileSystem.exists(targetDbPath))) {
+        return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
       }
 
       // SQLite locking is not enough on its own: the seed's transaction can take

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -71,8 +71,32 @@ class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
   }
 }
 
-const stateDbPath = (path: Path.Path, baseDir: string) =>
-  path.join(baseDir, "userdata", "state.sqlite");
+/**
+ * The state directory holding a base directory's database.
+ *
+ * `deriveServerPaths` picks `dev` for an implicit dev home and `userdata`
+ * otherwise — a split that depends on how the server was started, which the
+ * person seeding has no reason to know. Hard-coding `userdata` made a
+ * main-checkout `bun run dev` (whose state lives in `<base>/dev`) unreachable:
+ * the seed reported "no database, start the dev server so migrations run" about
+ * a server that was already running.
+ *
+ * Whichever one exists wins; `userdata` breaks the tie, since that is what an
+ * explicit `--home-dir` produces.
+ */
+const resolveStateDir = Effect.fn("devSeed.resolveStateDir")(function* (baseDir: string) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  for (const stateDir of ["userdata", "dev"] as const) {
+    if (yield* fileSystem.exists(path.join(baseDir, stateDir, "state.sqlite"))) {
+      return stateDir;
+    }
+  }
+  return "userdata";
+});
+
+const stateDbPath = (path: Path.Path, baseDir: string, stateDir: string) =>
+  path.join(baseDir, stateDir, "state.sqlite");
 
 /**
  * Copies the files behind the copied messages' attachment references.
@@ -193,7 +217,12 @@ const devSeedCli = Command.make("dev-seed", {
         return yield* new DevSeedTargetError({ reason: "same-source", detail: targetBaseDir });
       }
 
-      const targetDbPath = stateDbPath(path, targetBaseDir);
+      const [sourceStateDir, targetStateDir] = yield* Effect.all([
+        resolveStateDir(sourceBaseDir),
+        resolveStateDir(targetBaseDir),
+      ]);
+      const sourceDbPath = stateDbPath(path, sourceBaseDir, sourceStateDir);
+      const targetDbPath = stateDbPath(path, targetBaseDir, targetStateDir);
       if (!(yield* fileSystem.exists(targetDbPath))) {
         return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
       }
@@ -215,7 +244,7 @@ const devSeedCli = Command.make("dev-seed", {
       const summary = yield* Effect.try({
         try: () =>
           seedDevDatabase({
-            sourceDbPath: stateDbPath(path, sourceBaseDir),
+            sourceDbPath,
             targetDbPath,
             threadLimit: input.threads,
             activityLimit: input.activities,
@@ -224,16 +253,17 @@ const devSeedCli = Command.make("dev-seed", {
         catch: (cause) => cause as DevSeedError,
       });
 
+      // Attachments sit beside the database, so they follow the same state dir.
       const copiedAttachments = yield* copyAttachments({
-        sourceDir: path.join(sourceBaseDir, "userdata", "attachments"),
-        targetDir: path.join(targetBaseDir, "userdata", "attachments"),
+        sourceDir: path.join(sourceBaseDir, sourceStateDir, "attachments"),
+        targetDir: path.join(targetBaseDir, targetStateDir, "attachments"),
         attachmentIds: summary.attachmentIds,
       });
 
       yield* Console.log(
         [
           `Seeded ${targetDbPath}`,
-          `  from     ${stateDbPath(path, sourceBaseDir)}`,
+          `  from     ${sourceDbPath}`,
           `  projects ${String(summary.projects)}`,
           `  threads  ${String(summary.threads)}`,
           `  messages ${String(summary.messages)}`,

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -38,6 +38,14 @@ const resolveSharedHome = (path: Path.Path): string => {
   );
 };
 
+const isPathWithin = (path: Path.Path, parent: string, candidate: string): boolean => {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+};
+
 class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
   "DevSeedTargetError",
   {
@@ -283,7 +291,7 @@ const devSeedCli = Command.make("dev-seed", {
         canonicalDbPath(sourceDbPath),
         fileSystem.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
       ]);
-      if (canonicalTargetDb.startsWith(`${canonicalShared}${path.sep}`)) {
+      if (isPathWithin(path, canonicalShared, canonicalTargetDb)) {
         return yield* new DevSeedTargetError({ reason: "shared-home", detail: canonicalTargetDb });
       }
       // After the shared-home refusal: that one must come first because the

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -17,13 +17,11 @@ import { Command, Flag } from "effect/unstable/cli";
 
 import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
 
-import { DevSeedError, seedDevDatabase } from "./lib/dev-seed.ts";
+import { DevSeedError, MAX_SEED_THREAD_LIMIT, seedDevDatabase } from "./lib/dev-seed.ts";
 import { findRunningServerPid } from "./lib/server-runtime-probe.ts";
 
 const DEFAULT_THREAD_LIMIT = 25;
 const DEFAULT_ACTIVITY_LIMIT = 200;
-/** SQLite's default SQLITE_MAX_VARIABLE_NUMBER; one bound parameter per thread. */
-const MAX_THREAD_LIMIT = 32_766;
 
 class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
   "DevSeedTargetError",
@@ -140,16 +138,15 @@ const devSeedCli = Command.make("dev-seed", {
     Flag.map(Option.getOrUndefined),
   ),
   // Bounded below: SQLite reads a negative LIMIT as "no limit", which would
-  // quietly turn a capped copy into a full-table one. Bounded above because
-  // every selected thread becomes one bound parameter in the copy's `IN (...)`,
-  // and SQLite's compiled-in ceiling is 32766 — past it the seed dies with
-  // "too many SQL variables" after the target has already been emptied.
+  // quietly turn a capped copy into a full-table one. The upper bound comes
+  // from the seeder itself, which binds one variable per selected thread —
+  // stating it separately here is what previously let the two drift apart.
   threads: Flag.integer("threads").pipe(
     Flag.withSchema(
-      Schema.Int.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(MAX_THREAD_LIMIT)),
+      Schema.Int.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(MAX_SEED_THREAD_LIMIT)),
     ),
     Flag.withDescription(
-      `How many recent threads to copy (default ${String(DEFAULT_THREAD_LIMIT)}, max ${String(MAX_THREAD_LIMIT)}).`,
+      `How many recent threads to copy (default ${String(DEFAULT_THREAD_LIMIT)}, max ${String(MAX_SEED_THREAD_LIMIT)}).`,
     ),
     Flag.withDefault(DEFAULT_THREAD_LIMIT),
   ),

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -28,7 +28,13 @@ const MAX_THREAD_LIMIT = 32_766;
 class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
   "DevSeedTargetError",
   {
-    reason: Schema.Literals(["shared-home", "missing-target", "not-a-worktree", "server-running"]),
+    reason: Schema.Literals([
+      "shared-home",
+      "missing-target",
+      "not-a-worktree",
+      "server-running",
+      "same-source",
+    ]),
     detail: Schema.String,
   },
 ) {
@@ -55,6 +61,13 @@ class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
           "Seeding replaces its projections and empties its event log while it holds them open,",
           "which leaves the running server's in-memory read model describing rows that no longer exist.",
           "Stop it, run the seed, then start it again.",
+        ].join("\n");
+      case "same-source":
+        return [
+          `Refusing to seed ${this.detail} from itself.`,
+          "The copy would restore what the delete removed, but the event log and the",
+          "projector cursors are cleared either way — so the directory loses its history",
+          "and keeps only whatever the thread and activity caps selected.",
         ].join("\n");
     }
   }
@@ -167,12 +180,20 @@ const devSeedCli = Command.make("dev-seed", {
 
       // The whole point is to keep dev data off the real home; overwriting it
       // here would be the exact accident this command exists to avoid.
-      const [canonicalTarget, canonicalShared] = yield* Effect.all([
+      const [canonicalTarget, canonicalSource, canonicalShared] = yield* Effect.all([
         fileSystem.realPath(targetBaseDir).pipe(Effect.orElseSucceed(() => targetBaseDir)),
+        fileSystem.realPath(sourceBaseDir).pipe(Effect.orElseSucceed(() => sourceBaseDir)),
         fileSystem.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
       ]);
       if (canonicalTarget === canonicalShared) {
         return yield* new DevSeedTargetError({ reason: "shared-home", detail: targetBaseDir });
+      }
+      // Seeding a directory from itself is not the data loss it looks like —
+      // the source reads a pre-transaction snapshot, so the copy puts the rows
+      // back. What does not come back is the event log and the cursors, and
+      // anything outside the caps. Nobody means to ask for that.
+      if (canonicalTarget === canonicalSource) {
+        return yield* new DevSeedTargetError({ reason: "same-source", detail: targetBaseDir });
       }
 
       const targetDbPath = stateDbPath(path, targetBaseDir);

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -18,7 +18,7 @@ import { Command, Flag } from "effect/unstable/cli";
 import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
 
 import { DevSeedError, MAX_SEED_THREAD_LIMIT, seedDevDatabase } from "./lib/dev-seed.ts";
-import { findRunningServerPid } from "./lib/server-runtime-probe.ts";
+import { findRunningServerPid, findRunningServerPidSync } from "./lib/server-runtime-probe.ts";
 
 const DEFAULT_THREAD_LIMIT = 25;
 const DEFAULT_ACTIVITY_LIMIT = 200;
@@ -86,25 +86,35 @@ class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
  * `dev` — so the tie goes to whichever was written most recently, i.e. the one
  * the last server to run actually opened. The chosen path is printed, so a
  * wrong guess is visible rather than silent.
+ *
+ * Recency is the newest of the database and its `-wal` sidecar. The server runs
+ * SQLite in WAL mode, where writes land in the sidecar and the main file's
+ * mtime can sit unchanged until a checkpoint — so reading the database alone
+ * makes a busy directory look older than a dormant one.
  */
 const resolveStateDir = Effect.fn("devSeed.resolveStateDir")(function* (baseDir: string) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 
+  const modifiedAtMs = (info: FileSystem.File.Info): number =>
+    Option.match(info.mtime, { onSome: (mtime) => mtime.getTime(), onNone: () => 0 });
+
   const candidates: Array<{ readonly stateDir: string; readonly modifiedAtMs: number }> = [];
   for (const stateDir of ["userdata", "dev"] as const) {
-    const info = yield* fileSystem
-      .stat(path.join(baseDir, stateDir, "state.sqlite"))
-      .pipe(Effect.option);
-    if (Option.isSome(info)) {
-      candidates.push({
-        stateDir,
-        modifiedAtMs: Option.match(info.value.mtime, {
-          onSome: (mtime) => mtime.getTime(),
-          onNone: () => 0,
-        }),
-      });
+    const dbPath = path.join(baseDir, stateDir, "state.sqlite");
+    const info = yield* fileSystem.stat(dbPath).pipe(Effect.option);
+    if (Option.isNone(info)) {
+      continue;
     }
+    // The sidecar is absent outside WAL mode, and after a clean checkpoint.
+    const walInfo = yield* fileSystem.stat(`${dbPath}-wal`).pipe(Effect.option);
+    candidates.push({
+      stateDir,
+      modifiedAtMs: Math.max(
+        modifiedAtMs(info.value),
+        Option.match(walInfo, { onSome: modifiedAtMs, onNone: () => 0 }),
+      ),
+    });
   }
 
   // `userdata` first above, so an equal or missing mtime keeps the old default.
@@ -271,6 +281,10 @@ const devSeedCli = Command.make("dev-seed", {
             threadLimit: input.threads,
             activityLimit: input.activities,
             seededAt,
+            // The check above happens before the copy, which can take seconds.
+            // Re-checked just before the commit so a server that started in
+            // between aborts the seed instead of having its database swapped.
+            findRunningServerPid: () => findRunningServerPidSync(targetBaseDir),
           }),
         catch: (cause) => cause as DevSeedError,
       });

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+// @effect-diagnostics nodeBuiltinImport:off - node:os resolves the shared T3 home guard.
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodeOS from "node:os";
+import * as Console from "effect/Console";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { resolveWorktreeT3Home } from "@t3tools/shared/devHome";
+
+import { DevSeedError, seedDevDatabase } from "./lib/dev-seed.ts";
+
+const DEFAULT_THREAD_LIMIT = 25;
+const DEFAULT_ACTIVITY_LIMIT = 200;
+
+class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
+  "DevSeedTargetError",
+  {
+    reason: Schema.Literals(["shared-home", "missing-target", "not-a-worktree"]),
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    switch (this.reason) {
+      case "shared-home":
+        return [
+          `Refusing to seed ${this.detail}: that is the shared T3 Code home.`,
+          "This command overwrites projection tables. Run it from a worktree, or pass --to <base-dir>.",
+        ].join("\n");
+      case "missing-target":
+        return [
+          `No database at ${this.detail}.`,
+          "Start the dev server once so migrations run (`bun run dev`), then seed.",
+        ].join("\n");
+      case "not-a-worktree":
+        return [
+          "Not inside a git worktree, so there is no worktree-local data directory to seed.",
+          "Pass --to <base-dir> to choose one explicitly.",
+        ].join("\n");
+    }
+  }
+}
+
+const stateDbPath = (path: Path.Path, baseDir: string) =>
+  path.join(baseDir, "userdata", "state.sqlite");
+
+const devSeedCli = Command.make("dev-seed", {
+  from: Flag.string("from").pipe(
+    Flag.withDescription(
+      "Base directory to copy from (default: the shared T3 Code home, ~/.t3). Read-only.",
+    ),
+    Flag.optional,
+    Flag.map(Option.getOrUndefined),
+  ),
+  to: Flag.string("to").pipe(
+    Flag.withDescription(
+      "Base directory to seed (default: this worktree's .t3). Its projection tables are replaced.",
+    ),
+    Flag.optional,
+    Flag.map(Option.getOrUndefined),
+  ),
+  // Bounded: SQLite reads a negative LIMIT as "no limit", which would quietly
+  // turn a capped copy into a full-table one.
+  threads: Flag.integer("threads").pipe(
+    Flag.withSchema(Schema.Int.check(Schema.isGreaterThan(0))),
+    Flag.withDescription(
+      `How many recent threads to copy (default ${String(DEFAULT_THREAD_LIMIT)}).`,
+    ),
+    Flag.withDefault(DEFAULT_THREAD_LIMIT),
+  ),
+  activities: Flag.integer("activities").pipe(
+    Flag.withSchema(Schema.Int.check(Schema.isGreaterThan(0))),
+    Flag.withDescription(
+      `Newest activities kept per thread (default ${String(DEFAULT_ACTIVITY_LIMIT)}).`,
+    ),
+    Flag.withDefault(DEFAULT_ACTIVITY_LIMIT),
+  ),
+}).pipe(
+  Command.withDescription(
+    "Copy recent projects and threads from a T3 Code data directory into an isolated dev one.",
+  ),
+  Command.withHandler((input) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      const sharedHome = path.join(NodeOS.homedir(), ".t3");
+      const sourceBaseDir = input.from ? path.resolve(input.from) : sharedHome;
+
+      const defaultTarget = yield* resolveWorktreeT3Home(process.cwd());
+      const targetBaseDir = input.to ? path.resolve(input.to) : defaultTarget;
+      if (targetBaseDir === undefined) {
+        return yield* new DevSeedTargetError({ reason: "not-a-worktree", detail: process.cwd() });
+      }
+
+      // The whole point is to keep dev data off the real home; overwriting it
+      // here would be the exact accident this command exists to avoid.
+      const [canonicalTarget, canonicalShared] = yield* Effect.all([
+        fileSystem.realPath(targetBaseDir).pipe(Effect.orElseSucceed(() => targetBaseDir)),
+        fileSystem.realPath(sharedHome).pipe(Effect.orElseSucceed(() => sharedHome)),
+      ]);
+      if (canonicalTarget === canonicalShared) {
+        return yield* new DevSeedTargetError({ reason: "shared-home", detail: targetBaseDir });
+      }
+
+      const targetDbPath = stateDbPath(path, targetBaseDir);
+      if (!(yield* fileSystem.exists(targetDbPath))) {
+        return yield* new DevSeedTargetError({ reason: "missing-target", detail: targetDbPath });
+      }
+
+      const seededAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+      const summary = yield* Effect.try({
+        try: () =>
+          seedDevDatabase({
+            sourceDbPath: stateDbPath(path, sourceBaseDir),
+            targetDbPath,
+            threadLimit: input.threads,
+            activityLimit: input.activities,
+            seededAt,
+          }),
+        catch: (cause) => cause as DevSeedError,
+      });
+
+      yield* Console.log(
+        [
+          `Seeded ${targetDbPath}`,
+          `  from     ${stateDbPath(path, sourceBaseDir)}`,
+          `  projects ${String(summary.projects)}`,
+          `  threads  ${String(summary.threads)}`,
+          `  messages ${String(summary.messages)}`,
+          `  activity ${String(summary.activities)}`,
+          `  turns    ${String(summary.turns)}  sessions ${String(summary.sessions)}`,
+          ...(summary.skippedColumns.length > 0
+            ? [
+                `  note: skipped ${String(summary.skippedColumns.length)} column(s) absent from the target schema`,
+                `        (${summary.skippedColumns.join(", ")})`,
+              ]
+            : []),
+          "",
+          "Restart the dev server to pick it up.",
+        ].join("\n"),
+      );
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.logError(
+          error instanceof DevSeedError
+            ? `${error.message}${error.hint ? `\n${error.hint}` : ""}`
+            : error.message,
+        ),
+      ),
+    ),
+  ),
+);
+
+if (import.meta.main) {
+  Command.run(devSeedCli, { version: "0.0.0" }).pipe(
+    Effect.provide(Layer.mergeAll(Logger.layer([Logger.consolePretty()]), NodeServices.layer)),
+    NodeRuntime.runMain,
+  );
+}

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -23,6 +23,21 @@ import { findRunningServerPid, findRunningServerPidSync } from "./lib/server-run
 const DEFAULT_THREAD_LIMIT = 25;
 const DEFAULT_ACTIVITY_LIMIT = 200;
 
+const resolveSharedHome = (path: Path.Path): string => {
+  const configured = process.env.T3CODE_HOME?.trim();
+  if (!configured) {
+    return path.join(NodeOS.homedir(), ".t3");
+  }
+  if (configured === "~") {
+    return NodeOS.homedir();
+  }
+  return path.resolve(
+    configured.startsWith("~/") || configured.startsWith("~\\")
+      ? path.join(NodeOS.homedir(), configured.slice(2))
+      : configured,
+  );
+};
+
 class DevSeedTargetError extends Schema.TaggedErrorClass<DevSeedTargetError>()(
   "DevSeedTargetError",
   {
@@ -156,10 +171,6 @@ const copyAttachments = Effect.fn("devSeed.copyAttachments")(function* (input: {
   const entries = yield* fileSystem
     .readDirectory(input.sourceDir)
     .pipe(Effect.orElseSucceed(() => [] as Array<string>));
-  if (entries.length === 0) {
-    return 0;
-  }
-
   const wanted = new Set(input.attachmentIds);
   const matches = entries.filter((entry) => wanted.has(path.parse(entry).name));
   if (matches.length === 0) {
@@ -188,7 +199,7 @@ const copyAttachments = Effect.fn("devSeed.copyAttachments")(function* (input: {
 const devSeedCli = Command.make("dev-seed", {
   from: Flag.string("from").pipe(
     Flag.withDescription(
-      "Base directory to copy from (default: the shared T3 Code home, ~/.t3). Read-only.",
+      "Base directory to copy from (default: T3CODE_HOME, or ~/.t3). Read-only.",
     ),
     Flag.optional,
     Flag.map(Option.getOrUndefined),
@@ -229,7 +240,7 @@ const devSeedCli = Command.make("dev-seed", {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
 
-      const sharedHome = path.join(NodeOS.homedir(), ".t3");
+      const sharedHome = resolveSharedHome(path);
       const sourceBaseDir = input.from ? path.resolve(input.from) : sharedHome;
 
       const defaultTarget = yield* resolveWorktreeT3Home(process.cwd());

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -264,7 +264,11 @@ const devSeedCli = Command.make("dev-seed", {
       // What it cannot do is tell that server the projections it is holding in
       // memory, and the event log it is appending to, were both replaced under
       // it. Its next write then lands on top of a read model it never built.
-      const runningPid = yield* findRunningServerPid(targetBaseDir);
+      //
+      // Scoped to the state directory being seeded: a server using only the
+      // other directory's database is not touching this one, and blocking on it
+      // would refuse seeds that are perfectly safe.
+      const runningPid = yield* findRunningServerPid(targetBaseDir, targetStateDir);
       if (Option.isSome(runningPid)) {
         return yield* new DevSeedTargetError({
           reason: "server-running",
@@ -284,7 +288,7 @@ const devSeedCli = Command.make("dev-seed", {
             // The check above happens before the copy, which can take seconds.
             // Re-checked just before the commit so a server that started in
             // between aborts the seed instead of having its database swapped.
-            findRunningServerPid: () => findRunningServerPidSync(targetBaseDir),
+            findRunningServerPid: () => findRunningServerPidSync(targetBaseDir, targetStateDir),
           }),
         catch: (cause) => cause as DevSeedError,
       });

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -605,6 +605,57 @@ describe("seedDevDatabase", () => {
     });
   }
 
+  // The CLI checks for a running server before calling, but a copy takes time
+  // and a server can start during it. The pre-commit re-check has to abort
+  // rather than persist a swap underneath that server.
+  it("aborts without committing when a server appears mid-copy", () => {
+    withDatabases(({ source, target }) => {
+      assert.throws(
+        () =>
+          seedDevDatabase({
+            sourceDbPath: source,
+            targetDbPath: target,
+            threadLimit: 3,
+            activityLimit: 10,
+            seededAt: SEEDED_AT,
+            findRunningServerPid: () => 4242,
+          }),
+        DevSeedError,
+      );
+
+      // Everything destructive ran inside the transaction, so the rollback
+      // leaves the target's own rows intact.
+      const projects = query<{ project_id: string }>(
+        target,
+        "SELECT project_id FROM projection_projects",
+      );
+      assert.deepStrictEqual(
+        projects.map((row) => row.project_id),
+        ["stale"],
+      );
+      const [events] = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM orchestration_events",
+      );
+      assert.equal(events?.count, 1);
+    });
+  });
+
+  it("commits when no server appeared during the copy", () => {
+    withDatabases(({ source, target }) => {
+      const summary = seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+        findRunningServerPid: () => undefined,
+      });
+
+      assert.equal(summary.threads, 3);
+    });
+  });
+
   // A caller that bypasses the CLI flag would otherwise discover the ceiling
   // only after the target had been emptied and the copy rolled back.
   it("refuses a thread limit above the ceiling before touching the target", () => {

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -46,10 +46,13 @@ function createSchema(
   database.exec(`CREATE TABLE projection_thread_sessions (
     thread_id TEXT PRIMARY KEY, status TEXT NOT NULL, provider_name TEXT,
     active_turn_id TEXT, last_error TEXT, updated_at TEXT NOT NULL)`);
+  // Mirrors migration 005: `checkpoint_turn_count` matters because
+  // dropPendingTurnStarts keys its guard on it, and a fixture without the
+  // column only ever exercises the degraded path.
   database.exec(`CREATE TABLE projection_turns (
     row_id INTEGER PRIMARY KEY AUTOINCREMENT, thread_id TEXT NOT NULL, turn_id TEXT,
     state TEXT NOT NULL, requested_at TEXT NOT NULL, completed_at TEXT,
-    checkpoint_files_json TEXT NOT NULL,
+    checkpoint_turn_count INTEGER, checkpoint_files_json TEXT NOT NULL,
     UNIQUE (thread_id, turn_id))`);
   database.exec(`CREATE TABLE projection_thread_proposed_plans (
     plan_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, plan_markdown TEXT NOT NULL,
@@ -369,6 +372,40 @@ describe("seedDevDatabase", () => {
         "SELECT COUNT(*) count FROM projection_turns WHERE state = 'pending' OR turn_id IS NULL",
       );
       assert.equal(pending?.count, 0);
+    });
+  });
+
+  // The delete mirrors the server's predicate, which spares rows carrying a
+  // checkpoint. Without the `checkpoint_turn_count IS NULL` clause a checkpoint
+  // row that happened to be pending would be destroyed along with the starts.
+  it("spares a pending row that carries a checkpoint", () => {
+    withDatabases(({ source, target }) => {
+      // A checkpoint row on a thread inside the copied range.
+      const sourceDatabase = new NodeSqlite.DatabaseSync(source);
+      sourceDatabase
+        .prepare(
+          `INSERT INTO projection_turns (thread_id, turn_id, state, requested_at,
+           checkpoint_turn_count, checkpoint_files_json) VALUES ('t4', NULL, 'pending', ?, 7, '[]')`,
+        )
+        .run(SEEDED_AT);
+      sourceDatabase.close();
+
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const checkpoints = query<{ checkpoint_turn_count: number }>(
+        target,
+        "SELECT checkpoint_turn_count FROM projection_turns WHERE checkpoint_turn_count IS NOT NULL",
+      );
+      assert.deepStrictEqual(
+        checkpoints.map((row) => row.checkpoint_turn_count),
+        [7],
+      );
     });
   });
 

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -66,9 +66,13 @@ function makeSource(
   path: string,
   threadCount: number,
   activitiesPerThread = 3,
-  options?: { readonly legacyThreads?: boolean },
+  options?: { readonly legacyThreads?: boolean; readonly minimalRows?: boolean },
 ) {
   const legacyThreads = options?.legacyThreads ?? false;
+  // Thread rows only, for the scale test: building sessions and messages for
+  // 32k threads costs half a minute and proves nothing the thread-keyed
+  // statements don't already exercise.
+  const minimalRows = options?.minimalRows ?? false;
   const database = new NodeSqlite.DatabaseSync(path);
   createSchema(database, { withMonitor: true, legacyThreads });
   database
@@ -77,6 +81,9 @@ function makeSource(
     )
     .run();
 
+  // One transaction rather than one per insert: at 32k threads the implicit
+  // per-statement commits dominate the fixture's runtime.
+  database.exec("BEGIN");
   for (let index = 0; index < threadCount; index += 1) {
     const threadId = `t${String(index)}`;
     // Later index → later timestamp → more recent.
@@ -117,6 +124,9 @@ function makeSource(
         at,
         midFlight || queued ? null : at,
       );
+    if (minimalRows) {
+      continue;
+    }
     database
       .prepare(`INSERT INTO projection_thread_sessions VALUES (?,'running','claude',?,'boom',?)`)
       .run(threadId, `turn-${threadId}`, at);
@@ -136,6 +146,7 @@ function makeSource(
         .run(`a-${threadId}-${String(a)}`, threadId, "{}", `2026-07-10T00:00:0${String(a)}.000Z`);
     }
   }
+  database.exec("COMMIT");
   database.close();
 }
 
@@ -172,6 +183,7 @@ const withDatabases = <A>(
     readonly activities?: number;
     readonly dropProposedPlans?: boolean;
     readonly legacySource?: boolean;
+    readonly minimalRows?: boolean;
   },
 ): A => {
   const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-dev-seed-"));
@@ -179,6 +191,7 @@ const withDatabases = <A>(
   const target = NodePath.join(directory, "target.sqlite");
   makeSource(source, options?.threads ?? 5, options?.activities ?? 3, {
     legacyThreads: options?.legacySource ?? false,
+    minimalRows: options?.minimalRows ?? false,
   });
   makeTarget(target, { dropProposedPlans: options?.dropProposedPlans ?? false });
   try {
@@ -494,6 +507,36 @@ describe("seedDevDatabase", () => {
         assert.deepStrictEqual(titles, ["Thread 4", "Thread 3"]);
       },
       { legacySource: true },
+    );
+  });
+
+  // Every statement keyed on thread ids must cost exactly one bound variable
+  // per thread: `--threads` is capped at SQLite's ceiling (32766), so a single
+  // extra binding makes the documented maximum fail — after the target has
+  // already been emptied. Runs the real seed, since the point is that no code
+  // path adds a binding, not that one hand-written statement doesn't.
+  it("seeds at the maximum thread limit without exhausting SQL variables", () => {
+    const MAX_THREADS = 32_766;
+    withDatabases(
+      ({ source, target }) => {
+        const summary = seedDevDatabase({
+          sourceDbPath: source,
+          targetDbPath: target,
+          threadLimit: MAX_THREADS,
+          activityLimit: 1,
+          seededAt: SEEDED_AT,
+        });
+
+        assert.equal(summary.threads, MAX_THREADS);
+        const [unsettled] = query<{ count: number }>(
+          target,
+          "SELECT COUNT(*) count FROM projection_turns WHERE state IN ('running','pending')",
+        );
+        assert.equal(unsettled?.count, 0);
+      },
+      // Threads only: the per-thread tables are what drive the binding count,
+      // and skipping their rows keeps the fixture cheap to build.
+      { threads: MAX_THREADS, activities: 0, minimalRows: true },
     );
   });
 

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -5,7 +5,7 @@ import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 import * as NodeSqlite from "node:sqlite";
 
-import { DevSeedError, seedDevDatabase } from "./dev-seed.ts";
+import { DevSeedError, MAX_SEED_THREAD_LIMIT, seedDevDatabase } from "./dev-seed.ts";
 
 const SEEDED_AT = "2026-07-26T00:00:00.000Z";
 
@@ -511,23 +511,22 @@ describe("seedDevDatabase", () => {
   });
 
   // Every statement keyed on thread ids must cost exactly one bound variable
-  // per thread: `--threads` is capped at SQLite's ceiling (32766), so a single
-  // extra binding makes the documented maximum fail — after the target has
-  // already been emptied. Runs the real seed, since the point is that no code
-  // path adds a binding, not that one hand-written statement doesn't.
+  // per thread: the limit *is* SQLite's ceiling, so a single extra binding
+  // makes the maximum fail — after the target has already been emptied. Runs
+  // the real seed, since the point is that no code path adds a binding, not
+  // that one hand-written statement doesn't.
   it("seeds at the maximum thread limit without exhausting SQL variables", () => {
-    const MAX_THREADS = 32_766;
     withDatabases(
       ({ source, target }) => {
         const summary = seedDevDatabase({
           sourceDbPath: source,
           targetDbPath: target,
-          threadLimit: MAX_THREADS,
+          threadLimit: MAX_SEED_THREAD_LIMIT,
           activityLimit: 1,
           seededAt: SEEDED_AT,
         });
 
-        assert.equal(summary.threads, MAX_THREADS);
+        assert.equal(summary.threads, MAX_SEED_THREAD_LIMIT);
         const [unsettled] = query<{ count: number }>(
           target,
           "SELECT COUNT(*) count FROM projection_turns WHERE state IN ('running','pending')",
@@ -536,8 +535,36 @@ describe("seedDevDatabase", () => {
       },
       // Threads only: the per-thread tables are what drive the binding count,
       // and skipping their rows keeps the fixture cheap to build.
-      { threads: MAX_THREADS, activities: 0, minimalRows: true },
+      { threads: MAX_SEED_THREAD_LIMIT, activities: 0, minimalRows: true },
     );
+  });
+
+  // A caller that bypasses the CLI flag would otherwise discover the ceiling
+  // only after the target had been emptied and the copy rolled back.
+  it("refuses a thread limit above the ceiling before touching the target", () => {
+    withDatabases(({ source, target }) => {
+      assert.throws(
+        () =>
+          seedDevDatabase({
+            sourceDbPath: source,
+            targetDbPath: target,
+            threadLimit: MAX_SEED_THREAD_LIMIT + 1,
+            activityLimit: 10,
+            seededAt: SEEDED_AT,
+          }),
+        DevSeedError,
+      );
+
+      // The target's own row is still there: nothing was deleted.
+      const projects = query<{ project_id: string }>(
+        target,
+        "SELECT project_id FROM projection_projects",
+      );
+      assert.deepStrictEqual(
+        projects.map((row) => row.project_id),
+        ["stale"],
+      );
+    });
   });
 
   it("reports a source with nothing to copy", () => {

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -571,6 +571,40 @@ describe("seedDevDatabase", () => {
     );
   });
 
+  // SQLite reads a negative LIMIT as "no limit", so an unchecked value turns a
+  // capped copy into a full-table one rather than failing.
+  for (const limits of [
+    { threadLimit: 0, activityLimit: 10 },
+    { threadLimit: -1, activityLimit: 10 },
+    { threadLimit: 5, activityLimit: 0 },
+    { threadLimit: 5, activityLimit: -1 },
+  ]) {
+    it(`refuses threadLimit ${String(limits.threadLimit)} / activityLimit ${String(limits.activityLimit)}`, () => {
+      withDatabases(({ source, target }) => {
+        assert.throws(
+          () =>
+            seedDevDatabase({
+              sourceDbPath: source,
+              targetDbPath: target,
+              ...limits,
+              seededAt: SEEDED_AT,
+            }),
+          DevSeedError,
+        );
+
+        // Rejected before the destructive transaction opened.
+        const projects = query<{ project_id: string }>(
+          target,
+          "SELECT project_id FROM projection_projects",
+        );
+        assert.deepStrictEqual(
+          projects.map((row) => row.project_id),
+          ["stale"],
+        );
+      });
+    });
+  }
+
   // A caller that bypasses the CLI flag would otherwise discover the ceiling
   // only after the target had been emptied and the copy rolled back.
   it("refuses a thread limit above the ceiling before touching the target", () => {
@@ -597,6 +631,75 @@ describe("seedDevDatabase", () => {
         ["stale"],
       );
     });
+  });
+
+  // Down to one recency column, the ordering expression cannot be a COALESCE:
+  // SQLite requires at least two arguments and throws otherwise, which would
+  // abort the seed on exactly the old schema the column filter exists to serve.
+  it("reads a source with only one recency column", () => {
+    const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-dev-seed-1col-"));
+    const source = NodePath.join(directory, "source.sqlite");
+    const target = NodePath.join(directory, "target.sqlite");
+    try {
+      const database = new NodeSqlite.DatabaseSync(source);
+      // created_at alone: no updated_at, no archived_at, no latest_user_message_at.
+      database.exec(`CREATE TABLE projection_threads (
+        thread_id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL,
+        created_at TEXT NOT NULL, deleted_at TEXT)`);
+      // Matches the target's project columns; only the thread recency columns
+      // are being varied here.
+      database.exec(`CREATE TABLE projection_projects (
+        project_id TEXT PRIMARY KEY, title TEXT NOT NULL, workspace_root TEXT NOT NULL,
+        scripts_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        deleted_at TEXT)`);
+      database.exec(`CREATE TABLE projection_state (projector TEXT PRIMARY KEY,
+        last_applied_sequence INTEGER NOT NULL, updated_at TEXT NOT NULL)`);
+      database
+        .prepare(`INSERT INTO projection_projects VALUES ('p1','P','/repo','[]',?,?,NULL)`)
+        .run(SEEDED_AT, SEEDED_AT);
+      for (const thread of [
+        { id: "old", at: "2026-07-10T00:00:00.000Z" },
+        { id: "new", at: "2026-07-20T00:00:00.000Z" },
+      ]) {
+        database
+          .prepare(`INSERT INTO projection_threads VALUES (?,?,?,?,NULL)`)
+          .run(thread.id, "p1", thread.id, thread.at);
+      }
+      database.close();
+
+      // The target mirrors the source's thread columns: this test varies the
+      // recency columns, and a target demanding one the source lacks would fail
+      // on the NOT NULL rather than on the ordering expression under test.
+      const targetDatabase = new NodeSqlite.DatabaseSync(target);
+      targetDatabase.exec(`CREATE TABLE projection_threads (
+        thread_id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL,
+        created_at TEXT NOT NULL, deleted_at TEXT)`);
+      targetDatabase.exec(`CREATE TABLE projection_projects (
+        project_id TEXT PRIMARY KEY, title TEXT NOT NULL, workspace_root TEXT NOT NULL,
+        scripts_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        deleted_at TEXT)`);
+      targetDatabase.exec(`CREATE TABLE projection_state (projector TEXT PRIMARY KEY,
+        last_applied_sequence INTEGER NOT NULL, updated_at TEXT NOT NULL)`);
+      targetDatabase.close();
+
+      const summary = seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      assert.equal(summary.threads, 1);
+      // Ordering still applies: the newer thread is the one kept.
+      const titles = query<{ title: string }>(target, "SELECT title FROM projection_threads");
+      assert.deepStrictEqual(
+        titles.map((row) => row.title),
+        ["new"],
+      );
+    } finally {
+      NodeFS.rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("reports a source with nothing to copy", () => {

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -1,0 +1,432 @@
+// @effect-diagnostics nodeBuiltinImport:off - test fixtures build real SQLite files on disk.
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import { DevSeedError, seedDevDatabase } from "./dev-seed.ts";
+
+const SEEDED_AT = "2026-07-26T00:00:00.000Z";
+
+/**
+ * The subset of the real schema the seeder touches. `monitor_json` is included
+ * only in the source, to stand in for the migration drift between an installed
+ * app and a worktree that is a migration behind.
+ */
+function createSchema(
+  database: NodeSqlite.DatabaseSync,
+  options: { readonly withMonitor: boolean; readonly legacyThreads?: boolean },
+) {
+  database.exec(`CREATE TABLE projection_projects (
+    project_id TEXT PRIMARY KEY, title TEXT NOT NULL, workspace_root TEXT NOT NULL,
+    scripts_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, deleted_at TEXT)`);
+  // A pre-017/023 source has neither archived_at nor latest_user_message_at.
+  database.exec(`CREATE TABLE projection_threads (
+    thread_id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT NOT NULL,
+    latest_turn_id TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+    deleted_at TEXT${options.legacyThreads ? "" : ", archived_at TEXT, latest_user_message_at TEXT"},
+    pending_approval_count INTEGER NOT NULL DEFAULT 0,
+    pending_user_input_count INTEGER NOT NULL DEFAULT 0
+    ${options.withMonitor ? ", monitor_json TEXT" : ""})`);
+  database.exec(`CREATE TABLE projection_thread_messages (
+    message_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, role TEXT NOT NULL,
+    text TEXT NOT NULL, is_streaming INTEGER NOT NULL,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE projection_thread_activities (
+    activity_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, tone TEXT NOT NULL,
+    kind TEXT NOT NULL, summary TEXT NOT NULL, payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE projection_thread_sessions (
+    thread_id TEXT PRIMARY KEY, status TEXT NOT NULL, provider_name TEXT,
+    active_turn_id TEXT, last_error TEXT, updated_at TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE projection_turns (
+    row_id INTEGER PRIMARY KEY AUTOINCREMENT, thread_id TEXT NOT NULL, turn_id TEXT,
+    state TEXT NOT NULL, requested_at TEXT NOT NULL, checkpoint_files_json TEXT NOT NULL,
+    UNIQUE (thread_id, turn_id))`);
+  database.exec(`CREATE TABLE projection_thread_proposed_plans (
+    plan_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, plan_markdown TEXT NOT NULL,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE projection_pending_approvals (
+    request_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, status TEXT NOT NULL,
+    created_at TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE projection_state (
+    projector TEXT PRIMARY KEY, last_applied_sequence INTEGER NOT NULL, updated_at TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE orchestration_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT NOT NULL UNIQUE,
+    stream_id TEXT NOT NULL, event_type TEXT NOT NULL, payload_json TEXT NOT NULL)`);
+}
+
+/** Source DB with `threadCount` threads, oldest first so recency ordering is testable. */
+function makeSource(
+  path: string,
+  threadCount: number,
+  activitiesPerThread = 3,
+  options?: { readonly legacyThreads?: boolean },
+) {
+  const legacyThreads = options?.legacyThreads ?? false;
+  const database = new NodeSqlite.DatabaseSync(path);
+  createSchema(database, { withMonitor: true, legacyThreads });
+  database
+    .prepare(
+      `INSERT INTO projection_projects VALUES ('p1','Project','/repo','[]','${SEEDED_AT}','${SEEDED_AT}',NULL)`,
+    )
+    .run();
+
+  for (let index = 0; index < threadCount; index += 1) {
+    const threadId = `t${String(index)}`;
+    // Later index → later timestamp → more recent.
+    const at = `2026-07-${String(10 + index).padStart(2, "0")}T00:00:00.000Z`;
+    if (legacyThreads) {
+      database
+        .prepare(
+          `INSERT INTO projection_threads (thread_id, project_id, title, latest_turn_id,
+           created_at, updated_at, pending_approval_count, pending_user_input_count, monitor_json)
+           VALUES (?,?,?,?,?,?,?,?,?)`,
+        )
+        .run(threadId, "p1", `Thread ${String(index)}`, `turn-${threadId}`, at, at, 4, 2, "{}");
+    } else {
+      database
+        .prepare(
+          `INSERT INTO projection_threads (thread_id, project_id, title, latest_turn_id,
+           created_at, updated_at, latest_user_message_at, pending_approval_count,
+           pending_user_input_count, monitor_json)
+           VALUES (?,?,?,?,?,?,?,?,?,?)`,
+        )
+        .run(threadId, "p1", `Thread ${String(index)}`, `turn-${threadId}`, at, at, at, 4, 2, "{}");
+    }
+    database
+      .prepare(
+        `INSERT INTO projection_turns (thread_id, turn_id, state, requested_at, checkpoint_files_json)
+         VALUES (?,?,?,?,'[]')`,
+      )
+      .run(threadId, `turn-${threadId}`, "completed", at);
+    database
+      .prepare(`INSERT INTO projection_thread_sessions VALUES (?,'running','claude',?,'boom',?)`)
+      .run(threadId, `turn-${threadId}`, at);
+    database
+      .prepare(`INSERT INTO projection_thread_messages VALUES (?,?, 'user','hello',0,?,?)`)
+      .run(`m-${threadId}`, threadId, at, at);
+    for (let a = 0; a < activitiesPerThread; a += 1) {
+      database
+        .prepare(`INSERT INTO projection_thread_activities VALUES (?,?,'neutral','tool','ran',?,?)`)
+        .run(`a-${threadId}-${String(a)}`, threadId, "{}", `2026-07-10T00:00:0${String(a)}.000Z`);
+    }
+  }
+  database.close();
+}
+
+function makeTarget(path: string, options?: { readonly dropProposedPlans?: boolean }) {
+  const database = new NodeSqlite.DatabaseSync(path);
+  // No monitor_json: the target is a migration behind, as a worktree often is.
+  createSchema(database, { withMonitor: false });
+  database
+    .prepare(
+      `INSERT INTO projection_projects VALUES ('stale','Stale','/old','[]','${SEEDED_AT}','${SEEDED_AT}',NULL)`,
+    )
+    .run();
+  // History from the target's own past life, which must not survive the seed.
+  database
+    .prepare(`INSERT INTO orchestration_events (event_id, stream_id, event_type, payload_json)
+      VALUES ('old-event','stale-thread','thread.created','{}')`)
+    .run();
+  if (options?.dropProposedPlans) {
+    // A target far enough behind that a whole table is missing (migration 013).
+    database.exec("DROP TABLE projection_thread_proposed_plans");
+  }
+  database.close();
+}
+
+const withDatabases = <A>(
+  run: (paths: { readonly source: string; readonly target: string }) => A,
+  options?: {
+    readonly threads?: number;
+    readonly activities?: number;
+    readonly dropProposedPlans?: boolean;
+    readonly legacySource?: boolean;
+  },
+): A => {
+  const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-dev-seed-"));
+  const source = NodePath.join(directory, "source.sqlite");
+  const target = NodePath.join(directory, "target.sqlite");
+  makeSource(source, options?.threads ?? 5, options?.activities ?? 3, {
+    legacyThreads: options?.legacySource ?? false,
+  });
+  makeTarget(target, { dropProposedPlans: options?.dropProposedPlans ?? false });
+  try {
+    return run({ source, target });
+  } finally {
+    NodeFS.rmSync(directory, { recursive: true, force: true });
+  }
+};
+
+const query = <T>(path: string, sql: string): Array<T> => {
+  const database = new NodeSqlite.DatabaseSync(path, { readOnly: true });
+  try {
+    return database.prepare(sql).all() as Array<T>;
+  } finally {
+    database.close();
+  }
+};
+
+describe("seedDevDatabase", () => {
+  it("copies the most recent threads and their project", () => {
+    withDatabases(({ source, target }) => {
+      const summary = seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 2,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      assert.equal(summary.threads, 2);
+      assert.equal(summary.projects, 1);
+
+      const titles = query<{ title: string }>(
+        target,
+        "SELECT title FROM projection_threads ORDER BY latest_user_message_at DESC",
+      ).map((row) => row.title);
+      // Threads 4 and 3 are the newest of the five.
+      assert.deepStrictEqual(titles, ["Thread 4", "Thread 3"]);
+    });
+  });
+
+  it("replaces whatever the target held before", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const projects = query<{ project_id: string }>(
+        target,
+        "SELECT project_id FROM projection_projects",
+      ).map((row) => row.project_id);
+      assert.deepStrictEqual(projects, ["p1"]);
+    });
+  });
+
+  // The target can be a migration behind the source; copying its columns
+  // blindly would fail on the first schema change.
+  it("skips columns the target does not have", () => {
+    withDatabases(({ source, target }) => {
+      const summary = seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      assert.deepStrictEqual(summary.skippedColumns, ["projection_threads.monitor_json"]);
+      assert.equal(summary.threads, 1);
+    });
+  });
+
+  // A copied "running" session has no agent behind it, so the thread would spin
+  // forever and the session reaper would skip it.
+  it("neutralizes live session state", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const sessions = query<{ status: string; active_turn_id: string | null }>(
+        target,
+        "SELECT status, active_turn_id FROM projection_thread_sessions",
+      );
+      assert.isAbove(sessions.length, 0);
+      for (const session of sessions) {
+        assert.equal(session.status, "stopped");
+        assert.isNull(session.active_turn_id);
+      }
+    });
+  });
+
+  // Approvals are not copied, so the badge counts must not survive.
+  it("clears pending counts that have no rows behind them", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const [counts] = query<{ approvals: number; inputs: number }>(
+        target,
+        "SELECT SUM(pending_approval_count) approvals, SUM(pending_user_input_count) inputs FROM projection_threads",
+      );
+      assert.equal(counts?.approvals, 0);
+      assert.equal(counts?.inputs, 0);
+    });
+  });
+
+  it("caps activities per thread, keeping the newest", () => {
+    withDatabases(
+      ({ source, target }) => {
+        const summary = seedDevDatabase({
+          sourceDbPath: source,
+          targetDbPath: target,
+          threadLimit: 2,
+          activityLimit: 2,
+          seededAt: SEEDED_AT,
+        });
+
+        assert.equal(summary.activities, 4); // 2 threads × 2 kept
+        const ids = query<{ activity_id: string }>(
+          target,
+          "SELECT activity_id FROM projection_thread_activities ORDER BY activity_id",
+        ).map((row) => row.activity_id);
+        // Of a-*-0/1/2, the newest two are 1 and 2.
+        assert.deepStrictEqual(ids, ["a-t3-1", "a-t3-2", "a-t4-1", "a-t4-2"]);
+      },
+      // One more per thread than the cap keeps, so the cap is observable.
+      { activities: 3 },
+    );
+  });
+
+  // Required, or computeSnapshotSequence reports 0 for every shell snapshot.
+  it("writes a cursor row for every projector", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const rows = query<{ projector: string; last_applied_sequence: number }>(
+        target,
+        "SELECT projector, last_applied_sequence FROM projection_state",
+      );
+      assert.equal(rows.length, 9);
+      // All at 0. The cursor is exclusive and the event log was emptied, so
+      // any positive value would make each projector skip that many of the
+      // user's first real events — a different count each, which desynchronizes
+      // the projections permanently.
+      for (const row of rows) {
+        assert.equal(row.last_applied_sequence, 0);
+      }
+    });
+  });
+
+  // The copied projections describe a different world than whatever history
+  // the target still holds; replaying it would resurrect the target's own
+  // deleted threads and projects over the seed.
+  it("empties the target event log", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const [events] = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM orchestration_events",
+      );
+      assert.equal(events?.count, 0);
+    });
+  });
+
+  // A target behind on migrations can be missing a table outright; that should
+  // degrade like column drift does, not abort the seed.
+  it("tolerates a table the target does not have", () => {
+    withDatabases(
+      ({ source, target }) => {
+        const summary = seedDevDatabase({
+          sourceDbPath: source,
+          targetDbPath: target,
+          threadLimit: 2,
+          activityLimit: 10,
+          seededAt: SEEDED_AT,
+        });
+
+        assert.equal(summary.threads, 2);
+      },
+      { dropProposedPlans: true },
+    );
+  });
+
+  // The recency columns arrived in migrations 017 and 023; a source older than
+  // those must still be readable, since the rest of the copy tolerates drift.
+  it("reads a source that predates the recency columns", () => {
+    withDatabases(
+      ({ source, target }) => {
+        const summary = seedDevDatabase({
+          sourceDbPath: source,
+          targetDbPath: target,
+          threadLimit: 2,
+          activityLimit: 10,
+          seededAt: SEEDED_AT,
+        });
+
+        assert.equal(summary.threads, 2);
+        const titles = query<{ title: string }>(
+          target,
+          "SELECT title FROM projection_threads ORDER BY updated_at DESC",
+        ).map((row) => row.title);
+        assert.deepStrictEqual(titles, ["Thread 4", "Thread 3"]);
+      },
+      { legacySource: true },
+    );
+  });
+
+  it("reports a source with nothing to copy", () => {
+    withDatabases(
+      ({ source, target }) => {
+        assert.throws(
+          () =>
+            seedDevDatabase({
+              sourceDbPath: source,
+              targetDbPath: target,
+              threadLimit: 5,
+              activityLimit: 10,
+              seededAt: SEEDED_AT,
+            }),
+          DevSeedError,
+        );
+      },
+      { threads: 0 },
+    );
+  });
+
+  it("leaves the target untouched when the source cannot be opened", () => {
+    withDatabases(({ target }) => {
+      assert.throws(
+        () =>
+          seedDevDatabase({
+            sourceDbPath: NodePath.join(NodePath.dirname(target), "missing.sqlite"),
+            targetDbPath: target,
+            threadLimit: 5,
+            activityLimit: 10,
+            seededAt: SEEDED_AT,
+          }),
+        DevSeedError,
+      );
+
+      // The pre-existing row survives: nothing was deleted before the failure.
+      const projects = query<{ project_id: string }>(
+        target,
+        "SELECT project_id FROM projection_projects",
+      );
+      assert.deepStrictEqual(
+        projects.map((row) => row.project_id),
+        ["stale"],
+      );
+    });
+  });
+});

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -101,8 +101,10 @@ function makeSource(
     }
     // The newest thread is left mid-turn, as a copy taken while an agent is
     // working would be: a running turn with no completion, and a message still
-    // streaming into it.
+    // streaming into it. The one before it is left "pending" — a user message
+    // accepted but whose provider turn never started.
     const midFlight = index === threadCount - 1;
+    const queued = index === threadCount - 2;
     database
       .prepare(
         `INSERT INTO projection_turns (thread_id, turn_id, state, requested_at, completed_at, checkpoint_files_json)
@@ -111,9 +113,9 @@ function makeSource(
       .run(
         threadId,
         `turn-${threadId}`,
-        midFlight ? "running" : "completed",
+        midFlight ? "running" : queued ? "pending" : "completed",
         at,
-        midFlight ? null : at,
+        midFlight || queued ? null : at,
       );
     database
       .prepare(`INSERT INTO projection_thread_sessions VALUES (?,'running','claude',?,'boom',?)`)
@@ -297,10 +299,11 @@ describe("seedDevDatabase", () => {
     });
   });
 
-  // A copied running turn has no agent left to finish it. The session override
-  // alone does not cover this: the turn is read independently, and an unsettled
-  // one keeps the thread spinning and its timeline unfoldable forever.
-  it("settles turns copied mid-flight", () => {
+  // A copied turn has no agent left to finish it, whether it was already
+  // running or still queued behind a "pending" row. The session override alone
+  // does not cover either: the turn is read independently, and an unsettled one
+  // keeps the thread spinning and its timeline unfoldable forever.
+  it("settles turns copied before they finished", () => {
     withDatabases(({ source, target }) => {
       seedDevDatabase({
         sourceDbPath: source,
@@ -314,9 +317,11 @@ describe("seedDevDatabase", () => {
         target,
         "SELECT state, completed_at FROM projection_turns",
       );
+      // The fixture puts one running turn and one pending turn in this range.
       assert.isAbove(turns.length, 0);
       for (const turn of turns) {
         assert.notEqual(turn.state, "running");
+        assert.notEqual(turn.state, "pending");
         assert.isNotNull(turn.completed_at);
       }
     });

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -39,10 +39,12 @@ function createSchema(
     message_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, role TEXT NOT NULL,
     text TEXT NOT NULL, is_streaming INTEGER NOT NULL, attachments_json TEXT,
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL)`);
+  // `sequence` (migration 008) is what the app orders activities by, ahead of
+  // created_at, so the copy's per-thread cap has to see it.
   database.exec(`CREATE TABLE projection_thread_activities (
     activity_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, tone TEXT NOT NULL,
     kind TEXT NOT NULL, summary TEXT NOT NULL, payload_json TEXT NOT NULL,
-    created_at TEXT NOT NULL)`);
+    sequence INTEGER, created_at TEXT NOT NULL)`);
   database.exec(`CREATE TABLE projection_thread_sessions (
     thread_id TEXT PRIMARY KEY, status TEXT NOT NULL, provider_name TEXT,
     active_turn_id TEXT, last_error TEXT, updated_at TEXT NOT NULL)`);
@@ -155,8 +157,16 @@ function makeSource(
       );
     for (let a = 0; a < activitiesPerThread; a += 1) {
       database
-        .prepare(`INSERT INTO projection_thread_activities VALUES (?,?,'neutral','tool','ran',?,?)`)
-        .run(`a-${threadId}-${String(a)}`, threadId, "{}", `2026-07-10T00:00:0${String(a)}.000Z`);
+        .prepare(
+          `INSERT INTO projection_thread_activities VALUES (?,?,'neutral','tool','ran',?,?,?)`,
+        )
+        .run(
+          `a-${threadId}-${String(a)}`,
+          threadId,
+          "{}",
+          a,
+          `2026-07-10T00:00:0${String(a)}.000Z`,
+        );
     }
   }
   database.exec("COMMIT");
@@ -372,6 +382,41 @@ describe("seedDevDatabase", () => {
         "SELECT COUNT(*) count FROM projection_turns WHERE state = 'pending' OR turn_id IS NULL",
       );
       assert.equal(pending?.count, 0);
+    });
+  });
+
+  // A burst of tool activity lands many rows on the same timestamp. Capping on
+  // created_at alone then cuts arbitrarily among them, and can keep exactly the
+  // rows the timeline treats as oldest.
+  it("caps activities by the order the app displays them", () => {
+    withDatabases(({ source, target }) => {
+      const sourceDatabase = new NodeSqlite.DatabaseSync(source);
+      sourceDatabase.exec("DELETE FROM projection_thread_activities");
+      const tied = "2026-07-10T00:00:00.000Z";
+      for (const sequence of [1, 2, 3, 4]) {
+        sourceDatabase
+          .prepare(
+            `INSERT INTO projection_thread_activities
+             VALUES (?, 't4', 'neutral', 'tool', 'ran', '{}', ?, ?)`,
+          )
+          .run(`tie-${String(sequence)}`, sequence, tied);
+      }
+      sourceDatabase.close();
+
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 2,
+        seededAt: SEEDED_AT,
+      });
+
+      const kept = query<{ activity_id: string }>(
+        target,
+        "SELECT activity_id FROM projection_thread_activities ORDER BY sequence DESC",
+      ).map((row) => row.activity_id);
+      // The two highest sequences, not whichever two the storage order yielded.
+      assert.deepStrictEqual(kept, ["tie-4", "tie-3"]);
     });
   });
 

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -31,7 +31,7 @@ function createSchema(
     ${options.withMonitor ? ", monitor_json TEXT" : ""})`);
   database.exec(`CREATE TABLE projection_thread_messages (
     message_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, role TEXT NOT NULL,
-    text TEXT NOT NULL, is_streaming INTEGER NOT NULL,
+    text TEXT NOT NULL, is_streaming INTEGER NOT NULL, attachments_json TEXT,
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL)`);
   database.exec(`CREATE TABLE projection_thread_activities (
     activity_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, tone TEXT NOT NULL,
@@ -42,7 +42,8 @@ function createSchema(
     active_turn_id TEXT, last_error TEXT, updated_at TEXT NOT NULL)`);
   database.exec(`CREATE TABLE projection_turns (
     row_id INTEGER PRIMARY KEY AUTOINCREMENT, thread_id TEXT NOT NULL, turn_id TEXT,
-    state TEXT NOT NULL, requested_at TEXT NOT NULL, checkpoint_files_json TEXT NOT NULL,
+    state TEXT NOT NULL, requested_at TEXT NOT NULL, completed_at TEXT,
+    checkpoint_files_json TEXT NOT NULL,
     UNIQUE (thread_id, turn_id))`);
   database.exec(`CREATE TABLE projection_thread_proposed_plans (
     plan_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, plan_markdown TEXT NOT NULL,
@@ -55,6 +56,9 @@ function createSchema(
   database.exec(`CREATE TABLE orchestration_events (
     sequence INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT NOT NULL UNIQUE,
     stream_id TEXT NOT NULL, event_type TEXT NOT NULL, payload_json TEXT NOT NULL)`);
+  database.exec(`CREATE TABLE provider_session_runtime (
+    thread_id TEXT PRIMARY KEY, provider_name TEXT NOT NULL, adapter_key TEXT NOT NULL,
+    status TEXT NOT NULL, last_seen_at TEXT NOT NULL)`);
 }
 
 /** Source DB with `threadCount` threads, oldest first so recency ordering is testable. */
@@ -95,18 +99,35 @@ function makeSource(
         )
         .run(threadId, "p1", `Thread ${String(index)}`, `turn-${threadId}`, at, at, at, 4, 2, "{}");
     }
+    // The newest thread is left mid-turn, as a copy taken while an agent is
+    // working would be: a running turn with no completion, and a message still
+    // streaming into it.
+    const midFlight = index === threadCount - 1;
     database
       .prepare(
-        `INSERT INTO projection_turns (thread_id, turn_id, state, requested_at, checkpoint_files_json)
-         VALUES (?,?,?,?,'[]')`,
+        `INSERT INTO projection_turns (thread_id, turn_id, state, requested_at, completed_at, checkpoint_files_json)
+         VALUES (?,?,?,?,?,'[]')`,
       )
-      .run(threadId, `turn-${threadId}`, "completed", at);
+      .run(
+        threadId,
+        `turn-${threadId}`,
+        midFlight ? "running" : "completed",
+        at,
+        midFlight ? null : at,
+      );
     database
       .prepare(`INSERT INTO projection_thread_sessions VALUES (?,'running','claude',?,'boom',?)`)
       .run(threadId, `turn-${threadId}`, at);
     database
-      .prepare(`INSERT INTO projection_thread_messages VALUES (?,?, 'user','hello',0,?,?)`)
-      .run(`m-${threadId}`, threadId, at, at);
+      .prepare(`INSERT INTO projection_thread_messages VALUES (?,?, 'user','hello',?,?,?,?)`)
+      .run(
+        `m-${threadId}`,
+        threadId,
+        midFlight ? 1 : 0,
+        JSON.stringify([{ type: "image", id: `${threadId}-image`, name: "shot.png" }]),
+        at,
+        at,
+      );
     for (let a = 0; a < activitiesPerThread; a += 1) {
       database
         .prepare(`INSERT INTO projection_thread_activities VALUES (?,?,'neutral','tool','ran',?,?)`)
@@ -129,6 +150,11 @@ function makeTarget(path: string, options?: { readonly dropProposedPlans?: boole
   database
     .prepare(`INSERT INTO orchestration_events (event_id, stream_id, event_type, payload_json)
       VALUES ('old-event','stale-thread','thread.created','{}')`)
+    .run();
+  // A binding for a thread the seed is about to delete.
+  database
+    .prepare(`INSERT INTO provider_session_runtime
+      VALUES ('stale-thread','claude','claude-code','running','${SEEDED_AT}')`)
     .run();
   if (options?.dropProposedPlans) {
     // A target far enough behind that a whole table is missing (migration 013).
@@ -268,6 +294,87 @@ describe("seedDevDatabase", () => {
       );
       assert.equal(counts?.approvals, 0);
       assert.equal(counts?.inputs, 0);
+    });
+  });
+
+  // A copied running turn has no agent left to finish it. The session override
+  // alone does not cover this: the turn is read independently, and an unsettled
+  // one keeps the thread spinning and its timeline unfoldable forever.
+  it("settles turns copied mid-flight", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const turns = query<{ state: string; completed_at: string | null }>(
+        target,
+        "SELECT state, completed_at FROM projection_turns",
+      );
+      assert.isAbove(turns.length, 0);
+      for (const turn of turns) {
+        assert.notEqual(turn.state, "running");
+        assert.isNotNull(turn.completed_at);
+      }
+    });
+  });
+
+  // Nothing will ever stream into a copied message, so a carried-over flag
+  // renders a caret that never resolves.
+  it("clears the streaming flag on copied messages", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const streaming = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM projection_thread_messages WHERE is_streaming <> 0",
+      );
+      assert.equal(streaming[0]?.count, 0);
+    });
+  });
+
+  // The rows carry attachment metadata but the bytes live on disk, so the
+  // caller has to be told which files to bring along.
+  it("reports the attachment ids the copied messages reference", () => {
+    withDatabases(({ source, target }) => {
+      const summary = seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 2,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      assert.deepStrictEqual([...summary.attachmentIds].sort(), ["t3-image", "t4-image"]);
+    });
+  });
+
+  // Bindings are keyed by thread id and are not copied; left behind they name
+  // threads the seed just deleted, which the session reaper then tries to stop.
+  it("clears provider runtime bindings the seed orphans", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const [bindings] = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM provider_session_runtime",
+      );
+      assert.equal(bindings?.count, 0);
     });
   });
 

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -404,15 +404,19 @@ describe("seedDevDatabase", () => {
     withDatabases(({ source, target }) => {
       const sourceDatabase = new NodeSqlite.DatabaseSync(source);
       sourceDatabase.exec("DELETE FROM projection_thread_activities");
+      const insert = sourceDatabase.prepare(
+        `INSERT INTO projection_thread_activities
+         VALUES (?, 't4', 'neutral', 'tool', 'ran', '{}', ?, ?)`,
+      );
       const tied = "2026-07-10T00:00:00.000Z";
-      for (const sequence of [1, 2, 3, 4]) {
-        sourceDatabase
-          .prepare(
-            `INSERT INTO projection_thread_activities
-             VALUES (?, 't4', 'neutral', 'tool', 'ran', '{}', ?, ?)`,
-          )
-          .run(`tie-${String(sequence)}`, sequence, tied);
+      // Timestamps tie within a burst...
+      for (const sequence of [1, 2, 3]) {
+        insert.run(`tie-${String(sequence)}`, sequence, tied);
       }
+      // ...and can disagree with sequence outright under clock skew. The app
+      // ranks by sequence first, so this row outranks every tied one despite
+      // its older timestamp.
+      insert.run("skewed-4", 4, "2026-07-09T00:00:00.000Z");
       sourceDatabase.close();
 
       seedDevDatabase({
@@ -427,8 +431,9 @@ describe("seedDevDatabase", () => {
         target,
         "SELECT activity_id FROM projection_thread_activities ORDER BY sequence DESC",
       ).map((row) => row.activity_id);
-      // The two highest sequences, not whichever two the storage order yielded.
-      assert.deepStrictEqual(kept, ["tie-4", "tie-3"]);
+      // The two highest sequences — not the two newest timestamps, and not
+      // whichever two the storage order yielded.
+      assert.deepStrictEqual(kept, ["skewed-4", "tie-3"]);
     });
   });
 

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -324,6 +324,11 @@ describe("seedDevDatabase", () => {
         assert.equal(session.status, "stopped");
         assert.isNull(session.active_turn_id);
       }
+      const [threadsWithLatestTurn] = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM projection_threads WHERE latest_turn_id IS NOT NULL",
+      );
+      assert.equal(threadsWithLatestTurn?.count, 0);
     });
   });
 
@@ -434,6 +439,35 @@ describe("seedDevDatabase", () => {
       // The two highest sequences — not the two newest timestamps, and not
       // whichever two the storage order yielded.
       assert.deepStrictEqual(kept, ["skewed-4", "tie-3"]);
+    });
+  });
+
+  it("uses activity id as the final cap tiebreaker", () => {
+    withDatabases(({ source, target }) => {
+      const sourceDatabase = new NodeSqlite.DatabaseSync(source);
+      sourceDatabase.exec("DELETE FROM projection_thread_activities");
+      const insert = sourceDatabase.prepare(
+        `INSERT INTO projection_thread_activities
+         VALUES (?, 't4', 'neutral', 'tool', 'ran', '{}', 7, ?)`,
+      );
+      const tied = "2026-07-10T00:00:00.000Z";
+      insert.run("tie-a", tied);
+      insert.run("tie-z", tied);
+      sourceDatabase.close();
+
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 1,
+        seededAt: SEEDED_AT,
+      });
+
+      const kept = query<{ activity_id: string }>(
+        target,
+        "SELECT activity_id FROM projection_thread_activities",
+      );
+      assert.deepStrictEqual(kept, [{ activity_id: "tie-z" }]);
     });
   });
 
@@ -648,6 +682,35 @@ describe("seedDevDatabase", () => {
       },
       { legacySource: true },
     );
+  });
+
+  it("falls back to user messages when stored recency is missing", () => {
+    withDatabases(({ source, target }) => {
+      const sourceDatabase = new NodeSqlite.DatabaseSync(source);
+      sourceDatabase.exec("UPDATE projection_threads SET latest_user_message_at = NULL");
+      sourceDatabase
+        .prepare(
+          `UPDATE projection_thread_messages
+           SET created_at = '2099-01-01T00:00:00.000Z'
+           WHERE thread_id = 't0' AND role = 'user'`,
+        )
+        .run();
+      sourceDatabase.close();
+
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 1,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const threads = query<{ thread_id: string }>(
+        target,
+        "SELECT thread_id FROM projection_threads",
+      );
+      assert.deepStrictEqual(threads, [{ thread_id: "t0" }]);
+    });
   });
 
   // Every statement keyed on thread ids must cost exactly one bound variable

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -8,6 +8,12 @@ import * as NodeSqlite from "node:sqlite";
 import { DevSeedError, MAX_SEED_THREAD_LIMIT, seedDevDatabase } from "./dev-seed.ts";
 
 const SEEDED_AT = "2026-07-26T00:00:00.000Z";
+/**
+ * A completion timestamp left on a still-running turn by a settle that a later
+ * checkpoint reverted. Far enough in the future to be unmistakable if it leaks
+ * into a seeded row.
+ */
+const STALE_COMPLETED_AT = "2099-01-01T00:00:00.000Z";
 
 /**
  * The subset of the real schema the seeder touches. `monitor_json` is included
@@ -119,10 +125,14 @@ function makeSource(
       )
       .run(
         threadId,
-        `turn-${threadId}`,
+        // A pending start has no turn id — that is what identifies it.
+        queued ? null : `turn-${threadId}`,
         midFlight ? "running" : queued ? "pending" : "completed",
         at,
-        midFlight || queued ? null : at,
+        // The running turn carries a stale completion from an earlier settle
+        // that a later checkpoint reverted, which must not survive as the
+        // interruption time.
+        midFlight ? STALE_COMPLETED_AT : queued ? null : at,
       );
     if (minimalRows) {
       continue;
@@ -312,11 +322,10 @@ describe("seedDevDatabase", () => {
     });
   });
 
-  // A copied turn has no agent left to finish it, whether it was already
-  // running or still queued behind a "pending" row. The session override alone
-  // does not cover either: the turn is read independently, and an unsettled one
-  // keeps the thread spinning and its timeline unfoldable forever.
-  it("settles turns copied before they finished", () => {
+  // A copied running turn has no agent left to finish it. The session override
+  // alone does not cover it: the turn is read independently, and an unsettled
+  // one keeps the thread spinning and its timeline unfoldable forever.
+  it("settles turns copied while still running", () => {
     withDatabases(({ source, target }) => {
       seedDevDatabase({
         sourceDbPath: source,
@@ -330,13 +339,36 @@ describe("seedDevDatabase", () => {
         target,
         "SELECT state, completed_at FROM projection_turns",
       );
-      // The fixture puts one running turn and one pending turn in this range.
       assert.isAbove(turns.length, 0);
       for (const turn of turns) {
         assert.notEqual(turn.state, "running");
-        assert.notEqual(turn.state, "pending");
         assert.isNotNull(turn.completed_at);
+        // A settle that a later checkpoint reverted can leave a completion on a
+        // running turn; carrying it over would date the interruption to then.
+        assert.notEqual(turn.completed_at, STALE_COMPLETED_AT);
       }
+    });
+  });
+
+  // The server deletes pending starts rather than settling them
+  // (clearPendingProjectionTurnsByThread). They also cannot be settled
+  // coherently: turn_id is NULL, so an "interrupted" one is a terminal turn
+  // with no id — a shape no real turn has.
+  it("drops pending turn starts instead of settling them", () => {
+    withDatabases(({ source, target }) => {
+      seedDevDatabase({
+        sourceDbPath: source,
+        targetDbPath: target,
+        threadLimit: 3,
+        activityLimit: 10,
+        seededAt: SEEDED_AT,
+      });
+
+      const [pending] = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM projection_turns WHERE state = 'pending' OR turn_id IS NULL",
+      );
+      assert.equal(pending?.count, 0);
     });
   });
 

--- a/scripts/lib/dev-seed.test.ts
+++ b/scripts/lib/dev-seed.test.ts
@@ -70,6 +70,13 @@ function createSchema(
   database.exec(`CREATE TABLE provider_session_runtime (
     thread_id TEXT PRIMARY KEY, provider_name TEXT NOT NULL, adapter_key TEXT NOT NULL,
     status TEXT NOT NULL, last_seen_at TEXT NOT NULL)`);
+  // Cleared alongside the event log: a receipt records a command whose events
+  // the seed just deleted, so a retry of that command would be treated as
+  // already applied.
+  database.exec(`CREATE TABLE orchestration_command_receipts (
+    command_id TEXT PRIMARY KEY, aggregate_kind TEXT NOT NULL, aggregate_id TEXT NOT NULL,
+    accepted_at TEXT NOT NULL, result_sequence INTEGER NOT NULL, status TEXT NOT NULL,
+    error TEXT)`);
 }
 
 /** Source DB with `threadCount` threads, oldest first so recency ordering is testable. */
@@ -191,6 +198,11 @@ function makeTarget(path: string, options?: { readonly dropProposedPlans?: boole
   database
     .prepare(`INSERT INTO provider_session_runtime
       VALUES ('stale-thread','claude','claude-code','running','${SEEDED_AT}')`)
+    .run();
+  // A receipt for a command whose events the seed is about to delete.
+  database
+    .prepare(`INSERT INTO orchestration_command_receipts
+      VALUES ('old-command','thread','stale-thread','${SEEDED_AT}',1,'accepted',NULL)`)
     .run();
   if (options?.dropProposedPlans) {
     // A target far enough behind that a whole table is missing (migration 013).
@@ -578,6 +590,15 @@ describe("seedDevDatabase", () => {
         "SELECT COUNT(*) count FROM orchestration_events",
       );
       assert.equal(events?.count, 0);
+
+      // Receipts go with them: one left behind records a command whose events
+      // no longer exist, so re-issuing that command would be treated as
+      // already applied and produce nothing.
+      const [receipts] = query<{ count: number }>(
+        target,
+        "SELECT COUNT(*) count FROM orchestration_command_receipts",
+      );
+      assert.equal(receipts?.count, 0);
     });
   });
 

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -227,6 +227,14 @@ function copyRows(input: {
 const UNSETTLED_TURN_STATES = ["running", "pending"] as const;
 
 /**
+ * Inlined rather than bound, so the statement below costs exactly one variable
+ * per thread. `--threads` is capped at SQLite's variable ceiling, so two extra
+ * bindings put the maximum documented value two over the limit. Safe to
+ * interpolate: these are internal literals, never input.
+ */
+const UNSETTLED_TURN_STATES_SQL = UNSETTLED_TURN_STATES.map((state) => `'${state}'`).join(", ");
+
+/**
  * Settles turns copied mid-flight, matching what the server does to a turn
  * whose session leaves "running": `settledTurnStateForSessionStatus` in
  * apps/server/src/orchestration/Layers/ProjectionPipeline.ts maps the "stopped"
@@ -251,10 +259,10 @@ function settleUnfinishedTurns(
   target
     .prepare(
       `UPDATE projection_turns SET state = 'interrupted'${setCompletedAt}
-       WHERE state IN (${placeholders(UNSETTLED_TURN_STATES.length)})
+       WHERE state IN (${UNSETTLED_TURN_STATES_SQL})
          AND thread_id IN (${placeholders(threadIds.length)})`,
     )
-    .run(...UNSETTLED_TURN_STATES, ...threadIds);
+    .run(...threadIds);
 }
 
 export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -34,8 +34,10 @@ import { PROJECTION_TABLES_IN_DEPENDENCY_ORDER, PROJECTOR_NAMES } from "./projec
  */
 export const MAX_SEED_THREAD_LIMIT = 32_766;
 
+/** Inputs to {@link seedDevDatabase}. Both limits must be positive. */
 export interface DevSeedOptions {
   readonly sourceDbPath: string;
+  /** Emptied and rewritten. Must not be a database a server has open. */
   readonly targetDbPath: string;
   /** How many recent threads to copy. Capped at {@link MAX_SEED_THREAD_LIMIT}. */
   readonly threadLimit: number;
@@ -49,6 +51,7 @@ export interface DevSeedOptions {
   readonly seededAt: string;
 }
 
+/** What {@link seedDevDatabase} copied, for the CLI's summary output. */
 export interface DevSeedSummary {
   readonly projects: number;
   readonly threads: number;
@@ -65,6 +68,11 @@ export interface DevSeedSummary {
   readonly attachmentIds: ReadonlyArray<string>;
 }
 
+/**
+ * A seed that could not proceed. `hint` carries the actionable half — the
+ * underlying cause, or what to do about it — which the CLI prints on its own
+ * line beneath the message.
+ */
 export class DevSeedError extends Error {
   override readonly name = "DevSeedError";
   readonly hint: string | undefined;
@@ -311,6 +319,21 @@ function dropPendingTurnStarts(
     .run(...threadIds);
 }
 
+/**
+ * Replaces the target's projections with a recent slice of the source's.
+ *
+ * Destructive and not incremental: every projection table, the event log, and
+ * the command receipts are emptied first, inside one transaction that rolls
+ * back on any failure. Validation that can reject the whole run happens before
+ * that transaction opens, so a rejected seed leaves the target as it was.
+ *
+ * The caller must ensure no server is using the target — see the guard in
+ * scripts/dev-seed.ts. Returns counts plus the attachment ids whose files the
+ * caller still has to copy.
+ *
+ * @throws {DevSeedError} on bad limits, an unopenable database, or a source
+ * with no active threads.
+ */
 export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
   // Checked before anything is opened, and certainly before the target is
   // emptied: overrunning the ceiling mid-copy destroys the target's data and

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -1,0 +1,370 @@
+/**
+ * Copies recent projects and threads from one T3 Code database into another, so
+ * an isolated dev server opens on something recognisable instead of an empty
+ * sidebar.
+ *
+ * Projections only — no event history is copied, and the target's own log is
+ * emptied. The copied projections describe a different world than whatever the
+ * target recorded, so replaying its retained events over them would resurrect
+ * threads and projects it had deleted; copying a *partial* source range is
+ * worse still, since the projector would replay a tail whose creating events
+ * are missing. With the log empty and every projector cursor at 0 (the cursor
+ * is exclusive), bootstrap streams nothing and leaves the copied rows alone.
+ * See .agents/skills/test-t3-app/references/sqlite-fixtures.md.
+ */
+
+import * as NodeSqlite from "node:sqlite";
+
+import { PROJECTION_TABLES_IN_DEPENDENCY_ORDER, PROJECTOR_NAMES } from "./projection-tables.ts";
+
+export interface DevSeedOptions {
+  readonly sourceDbPath: string;
+  readonly targetDbPath: string;
+  /** How many recent threads to copy. */
+  readonly threadLimit: number;
+  /**
+   * Newest activities kept per thread. The real table runs to six figures, and
+   * the tail is what makes a thread look alive, so a cap keeps the copy quick
+   * without making it look empty.
+   */
+  readonly activityLimit: number;
+  /** ISO-8601 timestamp stamped on the projector cursor rows. */
+  readonly seededAt: string;
+}
+
+export interface DevSeedSummary {
+  readonly projects: number;
+  readonly threads: number;
+  readonly messages: number;
+  readonly activities: number;
+  readonly turns: number;
+  readonly sessions: number;
+  readonly skippedColumns: ReadonlyArray<string>;
+}
+
+export class DevSeedError extends Error {
+  override readonly name = "DevSeedError";
+  readonly hint: string | undefined;
+  constructor(message: string, hint?: string) {
+    super(message);
+    this.hint = hint;
+  }
+}
+
+const columnsOf = (database: NodeSqlite.DatabaseSync, table: string): ReadonlyArray<string> =>
+  database
+    .prepare(`SELECT name FROM pragma_table_info(?)`)
+    .all(table)
+    .map((row) => String((row as { name: unknown }).name));
+
+/**
+ * Columns present in both databases. The two can sit on different migrations —
+ * a dev worktree is often a migration behind or ahead of the installed app — so
+ * `SELECT *` would fail on the first schema change. Copying the intersection
+ * degrades gracefully instead: a column only the target knows about keeps its
+ * default.
+ */
+function sharedColumns(
+  source: NodeSqlite.DatabaseSync,
+  target: NodeSqlite.DatabaseSync,
+  table: string,
+): { readonly shared: ReadonlyArray<string>; readonly skipped: ReadonlyArray<string> } {
+  const sourceColumns = columnsOf(source, table);
+  const targetColumns = new Set(columnsOf(target, table));
+  const shared = sourceColumns.filter((column) => targetColumns.has(column));
+  const skipped = sourceColumns
+    .filter((column) => !targetColumns.has(column))
+    .map((column) => `${table}.${column}`);
+  return { shared, skipped };
+}
+
+const placeholders = (count: number) => Array.from({ length: count }, () => "?").join(", ");
+
+const hasTable = (database: NodeSqlite.DatabaseSync, table: string): boolean =>
+  database.prepare(`SELECT 1 FROM pragma_table_info(?)`).get(table) !== undefined;
+
+const hasColumn = (database: NodeSqlite.DatabaseSync, table: string, column: string): boolean =>
+  columnsOf(database, table).includes(column);
+
+/**
+ * Copies rows for `table` whose `keyColumn` is in `keys`, optionally keeping
+ * only the newest `perKeyLimit` rows per key.
+ */
+function copyRows(input: {
+  readonly source: NodeSqlite.DatabaseSync;
+  readonly target: NodeSqlite.DatabaseSync;
+  readonly table: string;
+  readonly keyColumn: string;
+  readonly keys: ReadonlyArray<string>;
+  readonly omitColumns?: ReadonlyArray<string>;
+  readonly perKeyLimit?: { readonly orderBy: string; readonly limit: number };
+  readonly overrides?: Readonly<Record<string, unknown>>;
+}): { readonly copied: number; readonly skipped: ReadonlyArray<string> } {
+  if (input.keys.length === 0) {
+    return { copied: 0, skipped: [] };
+  }
+
+  const { shared, skipped } = sharedColumns(input.source, input.target, input.table);
+  const omit = new Set(input.omitColumns ?? []);
+  const columns = shared.filter((column) => !omit.has(column));
+  if (columns.length === 0) {
+    return { copied: 0, skipped };
+  }
+
+  const selectList = columns.map((column) => `"${column}"`).join(", ");
+  // OR REPLACE never fires after the wholesale DELETE, but keeps the copy
+  // robust if the delete list and the copy list ever drift apart.
+  const insert = input.target.prepare(
+    `INSERT OR REPLACE INTO ${input.table} (${selectList}) VALUES (${placeholders(columns.length)})`,
+  );
+  const overrides = input.overrides ?? {};
+  let copied = 0;
+  // Iterate rather than materialize: messages are uncapped, and buffering
+  // every row of a large copy into a JS array costs memory for nothing —
+  // the target transaction is already open.
+  const insertFrom = (rows: Iterable<unknown>) => {
+    for (const row of rows as Iterable<Record<string, unknown>>) {
+      insert.run(
+        ...columns.map((column) => {
+          const value = Object.hasOwn(overrides, column) ? overrides[column] : row[column];
+          // node:sqlite binds only null/number/bigint/string/Uint8Array; every
+          // projection column is one of those, and undefined means "absent".
+          return (value ?? null) as null | number | bigint | string | Uint8Array;
+        }),
+      );
+      copied += 1;
+    }
+  };
+
+  if (input.perKeyLimit) {
+    // Per-key cap: one bounded query per key beats a window function — the
+    // (thread_id, created_at) index lets each query walk backwards and stop
+    // at the limit instead of ranking every row.
+    const statement = input.source.prepare(
+      `SELECT ${selectList} FROM ${input.table} WHERE "${input.keyColumn}" = ?
+       ORDER BY ${input.perKeyLimit.orderBy} DESC LIMIT ?`,
+    );
+    for (const key of input.keys) {
+      insertFrom(statement.iterate(key, input.perKeyLimit.limit));
+    }
+  } else {
+    insertFrom(
+      input.source
+        .prepare(
+          `SELECT ${selectList} FROM ${input.table} WHERE "${input.keyColumn}" IN (${placeholders(input.keys.length)})`,
+        )
+        .iterate(...input.keys),
+    );
+  }
+
+  return { copied, skipped };
+}
+
+export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
+  let source: NodeSqlite.DatabaseSync;
+  try {
+    source = new NodeSqlite.DatabaseSync(options.sourceDbPath, { readOnly: true });
+  } catch (cause) {
+    throw new DevSeedError(
+      `could not open the source database at ${options.sourceDbPath}`,
+      `${String(cause)}. Has T3 Code run at least once?`,
+    );
+  }
+
+  let target: NodeSqlite.DatabaseSync;
+  try {
+    target = new NodeSqlite.DatabaseSync(options.targetDbPath);
+  } catch (cause) {
+    source.close();
+    throw new DevSeedError(
+      `could not open the target database at ${options.targetDbPath}`,
+      `${String(cause)}. Start the dev server once so migrations run, then retry.`,
+    );
+  }
+
+  try {
+    // Threads the user actually touched most recently. Mirrors the sidebar's own
+    // ordering (packages/client-runtime/src/state/threadSort.ts). Both recency
+    // columns arrived in later migrations, so an older source database is read
+    // with whichever of them it actually has — the rest of the copy tolerates
+    // schema drift, and this query must too.
+    const recencyColumns = ["latest_user_message_at", "updated_at", "created_at"].filter((column) =>
+      hasColumn(source, "projection_threads", column),
+    );
+    const activeFilters = ["deleted_at", "archived_at"]
+      .filter((column) => hasColumn(source, "projection_threads", column))
+      .map((column) => `${column} IS NULL`);
+    const threadIds = (
+      source
+        .prepare(
+          `SELECT thread_id FROM projection_threads
+           ${activeFilters.length > 0 ? `WHERE ${activeFilters.join(" AND ")}` : ""}
+           ORDER BY COALESCE(${recencyColumns.join(", ")}) DESC
+           LIMIT ?`,
+        )
+        .all(options.threadLimit) as Array<{ thread_id: string }>
+    ).map((row) => row.thread_id);
+
+    if (threadIds.length === 0) {
+      throw new DevSeedError(
+        "the source database has no active threads to copy",
+        "Use T3 Code normally first, or point --from at a different data directory.",
+      );
+    }
+
+    const projectIds = (
+      source
+        .prepare(
+          `SELECT DISTINCT project_id FROM projection_threads
+           WHERE thread_id IN (${placeholders(threadIds.length)})`,
+        )
+        .all(...threadIds) as Array<{ project_id: string }>
+    ).map((row) => row.project_id);
+
+    const skipped: Array<string> = [];
+    const record = (result: {
+      readonly copied: number;
+      readonly skipped: ReadonlyArray<string>;
+    }) => {
+      skipped.push(...result.skipped);
+      return result.copied;
+    };
+
+    target.exec("BEGIN IMMEDIATE");
+
+    for (const table of PROJECTION_TABLES_IN_DEPENDENCY_ORDER) {
+      // A target behind on migrations may not have every table yet; skipping is
+      // consistent with how column drift is handled, and beats aborting the seed.
+      if (hasTable(target, table)) {
+        target.exec(`DELETE FROM ${table}`);
+      }
+    }
+
+    // Projections are copied wholesale, so any event history the target still
+    // holds describes a different world. Replaying it over the copied rows
+    // would resurrect the target's own deleted threads and projects.
+    if (hasTable(target, "orchestration_events")) {
+      target.exec("DELETE FROM orchestration_events");
+    }
+    if (hasTable(target, "orchestration_command_receipts")) {
+      target.exec("DELETE FROM orchestration_command_receipts");
+    }
+
+    const projects = record(
+      copyRows({
+        source,
+        target,
+        table: "projection_projects",
+        keyColumn: "project_id",
+        keys: projectIds,
+      }),
+    );
+    const threads = record(
+      copyRows({
+        source,
+        target,
+        table: "projection_threads",
+        keyColumn: "thread_id",
+        keys: threadIds,
+        // Approvals are not copied (see below), so the badge must not claim any.
+        overrides: { pending_approval_count: 0, pending_user_input_count: 0 },
+      }),
+    );
+    // row_id is an AUTOINCREMENT surrogate; let the target assign its own.
+    const turns = record(
+      copyRows({
+        source,
+        target,
+        table: "projection_turns",
+        keyColumn: "thread_id",
+        keys: threadIds,
+        omitColumns: ["row_id"],
+      }),
+    );
+    const messages = record(
+      copyRows({
+        source,
+        target,
+        table: "projection_thread_messages",
+        keyColumn: "thread_id",
+        keys: threadIds,
+      }),
+    );
+    const activities = record(
+      copyRows({
+        source,
+        target,
+        table: "projection_thread_activities",
+        keyColumn: "thread_id",
+        keys: threadIds,
+        perKeyLimit: { orderBy: "created_at", limit: options.activityLimit },
+      }),
+    );
+    const sessions = record(
+      copyRows({
+        source,
+        target,
+        table: "projection_thread_sessions",
+        keyColumn: "thread_id",
+        keys: threadIds,
+        // No agent process is attached in the copy. A carried-over "running"
+        // status with an active turn renders a thread that spins forever, and
+        // ProviderSessionReaper skips reaping anything with an active turn.
+        overrides: { status: "stopped", active_turn_id: null, last_error: null },
+      }),
+    );
+    record(
+      copyRows({
+        source,
+        target,
+        table: "projection_thread_proposed_plans",
+        keyColumn: "thread_id",
+        keys: threadIds,
+      }),
+    );
+    // projection_pending_approvals is deliberately skipped: migration 025 deletes
+    // approvals with no matching `approval.requested` activity, and the activity
+    // cap above can easily drop it.
+
+    // Required: computeSnapshotSequence returns 0 unless every projector has a
+    // row, which makes every shell snapshot advertise sequence 0.
+    //
+    // The cursor is exclusive (`WHERE sequence > cursor`) and the event log was
+    // just emptied, so `sequence` restarts at 1. Any positive cursor would make
+    // each projector skip that many of the user's first real events — and a
+    // different count per projector, leaving the projections permanently
+    // inconsistent. Every projector starts at 0: nothing to skip, nothing to
+    // replay.
+    const insertState = target.prepare(
+      `INSERT OR REPLACE INTO projection_state (projector, last_applied_sequence, updated_at)
+       VALUES (?, 0, ?)`,
+    );
+    for (const projector of PROJECTOR_NAMES) {
+      insertState.run(projector, options.seededAt);
+    }
+
+    target.exec("COMMIT");
+
+    return {
+      projects,
+      threads,
+      messages,
+      activities,
+      turns,
+      sessions,
+      skippedColumns: [...new Set(skipped)].sort(),
+    };
+  } catch (cause) {
+    try {
+      target.exec("ROLLBACK");
+    } catch {
+      // Already rolled back, or the transaction never opened.
+    }
+    throw cause instanceof DevSeedError
+      ? cause
+      : new DevSeedError(`could not seed the dev database: ${String(cause)}`);
+  } finally {
+    source.close();
+    target.close();
+  }
+}

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -321,6 +321,21 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
       "Each thread costs one SQLite bound variable, and that is the engine's limit.",
     );
   }
+  // Both limits are bound straight into `LIMIT ?`, where SQLite reads a
+  // negative value as "no limit" — so a caller bypassing the CLI flags turns a
+  // capped copy into a full-table one, silently. The flags already reject this;
+  // enforcing it here keeps the options contract true of the function itself.
+  for (const [name, value] of [
+    ["threadLimit", options.threadLimit],
+    ["activityLimit", options.activityLimit],
+  ] as const) {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new DevSeedError(
+        `${name} must be a positive integer, got ${String(value)}`,
+        "SQLite reads a negative LIMIT as unbounded, which would copy the whole table.",
+      );
+    }
+  }
 
   let source: NodeSqlite.DatabaseSync;
   try {
@@ -368,6 +383,14 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
     const recencyColumns = ["latest_user_message_at", "updated_at", "created_at"].filter((column) =>
       hasColumn(source, "projection_threads", column),
     );
+    // SQLite's COALESCE requires at least two arguments, so a source down to a
+    // single recency column — the pre-migration-017 case this filter exists to
+    // support — would throw rather than degrade. `created_at` is NOT NULL from
+    // migration 005 on, so there is always at least one.
+    const recencyOrder =
+      recencyColumns.length > 1
+        ? `COALESCE(${recencyColumns.join(", ")})`
+        : (recencyColumns[0] ?? "rowid");
     const activeFilters = ["deleted_at", "archived_at"]
       .filter((column) => hasColumn(source, "projection_threads", column))
       .map((column) => `${column} IS NULL`);
@@ -376,7 +399,7 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         .prepare(
           `SELECT thread_id FROM projection_threads
            ${activeFilters.length > 0 ? `WHERE ${activeFilters.join(" AND ")}` : ""}
-           ORDER BY COALESCE(${recencyColumns.join(", ")}) DESC
+           ORDER BY ${recencyOrder} DESC
            LIMIT ?`,
         )
         .all(options.threadLimit) as Array<{ thread_id: string }>

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -21,10 +21,23 @@ import * as NodeSqlite from "node:sqlite";
 
 import { PROJECTION_TABLES_IN_DEPENDENCY_ORDER, PROJECTOR_NAMES } from "./projection-tables.ts";
 
+/**
+ * The most threads one call can copy: SQLite's default
+ * SQLITE_MAX_VARIABLE_NUMBER, because the statements below bind one variable
+ * per selected thread.
+ *
+ * Exported so the CLI's `--threads` bound comes from the code that actually has
+ * to satisfy it. When the two were stated separately, a statement that bound
+ * two extra literals put the CLI's own documented maximum over the ceiling —
+ * and it failed after the target had been emptied. Anything added to those
+ * statements has to stay free of per-call bindings, or this has to come down.
+ */
+export const MAX_SEED_THREAD_LIMIT = 32_766;
+
 export interface DevSeedOptions {
   readonly sourceDbPath: string;
   readonly targetDbPath: string;
-  /** How many recent threads to copy. */
+  /** How many recent threads to copy. Capped at {@link MAX_SEED_THREAD_LIMIT}. */
   readonly threadLimit: number;
   /**
    * Newest activities kept per thread. The real table runs to six figures, and
@@ -266,6 +279,16 @@ function settleUnfinishedTurns(
 }
 
 export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
+  // Checked before anything is opened, and certainly before the target is
+  // emptied: overrunning the ceiling mid-copy destroys the target's data and
+  // rolls back without replacing it.
+  if (options.threadLimit > MAX_SEED_THREAD_LIMIT) {
+    throw new DevSeedError(
+      `cannot copy more than ${String(MAX_SEED_THREAD_LIMIT)} threads in one pass`,
+      "Each thread costs one SQLite bound variable, and that is the engine's limit.",
+    );
+  }
+
   let source: NodeSqlite.DatabaseSync;
   try {
     source = new NodeSqlite.DatabaseSync(options.sourceDbPath, { readOnly: true });

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -49,6 +49,19 @@ export interface DevSeedOptions {
   readonly activityLimit: number;
   /** ISO-8601 timestamp stamped on the projector cursor rows. */
   readonly seededAt: string;
+  /**
+   * Re-checked just before the commit, after every destructive statement has
+   * run but while a rollback still costs nothing. The caller's own check
+   * happens before this function is entered, leaving a window in which a server
+   * can start; returning a pid here aborts rather than persisting a swap
+   * underneath it.
+   *
+   * Cannot close the window completely — a server starting between this call
+   * and the commit is still possible, since a filesystem read and a SQLite
+   * transaction have no common lock — but it shrinks it from the whole copy to
+   * the commit itself.
+   */
+  readonly findRunningServerPid?: () => number | undefined;
 }
 
 /** What {@link seedDevDatabase} copied, for the CLI's summary output. */
@@ -592,6 +605,18 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
     // Read back inside the transaction: these are the rows that were just
     // written, not the source's, so a column the target lacks is already gone.
     const attachmentIds = collectAttachmentIds(target, threadIds);
+
+    // Last moment a rollback is still free. The caller checked before calling,
+    // but a server can start during a copy that takes seconds; checking again
+    // here narrows the window to the commit itself. Everything above is inside
+    // the transaction, so aborting now leaves the target exactly as it was.
+    const lateRunningPid = options.findRunningServerPid?.();
+    if (lateRunningPid !== undefined) {
+      throw new DevSeedError(
+        `a T3 Code server (pid ${String(lateRunningPid)}) started while the seed was running`,
+        "Nothing was changed. Stop it and run the seed again.",
+      );
+    }
 
     target.exec("COMMIT");
 

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -411,31 +411,51 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
   }
 
   try {
-    // Threads the user actually touched most recently. Mirrors the sidebar's own
-    // ordering (packages/client-runtime/src/state/threadSort.ts). Both recency
-    // columns arrived in later migrations, so an older source database is read
-    // with whichever of them it actually has — the rest of the copy tolerates
-    // schema drift, and this query must too.
-    const recencyColumns = ["latest_user_message_at", "updated_at", "created_at"].filter((column) =>
-      hasColumn(source, "projection_threads", column),
-    );
+    // Threads the user actually touched most recently. Mirrors the sidebar's
+    // own ordering (packages/client-runtime/src/state/threadSort.ts), including
+    // its user-message scan when the materialized timestamp is null. Both
+    // recency columns arrived in later migrations, so an older source database
+    // is read with whichever inputs it actually has.
+    const recencyExpressions: Array<string> = [];
+    if (hasColumn(source, "projection_threads", "latest_user_message_at")) {
+      recencyExpressions.push('threads."latest_user_message_at"');
+    }
+    if (
+      hasTable(source, "projection_thread_messages") &&
+      ["thread_id", "role", "created_at"].every((column) =>
+        hasColumn(source, "projection_thread_messages", column),
+      )
+    ) {
+      recencyExpressions.push(`(
+        SELECT MAX(messages."created_at")
+        FROM projection_thread_messages AS messages
+        WHERE messages."thread_id" = threads."thread_id"
+          AND messages."role" = 'user'
+      )`);
+    }
+    for (const column of ["updated_at", "created_at"]) {
+      if (hasColumn(source, "projection_threads", column)) {
+        recencyExpressions.push(`threads."${column}"`);
+      }
+    }
     // SQLite's COALESCE requires at least two arguments, so a source down to a
     // single recency column — the pre-migration-017 case this filter exists to
     // support — would throw rather than degrade. `created_at` is NOT NULL from
     // migration 005 on, so there is always at least one.
     const recencyOrder =
-      recencyColumns.length > 1
-        ? `COALESCE(${recencyColumns.join(", ")})`
-        : (recencyColumns[0] ?? "rowid");
+      recencyExpressions.length > 1
+        ? `COALESCE(${recencyExpressions.join(", ")})`
+        : (recencyExpressions[0] ?? "threads.rowid");
     const activeFilters = ["deleted_at", "archived_at"]
       .filter((column) => hasColumn(source, "projection_threads", column))
-      .map((column) => `${column} IS NULL`);
+      .map((column) => `threads."${column}" IS NULL`);
     const threadIds = (
       source
         .prepare(
-          `SELECT thread_id FROM projection_threads
+          `SELECT threads."thread_id" AS thread_id
+           FROM projection_threads AS threads
            ${activeFilters.length > 0 ? `WHERE ${activeFilters.join(" AND ")}` : ""}
-           ORDER BY ${recencyOrder} DESC
+           ORDER BY ${recencyOrder} DESC, threads."thread_id" DESC
            LIMIT ?`,
         )
         .all(options.threadLimit) as Array<{ thread_id: string }>
@@ -512,7 +532,13 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         keyColumn: "thread_id",
         keys: threadIds,
         // Approvals are not copied (see below), so the badge must not claim any.
-        overrides: { pending_approval_count: 0, pending_user_input_count: 0 },
+        // Sessions are copied as stopped with no active turn, matching the
+        // thread.session-set projection by clearing its latest turn pointer.
+        overrides: {
+          latest_turn_id: null,
+          pending_approval_count: 0,
+          pending_user_input_count: 0,
+        },
       }),
     );
     // row_id is an AUTOINCREMENT surrogate; let the target assign its own.
@@ -553,8 +579,8 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         table: "projection_thread_activities",
         keyColumn: "thread_id",
         keys: threadIds,
-        // Ordered the way the app reads these back — `sequence` first, then
-        // `created_at` (ProjectionSnapshotQuery). Any other key order can keep
+        // Ordered the way the app reads these back — `sequence`, `created_at`,
+        // then `activity_id` (ProjectionSnapshotQuery). Any other key order can keep
         // rows the timeline treats as oldest: timestamps tie within a burst of
         // tool activity, and can even disagree with `sequence` outright when
         // events arrive with skewed clocks. Descending, a NULL `sequence`
@@ -564,8 +590,8 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         // back to the timestamp — same drift tolerance as the rest of the copy.
         perKeyLimit: {
           orderBy: hasColumn(source, "projection_thread_activities", "sequence")
-            ? `"sequence" DESC, "created_at"`
-            : `"created_at"`,
+            ? `"sequence" DESC, "created_at" DESC, "activity_id"`
+            : `"created_at" DESC, "activity_id"`,
           limit: options.activityLimit,
         },
       }),
@@ -580,6 +606,9 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         // No agent process is attached in the copy. A carried-over "running"
         // status with an active turn renders a thread that spins forever, and
         // ProviderSessionReaper skips reaping anything with an active turn.
+        // "ready"/"idle" are live-session completion signals to agent
+        // awareness, so preserving those would publish historical fixtures as
+        // newly completed work. Every copied session is intentionally stopped.
         overrides: { status: "stopped", active_turn_id: null, last_error: null },
       }),
     );

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -256,6 +256,12 @@ function settleRunningTurns(
   const setCompletedAt = hasColumn(target, "projection_turns", "completed_at")
     ? `, completed_at = requested_at`
     : "";
+  // `turn_id IS NOT NULL` mirrors the server's own settle filter
+  // (ProjectionPipeline, on the session leaving "running"). No writer produces
+  // a row that is both null-id and running today — the only null-id insert
+  // writes 'pending' — so this is guarding the invariant rather than a case,
+  // and it keeps the two predicates comparable if that ever changes.
+  //
   // 'running' is inlined, not bound: `--threads` is capped at SQLite's variable
   // ceiling, so every binding beyond one per thread puts the maximum over the
   // limit. Safe to interpolate — an internal literal, never input.
@@ -263,6 +269,7 @@ function settleRunningTurns(
     .prepare(
       `UPDATE projection_turns SET state = 'interrupted'${setCompletedAt}
        WHERE state = 'running'
+         AND turn_id IS NOT NULL
          AND thread_id IN (${placeholders(threadIds.length)})`,
     )
     .run(...threadIds);

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -217,32 +217,44 @@ function copyRows(input: {
 }
 
 /**
+ * Turn states that describe work an agent still owes: "running" for a turn in
+ * flight, "pending" for one whose user message was accepted but whose provider
+ * turn had not started yet (`insertPendingProjectionTurn` in
+ * apps/server/src/persistence/Layers/ProjectionTurns.ts). Neither can make
+ * progress in a copy, and only the thread's own next message would clear a
+ * pending one.
+ */
+const UNSETTLED_TURN_STATES = ["running", "pending"] as const;
+
+/**
  * Settles turns copied mid-flight, matching what the server does to a turn
  * whose session leaves "running": `settledTurnStateForSessionStatus` in
  * apps/server/src/orchestration/Layers/ProjectionPipeline.ts maps the "stopped"
  * status the sessions are copied with to "interrupted".
  *
  * An UPDATE rather than a copy override, because only the rows that were
- * actually running should change; the rest keep their real recorded state.
+ * actually unsettled should change; the rest keep their real recorded state.
  */
-function settleRunningTurns(
+function settleUnfinishedTurns(
   target: NodeSqlite.DatabaseSync,
   threadIds: ReadonlyArray<string>,
 ): void {
   if (threadIds.length === 0 || !hasColumn(target, "projection_turns", "state")) {
     return;
   }
-  // completed_at is what marks a turn settled alongside its state; a running
-  // turn has none, and leaving it null keeps the thread unsettled regardless.
+  // completed_at is what marks a turn settled alongside its state; an
+  // unfinished turn has none, and leaving it null keeps the thread unsettled
+  // regardless of the state written here.
   const setCompletedAt = hasColumn(target, "projection_turns", "completed_at")
     ? `, completed_at = COALESCE(completed_at, requested_at)`
     : "";
   target
     .prepare(
       `UPDATE projection_turns SET state = 'interrupted'${setCompletedAt}
-       WHERE state = 'running' AND thread_id IN (${placeholders(threadIds.length)})`,
+       WHERE state IN (${placeholders(UNSETTLED_TURN_STATES.length)})
+         AND thread_id IN (${placeholders(threadIds.length)})`,
     )
-    .run(...threadIds);
+    .run(...UNSETTLED_TURN_STATES, ...threadIds);
 }
 
 export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
@@ -265,6 +277,22 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
       `could not open the target database at ${options.targetDbPath}`,
       `${String(cause)}. Start the dev server once so migrations run, then retry.`,
     );
+  }
+
+  // The source is normally the *live* installed app's database — only the
+  // target is guarded against a running server, because reading is harmless.
+  // Reading it across a dozen separate implicit transactions is not: the app
+  // can delete a project between the query that picks it up and the copy that
+  // reads its row, leaving a copied thread whose project no longer exists (no
+  // foreign keys are declared, so nothing catches it). One deferred read
+  // transaction pins every query below to a single snapshot.
+  let sourceTransactionOpen = false;
+  try {
+    source.exec("BEGIN");
+    sourceTransactionOpen = true;
+  } catch {
+    // A concurrent writer can leave the connection unable to start one. The
+    // copy is still worth doing — it just loses snapshot isolation.
   }
 
   try {
@@ -376,11 +404,11 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
       }),
     );
     // A thread copied mid-turn has no agent to finish it. The session status is
-    // forced to "stopped" below, but the turn is read independently: a
-    // `state = 'running'` turn keeps the thread unsettled and unfoldable
-    // forever (deriveUnsettledTurnId in MessagesTimeline.logic.ts). Interrupted
-    // is what the server itself settles an abandoned turn to.
-    settleRunningTurns(target, threadIds);
+    // forced to "stopped" below, but the turn is read independently: an
+    // unfinished turn keeps the thread unsettled and unfoldable forever
+    // (deriveUnsettledTurnId in MessagesTimeline.logic.ts). Interrupted is what
+    // the server itself settles an abandoned turn to.
+    settleUnfinishedTurns(target, threadIds);
     const messages = record(
       copyRows({
         source,
@@ -475,6 +503,15 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
       ? cause
       : new DevSeedError(`could not seed the dev database: ${String(cause)}`);
   } finally {
+    if (sourceTransactionOpen) {
+      try {
+        // Read-only, so there is nothing to commit; end it before closing so
+        // the snapshot is released explicitly rather than by teardown.
+        source.exec("ROLLBACK");
+      } catch {
+        // Already ended, which is equally fine for a read-only transaction.
+      }
+    }
     source.close();
     target.close();
   }

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -553,7 +553,20 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         table: "projection_thread_activities",
         keyColumn: "thread_id",
         keys: threadIds,
-        perKeyLimit: { orderBy: "created_at", limit: options.activityLimit },
+        // Ordered the way the app reads these back — `sequence` first, then
+        // `created_at` (ProjectionSnapshotQuery). Capping on `created_at`
+        // alone cuts arbitrarily among rows sharing a timestamp, which is the
+        // common case for a burst of tool activity: the "newest N" kept can be
+        // the oldest N in the order the timeline actually displays.
+        //
+        // `sequence` arrived in migration 008, so a source without it falls
+        // back to the timestamp — same drift tolerance as the rest of the copy.
+        perKeyLimit: {
+          orderBy: hasColumn(source, "projection_thread_activities", "sequence")
+            ? `"created_at" DESC, "sequence"`
+            : `"created_at"`,
+          limit: options.activityLimit,
+        },
       }),
     );
     const sessions = record(

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -232,7 +232,7 @@ function copyRows(input: {
     // at the limit instead of ranking every row.
     const statement = input.source.prepare(
       `SELECT ${selectList} FROM ${input.table} WHERE "${input.keyColumn}" = ?
-       ORDER BY ${input.perKeyLimit.orderBy} DESC LIMIT ?`,
+       ORDER BY ${input.perKeyLimit.orderBy} LIMIT ?`,
     );
     for (const key of input.keys) {
       insertFrom(statement.iterate(key, input.perKeyLimit.limit));
@@ -590,8 +590,8 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         // back to the timestamp — same drift tolerance as the rest of the copy.
         perKeyLimit: {
           orderBy: hasColumn(source, "projection_thread_activities", "sequence")
-            ? `"sequence" DESC, "created_at" DESC, "activity_id"`
-            : `"created_at" DESC, "activity_id"`,
+            ? `"sequence" DESC, "created_at" DESC, "activity_id" DESC`
+            : `"created_at" DESC, "activity_id" DESC`,
           limit: options.activityLimit,
         },
       }),

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -230,49 +230,75 @@ function copyRows(input: {
 }
 
 /**
- * Turn states that describe work an agent still owes: "running" for a turn in
- * flight, "pending" for one whose user message was accepted but whose provider
- * turn had not started yet (`insertPendingProjectionTurn` in
- * apps/server/src/persistence/Layers/ProjectionTurns.ts). Neither can make
- * progress in a copy, and only the thread's own next message would clear a
- * pending one.
- */
-const UNSETTLED_TURN_STATES = ["running", "pending"] as const;
-
-/**
- * Inlined rather than bound, so the statement below costs exactly one variable
- * per thread. `--threads` is capped at SQLite's variable ceiling, so two extra
- * bindings put the maximum documented value two over the limit. Safe to
- * interpolate: these are internal literals, never input.
- */
-const UNSETTLED_TURN_STATES_SQL = UNSETTLED_TURN_STATES.map((state) => `'${state}'`).join(", ");
-
-/**
- * Settles turns copied mid-flight, matching what the server does to a turn
- * whose session leaves "running": `settledTurnStateForSessionStatus` in
+ * Settles turns copied while still running, matching what the server does to a
+ * turn whose session leaves "running": `settledTurnStateForSessionStatus` in
  * apps/server/src/orchestration/Layers/ProjectionPipeline.ts maps the "stopped"
  * status the sessions are copied with to "interrupted".
  *
+ * "pending" rows are deleted rather than settled — see `dropPendingTurnStarts`.
+ *
  * An UPDATE rather than a copy override, because only the rows that were
- * actually unsettled should change; the rest keep their real recorded state.
+ * actually running should change; the rest keep their real recorded state.
  */
-function settleUnfinishedTurns(
+function settleRunningTurns(
   target: NodeSqlite.DatabaseSync,
   threadIds: ReadonlyArray<string>,
 ): void {
   if (threadIds.length === 0 || !hasColumn(target, "projection_turns", "state")) {
     return;
   }
-  // completed_at is what marks a turn settled alongside its state; an
-  // unfinished turn has none, and leaving it null keeps the thread unsettled
-  // regardless of the state written here.
+  // A settled turn needs a completion time, and `requested_at` is the only
+  // timestamp guaranteed present. Overwritten unconditionally rather than
+  // COALESCEd: a running turn can carry a stale `completed_at` from an earlier
+  // settle that a later checkpoint reverted to "running" (the `...existingTurn`
+  // spread in ProjectionPipeline preserves it), and keeping that value would
+  // date the interruption to whenever that checkpoint landed.
   const setCompletedAt = hasColumn(target, "projection_turns", "completed_at")
-    ? `, completed_at = COALESCE(completed_at, requested_at)`
+    ? `, completed_at = requested_at`
     : "";
+  // 'running' is inlined, not bound: `--threads` is capped at SQLite's variable
+  // ceiling, so every binding beyond one per thread puts the maximum over the
+  // limit. Safe to interpolate — an internal literal, never input.
   target
     .prepare(
       `UPDATE projection_turns SET state = 'interrupted'${setCompletedAt}
-       WHERE state IN (${UNSETTLED_TURN_STATES_SQL})
+       WHERE state = 'running'
+         AND thread_id IN (${placeholders(threadIds.length)})`,
+    )
+    .run(...threadIds);
+}
+
+/**
+ * Drops turn rows copied in the "pending" state — a user message accepted
+ * before its provider turn started.
+ *
+ * Deleted rather than settled, because that is what the server does with them:
+ * `clearPendingProjectionTurnsByThread` removes them once the turn starts or
+ * the thread is stopped, and nothing settles them in place. They also cannot be
+ * settled coherently — `turn_id` is NULL, so an "interrupted" pending row is a
+ * terminal turn with no id, a shape no real turn ever has.
+ *
+ * Matches the server's own predicate exactly, so a checkpoint row is never
+ * caught by it.
+ */
+function dropPendingTurnStarts(
+  target: NodeSqlite.DatabaseSync,
+  threadIds: ReadonlyArray<string>,
+): void {
+  if (threadIds.length === 0 || !hasColumn(target, "projection_turns", "state")) {
+    return;
+  }
+  // The checkpoint guard is only meaningful where the column exists; an older
+  // target without it has no checkpoint rows to protect.
+  const excludeCheckpoints = hasColumn(target, "projection_turns", "checkpoint_turn_count")
+    ? "AND checkpoint_turn_count IS NULL"
+    : "";
+  target
+    .prepare(
+      `DELETE FROM projection_turns
+       WHERE state = 'pending'
+         AND turn_id IS NULL
+         ${excludeCheckpoints}
          AND thread_id IN (${placeholders(threadIds.length)})`,
     )
     .run(...threadIds);
@@ -438,8 +464,10 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
     // forced to "stopped" below, but the turn is read independently: an
     // unfinished turn keeps the thread unsettled and unfoldable forever
     // (deriveUnsettledTurnId in MessagesTimeline.logic.ts). Interrupted is what
-    // the server itself settles an abandoned turn to.
-    settleUnfinishedTurns(target, threadIds);
+    // the server itself settles an abandoned turn to; a pending start is
+    // something it deletes outright.
+    settleRunningTurns(target, threadIds);
+    dropPendingTurnStarts(target, threadIds);
     const messages = record(
       copyRows({
         source,

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -554,16 +554,17 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         keyColumn: "thread_id",
         keys: threadIds,
         // Ordered the way the app reads these back — `sequence` first, then
-        // `created_at` (ProjectionSnapshotQuery). Capping on `created_at`
-        // alone cuts arbitrarily among rows sharing a timestamp, which is the
-        // common case for a burst of tool activity: the "newest N" kept can be
-        // the oldest N in the order the timeline actually displays.
+        // `created_at` (ProjectionSnapshotQuery). Any other key order can keep
+        // rows the timeline treats as oldest: timestamps tie within a burst of
+        // tool activity, and can even disagree with `sequence` outright when
+        // events arrive with skewed clocks. Descending, a NULL `sequence`
+        // sorts last, mirroring where the app's ascending reads place it.
         //
         // `sequence` arrived in migration 008, so a source without it falls
         // back to the timestamp — same drift tolerance as the rest of the copy.
         perKeyLimit: {
           orderBy: hasColumn(source, "projection_thread_activities", "sequence")
-            ? `"created_at" DESC, "sequence"`
+            ? `"sequence" DESC, "created_at"`
             : `"created_at"`,
           limit: options.activityLimit,
         },

--- a/scripts/lib/dev-seed.ts
+++ b/scripts/lib/dev-seed.ts
@@ -8,9 +8,13 @@
  * target recorded, so replaying its retained events over them would resurrect
  * threads and projects it had deleted; copying a *partial* source range is
  * worse still, since the projector would replay a tail whose creating events
- * are missing. With the log empty and every projector cursor at 0 (the cursor
- * is exclusive), bootstrap streams nothing and leaves the copied rows alone.
- * See .agents/skills/test-t3-app/references/sqlite-fixtures.md.
+ * are missing. With the log empty and every projector cursor at 0, bootstrap
+ * streams nothing and leaves the copied rows alone.
+ *
+ * Everything that would otherwise wait on an agent is settled too — sessions,
+ * turns, streaming messages, badge counts, provider bindings — because no agent
+ * process comes with the copy. See
+ * .agents/skills/test-t3-app/references/sqlite-fixtures.md.
  */
 
 import * as NodeSqlite from "node:sqlite";
@@ -40,6 +44,12 @@ export interface DevSeedSummary {
   readonly turns: number;
   readonly sessions: number;
   readonly skippedColumns: ReadonlyArray<string>;
+  /**
+   * Attachment ids the copied messages reference. The rows carry the metadata
+   * but the bytes live on disk beside the database, so the caller has to copy
+   * those files too — otherwise a seeded thread renders an image that 404s.
+   */
+  readonly attachmentIds: ReadonlyArray<string>;
 }
 
 export class DevSeedError extends Error {
@@ -85,6 +95,52 @@ const hasTable = (database: NodeSqlite.DatabaseSync, table: string): boolean =>
 
 const hasColumn = (database: NodeSqlite.DatabaseSync, table: string, column: string): boolean =>
   columnsOf(database, table).includes(column);
+
+/**
+ * Attachment ids referenced by the copied messages, so the caller can copy the
+ * files that back them. `attachments_json` is a JSON array of ChatAttachment
+ * (packages/contracts/src/orchestration.ts); anything unparseable is skipped
+ * rather than failing the seed, since a missing image is a cosmetic problem and
+ * an aborted seed is not.
+ */
+function collectAttachmentIds(
+  target: NodeSqlite.DatabaseSync,
+  threadIds: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  if (
+    threadIds.length === 0 ||
+    !hasColumn(target, "projection_thread_messages", "attachments_json")
+  ) {
+    return [];
+  }
+  const ids = new Set<string>();
+  const rows = target
+    .prepare(
+      `SELECT attachments_json FROM projection_thread_messages
+       WHERE attachments_json IS NOT NULL AND thread_id IN (${placeholders(threadIds.length)})`,
+    )
+    .iterate(...threadIds) as Iterable<{ attachments_json: unknown }>;
+  for (const row of rows) {
+    if (typeof row.attachments_json !== "string") {
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(row.attachments_json);
+      if (!Array.isArray(parsed)) {
+        continue;
+      }
+      for (const attachment of parsed) {
+        const id: unknown = (attachment as { id?: unknown } | null)?.id;
+        if (typeof id === "string" && id.length > 0) {
+          ids.add(id);
+        }
+      }
+    } catch {
+      // A row whose JSON does not parse cannot name a file to copy.
+    }
+  }
+  return [...ids];
+}
 
 /**
  * Copies rows for `table` whose `keyColumn` is in `keys`, optionally keeping
@@ -158,6 +214,35 @@ function copyRows(input: {
   }
 
   return { copied, skipped };
+}
+
+/**
+ * Settles turns copied mid-flight, matching what the server does to a turn
+ * whose session leaves "running": `settledTurnStateForSessionStatus` in
+ * apps/server/src/orchestration/Layers/ProjectionPipeline.ts maps the "stopped"
+ * status the sessions are copied with to "interrupted".
+ *
+ * An UPDATE rather than a copy override, because only the rows that were
+ * actually running should change; the rest keep their real recorded state.
+ */
+function settleRunningTurns(
+  target: NodeSqlite.DatabaseSync,
+  threadIds: ReadonlyArray<string>,
+): void {
+  if (threadIds.length === 0 || !hasColumn(target, "projection_turns", "state")) {
+    return;
+  }
+  // completed_at is what marks a turn settled alongside its state; a running
+  // turn has none, and leaving it null keeps the thread unsettled regardless.
+  const setCompletedAt = hasColumn(target, "projection_turns", "completed_at")
+    ? `, completed_at = COALESCE(completed_at, requested_at)`
+    : "";
+  target
+    .prepare(
+      `UPDATE projection_turns SET state = 'interrupted'${setCompletedAt}
+       WHERE state = 'running' AND thread_id IN (${placeholders(threadIds.length)})`,
+    )
+    .run(...threadIds);
 }
 
 export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
@@ -249,6 +334,15 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
     if (hasTable(target, "orchestration_command_receipts")) {
       target.exec("DELETE FROM orchestration_command_receipts");
     }
+    // Provider bindings are keyed by thread id and are not copied (no agent
+    // process comes with the seed). Left in place they outlive the threads they
+    // name: ProviderSessionReaper sweeps every non-stopped binding, finds no
+    // thread behind it, and so never hits its active-turn guard — it just tries
+    // to stop a session for a thread that no longer exists, against a provider
+    // instance this worktree may not even define.
+    if (hasTable(target, "provider_session_runtime")) {
+      target.exec("DELETE FROM provider_session_runtime");
+    }
 
     const projects = record(
       copyRows({
@@ -281,6 +375,12 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         omitColumns: ["row_id"],
       }),
     );
+    // A thread copied mid-turn has no agent to finish it. The session status is
+    // forced to "stopped" below, but the turn is read independently: a
+    // `state = 'running'` turn keeps the thread unsettled and unfoldable
+    // forever (deriveUnsettledTurnId in MessagesTimeline.logic.ts). Interrupted
+    // is what the server itself settles an abandoned turn to.
+    settleRunningTurns(target, threadIds);
     const messages = record(
       copyRows({
         source,
@@ -288,6 +388,9 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
         table: "projection_thread_messages",
         keyColumn: "thread_id",
         keys: threadIds,
+        // Same reason: a message copied while streaming has nothing left to
+        // stream into it, so it would render with a caret that never resolves.
+        overrides: { is_streaming: 0 },
       }),
     );
     const activities = record(
@@ -329,12 +432,15 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
     // Required: computeSnapshotSequence returns 0 unless every projector has a
     // row, which makes every shell snapshot advertise sequence 0.
     //
-    // The cursor is exclusive (`WHERE sequence > cursor`) and the event log was
-    // just emptied, so `sequence` restarts at 1. Any positive cursor would make
-    // each projector skip that many of the user's first real events — and a
-    // different count per projector, leaving the projections permanently
-    // inconsistent. Every projector starts at 0: nothing to skip, nothing to
-    // replay.
+    // Zero, not the source's cursors. `orchestration_events.sequence` is
+    // AUTOINCREMENT, so emptying the log does not reset its high-water mark and
+    // the next real event continues from wherever the target left off. A cursor
+    // carried over from the source is unrelated to that number: it could sit
+    // above it (each projector then silently skipping a different count of the
+    // user's first real events, desynchronizing the projections for good) or
+    // below it (replaying events over rows they never produced). Zero is below
+    // every future sequence, so bootstrap streams the empty log, finds nothing,
+    // and leaves the copied rows exactly as they are.
     const insertState = target.prepare(
       `INSERT OR REPLACE INTO projection_state (projector, last_applied_sequence, updated_at)
        VALUES (?, 0, ?)`,
@@ -342,6 +448,10 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
     for (const projector of PROJECTOR_NAMES) {
       insertState.run(projector, options.seededAt);
     }
+
+    // Read back inside the transaction: these are the rows that were just
+    // written, not the source's, so a column the target lacks is already gone.
+    const attachmentIds = collectAttachmentIds(target, threadIds);
 
     target.exec("COMMIT");
 
@@ -353,6 +463,7 @@ export function seedDevDatabase(options: DevSeedOptions): DevSeedSummary {
       turns,
       sessions,
       skippedColumns: [...new Set(skipped)].sort(),
+      attachmentIds,
     };
   } catch (cause) {
     try {

--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -1,11 +1,15 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
+  claimDevShareLease,
+  cleanupOwnedDevShare,
   type DevShareError,
   DevServeFailedError,
   shareDevServer,
@@ -27,11 +31,17 @@ const encode = (value: string) => Stream.make(new TextEncoder().encode(value));
  * test set the outcome of the `off` (pre-clear) and `serve` calls separately —
  * they are the same subcommand and are told apart by the trailing `off`.
  */
-const spawnerLayer = (input: { readonly off?: CallResult; readonly serve?: CallResult }) =>
+const spawnerLayer = (input: {
+  readonly off?: CallResult;
+  readonly serve?: CallResult;
+  readonly onOff?: Effect.Effect<void>;
+  readonly calls?: Array<ReadonlyArray<string>>;
+}) =>
   Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
     ChildProcessSpawner.make((command) => {
       const args = "args" in command ? (command.args as ReadonlyArray<string>) : [];
+      input.calls?.push(args);
       const result: CallResult = args.includes("status")
         ? { exitCode: 0 }
         : args.includes("off")
@@ -41,7 +51,9 @@ const spawnerLayer = (input: { readonly off?: CallResult; readonly serve?: CallR
       return Effect.succeed(
         ChildProcessSpawner.makeHandle({
           pid: ChildProcessSpawner.ProcessId(1),
-          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.exitCode)),
+          exitCode: (args.includes("off") ? (input.onOff ?? Effect.void) : Effect.void).pipe(
+            Effect.as(ChildProcessSpawner.ExitCode(result.exitCode)),
+          ),
           isRunning: Effect.succeed(false),
           kill: () => Effect.void,
           unref: Effect.succeed(Effect.void),
@@ -173,6 +185,55 @@ describe("shareDevServer", () => {
       assert.equal(error.stage, "clear-existing");
       assert.include(error.message, "could not clear the existing mapping");
       assert.include(error.message, "permission denied");
+    }),
+  );
+});
+
+it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
+  it.effect("restores a newer runner's mapping when ownership changes during cleanup", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-dev-share-lease-",
+      });
+      const leasePath = `${directory}/5788.owner`;
+      const oldLease = { leasePath, ownerId: "old-runner", webPort: 5788 };
+      const calls: Array<ReadonlyArray<string>> = [];
+
+      yield* claimDevShareLease(oldLease);
+      const result = yield* cleanupOwnedDevShare(oldLease).pipe(
+        Effect.provide(
+          spawnerLayer({
+            calls,
+            onOff: fileSystem.writeFileString(leasePath, "new-runner").pipe(Effect.orDie),
+          }),
+        ),
+      );
+
+      assert.equal(result.status, "restored");
+      assert.isTrue(calls.some((args) => args.includes("off")));
+      assert.isTrue(calls.some((args) => args.includes("http://127.0.0.1:5788")));
+    }),
+  );
+
+  it.effect("leaves the mapping alone when a newer runner already owns it", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-dev-share-lease-",
+      });
+      const leasePath = `${directory}/5788.owner`;
+      const oldLease = { leasePath, ownerId: "old-runner", webPort: 5788 };
+      const calls: Array<ReadonlyArray<string>> = [];
+
+      yield* claimDevShareLease(oldLease);
+      yield* claimDevShareLease({ ...oldLease, ownerId: "new-runner" });
+      const result = yield* cleanupOwnedDevShare(oldLease).pipe(
+        Effect.provide(spawnerLayer({ calls })),
+      );
+
+      assert.equal(result.status, "superseded");
+      assert.isEmpty(calls);
     }),
   );
 });

--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -191,13 +191,14 @@ describe("shareDevServer", () => {
 });
 
 it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
-  it.effect("keeps the prior owner when a replacement share fails", () =>
+  it.effect("cleans up a claimed mapping when replacement sharing fails", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const directory = yield* fileSystem.makeTempDirectoryScoped({
         prefix: "t3-dev-share-lease-",
       });
       const leasePath = `${directory}/5788.owner`;
+      const calls: Array<ReadonlyArray<string>> = [];
 
       yield* fileSystem.writeFileString(leasePath, "old-runner");
       yield* acquireDevShare({
@@ -207,6 +208,7 @@ it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
       }).pipe(
         Effect.provide(
           spawnerLayer({
+            calls,
             off: { exitCode: 0 },
             serve: { exitCode: 1, stderr: "permission denied" },
           }),
@@ -214,7 +216,8 @@ it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
         Effect.flip,
       );
 
-      assert.equal(yield* fileSystem.readFileString(leasePath), "old-runner");
+      assert.equal(yield* fileSystem.readFileString(leasePath), "new-runner");
+      assert.equal(calls.filter((args) => args.includes("off")).length, 2);
     }),
   );
 

--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -192,6 +192,40 @@ describe("shareDevServer", () => {
 });
 
 it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
+  it.effect("claims ownership via an atomic rename", () =>
+    Effect.gen(function* () {
+      const leasePath = "/leases/5788.owner";
+      const tempDirectory = "/leases/5788.owner.temp";
+      const writes: Array<readonly [path: string, contents: string]> = [];
+      const renames: Array<readonly [from: string, to: string]> = [];
+
+      yield* claimDevShareLease({ leasePath, ownerId: "new-runner", webPort: 5788 }).pipe(
+        Effect.provideService(
+          FileSystem.FileSystem,
+          FileSystem.makeNoop({
+            makeDirectory: () => Effect.void,
+            makeTempDirectoryScoped: (options) => {
+              assert.equal(options?.directory, "/leases");
+              assert.equal(options?.prefix, "5788.owner.");
+              return Effect.succeed(tempDirectory);
+            },
+            writeFileString: (path, contents) => {
+              writes.push([path, contents]);
+              return Effect.void;
+            },
+            rename: (from, to) => {
+              renames.push([from, to]);
+              return Effect.void;
+            },
+          }),
+        ),
+      );
+
+      assert.deepEqual(writes, [[`${tempDirectory}/owner.tmp`, "new-runner"]]);
+      assert.deepEqual(renames, [[`${tempDirectory}/owner.tmp`, leasePath]]);
+    }),
+  );
+
   it.effect("keeps the prior owner when clearing its mapping fails", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -191,7 +191,7 @@ describe("shareDevServer", () => {
 });
 
 it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
-  it.effect("cleans up a claimed mapping when replacement sharing fails", () =>
+  it.effect("keeps the prior owner when clearing its mapping fails", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const directory = yield* fileSystem.makeTempDirectoryScoped({
@@ -209,6 +209,33 @@ it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
         Effect.provide(
           spawnerLayer({
             calls,
+            off: { exitCode: 1, stderr: "permission denied" },
+          }),
+        ),
+        Effect.flip,
+      );
+
+      assert.equal(yield* fileSystem.readFileString(leasePath), "old-runner");
+      assert.equal(calls.filter((args) => args.includes("off")).length, 1);
+    }),
+  );
+
+  it.effect("claims ownership after clearing and before publishing", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-dev-share-lease-",
+      });
+      const leasePath = `${directory}/5788.owner`;
+
+      yield* fileSystem.writeFileString(leasePath, "old-runner");
+      yield* acquireDevShare({
+        leasePath,
+        ownerId: "new-runner",
+        webPort: 5788,
+      }).pipe(
+        Effect.provide(
+          spawnerLayer({
             off: { exitCode: 0 },
             serve: { exitCode: 1, stderr: "permission denied" },
           }),
@@ -217,7 +244,6 @@ it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
       );
 
       assert.equal(yield* fileSystem.readFileString(leasePath), "new-runner");
-      assert.equal(calls.filter((args) => args.includes("off")).length, 2);
     }),
   );
 

--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -8,6 +8,7 @@ import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
+  acquireDevShare,
   claimDevShareLease,
   cleanupOwnedDevShare,
   type DevShareError,
@@ -190,6 +191,33 @@ describe("shareDevServer", () => {
 });
 
 it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
+  it.effect("keeps the prior owner when a replacement share fails", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-dev-share-lease-",
+      });
+      const leasePath = `${directory}/5788.owner`;
+
+      yield* fileSystem.writeFileString(leasePath, "old-runner");
+      yield* acquireDevShare({
+        leasePath,
+        ownerId: "new-runner",
+        webPort: 5788,
+      }).pipe(
+        Effect.provide(
+          spawnerLayer({
+            off: { exitCode: 0 },
+            serve: { exitCode: 1, stderr: "permission denied" },
+          }),
+        ),
+        Effect.flip,
+      );
+
+      assert.equal(yield* fileSystem.readFileString(leasePath), "old-runner");
+    }),
+  );
+
   it.effect("restores a newer runner's mapping when ownership changes during cleanup", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/scripts/lib/dev-share.test.ts
+++ b/scripts/lib/dev-share.test.ts
@@ -12,6 +12,7 @@ import {
   claimDevShareLease,
   cleanupOwnedDevShare,
   type DevShareError,
+  DevShareLeaseClaimError,
   DevServeFailedError,
   shareDevServer,
   unshareDevServer,
@@ -244,6 +245,28 @@ it.layer(NodeServices.layer)("dev share cleanup ownership", (it) => {
       );
 
       assert.equal(yield* fileSystem.readFileString(leasePath), "new-runner");
+    }),
+  );
+
+  it.effect("restores the mapping when ownership cannot be claimed", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-dev-share-lease-",
+      });
+      const blockedDirectory = `${directory}/not-a-directory`;
+      const calls: Array<ReadonlyArray<string>> = [];
+
+      yield* fileSystem.writeFileString(blockedDirectory, "blocked");
+      const error = yield* acquireDevShare({
+        leasePath: `${blockedDirectory}/5788.owner`,
+        ownerId: "new-runner",
+        webPort: 5788,
+      }).pipe(Effect.provide(spawnerLayer({ calls })), Effect.flip);
+
+      assert.instanceOf(error, DevShareLeaseClaimError);
+      assert.isTrue(calls.some((args) => args.includes("off")));
+      assert.isTrue(calls.some((args) => args.includes("http://127.0.0.1:5788")));
     }),
   );
 

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -199,8 +199,19 @@ export const claimDevShareLease = Effect.fn("devShare.claimDevShareLease")(funct
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  yield* fileSystem.makeDirectory(path.dirname(lease.leasePath), { recursive: true }).pipe(
-    Effect.andThen(fileSystem.writeFileString(lease.leasePath, lease.ownerId)),
+  yield* Effect.scoped(
+    Effect.gen(function* () {
+      const leaseDirectory = path.dirname(lease.leasePath);
+      yield* fileSystem.makeDirectory(leaseDirectory, { recursive: true });
+      const tempDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        directory: leaseDirectory,
+        prefix: `${path.basename(lease.leasePath)}.`,
+      });
+      const tempPath = path.join(tempDirectory, "owner.tmp");
+      yield* fileSystem.writeFileString(tempPath, lease.ownerId);
+      yield* fileSystem.rename(tempPath, lease.leasePath);
+    }),
+  ).pipe(
     Effect.mapError((cause) => new DevShareLeaseClaimError({ leasePath: lease.leasePath, cause })),
   );
   return lease;

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -255,11 +255,7 @@ export const cleanupOwnedDevShare = Effect.fn("devShare.cleanupOwnedDevShare")(f
   );
 });
 
-/**
- * Publishes `webPort` on the tailnet at the same port number and returns the
- * resulting HTTPS URL. Idempotent: re-running replaces any existing mapping.
- */
-export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (input: {
+const prepareDevShare = Effect.fn("devShare.prepareDevShare")(function* (input: {
   readonly webPort: number;
 }) {
   const status = yield* readTailscaleStatus.pipe(
@@ -287,7 +283,17 @@ export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (in
     });
   }
 
-  yield* ensureTailscaleServe({ localPort: input.webPort, servePort: input.webPort }).pipe(
+  return status.magicDnsName;
+});
+
+const publishDevShare = Effect.fn("devShare.publishDevShare")(function* (input: {
+  readonly host: string;
+  readonly webPort: number;
+}) {
+  yield* ensureTailscaleServe({
+    localPort: input.webPort,
+    servePort: input.webPort,
+  }).pipe(
     Effect.mapError((error) => {
       const explanation = explainCommandFailure(error);
       return new DevServeFailedError({
@@ -301,24 +307,33 @@ export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (in
 
   return {
     url: buildTailscaleHttpsBaseUrl({
-      magicDnsName: status.magicDnsName,
+      magicDnsName: input.host,
       servePort: input.webPort,
     }),
-    host: status.magicDnsName,
+    host: input.host,
   } satisfies DevShareResult;
 });
 
 /**
- * Claims cleanup ownership before publishing, then cleans up immediately if
- * publishing fails. This keeps the handoff atomic from the runners' point of
- * view: the prior runner can stop cleaning as soon as the successor claims,
- * because that successor owns both the attempted mapping and its rollback.
+ * Publishes `webPort` on the tailnet at the same port number and returns the
+ * resulting HTTPS URL. Idempotent: re-running replaces any existing mapping.
+ */
+export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (input: {
+  readonly webPort: number;
+}) {
+  const host = yield* prepareDevShare(input);
+  return yield* publishDevShare({ ...input, host });
+});
+
+/**
+ * Transfers cleanup ownership after the old mapping is known to be gone and
+ * before the new mapping is published. Failures on either side of that
+ * boundary therefore cannot leave a surviving mapping without an owner.
  */
 export const acquireDevShare = Effect.fn("devShare.acquireDevShare")(function* (
   lease: DevShareLease,
 ) {
+  const host = yield* prepareDevShare({ webPort: lease.webPort });
   yield* claimDevShareLease(lease);
-  return yield* shareDevServer({ webPort: lease.webPort }).pipe(
-    Effect.tapError(() => cleanupOwnedDevShare(lease)),
-  );
+  return yield* publishDevShare({ host, webPort: lease.webPort });
 });

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -307,3 +307,16 @@ export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (in
     host: status.magicDnsName,
   } satisfies DevShareResult;
 });
+
+/**
+ * Claims cleanup ownership only after the tailnet mapping exists. A failed
+ * replacement must leave the prior runner as the owner so its finalizer can
+ * still remove any mapping that survived the attempt.
+ */
+export const acquireDevShare = Effect.fn("devShare.acquireDevShare")(function* (
+  lease: DevShareLease,
+) {
+  const shared = yield* shareDevServer({ webPort: lease.webPort });
+  yield* claimDevShareLease(lease);
+  return shared;
+});

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -115,14 +115,22 @@ export class DevServeFailedError extends Schema.TaggedErrorClass<DevServeFailedE
 
 export class DevShareLeaseClaimError extends Schema.TaggedErrorClass<DevShareLeaseClaimError>()(
   "DevShareLeaseClaimError",
-  { leasePath: Schema.String, cause: Schema.Defect() },
+  {
+    leasePath: Schema.String,
+    cause: Schema.Defect(),
+    restoreCause: Schema.optional(Schema.Defect()),
+  },
 ) {
   override get message(): string {
-    return `could not claim cleanup ownership at ${this.leasePath}`;
+    return this.restoreCause === undefined
+      ? `could not claim cleanup ownership at ${this.leasePath}`
+      : `could not claim cleanup ownership at ${this.leasePath} or restore the previous tailnet mapping`;
   }
 
   get hint(): string {
-    return "Check that the dev data directory is writable.";
+    return this.restoreCause === undefined
+      ? "Check that the dev data directory is writable."
+      : "Check that the dev data directory is writable, then run the share command again.";
   }
 }
 
@@ -333,7 +341,25 @@ export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (in
 export const acquireDevShare = Effect.fn("devShare.acquireDevShare")(function* (
   lease: DevShareLease,
 ) {
-  const host = yield* prepareDevShare({ webPort: lease.webPort });
-  yield* claimDevShareLease(lease);
-  return yield* publishDevShare({ host, webPort: lease.webPort });
+  return yield* Effect.gen(function* () {
+    const host = yield* prepareDevShare({ webPort: lease.webPort });
+    yield* claimDevShareLease(lease).pipe(
+      Effect.catch((error: DevShareLeaseClaimError) =>
+        publishDevShare({ host, webPort: lease.webPort }).pipe(
+          Effect.matchEffect({
+            onFailure: (restoreCause) =>
+              Effect.fail(
+                new DevShareLeaseClaimError({
+                  leasePath: lease.leasePath,
+                  cause: error.cause,
+                  restoreCause,
+                }),
+              ),
+            onSuccess: () => Effect.fail(error),
+          }),
+        ),
+      ),
+    );
+    return yield* publishDevShare({ host, webPort: lease.webPort });
+  }).pipe(Effect.uninterruptible);
 });

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -22,6 +22,9 @@ import {
   type TailscaleStderrDiagnostic,
 } from "@t3tools/tailscale";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -110,10 +113,24 @@ export class DevServeFailedError extends Schema.TaggedErrorClass<DevServeFailedE
   }
 }
 
+export class DevShareLeaseClaimError extends Schema.TaggedErrorClass<DevShareLeaseClaimError>()(
+  "DevShareLeaseClaimError",
+  { leasePath: Schema.String, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `could not claim cleanup ownership at ${this.leasePath}`;
+  }
+
+  get hint(): string {
+    return "Check that the dev data directory is writable.";
+  }
+}
+
 export const DevShareError = Schema.Union([
   TailscaleUnavailableError,
   TailnetNameMissingError,
   DevServeFailedError,
+  DevShareLeaseClaimError,
 ]);
 export type DevShareError = typeof DevShareError.Type;
 export const isDevShareError = Schema.is(DevShareError);
@@ -162,6 +179,81 @@ export interface DevShareResult {
   readonly url: string;
   readonly host: string;
 }
+
+export interface DevShareLease {
+  readonly leasePath: string;
+  readonly ownerId: string;
+  readonly webPort: number;
+}
+
+export const claimDevShareLease = Effect.fn("devShare.claimDevShareLease")(function* (
+  lease: DevShareLease,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* fileSystem.makeDirectory(path.dirname(lease.leasePath), { recursive: true }).pipe(
+    Effect.andThen(fileSystem.writeFileString(lease.leasePath, lease.ownerId)),
+    Effect.mapError((cause) => new DevShareLeaseClaimError({ leasePath: lease.leasePath, cause })),
+  );
+  return lease;
+});
+
+export type DevShareCleanupResult =
+  | { readonly status: "cleared" | "superseded" | "restored" }
+  | { readonly status: "failed"; readonly explanation: string };
+
+/**
+ * Clears only the mapping this runner owns. If a successor claims the lease
+ * while `tailscale serve off` is in flight, restore the same port mapping so
+ * the old finalizer cannot silently disconnect the new runner.
+ */
+export const cleanupOwnedDevShare = Effect.fn("devShare.cleanupOwnedDevShare")(function* (
+  lease: DevShareLease,
+): Effect.fn.Return<
+  DevShareCleanupResult,
+  never,
+  FileSystem.FileSystem | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const readOwner = fileSystem
+    .readFileString(lease.leasePath)
+    .pipe(Effect.option, Effect.map(Option.getOrUndefined));
+  const ownerBefore = yield* readOwner;
+  if (ownerBefore !== lease.ownerId) {
+    return { status: "superseded" };
+  }
+
+  const result = yield* unshareDevServer(lease.webPort);
+  if (!result.cleared) {
+    return {
+      status: "failed",
+      explanation:
+        result.explanation ??
+        `could not remove the tailnet mapping for port ${String(lease.webPort)}`,
+    };
+  }
+
+  const ownerAfter = yield* readOwner;
+  if (ownerAfter === lease.ownerId) {
+    return { status: "cleared" };
+  }
+
+  return yield* ensureTailscaleServe({
+    localPort: lease.webPort,
+    servePort: lease.webPort,
+  }).pipe(
+    Effect.as({ status: "restored" } as const),
+    Effect.catch((cause: TailscaleCommandError) =>
+      Effect.succeed({
+        status: "failed",
+        explanation:
+          explainCommandFailure(cause) ??
+          `a newer runner claimed port ${String(lease.webPort)}, but its mapping could not be restored`,
+      } as const),
+    ),
+    Effect.uninterruptible,
+  );
+});
 
 /**
  * Publishes `webPort` on the tailnet at the same port number and returns the

--- a/scripts/lib/dev-share.ts
+++ b/scripts/lib/dev-share.ts
@@ -309,14 +309,16 @@ export const shareDevServer = Effect.fn("devShare.shareDevServer")(function* (in
 });
 
 /**
- * Claims cleanup ownership only after the tailnet mapping exists. A failed
- * replacement must leave the prior runner as the owner so its finalizer can
- * still remove any mapping that survived the attempt.
+ * Claims cleanup ownership before publishing, then cleans up immediately if
+ * publishing fails. This keeps the handoff atomic from the runners' point of
+ * view: the prior runner can stop cleaning as soon as the successor claims,
+ * because that successor owns both the attempted mapping and its rollback.
  */
 export const acquireDevShare = Effect.fn("devShare.acquireDevShare")(function* (
   lease: DevShareLease,
 ) {
-  const shared = yield* shareDevServer({ webPort: lease.webPort });
   yield* claimDevShareLease(lease);
-  return shared;
+  return yield* shareDevServer({ webPort: lease.webPort }).pipe(
+    Effect.tapError(() => cleanupOwnedDevShare(lease)),
+  );
 });

--- a/scripts/lib/projection-tables.ts
+++ b/scripts/lib/projection-tables.ts
@@ -1,0 +1,33 @@
+/**
+ * The projection read-model surface that seeding scripts write to.
+ *
+ * Must match `ORCHESTRATION_PROJECTOR_NAMES` in
+ * apps/server/src/orchestration/Layers/ProjectionPipeline.ts — that package
+ * exposes no importable surface, so this is a maintained copy. If a projector
+ * is missing here, `computeSnapshotSequence` reports 0 and every shell
+ * snapshot advertises sequence 0.
+ */
+export const PROJECTOR_NAMES = [
+  "projection.projects",
+  "projection.threads",
+  "projection.thread-messages",
+  "projection.thread-proposed-plans",
+  "projection.thread-activities",
+  "projection.thread-sessions",
+  "projection.thread-turns",
+  "projection.checkpoints",
+  "projection.pending-approvals",
+] as const;
+
+/** Deleted in this order so a row never outlives what it points at. */
+export const PROJECTION_TABLES_IN_DEPENDENCY_ORDER = [
+  "projection_pending_approvals",
+  "projection_thread_proposed_plans",
+  "projection_thread_activities",
+  "projection_thread_messages",
+  "projection_thread_sessions",
+  "projection_turns",
+  "projection_threads",
+  "projection_projects",
+  "projection_state",
+] as const;

--- a/scripts/lib/server-runtime-probe.test.ts
+++ b/scripts/lib/server-runtime-probe.test.ts
@@ -86,6 +86,20 @@ describe("findRunningServerPid", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
+  // `process.kill` reads these as signal-group targets, not process lookups, so
+  // neither throws — a naive probe calls both "live" and blocks seeding forever
+  // on a file no server ever wrote.
+  for (const pid of [0, -1]) {
+    it.effect(`ignores a state file recording pid ${String(pid)}`, () =>
+      Effect.gen(function* () {
+        const baseDir = yield* makeBaseDir();
+        yield* writeRuntimeState({ baseDir, stateDir: "dev", contents: runtimeStateJson(pid) });
+
+        assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir)));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    );
+  }
+
   it.effect("reports nothing when no state files exist", () =>
     Effect.gen(function* () {
       const baseDir = yield* makeBaseDir();

--- a/scripts/lib/server-runtime-probe.test.ts
+++ b/scripts/lib/server-runtime-probe.test.ts
@@ -153,3 +153,34 @@ describe("findRunningServerPidSync agrees with the Effect probe", () => {
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 });
+
+// A caller that has resolved which database it is about to touch must not be
+// blocked by a server using only the other one.
+describe("scoping to one state directory", () => {
+  it.effect("ignores a live server in the other directory", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir,
+        stateDir: "dev",
+        contents: runtimeStateJson(process.pid),
+      });
+
+      assert.isUndefined(findRunningServerPidSync(baseDir, "userdata"));
+      assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir, "userdata")));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("still reports a live server in the named directory", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir,
+        stateDir: "dev",
+        contents: runtimeStateJson(process.pid),
+      });
+
+      assert.equal(findRunningServerPidSync(baseDir, "dev"), process.pid);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/scripts/lib/server-runtime-probe.test.ts
+++ b/scripts/lib/server-runtime-probe.test.ts
@@ -5,7 +5,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
-import { findRunningServerPid } from "./server-runtime-probe.ts";
+import { findRunningServerPid, findRunningServerPidSync } from "./server-runtime-probe.ts";
 
 /** A pid that cannot belong to a live process (above the usual pid_max). */
 const DEAD_PID = 0x7ffffffe;
@@ -104,6 +104,52 @@ describe("findRunningServerPid", () => {
     Effect.gen(function* () {
       const baseDir = yield* makeBaseDir();
       assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir)));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});
+
+/**
+ * The sync probe exists only because `seedDevDatabase` holds an open SQLite
+ * transaction and cannot await an Effect. Two implementations of one rule drift
+ * apart silently, so every case is asserted against both rather than trusting
+ * them to agree.
+ */
+describe("findRunningServerPidSync agrees with the Effect probe", () => {
+  const cases = [
+    { name: "a live server in dev", stateDir: "dev", contents: runtimeStateJson(process.pid) },
+    {
+      name: "a live server in userdata",
+      stateDir: "userdata",
+      contents: runtimeStateJson(process.pid),
+    },
+    { name: "a dead pid", stateDir: "dev", contents: runtimeStateJson(DEAD_PID) },
+    { name: "pid 0", stateDir: "dev", contents: runtimeStateJson(0) },
+    { name: "pid -1", stateDir: "dev", contents: runtimeStateJson(-1) },
+    { name: "unparseable json", stateDir: "dev", contents: "{not json" },
+    { name: "json without a pid", stateDir: "dev", contents: JSON.stringify({ version: 1 }) },
+  ] as const;
+
+  for (const testCase of cases) {
+    it.effect(testCase.name, () =>
+      Effect.gen(function* () {
+        const baseDir = yield* makeBaseDir();
+        yield* writeRuntimeState({
+          baseDir,
+          stateDir: testCase.stateDir,
+          contents: testCase.contents,
+        });
+
+        const viaEffect = Option.getOrUndefined(yield* findRunningServerPid(baseDir));
+        assert.equal(findRunningServerPidSync(baseDir), viaEffect);
+      }).pipe(Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  it.effect("both report nothing when no state files exist", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir)));
+      assert.isUndefined(findRunningServerPidSync(baseDir));
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 });

--- a/scripts/lib/server-runtime-probe.test.ts
+++ b/scripts/lib/server-runtime-probe.test.ts
@@ -1,0 +1,95 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+
+import { findRunningServerPid } from "./server-runtime-probe.ts";
+
+/** A pid that cannot belong to a live process (above the usual pid_max). */
+const DEAD_PID = 0x7ffffffe;
+
+const writeRuntimeState = Effect.fn(function* (input: {
+  readonly baseDir: string;
+  readonly stateDir: "dev" | "userdata";
+  readonly contents: string;
+}) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = path.join(input.baseDir, input.stateDir);
+  yield* fileSystem.makeDirectory(directory, { recursive: true });
+  yield* fileSystem.writeFileString(path.join(directory, "server-runtime.json"), input.contents);
+});
+
+const runtimeStateJson = (pid: number) =>
+  JSON.stringify({
+    version: 1,
+    pid,
+    port: 16_602,
+    origin: "http://127.0.0.1:16602",
+    startedAt: "2026-07-20T00:00:00.000Z",
+  });
+
+const makeBaseDir = Effect.fnUntraced(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  return yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-runtime-probe-test-" });
+});
+
+describe("findRunningServerPid", () => {
+  it.effect("reports the pid of a live server in the dev state directory", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir,
+        stateDir: "dev",
+        contents: runtimeStateJson(process.pid),
+      });
+
+      assert.equal(Option.getOrThrow(yield* findRunningServerPid(baseDir)), process.pid);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  // An explicit --home-dir puts runtime state in userdata instead, and the
+  // caller of a seed has no reason to know which of the two was used.
+  it.effect("also finds a live server in the userdata state directory", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      yield* writeRuntimeState({
+        baseDir,
+        stateDir: "userdata",
+        contents: runtimeStateJson(process.pid),
+      });
+
+      assert.equal(Option.getOrThrow(yield* findRunningServerPid(baseDir)), process.pid);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  // A server killed with SIGKILL never clears its state file. Treating that as
+  // "running" would block seeding for good, with nothing to clear it.
+  it.effect("ignores a state file whose process is gone", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      yield* writeRuntimeState({ baseDir, stateDir: "dev", contents: runtimeStateJson(DEAD_PID) });
+
+      assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir)));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  // A half-written file says nothing about liveness either way.
+  it.effect("ignores a state file it cannot parse", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      yield* writeRuntimeState({ baseDir, stateDir: "dev", contents: "{not json" });
+
+      assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir)));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("reports nothing when no state files exist", () =>
+    Effect.gen(function* () {
+      const baseDir = yield* makeBaseDir();
+      assert.isTrue(Option.isNone(yield* findRunningServerPid(baseDir)));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/scripts/lib/server-runtime-probe.ts
+++ b/scripts/lib/server-runtime-probe.ts
@@ -1,0 +1,72 @@
+/**
+ * Whether a T3 Code server is currently running against a data directory.
+ *
+ * A maintained copy of the parts of `apps/server/src/serverRuntimeState.ts` that
+ * host scripts need: that package exposes no importable surface to `scripts/`,
+ * the same reason `./projection-tables.ts` exists. Only the fields read here are
+ * modelled, so a server that adds a field stays readable.
+ */
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+/** The two state directories `deriveServerPaths` can select. */
+const STATE_DIRS = ["dev", "userdata"] as const;
+
+const RuntimeStateProbe = Schema.Struct({
+  pid: Schema.Int,
+});
+
+const decodeRuntimeStateProbe = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(RuntimeStateProbe),
+);
+
+/**
+ * The runtime-state file is removed by a release finalizer, so a server killed
+ * with SIGKILL — or one that crashed — leaves it behind. Signal 0 runs the
+ * permission and existence checks without delivering a signal, which is what
+ * distinguishes "still running" from "left this here on the way out".
+ *
+ * PIDs are reused eventually, so a false positive is possible in principle. For
+ * a guard on a destructive local-dev command that errs the safe way: the worst
+ * case is being told to stop a server that is already stopped.
+ */
+const isPidLive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause) {
+    // EPERM means the process exists but belongs to another user.
+    return (cause as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+/**
+ * The pid of a live server under `baseDir`, if any.
+ *
+ * Both state directories are checked because which one a given server chose
+ * depends on flags the caller of this should not have to reason about — the
+ * same reason `auth pairing url` checks both.
+ */
+export const findRunningServerPid = Effect.fn("findRunningServerPid")(function* (baseDir: string) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  for (const stateDir of STATE_DIRS) {
+    const statePath = path.join(baseDir, stateDir, "server-runtime.json");
+    const raw = yield* fileSystem.readFileString(statePath).pipe(Effect.option);
+    if (Option.isNone(raw)) {
+      continue;
+    }
+    // A malformed or half-written file says nothing about liveness; treating it
+    // as "a server is up" would block seeding with no way to clear it.
+    const state = yield* decodeRuntimeStateProbe(raw.value).pipe(Effect.option);
+    if (Option.isSome(state) && isPidLive(state.value.pid)) {
+      return Option.some(state.value.pid);
+    }
+  }
+
+  return Option.none<number>();
+});

--- a/scripts/lib/server-runtime-probe.ts
+++ b/scripts/lib/server-runtime-probe.ts
@@ -11,22 +11,10 @@
 import * as NodeFS from "node:fs";
 import * as NodePath from "node:path";
 import * as Effect from "effect/Effect";
-import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
-import * as Path from "effect/Path";
-import * as Schema from "effect/Schema";
 
 /** The two state directories `deriveServerPaths` can select. */
 const STATE_DIRS = ["dev", "userdata"] as const;
-
-const RuntimeStateProbe = Schema.Struct({
-  /** Positive, for the reason `isPidLive` explains. */
-  pid: Schema.Int.check(Schema.isGreaterThan(0)),
-});
-
-const decodeRuntimeStateProbe = Schema.decodeUnknownEffect(
-  Schema.fromJsonString(RuntimeStateProbe),
-);
 
 /**
  * The runtime-state file is removed by a release finalizer, so a server killed
@@ -60,59 +48,51 @@ const isPidLive = (pid: number): boolean => {
 };
 
 /**
- * The pid of a live server under `baseDir`, if any.
+ * The pid of a live server whose state file sits in one directory.
  *
- * Both state directories are checked because which one a given server chose
- * depends on flags the caller of this should not have to reason about — the
- * same reason `auth pairing url` checks both.
+ * Synchronous because its main caller runs inside `seedDevDatabase`'s open
+ * SQLite transaction, where nothing can await. Applies one rule everywhere: a
+ * positive live pid counts, anything unparseable does not — a malformed or
+ * half-written file says nothing about liveness, and treating it as "a server
+ * is up" would block seeding with no way to clear it.
  */
-export const findRunningServerPid = Effect.fn("findRunningServerPid")(function* (baseDir: string) {
-  const fileSystem = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-
-  for (const stateDir of STATE_DIRS) {
-    const statePath = path.join(baseDir, stateDir, "server-runtime.json");
-    const raw = yield* fileSystem.readFileString(statePath).pipe(Effect.option);
-    if (Option.isNone(raw)) {
-      continue;
-    }
-    // A malformed or half-written file says nothing about liveness; treating it
-    // as "a server is up" would block seeding with no way to clear it.
-    const state = yield* decodeRuntimeStateProbe(raw.value).pipe(Effect.option);
-    if (Option.isSome(state) && isPidLive(state.value.pid)) {
-      return Option.some(state.value.pid);
-    }
+function findPidInStateDir(baseDir: string, stateDir: string): number | undefined {
+  let raw: string;
+  try {
+    raw = NodeFS.readFileSync(NodePath.join(baseDir, stateDir, "server-runtime.json"), "utf8");
+  } catch {
+    return undefined;
   }
-
-  return Option.none<number>();
-});
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const pid: unknown = (parsed as { pid?: unknown } | null)?.pid;
+    return typeof pid === "number" && isPidLive(pid) ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
- * The same probe, synchronously.
+ * The pid of a live server under `baseDir`, if any.
  *
- * `seedDevDatabase` is synchronous — it holds an open SQLite transaction — so
- * its last-moment re-check cannot await an Effect. Reads the file directly
- * rather than through the platform layer for that reason, and applies the same
- * rules: a positive live pid counts, anything unparseable does not.
+ * `stateDir` scopes the probe to one state directory when the caller has
+ * already resolved which database it is about to touch — a server using only
+ * the *other* directory's database is not a conflict and must not block it.
+ * Omitted, both directories count, for callers guarding the base as a whole.
  */
-export function findRunningServerPidSync(baseDir: string): number | undefined {
-  for (const stateDir of STATE_DIRS) {
-    const statePath = NodePath.join(baseDir, stateDir, "server-runtime.json");
-    let raw: string;
-    try {
-      raw = NodeFS.readFileSync(statePath, "utf8");
-    } catch {
-      continue;
-    }
-    try {
-      const parsed: unknown = JSON.parse(raw);
-      const pid: unknown = (parsed as { pid?: unknown } | null)?.pid;
-      if (typeof pid === "number" && isPidLive(pid)) {
-        return pid;
-      }
-    } catch {
-      // Half-written or malformed: says nothing about liveness either way.
+export function findRunningServerPidSync(baseDir: string, stateDir?: string): number | undefined {
+  for (const candidate of stateDir === undefined ? STATE_DIRS : [stateDir]) {
+    const pid = findPidInStateDir(baseDir, candidate);
+    if (pid !== undefined) {
+      return pid;
     }
   }
   return undefined;
 }
+
+/** {@link findRunningServerPidSync} for Effect callers. */
+export const findRunningServerPid = (
+  baseDir: string,
+  stateDir?: string,
+): Effect.Effect<Option.Option<number>> =>
+  Effect.sync(() => Option.fromNullishOr(findRunningServerPidSync(baseDir, stateDir)));

--- a/scripts/lib/server-runtime-probe.ts
+++ b/scripts/lib/server-runtime-probe.ts
@@ -16,7 +16,8 @@ import * as Schema from "effect/Schema";
 const STATE_DIRS = ["dev", "userdata"] as const;
 
 const RuntimeStateProbe = Schema.Struct({
-  pid: Schema.Int,
+  /** Positive, for the reason `isPidLive` explains. */
+  pid: Schema.Int.check(Schema.isGreaterThan(0)),
 });
 
 const decodeRuntimeStateProbe = Schema.decodeUnknownEffect(
@@ -34,12 +35,23 @@ const decodeRuntimeStateProbe = Schema.decodeUnknownEffect(
  * case is being told to stop a server that is already stopped.
  */
 const isPidLive = (pid: number): boolean => {
+  // `process.kill` reads non-positive pids as signal-group targets rather than
+  // process lookups — 0 signals the caller's own group, -1 every permitted
+  // process — so neither throws and both would report "live" unconditionally.
+  // The schema rejects those, and this repeats the check so the invariant
+  // travels with the code that depends on it.
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return false;
+  }
   try {
     process.kill(pid, 0);
     return true;
   } catch (cause) {
-    // EPERM means the process exists but belongs to another user.
-    return (cause as NodeJS.ErrnoException).code === "EPERM";
+    // EPERM means the process exists but belongs to another user. An
+    // out-of-range pid throws a TypeError instead, which has no errno.
+    return typeof cause === "object" && cause !== null && "code" in cause
+      ? cause.code === "EPERM"
+      : false;
   }
 };
 

--- a/scripts/lib/server-runtime-probe.ts
+++ b/scripts/lib/server-runtime-probe.ts
@@ -6,6 +6,10 @@
  * the same reason `./projection-tables.ts` exists. Only the fields read here are
  * modelled, so a server that adds a field stays readable.
  */
+// @effect-diagnostics nodeBuiltinImport:off - the sync probe runs inside a
+// synchronous SQLite transaction, where the platform layer is not available.
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -82,3 +86,33 @@ export const findRunningServerPid = Effect.fn("findRunningServerPid")(function* 
 
   return Option.none<number>();
 });
+
+/**
+ * The same probe, synchronously.
+ *
+ * `seedDevDatabase` is synchronous — it holds an open SQLite transaction — so
+ * its last-moment re-check cannot await an Effect. Reads the file directly
+ * rather than through the platform layer for that reason, and applies the same
+ * rules: a positive live pid counts, anything unparseable does not.
+ */
+export function findRunningServerPidSync(baseDir: string): number | undefined {
+  for (const stateDir of STATE_DIRS) {
+    const statePath = NodePath.join(baseDir, stateDir, "server-runtime.json");
+    let raw: string;
+    try {
+      raw = NodeFS.readFileSync(statePath, "utf8");
+    } catch {
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      const pid: unknown = (parsed as { pid?: unknown } | null)?.pid;
+      if (typeof pid === "number" && isPidLive(pid)) {
+        return pid;
+      }
+    } catch {
+      // Half-written or malformed: says nothing about liveness either way.
+    }
+  }
+  return undefined;
+}

--- a/scripts/mobile-showcase-environment.ts
+++ b/scripts/mobile-showcase-environment.ts
@@ -1,4 +1,5 @@
 // @effect-diagnostics nodeBuiltinImport:off globalDate:off - This host-side fixture creates an isolated local T3 environment.
+import { PROJECTOR_NAMES } from "./lib/projection-tables.ts";
 import * as NodeChildProcess from "node:child_process";
 import * as NodeFSP from "node:fs/promises";
 import * as NodePath from "node:path";
@@ -13,18 +14,6 @@ export const SHOWCASE_TERMINAL_ID = "term-1";
 
 export const SHOWCASE_SCENES = ["threads", "thread", "terminal", "review", "environments"] as const;
 export type ShowcaseScene = (typeof SHOWCASE_SCENES)[number];
-
-const PROJECTOR_NAMES = [
-  "projection.projects",
-  "projection.threads",
-  "projection.thread-messages",
-  "projection.thread-proposed-plans",
-  "projection.thread-activities",
-  "projection.thread-sessions",
-  "projection.thread-turns",
-  "projection.checkpoints",
-  "projection.pending-approvals",
-] as const;
 
 const MODEL_SELECTION = JSON.stringify({ instanceId: "codex", model: "gpt-5.4" });
 const PROJECT_SCRIPTS = JSON.stringify([


### PR DESCRIPTION
> [!NOTE]
> **Dev mode overhaul — PR 3 of 3.** The stack moves from [worktree-isolated dev state](https://github.com/pingdotgg/t3code/pull/4555) → [single-origin and Tailscale sharing](https://github.com/pingdotgg/t3code/pull/4556) → [pairing and seed utilities](https://github.com/pingdotgg/t3code/pull/4557). This final PR is stacked on #4556.

## What

- Add `dev:pair` to find a live dev server’s recorded state and issue a fresh pairing URL with the correct web origin.
- Add `dev:seed` to copy recent projection data into an isolated dev database while refusing to write to the shared home.
- Record the dev URL in runtime state and ignore stale server records.
- Share the projection-table list with the mobile showcase tooling and document the workflows.

## Why

Isolated worktree databases are intentionally empty, and replacing a consumed pairing URL previously required reconstructing internal ports, state paths, and origins by hand. These are useful developer conveniences, but they are not required for the hosting fix itself.

## Impact

This is PR 3 of 3 and is stacked on #4556. Keeping these optional utilities last lets the core isolation and sharing changes land without the larger data-copy implementation.

## Verification

- `vp test run scripts/lib/dev-seed.test.ts apps/server/src/cli/auth.test.ts apps/server/src/serverRuntimeState.test.ts` (24 tests)
- targeted lint
- server and scripts typechecks

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dev server pairing URL command and database seeding CLI with tailnet lease management
> - Adds `dev:pair` npm script (`t3 auth pairing url`) that discovers a live dev or userdata server runtime state and prints a one-time pairing URL, preferring the dev instance when both are running.
> - Adds `dev:seed` npm script ([scripts/dev-seed.ts](https://github.com/pingdotgg/t3code/pull/4557/files#diff-e4cb3f1c82bca6bb1f35b33ca2d1c8c8422234e576efad541b3fba01b551daef)) that seeds recent projects, threads, messages, turns, sessions, and activities from a source T3 data directory into a target dev database; refuses to run against a live server or a path inside the shared home.
> - Adds lease-based tailnet share ownership in [scripts/lib/dev-share.ts](https://github.com/pingdotgg/t3code/pull/4557/files#diff-fd5b0e9907d754def0ec9a0942bd952f2df50d8cf55618a633b96352d0b134e3): `acquireDevShare` atomically claims a per-port owner file before publishing, and `cleanupOwnedDevShare` restores a successor's mapping if ownership changes during teardown.
> - Adds `findRunningServerPid` in [scripts/lib/server-runtime-probe.ts](https://github.com/pingdotgg/t3code/pull/4557/files#diff-652e229258c649cc9c2d0723c471c9b0c164124df5e70d879793184619f93d64) to synchronously detect live server PIDs from `server-runtime.json` state files, used by both the seed CLI and the pairing URL command.
> - Behavioral Change: `resolveSessionCookieName` drops the port suffix for desktop (non-dev) sessions; cookie name is now `t3_session` instead of `t3_session_<port>` when `devUrl` is absent, affecting existing desktop sessions on upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6588b84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Desktop and hosted sessions now use a single cookie name (users may need to re-pair), while `dev:seed` is destructive to target projections/event logs though guarded against the shared home and live servers.
> 
> **Overview**
> **Dev pairing and seeding** — `bun run dev:pair` (`auth pairing url`) locates a live server by reading `server-runtime.json` under `dev`/`userdata`, verifies the recorded PID is still alive, and mints a one-time pairing URL using the stored web origin (including tailnet `devUrl`). `bun run dev:seed` copies a capped slice of projection data (and attachment files) from `~/.t3` into a worktree-isolated database, with guards against the shared home (including symlinked paths), same-source seeds, and seeding while a server holds the target DB open (with a late re-check before commit).
> 
> **Runtime state and config** — Persisted runtime state now optionally records `devUrl`; stale files from crashed processes are ignored via PID liveness probing. `deriveServerPaths` accepts an explicit `stateDir` so pairing tooling targets the same database the running server uses.
> 
> **Auth cookies** — `resolveSessionCookieName` no longer special-cases desktop: production/desktop use `t3_session`; only servers with a `devUrl` get port-scoped `t3_session_<port>`.
> 
> **Tailscale `--share`** — Dev sharing uses file leases (`acquireDevShare` / `cleanupOwnedDevShare`) so one runner’s exit does not tear down another’s mapping; cleanup can restore a mapping if ownership changed mid-flight.
> 
> **Docs and tests** — Agent skills and `scripts.md` document `bun run dev`, `dev:pair`, and `dev:seed`; sqlite fixture docs note `projection_state` cursors; large test coverage for seeding, auth CLI discovery, runtime liveness, and share leases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6588b843da90ba8865a541af05f9961156639649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to share local development servers, generate pairing URLs, and seed isolated development data.
  * Development servers now support worktree-specific ports and improved browser proxying.
  * Shared development environments can use HTTPS tailnet URLs with configurable allowed origins.
  * Session cookies are isolated by server port, preventing conflicts between concurrent instances.
  * Tailscale errors now include concise diagnostic details.

* **Documentation**
  * Expanded development setup guidance, browser workflow instructions, pairing recovery, port handling, and database seeding safety notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->