### PR TITLE
Fix session renaming bug

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,6 +12,7 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
+import { isDefaultThreadTitle } from "@t3tools/shared/threadTitle";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
@@ -86,8 +87,6 @@ const turnStartKeyForEvent = (event: ProviderIntentEvent): string =>
 const HANDLED_TURN_START_KEY_MAX = 10_000;
 const HANDLED_TURN_START_KEY_TTL = Duration.minutes(30);
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
-const DEFAULT_THREAD_TITLE = "New thread";
-
 export function providerErrorLabel(value: string | undefined): string {
   const normalized = value?.trim();
   return normalized && normalized.length > 0 ? normalized : "unknown";
@@ -104,14 +103,13 @@ export function providerErrorLabelFromInstanceHint(input: {
 }
 
 function canReplaceThreadTitle(currentTitle: string, titleSeed?: string): boolean {
-  const trimmedCurrentTitle = currentTitle.trim();
-  if (trimmedCurrentTitle === DEFAULT_THREAD_TITLE) {
+  if (isDefaultThreadTitle(currentTitle)) {
     return true;
   }
 
   const trimmedTitleSeed = titleSeed?.trim();
   return trimmedTitleSeed !== undefined && trimmedTitleSeed.length > 0
-    ? trimmedCurrentTitle === trimmedTitleSeed
+    ? currentTitle.trim() === trimmedTitleSeed
     : false;
 }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2836,7 +2836,7 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(
       harness.readModel,
       (entry) =>
-        entry.title === "Renamed by provider" &&
+        entry.title === "Thread" &&
         entry.activities.some(
           (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.plan.updated",
         ) &&
@@ -2851,7 +2851,7 @@ describe("ProviderRuntimeIngestion", () => {
         ),
     );
 
-    expect(thread.title).toBe("Renamed by provider");
+    expect(thread.title).toBe("Thread");
 
     const planActivity = thread.activities.find(
       (activity: ProviderRuntimeTestActivity) => activity.id === "evt-turn-plan-updated",
@@ -2890,6 +2890,170 @@ describe("ProviderRuntimeIngestion", () => {
     expect(checkpoint?.status).toBe("missing");
     expect(checkpoint?.assistantMessageId).toBe("assistant:item-p1-assistant");
     expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
+  });
+
+  it("applies provider thread.metadata.updated when thread title is the default", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-thread-create-default"),
+        threadId: ThreadId.make("thread-default"),
+        projectId: asProjectId("project-1"),
+        title: "New thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-default"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-default"),
+      payload: {
+        name: "Provider default title",
+        metadata: { source: "provider" },
+      },
+    });
+
+    await harness.drain();
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.title === "Provider default title",
+      2000,
+      asThreadId("thread-default"),
+    );
+
+    expect(thread.title).toBe("Provider default title");
+  });
+
+  it("rejects provider thread.metadata.updated when thread title is already customized", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-custom-title"),
+        threadId: ThreadId.make("thread-1"),
+        title: "My custom title",
+      }),
+    );
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-custom"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      payload: {
+        name: "Provider override attempt",
+        metadata: { source: "provider" },
+      },
+    });
+
+    await harness.drain();
+
+    await waitForThread(
+      harness.readModel,
+      (entry) => entry.id === "thread-1" && entry.title === "My custom title",
+    );
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === "thread-1");
+    expect(thread?.title).toBe("My custom title");
+  });
+
+  it("skips provider thread.metadata.updated when payload.name is missing", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-thread-create-no-name"),
+        threadId: ThreadId.make("thread-no-name"),
+        projectId: asProjectId("project-1"),
+        title: "New thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-no-name"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-no-name"),
+      payload: {},
+    });
+
+    await harness.drain();
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === "thread-no-name");
+    expect(thread?.title).toBe("New thread");
+  });
+
+  it("skips provider thread.metadata.updated when payload.name is empty string", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-thread-create-empty"),
+        threadId: ThreadId.make("thread-empty-name"),
+        projectId: asProjectId("project-1"),
+        title: "New thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-empty"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-empty-name"),
+      payload: {
+        name: "",
+      },
+    });
+
+    await harness.drain();
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === "thread-empty-name");
+    expect(thread?.title).toBe("New thread");
   });
 
   it("projects context window updates into normalized thread activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2892,12 +2892,12 @@ describe("ProviderRuntimeIngestion", () => {
     expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
   });
 
-  it("applies provider thread.metadata.updated when thread title is the default", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  effectIt.effect("applies provider thread.metadata.updated when thread title is the default", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
+      yield* harness.engine.dispatch({
         type: "thread.create",
         commandId: CommandId.make("cmd-thread-create-default"),
         threadId: ThreadId.make("thread-default"),
@@ -2912,76 +2912,82 @@ describe("ProviderRuntimeIngestion", () => {
         branch: null,
         worktreePath: null,
         createdAt: now,
+      });
+
+      harness.emit({
+        type: "thread.metadata.updated",
+        eventId: asEventId("evt-thread-metadata-default"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: now,
+        threadId: asThreadId("thread-default"),
+        payload: {
+          name: "Provider default title",
+          metadata: { source: "provider" },
+        },
+      });
+
+      yield* Effect.promise(() => harness.drain());
+
+      const thread = yield* Effect.promise(() =>
+        waitForThread(
+          harness.readModel,
+          (entry) => entry.title === "Provider default title",
+          2000,
+          asThreadId("thread-default"),
+        ),
+      );
+
+      expect(thread.title).toBe("Provider default title");
+    }),
+  );
+
+  effectIt.effect(
+    "rejects provider thread.metadata.updated when thread title is already customized",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const now = "2026-01-01T00:00:00.000Z";
+
+        yield* harness.engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make("cmd-thread-custom-title"),
+          threadId: ThreadId.make("thread-1"),
+          title: "My custom title",
+        });
+
+        harness.emit({
+          type: "thread.metadata.updated",
+          eventId: asEventId("evt-thread-metadata-custom"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: now,
+          threadId: asThreadId("thread-1"),
+          payload: {
+            name: "Provider override attempt",
+            metadata: { source: "provider" },
+          },
+        });
+
+        yield* Effect.promise(() => harness.drain());
+
+        yield* Effect.promise(() =>
+          waitForThread(
+            harness.readModel,
+            (entry) => entry.id === "thread-1" && entry.title === "My custom title",
+          ),
+        );
+
+        const readModel = yield* Effect.promise(() => harness.readModel());
+        const thread = readModel.threads.find((entry) => entry.id === "thread-1");
+        expect(thread?.title).toBe("My custom title");
       }),
-    );
+  );
 
-    harness.emit({
-      type: "thread.metadata.updated",
-      eventId: asEventId("evt-thread-metadata-default"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-default"),
-      payload: {
-        name: "Provider default title",
-        metadata: { source: "provider" },
-      },
-    });
+  effectIt.effect("skips provider thread.metadata.updated when payload.name is missing", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await harness.drain();
-
-    const thread = await waitForThread(
-      harness.readModel,
-      (entry) => entry.title === "Provider default title",
-      2000,
-      asThreadId("thread-default"),
-    );
-
-    expect(thread.title).toBe("Provider default title");
-  });
-
-  it("rejects provider thread.metadata.updated when thread title is already customized", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-thread-custom-title"),
-        threadId: ThreadId.make("thread-1"),
-        title: "My custom title",
-      }),
-    );
-
-    harness.emit({
-      type: "thread.metadata.updated",
-      eventId: asEventId("evt-thread-metadata-custom"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-1"),
-      payload: {
-        name: "Provider override attempt",
-        metadata: { source: "provider" },
-      },
-    });
-
-    await harness.drain();
-
-    await waitForThread(
-      harness.readModel,
-      (entry) => entry.id === "thread-1" && entry.title === "My custom title",
-    );
-
-    const readModel = await harness.readModel();
-    const thread = readModel.threads.find((entry) => entry.id === "thread-1");
-    expect(thread?.title).toBe("My custom title");
-  });
-
-  it("skips provider thread.metadata.updated when payload.name is missing", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
+      yield* harness.engine.dispatch({
         type: "thread.create",
         commandId: CommandId.make("cmd-thread-create-no-name"),
         threadId: ThreadId.make("thread-no-name"),
@@ -2996,31 +3002,31 @@ describe("ProviderRuntimeIngestion", () => {
         branch: null,
         worktreePath: null,
         createdAt: now,
-      }),
-    );
+      });
 
-    harness.emit({
-      type: "thread.metadata.updated",
-      eventId: asEventId("evt-thread-metadata-no-name"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-no-name"),
-      payload: {},
-    });
+      harness.emit({
+        type: "thread.metadata.updated",
+        eventId: asEventId("evt-thread-metadata-no-name"),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: now,
+        threadId: asThreadId("thread-no-name"),
+        payload: {},
+      });
 
-    await harness.drain();
+      yield* Effect.promise(() => harness.drain());
 
-    const readModel = await harness.readModel();
-    const thread = readModel.threads.find((entry) => entry.id === "thread-no-name");
-    expect(thread?.title).toBe("New thread");
-  });
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === "thread-no-name");
+      expect(thread?.title).toBe("New thread");
+    }),
+  );
 
-  it("skips provider thread.metadata.updated when payload.name is empty string", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  effectIt.effect("skips provider thread.metadata.updated when payload.name is empty string", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
+      yield* harness.engine.dispatch({
         type: "thread.create",
         commandId: CommandId.make("cmd-thread-create-empty"),
         threadId: ThreadId.make("thread-empty-name"),
@@ -3035,67 +3041,69 @@ describe("ProviderRuntimeIngestion", () => {
         branch: null,
         worktreePath: null,
         createdAt: now,
-      }),
-    );
+      });
 
-    harness.emit({
-      type: "thread.metadata.updated",
-      eventId: asEventId("evt-thread-metadata-empty"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-empty-name"),
-      payload: {
-        name: "",
-      },
-    });
-
-    await harness.drain();
-
-    const readModel = await harness.readModel();
-    const thread = readModel.threads.find((entry) => entry.id === "thread-empty-name");
-    expect(thread?.title).toBe("New thread");
-  });
-
-  it("skips provider thread.metadata.updated when payload.name sanitizes to empty", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.create",
-        commandId: CommandId.make("cmd-thread-create-whitespace"),
-        threadId: ThreadId.make("thread-whitespace-name"),
-        projectId: asProjectId("project-1"),
-        title: "New thread",
-        modelSelection: {
-          instanceId: ProviderInstanceId.make("codex"),
-          model: "gpt-5-codex",
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        branch: null,
-        worktreePath: null,
+      harness.emit({
+        type: "thread.metadata.updated",
+        eventId: asEventId("evt-thread-metadata-empty"),
+        provider: ProviderDriverKind.make("codex"),
         createdAt: now,
+        threadId: asThreadId("thread-empty-name"),
+        payload: {
+          name: "",
+        },
+      });
+
+      yield* Effect.promise(() => harness.drain());
+
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === "thread-empty-name");
+      expect(thread?.title).toBe("New thread");
+    }),
+  );
+
+  effectIt.effect(
+    "skips provider thread.metadata.updated when payload.name sanitizes to empty",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() => createHarness());
+        const now = "2026-01-01T00:00:00.000Z";
+
+        yield* harness.engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make("cmd-thread-create-whitespace"),
+          threadId: ThreadId.make("thread-whitespace-name"),
+          projectId: asProjectId("project-1"),
+          title: "New thread",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+        });
+
+        harness.emit({
+          type: "thread.metadata.updated",
+          eventId: asEventId("evt-thread-metadata-whitespace"),
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: now,
+          threadId: asThreadId("thread-whitespace-name"),
+          payload: {
+            name: "   ",
+          },
+        });
+
+        yield* Effect.promise(() => harness.drain());
+
+        const readModel = yield* Effect.promise(() => harness.readModel());
+        const thread = readModel.threads.find((entry) => entry.id === "thread-whitespace-name");
+        expect(thread?.title).toBe("New thread");
       }),
-    );
-
-    harness.emit({
-      type: "thread.metadata.updated",
-      eventId: asEventId("evt-thread-metadata-whitespace"),
-      provider: ProviderDriverKind.make("codex"),
-      createdAt: now,
-      threadId: asThreadId("thread-whitespace-name"),
-      payload: {
-        name: "   ",
-      },
-    });
-
-    await harness.drain();
-
-    const readModel = await harness.readModel();
-    const thread = readModel.threads.find((entry) => entry.id === "thread-whitespace-name");
-    expect(thread?.title).toBe("New thread");
-  });
+  );
 
   it("projects context window updates into normalized thread activities", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3056,6 +3056,47 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread?.title).toBe("New thread");
   });
 
+  it("skips provider thread.metadata.updated when payload.name sanitizes to empty", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-thread-create-whitespace"),
+        threadId: ThreadId.make("thread-whitespace-name"),
+        projectId: asProjectId("project-1"),
+        title: "New thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    harness.emit({
+      type: "thread.metadata.updated",
+      eventId: asEventId("evt-thread-metadata-whitespace"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-whitespace-name"),
+      payload: {
+        name: "   ",
+      },
+    });
+
+    await harness.drain();
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === "thread-whitespace-name");
+    expect(thread?.title).toBe("New thread");
+  });
+
   it("projects context window updates into normalized thread activities", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -26,6 +26,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { isDefaultThreadTitle, sanitizeTitle } from "@t3tools/shared/threadTitle";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
@@ -1704,12 +1705,14 @@ const make = Effect.gen(function* () {
       }
 
       if (event.type === "thread.metadata.updated" && event.payload.name) {
-        yield* orchestrationEngine.dispatch({
-          type: "thread.meta.update",
-          commandId: yield* providerCommandId(event, "thread-meta-update"),
-          threadId: thread.id,
-          title: event.payload.name,
-        });
+        if (isDefaultThreadTitle(thread.title)) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.meta.update",
+            commandId: yield* providerCommandId(event, "thread-meta-update"),
+            threadId: thread.id,
+            title: sanitizeTitle(event.payload.name),
+          });
+        }
       }
 
       if (event.type === "turn.diff.updated") {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1706,12 +1706,15 @@ const make = Effect.gen(function* () {
 
       if (event.type === "thread.metadata.updated" && event.payload.name) {
         if (isDefaultThreadTitle(thread.title)) {
-          yield* orchestrationEngine.dispatch({
-            type: "thread.meta.update",
-            commandId: yield* providerCommandId(event, "thread-meta-update"),
-            threadId: thread.id,
-            title: sanitizeTitle(event.payload.name),
-          });
+          const sanitized = sanitizeTitle(event.payload.name);
+          if (sanitized.length > 0) {
+            yield* orchestrationEngine.dispatch({
+              type: "thread.meta.update",
+              commandId: yield* providerCommandId(event, "thread-meta-update"),
+              threadId: thread.id,
+              title: sanitized,
+            });
+          }
         }
       }
 

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -58,6 +58,7 @@ import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
 import { resolveThreadActionProjectRef, startNewThreadFromContext } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
@@ -467,6 +468,14 @@ function CommandPaletteDialog(props: {
   );
 }
 
+function renderThreadLeadingContent(thread: EnvironmentThreadShell) {
+  return <ThreadRowLeadingStatus thread={thread} />;
+}
+
+function renderThreadTrailingContent(thread: EnvironmentThreadShell) {
+  return <ThreadRowTrailingStatus thread={thread} />;
+}
+
 function OpenCommandPaletteDialog(props: {
   readonly openIntent: CommandPaletteOpenIntent | null;
   readonly setOpen: (open: boolean) => void;
@@ -852,8 +861,8 @@ function OpenCommandPaletteDialog(props: {
         projectTitleById,
         sortOrder: clientSettings.sidebarThreadSortOrder,
         icon: <MessageSquareIcon className={ITEM_ICON_CLASS} />,
-        renderLeadingContent: (thread) => <ThreadRowLeadingStatus thread={thread} />,
-        renderTrailingContent: (thread) => <ThreadRowTrailingStatus thread={thread} />,
+        renderLeadingContent: renderThreadLeadingContent,
+        renderTrailingContent: renderThreadTrailingContent,
         runThread: async (thread) => {
           await navigate({
             to: "/$environmentId/$threadId",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -163,6 +163,10 @@
       "types": "./src/terminalLabels.ts",
       "import": "./src/terminalLabels.ts"
     },
+    "./threadTitle": {
+      "types": "./src/threadTitle.ts",
+      "import": "./src/threadTitle.ts"
+    },
     "./relayClient": {
       "types": "./src/relayClient.ts",
       "import": "./src/relayClient.ts"

--- a/packages/shared/src/threadTitle.test.ts
+++ b/packages/shared/src/threadTitle.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vite-plus/test";
+import { isDefaultThreadTitle, sanitizeTitle, DEFAULT_THREAD_TITLE } from "./threadTitle.ts";
+
+describe("isDefaultThreadTitle", () => {
+  it("returns true for the default title", () => {
+    expect(isDefaultThreadTitle("New thread")).toBe(true);
+  });
+
+  it("returns true for the default title with whitespace", () => {
+    expect(isDefaultThreadTitle("  New thread  ")).toBe(true);
+  });
+
+  it("returns false for a custom title", () => {
+    expect(isDefaultThreadTitle("My custom title")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isDefaultThreadTitle("")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isDefaultThreadTitle(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isDefaultThreadTitle(undefined)).toBe(false);
+  });
+});
+
+describe("sanitizeTitle", () => {
+  it("preserves a normal title", () => {
+    expect(sanitizeTitle("Hello World")).toBe("Hello World");
+  });
+
+  it("trims whitespace", () => {
+    expect(sanitizeTitle("  hello  ")).toBe("hello");
+  });
+
+  it("strips control characters", () => {
+    expect(sanitizeTitle("hello\x00world")).toBe("helloworld");
+    expect(sanitizeTitle("hello\x1Fworld")).toBe("helloworld");
+  });
+
+  it("truncates to MAX_TITLE_LENGTH", () => {
+    const long = "a".repeat(1000);
+    expect(sanitizeTitle(long).length).toBe(500);
+  });
+});
+
+describe("DEFAULT_THREAD_TITLE", () => {
+  it("equals New thread", () => {
+    expect(DEFAULT_THREAD_TITLE).toBe("New thread");
+  });
+});

--- a/packages/shared/src/threadTitle.test.ts
+++ b/packages/shared/src/threadTitle.test.ts
@@ -41,6 +41,16 @@ describe("sanitizeTitle", () => {
     expect(sanitizeTitle("hello\x1Fworld")).toBe("helloworld");
   });
 
+  it("returns empty string for whitespace-only input", () => {
+    expect(sanitizeTitle("   ")).toBe("");
+    expect(sanitizeTitle(" \t ")).toBe("");
+  });
+
+  it("returns empty string for control-char-only input", () => {
+    expect(sanitizeTitle("\x00")).toBe("");
+    expect(sanitizeTitle("\x00\x00")).toBe("");
+  });
+
   it("truncates to MAX_TITLE_LENGTH", () => {
     const long = "a".repeat(1000);
     expect(sanitizeTitle(long).length).toBe(500);

--- a/packages/shared/src/threadTitle.ts
+++ b/packages/shared/src/threadTitle.ts
@@ -1,0 +1,14 @@
+const MAX_TITLE_LENGTH = 500;
+
+export const DEFAULT_THREAD_TITLE = "New thread";
+
+export function isDefaultThreadTitle(title: string | null | undefined): boolean {
+  return (title ?? "").trim() === DEFAULT_THREAD_TITLE;
+}
+
+export function sanitizeTitle(title: string): string {
+  return title
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "")
+    .slice(0, MAX_TITLE_LENGTH)
+    .trim();
+}

--- a/packages/shared/src/threadTitle.ts
+++ b/packages/shared/src/threadTitle.ts
@@ -8,7 +8,10 @@ export function isDefaultThreadTitle(title: string | null | undefined): boolean 
 
 export function sanitizeTitle(title: string): string {
   return title
-    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "")
+    .replace(/./g, (c) => {
+      const code = c.charCodeAt(0);
+      return code > 0x1f || code === 0x09 || code === 0x0a || code === 0x0d ? c : "";
+    })
     .slice(0, MAX_TITLE_LENGTH)
     .trim();
 }


### PR DESCRIPTION
Provider-emitted `thread.metadata.updated` events were unconditionally overwriting thread titles, reverting user custom renames and blocking auto-titling from working reliably.

The fix:

- **Guard provider title updates** — only apply a provider's thread title when the current title is still the default `"New thread"` (checked via `isDefaultThreadTitle`)
- **Sanitize provider titles** — strip control characters and truncate at 500 chars
- **Unify title policy** — `ProviderCommandReactor.canReplaceThreadTitle` now delegates to the shared `isDefaultThreadTitle` instead of its own local constant
- **Tests** — unit tests for `isDefaultThreadTitle` / `sanitizeTitle`, integration tests for default/custom/missing/empty title scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration thread metadata behavior that users see in the UI, but the logic is narrowly scoped with clear guards and broad test coverage.
> 
> **Overview**
> **Fixes provider-driven session renaming** by stopping `thread.metadata.updated` from overwriting user-chosen titles.
> 
> Provider title updates in runtime ingestion now run only when the current title is still the default (`"New thread"` via `isDefaultThreadTitle`), and the incoming name is passed through `sanitizeTitle` (control-character stripping, 500-char cap) before `thread.meta.update` is dispatched. Custom titles are left unchanged; empty or whitespace-only provider names are ignored.
> 
> **Shared title helpers** live in `@t3tools/shared/threadTitle` and replace the server’s local default constant in `ProviderCommandReactor.canReplaceThreadTitle`. Integration expectations were updated so a non-default harness title (`"Thread"`) is not renamed by provider metadata; new tests cover default apply, custom reject, and missing/empty/sanitized-empty names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd29c498188b9a673943f685c1154b9839712ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix session renaming bug by preventing providers from overwriting user-customized thread titles
> - Adds a shared `threadTitle` module ([threadTitle.ts](https://github.com/pingdotgg/t3code/pull/4558/files#diff-82726620d9b716c3449fdc5716503a94ce151d5b6ce6b8c0308a178c09d92fd1)) exporting `DEFAULT_THREAD_TITLE`, `isDefaultThreadTitle`, and `sanitizeTitle` utilities.
> - Updates the `thread.metadata.updated` handler in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/4558/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) to only apply provider-proposed names when the current thread title is the default; the proposed name is also sanitized before use.
> - Updates `canReplaceThreadTitle` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/4558/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) to use `isDefaultThreadTitle` instead of a local constant.
> - Behavioral Change: Provider-driven renames are now silently ignored if the user has already set a custom title, or if the sanitized proposed name is empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acd29c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->